### PR TITLE
Add support for operator name aliasing

### DIFF
--- a/docs/config/advanced.md
+++ b/docs/config/advanced.md
@@ -29,7 +29,7 @@ rules:
       - pattern-not-inside: assert(...)
       - pattern-not-inside: assertTrue(...)
       - pattern-not-inside: assertFalse(...)
-      - patterns-or:
+      - pattern-either:
           - pattern: $X == $X
           - pattern: $X != $X
           - patterns:
@@ -61,8 +61,8 @@ Will match nothing, because foo() and foo(1) can never occur together. If we mad
 There are several operators that can be used in a rule. At the top level, there are three:
 
 - `pattern`: The rule will only fire if this pattern is found.
-- `patterns-or`: (logical OR) Nest multiple other patterns under this; any of those patterns will count as a match.
-- `patterns-and`: (logical AND) You can put multiple patterns under this to create nested, implicitly-ANDed instructions.
+- `pattern-either`: (logical OR) Nest multiple other patterns under this; any of those patterns will count as a match.
+- `patterns`: (logical AND) You can put multiple patterns under this to create nested, implicitly-ANDed instructions.
 
 ### filter operators
 
@@ -89,7 +89,7 @@ Each rule object has these fields:
 | Field     | Type          | Description                                                                                                        | Required |
 | --------- | ------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
 | id        | string        | None unique check-id that should be descriptive and understandable in isolation by the user. e.g. `no-unused-var`. | Y        |
-| `pattern` or `patterns-and` or `patterns-or`   | string        | See example patterns in this document.                                                                                        | Y        |
+| `pattern` or `patterns` or `pattern-either`   | string        | See example patterns in this document.                                                                                        | Y        |
 | message   | string        | Description of the rule that will be output when a match is found.                                                 | Y        |
 | languages | array<string> | Languages the check is relevant for. Can be python or javascript.                                                  | Y        |
 | severity  | string        | Case sensitive string equal to WARNING, ERROR                                                                  | Y        |

--- a/docs/config/advanced.md
+++ b/docs/config/advanced.md
@@ -29,7 +29,7 @@ rules:
       - pattern-not-inside: assert(...)
       - pattern-not-inside: assertTrue(...)
       - pattern-not-inside: assertFalse(...)
-      - pattern-either:
+      - patterns-or:
           - pattern: $X == $X
           - pattern: $X != $X
           - patterns:
@@ -61,8 +61,8 @@ Will match nothing, because foo() and foo(1) can never occur together. If we mad
 There are several operators that can be used in a rule. At the top level, there are three:
 
 - `pattern`: The rule will only fire if this pattern is found.
-- `pattern-either`: (logical OR) Nest multiple other patterns under this; any of those patterns will count as a match.
-- `pattterns`: (logical AND) You can put multiple patterns under this to create nested, implicitly-ANDed instructions.
+- `patterns-or`: (logical OR) Nest multiple other patterns under this; any of those patterns will count as a match.
+- `patterns-and`: (logical AND) You can put multiple patterns under this to create nested, implicitly-ANDed instructions.
 
 ### filter operators
 
@@ -89,7 +89,7 @@ Each rule object has these fields:
 | Field     | Type          | Description                                                                                                        | Required |
 | --------- | ------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
 | id        | string        | None unique check-id that should be descriptive and understandable in isolation by the user. e.g. `no-unused-var`. | Y        |
-| `pattern` or `patterns` or `pattern-either`   | string        | See example patterns in this document.                                                                                        | Y        |
+| `pattern` or `patterns-and` or `patterns-or`   | string        | See example patterns in this document.                                                                                        | Y        |
 | message   | string        | Description of the rule that will be output when a match is found.                                                 | Y        |
 | languages | array<string> | Languages the check is relevant for. Can be python or javascript.                                                  | Y        |
 | severity  | string        | Case sensitive string equal to WARNING, ERROR                                                                  | Y        |

--- a/sgrep/lib/equivalence.ml
+++ b/sgrep/lib/equivalence.ml
@@ -29,7 +29,7 @@
  * and have the engine handles this equivalence.
  *
  * alternatives:
- *  - macros/templates over the yaml rule file to generate some patterns-or,
+ *  - macros/templates over the yaml rule file to generate some pattern-either,
  *    but this may be a bit hacky and add yet another layer
  *    (sgrep-core -> sgrep-python -> sgrep-yaml-generator)
  *    As Matt said, adding a templating language, on top of a markup language
