### PR TITLE
perf test suite

### DIFF
--- a/sgrep_lint/tests/run-perf-tests.sh
+++ b/sgrep_lint/tests/run-perf-tests.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+# set -x
+
+HYPERFINE="hyperfine -m 2 --warmup 0 "
+
+A_VERSION="0.4.8"
+B_VERSION="0.4.9"
+
+
+test_test_suite() {
+    rm -rf /tmp/sgrep-rules && git clone https://github.com/returntocorp/sgrep-rules /tmp/sgrep-rules
+    ls -al /tmp/sgrep-rules
+    CMDA="${SGREP_A} --dangerously-allow-arbitrary-code-execution-from-rules --strict --test --test-ignore-todo /tmp/sgrep-rules"
+    CMDB="${SGREP_B} --dangerously-allow-arbitrary-code-execution-from-rules --strict --test --test-ignore-todo /tmp/sgrep-rules"
+    $CMDA
+    $CMDB
+    $HYPERFINE --export-markdown testsuite.md "${CMDA}" "${CMDB}"
+}
+
+test_sample_repos() {
+    rm -rf /tmp/sample && git clone --depth=1 https://github.com/apache/airflow /tmp/sample/
+    cd /tmp/sample
+    SGREP_A="docker run --rm -v ${PWD}:/home/repo returntocorp/sgrep:${A_VERSION}"
+    SGREP_B="docker run --rm -v ${PWD}:/home/repo returntocorp/sgrep:${B_VERSION}"
+
+    CMDA="${SGREP_A} --config=r2c --dangerously-allow-arbitrary-code-execution-from-rules --strict"
+    CMDB="${SGREP_B} --config=r2c --dangerously-allow-arbitrary-code-execution-from-rules --strict"
+    #$CMDA
+    #$CMDB
+    $HYPERFINE --export-markdown ${THIS_DIR}/testsuite.md "${CMDA}" "${CMDB}"
+    cat ${THIS_DIR}/testsuite.md
+    cd -
+    
+}
+
+echo "-----------------------"
+echo "starting perf tests"
+
+THIS_DIR="$(dirname "$(realpath "$0")")";
+cd "${THIS_DIR}"
+
+#test_test_suite
+test_sample_repos
+
+echo "-----------------------"
+echo "all per tests completed"


### PR DESCRIPTION
Output example, showing 2x regression in 0.4.8 -> 0.4.9 :

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `docker run --rm -v /tmp/sample:/home/repo returntocorp/sgrep:0.4.8 --config=r2c --dangerously-allow-arbitrary-code-execution-from-rules --strict` | 112.435 ± 4.908 | 108.965 | 115.906 | 1.00 |
| `docker run --rm -v /tmp/sample:/home/repo returntocorp/sgrep:0.4.9 --config=r2c --dangerously-allow-arbitrary-code-execution-from-rules --strict` | 222.313 ± 1.185 | 221.475 | 223.150 | 1.98 ± 0.09 |