### PR TITLE
filter exclude-dir by string prefix not Glob pattern

### DIFF
--- a/sgrep/bin/main_sgrep.ml
+++ b/sgrep/bin/main_sgrep.ml
@@ -520,7 +520,7 @@ let options () =
     "-include", Arg.String (fun s -> Common.push s includes),
     " <GLOB> search only files whose basename matches GLOB";
     "-exclude-dir", Arg.String (fun s -> Common.push s exclude_dirs),
-    " <DIR> exclude directories matching the pattern DIR";
+    " <DIR> exclude directories with the prefix DIR";
 
     "-json", Arg.Set output_format_json, 
     " output JSON format";

--- a/sgrep/lib_files/files_filter.ml
+++ b/sgrep/lib_files/files_filter.ml
@@ -47,6 +47,18 @@ exception GlobSyntaxError of string
 (*****************************************************************************)
 (* Parsing *)
 (*****************************************************************************)
+
+let starts_with str p =
+  if String.length str < String.length p then 
+    false
+  else
+    let rec loop str p i =
+      if i = String.length p then true else
+      if String.unsafe_get str i <> String.unsafe_get p i then false
+      else loop str p (i+1)
+    in
+    loop str p 0
+
 let mk_filters ~excludes ~includes ~exclude_dirs =
  try 
   { excludes = excludes |> List.map Glob.of_string;
@@ -66,14 +78,12 @@ let filter filters xs =
   xs |> List.filter (fun file ->
     let base = Filename.basename file in
     let dir = Filename.dirname file in
-    let dirs = Str.split (Str.regexp "/") dir in
     (* todo? includes have priority over excludes? *)
     (filters.excludes |> List.for_all (fun glob -> not (Glob.test glob base)))
     &&
     (filters.includes |> List.exists (fun glob -> Glob.test glob base))
     &&
-    (filters.exclude_dirs |> List.for_all 
-       (fun glob -> not (dirs |> List.exists (fun dir -> Glob.test glob dir))))
+    (filters.exclude_dirs |> List.for_all (fun glob -> not (starts_with dir (Glob.to_string glob))))
     
  )
   

--- a/sgrep/lib_files/unit_files.ml
+++ b/sgrep/lib_files/unit_files.ml
@@ -17,7 +17,7 @@ let unittest =
         let filters = Files_filter.mk_filters
           ~excludes:["*.{c,h}"; "*.go"]
           ~includes:["foo.*"]
-          ~exclude_dirs:["a/c"] in  (* I would like this to be 'a/c' so a/b/c still exists but if I change to 'a/c' then 'a/c/d/foo.js doesn't get filtered out *)
+          ~exclude_dirs:["a/c"] in
         assert_equal ~msg:"it should filter files"
           ["a/b/foo.js"; "a/b/c/foo.js";]
           (Files_filter.filter filters files)

--- a/sgrep/lib_files/unit_files.ml
+++ b/sgrep/lib_files/unit_files.ml
@@ -9,15 +9,17 @@ let unittest =
             "a/b/bar.c";
             "a/b/bar.js";
             "a/b/foo.go";
+            "a/b/c/foo.js";
             "a/c/foo.c";
             "a/c/foo.js";
+            "a/c/d/foo.js"
         ] in
         let filters = Files_filter.mk_filters
           ~excludes:["*.{c,h}"; "*.go"]
           ~includes:["foo.*"]
-          ~exclude_dirs:["c"] in
+          ~exclude_dirs:["a/c"] in  (* I would like this to be 'a/c' so a/b/c still exists but if I change to 'a/c' then 'a/c/d/foo.js doesn't get filtered out *)
         assert_equal ~msg:"it should filter files"
-          ["a/b/foo.js"]
+          ["a/b/foo.js"; "a/b/c/foo.js";]
           (Files_filter.filter filters files)
      )
   ]


### PR DESCRIPTION
I noticed that the original exclude dir only filtered by things after the last `/` see 
 https://dune.readthedocs.io/en/stable/concepts.html#glob 

I realized that `-exclude-dir c` would match `c`, `a/c`, `a/b/d/e/f/c/h/foo.js` I believe it makes sense for GLOB patterns for `-include` and `-exclude` since like `grep` they only operate on the base name so things like `-exclude *.{h}` makes a lot of sense (although the fact that sgrep has -lang makes more sense to me and negates this need a bit)

The use-case in my mind is `--exclude-dir node_modules`. Note that this doesn't help with things like `--exclude-dir **/tests/**/*.js` which would be really nice but without a better glob library feels out of reach for now