### PR TITLE
Whitelist homebrew with setup.py

### DIFF
--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -62,6 +62,7 @@ class PostInstallCommand(install):
             return
         if "HOMEBREW_SYSTEM" in os.environ:
             print("Not attempting to install binary while running under homebrew")
+            install.run(self)
             return
         # So ths builds the executable, and even installs it
         # but we can't install to the bin directory:

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -60,6 +60,9 @@ class PostInstallCommand(install):
         if "TOX_ENV_NAME" in os.environ:
             print("Not attempting to install binary while running under tox")
             return
+        if "HOMEBREW_SYSTEM" in os.environ:
+            print("Not attempting to install binary while running under homebrew")
+            return
         # So ths builds the executable, and even installs it
         # but we can't install to the bin directory:
         #     https://github.com/pypa/setuptools/issues/210#issuecomment-216657975


### PR DESCRIPTION
When the package is being installed with homebrew, we've already
compiled & installed semgrep-core. We don't need to compile it again.