### PR TITLE
.github/workflows: Update sgrep to semgrep

### DIFF
--- a/.github/workflows/semgrep-lint.yml
+++ b/.github/workflows/semgrep-lint.yml
@@ -1,4 +1,4 @@
-name: sgrep-lint
+name: semgrep-lint
 
 on:
   pull_request:
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: sgrep action step
-        id: sgrep
-        uses: returntocorp/sgrep-action@develop
+      - name: semgrep action step
+        id: semgrep
+        uses: returntocorp/semgrep-action@develop
         with:
           config: r2c
           output: https://sgrep.r2c.dev/api/report/${{ github.repository }}

--- a/.github/workflows/semgrep-lint.yml
+++ b/.github/workflows/semgrep-lint.yml
@@ -1,4 +1,4 @@
-name: semgrep-lint
+name: semgrep
 
 on:
   pull_request:


### PR DESCRIPTION
https://github.com/returntocorp/semgrep-action

Prior to this commit GHA was broken by having to follow a repo redirect.

This commit updates the action to use the new repo name.

Changes were validated by letting GHA run.