### PR TITLE
Implement metavariable matching between patterns

### DIFF
--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -35,8 +35,17 @@ class PatternMatch:
         return self._raw_json["extra"]
 
     @property
+    def vars(self) -> Dict[str, Any]:
+        metavars = {v: data.get("unique_id", {}) for v, data in self.metavars.items()}
+        return {v: uid.get("sid", "md5sum") for v, uid in metavars.items()}
+
+    @property
     def range(self) -> Range:
-        return Range(self._raw_json["start"]["offset"], self._raw_json["end"]["offset"])
+        return Range(
+            self._raw_json["start"]["offset"],
+            self._raw_json["end"]["offset"],
+            self.vars,
+        )
 
     @property
     def start(self) -> Dict[str, Any]:

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -138,10 +138,7 @@ class Range(NamedTuple):
         :param rhs: The other Range
         """
         to_match = set(self.vars.keys()).intersection(rhs.vars.keys())
-        return all(
-            v in self.vars and v in rhs.vars and self.vars[v] == rhs.vars[v]
-            for v in to_match
-        )
+        return all(self.vars[v] == rhs.vars[v] for v in to_match)
 
     def __repr__(self) -> str:
         return f"{self.start}-{self.end} { {m: self.vars.get(m, 'None') for m in self.vars} }"

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -130,8 +130,8 @@ class Range(NamedTuple):
 
     def vars_match(self, rhs: "Range") -> bool:
         """
-        Returns true if and only if all metavariables that match as variable nodes in either
-        this or the other Range refer to the same identical variable nodes, in the same scope
+        Returns true if and only if all metavariables in both this and the other Range refer to the same
+        variables (if variable nodes), in the same scope, or the same expressions (if expression nodes).
 
         That is, if two patterns define a "$X", and $X refers to a variable in one pattern, then
         $X must refer to the same variable in both patterns

--- a/semgrep/tests/e2e/rules/inside.yaml
+++ b/semgrep/tests/e2e/rules/inside.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: open-from-request
+    patterns:
+      - pattern-inside: |
+          $X = request.get("...")
+          ...
+      - pattern: open($X)
+    languages: [python]
+    severity: ERROR
+    message: Unsafe open from request data

--- a/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
@@ -1,0 +1,44 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.open-from-request",
+      "end": {
+        "col": 14,
+        "line": 4
+      },
+      "extra": {
+        "lines": "    open(path)",
+        "message": "Unsafe open from request data",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "path",
+            "end": {
+              "col": 14,
+              "line": 4,
+              "offset": 95
+            },
+            "start": {
+              "col": 10,
+              "line": 4,
+              "offset": 91
+            },
+            "unique_id": {
+              "kind": "Local",
+              "sid": 2,
+              "type": "id",
+              "value": "path"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/inside.py",
+      "start": {
+        "col": 5,
+        "line": 4
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/basic/inside.py
+++ b/semgrep/tests/e2e/targets/basic/inside.py
@@ -1,0 +1,16 @@
+def foo(request):
+    # ERROR: open-from-request
+    path = request.get("unsafe")
+    open(path)
+
+def bar(request):
+    foo = request.get("unsafe")
+    path = "safe_path"
+    open(path)
+
+# This _should_ be detected, but is not
+# due to semgrep#707
+z = request.get("unsafe")
+def baz():
+    open(z)
+

--- a/semgrep/tests/e2e/test_metavariable_matching.py
+++ b/semgrep/tests/e2e/test_metavariable_matching.py
@@ -1,0 +1,4 @@
+def test_equivalence(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/inside.yaml", target_name="basic"), "results.json",
+    )

--- a/semgrep/tests/unit/test_evaluation.py
+++ b/semgrep/tests/unit/test_evaluation.py
@@ -33,7 +33,7 @@ def PatternMatchMock(
     start: int, end: int, metavars: Optional[Dict[str, Any]] = None
 ) -> MagicMock:
     mock = MagicMock()
-    range_property = PropertyMock(return_value=Range(start, end))
+    range_property = PropertyMock(return_value=Range(start, end, metavars or {}))
     type(mock).range = range_property
     metavars_property = PropertyMock(return_value=metavars)
     type(mock).metavars = metavars_property
@@ -77,7 +77,7 @@ def testA() -> None:
         RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
-    assert result == set([Range(0, 100)]), f"{result}"
+    assert result == set([Range(0, 100, {})]), f"{result}"
 
 
 def testB() -> None:
@@ -114,7 +114,7 @@ def testB() -> None:
         ),
     ]
     result = evaluate_expression(expression, results)
-    assert result == set([Range(30, 70)]), f"{result}"
+    assert result == set([Range(30, 70, {})]), f"{result}"
 
 
 def testC() -> None:
@@ -149,7 +149,7 @@ def testC() -> None:
         RuleExpr(OPERATORS.AND, "pattern2"),
     ]
     result = evaluate_expression(expression, results)
-    assert result == set([Range(200, 300)]), f"{result}"
+    assert result == set([Range(200, 300, {})]), f"{result}"
 
 
 def testD() -> None:
@@ -225,7 +225,7 @@ def testE() -> None:
         RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     result = evaluate_expression(expression, results)
-    assert result == set([Range(300, 400), Range(350, 400)]), f"{result}"
+    assert result == set([Range(300, 400, {}), Range(350, 400, {})]), f"{result}"
 
     """
         and-inside P2
@@ -239,7 +239,7 @@ def testE() -> None:
         RuleExpr(OPERATORS.AND, "pattern1"),
     ]
     result = evaluate_expression(expression, results)
-    assert result == set([Range(100, 200)]), f"{result}"
+    assert result == set([Range(100, 200, {})]), f"{result}"
 
     """
         and-inside P1
@@ -248,7 +248,12 @@ def testE() -> None:
     expression = [RuleExpr(OPERATORS.AND_INSIDE, "pattern1")]
     result = evaluate_expression(expression, results)
     assert result == set(
-        [Range(100, 200), Range(300, 400), Range(350, 400), Range(500, 600)]
+        [
+            Range(100, 200, {}),
+            Range(300, 400, {}),
+            Range(350, 400, {}),
+            Range(500, 600, {}),
+        ]
     ), f"{result}"
 
     """
@@ -336,7 +341,7 @@ def testF() -> None:
     ]
     result = evaluate_expression(expression, results)
     assert result == set(
-        [Range(100, 200), Range(500, 600), Range(700, 800)]
+        [Range(100, 200, {}), Range(500, 600, {}), Range(700, 800, {})]
     ), f"{result}"
 
     # TODO test and-all (`patterns` subkey)
@@ -474,4 +479,4 @@ def test_evaluate_python() -> None:
     ]
 
     result = evaluate_expression(expression, results, flags={RCE_RULE_FLAG: True})
-    assert result == set([Range(400, 500)]), f"{result}"
+    assert result == set([Range(400, 500, {})]), f"{result}"


### PR DESCRIPTION
This commit implements metavariable matching between patterns. What this
means:

  - Two patterns are equal only if, for any commonly defined
    metavariables, those metavariables refer to the same variable (if
    a variable) or expression
  - A pattern is "inside" another pattern only if, for any commonly defined
    metavariables, those metavariables refer to the same variable (if
    a variable) or expression

See semgrep/tests/e2e/rules/inside.yaml and
semgrep/tests/e2e/targets/basic/inside.py for an example of how this
metavariable matching works.