### PR TITLE
Fix -exclude-dir to exlude if any dir component match

### DIFF
--- a/sgrep/bin/main_sgrep.ml
+++ b/sgrep/bin/main_sgrep.ml
@@ -276,7 +276,9 @@ let sgrep_ast pattern file any_ast =
 (* Main action *)
 (*****************************************************************************)
 let sgrep_with_one_pattern xs =
-  let xs = List.map Common.fullpath xs in
+  (* old: let xs = List.map Common.fullpath xs in
+   * better no fullpath here, not our responsability.
+   *)
 
   let pattern, query_string =
     match !pattern_file, !pattern_string with

--- a/sgrep/lib_files/files_filter.ml
+++ b/sgrep/lib_files/files_filter.ml
@@ -18,6 +18,17 @@ module Glob = Dune_glob__Glob
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
+(* Filter files.
+ *
+ * In theory we should use find ... | grep ... | xargs sgrep ...
+ * which would be more the UNIX spirit, but on huge codebase
+ * xargs fails.
+ *
+ * We just copy the options in GNU grep.
+ *
+ * todo?
+ *  - also process .gitignore as in ripgrep?
+ *)
 
 (*****************************************************************************)
 (* Types *)
@@ -55,13 +66,14 @@ let filter filters xs =
   xs |> List.filter (fun file ->
     let base = Filename.basename file in
     let dir = Filename.dirname file in
+    let dirs = Str.split (Str.regexp "/") dir in
     (* todo? includes have priority over excludes? *)
     (filters.excludes |> List.for_all (fun glob -> not (Glob.test glob base)))
     &&
     (filters.includes |> List.exists (fun glob -> Glob.test glob base))
     &&
     (filters.exclude_dirs |> List.for_all 
-            (fun glob -> not (Glob.test glob dir)))
+       (fun glob -> not (dirs |> List.exists (fun dir -> Glob.test glob dir))))
     
  )
   

--- a/sgrep/lib_files/unit_files.ml
+++ b/sgrep/lib_files/unit_files.ml
@@ -15,7 +15,7 @@ let unittest =
         let filters = Files_filter.mk_filters
           ~excludes:["*.{c,h}"; "*.go"]
           ~includes:["foo.*"]
-          ~exclude_dirs:["a/c"] in
+          ~exclude_dirs:["c"] in
         assert_equal ~msg:"it should filter files"
           ["a/b/foo.js"]
           (Files_filter.filter filters files)


### PR DESCRIPTION
This can help fix issue #389

Test plan:
+ /home/pad/github/sgrep/sgrep/_build/default/bin/main_sgrep.exe -lang c -lang go -e $X == $X -exclude-dir vendor .

now skip vendor directory