### PR TITLE
Basic include/exclude file filtering logic in semgrep-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache perl m4
 USER opam
 
 WORKDIR /home/opam/opam-repository
-RUN git pull && opam update && opam switch 4.07 && opam install ocamlfind camlp4 num ocamlgraph json-wheel conf-perl dune yaml grain_dypgen menhir
+RUN git pull && opam update && opam switch 4.07 && opam install ocamlfind camlp4 num ocamlgraph json-wheel conf-perl dune yaml grain_dypgen menhir dune-glob
 
 COPY --chown=opam . /home/opam/sgrep/
 WORKDIR /home/opam/sgrep

--- a/sgrep/bin/dune
+++ b/sgrep/bin/dune
@@ -23,6 +23,7 @@
     
     sgrep
     sgrep_fuzzy
+    sgrep_files
  )
  ; for ocamldebug
  (modes byte)

--- a/sgrep/lib_files/dune
+++ b/sgrep/lib_files/dune
@@ -1,0 +1,8 @@
+(library
+ (public_name sgrep_files)
+ (wrapped false)
+ (libraries
+   dune-glob
+   commons
+ )
+)

--- a/sgrep/lib_files/files_filter.ml
+++ b/sgrep/lib_files/files_filter.ml
@@ -22,6 +22,7 @@ module Glob = Dune_glob__Glob
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
+(* see https://dune.readthedocs.io/en/stable/concepts.html#glob *)
 type glob = Glob.t
 
 type filters = {

--- a/sgrep/lib_files/files_filter.ml
+++ b/sgrep/lib_files/files_filter.ml
@@ -1,0 +1,67 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ * 
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+module Glob = Dune_glob__Glob
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+type glob = Glob.t
+
+type filters = {
+  excludes: glob list;
+  includes: glob list;
+  exclude_dirs: glob list;
+}
+
+exception GlobSyntaxError of string
+
+(*****************************************************************************)
+(* Parsing *)
+(*****************************************************************************)
+let mk_filters ~excludes ~includes ~exclude_dirs =
+ try 
+  { excludes = excludes |> List.map Glob.of_string;
+    includes = 
+      if includes = []
+      then [Glob.universal]
+      else includes |> List.map Glob.of_string;
+    exclude_dirs = exclude_dirs |> List.map Glob.of_string;
+  } 
+ with Invalid_argument s -> raise (GlobSyntaxError s)
+
+(*****************************************************************************)
+(* Main entry point *)
+(*****************************************************************************)
+
+let filter filters xs =
+  xs |> List.filter (fun file ->
+    let base = Filename.basename file in
+    let dir = Filename.dirname file in
+    (* todo? includes have priority over excludes? *)
+    (filters.excludes |> List.for_all (fun glob -> not (Glob.test glob base)))
+    &&
+    (filters.includes |> List.exists (fun glob -> Glob.test glob base))
+    &&
+    (filters.exclude_dirs |> List.for_all 
+            (fun glob -> not (Glob.test glob dir)))
+    
+ )
+  
+

--- a/sgrep/lib_files/files_filter.mli
+++ b/sgrep/lib_files/files_filter.mli
@@ -1,0 +1,9 @@
+
+type filters
+
+val mk_filters: 
+  excludes: string list -> includes: string list -> exclude_dirs: string list->
+  filters
+
+val filter: filters -> Common.filename list -> Common.filename list
+

--- a/sgrep/lib_files/files_filter.mli
+++ b/sgrep/lib_files/files_filter.mli
@@ -1,9 +1,23 @@
 
-type filters
+(* This uses an external "globbing" library whose syntax is similar
+ * to UNIX globbing (as in .gitignore file for example).
+ * See https://dune.readthedocs.io/en/stable/concepts.html#glob
+ * for more information on its syntax.
+ *)
+type glob
 
+type filters = {
+  excludes: glob list;
+  includes: glob list;
+  exclude_dirs: glob list;
+}
+
+exception GlobSyntaxError of string
+(* may raise GlobSyntaxError *)
 val mk_filters: 
   excludes: string list -> includes: string list -> exclude_dirs: string list->
   filters
 
+(* entry point *)
 val filter: filters -> Common.filename list -> Common.filename list
 

--- a/sgrep/lib_files/files_finder.ml
+++ b/sgrep/lib_files/files_finder.ml
@@ -1,0 +1,24 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ * 
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+
+(*****************************************************************************)
+(* Main entry point *)
+(*****************************************************************************)
+let files_of_dirs_or_files xs =
+  Common.files_of_dir_or_files_no_vcs_nofilter xs

--- a/sgrep/lib_files/files_finder.mli
+++ b/sgrep/lib_files/files_finder.mli
@@ -1,0 +1,2 @@
+
+val files_of_dirs_or_files: string list -> Common.filename list

--- a/sgrep/lib_files/unit_files.ml
+++ b/sgrep/lib_files/unit_files.ml
@@ -1,0 +1,23 @@
+open OUnit
+
+let unittest =
+  "file filtering" >::: [
+    "basic exclude/include" >:: (fun () ->
+        let files = [
+            "a/b/foo.c";
+            "a/b/foo.js";
+            "a/b/bar.c";
+            "a/b/bar.js";
+            "a/b/foo.go";
+            "a/c/foo.c";
+            "a/c/foo.js";
+        ] in
+        let filters = Files_filter.mk_filters
+          ~excludes:["*.{c,h}"; "*.go"]
+          ~includes:["foo.*"]
+          ~exclude_dirs:["a/c"] in
+        assert_equal ~msg:"it should filter files"
+          ["a/b/foo.js"]
+          (Files_filter.filter filters files)
+     )
+  ]

--- a/sgrep/lib_files/unit_files.mli
+++ b/sgrep/lib_files/unit_files.mli
@@ -1,0 +1,6 @@
+(* Returns the testsuite for this directory To be concatenated by 
+ * the caller (e.g. in pfff/main_test.ml ) with other testsuites and 
+ * run via OUnit.run_test_tt 
+ *)
+val unittest: 
+  OUnit.test

--- a/sgrep/sgrep.opam
+++ b/sgrep/sgrep.opam
@@ -27,6 +27,7 @@ depends: [
   "yaml"
   "grain_dypgen"
   "menhir"
+  "dune-glob"
   "pfff"
 ]
 

--- a/sgrep/tests/dune
+++ b/sgrep/tests/dune
@@ -23,5 +23,6 @@
     
     sgrep
     sgrep_fuzzy
+    sgrep_files
   )
 )

