### PR TITLE
Rename usages of semgrep-core build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts/bin/sgrep-lint-files
-          cp ./semgrep-core/_build/default/bin/main_semgrep_core.exe artifacts/semgrep-core
+          cp ./semgrep-core/_build/default/bin/Main.exe artifacts/semgrep-core
           cp -r ./semgrep/build/semgrep.dist/* artifacts
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /home/opam/sgrep
 RUN git submodule update --init --recursive
 RUN eval $(opam env) && opam install -y ./pfff
 RUN eval $(opam env) && cd semgrep-core && opam install -y . && make all
-RUN semgrep-core/_build/default/bin/main_semgrep_core.exe -version
+RUN semgrep-core/_build/default/bin/Main.exe -version
 
 
 ## final output, combining both
@@ -43,7 +43,7 @@ COPY --from=build-semgrep /root/.local /root/.local
 ENV PATH=/root/.local/bin:$PATH
 
 RUN semgrep --help
-COPY --from=build-semgrep-core /home/opam/sgrep/semgrep-core/_build/default/bin/main_semgrep_core.exe /bin/semgrep-core
+COPY --from=build-semgrep-core /home/opam/sgrep/semgrep-core/_build/default/bin/Main.exe /bin/semgrep-core
 RUN semgrep-core --help
 
 ENV SEMGREP_IN_DOCKER=1

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,14 +44,14 @@ Then to test semgrep on a file, for example tests/GENERIC/test.py run:
 
 ```bash
 cd semgrep_core
-./_build/default/bin/main_semgrep_core.exe -e foo tests/python
+./_build/default/bin/Main.exe -e foo tests/python
 ...
 ```
 
 If you want to test semgrep on a directory with a set of given rules, run:
 
 ```bash
-cp ./semgrep_core/_build/default/bin/main_semgrep_core.exe /usr/local/bin/semgrep_core
+cp ./semgrep_core/_build/default/bin/Main.exe /usr/local/bin/semgrep_core
 cd semgrep
 pipenv install --dev
 # You need to BYO semgrep-core -- You can either:

--- a/release-scripts/osx-release.sh
+++ b/release-scripts/osx-release.sh
@@ -12,5 +12,5 @@ if [[ -z "$SKIP_NUITKA" ]]; then
   cd semgrep && sudo make all && cd ..
   cp -r ./semgrep/build/semgrep.dist/* artifacts/
 fi
-cp ./semgrep-core/_build/default/bin/main_semgrep_core.exe artifacts/semgrep-core
+cp ./semgrep-core/_build/default/bin/Main.exe artifacts/semgrep-core
 zip -r artifacts.zip artifacts

--- a/release-scripts/ubuntu-release.sh
+++ b/release-scripts/ubuntu-release.sh
@@ -14,7 +14,7 @@ if [[ -z "$SKIP_NUITKA" ]]; then
   eval "$(opam env --root /home/opam/.opam --set-root)" && cd semgrep && export PATH=/github/home/.local/bin:$PATH && sudo make all && cd ..
 fi
 mkdir -p semgrep-files
-cp ./semgrep-core/_build/default/bin/main_semgrep_core.exe semgrep-files/semgrep-core
+cp ./semgrep-core/_build/default/bin/Main.exe semgrep-files/semgrep-core
 cp -r ./semgrep/build/semgrep.dist/* semgrep-files
 ls semgrep-files
 chmod +x semgrep-files/semgrep-core


### PR DESCRIPTION
#801 caused all the build jobs to start failing because it renames the semgrep-core artifact -- rather than rebase it out, attempting to just fix it.