### PR TITLE
Fix deferred yaml import for equivalences

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -104,6 +104,8 @@ class CoreRunner:
     def _write_equivalences_file(self, fp: IO, equivalences: List[Equivalence]) -> None:
         # I don't even know why this is a thing.
         # cf. https://stackoverflow.com/questions/51272814/python-yaml-dumping-pointer-references
+        import yaml  # here for faster startup times
+
         yaml.SafeDumper.ignore_aliases = (  # type: ignore
             lambda *args: True
         )


### PR DESCRIPTION
Deferred yaml import to _write_equivalences_file to match: https://github.com/returntocorp/semgrep/pull/640