### PR TITLE
Use git tag for semgrep-core version string

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -1,4 +1,7 @@
 all:
+    # Update output of semgrep-core -version
+	sed -i'' -e "s/%%VERSION%%/$(shell git describe --dirty --tags --long)/g" ./bin/main_semgrep_core.ml
+
 	dune build
 	dune build ./_build/default/tests/test.bc
 clean:

--- a/semgrep-core/bin/main_semgrep_core.ml
+++ b/semgrep-core/bin/main_semgrep_core.ml
@@ -795,8 +795,8 @@ let options () =
   (*s: [[Main_semgrep_core.options]] concatenated actions *)
   Common.options_of_actions action (all_actions()) @
   (*e: [[Main_semgrep_core.options]] concatenated actions *)
-  [ "-version",   Arg.Unit (fun () -> 
-    pr2 (spf "semgrep-core version: %s" Config_pfff.version);
+  [ "-version",   Arg.Unit (fun () ->
+    pr2 (spf "semgrep-core version: %%VERSION%%, pfff: %s" Config_pfff.version);
     exit 0;
     ), "  guess what"; 
   ]


### PR DESCRIPTION
building semgrep-core will shim some output of `git describe --dirty --tags --long` as the version string. On a tagged release this will be equivalent to something like `v0.8.0`

Closes #76 