### PR TITLE
Expand argparse arguments

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -250,7 +250,9 @@ def cli() -> None:
             else:
                 dump_parsed_ast(args.json, args.lang, args.pattern, args.target)
         elif args.validate:
-            _, invalid_configs = semgrep.semgrep_main.get_config(args)
+            _, invalid_configs = semgrep.semgrep_main.get_config(
+                args.generate_config, args.pattern, args.lang, args.config
+            )
             if invalid_configs:
                 print_error_exit(
                     f"run with --validate and there were {len(invalid_configs)} errors loading configs"
@@ -261,7 +263,28 @@ def cli() -> None:
         elif args.test:
             semgrep.test.test_main(args)
         else:
-            semgrep.semgrep_main.main(args)
+            semgrep.semgrep_main.main(
+                target=args.target,
+                pattern=args.pattern,
+                lang=args.lang,
+                config=args.config,
+                generate_config=args.generate_config,
+                no_rewrite_rule_ids=args.no_rewrite_rule_ids,
+                jobs=args.jobs,
+                include=args.include,
+                include_dir=args.include_dir,
+                exclude=args.exclude,
+                exclude_dir=args.exclude_dir,
+                exclude_tests=args.exclude_tests,
+                json_format=args.json,
+                sarif=args.sarif,
+                output_destination=args.output,
+                quiet=args.quiet,
+                strict=args.strict,
+                exit_on_error=args.error,
+                autofix=args.autofix,
+                dangerously_allow_arbitrary_code_execution_from_rules=args.dangerously_allow_arbitrary_code_execution_from_rules,
+            )
     except NotImplementedError as ex:
         print_error_exit(
             f"semgrep encountered an error: {ex}; this is not your fault. {PLEASE_FILE_ISSUE_TEXT}"

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -169,35 +169,30 @@ def confusion_matrix_to_string(confusion: List[int]) -> str:
 
 
 def invoke_semgrep(
-    verbose: bool, strict: bool, test_files: List[Path], config: Path, unsafe: bool
+    strict: bool, test_files: List[Path], config: Path, unsafe: bool
 ) -> Any:
     return json.loads(
         semgrepmain(
-            argparse.Namespace(
-                verbose=verbose,
-                strict=strict,
-                dump_ast=False,
-                no_rewrite_rule_ids=True,
-                dangerously_allow_arbitrary_code_execution_from_rules=unsafe,
-                config=str(config),
-                quiet=True,
-                precommit=False,
-                generate_config=False,
-                pattern=None,
-                validate=False,
-                json=True,
-                sarif=False,
-                exclude_tests=False,
-                jobs=1,
-                exclude=[],
-                include=[],
-                exclude_dir=[],
-                include_dir=[],
-                output=None,
-                error=False,
-                autofix=False,
-                target=[str(t) for t in test_files],
-            )
+            target=[str(t) for t in test_files],
+            pattern="",
+            lang="",
+            config=str(config),
+            generate_config=False,
+            no_rewrite_rule_ids=True,
+            jobs=1,
+            include=[],
+            include_dir=[],
+            exclude=[],
+            exclude_dir=[],
+            exclude_tests=False,
+            json_format=True,
+            sarif=False,
+            output_destination="",
+            quiet=True,
+            strict=strict,
+            exit_on_error=False,
+            autofix=False,
+            dangerously_allow_arbitrary_code_execution_from_rules=unsafe,
         )
     )
 
@@ -235,9 +230,7 @@ def generate_file_pairs(
                 continue
             # invoke semgrep
             try:
-                output_json = invoke_semgrep(
-                    semgrep_verbose, strict, test_files, filename, unsafe
-                )
+                output_json = invoke_semgrep(strict, test_files, filename, unsafe)
                 tested.append(
                     (filename, score_output_json(output_json, test_files, ignore_todo))
                 )


### PR DESCRIPTION
Instead of functions accepting an argparse object explicitly pass each needed
argument. Reduces random dictionary like objects being passed around semgrep.

This also makes it possible to call semgrep as a python library.