@@ -42,7 +42,7 @@
  * in generic_vs_generic.ml or normalize_ast.ml because they are too
  * difficult to encode otherwise (e.g., the less-is-ok).
  * todo: we should give them name too, so they can be disabled too.
- * 
+ *
  * related work:
  *  - standard.iso in coccinelle
  *    https://github.com/coccinelle/coccinelle/blob/master/standard.iso

--- a/sgrep/lib/equivalence.ml
+++ b/sgrep/lib/equivalence.ml
@@ -29,7 +29,7 @@
  * and have the engine handles this equivalence.
  *
  * alternatives:
- *  - macros/templates over the yaml rule file to generate some pattern-either,
+ *  - macros/templates over the yaml rule file to generate some patterns-or,
  *    but this may be a bit hacky and add yet another layer
  *    (sgrep-core -> sgrep-python -> sgrep-yaml-generator)
  *    As Matt said, adding a templating language, on top of a markup language

--- a/sgrep/lib/rule.ml
+++ b/sgrep/lib/rule.ml
@@ -23,7 +23,7 @@
  * update: if you need advanced patterns with boolean logic (which used
  * to be partially provided by the hacky OK error keyword), use
  * instead the sgrep python wrapper! It also uses a yaml file but it
- * has more features, e.g. some pattern-either fields, pattern-inside, 
+ * has more features, e.g. some patterns-or fields, pattern-inside,
  * where-eval, etc.
  *)
 

--- a/sgrep/lib/rule.ml
+++ b/sgrep/lib/rule.ml
@@ -23,7 +23,7 @@
  * update: if you need advanced patterns with boolean logic (which used
  * to be partially provided by the hacky OK error keyword), use
  * instead the sgrep python wrapper! It also uses a yaml file but it
- * has more features, e.g. some patterns-or fields, pattern-inside,
+ * has more features, e.g. some pattern-either fields, pattern-inside,
  * where-eval, etc.
  *)
 

--- a/sgrep_lint/sgrep_types.py
+++ b/sgrep_lint/sgrep_types.py
@@ -1,9 +1,8 @@
+from dataclasses import dataclass
 from typing import Dict
 from typing import List
 from typing import NewType
 from typing import Optional
-
-from dataclasses import dataclass
 
 
 PatternId = NewType("PatternId", str)

--- a/sgrep_lint/sgrep_types.py
+++ b/sgrep_lint/sgrep_types.py
@@ -25,10 +25,10 @@ OPERATORS_WITH_CHILDREN = [OPERATORS.AND_ALL, OPERATORS.AND_EITHER]
 OPERATOR_PATTERN_NAMES_MAP = {
     OPERATORS.AND_INSIDE: ["pattern-inside"],
     OPERATORS.AND_NOT_INSIDE: ["pattern-not-inside"],
-    OPERATORS.AND_EITHER: ["pattern-either", "patterns-or"],
+    OPERATORS.AND_EITHER: ["pattern-either"],
     OPERATORS.AND_NOT: ["pattern-not"],
     OPERATORS.AND: ["pattern"],
-    OPERATORS.AND_ALL: ["patterns", "patterns-and"],
+    OPERATORS.AND_ALL: ["patterns"],
     OPERATORS.WHERE_PYTHON: ["pattern-where-python"],
     OPERATORS.FIX: ["fix"],
 }

--- a/sgrep_lint/sgrep_types.py
+++ b/sgrep_lint/sgrep_types.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
 from typing import Dict
 from typing import List
 from typing import NewType
 from typing import Optional
+
+from dataclasses import dataclass
 
 
 PatternId = NewType("PatternId", str)
@@ -22,18 +23,16 @@ class OPERATORS:
 
 OPERATORS_WITH_CHILDREN = [OPERATORS.AND_ALL, OPERATORS.AND_EITHER]
 
