### PR TITLE
Ensure the CI jobs alls have unique names

### DIFF
--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -1,4 +1,4 @@
-name: homebrew
+name: homebrew-test
 
 on:
   pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: ci
+name: ci-build
 
 on:
   pull_request:

--- a/.github/workflows/docker-push-develop.yml
+++ b/.github/workflows/docker-push-develop.yml
@@ -1,4 +1,4 @@
-name: docker
+name: docker-push-dev
 
 on:
   push:

--- a/.github/workflows/docker-push-on-pr.yml
+++ b/.github/workflows/docker-push-on-pr.yml
@@ -1,4 +1,4 @@
-name: docker
+name: docker-push-pr
 
 on:
   pull_request:

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -1,4 +1,4 @@
-name: mac
+name: mac-build
 
 on:
   push:


### PR DESCRIPTION
Will make the github actions view work better and avoid behavior were job results are supressed from naming conflicts