### PR TITLE
Update semgrep pattern feature documentation in simple.md

### DIFF
--- a/docs/config/simple.md
+++ b/docs/config/simple.md
@@ -1,208 +1,344 @@
 # Simple
 
-## Example semgrep Patterns
+This document describes `semgrep` pattern features and provides pattern examples.
+
+Contents:
+
+* [Pattern Features](#pattern-features)
+  * [Expression Matching](#expression-matching)
+  * [Metavariables](#metavariables)
+  * [Ellipsis Operator](#ellipsis-operator)
+    * [Function Calls](#function-calls)
+    * [Method Calls](#method-calls)
+    * [Function Definitions](#function-definitions)
+    * [Class Definitions](#class-definitions)
+    * [Strings](#strings)
+	* [Arrays](#arrays)
+    * [Conditionals and Loops](#conditionals-and-loops)
+  * [Equivalences](#equivalences)
+    * [Imports](#imports)
+    * [Constant Propagation](#constant-propagation)
+* [Limitations](#limitations)
+  * [Statement Types](#statement-types)
+  * [Partial Statements](#partial-statements)
+
+## Pattern Features
 
 ### Expression Matching
 
+Expression matching searches code for the given pattern. This pattern can match
+a full expression, or be part of a subexpression:
+
 ```text
-pattern: 1 + foo(42)
+pattern: 1 + func(42)
+```
 
-# CODE EXAMPLES
-
-foobar(1 + foo(42)) + whatever()
+```python
+foo(1 + func(42)) + bar()
 ```
 
 ### Metavariables
 
+Metavariables are used to track a value across a specific code scope. This
+includes variables, functions, arguments, classes, object methods, imports,
+exceptions, and more.
+
+This pattern will match the following pieces of code:
+
 ```text
 pattern: $X + $Y
+```
 
-# CODE EXAMPLES
-
+```python
 foo() + bar()
 ```
 
-**Matching Identifiers**
+```python
+current + total
+```
+
+Patterns can also be used to match imports:
 
 ```text
 pattern: import $X
+```
 
-# CODE EXAMPLES
-
+```python
 import random
 ```
 
-**Reusing Metavariables**
-
-```text
-pattern: ￼$X == $X
-
-# CODE EXAMPLES
-
-1+2 == 1+2
-```
-
-### Function Calls
-
-```text
-pattern: foo(...)
-
-# CODE EXAMPLES
-
-foo(1,2)
-```
-
-The above will not match patterns like `obj.foo(1,2)` because the AST for a function differs from a method call internally.
-
-**With Arguments After a Match**
-
-```text
-pattern: foo(1, ...)
-
-# CODE EXAMPLES
-
-foo(1, "extra stuff", False)
-foo(1) # matches no arguments as well
-```
-
-**With Arguments Before a Match**
-
-```text
-pattern: foo(..., 1, ...)
-
-# CODE EXAMPLES
-
-foo(1, 2)
-foo(2, 1)
-foo(2, 3, 1)
-```
-
-**Object with Method Call**
-
-```text
-pattern: $X.get(..., None)
-
-# CODE EXAMPLES
-
-json_data.get('success', None)
-```
-
-**Keyword Arguments in Any Order**
-
-```text
-pattern: foo(kwd1=$X, err=$Y)
-
-# CODE EXAMPLES (keyword arguments in arbitrary order)
-
-foo(err=False, kwd1=True)
-```
-
-### String Matching
-
-**Using the ‘...’ Operator**
-
-```text
-pattern: foo("...")
-
-# CODE EXAMPLES
-
-foo("this is a specific string")
-```
-
-**Using** [**OCaml regular expression**](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Str.html) **Patterns**
-
-```text
-pattern: foo("=~/.*a.*/")
-
-# CODE EXAMPLES
-
-foo("this has an a")
-```
-
-### Conditionals
+Re-using metavariables shows their true power. We can re-use a metavariable
+to detect useless assignments:
 
 ```text
 pattern: |
-    if $X:
-        $Y
-
-# CODE EXAMPLES
-
-if __name__ == "__main__":
-    print('hello world')
+  $X = $Y
+  $X = $Z
 ```
+
+*Note the YAML `|` operator allows for [multiline strings](https://yaml-multiline.info/).*
+
+```python
+initial_value = 10  # Oops, useless assignment
+initial_value = get_initial_value()
+```
+
+### Ellipsis Operator
+
+The ellipsis operator (`...`) abstracts away sequences. In other words, it
+allows you to gloss over the details so you can focus on what's important.
+
+#### Function Calls
+
+The ellipsis operator can be used to search for specific function calls or
+function calls with specific arguments. To search for all calls to a specific
+function:
+
+```text
+pattern: insecure_function(...)
+```
+
+We can also search for calls with arguments after a match:
+
+```text
+pattern: func(1, ...)
+```
+
+```python
+func(1, "extra stuff", False)
+func(1)  # Matches no arguments as well
+```
+
+Or calls with arguments before a match:
+
+```text
+pattern: func(..., 1)
+```
+
+```python
+func("extra stuff", False, 1)
+func(1)  # Matches no arguments as well
+```
+
+Or calls where an argument appears anywhere:
+
+```text
+pattern: requests.get(..., verify=False, ...)
+```
+
+```python
+requests.get(verify=False, url=URL)
+requests.get(URL, verify=False, timeout=3)
+requests.get(URL, verify=False)
+```
+
+The keyword argument value can also be matched:
+
+```text
+pattern: $FUNC(..., $KEY=$VALUE, ...)
+```
+
+#### Method Calls
+
+The ellipsis operator can be used to search for method calls on a specific
+object type:
+
+```text
+pattern: $OBJECT.extractall(...)
+```
+
+```python
+tarball.extractall('/path/to/directory')  # Oops, potential arbitrary file overwrite
+```
+
+#### Function Definitions
+
+The ellipsis operator can be used in function argument lists or in the function
+body. To find function definitions with [mutable default arguments](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments):
 
 ```text
 pattern: |
-    if $X:
-        ...
-
-# CODE EXAMPLES
-
-if __name__ == "__main__":
-    print('hello world')
-    foo()
-    bar()
+  def $FUNC(..., $ARG={}, ...):
+      ...
 ```
 
-Note you can’t match a half statement; both of the examples above must specify the contents of the condition’s body \(e.g. `$Y` and `...`\), otherwise they are not valid AST elements.
+*Note the YAML `|` operator allows for [multiline strings](https://yaml-multiline.info/).*
 
-### In a statement context, a Metavariable can also match any statement
+```python
+def parse_data(parser, data={}):  # Oops, mutable default arguments
+    pass
+```
+
+#### Class Definitions
+
+The ellipsis operator can be used in class definitions. To find classes that
+inherit from a certain parent:
 
 ```text
 pattern: |
-    if $X:
-        $Y
-
-# CODE EXAMPLES
-if 1:
-  foo()
-
-if 2:
-  return 1
-
-if 3:     # matches a “block” (a single statement containing multiple statements)
-  foo()
-  bar()
+  class $CLASS(InsecureBaseClass):
+      ...
 ```
 
-Because in Python there is usually no terminator \(e.g., `;`\), there is an ambiguity about `$Y` in the above, which could match a statement and also an expression that is then matched later.
+*Note the YAML `|` operator allows for [multiline strings](https://yaml-multiline.info/).*
 
-### Match on import types
+```python
+class DataRetriever(InsecureBaseClass):
+    def __init__(self):
+        pass
+```
+
+#### Strings
+
+The ellipsis operator can be used to search for strings containing any data:
+
+```text
+pattern: crypto.set_secret_key("...")
+```
+
+```python
+crypto.set_secret_key("HARDCODED SECRET")
+```
+
+[OCaml regular expressions](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Str.html)
+can also be used to search for specific strings:
+
+```text
+pattern: requests.get("=~/.*dev\.corp\.com.*/")
+```
+
+```python
+requests.get("api.dev.corp.com")  # Oops, development API left in
+```
+
+#### Arrays
+
+The ellipsis operator can be used to match literal arrays:
+
+```text
+pattern: user_list = [..., 10]
+```
+
+```python
+user_list = [8, 9, 10]
+```
+
+#### Conditionals and Loops
+
+The ellipsis operator can be used inside conditionals or loops:
+
+```text
+pattern: |
+  if $CONDITION:
+      ...
+```
+
+*Note the YAML `|` operator allows for [multiline strings](https://yaml-multiline.info/).*
+
+```python
+if can_make_request:
+    check_status()
+    make_request()
+    return
+```
+
+A metavariable can also be used to match a conditional or loop body if the
+body statement information will be re-used later:
+
+```text
+pattern: |
+  if $CONDITION:
+      $BODY
+```
+
+```python
+if can_make_request:
+    single_request_statement()
+```
+
+**Note you can’t match a half statement; both of the examples above must
+specify the contents of the condition's body (e.g. `$BODY` or `...`),
+otherwise they are not valid patterns.**
+
+### Equivalences
+
+`semgrep` will handle certain types of equivalent code.
+
+#### Imports
+
+Equivalent imports using aliasing or submodules will be matched.
 
 ```text
 pattern: subprocess.Popen(...)
+```
 
-# CODE EXAMPLES
+```python
+import subprocess.Popen as sub_popen
+sub_popen('ls')
+```
 
-import subprocess as s
-s.Popen()
+```text
+pattern: foo.bar.baz.qux(...)
+```
+
+```python
+from foo.bar import baz
+baz.qux()
+```
+
+#### Constant Propagation
+
+JavaScript code will match propagated constants:
+
+```text
+pattern: api("literal");
+```
+
+```javascript
+api("literal");
+
+const LITERAL = "literal";
+api(LITERAL);
+
+const LIT = "lit";
+api(LIT + "eral");
+
+const LIT = "lit";
+api(`${LIT}eral`);
 ```
 
 ## Limitations
 
-### semgrep is not grep
+### Statements Types
+
+`semgrep` handles statements different than other expressions like imports. For
+example, the following pattern will match these statements:
 
 ```text
-'foo'
-which is parsed as an expression pattern, will match code like
+pattern: foo
+```
+
+```python
 foo()
-bar+foo
+bar + foo
 foo(1,2)
-
-but will not match code like
-import foo
-
-because in the above, foo is not an expression, but rather a name part of an import statement.
 ```
 
-### You can not use a half expression or half statement pattern
+It will not match the following:
+
+```python
+import foo
+```
+
+### Partial Statements
+
+Partial statements are not valid patterns. For example, the following are
+invalid:
 
 ```text
-'1+'  or 'if $X:' are not valid patterns because they are not full AST elements.
+pattern: 1+
 ```
 
-## Contributions & Ideas
-
-Have an idea? Fork the code, or file an issue!
-
+```text
+pattern: if $CONDITION:
+```

--- a/docs/config/simple.md
+++ b/docs/config/simple.md
@@ -288,23 +288,40 @@ baz.qux()
 
 #### Constants
 
-JavaScript code will match propagated constants:
+Languages supporting constants allow for constant propagation. In other words,
+the constant's value is considered equivalent to a literal value. The following
+patterns will catch each respective code snippet:
+
+**Javascript:**
 
 ```text
-pattern: api("literal");
+pattern: crypto.subtle.digest("SHA-1", ...);
 ```
 
 ```javascript
-api("literal");
+crypto.subtle.digest("SHA-1", "text");
 
-const LITERAL = "literal";
-api(LITERAL);
+const LITERAL = "SHA-1";
+crypto.subtle.digest(LITERAL, "text");
 
-const LIT = "lit";
-api(LIT + "eral");
+const LIT = "SHA";
+crypto.subtle.digest(LIT + "-1", "text");
 
-const LIT = "lit";
-api(`${LIT}eral`);
+const LIT = "SHA";
+crypto.subtle.digest(`${LIT}-1`, "text");
+```
+
+**Go:**
+
+```text
+pattern: crypto.hash("MD5", ...)
+```
+
+```go
+crypto.hash("MD5", "text")
+
+const algorithm = "MD5"
+crypto.hash(algorithm, "text")
 ```
 
 ## Limitations

--- a/docs/config/simple.md
+++ b/docs/config/simple.md
@@ -17,7 +17,7 @@ Contents:
     * [Conditionals and Loops](#conditionals-and-loops)
   * [Equivalences](#equivalences)
     * [Imports](#imports)
-    * [Constant Propagation](#constant-propagation)
+    * [Constants](#constants)
 * [Limitations](#limitations)
   * [Statement Types](#statement-types)
   * [Partial Statements](#partial-statements)
@@ -286,7 +286,7 @@ from foo.bar import baz
 baz.qux()
 ```
 
-#### Constant Propagation
+#### Constants
 
 JavaScript code will match propagated constants:
 


### PR DESCRIPTION
Fix #380. This change updates simple.md documentation with the latest
features and reorganizes the content for easier digestion.

See this link for the rendered Markdown: https://github.com/returntocorp/semgrep/blob/e2f60c3ddc8bd6d4e384429983357abe7043f7c3/docs/config/simple.md