-PATTERN_NAMES_MAP = {
-    "pattern-inside": OPERATORS.AND_INSIDE,
-    "pattern-not-inside": OPERATORS.AND_NOT_INSIDE,
-    "pattern-either": OPERATORS.AND_EITHER,
-    "pattern-not": OPERATORS.AND_NOT,
-    "pattern": OPERATORS.AND,
-    "patterns": OPERATORS.AND_ALL,
-    "pattern-where-python": OPERATORS.WHERE_PYTHON,
-    "fix": OPERATORS.FIX,
+OPERATOR_PATTERN_NAMES_MAP = {
+    OPERATORS.AND_INSIDE: ["pattern-inside"],
+    OPERATORS.AND_NOT_INSIDE: ["pattern-not-inside"],
+    OPERATORS.AND_EITHER: ["pattern-either", "patterns-or"],
+    OPERATORS.AND_NOT: ["pattern-not"],
+    OPERATORS.AND: ["pattern"],
+    OPERATORS.AND_ALL: ["patterns", "patterns-and"],
+    OPERATORS.WHERE_PYTHON: ["pattern-where-python"],
+    OPERATORS.FIX: ["fix"],
 }
-
-INVERSE_PATTERN_NAMES_MAP = dict((v, k) for k, v in PATTERN_NAMES_MAP.items())
 
 # These are the only valid top-level keys
 YAML_MUST_HAVE_KEYS = {"id", "message", "languages", "severity"}
@@ -43,9 +42,11 @@ YAML_VALID_TOP_LEVEL_OPERATORS = {
     OPERATORS.AND_EITHER,
     OPERATORS.FIX,
 }
-YAML_ALL_VALID_RULE_KEYS = set(
-    [INVERSE_PATTERN_NAMES_MAP[k] for k in YAML_VALID_TOP_LEVEL_OPERATORS]
-).union(YAML_MUST_HAVE_KEYS)
+YAML_ALL_VALID_RULE_KEYS = {
+    pattern_name
+    for op in YAML_VALID_TOP_LEVEL_OPERATORS
+    for pattern_name in OPERATOR_PATTERN_NAMES_MAP[op]
+} | YAML_MUST_HAVE_KEYS
 
 
 class InvalidRuleSchema(BaseException):
@@ -66,35 +67,44 @@ class BooleanRuleExpression:
         if self.operator in set(OPERATORS_WITH_CHILDREN):
             if self.operand is not None:
                 raise InvalidRuleSchema(
-                    f"operator `{pattern_name_for_operator(self.operator)}` cannot have operand but found {self.operand}"
+                    f"operators `{pattern_names_for_operator(self.operator)}` cannot have operand but found {self.operand}"
                 )
         else:
             if self.children is not None:
                 raise InvalidRuleSchema(
-                    f"only {list(map(pattern_name_for_operator, OPERATORS_WITH_CHILDREN))} operators can have children, but found `{pattern_name_for_operator(self.operator)}` with children"
+                    f"only {pattern_names_for_operators(OPERATORS_WITH_CHILDREN)} operators can have children, but found `{pattern_names_for_operator(self.operator)}` with children"
                 )
 
             if self.operand is None:
                 raise InvalidRuleSchema(
-                    f"operator `{pattern_name_for_operator(self.operator)}` must have operand"
+                    f"operators `{pattern_names_for_operator(self.operator)}` must have operand"
                 )
             else:
                 if type(self.operand) != str:
                     raise InvalidRuleSchema(
-                        f"operand of operator `{pattern_name_for_operator(self.operator)}` ought to have type string, but is {type(self.operand)}: {self.operand}"
+                        f"operand of operators `{pattern_names_for_operator(self.operator)}` must have type string, but is {type(self.operand)}: {self.operand}"
                     )
 
 
 def operator_for_pattern_name(pattern_name: str) -> Operator:
-    if not pattern_name in PATTERN_NAMES_MAP:
-        raise NotImplementedError(
-            f"invalid pattern name: {pattern_name}, valid pattern names are {list(PATTERN_NAMES_MAP.keys())}"
-        )
-    return PATTERN_NAMES_MAP[pattern_name]
+    for op, pattern_names in OPERATOR_PATTERN_NAMES_MAP.items():
+        if pattern_name in pattern_names:
+            return op
+
+    valid_pattern_names: List[str] = sum(OPERATOR_PATTERN_NAMES_MAP.values(), [])
+    raise NotImplementedError(
+        f"invalid pattern name: {pattern_name}, valid pattern names are {valid_pattern_names}"
+    )
 
 
-def pattern_name_for_operator(operator: Operator) -> str:
-    return INVERSE_PATTERN_NAMES_MAP[operator]
+def pattern_names_for_operator(operator: Operator) -> List[str]:
+    return OPERATOR_PATTERN_NAMES_MAP[operator]
+
+
+def pattern_names_for_operators(operators: List[Operator]) -> List[str]:
+    return sum(
+        (pattern_names_for_operator(op) for op in OPERATOR_PATTERN_NAMES_MAP), []
+    )
 
 
 @dataclass(frozen=True)

--- a/sgrep_lint/tests/python/eqeq.yaml
+++ b/sgrep_lint/tests/python/eqeq.yaml
@@ -15,10 +15,10 @@ rules:
       - pattern-not-inside: assert(...)
       - pattern-not-inside: assertTrue(...)
       - pattern-not-inside: assertFalse(...)
-      - pattern-either:
+      - patterns-or:
         - pattern: $X == $X
         - pattern: $X != $X
-        - patterns:
+        - patterns-and:
           - pattern-inside: |
               def __init__(...):
                   ...

--- a/sgrep_lint/tests/python/eqeq.yaml
+++ b/sgrep_lint/tests/python/eqeq.yaml
@@ -15,10 +15,10 @@ rules:
       - pattern-not-inside: assert(...)
       - pattern-not-inside: assertTrue(...)
       - pattern-not-inside: assertFalse(...)
-      - patterns-or:
+      - pattern-either:
         - pattern: $X == $X
         - pattern: $X != $X
-        - patterns-and:
+        - patterns:
           - pattern-inside: |
               def __init__(...):
                   ...

--- a/sgrep_lint/tests/test_evaluation.py
+++ b/sgrep_lint/tests/test_evaluation.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 
 from constants import RCE_RULE_FLAG
+from evaluation import build_boolean_expression
 from evaluation import enumerate_patterns_in_boolean_expression
 from evaluation import evaluate_expression as raw_evalute_expression
 from sgrep_types import BooleanRuleExpression
@@ -351,6 +352,34 @@ def test_exprs():
     ]
 
     assert flat == expected, f"flat: {flat}"
