### PR TITLE
.github: Run r2c.registry.latest via Bento Action

### DIFF
--- a/.bento/config.yml
+++ b/.bento/config.yml
@@ -1,0 +1,105 @@
+autorun:
+  block: true
+formatter:
+- clippy: {}
+tools:
+  bandit:
+    ignore:
+    - any-other-function-with-shell-equals-true
+    - assert-used
+    - hardcoded-bind-all-interfaces
+    - hardcoded-password-default
+    - hardcoded-password-funcarg
+    - hardcoded-password-string
+    - hardcoded-sql-expressions
+    - hardcoded-tmp-directory
+    - import-lxml
+    - import-pickle
+    - import-subprocess
+    - import-xml-expat
+    - import-xml-minidom
+    - import-xml-pulldom
+    - import-xml-sax
+    - import_xml-etree
+    - md5
+    - random
+    - start-process-with-no-shell
+    - start-process-with-partial-path
+    - subprocess-without-shell-equals-true
+    - try-except-continue
+    - urllib-urlopen
+    run: true
+  dlint:
+    ignore: []
+    run: true
+  flake8:
+    ignore:
+    - bad-wildcard-import
+    - bare-except-bugbear
+    - no-getattr
+    - no-setattr
+    - unused-loop-variable
+    - unused-module
+    - unused-variable
+    run: true
+  hadolint:
+    ignore:
+    - DL3008
+    - DL3010
+    - DL3012
+    - DL3018
+    - DL3020
+    - DL3022
+    - DL3027
+    - DL4001
+    run: true
+  r2c.click:
+    ignore:
+    - names-are-well-formed
+    run: true
+  r2c.flask:
+    ignore: []
+    run: true
+  r2c.registry.latest:
+    ignore: []
+    run: true
+  r2c.requests:
+    ignore:
+    - use-timeout
+    run: true
+  shellcheck:
+    ignore:
+    - SC1004
+    - SC1008
+    - SC1009
+    - SC1047
+    - SC1050
+    - SC1062
+    - SC1071
+    - SC1072
+    - SC1090
+    - SC1091
+    - SC1105
+    - SC1107
+    - SC1123
+    - SC1124
+    - SC1126
+    - SC2001
+    - SC2002
+    - SC2003
+    - SC2004
+    - SC2005
+    - SC2006
+    - SC2007
+    - SC2009
+    - SC2034
+    - SC2035
+    - SC2039
+    - SC2155
+    - SC2164
+    - SC2181
+    - SC2186
+    - SC2196
+    - SC2197
+    - SC2230
+    run: true

--- a/.bentoignore
+++ b/.bentoignore
@@ -1,0 +1,33 @@
+# Items added to this file will be ignored by bento.
+#
+# This file uses .gitignore syntax:
+#
+# To ignore a file anywhere it occurs in your project, enter a
+# glob pattern here. E.g. "*.min.js".
+#
+# To ignore a directory anywhere it occurs in your project, add
+# a trailing slash to the file name. E.g. "dist/".
+#
+# To ignore a file or directory only relative to the project root,
+# include a slash anywhere except the last character. E.g.
+# "/dist/", or "src/generated".
+#
+# Some parts of .gitignore syntax are not supported, and patterns
+# using this syntax will be dropped from the ignore list:
+# - Explicit "include syntax", e.g. "!kept/".
+# - Multi-character expansion syntax, e.g. "*.py[cod]"
+#
+# To include ignore patterns from another file, start a line
+# with ':include', followed by the path of the file. E.g.
+# ":include path/to/other/ignore/file".
+#
+# To ignore a file with a literal ':' character, escape it with
+# a backslash, e.g. "\:foo".
+
+# Ignore Bento environment files
+.bento/
+
+# Ignore git items
+.gitignore
+.git/
+:include .gitignore

--- a/.github/workflows/bento.yml
+++ b/.github/workflows/bento.yml
@@ -1,0 +1,15 @@
+jobs:
+  bento:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - id: bento
+      name: Bento
+      uses: returntocorp/bento-action@v1
+      with:
+        acceptTermsWithEmail: test@returntocorp.com
+        slackWebhookURL: ${{ secrets.BENTO_SLACK_WEBHOOK_URL }}
+name: Bento
+'on':
+- pull_request


### PR DESCRIPTION
This commit:

 - Adds the Bento Action as a new workflow if needed

 - Sets up Slack notifications on failure

 - Enables the r2c.registry.latest tool in the Bento config

Relates to https://github.com/returntocorp/enterprise/issues/19
