### PR TITLE
* sgrep/tests/java/dots_attribute.sgrep: Support!

### DIFF
--- a/sgrep/tests/java/dots_attribute.java
+++ b/sgrep/tests/java/dots_attribute.java
@@ -1,0 +1,14 @@
+class Foo {
+  //ERROR: match!
+  @RequestMapping(method = RequestMethod.GET)
+  @PreAuthorize(PermissionUtils.CAN_ADMIN_DO_THIS)
+  public
+  @ResponseBody
+  ResponseEntity<SomeReturnObjectType> 
+  list
+    (@RequestParam(required = false) Integer someId,
+     @RequestParam(required = false) boolean doThing,
+     ...) throws Exception { 
+    return 1;
+  }
+}

--- a/sgrep/tests/java/dots_attribute.sgrep
+++ b/sgrep/tests/java/dots_attribute.sgrep
@@ -1,0 +1,2 @@
+@RequestMapping(...) 
+public $T $METHOD(...) { ... }


### PR DESCRIPTION
Note that you need to specify '$T' for the return type otherwise
the pattern does not parse.

Test plan:
test file included.