### PR TITLE
Check for invalid meta-variables in sgrep patterns (#252)

### DIFF
--- a/sgrep/bin/main_sgrep.ml
+++ b/sgrep/bin/main_sgrep.ml
@@ -219,7 +219,7 @@ let parse_pattern str =
  try (
   Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->
    match Lang.lang_of_string_opt !lang with
-   | Some lang -> PatGen (Parse_generic.parse_pattern lang str)
+   | Some lang -> PatGen (Check_sgrep.parse_check_pattern lang str)
    | None ->
      (match Lang_fuzzy.lang_of_string_opt !lang with
      | Some lang -> PatFuzzy (Parse_fuzzy.parse_pattern lang str)

--- a/sgrep/lib/check_sgrep.ml
+++ b/sgrep/lib/check_sgrep.ml
@@ -1,0 +1,29 @@
+
+(* for these languages, we are sure that $x is an error *)
+let lang_has_no_dollar_ids = Lang.(function
+  | Python | Python2 | Python3
+  | Java
+  | Go
+  | C
+  | ML
+  -> true
+  | Javascript
+  -> false)
+
+let check_pattern_metavars lang ast =
+  let kident_metavar (k, _out) ((str, _tok) as ident) =
+    if str.[0] = '$' && not (Metavars_generic.is_metavar_name str) then
+      failwith (Common.spf "`%s' is neither a valid identifier in %s nor a valid meta-variable"
+                            str (Lang.string_of_lang lang));
+    k ident
+    in
+  if lang_has_no_dollar_ids lang then
+    Visitor_ast.(mk_visitor ({default_visitor with kident = kident_metavar}) ast)
+
+let check_pattern lang ast =
+  check_pattern_metavars lang ast;
+  ast
+
+let parse_check_pattern lang str =
+  Parse_generic.parse_pattern lang str
+  |> check_pattern lang

--- a/sgrep/lib/check_sgrep.mli
+++ b/sgrep/lib/check_sgrep.mli
@@ -1,0 +1,6 @@
+
+(** Check sgrep patterns for potential issues. *)
+val check_pattern : Lang.t -> Ast_generic.any -> Ast_generic.any
+
+(** Parse an sgrep pattern and then check it. *)
+val parse_check_pattern : Lang.t -> string -> Ast_generic.any

--- a/sgrep/lib/parse_rules.ml
+++ b/sgrep/lib/parse_rules.ml
@@ -69,7 +69,7 @@ let parse file =
                in
                let pattern =
                  (* todo? call Normalize_ast.normalize here? *)
-                 try Parse_generic.parse_pattern lang pattern
+                 try Check_sgrep.parse_check_pattern lang pattern
                  with exn ->
                    raise (InvalidPatternException (id, pattern, (Lang.string_of_lang lang), (Common.exn_to_s exn)))
                in


### PR DESCRIPTION
Hi,

Following up on our discussion on #252, here is my first take on it. This should check all patterns that _sgrep_ takes as input via `-e`, `-f`, or `-rules_file`. I hope this in line with your expectations. Otherwise let me know if there is something to improve for the patch to be accepted (perhaps adding some test?).