--- a/sgrep/tests/test.ml
+++ b/sgrep/tests/test.ml
@@ -186,6 +186,7 @@ let test regexp =
       (* TODO Unit_matcher.spatch_unittest ~xxx *)
       (* TODO Unit_matcher_php.unittest; (* sgrep, spatch, refactoring, unparsing *) *)
       lint_regression_tests;
+      Unit_files.unittest;
     ]
   in
   let suite =


### PR DESCRIPTION
This diff fixes issue https://github.com/returntocorp/enterprise/issues/55

Test plan:
unit tests included
make test

./_build/default/bin/main_sgrep.exe -rules_file data/basic.yml tests/ -exclude '*.sgrep' -exclude '*.TODO' -include '*.{js,py}' -exclude-dir 'tests/js' -exclude-dir 'tests/TODO' -exclude 'stupid.*'

seems to work and display only a few errors:
{
  "matches": [
    {
      "check_id": "stupid_equal",
      "path": "tests/python/equivalence_eq.py",
      "start": { "line": 5, "col": 8, "offset": 64 },
      "end": { "line": 5, "col": 22, "offset": 78 },
      "extra": {
        "message": "Dude, $X == $X is always true (Unless X is NAN ...)",
        "metavars": {
          "$X": {
            "start": { "line": 5, "col": 8, "offset": 64 },
            "end": { "line": 5, "col": 13, "offset": 69 },
            "abstract_content": "a+b",
            "unique_id": {
              "type": "AST",
              "md5sum": "46f49cbe835034c2551d3720ed5b5d5e"
            }
          }
        }
      }
    },

...