+
+
+def test_build_exprs():
+    base_rule = {
+        "id": "test-id",
+        "message": "test message",
+        "languages": ["python"],
+        "severity": "ERROR",
+    }
+    rules = [
+        {**base_rule, **{"pattern": "test(...)"}},
+        {**base_rule, **{"patterns": [{"pattern": "test(...)"}]}},
+        {**base_rule, **{"patterns-and": [{"pattern": "test(...)"}]}},
+        {**base_rule, **{"pattern-either": [{"pattern": "test(...)"}]}},
+        {**base_rule, **{"patterns-or": [{"pattern": "test(...)"}]}},
+    ]
+
+    results = [build_boolean_expression(rule) for rule in rules]
+    base_expected = [BooleanRuleExpression(OPERATORS.AND, '.0', None, "test(...)")]
+    expected = [
+        BooleanRuleExpression(OPERATORS.AND, "test-id", None, "test(...)"),
+        BooleanRuleExpression(OPERATORS.AND_ALL, None, base_expected, None),
+        BooleanRuleExpression(OPERATORS.AND_ALL, None, base_expected, None),
+        BooleanRuleExpression(OPERATORS.AND_EITHER, None, base_expected, None),
+        BooleanRuleExpression(OPERATORS.AND_EITHER, None, base_expected, None),
+    ]
+
+    assert results == expected
 
 
 def test_evaluate_python():

--- a/sgrep_lint/tests/test_evaluation.py
+++ b/sgrep_lint/tests/test_evaluation.py
@@ -364,9 +364,7 @@ def test_build_exprs():
     rules = [
         {**base_rule, **{"pattern": "test(...)"}},
         {**base_rule, **{"patterns": [{"pattern": "test(...)"}]}},
-        {**base_rule, **{"patterns-and": [{"pattern": "test(...)"}]}},
         {**base_rule, **{"pattern-either": [{"pattern": "test(...)"}]}},
-        {**base_rule, **{"patterns-or": [{"pattern": "test(...)"}]}},
     ]
 
     results = [build_boolean_expression(rule) for rule in rules]
@@ -374,8 +372,6 @@ def test_build_exprs():
     expected = [
         BooleanRuleExpression(OPERATORS.AND, "test-id", None, "test(...)"),
         BooleanRuleExpression(OPERATORS.AND_ALL, None, base_expected, None),
-        BooleanRuleExpression(OPERATORS.AND_ALL, None, base_expected, None),
-        BooleanRuleExpression(OPERATORS.AND_EITHER, None, base_expected, None),
         BooleanRuleExpression(OPERATORS.AND_EITHER, None, base_expected, None),
     ]
 


### PR DESCRIPTION
There are plans in the future to make the operators in the rule yaml file for
boolean composition to be more user friendly.

This change allows for such aliases to be made while staying backwards compatible.

This does not make any actual aliases yet. 