### PR TITLE
Error output is valid w r2c output

### DIFF
--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -96,8 +96,7 @@ def build_output_json(output_json: Dict[str, Any]) -> str:
     # https://docs.r2c.dev/en/latest/api/output.html#errors
     errors = output_json["errors"]
     if errors:
-        output_json["errors"] = {
-            "data": {"errors": output_json["errors"]},
-            "message": "SgrepRuntimeErrors",
-        }
+        output_json["errors"] = [
+            {"data": error, "message": "SgrepRuntimeErrors"} for error in errors
+        ]
     return json.dumps(output_json)

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -97,7 +97,7 @@ def build_output_json(output_json: Dict[str, Any]) -> str:
     errors = output_json["errors"]
     if errors:
         output_json["errors"] = {
-            "data": output_json["errors"],
+            "data": {"errors": output_json["errors"]},
             "message": "SgrepRuntimeErrors",
         }
     return json.dumps(output_json)


### PR DESCRIPTION
During reshuffle, the error output was output sync w/
https://docs.r2c.dev/en/latest/api/output.html#errors
This fixes is back up!