### PR TITLE
Skip equality AST normalization for Python

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -796,7 +796,7 @@ let options () =
   Common.options_of_actions action (all_actions()) @
   (*e: [[Main_semgrep_core.options]] concatenated actions *)
   [ "-version",   Arg.Unit (fun () ->
-    pr2 (spf "semgrep-core version: v0.7.0-43-gefdd403, pfff: %s" Config_pfff.version);
+    pr2 (spf "semgrep-core version: %%VERSION%%, pfff: %s" Config_pfff.version);
     exit 0;
     ), "  guess what"; 
   ]

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -360,7 +360,7 @@ let sgrep_ast pattern file any_ast =
       )
       (*e: [[Main_semgrep_core.sgrep_ast()]] [[hook]] argument to [[check]] *)
       [rule] (parse_equivalences ())
-      file ast |> ignore;
+      file lang ast |> ignore;
 
   (*s: [[Main_semgrep_core.sgrep_ast()]] match [[pattern]] and [[any_ast]] other cases *)
   | PatFuzzy pattern, Fuzzy ast ->
@@ -534,7 +534,7 @@ let sgrep_with_rules rules_file xs =
             rules |> List.filter (fun r -> List.mem lang r.R.languages) in
          Semgrep_generic.check ~hook:(fun _ _ -> ()) 
             rules (parse_equivalences ())
-            file ast
+            file lang ast
        )
   in
   print_matches_and_errors files matches errs
@@ -796,7 +796,7 @@ let options () =
   Common.options_of_actions action (all_actions()) @
   (*e: [[Main_semgrep_core.options]] concatenated actions *)
   [ "-version",   Arg.Unit (fun () ->
-    pr2 (spf "semgrep-core version: %%VERSION%%, pfff: %s" Config_pfff.version);
+    pr2 (spf "semgrep-core version: v0.7.0-43-gefdd403, pfff: %s" Config_pfff.version);
     exit 0;
     ), "  guess what"; 
   ]

--- a/semgrep-core/data/basic_equivalences.yml
+++ b/semgrep-core/data/basic_equivalences.yml
@@ -5,6 +5,7 @@ equivalences:
     languages: [python, javascript, c, go, java]
   - id: eq-to-no-eq
     pattern: $X == $X ==> $X != $X
+    # python is excluded, as != is sometimes interpreted as a call to .__ne__
     languages: [javascript, c, go, java]
 #  - id: if-commute
 #    pattern: if $E: $S1 else: $S2 <==> if !$E: $S2 else: $S1

--- a/semgrep-core/data/basic_equivalences.yml
+++ b/semgrep-core/data/basic_equivalences.yml
@@ -5,7 +5,7 @@ equivalences:
     languages: [python, javascript, c, go, java]
   - id: eq-to-no-eq
     pattern: $X == $X ==> $X != $X
-    languages: [python, javascript, c, go, java]
+    languages: [javascript, c, go, java]
 #  - id: if-commute
 #    pattern: if $E: $S1 else: $S2 <==> if !$E: $S2 else: $S1
 #    languages: [python, javascript, c, go, java]

--- a/semgrep-core/matching/Semgrep_generic.ml
+++ b/semgrep-core/matching/Semgrep_generic.ml
@@ -190,7 +190,7 @@ let apply_equivalences equivs any =
 (*****************************************************************************)
 
 (*s: function [[Semgrep_generic.check2]] *)
-let check2 ~hook rules equivs file ast =
+let check2 ~hook rules equivs file lang ast =
 
   let matches = ref [] in
 
@@ -198,7 +198,7 @@ let check2 ~hook rules equivs file ast =
    * update: this is less necessary once you have user-defined
    * code equivalences (see Equivalence.ml).
    *)
-  let prog = Normalize_AST.normalize (Pr ast) in
+  let prog = Normalize_AST.normalize (Pr ast) lang in
 
   let expr_rules = ref [] in
   let stmt_rules = ref [] in
@@ -288,7 +288,9 @@ let check2 ~hook rules equivs file ast =
 (*e: function [[Semgrep_generic.check2]] *)
 
 (*s: function [[Semgrep_generic.check]] *)
-let check ~hook a b c =
-  Common.profile_code "Sgrep_generic.check" (fun () -> check2 ~hook a b c)
+let check ~hook rules equivs file lang =
+  Common.profile_code "Sgrep_generic.check" (
+    fun () -> check2 ~hook rules equivs file lang
+  )
 (*e: function [[Semgrep_generic.check]] *)
 (*e: semgrep/matching/Semgrep_generic.ml *)

--- a/semgrep-core/matching/Semgrep_generic.mli
+++ b/semgrep-core/matching/Semgrep_generic.mli
@@ -4,8 +4,11 @@
 val check: 
   hook:(Metavars_generic.metavars_binding -> Parse_info.t list Lazy.t -> unit)
   ->
-  Rule.rules -> Equivalence.equivalences ->
-  Common.filename -> AST_generic.program -> 
+  Rule.rules ->
+  Equivalence.equivalences ->
+  Common.filename ->
+  Lang.t ->
+  AST_generic.program ->
   Match_result.t list
 (*e: signature [[Semgrep_generic.check]] *)
 

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -104,7 +104,7 @@ let regression_tests_for_lang files lang =
         let (minii, _maxii) = Parse_info.min_max_ii_by_pos toks in
         Error_code.error minii (Error_code.SgrepLint ("",""))
       )
-      [rule] equiv file ast |> ignore;
+      [rule] equiv file lang ast |> ignore;
 
     let actual = !Error_code.g_errors in
     let expected = Error_code.expected_error_lines_of_files [file] in
@@ -175,7 +175,7 @@ let lint_regression_tests =
   test_files |> List.iter (fun file ->
     E.try_with_exn_to_error file (fun () ->
     let ast = Parse_generic.parse_with_lang lang file in
-    Semgrep_generic.check ~hook:(fun _ _ -> ()) rules equivs file ast 
+    Semgrep_generic.check ~hook:(fun _ _ -> ()) rules equivs file lang ast 
       |> List.iter JSON_report.match_to_error;
   ));
 

--- a/semgrep-core/tests/python/equivalence_eq.py
+++ b/semgrep-core/tests/python/equivalence_eq.py
@@ -5,7 +5,7 @@ def test_equal():
     if a + b == a + b:
         return 1
 
-    # ERROR: match
+    # OK
     if a + b != a + b:
         return 1
     return 0


### PR DESCRIPTION
In Python, == is not necessarily equivalent to !=.

We've already wired up this skip in pfff; this commit merely plumbs it
up within pfff.

Changes were validated by updating the relevant test case.