### PR TITLE
Produce sha checksums for release assets

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -44,7 +44,7 @@ jobs:
           asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
           asset_content_type: application/zip
       - name: Upload Release Checksum
-        id: upload-release-asset-osx
+        id: upload-checksum-asset-osx
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
           asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
           asset_content_type: application/gzip
       - name: Upload Release Checksum
-        id: upload-release-asset-ubuntu
+        id: upload-release-checksum-ubuntu
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -22,10 +22,14 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: true
           prerelease: false
+
+  ## OSX Artifacts
       - uses: actions/download-artifact@v1
         with:
           name: semgrep-osx-${{ github.sha }}
           path: semgrep-osx
+      - name: Compute checksum
+        run: cat ./semgrep-osx/artifacts.zip | sha256sum > ./semgrep-osx/artifacts.zip.sha256
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -39,10 +43,24 @@ jobs:
           asset_path: ./semgrep-osx/artifacts.zip
           asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
           asset_content_type: application/zip
+      - name: Upload Release Checksum
+        id: upload-release-asset-osx
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./osx.sha256
+          asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
+          asset_content_type: application/zip
+
+  ## Ubuntu Artifacts
       - uses: actions/download-artifact@v1
         with:
           name: semgrep-ubuntu-16.04-${{ github.sha }}
           path: semgrep-ubuntu
+      - name: Compute checksum
+        run: cat ./semgrep-ubuntu/artifacts.tar.gz | sha256sum > ./semgrep-ubuntu/artifacts.tar.gz.sha256
       - name: Upload Release Asset
         id: upload-release-asset-ubuntu
         uses: actions/upload-release-asset@v1
@@ -53,6 +71,17 @@ jobs:
           asset_path: ./semgrep-ubuntu/artifacts.tar.gz
           asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
           asset_content_type: application/gzip
+      - name: Upload Release Checksum
+        id: upload-release-asset-ubuntu
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./semgrep-ubuntu/artifacts.tar.gz.sha256
+          asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz.sha256
+          asset_content_type: application/gzip
+
   release-osx:
     name: Build the OSX binaries
     runs-on: macos-latest

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -23,7 +23,7 @@ jobs:
           draft: true
           prerelease: false
 
-  ## OSX Artifacts
+          # OSX
       - uses: actions/download-artifact@v1
         with:
           name: semgrep-osx-${{ github.sha }}
@@ -50,11 +50,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./osx.sha256
+          asset_path: ./semgrep-osx/artifacts.zip.sha256
           asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
           asset_content_type: application/zip
 
-  ## Ubuntu Artifacts
+          ## UBUNTU
       - uses: actions/download-artifact@v1
         with:
           name: semgrep-ubuntu-16.04-${{ github.sha }}
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run OSX release script
-        run: ./release-scripts/osx-release.sh
+        run: ./release-scripts/osx-release-stub.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -106,9 +106,9 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Run Ubuntu build script
-        run: ./release-scripts/ubuntu-release.sh
+        run: ./release-scripts/ubuntu-release-stub.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: sgrep-ubuntu-16.04-${{ github.sha }}
+          name: semgrep-ubuntu-16.04-${{ github.sha }}
           path: artifacts.tar.gz

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run OSX release script
-        run: ./release-scripts/osx-release-stub.sh
+        run: ./release-scripts/osx-release.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -106,7 +106,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: Run Ubuntu build script
-        run: ./release-scripts/ubuntu-release-stub.sh
+        run: ./release-scripts/ubuntu-release.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/release-scripts/osx-release-stub.sh
+++ b/release-scripts/osx-release-stub.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+mkdir -p artifacts
+echo "semgrep" > artifacts/semgrep
+zip -r artifacts.zip artifacts

--- a/release-scripts/ubuntu-release-stub.sh
+++ b/release-scripts/ubuntu-release-stub.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+## For testing release jobs, make an empty ubuntu release quickly
+set -e
+
+mkdir -p semgrep-lint-files
+echo "sgrep-core" > semgrep-lint-files/sgrep
+echo "sgrep-lint" > semgrep-lint-files/sgrep-lint
+chmod +x semgrep-lint-files/sgrep
+chmod +x semgrep-lint-files/sgrep-lint
+tar -cvzf artifacts.tar.gz semgrep-lint-files/


### PR DESCRIPTION
I also added some handy scripts for testing release jobs -- they make empty release assets so if you're editing the overall job structure, you don't have to wait 45 minutes.

Produces releases like this: https://github.com/rcoh/semgrep/releases/tag/untagged-e0425c01bb116b264e52