### PR TITLE
Turn on pre-commit hooks for ocaml code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "^semgrep/tests/e2e/(targets|snapshots)|semgrep-core/tests|semgrep-core/old|semgrep-core/lib|semgrep-core/demos|semgrep-core/bin|.*\\.ml|.*\\.md"
+exclude: "^semgrep/tests/e2e/(targets|snapshots)|semgrep-core/tests|.*\\.md"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -22,10 +22,10 @@ module J = Json_type
 (* A syntactical grep. https://sgrep.dev/
  * Right now there is good support for Python, Javascript, Java, Go, and C
  * and partial support for PHP, C++, and OCaml.
- * 
+ *
  * opti: git grep foo | xargs sgrep -e 'foo(...)'
- * 
- * related: 
+ *
+ * related:
  *  - Structural Search and Replace (SSR) in Jetbrains IDE
  *    http://www.jetbrains.com/idea/documentation/ssr.html
  *    http://tv.jetbrains.net/videocontent/intellij-idea-static-analysis-custom-rules-with-structural-search-replace
@@ -39,7 +39,7 @@ module J = Json_type
  *  - cgrep http://awgn.github.io/cgrep/
  *  - hound https://codeascraft.com/2015/01/27/announcing-hound-a-lightning-fast-code-search-tool/
  *  - many grep-based linters (in Zulip, autodesk, bento, etc.)
- * 
+ *
  * See also codequery for more structural queries.
  * See also old information at https://github.com/facebook/pfff/wiki/Sgrep.
  *)
@@ -158,19 +158,19 @@ let set_gc () =
 let map f xs =
   if !ncores <= 1
   then List.map f xs
-  else 
+  else
     let n = List.length xs in
     (* Heuristic. Note that if you don't set a chunksize, Parmap
      * will evenly split the list xs, which does not provide any load
      * balancing.
      *)
-    let chunksize = 
+    let chunksize =
       match n with
       | _ when n > 1000 -> 10
       | _ when n > 100 -> 5
       | _ when n = 0 -> 1
       | _ when n <= !ncores -> 1
-      | _ -> n / !ncores 
+      | _ -> n / !ncores
     in
     assert (!ncores > 0 && chunksize > 0);
     Parmap.parmap ~ncores:!ncores ~chunksize f (Parmap.L xs)
@@ -182,8 +182,8 @@ let _matching_tokens = ref []
 (*e: constant [[Main_semgrep_core._matching_tokens]] *)
 
 (*s: function [[Main_semgrep_core.print_match]] *)
-let print_match mvars mvar_binding ii_of_any tokens_matched_code = 
-  (* there are a few fake tokens in the generic ASTs now (e.g., 
+let print_match mvars mvar_binding ii_of_any tokens_matched_code =
+  (* there are a few fake tokens in the generic ASTs now (e.g.,
    * for DotAccess generated outside the grammar) *)
   let toks = tokens_matched_code |> List.filter PI.is_origintok in
   (if mvars = []
@@ -193,9 +193,9 @@ let print_match mvars mvar_binding ii_of_any tokens_matched_code =
       (* similar to the code of Lib_matcher.print_match, maybe could
        * factorize code a bit.
        *)
-      let (mini, _maxi) = 
+      let (mini, _maxi) =
         PI.min_max_ii_by_pos toks in
-      let (file, line) = 
+      let (file, line) =
         PI.file_of_info mini, PI.line_of_info mini in
 
       let strings_metavars =
@@ -203,7 +203,7 @@ let print_match mvars mvar_binding ii_of_any tokens_matched_code =
           match Common2.assoc_opt x mvar_binding with
           | Some any ->
               ii_of_any any
-              |> List.map PI.str_of_info 
+              |> List.map PI.str_of_info
               |> Matching_report.join_with_space_if_needed
           | None ->
               failwith (spf "the metavariable '%s' was not binded" x)
@@ -229,12 +229,12 @@ let gen_layer ~root ~query file =
 
   let toks = !_matching_tokens in
   let kinds = ["m" (* match *), "red"] in
-  
+
   (* todo: could now use Layer_code.simple_layer_of_parse_infos *)
   let files_and_lines = toks |> List.map (fun tok ->
     let file = PI.file_of_info tok in
     let line = PI.line_of_info tok in
-    let file = Common2.relative_to_absolute file in 
+    let file = Common2.relative_to_absolute file in
     Common.readable root file, line
   )
   in
@@ -258,7 +258,7 @@ let gen_layer ~root ~query file =
 
 (*s: function [[Main_semgrep_core.parse_generic]] *)
 (* coupling: you need also to modify tests/Test.ml *)
-let parse_generic lang file = 
+let parse_generic lang file =
   (*s: [[Main_semgrep_core.parse_generic()]] use standard macros if parsing C *)
   if lang = Lang.C && Sys.file_exists !Flag_parsing_cpp.macros_h
   then Parse_cpp.init_defs !Flag_parsing_cpp.macros_h;
@@ -285,10 +285,10 @@ let parse_equivalences () =
 
 (*s: function [[Main_semgrep_core.unsupported_language_message]] *)
 let unsupported_language_message some_lang =
-  spf "unsupported language: %s; supported language tags are: %s" 
+  spf "unsupported language: %s; supported language tags are: %s"
       some_lang supported_langs
 (*e: function [[Main_semgrep_core.unsupported_language_message]] *)
-  
+
 (*****************************************************************************)
 (* Language specific *)
 (*****************************************************************************)
@@ -314,7 +314,7 @@ let create_ast file =
     )
   (*e: [[Main_semgrep_core.create_ast()]] when not a supported language *)
 (*e: function [[Main_semgrep_core.create_ast]] *)
-  
+
 
 (*s: type [[Main_semgrep_core.pattern]] *)
 type pattern =
@@ -341,7 +341,7 @@ let parse_pattern str =
   with exn ->
       raise (Parse_rules.InvalidPatternException ("no-id", str, !lang, (Common.exn_to_s exn)))
 (*e: function [[Main_semgrep_core.parse_pattern]] *)
- 
+
 
 (*s: function [[Main_semgrep_core.sgrep_ast]] *)
 let sgrep_ast pattern file any_ast =
@@ -349,8 +349,8 @@ let sgrep_ast pattern file any_ast =
   |  _, NoAST -> () (* skipping *)
   | PatGen pattern, Gen (ast, lang) ->
     let rule = { R.
-      id = "-e/-f"; pattern; message = ""; severity = R.Error; 
-      languages = [lang] 
+      id = "-e/-f"; pattern; message = ""; severity = R.Error;
+      languages = [lang]
     } in
     Semgrep_generic.check
       (*s: [[Main_semgrep_core.sgrep_ast()]] [[hook]] argument to [[check]] *)
@@ -382,8 +382,8 @@ let sgrep_ast pattern file any_ast =
 (*s: function [[Main_semgrep_core.filter_files]] *)
 let filter_files files =
   files |> Files_filter.filter (Files_filter.mk_filters
-      ~excludes:!excludes 
-      ~exclude_dirs:!exclude_dirs 
+      ~excludes:!excludes
+      ~exclude_dirs:!exclude_dirs
       ~includes:!includes
       ~include_dirs:!include_dirs
   )
@@ -394,30 +394,30 @@ let get_final_files xs =
   let files =
     match Lang.lang_of_string_opt !lang with
     | None -> Files_finder.files_of_dirs_or_files xs
-    | Some lang -> Lang.files_of_dirs_or_files lang xs 
+    | Some lang -> Lang.files_of_dirs_or_files lang xs
   in
   let files = filter_files files in
   files
 (*e: function [[Main_semgrep_core.get_final_files]] *)
-  
+
 (*s: function [[Main_semgrep_core.iter_generic_ast_of_files_and_get_matches_and_exn_to_errors]] *)
 let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
-  let matches_and_errors = 
+  let matches_and_errors =
     files |> map (fun file ->
        if !verbose then pr2 (spf "Analyzing %s" file);
-       try 
-         let lang = 
+       try
+         let lang =
            match Lang.langs_of_filename file with
            | [lang] -> lang
            | x::_xs ->
                (match Lang.lang_of_string_opt !lang with
                | Some lang -> lang
-               | None -> 
+               | None ->
                  pr2 (spf "no language specified, defaulting to %s for %s"
                       (Lang.string_of_lang x) file);
                  x
                )
-           | [] -> 
+           | [] ->
               failwith (spf "can not extract generic AST from %s" file)
          in
          let ast = parse_generic lang file in
@@ -425,12 +425,12 @@ let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
          (* calling the hook *)
          f file lang ast, []
 
-       with exn -> 
+       with exn ->
          [], [Error_code.exn_to_error file exn]
     )
   in
   let matches = matches_and_errors |> List.map fst |> List.flatten in
-  let errors = matches_and_errors |> List.map snd |> List.flatten in  
+  let errors = matches_and_errors |> List.map snd |> List.flatten in
   matches, errors
 (*e: function [[Main_semgrep_core.iter_generic_ast_of_files_and_get_matches_and_exn_to_errors]] *)
 
@@ -441,7 +441,7 @@ let print_matches_and_errors files matches errs =
   let stats = J.Object [ "okfiles", J.Int count_ok; "errorfiles", J.Int count_errors; ] in
   let json = J.Object [
      "matches", J.Array (matches |> List.map JSON_report.match_to_json);
-     "errors", J.Array (errs |> List.map R2c.error_to_json);        
+     "errors", J.Array (errs |> List.map R2c.error_to_json);
      "stats", stats
   ] in
   let s = Json_io.string_of_json json in
@@ -475,7 +475,7 @@ let sgrep_with_one_pattern xs =
         parse_pattern s, s
     | _ -> raise Impossible
   in
-  let files = 
+  let files =
     match Lang.lang_of_string_opt !lang with
     | Some lang -> Lang.files_of_dirs_or_files lang xs
     (*s: [[Main_semgrep_core.sgrep_with_one_pattern()]] no [[lang]] specified *)
@@ -486,10 +486,10 @@ let sgrep_with_one_pattern xs =
   (*s: [[Main_semgrep_core.sgrep_with_one_pattern()]] filter [[files]] *)
   let files = filter_files files in
   (*e: [[Main_semgrep_core.sgrep_with_one_pattern()]] filter [[files]] *)
-  
+
   files |> List.iter (fun file ->
     (*s: [[Main_semgrep_core.sgrep_with_one_pattern()]] if [[verbose]] *)
-    if !verbose 
+    if !verbose
     then pr2 (spf "processing: %s" file);
     (*e: [[Main_semgrep_core.sgrep_with_one_pattern()]] if [[verbose]] *)
     let process file = sgrep_ast pattern file (create_ast file) in
@@ -527,12 +527,12 @@ let sgrep_with_rules rules_file xs =
   let rules = Parse_rules.parse rules_file in
   let files = get_final_files xs in
 
-  let matches, errs = 
-     files |> iter_generic_ast_of_files_and_get_matches_and_exn_to_errors 
+  let matches, errs =
+     files |> iter_generic_ast_of_files_and_get_matches_and_exn_to_errors
        (fun file lang ast ->
-         let rules = 
+         let rules =
             rules |> List.filter (fun r -> List.mem lang r.R.languages) in
-         Semgrep_generic.check ~hook:(fun _ _ -> ()) 
+         Semgrep_generic.check ~hook:(fun _ _ -> ())
             rules (parse_equivalences ())
             file lang ast
        )
@@ -552,10 +552,10 @@ let tainting_with_rules rules_file xs =
   let rules = Parse_tainting_rules.parse rules_file in
 
   let files = get_final_files xs in
-  let matches, errs = 
-     files |> iter_generic_ast_of_files_and_get_matches_and_exn_to_errors 
+  let matches, errs =
+     files |> iter_generic_ast_of_files_and_get_matches_and_exn_to_errors
        (fun file lang ast ->
-         let rules = 
+         let rules =
             rules |> List.filter (fun r -> List.mem lang r.TR.languages) in
          Tainting_generic.check rules file ast
        )
@@ -577,7 +577,7 @@ let rec read_all chan =
   let len = input chan buf 0 4096 in
   if len = 0
   then ""
-  else 
+  else
     let rest = read_all chan in
     Bytes.sub_string buf 0 len ^ rest
 (*e: function [[Main_semgrep_core.read_all]] *)
@@ -595,8 +595,8 @@ let validate_pattern () =
 (*e: function [[Main_semgrep_core.validate_pattern]] *)
 
 (*s: function [[Main_semgrep_core.json_of_v]] *)
-let json_of_v (v: OCaml.v) = 
-  let rec aux v = 
+let json_of_v (v: OCaml.v) =
+  let rec aux v =
     match v with
     | OCaml.VUnit -> J.String "()"
     | OCaml.VBool v1 ->
@@ -615,7 +615,7 @@ let json_of_v (v: OCaml.v) =
         | [] -> J.String (spf "%s" s)
         | [one_element] -> J.Object [s, (aux one_element)]
         | _ -> J.Object [s, J.Array (List.map aux xs)]
-        )          
+        )
     | OCaml.VVar (s, i64) -> J.String (spf "%s_%d" s (Int64.to_int i64))
     | OCaml.VArrow _ -> failwith "Arrow TODO"
     | OCaml.VNone -> J.Null
@@ -632,7 +632,7 @@ let json_of_v (v: OCaml.v) =
 (* Dumpers *)
 (*****************************************************************************)
 (*s: function [[Main_semgrep_core.dump_v_to_format]] *)
-let dump_v_to_format (v: OCaml.v) = 
+let dump_v_to_format (v: OCaml.v) =
   if (not !output_format_json)
     then (OCaml.string_of_v v)
     else (Json_io.string_of_json (json_of_v v))
@@ -658,7 +658,7 @@ let dump_pattern (file: Common.filename) =
 (*s: function [[Main_semgrep_core.dump_ast]] *)
 let dump_ast file =
   match Lang.langs_of_filename file with
-  | lang::_ -> 
+  | lang::_ ->
     let x = parse_generic lang file in
     let v = Meta_AST.vof_any (AST_generic.Pr x) in
     let s = dump_v_to_format v in
@@ -669,7 +669,7 @@ let dump_ast file =
 (*s: function [[Main_semgrep_core.dump_ext_of_lang]] *)
 let dump_ext_of_lang () =
   let lang_to_exts = keys |> List.map (
-    fun lang_str -> 
+    fun lang_str ->
       match Lang.lang_of_string_opt lang_str with
       | Some lang -> lang_str ^ "->" ^ String.concat ", " (Lang.ext_of_lang lang)
       | None -> ""
@@ -678,13 +678,13 @@ let dump_ext_of_lang () =
 (*e: function [[Main_semgrep_core.dump_ext_of_lang]] *)
 
 (*s: function [[Main_semgrep_core.dump_equivalences]] *)
-let dump_equivalences file = 
+let dump_equivalences file =
   let xs = Parse_equivalences.parse file in
   pr2_gen xs
 (*e: function [[Main_semgrep_core.dump_equivalences]] *)
 
 (*s: function [[Main_semgrep_core.dump_tainting_rules]] *)
-let dump_tainting_rules file = 
+let dump_tainting_rules file =
   let xs = Parse_tainting_rules.parse file in
   pr2_gen xs
 (*e: function [[Main_semgrep_core.dump_tainting_rules]] *)
@@ -719,16 +719,16 @@ let all_actions () = [
 (*e: function [[Main_semgrep_core.all_actions]] *)
 
 (*s: function [[Main_semgrep_core.options]] *)
-let options () = 
+let options () =
   [
-    "-e", Arg.Set_string pattern_string, 
+    "-e", Arg.Set_string pattern_string,
     " <pattern> expression pattern (need -lang)";
-    "-f", Arg.Set_string pattern_file, 
+    "-f", Arg.Set_string pattern_file,
     " <file> obtain pattern from file (need -lang)";
     "-rules_file", Arg.Set_string rules_file,
     " <file> obtain list of patterns from YAML file";
 
-    "-lang", Arg.Set_string lang, 
+    "-lang", Arg.Set_string lang,
     (spf " <str> choose language (valid choices: %s)" supported_langs);
 
     (*s: [[Main_semgrep_core.options]] user-defined equivalences case *)
@@ -746,7 +746,7 @@ let options () =
     " <DIR> search only in directories matching the pattern DIR";
     (*e: [[Main_semgrep_core.options]] file filters cases *)
     (*s: [[Main_semgrep_core.options]] [[-j]] case *)
-    "-j", Arg.Set_int ncores, 
+    "-j", Arg.Set_int ncores,
     " <int> number of cores to use (default = 1)";
     (*e: [[Main_semgrep_core.options]] [[-j]] case *)
     (*s: [[Main_semgrep_core.options]] report match mode cases *)
@@ -755,7 +755,7 @@ let options () =
     "-oneline", Arg.Unit (fun () -> match_format := Matching_report.OneLine),
     " print matches on one line, in normalized form";
     (*x: [[Main_semgrep_core.options]] report match mode cases *)
-    "-json", Arg.Set output_format_json, 
+    "-json", Arg.Set output_format_json,
     " output JSON format";
     (*e: [[Main_semgrep_core.options]] report match mode cases *)
     (*s: [[Main_semgrep_core.options]] other cases *)
@@ -771,11 +771,11 @@ let options () =
     "-error_recovery", Arg.Unit (fun () ->
         error_recovery := true;
         Flag_parsing.error_recovery := true;
-    ),  
+    ),
     (*e: [[Main_semgrep_core.options]] other cases *)
 
     " do not stop at first parsing error with -e/-f";
-    "-verbose", Arg.Unit (fun () -> 
+    "-verbose", Arg.Unit (fun () ->
       verbose := true;
       Flag_semgrep.verbose := true;
     ),
@@ -798,7 +798,7 @@ let options () =
   [ "-version",   Arg.Unit (fun () ->
     pr2 (spf "semgrep-core version: %%VERSION%%, pfff: %s" Config_pfff.version);
     exit 0;
-    ), "  guess what"; 
+    ), "  guess what";
   ]
 (*e: function [[Main_semgrep_core.options]] *)
 
@@ -807,39 +807,39 @@ let options () =
 (*****************************************************************************)
 
 (*s: function [[Main_semgrep_core.format_output_exception]] *)
-let format_output_exception e : string = 
+let format_output_exception e : string =
   (* if (ouptut_as_json) then *)
-  let msg = match e with 
+  let msg = match e with
     | Parse_rules.InvalidRuleException (pattern_id, msg)     ->
       J.Object [ "pattern_id", J.String pattern_id;
        "error", J.String "invalid rule";
        "message", J.String msg; ]
-    | Parse_rules.InvalidLanguageException (pattern_id, language) -> 
-      J.Object [ "pattern_id", J.String pattern_id; 
-      "error", J.String "invalid language"; 
+    | Parse_rules.InvalidLanguageException (pattern_id, language) ->
+      J.Object [ "pattern_id", J.String pattern_id;
+      "error", J.String "invalid language";
       "language", J.String language; ]
     | Parse_rules.InvalidPatternException (pattern_id, pattern, lang, message) ->
       J.Object [ "pattern_id", J.String pattern_id;
        "error", J.String "invalid pattern";
-       "pattern", J.String pattern; 
+       "pattern", J.String pattern;
        "language", J.String lang;
        "message", J.String message; ]
     | Parse_rules.UnparsableYamlException msg ->
       J.Object [  "error", J.String "unparsable yaml"; "message", J.String msg; ]
     | Parse_rules.InvalidYamlException msg ->
       J.Object [  "error", J.String "invalid yaml"; "message", J.String msg; ]
-    | exn -> 
+    | exn ->
       J.Object [  "error", J.String "unknown exception"; "message", J.String (Common.exn_to_s exn); ]
-  in 
+  in
     Json_io.string_of_json msg
 (*e: function [[Main_semgrep_core.format_output_exception]] *)
 
 
 (*s: function [[Main_semgrep_core.main]] *)
-let main () = 
+let main () =
   set_gc ();
 
-  let usage_msg = 
+  let usage_msg =
     spf "Usage: %s [options] <pattern> <files_or_dirs> \nOptions:"
       (Filename.basename Sys.argv.(0))
   in
@@ -847,24 +847,24 @@ let main () =
   let args = Common.parse_options (options()) usage_msg Sys.argv in
 
   (* must be done after Arg.parse, because Common.profile is set by it *)
-  Common.profile_code "Main total" (fun () -> 
+  Common.profile_code "Main total" (fun () ->
 
     (match args with
     (*s: [[Main_semgrep_core.main()]] match [[args]] actions *)
     (* --------------------------------------------------------- *)
     (* actions, useful to debug subpart *)
     (* --------------------------------------------------------- *)
-    | xs when List.mem !action (Common.action_list (all_actions())) -> 
+    | xs when List.mem !action (Common.action_list (all_actions())) ->
         Common.do_action !action xs (all_actions())
 
-    | _ when not (Common.null_string !action) -> 
+    | _ when not (Common.null_string !action) ->
         failwith ("unrecognized action or wrong params: " ^ !action)
     (*e: [[Main_semgrep_core.main()]] match [[args]] actions *)
 
     (* --------------------------------------------------------- *)
     (* main entry *)
     (* --------------------------------------------------------- *)
-    | x::xs -> 
+    | x::xs ->
         (match () with
         (*s: [[Main_semgrep_core.main()]] main entry match cases *)
         | _ when !rules_file <> "" ->
@@ -890,7 +890,7 @@ let main () =
     (* --------------------------------------------------------- *)
     (* empty entry *)
     (* --------------------------------------------------------- *)
-    | [] -> 
+    | [] ->
         Common.usage usage_msg (options())
     )
   )
@@ -899,7 +899,7 @@ let main () =
 (*****************************************************************************)
 (*s: toplevel [[Main_semgrep_core._1]] *)
 let _ =
-  Common.main_boilerplate (fun () -> 
+  Common.main_boilerplate (fun () ->
       main ();
   )
 (*e: toplevel [[Main_semgrep_core._1]] *)

--- a/semgrep-core/bin/dune
+++ b/semgrep-core/bin/dune
@@ -1,6 +1,6 @@
 (executables
  (names Main main_spatch )
- (libraries 
+ (libraries
     bigarray
     threads          ;; needed for json-wheel (Condition?)
     json-wheel       ;; Json_io, Json_type
@@ -8,7 +8,7 @@
     parmap
 
     commons commons_core commons_ocollection
-    pfff-config 
+    pfff-config
     pfff-h_program-lang
     pfff-lang_python pfff-lang_python-analyze
     pfff-lang_js pfff-lang_js-analyze
@@ -21,7 +21,7 @@
     pfff-lang_lisp
     pfff-lang_skip
     pfff-lang_FUZZY
-    
+
     semgrep_core
     semgrep_fuzzy
     semgrep_finding
@@ -36,7 +36,7 @@
 )
 
 
-; use bin/flags.sh to generate the OS specific build flags 
+; use bin/flags.sh to generate the OS specific build flags
 (rule
  (targets flags.sexp)
  (action (run %{workspace_root}/bin/flags.sh)))

--- a/semgrep-core/bin/flags.sh
+++ b/semgrep-core/bin/flags.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  echo "( :standard )" > flags.sexp        
+  echo "( :standard )" > flags.sexp
 else
   echo "(-ccopt -static)" > flags.sexp
 fi

--- a/semgrep-core/core/Metavars_generic.ml
+++ b/semgrep-core/core/Metavars_generic.ml
@@ -31,7 +31,7 @@ open Common
  * for error reporting on pattern itself? so use a 'string AST_generic.wrap'?
  *)
 (*s: type [[Metavars_generic.mvar]] *)
-type mvar = string 
+type mvar = string
 (*e: type [[Metavars_generic.mvar]] *)
 
 (*s: type [[Metavars_generic.metavars_binding]] *)
@@ -42,25 +42,25 @@ type metavars_binding = (mvar, AST_generic.any) Common.assoc
 (*e: type [[Metavars_generic.metavars_binding]] *)
 
 (*s: constant [[Metavars_generic.metavar_regexp_string]] *)
-(* ex: $X, $FAIL, $VAR2, $_ 
+(* ex: $X, $FAIL, $VAR2, $_
  * Note that some languages such as PHP or Javascript allows '$' in identifier
  * names, so forcing metavariables to have uppercase letters at least allow
  * us to match specifically also identifiers in lower case (e.g., $foo will
  * only match the $foo identifiers in some concrete code; this is not a
  * metavariable).
- * 
+ *
 *)
-let metavar_regexp_string = 
+let metavar_regexp_string =
   "^\\(\\$[A-Z_][A-Z_0-9]*\\)$"
 (*e: constant [[Metavars_generic.metavar_regexp_string]] *)
 
 (*s: function [[Metavars_generic.is_metavar_name]] *)
-(* 
+(*
  * Hacks abusing existing constructs to encode extra constructions.
  * One day we will have a pattern_ast.ml that mimics mostly
  * AST.ml and extends it with special sgrep constructs.
  *)
-let is_metavar_name s = 
+let is_metavar_name s =
   s =~ metavar_regexp_string
 (*e: function [[Metavars_generic.is_metavar_name]] *)
 (*e: semgrep/core/Metavars_generic.ml *)

--- a/semgrep-core/core/Rule.ml
+++ b/semgrep-core/core/Rule.ml
@@ -50,7 +50,7 @@ type rule = {
 (*s: type [[Rule.rules]] *)
  and rules = rule list
 (*e: type [[Rule.rules]] *)
- 
+
 (* TODO? just reuse Error_code.severity *)
 (*s: type [[Rule.severity]] *)
  and severity = Error | Warning | Info

--- a/semgrep-core/core/Tainting_rule.ml
+++ b/semgrep-core/core/Tainting_rule.ml
@@ -21,8 +21,8 @@ module R = Rule
 (* Prelude *)
 (*****************************************************************************)
 (* This is a spin-off of Rule.ml but specialized for tainting analysis.
- * 
- * At some point we may want tainting to be integrated and queryable 
+ *
+ * At some point we may want tainting to be integrated and queryable
  * directly from regular semgrep rules, but for now it's simpler
  * to have a specialized type and format.
  *)
@@ -42,7 +42,7 @@ type rule = {
   id: string;
 
   (* the list below are used to express disjunction *)
-  source: pattern list; 
+  source: pattern list;
   sanitizer: pattern list;
   sink: pattern list;
 

--- a/semgrep-core/demos/Makefile
+++ b/semgrep-core/demos/Makefile
@@ -15,4 +15,3 @@ simple_refactoring: simple_refactoring.ml
           simple_refactoring.ml
 clean::
 	rm -f simple_refactoring
-

--- a/semgrep-core/demos/dune
+++ b/semgrep-core/demos/dune
@@ -1,7 +1,7 @@
 (executables
  (names simple_refactoring)
  (flags (:standard -w -27))
- (libraries 
+ (libraries
    bigarray str
 
    commons
@@ -17,4 +17,3 @@
  (section bin)
  (files simple_refactoring.exe)
 )
-

--- a/semgrep-core/demos/simple_refactoring.ml
+++ b/semgrep-core/demos/simple_refactoring.ml
@@ -10,64 +10,64 @@ module PI = Parse_info
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* 
+(*
  * This file contains the implementation of a simple refactoring where we
  * remove the second argument in all calls to ArgAssert::isString() and
  * ArgAssert::isArray(). The goal is to provide a tutorial on how
  * to write PHP refactorings using the low level Pfff infrastructure.
- * For most refactoring, spatch should be fine, 
+ * For most refactoring, spatch should be fine,
  * see https://github.com/facebook/pfff/wiki/Spatch
- * 
+ *
  * To compile this file do:
- * 
+ *
  *    $ ocamlc -g -o simple_refactoring \
  *      -I ../commons -I ../lang_php/parsing \
  *      str.cma unix.cma nums.cma bigarray.cma \
  *      ../commons/lib.cma ../h_program-lang/lib.cma \
  *      ../lang_php/parsing/lib.cma \
  *      simple_refactoring.ml
- * 
+ *
  * To run do for instance:
- * 
- *    $ ./simple_refactoring ../tests/php/spatch/arg_assert.php 
- * 
+ *
+ *    $ ./simple_refactoring ../tests/php/spatch/arg_assert.php
+ *
  * which should output:
- * 
+ *
  *   processing: ../tests/php/spatch/arg_assert.php (0/1)
  *   --- ../tests/php/spatch/arg_assert.php	2010-10-22 13:09:09.0 -0700
  *   +++ /tmp/trans-17581-464603.php	2010-10-22 13:21:52.0 -0700
  *   @@ -1,7 +1,6 @@
  *    <?php
- *    
+ *
  *    function foo($s) {
  *   -  ArgAssert::isString($s, "s");
- *   -  ArgAssert::isArray($s, 
+ *   -  ArgAssert::isArray($s,
  *   -                     array(1, 2));
  *   +  ArgAssert::isString($s);
  *   +  ArgAssert::isArray($s);
  *    }
- * 
+ *
  * If you modify the 'apply_patch' variable below it will actually
  * do the modification in place on the file. It is set to false by
  * default for ease of prototyping.
- * 
- * 
+ *
+ *
  * (the equivalent semantic patch is simply:
  * - ArgAssert::isString(X, Y)
  * + ArgAssert::isString(X)
- * 
+ *
  * or
- * 
+ *
  *   ArgAssert::isString(X
  * -                     ,Y
  *                       )
  * )
- * 
+ *
  * Timing: 25 minutes
- * 
+ *
  * Alternatives:
  *  - lex-pass I believe has a special command just for that.
- * 
+ *
  * See also main_spatch.ml
  *)
 
@@ -81,7 +81,7 @@ let apply_patch = ref false
 (* Algorithm *)
 (*****************************************************************************)
 
-let main files_or_dirs = 
+let main files_or_dirs =
   let files = Lib_parsing_php.find_source_files_of_dir_or_files files_or_dirs in
 
   Flag_parsing.show_parsing_error := false;
@@ -99,7 +99,7 @@ let main files_or_dirs =
       V.kexpr = (fun (k, _) expr ->
         match expr with
 
-        (* 
+        (*
          * At this point 'expr' is the AST of a PHP expression that we
          * can match over a specific pattern. The pattern we want is
          * a static method call to the 'isString' function of the
@@ -107,12 +107,12 @@ let main files_or_dirs =
          * find the appropriate OCaml constructors for those
          * AST elements. An alternative is to use pfff -dump_php_ml
          * to get a first draft for the pattern. For instance
-         * 
+         *
          *   $ ./pfff -dump_php_ml tests/php/spatch/arg_assert2.php
-         * 
+         *
          * will output the internal representation of the AST of
          * arg_assert2.php, which is:
-         * 
+         *
          * [StmtList(
          *  [ExprStmt(
          *    (Lv(
@@ -126,10 +126,10 @@ let main files_or_dirs =
          *            i_11)),
          *         tlval_12)),
          *     t_13), i_14)]); FinalDef(i_15)]
-         * 
+         *
          * One can then copy paste part of this AST directly into this
          * file as an OCaml pattern.
-         * 
+         *
          * The i_<num> are matching the corresponding tokens in the AST.
          * For instance i_1 above is the token containing the information
          * on the "ArgAssert" in the file. This token contain information
@@ -137,14 +137,14 @@ let main files_or_dirs =
          * 'transfo' annotation that we can modify to remove the token
          * for instance.
          *)
-        | 
+        |
              (Call(
                ClassGet (Id (XName[QI(Name(("ArgAssert", i_9)))]), i_10,
                          Id (XName[QI(Name(("isString", i_11)))])),
                (i_left_paren,
                [Left(
                  Arg(
-                   (((IdVar(DName((var_name, i_13)), _scope_info)))))); 
+                   (((IdVar(DName((var_name, i_13)), _scope_info))))));
                 Right(i_token_comma);
                 Left(Arg((Sc(C(String((a_string, i_token_string)))))))
                ],
@@ -157,14 +157,14 @@ let main files_or_dirs =
         (* similar pattern except we accept any kind of expression as
          * the second argument, not just constant strings.
          *)
-        | 
+        |
              (Call(
                ClassGet (Id (XName[QI(Name(("ArgAssert", i_9)))]), i_10,
                          Id (XName[QI(Name(("isString", i_11)))])),
                (i_left_paren,
                [Left(
                  Arg(
-                   (((IdVar(DName((var_name, i_13)), _scope_info)))))); 
+                   (((IdVar(DName((var_name, i_13)), _scope_info))))));
                 Right(i_token_comma);
                 Left(Arg(an_expr))
                ],
@@ -172,7 +172,7 @@ let main files_or_dirs =
              )
            ->
             (* let's get all the tokens composing the expression *)
-            let tokens_in_expression = 
+            let tokens_in_expression =
               Lib_parsing_php.ii_of_any (Expr an_expr) in
 
             tokens_in_expression |> List.iter (fun tok ->
@@ -186,16 +186,16 @@ let main files_or_dirs =
     visitor (Program ast);
 
     (* step3: unparse the annotated AST and show the diff *)
-    let s = 
+    let s =
       Unparse_php.string_of_program_with_comments_using_transfo (ast, tokens) in
-    
+
     let tmpfile = Common.new_temp_file "trans" ".php" in
     Common.write_file ~file:tmpfile s;
-      
+
     let diff = Common.cmd_to_list (spf "diff -u %s %s" file tmpfile) in
     diff |> List.iter pr;
 
-    if !apply_patch 
+    if !apply_patch
     then Common.write_file ~file:file s;
   )
 
@@ -203,5 +203,5 @@ let main files_or_dirs =
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
-let _ = 
+let _ =
   main (Array.to_list Sys.argv)

--- a/semgrep-core/finding/Files_filter.ml
+++ b/semgrep-core/finding/Files_filter.ml
@@ -59,18 +59,18 @@ exception GlobSyntaxError of string
 (*****************************************************************************)
 (*s: function [[Files_filter.mk_filters]] *)
 let mk_filters ~excludes ~includes ~exclude_dirs ~include_dirs =
- try 
+ try
   { excludes = excludes |> List.map Glob.of_string;
-    includes = 
+    includes =
       if includes = []
       then [Glob.universal]
       else includes |> List.map Glob.of_string;
     exclude_dirs = exclude_dirs |> List.map Glob.of_string;
-    include_dirs = 
+    include_dirs =
       if include_dirs = []
       then [Glob.universal]
       else include_dirs |> List.map Glob.of_string;
-  } 
+  }
  with Invalid_argument s -> raise (GlobSyntaxError s)
 (*e: function [[Files_filter.mk_filters]] *)
 
@@ -88,10 +88,10 @@ let filter filters xs =
     &&
     (filters.includes |> List.exists (fun glob -> Glob.test glob base))
     &&
-    (filters.exclude_dirs |> List.for_all 
+    (filters.exclude_dirs |> List.for_all
        (fun glob -> not (dirs |> List.exists (fun dir -> Glob.test glob dir))))
     &&
-    (filters.include_dirs |> List.exists 
+    (filters.include_dirs |> List.exists
        (fun glob -> (dirs |> List.exists (fun dir -> Glob.test glob dir))))
  )
 (*e: function [[Files_filter.filter]] *)

--- a/semgrep-core/finding/Files_filter.mli
+++ b/semgrep-core/finding/Files_filter.mli
@@ -21,7 +21,7 @@ exception GlobSyntaxError of string
 (*e: exception [[Files_filter.GlobSyntaxError]] *)
 (*s: signature [[Files_filter.mk_filters]] *)
 (* may raise GlobSyntaxError *)
-val mk_filters: 
+val mk_filters:
   excludes: string list -> includes: string list -> exclude_dirs: string list -> include_dirs: string list ->
   filters
 (*e: signature [[Files_filter.mk_filters]] *)

--- a/semgrep-core/finding/Unit_files.ml
+++ b/semgrep-core/finding/Unit_files.ml
@@ -17,7 +17,7 @@ let unittest =
         let filters = Files_filter.mk_filters
           ~excludes:["*.{c,h}"; "*.go"]
           ~includes:["foo.*"]
-          ~exclude_dirs:["c"] 
+          ~exclude_dirs:["c"]
           ~include_dirs:["a"; "b"] in
         assert_equal ~msg:"it should filter files"
           ["a/b/foo.js"]

--- a/semgrep-core/finding/Unit_files.mli
+++ b/semgrep-core/finding/Unit_files.mli
@@ -1,10 +1,10 @@
 (*s: semgrep/finding/Unit_files.mli *)
 (*s: signature [[Unit_files.unittest]] *)
-(* Returns the testsuite for this directory To be concatenated by 
- * the caller (e.g. in pfff/main_test.ml ) with other testsuites and 
- * run via OUnit.run_test_tt 
+(* Returns the testsuite for this directory To be concatenated by
+ * the caller (e.g. in pfff/main_test.ml ) with other testsuites and
+ * run via OUnit.run_test_tt
  *)
-val unittest: 
+val unittest:
   OUnit.test
 (*e: signature [[Unit_files.unittest]] *)
 (*e: semgrep/finding/Unit_files.mli *)

--- a/semgrep-core/fuzzy/fuzzy_vs_fuzzy.ml
+++ b/semgrep-core/fuzzy/fuzzy_vs_fuzzy.ml
@@ -179,7 +179,7 @@ and m_arguments xsa xsb =
         xsa,
         xsb
       )
-    else failwith 
+    else failwith
       ("transformation (minus or plus) on '...' not allowed, " ^
        "rewrite your spatch")
 
@@ -202,10 +202,10 @@ and m_arguments xsa xsb =
         xsa,
         xsb
       )
-    else failwith 
+    else failwith
       ("transformation (minus or plus) on ',' not allowed when used with " ^
        "'...'. Rewrite your spatch: put your trailing comma on the line " ^
-       "with the '...'. See also " ^ 
+       "with the '...'. See also " ^
        "https://github.com/facebook/pfff/wiki/Spatch#wiki-spacing-issues")
 
   | [Right _; Left [A.Dots _i]], _bbs ->
@@ -230,7 +230,7 @@ and m_arguments xsa xsb =
 and m_either_m_argument a b =
   match a, b with
   | Left [A.Metavar (s, tok)], Left b ->
-    X.envf (s, tok) b >>= (function 
+    X.envf (s, tok) b >>= (function
     | ((s, _a), b) ->
       return (
         Left [A.Metavar (s, tok)],
@@ -251,7 +251,7 @@ and m_either_m_argument a b =
   | Left _, Right _
   | Right _, Left _ ->
     fail ()
-      
+
 
 (* ---------------------------------------------------------------------- *)
 (* tree *)
@@ -260,7 +260,7 @@ and m_tree a b =
   match a, b with
 
   | A.Metavar (s, tok), b ->
-    let ok = 
+    let ok =
       match b with
       | B.Parens _ -> true
       (* we don't want metavars to match symbols *)
@@ -270,7 +270,7 @@ and m_tree a b =
       | _ -> false
     in
     if ok then
-     X.envf (s, tok) [b] >>= (function 
+     X.envf (s, tok) [b] >>= (function
      | ((s, _a), [b]) ->
       return (
         A.Metavar (s, tok),
@@ -285,7 +285,7 @@ and m_tree a b =
     m_trees a2 b2 >>= (fun (a2, b2) ->
     m_tok a3 b3 >>= (fun (a3, b3) ->
       return (
-        A.Braces (a1, a2, a3), 
+        A.Braces (a1, a2, a3),
         B.Braces (b1, b2, b3)
       )
     )))
@@ -294,7 +294,7 @@ and m_tree a b =
     m_trees a2 b2 >>= (fun (a2, b2) ->
     m_tok a3 b3 >>= (fun (a3, b3) ->
       return (
-        A.Bracket (a1, a2, a3), 
+        A.Bracket (a1, a2, a3),
         B.Bracket (b1, b2, b3)
       )
     )))
@@ -303,7 +303,7 @@ and m_tree a b =
     m_arguments a2 b2 >>= (fun (a2, b2) ->
     m_tok a3 b3 >>= (fun (a3, b3) ->
       return (
-        A.Parens (a1, a2, a3), 
+        A.Parens (a1, a2, a3),
         B.Parens (b1, b2, b3)
       )
     )))
@@ -312,7 +312,7 @@ and m_tree a b =
     m_trees a2 b2 >>= (fun (a2, b2) ->
     m_tok a3 b3 >>= (fun (a3, b3) ->
       return (
-        A.Angle (a1, a2, a3), 
+        A.Angle (a1, a2, a3),
         B.Angle (b1, b2, b3)
       )
     )))

--- a/semgrep-core/fuzzy/fuzzy_vs_fuzzy.mli
+++ b/semgrep-core/fuzzy/fuzzy_vs_fuzzy.mli
@@ -3,21 +3,21 @@
 (* Ast_fuzzy vs Ast_fuzzy *)
 (*****************************************************************************)
 
-module type PARAM = 
-  sig 
+module type PARAM =
+  sig
     type tin
     type 'x tout
 
     type ('a, 'b) matcher = 'a -> 'b  -> tin -> ('a * 'b) tout
 
-    val (>>=): 
-      (tin -> ('a * 'b) tout)  -> 
-      ('a * 'b -> (tin -> ('c * 'd) tout)) -> 
+    val (>>=):
+      (tin -> ('a * 'b) tout)  ->
+      ('a * 'b -> (tin -> ('c * 'd) tout)) ->
       (tin -> ('c * 'd) tout)
 
-    val (>||>) : 
+    val (>||>) :
       (tin -> 'x tout) ->
-      (tin -> 'x tout) -> 
+      (tin -> 'x tout) ->
       (tin -> 'x tout)
 
     (* The classical monad combinators *)
@@ -45,7 +45,7 @@ module type PARAM =
 (*****************************************************************************)
 
 module X_VS_X :
-  functor (X : PARAM) -> 
+  functor (X : PARAM) ->
     sig
       type ('a, 'b) matcher = 'a -> 'b -> X.tin -> ('a * 'b) X.tout
 

--- a/semgrep-core/fuzzy/matching_fuzzy.ml
+++ b/semgrep-core/fuzzy/matching_fuzzy.ml
@@ -6,7 +6,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -35,27 +35,27 @@ let pr2, _pr2_once = Common2.mk_pr2_wrappers Flag_fuzzy.verbose
 
 module XMATCH = struct
   (* ------------------------------------------------------------------------*)
-  (* Combinators history *) 
+  (* Combinators history *)
   (* ------------------------------------------------------------------------*)
   (*
-   * version0: 
+   * version0:
    *   type ('a, 'b) matcher = 'a -> 'b -> bool
-   * 
+   *
    *   This just lets you know if you matched something.
-   * 
+   *
    * version1:
    *   type ('a, 'b) matcher = 'a -> 'b -> unit -> ('a, 'b) option
-   * 
+   *
    *   The Maybe monad.
-   * 
+   *
    * version2:
    *   type ('a, 'b) matcher = 'a -> 'b -> binding -> binding list
-   * 
+   *
    *   Why not returning a binding option ? because I may need at some
    *   point to return multiple possible bindings for one matching code.
    *   For instance with the pattern do 'f(..., X, ...)', X could be binded
    *   to different parts of the code.
-   * 
+   *
    *   Note that the empty list means a match failure.
    *)
 
@@ -64,9 +64,9 @@ module XMATCH = struct
   type ('a, 'b) matcher = 'a -> 'b  -> tin -> ('a * 'b) tout
 
   let ((>>=):
-          (tin -> ('a * 'b) tout)  -> 
-          (('a * 'b) -> (tin -> ('c * 'd) tout)) -> 
-          (tin -> ('c * 'd) tout)) = 
+          (tin -> ('a * 'b) tout)  ->
+          (('a * 'b) -> (tin -> ('c * 'd) tout)) ->
+          (tin -> ('c * 'd) tout)) =
     fun m1 m2 ->
       fun tin ->
         (* old:
@@ -75,13 +75,13 @@ module XMATCH = struct
            | Some (a,b) ->
            m2 (a, b) tin
         *)
-        (* let's get a list of possible environment match (could be 
+        (* let's get a list of possible environment match (could be
          * the empty list when it didn't match, playing the role None
          * had before)
          *)
         let xs = m1 tin in
         (* try m2 on each possible returned bindings *)
-        let xxs = xs |> List.map (fun ((a,b), binding) -> 
+        let xxs = xs |> List.map (fun ((a,b), binding) ->
           m2 (a, b) binding
         ) in
         List.flatten xxs
@@ -97,20 +97,20 @@ module XMATCH = struct
     (* opti? use set instead of list *)
     m1 tin @ m2 tin
 
-           
+
   let return (a,b) = fun tin ->
     (* old: Some (a,b) *)
     [(a,b), tin]
-      
+
   let fail = fun _tin ->
     (* old: None *)
     []
 
   (* ------------------------------------------------------------------------*)
-  (* Environment *) 
+  (* Environment *)
   (* ------------------------------------------------------------------------*)
 
-  let tokenf a b = 
+  let tokenf a b =
     let a1 = Parse_info.str_of_info a in
     let b1 = Parse_info.str_of_info b in
     if a1 =$= b1
@@ -134,9 +134,9 @@ module XMATCH = struct
      * generic '=' OCaml operator as 'a' and 'b' may represent
      * the same code but they will contain leaves in their AST
      * with different position information. So before doing
-     * the comparison we just need to remove/abstract-away 
+     * the comparison we just need to remove/abstract-away
      * the line number information in each ASTs.
-     * 
+     *
      * less: optimize by caching the abstract_lined ?
      *)
     let a = Lib_ast_fuzzy.abstract_position_trees a in
@@ -172,7 +172,7 @@ module XMATCH = struct
 end
 
 (*****************************************************************************)
-(* Entry point  *) 
+(* Entry point  *)
 (*****************************************************************************)
 
 module MATCH = Fuzzy_vs_fuzzy.X_VS_X (XMATCH)

--- a/semgrep-core/fuzzy/matching_fuzzy.mli
+++ b/semgrep-core/fuzzy/matching_fuzzy.mli
@@ -4,8 +4,8 @@
  * is empty (because your pattern didn't contain any metavariable for
  * instance).
  *)
-type ('a, 'b) matcher = 
-  'a -> 'b -> 
+type ('a, 'b) matcher =
+  'a -> 'b ->
   Metavars_fuzzy.fuzzy_binding list
 
 (* right now it does not do side effects on the first argument

--- a/semgrep-core/fuzzy/metavars_fuzzy.ml
+++ b/semgrep-core/fuzzy/metavars_fuzzy.ml
@@ -6,7 +6,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -21,12 +21,10 @@
 (* Types *)
 (*****************************************************************************)
 
-type mvar = string 
+type mvar = string
 
 type 'a metavars_binding = (mvar, 'a) Common.assoc
 
 type fuzzy_binding = Ast_fuzzy.trees metavars_binding
 
 let empty_environment () = []
-
-

--- a/semgrep-core/fuzzy/metavars_fuzzy.mli
+++ b/semgrep-core/fuzzy/metavars_fuzzy.mli
@@ -1,9 +1,8 @@
 
-type mvar = string 
+type mvar = string
 
 type 'a metavars_binding = (mvar, 'a) Common.assoc
 
 type fuzzy_binding = Ast_fuzzy.trees metavars_binding
 
 val empty_environment: unit -> 'a metavars_binding
-

--- a/semgrep-core/fuzzy/semgrep_fuzzy.ml
+++ b/semgrep-core/fuzzy/semgrep_fuzzy.ml
@@ -6,7 +6,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -18,7 +18,7 @@ module V = Lib_ast_fuzzy
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* See https://github.com/facebook/pfff/wiki/Sgrep 
+(* See https://github.com/facebook/pfff/wiki/Sgrep
 *)
 
 (*****************************************************************************)
@@ -52,7 +52,7 @@ let sgrep ~hook pattern ast =
             (* recurse on sublists *)
             k xs
           else begin
-            (* could also recurse to find nested matching inside 
+            (* could also recurse to find nested matching inside
              * the matched code itself
              *)
             let matched_tokens = Lib_ast_fuzzy.toks_of_trees shorter in
@@ -62,7 +62,7 @@ let sgrep ~hook pattern ast =
             k rest
           end
         end
-        else 
+        else
           (* at least recurse *)
           k xs
       );

--- a/semgrep-core/fuzzy/semgrep_fuzzy.mli
+++ b/semgrep-core/fuzzy/semgrep_fuzzy.mli
@@ -1,6 +1,6 @@
 
 type pattern = Ast_fuzzy.trees
 
-val sgrep:   
+val sgrep:
   hook:(Metavars_fuzzy.fuzzy_binding -> Parse_info.t list -> unit) ->
   pattern -> Ast_fuzzy.trees -> unit

--- a/semgrep-core/fuzzy/spatch_fuzzy.mli
+++ b/semgrep-core/fuzzy/spatch_fuzzy.mli
@@ -1,7 +1,7 @@
 
 type pattern = Ast_fuzzy.trees
 
-val parse: 
+val parse:
  pattern_of_string:(string -> pattern) ->
  ii_of_pattern:(pattern -> Parse_info.t list) ->
  Common.filename -> pattern
@@ -10,5 +10,5 @@ val parse:
  * then to unparse things in the correct way. See unparse_fuzzy.ml
  * for an example.
  *)
-val spatch: 
+val spatch:
   pattern -> Ast_fuzzy.trees -> bool

--- a/semgrep-core/fuzzy/transforming_fuzzy.mli
+++ b/semgrep-core/fuzzy/transforming_fuzzy.mli
@@ -1,6 +1,6 @@
 
-type ('a, 'b) transformer = 
-  'a -> 'b -> 
+type ('a, 'b) transformer =
+  'a -> 'b ->
   Metavars_fuzzy.fuzzy_binding list
 
 (* this works by side effect on the second argument and its .transfo field *)

--- a/semgrep-core/fuzzy/unit_fuzzy.ml
+++ b/semgrep-core/fuzzy/unit_fuzzy.ml
@@ -12,15 +12,15 @@ let sgrep_fuzzy_unittest ~ast_fuzzy_of_string =
     let triples = [
 
       (* ------------ *)
-      (* spacing *)  
+      (* spacing *)
       (* ------------ *)
-   
+
       (* basic string match of course *)
       "foo(1,2);", "foo(1,2);", true;
       "foo(1,3);", "foo(1,2);", false;
       (* matches even when space or newline differs *)
       "foo(1,2);", "foo(1,     2);", true;
-      "foo(1,2);", "foo(1,     
+      "foo(1,2);", "foo(1,
                         2);", true;
       (* matches even when have comments in the middle *)
       "foo(1,2);", "foo(1, /* foo */ 2);", true;
@@ -118,7 +118,7 @@ let sgrep_fuzzy_unittest ~ast_fuzzy_of_string =
 (* See https://github.com/facebook/pfff/wiki/Spatch *)
 
 (* run by spatch -test *)
-let spatch_fuzzy_unittest ~ast_fuzzy_of_string ~parse_file = 
+let spatch_fuzzy_unittest ~ast_fuzzy_of_string ~parse_file =
   "spatch regressions files" >:: (fun () ->
 
     let testdir = Filename.concat Config_pfff.path "tests/fuzzy/spatch/" in
@@ -140,7 +140,7 @@ let spatch_fuzzy_unittest ~ast_fuzzy_of_string ~parse_file =
             ~ii_of_pattern:Lib_ast_fuzzy.toks_of_trees
             spatchfile
         in
-        let trees, toks = 
+        let trees, toks =
           parse_file srcfile
         in
         let was_modified = Spatch_fuzzy.spatch pattern trees in
@@ -150,7 +150,7 @@ let spatch_fuzzy_unittest ~ast_fuzzy_of_string ~parse_file =
           else None
         in
 
-        let file_res = 
+        let file_res =
           match resopt with
           | None -> srcfile
           | Some s ->
@@ -162,11 +162,11 @@ let spatch_fuzzy_unittest ~ast_fuzzy_of_string ~parse_file =
         diff |> List.iter pr;
         if List.length diff > 1
         then assert_failure
-          (spf "spatch %s on %s should have resulted in %s" 
+          (spf "spatch %s on %s should have resulted in %s"
               (Filename.basename spatchfile)
               (Filename.basename srcfile)
               (Filename.basename expfile))
-      end 
+      end
       else failwith ("wrong format for expfile: " ^ expfile)
     )
   )

--- a/semgrep-core/fuzzy/unit_fuzzy.mli
+++ b/semgrep-core/fuzzy/unit_fuzzy.mli
@@ -1,10 +1,10 @@
 (* subsystems unittest *)
-val sgrep_fuzzy_unittest: 
-  ast_fuzzy_of_string:(string -> Ast_fuzzy.trees) -> 
+val sgrep_fuzzy_unittest:
+  ast_fuzzy_of_string:(string -> Ast_fuzzy.trees) ->
   OUnit.test
 
-val spatch_fuzzy_unittest: 
+val spatch_fuzzy_unittest:
   ast_fuzzy_of_string:(string -> Spatch_fuzzy.pattern) ->
-  parse_file:(string -> Ast_fuzzy.trees * 
+  parse_file:(string -> Ast_fuzzy.trees *
                        (Parse_info.token_kind * Parse_info.t) list) ->
   OUnit.test

--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -63,7 +63,7 @@ open Matching_generic
  * alternatives:
  *  - would it be simpler to work on a simpler AST, like a Term language,
  *    or even a Node/Leaf? or Ast_fuzzy? the "less-is-ok" would be
- *    difficult with that approach, because you need to know that some 
+ *    difficult with that approach, because you need to know that some
  *    parts of the AST are attributes/annotations that can be skipped.
  *    In the same way, code equivalences like name resolution on the AST
  *    would be more difficult with an untyped-general tree.
@@ -75,7 +75,7 @@ open Matching_generic
 (*****************************************************************************)
 
 (*s: function [[Generic_vs_generic.m_string_xhp_text]] *)
-(* equivalence: on different indentation 
+(* equivalence: on different indentation
  * todo? work? was copy-pasted from XHP sgrep matcher
 *)
 let m_string_xhp_text sa sb =
@@ -89,8 +89,8 @@ let m_string_xhp_text sa sb =
 (*****************************************************************************)
 
 (*s: function [[Generic_vs_generic.m_ident]] *)
-(* coupling: modify also m_ident_and_id_info_add_in_env_Expr *) 
-let m_ident a b = 
+(* coupling: modify also m_ident_and_id_info_add_in_env_Expr *)
+let m_ident a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_ident()]] metavariable case *)
   (* metavar: *)
@@ -122,7 +122,7 @@ let m_ident a b =
 
 
 (*s: function [[Generic_vs_generic.m_dotted_name]] *)
-let m_dotted_name a b = 
+let m_dotted_name a b =
   match a, b with
   (* TODO: [$X] should match any list *)
   (a, b) -> (m_list m_ident) a b
@@ -130,7 +130,7 @@ let m_dotted_name a b =
 
 
 (*s: function [[Generic_vs_generic.m_qualified_name]] *)
-let m_qualified_name a b = 
+let m_qualified_name a b =
   match a, b with
   (a, b) -> m_dotted_name a b
 (*e: function [[Generic_vs_generic.m_qualified_name]] *)
@@ -139,32 +139,32 @@ let m_qualified_name a b =
 (* less-is-ok: prefix matching is supported for imports, eg.:
  *  pattern: import foo.x should match: from foo.x.z.y
  *)
-let m_module_name_prefix a b = 
+let m_module_name_prefix a b =
   match a, b with
   | A.FileName(a1), B.FileName(b1) ->
     (* TODO figure out what prefix support means here *)
-    (m_wrap m_string_prefix) a1 b1 
+    (m_wrap m_string_prefix) a1 b1
   | A.DottedName(a1), B.DottedName(b1) ->
-    m_list_prefix m_ident a1 b1 
+    m_list_prefix m_ident a1 b1
   | A.FileName _, _
   | A.DottedName _, _
    -> fail ()
 (*e: function [[Generic_vs_generic.m_module_name_prefix]] *)
 
 (*s: function [[Generic_vs_generic.m_module_name]] *)
-let m_module_name a b = 
+let m_module_name a b =
   match a, b with
   | A.FileName(a1), B.FileName(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.DottedName(a1), B.DottedName(b1) ->
-    m_dotted_name a1 b1 
+    m_dotted_name a1 b1
   | A.FileName _, _
   | A.DottedName _, _
    -> fail ()
 (*e: function [[Generic_vs_generic.m_module_name]] *)
 
 (*s: function [[Generic_vs_generic.m_sid]] *)
-let m_sid a b = 
+let m_sid a b =
   if a =|= b then return () else fail ()
 (*e: function [[Generic_vs_generic.m_sid]] *)
 
@@ -180,9 +180,9 @@ let m_resolved_name_kind a b =
   | A.Global, B.Global ->
       return ()
   | A.ImportedEntity(a1), B.ImportedEntity(b1) ->
-    m_qualified_name a1 b1 
+    m_qualified_name a1 b1
   | A.ImportedModule(a1), B.ImportedModule(b1) ->
-    m_module_name a1 b1 
+    m_module_name a1 b1
   | A.Macro, B.Macro ->
     return ()
   | A.EnumConstant, B.EnumConstant ->
@@ -203,7 +203,7 @@ let m_resolved_name_kind a b =
 (*e: function [[Generic_vs_generic.m_resolved_name_kind]] *)
 
 (*s: function [[Generic_vs_generic._m_resolved_name]] *)
-let _m_resolved_name (a1, a2) (b1, b2) = 
+let _m_resolved_name (a1, a2) (b1, b2) =
   m_resolved_name_kind a1 b1 >>= (fun () ->
   m_sid a2 b2 )
 (*e: function [[Generic_vs_generic._m_resolved_name]] *)
@@ -250,14 +250,14 @@ and m_id_info a b =
   match a, b with
   { A. id_resolved = _a1; id_type = a2; id_const_literal = _a3 },
   { B. id_resolved = _b1; id_type = b2; id_const_literal = _b3 }
-   -> 
+   ->
 
      (* TODO:
       * right now doing import flask in a file means every reference
       * to flask.xxx will be tagged with a ImportedEntity, but
       * sgrep pattern might use flask.xxx without this tag, which prevents
       * matching, hence the comment for now. We need to correctly resolve
-      * names and always compare with the resolved_name instead of the 
+      * names and always compare with the resolved_name instead of the
       * name used in the code (which can be an alias)
       *
       * Note that is is independent of the check done in equal_ast to check
@@ -266,7 +266,7 @@ and m_id_info a b =
       *)
       (* (m_ref m_resolved_name) a3 b3  >>= (fun () ->  *)
 
-    (m_ref (m_option m_type_)) a2 b2 
+    (m_ref (m_option m_type_)) a2 b2
 (*e: function [[Generic_vs_generic.m_id_info]] *)
 
 (*****************************************************************************)
@@ -279,21 +279,21 @@ and make_dotted xs =
   | [] -> raise Impossible
   | x::xs ->
     let base = B.Id (x, B.empty_id_info()) in
-    List.fold_left (fun acc e -> 
+    List.fold_left (fun acc e ->
       let tok = Parse_info.fake_info "." in
       B.DotAccess (acc, tok, B.FId e)) base xs
 (*e: function [[Generic_vs_generic.make_dotted]] *)
 
-(* possibly go deeper when someone wants that a pattern like 
- *   'bar();' 
+(* possibly go deeper when someone wants that a pattern like
+ *   'bar();'
  * match also an expression statement like
  *   'x = bar();'.
  *
- * This is very hacky. 
+ * This is very hacky.
  *
  * alternatives:
  *  - force the user to use 'if(... <expr> ...)' (isaac, jmelton)
- *  - do as in coccinelle and use 'if(<... <expr> ...>)' 
+ *  - do as in coccinelle and use 'if(<... <expr> ...>)'
  *  - CURRENT: impicitely go deep without requiring an extra syntax
  *
  * todo? we could restrict ourselves to only a few forms? see SubAST_generic.ml
@@ -304,7 +304,7 @@ and make_dotted xs =
 (*s: function [[Generic_vs_generic.m_expr_deep]] *)
 and m_expr_deep a b =
   if not !Flag.go_deeper_expr
-  then m_expr a b 
+  then m_expr a b
   else
     m_expr a b >!> (fun () ->
       let subs = SubAST_generic.subexprs_of_expr b in
@@ -324,7 +324,7 @@ and m_expr_deep a b =
  * also add them in m_pattern
  *)
 (*s: function [[Generic_vs_generic.m_expr]] *)
-and m_expr a b = 
+and m_expr a b =
   match a, b with
   (* the order of the matches matters! take care! *)
   (*s: [[Generic_vs_generic.m_expr()]] disjunction case *)
@@ -334,8 +334,8 @@ and m_expr a b =
   (*e: [[Generic_vs_generic.m_expr()]] disjunction case *)
   (*s: [[Generic_vs_generic.m_expr()]] resolving alias case *)
   (* equivalence: name resolving! *)
-  | a,   B.Id (_, { B.id_resolved = 
-      {contents = Some ( ( B.ImportedEntity dotted 
+  | a,   B.Id (_, { B.id_resolved =
+      {contents = Some ( ( B.ImportedEntity dotted
                          | B.ImportedModule (B.DottedName dotted)
                          ), _sid)}; _}) ->
 
@@ -344,21 +344,21 @@ and m_expr a b =
   (*s: [[Generic_vs_generic.m_expr()]] metavariable case *)
   (*s: [[Generic_vs_generic.m_expr()]] forbidden metavariable case *)
   (* $X should not match an IdSpecial otherwise $X(...) could match
-   * a+b because this is transformed in a Call(IdSpecial Plus, ...) 
+   * a+b because this is transformed in a Call(IdSpecial Plus, ...)
    *)
-  | A.Id ((str,_tok), _id_info), B.IdSpecial _ 
+  | A.Id ((str,_tok), _id_info), B.IdSpecial _
       when MV.is_metavar_name str ->
       fail ()
   (*e: [[Generic_vs_generic.m_expr()]] forbidden metavariable case *)
   (* metavar: *)
-  | A.Id ((str,tok), _id_info), e2 
+  | A.Id ((str,tok), _id_info), e2
      when MV.is_metavar_name str ->
       envf (str, tok) (B.E (e2))
   (*e: [[Generic_vs_generic.m_expr()]] metavariable case *)
   (*s: [[Generic_vs_generic.m_expr()]] typed metavariable case *)
   (* metavar: typed! *)
-  | A.TypedMetavar ((str, tok), _, t), e2 
-      when MV.is_metavar_name str && 
+  | A.TypedMetavar ((str, tok), _, t), e2
+      when MV.is_metavar_name str &&
            Typechecking_generic.compatible_type t e2 ->
       envf (str, tok) (B.E e2)
   (*e: [[Generic_vs_generic.m_expr()]] typed metavariable case *)
@@ -375,19 +375,19 @@ and m_expr a b =
 
   (* must be before constant propagation case below *)
   | A.L(a1), B.L(b1) ->
-    m_literal a1 b1 
+    m_literal a1 b1
 
   (*s: [[Generic_vs_generic.m_expr()]] propagated constant case *)
-  (* equivalence: constant propagation and evaluation! 
+  (* equivalence: constant propagation and evaluation!
    * TODO: too late, must do that before 'metavar:' so that
    * const a = "foo"; ... a == "foo" would be catched by $X == $X.
    *)
-  | A.L(a1), b1 -> 
+  | A.L(a1), b1 ->
     (match Normalize_generic.constant_propagation_and_evaluate_literal b1 with
     | Some b1 ->
       m_literal a1 b1
     | None -> fail ()
-    ) 
+    )
   (*e: [[Generic_vs_generic.m_expr()]] propagated constant case *)
 
   (*s: [[Generic_vs_generic.m_expr()]] sequencable container cases *)
@@ -396,32 +396,32 @@ and m_expr a b =
   | A.Container(A.List, a2), B.Container(B.List, b2) ->
     (m_bracket (m_container_ordered_elements)) a2 b2
   | A.Tuple(a1), B.Tuple(b1) ->
-    m_container_ordered_elements a1 b1 
+    m_container_ordered_elements a1 b1
   (*e: [[Generic_vs_generic.m_expr()]] sequencable container cases *)
   | A.Container(a1, a2), B.Container(b1, b2) ->
-    m_container_operator a1 b1 >>= (fun () -> 
+    m_container_operator a1 b1 >>= (fun () ->
     (m_bracket (m_list m_expr)) a2 b2
     )
 
   (*s: [[Generic_vs_generic.m_expr()]] interpolated strings case *)
   (* dots '...' for string literal:
-   * Interpolated strings are transformed into Call(Special(Concat, ...), 
-   * hence we want Python patterns like f"...{$X}...", which are expanded to 
+   * Interpolated strings are transformed into Call(Special(Concat, ...),
+   * hence we want Python patterns like f"...{$X}...", which are expanded to
    * Call(Special(Concat, [L"..."; Id "$X"; L"..."])) to
    * match concrete code like f"foo{a}" such that "..." is seemingly
    * matching 0 or more literal expressions.
-   * bugfix: note that we want to do that only when inside 
+   * bugfix: note that we want to do that only when inside
    * Call(Special(Concat(...))), hence the special m_arguments_concat below,
    * otherwise regular call patterns like foo("...") would match code like
    * foo().
    *)
-  | A.Call(A.IdSpecial(A.ConcatString akind, _a1), a2), 
+  | A.Call(A.IdSpecial(A.ConcatString akind, _a1), a2),
     B.Call(B.IdSpecial(B.ConcatString bkind, _b1), b2) ->
     m_concat_string_kind akind bkind >>= (fun () ->
     m_arguments_concat a2 b2
     )
   (*e: [[Generic_vs_generic.m_expr()]] interpolated strings case *)
-  (* The pattern '$X = 1 + 2 + ...' is parsed as '$X = (1 + 2) + ...', but 
+  (* The pattern '$X = 1 + 2 + ...' is parsed as '$X = (1 + 2) + ...', but
    * if the concrete code is 'foo = 1 + 2 + 3 + 4', this will naively not
    * match because (1+2)+... will be matched against ((1+2)+3)+4 and fails.
    * The ellipsis operator with binary operators should be more flexible
@@ -429,9 +429,9 @@ and m_expr a b =
    * in Call() means we need to go deeper.
    *)
 
-  | A.Call(A.IdSpecial(A.ArithOp aop, _toka), 
-      [A.Arg a1;A.Arg(A.Ellipsis _tdots)]), 
-    B.Call(B.IdSpecial(B.ArithOp bop, _tokb), 
+  | A.Call(A.IdSpecial(A.ArithOp aop, _toka),
+      [A.Arg a1;A.Arg(A.Ellipsis _tdots)]),
+    B.Call(B.IdSpecial(B.ArithOp bop, _tokb),
       [B.Arg b1; B.Arg _b2]) ->
      m_arithmetic_operator aop bop >>= (fun () ->
        m_expr a1 b1 >!> (fun () ->
@@ -441,110 +441,110 @@ and m_expr a b =
 
   (* boilerplate *)
   | A.Id(a1, a2), B.Id(b1, b2) ->
-    m_ident a1 b1 >>= (fun () -> 
+    m_ident a1 b1 >>= (fun () ->
     m_id_info a2 b2 )
 
   | A.Call(a1, a2), B.Call(b1, b2) ->
-    m_expr a1 b1 >>= (fun () -> 
-    m_arguments a2 b2 
+    m_expr a1 b1 >>= (fun () ->
+    m_arguments a2 b2
     )
 
   | A.Assign(a1, at, a2), B.Assign(b1, bt, b2) ->
-    m_expr a1 b1 >>= (fun () -> 
+    m_expr a1 b1 >>= (fun () ->
     m_tok at bt >>= (fun () ->
-    m_expr a2 b2 
+    m_expr a2 b2
     ))
 
   | A.DotAccess(a1, at, a2), B.DotAccess(b1, bt, b2) ->
-    m_expr a1 b1 >>= (fun () -> 
-    m_tok at bt >>= (fun () -> 
-    m_field_ident a2 b2 
+    m_expr a1 b1 >>= (fun () ->
+    m_tok at bt >>= (fun () ->
+    m_field_ident a2 b2
     ))
 
   | A.ArrayAccess(a1, a2), B.ArrayAccess(b1, b2) ->
-    m_expr a1 b1 >>= (fun () -> 
-    m_expr a2 b2 
+    m_expr a1 b1 >>= (fun () ->
+    m_expr a2 b2
     )
 
   (*s: [[Generic_vs_generic.m_expr()]] boilerplate cases *)
     | A.Record(a1), B.Record(b1) ->
-      (m_bracket (m_fields)) a1 b1 
+      (m_bracket (m_fields)) a1 b1
     | A.Constructor(a1, a2), B.Constructor(b1, b2) ->
-      m_name a1 b1 >>= (fun () -> 
-      (m_list m_expr) a2 b2 
+      m_name a1 b1 >>= (fun () ->
+      (m_list m_expr) a2 b2
       )
     | A.Lambda(a1), B.Lambda(b1) ->
-      m_function_definition a1 b1 >>= (fun () -> 
+      m_function_definition a1 b1 >>= (fun () ->
       return ())
     | A.AnonClass(a1), B.AnonClass(b1) ->
-      m_class_definition a1 b1 
+      m_class_definition a1 b1
     | A.IdQualified(a1, a2), B.IdQualified(b1, b2) ->
-      m_name a1 b1 >>= (fun () -> 
-      m_id_info a2 b2 
+      m_name a1 b1 >>= (fun () ->
+      m_id_info a2 b2
       )
     | A.IdSpecial(a1), B.IdSpecial(b1) ->
-      m_wrap m_special a1 b1 
+      m_wrap m_special a1 b1
 
     | A.AssignOp(a1, a2, a3), B.AssignOp(b1, b2, b3) ->
-      m_expr a1 b1 >>= (fun () -> 
-      m_wrap m_arithmetic_operator a2 b2 >>= (fun () -> 
-      m_expr a3 b3 
+      m_expr a1 b1 >>= (fun () ->
+      m_wrap m_arithmetic_operator a2 b2 >>= (fun () ->
+      m_expr a3 b3
       ))
 
     | A.Xml(a1), B.Xml(b1) ->
-      m_xml a1 b1 
+      m_xml a1 b1
     | A.LetPattern(a1, a2), B.LetPattern(b1, b2) ->
-      m_pattern a1 b1 >>= (fun () -> 
-      m_expr a2 b2 
+      m_pattern a1 b1 >>= (fun () ->
+      m_expr a2 b2
       )
 
     | A.SliceAccess(a1, a2, a3, a4), B.SliceAccess(b1, b2, b3, b4) ->
-      m_expr a1 b1 >>= (fun () -> 
-      m_option m_expr a2 b2 >>= (fun () -> 
-      m_option m_expr a3 b3 >>= (fun () -> 
-      m_option m_expr a4 b4 
+      m_expr a1 b1 >>= (fun () ->
+      m_option m_expr a2 b2 >>= (fun () ->
+      m_option m_expr a3 b3 >>= (fun () ->
+      m_option m_expr a4 b4
       )))
     | A.Conditional(a1, a2, a3), B.Conditional(b1, b2, b3) ->
-      m_expr a1 b1 >>= (fun () -> 
-      m_expr a2 b2 >>= (fun () -> 
-      m_expr a3 b3 
+      m_expr a1 b1 >>= (fun () ->
+      m_expr a2 b2 >>= (fun () ->
+      m_expr a3 b3
       ))
     | A.MatchPattern(a1, a2), B.MatchPattern(b1, b2) ->
-      m_expr a1 b1 >>= (fun () -> 
-      (m_list m_action) a2 b2 
+      m_expr a1 b1 >>= (fun () ->
+      (m_list m_action) a2 b2
       )
     | A.Yield(a0, a1, a2), B.Yield(b0, b1, b2) ->
-      m_tok a0 b0 >>= (fun () -> 
-      m_option m_expr a1 b1 >>= (fun () -> 
-      m_bool a2 b2 
+      m_tok a0 b0 >>= (fun () ->
+      m_option m_expr a1 b1 >>= (fun () ->
+      m_bool a2 b2
       ))
     | A.Await(a0, a1), B.Await(b0, b1) ->
-      m_tok a0 b0 >>= (fun () -> 
-      m_expr a1 b1 
+      m_tok a0 b0 >>= (fun () ->
+      m_expr a1 b1
       )
     | A.Cast(a1, a2), B.Cast(b1, b2) ->
-      m_type_ a1 b1 >>= (fun () -> 
-      m_expr a2 b2 
+      m_type_ a1 b1 >>= (fun () ->
+      m_expr a2 b2
       )
     | A.Seq(a1), B.Seq(b1) ->
-      (m_list m_expr) a1 b1 
+      (m_list m_expr) a1 b1
     | A.Ref(a0, a1), B.Ref(b0, b1) ->
-      m_tok a0 b0 >>= (fun () -> 
-      m_expr a1 b1 
+      m_tok a0 b0 >>= (fun () ->
+      m_expr a1 b1
       )
     | A.DeRef(a0, a1), B.DeRef(b0, b1) ->
-      m_tok a0 b0 >>= (fun () -> 
-      m_expr a1 b1 
+      m_tok a0 b0 >>= (fun () ->
+      m_expr a1 b1
       )
 
 
     | A.OtherExpr(a1, a2), B.OtherExpr(b1, b2) ->
-      m_other_expr_operator a1 b1 >>= (fun () -> 
-      (m_list m_any) a2 b2 
+      m_other_expr_operator a1 b1 >>= (fun () ->
+      (m_list m_any) a2 b2
        )
     | A.Container _, _  | A.Tuple _, _  | A.Record _, _
     | A.Constructor _, _  | A.Lambda _, _  | A.AnonClass _, _
-    | A.Id _, _  | A.IdQualified _, _ | A.IdSpecial _, _  
+    | A.Id _, _  | A.IdQualified _, _ | A.IdSpecial _, _
     | A.Call _, _  | A.Xml _, _
     | A.Assign _, _  | A.AssignOp _, _  | A.LetPattern _, _  | A.DotAccess _, _
     | A.ArrayAccess _, _  | A.Conditional _, _  | A.MatchPattern _, _
@@ -560,14 +560,14 @@ and m_expr a b =
 and m_field_ident a b =
   match a, b with
   (* boilerplate *)
-  | A.FId a, B.FId b -> 
-      m_ident a b 
+  | A.FId a, B.FId b ->
+      m_ident a b
   (*s: [[Generic_vs_generic.m_field_ident()]] boilerplate cases *)
-  | A.FName a, B.FName b -> 
-      m_name a b 
-  | A.FDynamic a, B.FDynamic b -> 
-      m_expr a b 
-  | A.FId _, _ 
+  | A.FName a, B.FName b ->
+      m_name a b
+  | A.FDynamic a, B.FDynamic b ->
+      m_expr a b
+  | A.FId _, _
   | A.FName _, _
   | A.FDynamic _, _
     -> fail ()
@@ -578,26 +578,26 @@ and m_field_ident a b =
 and m_label_ident a b =
   match a, b with
   | A.LNone, B.LNone -> return ()
-  | A.LId a, B.LId b -> 
-      m_label a b 
-  | A.LInt a, B.LInt b -> 
-      m_wrap m_int a b 
-  | A.LDynamic a, B.LDynamic b -> 
-      m_expr a b 
+  | A.LId a, B.LId b ->
+      m_label a b
+  | A.LInt a, B.LInt b ->
+      m_wrap m_int a b
+  | A.LDynamic a, B.LDynamic b ->
+      m_expr a b
   | A.LNone, _
-  | A.LId _, _ 
+  | A.LId _, _
   | A.LInt _, _
   | A.LDynamic _, _
     -> fail ()
 (*e: function [[Generic_vs_generic.m_label_ident]] *)
 
 (*s: function [[Generic_vs_generic.m_literal]] *)
-and m_literal a b = 
+and m_literal a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_literal()]] ellipsis case *)
   (* dots: '...' on string *)
   | A.String("...", a), B.String(_s, b) ->
-      m_info a b 
+      m_info a b
   (*e: [[Generic_vs_generic.m_literal()]] ellipsis case *)
   (*s: [[Generic_vs_generic.m_literal()]] regexp case *)
   (* regexp matching *)
@@ -606,31 +606,31 @@ and m_literal a b =
       let re = Matching_generic.regexp_of_regexp_string name in
       if Str.string_match re sb 0
       then
-        m_info info_name info_sb 
+        m_info info_name info_sb
       else fail ()
   (*e: [[Generic_vs_generic.m_literal()]] regexp case *)
 
   (* boilerplate *)
   | A.String(a1), B.String(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.Unit(a1), B.Unit(b1) ->
-    m_tok a1 b1 
+    m_tok a1 b1
   | A.Bool(a1), B.Bool(b1) ->
-    (m_wrap m_bool) a1 b1 
+    (m_wrap m_bool) a1 b1
   | A.Int(a1), B.Int(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.Float(a1), B.Float(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.Imag(a1), B.Imag(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.Char(a1), B.Char(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.Regexp(a1), B.Regexp(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.Null(a1), B.Null(b1) ->
-    m_tok a1 b1 
+    m_tok a1 b1
   | A.Undefined(a1), B.Undefined(b1) ->
-    m_tok a1 b1 
+    m_tok a1 b1
 
   | A.Unit _, _  | A.Bool _, _  | A.Int _, _  | A.Float _, _  | A.Char _, _
   | A.String _, _  | A.Regexp _, _  | A.Null _, _  | A.Undefined _, _
@@ -639,23 +639,23 @@ and m_literal a b =
 (*e: function [[Generic_vs_generic.m_literal]] *)
 
 (*s: function [[Generic_vs_generic.m_action]] *)
-and m_action a b = 
+and m_action a b =
   match a, b with
   | (a1, a2), (b1, b2) ->
-    m_pattern a1 b1 >>= (fun () -> 
-    m_expr a2 b2 
+    m_pattern a1 b1 >>= (fun () ->
+    m_expr a2 b2
     )
 (*e: function [[Generic_vs_generic.m_action]] *)
 
 (*s: function [[Generic_vs_generic.m_arithmetic_operator]] *)
-and m_arithmetic_operator a b = 
+and m_arithmetic_operator a b =
   match a, b with
   | _ when a =*= b -> return ()
   | _ -> fail ()
 (*e: function [[Generic_vs_generic.m_arithmetic_operator]] *)
 
 (*s: function [[Generic_vs_generic.m_special]] *)
-and m_special a b = 
+and m_special a b =
   match a, b with
   | A.This, B.This ->
     return ()
@@ -680,12 +680,12 @@ and m_special a b =
   | A.Spread, B.Spread ->
     return ()
   | A.ArithOp(a1), B.ArithOp(b1) ->
-    m_arithmetic_operator a1 b1 
+    m_arithmetic_operator a1 b1
   | A.EncodedString(a1), B.EncodedString(b1) ->
-    m_wrap m_string a1 b1 
+    m_wrap m_string a1 b1
   | A.IncrDecr(a1, a2), B.IncrDecr(b1, b2) ->
-    m_bool a1 b1 >>= (fun () -> 
-    m_bool a2 b2 
+    m_bool a1 b1 >>= (fun () ->
+    m_bool a2 b2
     )
   | A.This, _  | A.Super, _  | A.Self, _  | A.Parent, _  | A.Eval, _
   | A.Typeof, _  | A.Instanceof, _  | A.Sizeof, _  | A.New, _
@@ -703,18 +703,18 @@ and m_concat_string_kind a b =
   | _ -> return ()
 
 (*s: function [[Generic_vs_generic.m_name_info]] *)
-and m_name_info a b = 
+and m_name_info a b =
   match a, b with
   { A. name_qualifier = a1; name_typeargs = a2; },
   { B. name_qualifier = b1; name_typeargs = b2; }
-   -> 
-    (m_option m_dotted_name) a1 b1 >>= (fun () -> 
-    (m_option m_type_arguments) a2 b2  
+   ->
+    (m_option m_dotted_name) a1 b1 >>= (fun () ->
+    (m_option m_type_arguments) a2 b2
     )
 (*e: function [[Generic_vs_generic.m_name_info]] *)
 
 (*s: function [[Generic_vs_generic.m_container_operator]] *)
-and m_container_operator a b = 
+and m_container_operator a b =
   match a, b with
   (* boilerplate *)
   | A.Array, B.Array ->
@@ -746,7 +746,7 @@ and m_other_expr_operator = m_other_xxx
 (*---------------------------------------------------------------------------*)
 
 (*s: function [[Generic_vs_generic.m_xml]] *)
-and m_xml a b = 
+and m_xml a b =
   match a, b with
   | { A.xml_tag = a1; xml_attrs = a2; xml_body = a3 },
     { B.xml_tag = b1; xml_attrs = b2; xml_body = b3 } ->
@@ -757,18 +757,18 @@ and m_xml a b =
 (*e: function [[Generic_vs_generic.m_xml]] *)
 
 (*s: function [[Generic_vs_generic.m_attrs]] *)
-and m_attrs a b = 
+and m_attrs a b =
   m_list__m_xml_attr a b
 (*e: function [[Generic_vs_generic.m_attrs]] *)
 
 (*s: function [[Generic_vs_generic.m_bodies]] *)
-and m_bodies a b = 
+and m_bodies a b =
   m_list__m_body a b
 (*e: function [[Generic_vs_generic.m_bodies]] *)
 
 (* todo: factorize in m_list_unordered_keys_no_dots *)
 (*s: function [[Generic_vs_generic.m_list__m_xml_attr]] *)
-and m_list__m_xml_attr 
+and m_list__m_xml_attr
  (xsa: A.xml_attribute list) (xsb: A.xml_attribute list) =
   match xsa, xsb with
   | [], [] ->
@@ -797,7 +797,7 @@ and m_list__m_xml_attr
         aux candidates
      (*e: [[Generic_vs_generic.m_list__m_xml_attr]] if metavar attribute *)
      else
-      (try 
+      (try
         let (before, there, after) = xsb |> Common2.split_when (function
             | ((s2, _), _) when s2 = s1 -> true
             | _ -> false
@@ -817,7 +817,7 @@ and m_list__m_xml_attr
 (*
   | xa::aas, xb::bbs ->
       m_xml_attr xa xb >>= (fun () ->
-      m_list__m_xml_attr aas bbs 
+      m_list__m_xml_attr aas bbs
       )
   | _::_, _ ->
       fail ()
@@ -851,7 +851,7 @@ and m_xml_attr_value a b =
 (*s: function [[Generic_vs_generic.m_body]] *)
 and m_body a b =
   match a, b with
-  | A.XmlText a1, B.XmlText b1 -> 
+  | A.XmlText a1, B.XmlText b1 ->
       m_wrap m_string_xhp_text a1 b1
   (* boilerplate *)
   (*s: [[Generic_vs_generic.m_body]] boilerplate cases *)
@@ -871,7 +871,7 @@ and m_body a b =
 (*---------------------------------------------------------------------------*)
 
 (*s: function [[Generic_vs_generic.m_arguments]] *)
-and m_arguments a b = 
+and m_arguments a b =
   match a, b with
   (a, b) -> (m_list__m_argument) a b
 (*e: function [[Generic_vs_generic.m_arguments]] *)
@@ -911,7 +911,7 @@ and m_list__m_argument (xsa: A.argument list) (xsb: A.argument list) =
         aux candidates
      (*e: [[Generic_vs_generic.m_list__m_argument()]] if metavar keyword argument *)
      else
-      (try 
+      (try
         let (before, there, after) = xsb |> Common2.split_when (function
             | A.ArgKwd ((s2,_), _) when s =$= s2 -> true
             | _ -> false) in
@@ -919,7 +919,7 @@ and m_list__m_argument (xsa: A.argument list) (xsb: A.argument list) =
         | A.ArgKwd (idb, eb) ->
            m_ident ida idb >>= (fun () ->
            m_expr ea eb >>= (fun () ->
-           m_list__m_argument xsa (before @ after) 
+           m_list__m_argument xsa (before @ after)
            ))
         | _ -> raise Impossible
         )
@@ -929,7 +929,7 @@ and m_list__m_argument (xsa: A.argument list) (xsb: A.argument list) =
   (* the general case *)
   | xa::aas, xb::bbs ->
       m_argument xa xb >>= (fun () ->
-      m_list__m_argument aas bbs 
+      m_list__m_argument aas bbs
       )
   | [], _
   | _::_, _ ->
@@ -941,7 +941,7 @@ and m_list__m_argument (xsa: A.argument list) (xsb: A.argument list) =
  * call to Normalize_generic below.
  *)
 (*s: function [[Generic_vs_generic.m_arguments_concat]] *)
-and m_arguments_concat a b = 
+and m_arguments_concat a b =
   match a,b with
   | [], [] ->
       return ()
@@ -951,9 +951,9 @@ and m_arguments_concat a b =
       return ()
 
   | A.Arg (A.L (A.String("...", a)))::xsa, B.Arg(bexpr)::xsb ->
-    (match Normalize_generic.constant_propagation_and_evaluate_literal bexpr 
+    (match Normalize_generic.constant_propagation_and_evaluate_literal bexpr
      with
-      | Some _ -> 
+      | Some _ ->
         (* can match nothing *)
         (m_arguments_concat xsa xsb) >||>
         (* can match more *)
@@ -965,7 +965,7 @@ and m_arguments_concat a b =
   (* the general case *)
   | xa::aas, xb::bbs ->
       m_argument xa xb >>= (fun () ->
-      m_arguments_concat aas bbs 
+      m_arguments_concat aas bbs
       )
   | [], _
   | _::_, _ ->
@@ -973,24 +973,24 @@ and m_arguments_concat a b =
 (*e: function [[Generic_vs_generic.m_arguments_concat]] *)
 
 (*s: function [[Generic_vs_generic.m_argument]] *)
-and m_argument a b = 
+and m_argument a b =
   match a, b with
   (* TODO: iso on keyword argument, keyword is optional in pattern *)
 
   (* boilerplate *)
   | A.Arg(a1), B.Arg(b1) ->
-    m_expr a1 b1 
+    m_expr a1 b1
   (*s: [[Generic_vs_generic.m_argument()]] boilerplate cases *)
   | A.ArgType(a1), B.ArgType(b1) ->
-    m_type_ a1 b1 
+    m_type_ a1 b1
 
   | A.ArgKwd(a1, a2), B.ArgKwd(b1, b2) ->
-    m_ident a1 b1 >>= (fun () -> 
-    m_expr a2 b2 
+    m_ident a1 b1 >>= (fun () ->
+    m_expr a2 b2
     )
   | A.ArgOther(a1, a2), B.ArgOther(b1, b2) ->
-    m_other_argument_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_argument_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.Arg _, _  | A.ArgKwd _, _  | A.ArgType _, _  | A.ArgOther _, _
    -> fail ()
@@ -1006,7 +1006,7 @@ and m_other_argument_operator = m_other_xxx
 (*****************************************************************************)
 
 (*s: function [[Generic_vs_generic.m_type_]] *)
-and m_type_ a b = 
+and m_type_ a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_type_]] metavariable case *)
   | A.TyName ((str,tok), _name_info), t2
@@ -1016,45 +1016,45 @@ and m_type_ a b =
 
   (* boilerplate *)
   | A.TyBuiltin(a1), B.TyBuiltin(b1) ->
-    (m_wrap m_string) a1 b1 
+    (m_wrap m_string) a1 b1
   | A.TyFun(a1, a2), B.TyFun(b1, b2) ->
-    (m_list m_parameter_classic) a1 b1 >>= (fun () -> 
-    m_type_ a2 b2 
+    (m_list m_parameter_classic) a1 b1 >>= (fun () ->
+    m_type_ a2 b2
     )
   | A.TyArray(a1, a2), B.TyArray(b1, b2) ->
-    (m_option m_expr) a1 b1 >>= (fun () -> 
-    m_type_ a2 b2 
+    (m_option m_expr) a1 b1 >>= (fun () ->
+    m_type_ a2 b2
     )
   | A.TyTuple(a1), B.TyTuple(b1) ->
     (*TODO: m_list__m_type_ ? *)
-    (m_bracket (m_list m_type_)) a1 b1 
+    (m_bracket (m_list m_type_)) a1 b1
 
   (*s: [[Generic_vs_generic.m_type_]] boilerplate cases *)
     | A.TyName(a1), B.TyName(b1) ->
-      m_name a1 b1 
+      m_name a1 b1
     | A.TyNameApply(a1, a2), B.TyNameApply(b1, b2) ->
-      m_name a1 b1 >>= (fun () -> 
-      m_type_arguments a2 b2 
+      m_name a1 b1 >>= (fun () ->
+      m_type_arguments a2 b2
       )
     | A.TyVar(a1), B.TyVar(b1) ->
-      m_ident a1 b1 
+      m_ident a1 b1
 
     | A.TyPointer(a0, a1), B.TyPointer(b0, b1) ->
-      m_tok a0 b0 >>= (fun () -> 
-      m_type_ a1 b1 
+      m_tok a0 b0 >>= (fun () ->
+      m_type_ a1 b1
       )
 
     | A.TyQuestion(a1, a2), B.TyQuestion(b1, b2) ->
-      m_type_ a1 b1 >>= (fun () -> 
-      m_tok a2 b2 
+      m_type_ a1 b1 >>= (fun () ->
+      m_tok a2 b2
       )
     | A.TyAnd(a1), B.TyAnd(b1) ->
-      (m_bracket (m_list m_ident_and_type_)) a1 b1 
+      (m_bracket (m_list m_ident_and_type_)) a1 b1
     | A.TyOr a1, B.TyOr b1 ->
-        m_list m_type_ a1 b1 
+        m_list m_type_ a1 b1
     | A.OtherType(a1, a2), B.OtherType(b1, b2) ->
-      m_other_type_operator a1 b1 >>= (fun () -> 
-      (m_list m_any) a2 b2 
+      m_other_type_operator a1 b1 >>= (fun () ->
+      (m_list m_any) a2 b2
        )
     | A.TyBuiltin _, _  | A.TyFun _, _  | A.TyNameApply _, _  | A.TyVar _, _
     | A.TyArray _, _  | A.TyPointer _, _ | A.TyTuple _, _  | A.TyQuestion _, _
@@ -1069,24 +1069,24 @@ and m_ident_and_type_ a b =
   match a, b with
   | (a1, a2), (b1, b2) ->
     m_ident a1 b1 >>= (fun () ->
-    m_type_ a2 b2 
+    m_type_ a2 b2
     )
 (*e: function [[Generic_vs_generic.m_ident_and_type_]] *)
 
 (*s: function [[Generic_vs_generic.m_type_arguments]] *)
-and m_type_arguments a b = 
+and m_type_arguments a b =
   match a, b with
   (a, b) -> (m_list m_type_argument) a b
 (*e: function [[Generic_vs_generic.m_type_arguments]] *)
 
 (*s: function [[Generic_vs_generic.m_type_argument]] *)
-and m_type_argument a b = 
+and m_type_argument a b =
   match a, b with
   | A.TypeArg(a1), B.TypeArg(b1) ->
-    m_type_ a1 b1 
+    m_type_ a1 b1
   | A.OtherTypeArg(a1, a2), B.OtherTypeArg(b1, b2) ->
-    m_other_type_argument_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_type_argument_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.TypeArg _, _  | A.OtherTypeArg _, _
    -> fail ()
@@ -1118,19 +1118,19 @@ and m_list__m_attribute (xsa: A.attribute list) (xsb: A.attribute list) =
   (*e: [[Generic_vs_generic.m_list__m_attribute]] empty list vs list case *)
   (*s: [[Generic_vs_generic.m_list__m_attribute]] [[KeywordAttr]] pattern case *)
   | ((A.KeywordAttr (k, tok)) as a)::xsa, xsb ->
-      (try 
+      (try
         let (before, there, after) = xsb |> Common2.split_when (function
             | A.KeywordAttr (k2, _) when k =*= k2 -> true
             | _ -> false) in
         (match there with
         | A.KeywordAttr (x) ->
               m_wrap m_keyword_attribute (k, tok) x >>= (fun () ->
-              m_list__m_attribute xsa (before @ after) 
+              m_list__m_attribute xsa (before @ after)
               )
         | _ -> raise Impossible
         )
       (*s: [[Generic_vs_generic.m_list__m_attribute]] [[KeywordAttr]] case when [[Not_found]] *)
-      with Not_found -> 
+      with Not_found ->
         (* we now allow some attribute (e.g., Var) to match other (e..g, Let),
          * so we should try all combinations.
          * opti: give an order to each attribute and zip (like in JS AI) *)
@@ -1149,7 +1149,7 @@ and m_list__m_attribute (xsa: A.attribute list) (xsb: A.attribute list) =
   (*e: [[Generic_vs_generic.m_list__m_attribute]] [[KeywordAttr]] pattern case *)
   (*s: [[Generic_vs_generic.m_list__m_attribute]] [[NamedAttr]] pattern case *)
   | A.NamedAttr ((s, _) as ida, idinfoa, argsa)::xsa, xsb ->
-      (try 
+      (try
         let (before, there, after) = xsb |> Common2.split_when (function
             (* todo: in theory we should resolve the possible alias s2 *)
             | A.NamedAttr ((s2, _), _idinfoaliasTODO, _) when s =$= s2 -> true
@@ -1160,7 +1160,7 @@ and m_list__m_attribute (xsa: A.attribute list) (xsb: A.attribute list) =
               (* less: should use m_ident_and_id_info_add_in_env_Expr? *)
               m_id_info idinfoa idinfob >>= (fun () ->
               m_list__m_argument argsa argsb >>= (fun () ->
-              m_list__m_attribute xsa (before @ after) 
+              m_list__m_attribute xsa (before @ after)
               )))
         | _ -> raise Impossible
         )
@@ -1170,14 +1170,14 @@ and m_list__m_attribute (xsa: A.attribute list) (xsb: A.attribute list) =
   (* the general case *)
   | xa::aas, xb::bbs ->
       m_attribute xa xb >>= (fun () ->
-      m_list__m_attribute aas bbs 
+      m_list__m_attribute aas bbs
       )
   | _::_, _ ->
       fail ()
 (*e: function [[Generic_vs_generic.m_list__m_attribute]] *)
 
 (*s: function [[Generic_vs_generic.m_keyword_attribute]] *)
-and m_keyword_attribute a b = 
+and m_keyword_attribute a b =
   match a, b with
  (* equivalent: quite JS-specific *)
   | A.Var, (A.Var | A.Let | A.Const) -> return ()
@@ -1186,30 +1186,30 @@ and m_keyword_attribute a b =
 (*e: function [[Generic_vs_generic.m_keyword_attribute]] *)
 
 (*s: function [[Generic_vs_generic.m_attribute]] *)
-and m_attribute a b = 
+and m_attribute a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_attribute]] resolving alias case *)
   (* equivalence: name resolving! *)
-  | a,   B.NamedAttr (_b1, { B.id_resolved = 
-      {contents = Some ( ( B.ImportedEntity dotted 
+  | a,   B.NamedAttr (_b1, { B.id_resolved =
+      {contents = Some ( ( B.ImportedEntity dotted
                          | B.ImportedModule (B.DottedName dotted)
                          ), _sid)}; _}, b2) ->
     let exp = make_dotted dotted in
     m_attribute a (B.OtherAttribute (B.OA_Expr, [B.E (B.Call (exp, b2))]))
   (*e: [[Generic_vs_generic.m_attribute]] resolving alias case *)
- 
+
   (* boilerplate *)
   | A.KeywordAttr(a1), B.KeywordAttr(b1) ->
-    m_wrap m_keyword_attribute a1 b1 
+    m_wrap m_keyword_attribute a1 b1
   | A.NamedAttr(a1, ida, a2), B.NamedAttr(b1, idb, b2) ->
-    m_ident a1 b1 >>= (fun () -> 
+    m_ident a1 b1 >>= (fun () ->
     (* less: should use m_ident_and_id_info_add_in_env_Expr? *)
     m_id_info ida idb >>= (fun () ->
-    (m_list__m_argument) a2 b2 
+    (m_list__m_argument) a2 b2
     ))
   | A.OtherAttribute(a1, a2), B.OtherAttribute(b1, b2) ->
-    m_other_attribute_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_attribute_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.KeywordAttr _, _  | A.NamedAttr _, _  | A.OtherAttribute _, _
    -> fail ()
@@ -1223,18 +1223,18 @@ and m_other_attribute_operator = m_other_xxx
 (*****************************************************************************)
 (* Statement *)
 (*****************************************************************************)
-(* possibly go deeper when someone wants that a pattern like 
+(* possibly go deeper when someone wants that a pattern like
  *   ...
  *   bar();
  * to match also calls to bar() deeply as in
  *   foo();
- *   if(true) 
+ *   if(true)
  *      bar();
- * 
+ *
  * When combined with the deep expr, this even allows to match code like
  *  if(true)
  *     x = bar();
- * 
+ *
  * This is currently very hacky. We just flatten the list of all substmts.
  *
  * alternatives:
@@ -1246,18 +1246,18 @@ and m_other_attribute_operator = m_other_xxx
 (* experimental! *)
 
 (*s: function [[Generic_vs_generic.m_stmts_deep]] *)
-and m_stmts_deep (xsa: A.stmt list) (xsb: A.stmt list) = 
+and m_stmts_deep (xsa: A.stmt list) (xsb: A.stmt list) =
   if !Flag.go_deeper_stmt && (has_ellipsis_stmts xsa)
-  then 
+  then
     m_list__m_stmt xsa xsb >!> (fun () ->
       let xsb' = SubAST_generic.flatten_substmts_of_stmts xsb in
       m_list__m_stmt xsa xsb'
     )
-  else m_list__m_stmt xsa xsb 
+  else m_list__m_stmt xsa xsb
 (*e: function [[Generic_vs_generic.m_stmts_deep]] *)
 
-and _m_stmts (xsa: A.stmt list) (xsb: A.stmt list) = 
-  m_list__m_stmt xsa xsb 
+and _m_stmts (xsa: A.stmt list) (xsb: A.stmt list) =
+  m_list__m_stmt xsa xsb
 
 (* TODO: factorize with m_list_and_dots less_is_ok = true *)
 (*s: function [[Generic_vs_generic.m_list__m_stmt]] *)
@@ -1295,14 +1295,14 @@ and m_list__m_stmt (xsa: A.stmt list) (xsb: A.stmt list) =
   (* the general case *)
   | xa::aas, xb::bbs ->
       m_stmt xa xb >>= (fun () ->
-      m_list__m_stmt aas bbs 
+      m_list__m_stmt aas bbs
       )
   | _::_, _ ->
       fail ()
 (*e: function [[Generic_vs_generic.m_list__m_stmt]] *)
 
 (*s: function [[Generic_vs_generic.m_stmt]] *)
-and m_stmt a b = 
+and m_stmt a b =
   match a, b with
   (* the order of the matches matters! take care! *)
   (*s: [[Generic_vs_generic.m_stmt()]] disjunction case *)
@@ -1312,7 +1312,7 @@ and m_stmt a b =
   (*e: [[Generic_vs_generic.m_stmt()]] disjunction case *)
   (*s: [[Generic_vs_generic.m_stmt()]] metavariable case *)
   (* metavar: *)
-  | A.ExprStmt(A.Id ((str,tok), _id_info)), b 
+  | A.ExprStmt(A.Id ((str,tok), _id_info)), b
      when MV.is_metavar_name str ->
       envf (str, tok) (B.S b)
   (*e: [[Generic_vs_generic.m_stmt()]] metavariable case *)
@@ -1323,21 +1323,21 @@ and m_stmt a b =
   (*x: [[Generic_vs_generic.m_stmt()]] ellipsis cases *)
   | A.Return(a0, a1), B.Return(b0, b1) ->
     m_tok a0 b0 >>= (fun () ->
-    m_option_ellipsis_ok m_expr a1 b1 
+    m_option_ellipsis_ok m_expr a1 b1
     )
   (*e: [[Generic_vs_generic.m_stmt()]] ellipsis cases *)
   (*s: [[Generic_vs_generic.m_stmt()]] deep matching cases *)
   (* deeper: go deep by default implicitly (no need for explicit <... ...>) *)
   | A.ExprStmt(a1), B.ExprStmt(b1) ->
-    m_expr_deep a1 b1 
+    m_expr_deep a1 b1
   (*x: [[Generic_vs_generic.m_stmt()]] deep matching cases *)
   (* TODO: ... should also allow a subset of stmts *)
   | A.Block(a1), B.Block(b1) ->
-    m_stmts_deep a1 b1 
+    m_stmts_deep a1 b1
   (*e: [[Generic_vs_generic.m_stmt()]] deep matching cases *)
   (*s: [[Generic_vs_generic.m_stmt()]] builtin equivalences cases *)
   (* equivalence: vardef ==> assign, and go deep *)
-  | A.ExprStmt a1, 
+  | A.ExprStmt a1,
     B.DefStmt ({ B.info={B.id_resolved={contents=resolved }; _}; _ } as ent,
       B.VarDef ({B.vinit = Some _; _} as def)) ->
       let b1 = AST.vardef_to_assign (ent, def) resolved in
@@ -1352,79 +1352,79 @@ and m_stmt a b =
   | A.If(a0, a1, a2, a3), B.If(b0, b1, b2, b3) ->
     m_tok a0 b0 >>= (fun () ->
     (* too many regressions doing m_expr_deep by default; Use DeepEllipsis *)
-    m_expr a1 b1 >>= (fun () -> 
-    m_stmt a2 b2 >>= (fun () -> 
-    m_stmt a3 b3 
+    m_expr a1 b1 >>= (fun () ->
+    m_stmt a2 b2 >>= (fun () ->
+    m_stmt a3 b3
     )))
 
   | A.While(a0, a1, a2), B.While(b0, b1, b2) ->
     m_tok a0 b0 >>= (fun () ->
-    m_expr a1 b1 >>= (fun () -> 
-    m_stmt a2 b2 
+    m_expr a1 b1 >>= (fun () ->
+    m_stmt a2 b2
     ))
   (*s: [[Generic_vs_generic.m_stmt]] boilerplate cases *)
   | A.DefStmt(a1), B.DefStmt(b1) ->
-    m_definition a1 b1 
+    m_definition a1 b1
   | A.DirectiveStmt(a1), B.DirectiveStmt(b1) ->
-    m_directive a1 b1 
+    m_directive a1 b1
   (*x: [[Generic_vs_generic.m_stmt]] boilerplate cases *)
 
     | A.DoWhile(a0, a1, a2), B.DoWhile(b0, b1, b2) ->
       m_tok a0 b0 >>= (fun () ->
-      m_stmt a1 b1 >>= (fun () -> 
-      m_expr a2 b2 
+      m_stmt a1 b1 >>= (fun () ->
+      m_expr a2 b2
       ))
     | A.For(a0, a1, a2), B.For(b0, b1, b2) ->
       m_tok a0 b0 >>= (fun () ->
-      m_for_header a1 b1 >>= (fun () -> 
-      m_stmt a2 b2 
+      m_for_header a1 b1 >>= (fun () ->
+      m_stmt a2 b2
       ))
     | A.Switch(at, a1, a2), B.Switch(bt, b1, b2) ->
-      m_tok at bt >>= (fun () -> 
-      m_option (m_expr) a1 b1 >>= (fun () -> 
-      (m_list m_case_and_body) a2 b2 
+      m_tok at bt >>= (fun () ->
+      m_option (m_expr) a1 b1 >>= (fun () ->
+      (m_list m_case_and_body) a2 b2
       ))
 
     | A.Continue(a0, a1), B.Continue(b0, b1) ->
       m_tok a0 b0 >>= (fun () ->
-      m_label_ident a1 b1 
+      m_label_ident a1 b1
       )
     | A.Break(a0, a1), B.Break(b0, b1) ->
       m_tok a0 b0 >>= (fun () ->
-      m_label_ident a1 b1 
+      m_label_ident a1 b1
       )
     | A.Label(a1, a2), B.Label(b1, b2) ->
-      m_label a1 b1 >>= (fun () -> 
-      m_stmt a2 b2 
+      m_label a1 b1 >>= (fun () ->
+      m_stmt a2 b2
       )
     | A.Goto(a0, a1), B.Goto(b0, b1) ->
       m_tok a0 b0 >>= (fun () ->
-      m_label a1 b1 
+      m_label a1 b1
       )
     | A.Throw(a0, a1), B.Throw(b0, b1) ->
       m_tok a0 b0 >>= (fun () ->
-      m_expr a1 b1 
+      m_expr a1 b1
       )
     | A.Try(a0, a1, a2, a3), B.Try(b0, b1, b2, b3) ->
       m_tok a0 b0 >>= (fun () ->
-      m_stmt a1 b1 >>= (fun () -> 
-      (m_list m_catch) a2 b2 >>= (fun () -> 
-      (m_option m_finally) a3 b3 
+      m_stmt a1 b1 >>= (fun () ->
+      (m_list m_catch) a2 b2 >>= (fun () ->
+      (m_option m_finally) a3 b3
       )))
     | A.Assert(a0, a1, a2), B.Assert(b0, b1, b2) ->
       m_tok a0 b0 >>= (fun () ->
-      m_expr a1 b1 >>= (fun () -> 
-      (m_option m_expr) a2 b2 
+      m_expr a1 b1 >>= (fun () ->
+      (m_option m_expr) a2 b2
       ))
 
     | A.OtherStmt(a1, a2), B.OtherStmt(b1, b2) ->
-      m_other_stmt_operator a1 b1 >>= (fun () -> 
-      (m_list m_any) a2 b2 
+      m_other_stmt_operator a1 b1 >>= (fun () ->
+      (m_list m_any) a2 b2
       )
     | A.OtherStmtWithStmt(a1, a2, a3), B.OtherStmtWithStmt(b1, b2, b3) ->
-      m_other_stmt_with_stmt_operator a1 b1 >>= (fun () -> 
-      m_expr a2 b2 >>= (fun () -> 
-      m_stmt a3 b3 
+      m_other_stmt_with_stmt_operator a1 b1 >>= (fun () ->
+      m_expr a2 b2 >>= (fun () ->
+      m_stmt a3 b3
       ))
 
     | A.ExprStmt _, _  | A.DefStmt _, _  | A.DirectiveStmt _, _
@@ -1437,83 +1437,83 @@ and m_stmt a b =
 (*e: function [[Generic_vs_generic.m_stmt]] *)
 
 (*s: function [[Generic_vs_generic.m_for_header]] *)
-and m_for_header a b = 
+and m_for_header a b =
   match a, b with
   | A.ForClassic(a1, a2, a3), B.ForClassic(b1, b2, b3) ->
-    (m_list m_for_var_or_expr) a1 b1 >>= (fun () -> 
-    m_option m_expr a2 b2 >>= (fun () -> 
-    m_option m_expr a3 b3 
+    (m_list m_for_var_or_expr) a1 b1 >>= (fun () ->
+    m_option m_expr a2 b2 >>= (fun () ->
+    m_option m_expr a3 b3
     ))
   | A.ForEach(a1, at, a2), B.ForEach(b1, bt, b2) ->
-    m_pattern a1 b1 >>= (fun () -> 
-    m_tok at bt >>= (fun () -> 
-    m_expr a2 b2 
+    m_pattern a1 b1 >>= (fun () ->
+    m_tok at bt >>= (fun () ->
+    m_expr a2 b2
     ))
   | A.ForClassic _, _  | A.ForEach _, _
    -> fail ()
 (*e: function [[Generic_vs_generic.m_for_header]] *)
 
 (*s: function [[Generic_vs_generic.m_for_var_or_expr]] *)
-and m_for_var_or_expr a b = 
+and m_for_var_or_expr a b =
   match a, b with
   | A.ForInitVar(a1, a2), B.ForInitVar(b1, b2) ->
-    m_entity a1 b1 >>= (fun () -> 
-    m_variable_definition a2 b2 
+    m_entity a1 b1 >>= (fun () ->
+    m_variable_definition a2 b2
     )
   | A.ForInitExpr(a1), B.ForInitExpr(b1) ->
-    m_expr a1 b1 
+    m_expr a1 b1
   | A.ForInitVar _, _  | A.ForInitExpr _, _
    -> fail ()
 (*e: function [[Generic_vs_generic.m_for_var_or_expr]] *)
 
 (*s: function [[Generic_vs_generic.m_label]] *)
-and m_label a b = 
+and m_label a b =
   match a, b with
   (a, b) -> m_ident a b
 (*e: function [[Generic_vs_generic.m_label]] *)
 
 (*s: function [[Generic_vs_generic.m_catch]] *)
-and m_catch a b = 
+and m_catch a b =
   match a, b with
   | (at, a1, a2), (bt, b1, b2) ->
-    m_tok at bt >>= (fun () -> 
-    m_pattern a1 b1 >>= (fun () -> 
-    m_stmt a2 b2 
+    m_tok at bt >>= (fun () ->
+    m_pattern a1 b1 >>= (fun () ->
+    m_stmt a2 b2
      ))
 (*e: function [[Generic_vs_generic.m_catch]] *)
 
 (*s: function [[Generic_vs_generic.m_finally]] *)
-and m_finally a b = 
+and m_finally a b =
   match a, b with
-  ((at, a), (bt, b)) -> 
+  ((at, a), (bt, b)) ->
       m_tok at bt >>= (fun () ->
-      m_stmt a b 
+      m_stmt a b
       )
 (*e: function [[Generic_vs_generic.m_finally]] *)
 
 (*s: function [[Generic_vs_generic.m_case_and_body]] *)
-and m_case_and_body a b = 
+and m_case_and_body a b =
   match a, b with
   | (a1, a2), (b1, b2) ->
-    (m_list m_case) a1 b1 >>= (fun () -> 
-    m_stmt a2 b2 
+    (m_list m_case) a1 b1 >>= (fun () ->
+    m_stmt a2 b2
     )
 (*e: function [[Generic_vs_generic.m_case_and_body]] *)
 
 (*s: function [[Generic_vs_generic.m_case]] *)
-and m_case a b = 
+and m_case a b =
   match a, b with
   | A.Case(a0, a1), B.Case(b0, b1) ->
     m_tok a0 b0 >>= (fun () ->
-    m_pattern a1 b1 
+    m_pattern a1 b1
     )
   | A.CaseEqualExpr(a0, a1), B.CaseEqualExpr(b0, b1) ->
     m_tok a0 b0 >>= (fun () ->
-    m_expr a1 b1 
+    m_expr a1 b1
     )
   | A.Default a0, B.Default b0 ->
-    m_tok a0 b0 
-  | A.Case _, _  | A.Default _, _ | A.CaseEqualExpr _, _  
+    m_tok a0 b0
+  | A.Case _, _  | A.Default _, _ | A.CaseEqualExpr _, _
    -> fail ()
 (*e: function [[Generic_vs_generic.m_case]] *)
 
@@ -1531,7 +1531,7 @@ and m_other_stmt_with_stmt_operator = m_other_xxx
 (*****************************************************************************)
 
 (*s: function [[Generic_vs_generic.m_pattern]] *)
-and m_pattern a b = 
+and m_pattern a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_pattern()]] disjunction case *)
   (* equivalence: user-defined equivalence! *)
@@ -1540,9 +1540,9 @@ and m_pattern a b =
   (*e: [[Generic_vs_generic.m_pattern()]] disjunction case *)
   (*s: [[Generic_vs_generic.m_pattern()]] metavariable case *)
   (* metavar: *)
-  | A.PatId ((str,tok), _id_info), b2 
+  | A.PatId ((str,tok), _id_info), b2
      when MV.is_metavar_name str ->
-      (try 
+      (try
         let e2 = AST.pattern_to_expr b2 in
         envf (str, tok) (B.E (e2))
        (* this can happen with PatAs in exception handler in Python *)
@@ -1554,52 +1554,52 @@ and m_pattern a b =
   (* boilerplate *)
   (*s: [[Generic_vs_generic.m_pattern]] boilerplate cases *)
     | A.PatId(a1, a2), B.PatId(b1, b2) ->
-      m_ident a1 b1 >>= (fun () -> 
-      m_id_info a2 b2 
+      m_ident a1 b1 >>= (fun () ->
+      m_id_info a2 b2
       )
     | A.PatLiteral(a1), B.PatLiteral(b1) ->
-      m_literal a1 b1 
+      m_literal a1 b1
     | A.PatType(a1), B.PatType(b1) ->
-      m_type_ a1 b1 
+      m_type_ a1 b1
     | A.PatConstructor(a1, a2), B.PatConstructor(b1, b2) ->
-      m_name a1 b1 >>= (fun () -> 
-      (m_list m_pattern) a2 b2 
+      m_name a1 b1 >>= (fun () ->
+      (m_list m_pattern) a2 b2
       )
     | A.PatTuple(a1), B.PatTuple(b1) ->
-      (m_list m_pattern) a1 b1 
+      (m_list m_pattern) a1 b1
     | A.PatList(a1), B.PatList(b1) ->
-      m_bracket (m_list m_pattern) a1 b1 
+      m_bracket (m_list m_pattern) a1 b1
     | A.PatRecord(a1), B.PatRecord(b1) ->
-      m_bracket (m_list m_field_pattern) a1 b1 
+      m_bracket (m_list m_field_pattern) a1 b1
     | A.PatKeyVal(a1, a2), B.PatKeyVal(b1, b2) ->
-      m_pattern a1 b1 >>= (fun () -> 
-      m_pattern a2 b2 
+      m_pattern a1 b1 >>= (fun () ->
+      m_pattern a2 b2
       )
     | A.PatUnderscore(a1), B.PatUnderscore(b1) ->
-      m_tok a1 b1 
+      m_tok a1 b1
     | A.PatDisj(a1, a2), B.PatDisj(b1, b2) ->
-      m_pattern a1 b1 >>= (fun () -> 
-      m_pattern a2 b2 
+      m_pattern a1 b1 >>= (fun () ->
+      m_pattern a2 b2
       )
     | A.PatAs(a1, (a2, a3)), B.PatAs(b1, (b2, b3)) ->
-      m_pattern a1 b1 >>= (fun () -> 
+      m_pattern a1 b1 >>= (fun () ->
       m_ident_and_id_info_add_in_env_Expr (a2, a3) (b2, b3)
       )
     | A.PatTyped(a1, a2), B.PatTyped(b1, b2) ->
-      m_pattern a1 b1 >>= (fun () -> 
-      m_type_ a2 b2  
+      m_pattern a1 b1 >>= (fun () ->
+      m_type_ a2 b2
       )
     | A.PatVar(a1, a2), B.PatVar(b1, b2) ->
-      m_type_ a1 b1 >>= (fun () -> 
-      m_option m_ident_and_id_info_add_in_env_Expr a2 b2 
+      m_type_ a1 b1 >>= (fun () ->
+      m_option m_ident_and_id_info_add_in_env_Expr a2 b2
       )
     | A.PatWhen(a1, a2), B.PatWhen(b1, b2) ->
-      m_pattern a1 b1 >>= (fun () -> 
-      m_expr a2 b2 
+      m_pattern a1 b1 >>= (fun () ->
+      m_expr a2 b2
       )
     | A.OtherPat(a1, a2), B.OtherPat(b1, b2) ->
-      m_other_pattern_operator a1 b1 >>= (fun () -> 
-      (m_list m_any) a2 b2 
+      m_other_pattern_operator a1 b1 >>= (fun () ->
+      (m_list m_any) a2 b2
       )
     | A.PatId _, _  | A.PatLiteral _, _  | A.PatConstructor _, _
     | A.PatTuple _, _  | A.PatList _, _  | A.PatRecord _, _  | A.PatKeyVal _, _
@@ -1610,11 +1610,11 @@ and m_pattern a b =
 (*e: function [[Generic_vs_generic.m_pattern]] *)
 
 (*s: function [[Generic_vs_generic.m_field_pattern]] *)
-and m_field_pattern a b = 
+and m_field_pattern a b =
   match a, b with
   | (a1, a2), (b1, b2) ->
-    m_name a1 b1 >>= (fun () -> 
-    m_pattern a2 b2 
+    m_name a1 b1 >>= (fun () ->
+    m_pattern a2 b2
     )
 (*e: function [[Generic_vs_generic.m_field_pattern]] *)
 
@@ -1628,16 +1628,16 @@ and m_other_pattern_operator = m_other_xxx
 (*****************************************************************************)
 
 (*s: function [[Generic_vs_generic.m_definition]] *)
-and m_definition a b = 
+and m_definition a b =
   match a, b with
   | (a1, a2), (b1, b2) ->
-    m_entity a1 b1 >>= (fun () -> 
-    m_definition_kind a2 b2 
+    m_entity a1 b1 >>= (fun () ->
+    m_definition_kind a2 b2
     )
 (*e: function [[Generic_vs_generic.m_definition]] *)
 
 (*s: function [[Generic_vs_generic.m_entity]] *)
-and m_entity a b = 
+and m_entity a b =
   match a, b with
   (* bugfix: when we use a metavar to match an entity, as in $X(...): ...
    * and later we use $X again to match a name, the $X is first an ident and
@@ -1645,34 +1645,34 @@ and m_entity a b =
    * make $X an expression early on
    *)
   { A. name = a1; attrs = a2; tparams = a4; info = a5 },
-  { B. name = b1; attrs = b2; tparams = b4; info = b5 } -> 
+  { B. name = b1; attrs = b2; tparams = b4; info = b5 } ->
     m_ident_and_id_info_add_in_env_Expr (a1, a5) (b1, b5) >>= (fun () ->
-    (m_list__m_attribute) a2 b2 >>= (fun () -> 
-    (m_list m_type_parameter) a4 b4 
+    (m_list__m_attribute) a2 b2 >>= (fun () ->
+    (m_list m_type_parameter) a4 b4
     ))
 (*e: function [[Generic_vs_generic.m_entity]] *)
 
 (*s: function [[Generic_vs_generic.m_definition_kind]] *)
-and m_definition_kind a b = 
+and m_definition_kind a b =
   match a, b with
   (* boilerplate *)
   | A.FuncDef(a1), B.FuncDef(b1) ->
-    m_function_definition a1 b1 
+    m_function_definition a1 b1
   | A.VarDef(a1), B.VarDef(b1) ->
-    m_variable_definition a1 b1 
+    m_variable_definition a1 b1
   | A.ClassDef(a1), B.ClassDef(b1) ->
-    m_class_definition a1 b1 
+    m_class_definition a1 b1
   (*s: [[Generic_vs_generic.m_definition_kind]] boilerplate cases *)
   | A.TypeDef(a1), B.TypeDef(b1) ->
-    m_type_definition a1 b1 
+    m_type_definition a1 b1
   | A.ModuleDef(a1), B.ModuleDef(b1) ->
-    m_module_definition a1 b1 
+    m_module_definition a1 b1
   | A.MacroDef(a1), B.MacroDef(b1) ->
-    m_macro_definition a1 b1 
+    m_macro_definition a1 b1
   | A.Signature(a1), B.Signature(b1) ->
-    m_type_ a1 b1 
+    m_type_ a1 b1
   | A.UseOuterDecl a1, B.UseOuterDecl b1 ->
-    m_tok a1 b1 
+    m_tok a1 b1
   | A.FuncDef _, _ | A.VarDef _, _  | A.ClassDef _, _  | A.TypeDef _, _
   | A.ModuleDef _, _  | A.MacroDef _, _  | A.Signature _, _
   | A.UseOuterDecl _, _
@@ -1681,24 +1681,24 @@ and m_definition_kind a b =
 (*e: function [[Generic_vs_generic.m_definition_kind]] *)
 
 (*s: function [[Generic_vs_generic.m_type_parameter_constraint]] *)
-and m_type_parameter_constraint a b = 
+and m_type_parameter_constraint a b =
   match a, b with
   | A.Extends(a1), B.Extends(b1) ->
-    m_type_ a1 b1 
+    m_type_ a1 b1
 (*e: function [[Generic_vs_generic.m_type_parameter_constraint]] *)
 
 (*s: function [[Generic_vs_generic.m_type_parameter_constraints]] *)
-and m_type_parameter_constraints a b = 
+and m_type_parameter_constraints a b =
   match a, b with
   (a, b) -> (m_list m_type_parameter_constraint) a b
 (*e: function [[Generic_vs_generic.m_type_parameter_constraints]] *)
 
 (*s: function [[Generic_vs_generic.m_type_parameter]] *)
-and m_type_parameter a b = 
+and m_type_parameter a b =
   match a, b with
   | (a1, a2), (b1, b2) ->
-    m_ident a1 b1 >>= (fun () -> 
-    m_type_parameter_constraints a2 b2 
+    m_ident a1 b1 >>= (fun () ->
+    m_type_parameter_constraints a2 b2
     )
 (*e: function [[Generic_vs_generic.m_type_parameter]] *)
 
@@ -1708,40 +1708,40 @@ and m_type_parameter a b =
 (* ------------------------------------------------------------------------- *)
 
 (*s: function [[Generic_vs_generic.m_function_definition]] *)
-and m_function_definition a b = 
+and m_function_definition a b =
   match a, b with
   { A. fparams = a1; frettype = a2; fbody = a3; },
-  { B. fparams = b1; frettype = b2; fbody = b3; } -> 
-    m_parameters a1 b1 >>= (fun () -> 
-    (m_option m_type_) a2 b2 >>= (fun () -> 
-    m_stmt a3 b3 
+  { B. fparams = b1; frettype = b2; fbody = b3; } ->
+    m_parameters a1 b1 >>= (fun () ->
+    (m_option m_type_) a2 b2 >>= (fun () ->
+    m_stmt a3 b3
     ))
 (*e: function [[Generic_vs_generic.m_function_definition]] *)
 
 (*s: function [[Generic_vs_generic.m_parameters]] *)
-and m_parameters a b = 
-  m_list_with_dots m_parameter 
+and m_parameters a b =
+  m_list_with_dots m_parameter
     (function A.ParamEllipsis _ -> true | _ -> false)
   false (* empty list can not match non-empty list *)
   a b
 (*e: function [[Generic_vs_generic.m_parameters]] *)
 
 (*s: function [[Generic_vs_generic.m_parameter]] *)
-and m_parameter a b = 
+and m_parameter a b =
   match a, b with
   (* boilerplate *)
   | A.ParamClassic(a1), B.ParamClassic(b1) ->
-    m_parameter_classic a1 b1 
+    m_parameter_classic a1 b1
   (*s: [[Generic_vs_generic.m_parameter]] boilerplate cases *)
   | A.ParamPattern(a1), B.ParamPattern(b1) ->
-    m_pattern a1 b1 
+    m_pattern a1 b1
   | A.OtherParam(a1, a2), B.OtherParam(b1, b2) ->
-    m_other_parameter_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_parameter_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.ParamEllipsis(a1), B.ParamEllipsis(b1) ->
-    m_tok a1 b1 
-  | A.ParamClassic _, _  | A.ParamPattern _, _  
+    m_tok a1 b1
+  | A.ParamClassic _, _  | A.ParamPattern _, _
   | A.ParamEllipsis _, _
   | A.OtherParam _, _
    -> fail ()
@@ -1749,7 +1749,7 @@ and m_parameter a b =
 (*e: function [[Generic_vs_generic.m_parameter]] *)
 
 (*s: function [[Generic_vs_generic.m_parameter_classic]] *)
-and m_parameter_classic a b = 
+and m_parameter_classic a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_parameter_classic]] metavariable case *)
   (* bugfix: when we use a metavar to match a parameter, as in foo($X): ...
@@ -1760,22 +1760,22 @@ and m_parameter_classic a b =
 
   | { A. pname = Some a1; pdefault = a2; ptype = a3; pattrs = a4; pinfo = a5 },
     { B. pname = Some b1; pdefault = b2; ptype = b3; pattrs = b4; pinfo = b5 }
-    -> 
+    ->
      m_ident_and_id_info_add_in_env_Expr (a1, a5) (b1, b5) >>= (fun () ->
-     (m_option m_expr) a2 b2 >>= (fun () -> 
-     (m_option_none_can_match_some m_type_) a3 b3 >>= (fun () -> 
-     (m_list__m_attribute) a4 b4 
+     (m_option m_expr) a2 b2 >>= (fun () ->
+     (m_option_none_can_match_some m_type_) a3 b3 >>= (fun () ->
+     (m_list__m_attribute) a4 b4
      )))
   (*e: [[Generic_vs_generic.m_parameter_classic]] metavariable case *)
 
   (* boilerplate *)
   | { A. pname = a1; pdefault = a2; ptype = a3; pattrs = a4; pinfo = a5 },
-    { B. pname = b1; pdefault = b2; ptype = b3; pattrs = b4; pinfo = b5 } -> 
-    (m_option m_ident) a1 b1 >>= (fun () -> 
-    (m_option m_expr) a2 b2 >>= (fun () -> 
-    (m_option m_type_) a3 b3 >>= (fun () -> 
-    (m_list__m_attribute) a4 b4 >>= (fun () -> 
-    m_id_info a5 b5 
+    { B. pname = b1; pdefault = b2; ptype = b3; pattrs = b4; pinfo = b5 } ->
+    (m_option m_ident) a1 b1 >>= (fun () ->
+    (m_option m_expr) a2 b2 >>= (fun () ->
+    (m_option m_type_) a3 b3 >>= (fun () ->
+    (m_list__m_attribute) a4 b4 >>= (fun () ->
+    m_id_info a5 b5
     ))))
 (*e: function [[Generic_vs_generic.m_parameter_classic]] *)
 
@@ -1789,13 +1789,13 @@ and m_other_parameter_operator = m_other_xxx
 (* ------------------------------------------------------------------------- *)
 
 (*s: function [[Generic_vs_generic.m_variable_definition]] *)
-and m_variable_definition a b = 
+and m_variable_definition a b =
   match a, b with
   (* boilerplate *)
   { A. vinit = a1; vtype = a2; },
-  { B. vinit = b1; vtype = b2; } -> 
-    (m_option m_expr) a1 b1 >>= (fun () -> 
-    (m_option m_type_) a2 b2 
+  { B. vinit = b1; vtype = b2; } ->
+    (m_option m_expr) a1 b1 >>= (fun () ->
+    (m_option m_type_) a2 b2
     )
 (*e: function [[Generic_vs_generic.m_variable_definition]] *)
 
@@ -1824,7 +1824,7 @@ and m_list__m_field (xsa: A.field list) (xsb: A.field list) =
   (* less-is-ok:
    * it's ok to have fields after in the concrete code as long as we
    * matched all the fields in the pattern?
-   * TODO? should we impose to use '...' if you allow extra fields? 
+   * TODO? should we impose to use '...' if you allow extra fields?
    * TODO: sgrep_generic though then displays the whole sequence as a match
    * instead of just the relevant part.
    *)
@@ -1860,9 +1860,9 @@ and m_list__m_field (xsa: A.field list) (xsb: A.field list) =
         aux candidates
      (*e: [[Generic_vs_generic.m_list__m_field()]] in [[DefStmt]] case if metavar field *)
      else
-      (try 
+      (try
         let (before, there, after) = xsb |> Common2.split_when (function
-            | (A.FieldStmt (A.DefStmt ({B.name = (s2, _tok); _}, _))) 
+            | (A.FieldStmt (A.DefStmt ({B.name = (s2, _tok); _}, _)))
                 when s2 = s1 -> true
             | _ -> false
         ) in
@@ -1879,27 +1879,27 @@ and m_list__m_field (xsa: A.field list) (xsb: A.field list) =
   (* the general case *)
   | xa::aas, xb::bbs ->
       m_field xa xb >>= (fun () ->
-      m_list__m_field aas bbs 
+      m_list__m_field aas bbs
       )
   | _::_, _ ->
       fail ()
 (*e: function [[Generic_vs_generic.m_list__m_field]] *)
 
 (*s: function [[Generic_vs_generic.m_field]] *)
-and m_field a b = 
+and m_field a b =
   match a, b with
   (* boilerplate *)
   | A.FieldStmt(a1), B.FieldStmt(b1) ->
-    m_stmt a1 b1 
+    m_stmt a1 b1
   (*s: [[Generic_vs_generic.m_field]] boilerplate cases *)
   | A.FieldDynamic(a1, a2, a3), B.FieldDynamic(b1, b2, b3) ->
-    m_expr a1 b1 >>= (fun () -> 
-    (m_list__m_attribute) a2 b2 >>= (fun () -> 
-    m_expr a3 b3 
+    m_expr a1 b1 >>= (fun () ->
+    (m_list__m_attribute) a2 b2 >>= (fun () ->
+    m_expr a3 b3
     ))
   | A.FieldSpread(a0, a1), B.FieldSpread(b0, b1) ->
     m_tok a0 b0 >>= (fun () ->
-    m_expr a1 b1 
+    m_expr a1 b1
     )
   | A.FieldDynamic _, _
   | A.FieldSpread _, _ | A.FieldStmt _, _
@@ -1913,32 +1913,32 @@ and m_field a b =
 (* ------------------------------------------------------------------------- *)
 
 (*s: function [[Generic_vs_generic.m_type_definition]] *)
-and m_type_definition a b = 
+and m_type_definition a b =
   match a, b with
   { A. tbody = a1;},
-  { B. tbody = b1; } -> 
-    m_type_definition_kind a1 b1 
+  { B. tbody = b1; } ->
+    m_type_definition_kind a1 b1
 (*e: function [[Generic_vs_generic.m_type_definition]] *)
 
 (*s: function [[Generic_vs_generic.m_type_definition_kind]] *)
-and m_type_definition_kind a b = 
+and m_type_definition_kind a b =
   match a, b with
   | A.OrType(a1), B.OrType(b1) ->
-    (m_list m_or_type) a1 b1 
+    (m_list m_or_type) a1 b1
   | A.AndType(a1), B.AndType(b1) ->
-    m_bracket (m_fields) a1 b1 
+    m_bracket (m_fields) a1 b1
   | A.AliasType(a1), B.AliasType(b1) ->
-    m_type_ a1 b1 
+    m_type_ a1 b1
   | A.NewType(a1), B.NewType(b1) ->
-    m_type_ a1 b1 
+    m_type_ a1 b1
   | A.Exception(a1, a2), B.Exception(b1, b2) ->
-    m_ident a1 b1 >>= (fun () -> 
+    m_ident a1 b1 >>= (fun () ->
     (* TODO: m_list__m_type_ ? *)
-    (m_list m_type_) a2 b2 
+    (m_list m_type_) a2 b2
     )
   | A.OtherTypeKind(a1, a2), B.OtherTypeKind(b1, b2) ->
-    m_other_type_kind_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_type_kind_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.OrType _, _ | A.AndType _, _ | A.AliasType _, _ | A.Exception _, _
   | A.NewType _, _
@@ -1947,24 +1947,24 @@ and m_type_definition_kind a b =
 (*e: function [[Generic_vs_generic.m_type_definition_kind]] *)
 
 (*s: function [[Generic_vs_generic.m_or_type]] *)
-and m_or_type a b = 
+and m_or_type a b =
   match a, b with
   | A.OrConstructor(a1, a2), B.OrConstructor(b1, b2) ->
-    (m_ident) a1 b1 >>= (fun () -> 
+    (m_ident) a1 b1 >>= (fun () ->
     (* TODO: m_list__m_type_ ? *)
-    (m_list m_type_) a2 b2 
+    (m_list m_type_) a2 b2
     )
   | A.OrEnum(a1, a2), B.OrEnum(b1, b2) ->
-    m_ident a1 b1 >>= (fun () -> 
-    m_option m_expr a2 b2 
+    m_ident a1 b1 >>= (fun () ->
+    m_option m_expr a2 b2
     )
   | A.OrUnion(a1, a2), B.OrUnion(b1, b2) ->
-    m_ident a1 b1 >>= (fun () -> 
-    (m_type_) a2 b2 
+    m_ident a1 b1 >>= (fun () ->
+    (m_type_) a2 b2
     )
   | A.OtherOr(a1, a2), B.OtherOr(b1, b2) ->
-    m_other_or_type_element_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_or_type_element_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.OrConstructor _, _ | A.OrEnum _, _ | A.OrUnion _, _ | A.OtherOr _, _
    -> fail ()
@@ -1982,7 +1982,7 @@ and m_other_or_type_element_operator = m_other_xxx
 and m_list__m_type_ (xsa: A.type_ list) (xsb: A.type_ list) =
   m_list_with_dots m_type_
    (* dots: '...', this is very Python Specific I think *)
-   (function 
+   (function
      | A.OtherType (A.OT_Arg, [A.Ar (A.Arg(A.Ellipsis _i))]) -> true
      | _ -> false
    )
@@ -1996,30 +1996,30 @@ and m_list__m_type_ (xsa: A.type_ list) (xsb: A.type_ list) =
 (* ------------------------------------------------------------------------- *)
 (* TODO: there are a few remaining m_list m_type_ we could transform
  * to use instead m_list__m_type_, for Exception, TyTuple and OrConstructor
- * but maybe quite different from list of types in inheritance 
+ * but maybe quite different from list of types in inheritance
  * TODO again like for m_list__m_field we should not care about the
  * order here.
  *)
 
 (*s: function [[Generic_vs_generic.m_class_definition]] *)
-and m_class_definition a b = 
+and m_class_definition a b =
   match a, b with
-  { A. ckind = a1; cextends = a2; cimplements = a3; cbody = a4; 
+  { A. ckind = a1; cextends = a2; cimplements = a3; cbody = a4;
       cmixins = a5;
     },
-  { B. ckind = b1; cextends = b2; cimplements = b3; cbody = b4; 
+  { B. ckind = b1; cextends = b2; cimplements = b3; cbody = b4;
       cmixins = b5;
-    } -> 
-    m_class_kind a1 b1 >>= (fun () -> 
-    (m_list__m_type_) a2 b2 >>= (fun () -> 
-    (m_list__m_type_) a3 b3 >>= (fun () -> 
-    (m_list__m_type_) a5 b5 >>= (fun () -> 
-    m_bracket (m_fields) a4 b4 
+    } ->
+    m_class_kind a1 b1 >>= (fun () ->
+    (m_list__m_type_) a2 b2 >>= (fun () ->
+    (m_list__m_type_) a3 b3 >>= (fun () ->
+    (m_list__m_type_) a5 b5 >>= (fun () ->
+    m_bracket (m_fields) a4 b4
     ))))
 (*e: function [[Generic_vs_generic.m_class_definition]] *)
 
 (*s: function [[Generic_vs_generic.m_class_kind]] *)
-and m_class_kind a b = 
+and m_class_kind a b =
   match a, b with
   | A.Class, B.Class ->
     return ()
@@ -2037,25 +2037,25 @@ and m_class_kind a b =
 (* ------------------------------------------------------------------------- *)
 
 (*s: function [[Generic_vs_generic.m_module_definition]] *)
-and m_module_definition a b = 
+and m_module_definition a b =
   match a, b with
   { A. mbody = a1; },
-  { B. mbody = b1; } -> 
-    m_module_definition_kind a1 b1 
+  { B. mbody = b1; } ->
+    m_module_definition_kind a1 b1
 (*e: function [[Generic_vs_generic.m_module_definition]] *)
 
 (*s: function [[Generic_vs_generic.m_module_definition_kind]] *)
-and m_module_definition_kind a b = 
+and m_module_definition_kind a b =
   match a, b with
   | A.ModuleAlias(a1), B.ModuleAlias(b1) ->
-    m_name a1 b1 
+    m_name a1 b1
   | A.ModuleStruct(a1, a2), B.ModuleStruct(b1, b2) ->
-    (m_option m_dotted_name) a1 b1 >>= (fun () -> 
-    (m_list m_item) a2 b2 
+    (m_option m_dotted_name) a1 b1 >>= (fun () ->
+    (m_list m_item) a2 b2
     )
   | A.OtherModule(a1, a2), B.OtherModule(b1, b2) ->
-    m_other_module_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_module_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.ModuleAlias _, _ | A.ModuleStruct _, _ | A.OtherModule _, _
    -> fail ()
@@ -2071,12 +2071,12 @@ and m_other_module_operator = m_other_xxx
 (* ------------------------------------------------------------------------- *)
 
 (*s: function [[Generic_vs_generic.m_macro_definition]] *)
-and m_macro_definition a b = 
+and m_macro_definition a b =
   match a, b with
   { A. macroparams = a1; macrobody = a2; },
-  { B. macroparams = b1; macrobody = b2; } -> 
-    (m_list m_ident) a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+  { B. macroparams = b1; macrobody = b2; } ->
+    (m_list m_ident) a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
 (*e: function [[Generic_vs_generic.m_macro_definition]] *)
 
@@ -2086,11 +2086,11 @@ and m_macro_definition a b =
 (*****************************************************************************)
 
 (*s: function [[Generic_vs_generic.m_directive]] *)
-and m_directive a b = 
+and m_directive a b =
   m_directive_basic a b >!> (fun () ->
     match a with
     (* normalize only if very simple import pattern (no alias) *)
-    | A.ImportFrom (_, _, _, None) | A.ImportAs (_, _, None) 
+    | A.ImportFrom (_, _, _, None) | A.ImportAs (_, _, None)
       ->
       (* equivalence: *)
       let normal_a = Normalize_generic.normalize_import_opt true a in
@@ -2098,7 +2098,7 @@ and m_directive a b =
       (match normal_a, normal_b with
       | Some (a0, a1), Some (b0, b1) ->
         m_tok a0 b0 >>= (fun () ->
-        m_module_name_prefix a1 b1 
+        m_module_name_prefix a1 b1
         )
       | _ -> fail ()
       )
@@ -2117,37 +2117,37 @@ and m_directive a b =
  * todo? not sure it makes sense to always allow m_module_name_prefix below
  *)
 (*s: function [[Generic_vs_generic.m_directive_basic]] *)
-and m_directive_basic a b = 
+and m_directive_basic a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_directive_basic]] import cases *)
   | A.ImportFrom(a0, a1, a2, a3), B.ImportFrom(b0, b1, b2, b3) ->
     m_tok a0 b0 >>= (fun () ->
-    m_module_name_prefix a1 b1 >>= (fun () -> 
-    m_ident a2 b2 >>= (fun () -> 
-    (m_option_none_can_match_some m_ident) a3 b3 
+    m_module_name_prefix a1 b1 >>= (fun () ->
+    m_ident a2 b2 >>= (fun () ->
+    (m_option_none_can_match_some m_ident) a3 b3
     )))
   | A.ImportAs(a0, a1, a2), B.ImportAs(b0, b1, b2) ->
     m_tok a0 b0 >>= (fun () ->
-    m_module_name_prefix a1 b1 >>= (fun () -> 
-    (m_option_none_can_match_some m_ident) a2 b2 
+    m_module_name_prefix a1 b1 >>= (fun () ->
+    (m_option_none_can_match_some m_ident) a2 b2
     ))
   | A.ImportAll(a0, a1, a2), B.ImportAll(b0, b1, b2) ->
     m_tok a0 b0 >>= (fun () ->
-    m_module_name_prefix a1 b1 >>= (fun () -> 
-    m_tok a2 b2 
+    m_module_name_prefix a1 b1 >>= (fun () ->
+    m_tok a2 b2
     ))
   (*e: [[Generic_vs_generic.m_directive_basic]] import cases *)
   (* boilerplate *)
   (*s: [[Generic_vs_generic.m_directive_basic]] boilerplate cases *)
   | A.Package(a0, a1), B.Package(b0, b1) ->
     m_tok a0 b0 >>= (fun () ->
-    m_dotted_name a1 b1 
+    m_dotted_name a1 b1
     )
   | A.PackageEnd a1, B.PackageEnd b1 ->
-      m_tok a1 b1 
+      m_tok a1 b1
   | A.OtherDirective(a1, a2), B.OtherDirective(b1, b2) ->
-    m_other_directive_operator a1 b1 >>= (fun () -> 
-    (m_list m_any) a2 b2 
+    m_other_directive_operator a1 b1 >>= (fun () ->
+    (m_list m_any) a2 b2
     )
   | A.ImportFrom _, _ | A.ImportAs _, _ | A.OtherDirective _, _
   | A.ImportAll _, _ | A.Package _, _ | A.PackageEnd _, _
@@ -2168,7 +2168,7 @@ and m_item a b = m_stmt a b
 (*e: function [[Generic_vs_generic.m_item]] *)
 
 (*s: function [[Generic_vs_generic.m_program]] *)
-and m_program a b = 
+and m_program a b =
   match a, b with
   (a, b) -> (m_list m_item) a b
 (*e: function [[Generic_vs_generic.m_program]] *)
@@ -2178,46 +2178,46 @@ and m_program a b =
 (*****************************************************************************)
 
 (*s: function [[Generic_vs_generic.m_any]] *)
-and m_any a b = 
+and m_any a b =
   match a, b with
   | A.Ss(a1), B.Ss(b1) ->
-    m_stmts_deep a1 b1 
+    m_stmts_deep a1 b1
   | A.E(a1), B.E(b1) ->
-    m_expr a1 b1 
+    m_expr a1 b1
   | A.S(a1), B.S(b1) ->
-    m_stmt a1 b1 
+    m_stmt a1 b1
   (* boilerplate *)
   (*s: [[Generic_vs_generic.m_any]] boilerplate cases *)
   | A.N(a1), B.N(b1) ->
-    m_name a1 b1 
+    m_name a1 b1
   | A.Tk(a1), B.Tk(b1) ->
-    m_tok a1 b1 
+    m_tok a1 b1
   | A.Di(a1), B.Di(b1) ->
-    m_dotted_name a1 b1 
+    m_dotted_name a1 b1
   | A.En(a1), B.En(b1) ->
-    m_entity a1 b1 
+    m_entity a1 b1
   | A.T(a1), B.T(b1) ->
-    m_type_ a1 b1 
+    m_type_ a1 b1
   | A.P(a1), B.P(b1) ->
-    m_pattern a1 b1 
+    m_pattern a1 b1
   | A.Def(a1), B.Def(b1) ->
-    m_definition a1 b1 
+    m_definition a1 b1
   | A.Dir(a1), B.Dir(b1) ->
-    m_directive a1 b1 
+    m_directive a1 b1
   | A.Fld(a1), B.Fld(b1) ->
-    m_field a1 b1 
+    m_field a1 b1
   | A.Pa(a1), B.Pa(b1) ->
-    m_parameter a1 b1 
+    m_parameter a1 b1
   | A.Ar(a1), B.Ar(b1) ->
-    m_argument a1 b1 
+    m_argument a1 b1
   | A.At(a1), B.At(b1) ->
-    m_attribute a1 b1 
+    m_attribute a1 b1
   | A.Dk(a1), B.Dk(b1) ->
-    m_definition_kind a1 b1 
+    m_definition_kind a1 b1
   | A.Pr(a1), B.Pr(b1) ->
-    m_program a1 b1 
+    m_program a1 b1
   | A.I(a1), B.I(b1) ->
-    m_ident a1 b1 
+    m_ident a1 b1
   | A.I _, _  | A.N _, _  | A.Di _, _  | A.En _, _  | A.E _, _
   | A.S _, _  | A.T _, _  | A.P _, _  | A.Def _, _  | A.Dir _, _
   | A.Pa _, _  | A.Ar _, _  | A.At _, _  | A.Dk _, _ | A.Pr _, _

--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -32,7 +32,7 @@ module Flag = Flag_semgrep
  *
  * todo:
  *  - factorize code in m_list__in_any_order at some point:
- *     * m_list__m_field 
+ *     * m_list__m_field
  *     * m_list__m_attribute
  *     * m_list__m_xml_attr
  *     * m_list__m_argument (harder)
@@ -44,32 +44,32 @@ module Flag = Flag_semgrep
 (*****************************************************************************)
 
 (* ------------------------------------------------------------------------*)
-(* Combinators history *) 
+(* Combinators history *)
 (* ------------------------------------------------------------------------*)
 (*
- * version0: 
+ * version0:
  *   type ('a, 'b) matcher = 'a -> 'b -> bool
- * 
+ *
  *   This just lets you know if you matched something.
- * 
+ *
  * version1:
  *   type ('a, 'b) matcher = 'a -> 'b -> unit -> ('a, 'b) option
- * 
+ *
  *   The Maybe monad.
- * 
+ *
  * version2:
  *   type ('a, 'b) matcher = 'a -> 'b -> binding -> binding list
- * 
+ *
  *   Why not returning a binding option ? because we need sometimes
  *   to return multiple possible bindings for one matching code.
  *   For instance with the pattern do 'f(..., $X, ...)', $X could be binded
  *   to different parts of the code.
- * 
+ *
  *   Note that the empty list means a match failure.
  *
  * version3:
  *   type ('a, 'b) matcher = 'a -> 'b -> tin -> ('a,'b) tout
- * 
+ *
  * version4: back to simpler
  *   type ('a, 'b) matcher = 'a -> 'b -> tin -> tout
  *)
@@ -92,7 +92,7 @@ type tout = tin list
  * represent a match between element A and B.
  *)
 (* currently 'a and 'b are usually the same type as we use the
- * same language for the host language and pattern language 
+ * same language for the host language and pattern language
  *)
 type ('a, 'b) matcher = 'a -> 'b -> tin -> tout
 (*e: type [[Matching_generic.matcher]] *)
@@ -106,7 +106,7 @@ type ('a, 'b) matcher = 'a -> 'b -> tin -> tout
 (* Debugging *)
 (*****************************************************************************)
 (*s: function [[Matching_generic.str_of_any]] *)
-let str_of_any any = 
+let str_of_any any =
   if !Flag.debug && !Flag.debug_with_full_position
   then Meta_parse_info._current_precision :=
     { Meta_parse_info.default_dumper_precision with Meta_parse_info.
@@ -143,13 +143,13 @@ let ((>>=):
   (unit -> (tin -> tout)) ->
   (tin -> tout)) = fun m1 m2 ->
   fun tin ->
-    (* let's get a list of possible environment match (could be 
+    (* let's get a list of possible environment match (could be
      * the empty list when it didn't match, playing the role None
      * had before)
      *)
     let xs = m1 tin in
     (* try m2 on each possible returned bindings *)
-    let xxs = xs |> List.map (fun binding -> 
+    let xxs = xs |> List.map (fun binding ->
       m2 () binding
     ) in
     List.flatten xxs
@@ -191,7 +191,7 @@ let (fail : tin -> tout) = fun _tin ->
   then failwith "Generic_vs_generic.fail: Match failure";
   []
 (*e: function [[Matching_generic.fail]] *)
-      
+
 (*****************************************************************************)
 (* Environment *)
 (*****************************************************************************)
@@ -204,8 +204,8 @@ let equal_ast_binded_code (a: AST.any) (b: AST.any) : bool =
   match a, b with
   | A.I _, A.I _
   | A.N _, A.N _
-  | A.E _, A.E _ 
-  | A.P _, A.P _ 
+  | A.E _, A.E _
+  | A.P _, A.P _
   | A.S _, A.S _
   | A.T _, A.T _
     ->
@@ -215,7 +215,7 @@ let equal_ast_binded_code (a: AST.any) (b: AST.any) : bool =
        * generic '=' OCaml operator as 'a' and 'b' may represent
        * the same code but they will contain leaves in their AST
        * with different position information. So before doing
-       * the comparison we just need to remove/abstract-away 
+       * the comparison we just need to remove/abstract-away
        * the line number information in each ASTs.
        *)
       let a = Lib.abstract_position_info_any a in
@@ -228,7 +228,7 @@ let equal_ast_binded_code (a: AST.any) (b: AST.any) : bool =
       end;
       res
 
-  | _, _ -> 
+  | _, _ ->
       false
 (*e: function [[Matching_generic.equal_ast_binded_code]] *)
 
@@ -255,13 +255,13 @@ let (envf: (MV.mvar AST.wrap, AST.any) matcher) =
   match check_and_add_metavar_binding (mvar, any) tin with
   | None ->
       (*s: [[Matching_generic.envf]] if [[verbose]] when fail *)
-      if !Flag.verbose 
+      if !Flag.verbose
       then pr2 (spf "envf: fail, %s (%s)" mvar (str_of_any any));
       (*e: [[Matching_generic.envf]] if [[verbose]] when fail *)
       fail tin
   | Some new_binding ->
       (*s: [[Matching_generic.envf]] if [[verbose]] when success *)
-      if !Flag.verbose 
+      if !Flag.verbose
       then pr2 (spf "envf: success, %s (%s)" mvar (str_of_any any));
       (*e: [[Matching_generic.envf]] if [[verbose]] when success *)
       return new_binding
@@ -277,7 +277,7 @@ let empty_environment () = []
 
 (*s: function [[Matching_generic.has_ellipsis_stmts]] *)
 (* guard for deep stmt matching *)
-let has_ellipsis_stmts xs = 
+let has_ellipsis_stmts xs =
   xs |> List.exists (function
     | A.ExprStmt (A.Ellipsis _) -> true
     | _ -> false
@@ -312,15 +312,15 @@ let is_regexp_string s =
  s =~ regexp_regexp_string
 (*e: function [[Matching_generic.is_regexp_string]] *)
 (*s: function [[Matching_generic.regexp_of_regexp_string]] *)
-let regexp_of_regexp_string s = 
+let regexp_of_regexp_string s =
   if s =~ regexp_regexp_string
-  then 
+  then
     let x = Common.matched1 s in
 (* TODO
       let rex = Pcre.regexp s in
       if Pcre.pmatch ~rex sb
 *)
-    Str.regexp x 
+    Str.regexp x
   else
     failwith (spf "This is not a regexp_string: " ^ s)
 (*e: function [[Matching_generic.regexp_of_regexp_string]] *)
@@ -337,7 +337,7 @@ let (m_option: ('a,'b) matcher -> ('a option,'b option) matcher) = fun f a b ->
   match a, b with
   | None, None -> return ()
   | Some xa, Some xb ->
-      f xa xb 
+      f xa xb
   | None, _
   | Some _, _
       -> fail ()
@@ -345,7 +345,7 @@ let (m_option: ('a,'b) matcher -> ('a option,'b option) matcher) = fun f a b ->
 
 (*s: function [[Matching_generic.m_option_ellipsis_ok]] *)
 (* dots: *)
-let m_option_ellipsis_ok f a b = 
+let m_option_ellipsis_ok f a b =
   match a, b with
   | None, None -> return ()
 
@@ -353,7 +353,7 @@ let m_option_ellipsis_ok f a b =
   | Some (A.Ellipsis _), None -> return ()
 
   | Some xa, Some xb ->
-      f xa xb 
+      f xa xb
   | None, _
   | Some _, _
       -> fail ()
@@ -367,7 +367,7 @@ let m_option_none_can_match_some f a b =
   | None, _ -> return ()
 
   | Some xa, Some xb ->
-      f xa xb 
+      f xa xb
   | Some _, _
       -> fail ()
 (*e: function [[Matching_generic.m_option_none_can_match_some]] *)
@@ -379,7 +379,7 @@ let m_option_none_can_match_some f a b =
 let (m_ref: ('a,'b) matcher -> ('a ref,'b ref) matcher) = fun f a b ->
   match a, b with
   { contents = xa}, { contents = xb} ->
-    f xa xb 
+    f xa xb
 (*e: function [[Matching_generic.m_ref]] *)
 
 (* ---------------------------------------------------------------------- *)
@@ -393,7 +393,7 @@ let rec m_list f a b =
       return ()
   | xa::aas, xb::bbs ->
       f xa xb >>= (fun () ->
-      m_list f aas bbs 
+      m_list f aas bbs
       )
   | [], _
   | _::_, _ ->
@@ -407,7 +407,7 @@ let rec m_list_prefix f a b =
       return ()
   | xa::aas, xb::bbs ->
       f xa xb >>= (fun () ->
-      m_list_prefix f aas bbs 
+      m_list_prefix f aas bbs
       )
   | [], _ -> return ()
   | _::_, _ ->
@@ -421,7 +421,7 @@ let rec m_list_with_dots f is_dots less_is_ok xsa xsb =
       return ()
   (*s: [[Matching_generic.m_list_with_dots()]]> empty list vs list case *)
   (* less-is-ok: empty list can sometimes match non-empty list *)
-  | [], _::_ when less_is_ok -> 
+  | [], _::_ when less_is_ok ->
     return ()
   (*e: [[Matching_generic.m_list_with_dots()]]> empty list vs list case *)
   (*s: [[Matching_generic.m_list_with_dots()]]> ellipsis cases *)
@@ -438,7 +438,7 @@ let rec m_list_with_dots f is_dots less_is_ok xsa xsb =
   (* the general case *)
   | xa::aas, xb::bbs ->
       f xa xb >>= (fun () ->
-      m_list_with_dots f is_dots less_is_ok aas bbs 
+      m_list_with_dots f is_dots less_is_ok aas bbs
       )
   | [], _
   | _::_, _ ->
@@ -450,12 +450,12 @@ let rec m_list_with_dots f is_dots less_is_ok xsa xsb =
 (* ---------------------------------------------------------------------- *)
 
 (*s: function [[Matching_generic.m_bool]] *)
-let m_bool a b = 
+let m_bool a b =
   if a = b then return () else fail ()
 (*e: function [[Matching_generic.m_bool]] *)
 
 (*s: function [[Matching_generic.m_int]] *)
-let m_int a b = 
+let m_int a b =
   if a =|= b then return () else fail ()
 (*e: function [[Matching_generic.m_int]] *)
 
@@ -499,12 +499,12 @@ let m_wrap f a b =
   match a, b with
   ((xaa, ainfo), (xbb, binfo)) ->
     f xaa xbb >>= (fun () ->
-    m_info ainfo binfo 
+    m_info ainfo binfo
     )
 (*e: function [[Matching_generic.m_wrap]] *)
 
 (*s: function [[Matching_generic.m_bracket]] *)
-let m_bracket f (a1, a2, a3) (b1, b2, b3) = 
+let m_bracket f (a1, a2, a3) (b1, b2, b3) =
    m_info a1 b1 >>= (fun () ->
    f a2 b2 >>= (fun () ->
    m_info a3 b3
@@ -516,7 +516,7 @@ let m_bracket f (a1, a2, a3) (b1, b2, b3) =
 (* ---------------------------------------------------------------------- *)
 
 (*s: function [[Matching_generic.m_other_xxx]] *)
-let m_other_xxx a b = 
+let m_other_xxx a b =
   match a, b with
   | a, b when a =*= b -> return ()
   | _ -> fail ()

--- a/semgrep-core/matching/Matching_generic.mli
+++ b/semgrep-core/matching/Matching_generic.mli
@@ -18,7 +18,7 @@ type tout = tin list
  * represent a match between element A and B.
  *)
 (* currently 'a and 'b are usually the same type as we use the
- * same language for the host language and pattern language 
+ * same language for the host language and pattern language
  *)
 type ('a, 'b) matcher = 'a -> 'b -> tin -> tout
 (*e: type [[Matching_generic.matcher]] *)

--- a/semgrep-core/matching/Normalize_generic.ml
+++ b/semgrep-core/matching/Normalize_generic.ml
@@ -39,18 +39,18 @@ open AST_generic
  *)
 
 let full_module_name is_pattern from_module_name import_opt =
-  match from_module_name, import_opt with 
-  | DottedName idents, Some (import_ident_name) -> 
+  match from_module_name, import_opt with
+  | DottedName idents, Some (import_ident_name) ->
       let new_module_name: dotted_ident = idents @ [import_ident_name] in
       Some (DottedName new_module_name)
-  | DottedName idents, None -> 
+  | DottedName idents, None ->
       Some (DottedName idents)
-  | FileName s, None -> 
+  | FileName s, None ->
       Some (FileName s)
-  | FileName s, _ when not is_pattern -> 
+  | FileName s, _ when not is_pattern ->
     (* bugfix: for languages such as JS, 'import x from "path"' should not
      * be converted in just "path". We should return None here as it
-     * does not make sense to allow this pattern to match 
+     * does not make sense to allow this pattern to match
      * import y from "path". Use just 'import "path"' if you just want
      * to check you vaguely imported a package.
      *)
@@ -63,9 +63,9 @@ let normalize_import_opt is_pattern i =
   match i with
   | ImportFrom(t, module_name, m, _alias_opt) ->
      full_module_name is_pattern module_name (Some m)>>= (fun x -> Some (t, x))
-  | ImportAs(t, module_name, _alias_opt) -> 
+  | ImportAs(t, module_name, _alias_opt) ->
      full_module_name is_pattern module_name None >>= (fun x -> Some (t, x))
-  | ImportAll(t, module_name, _t2) -> 
+  | ImportAll(t, module_name, _t2) ->
      full_module_name is_pattern module_name None >>= (fun x -> Some (t, x))
   | Package _
   | PackageEnd _
@@ -81,11 +81,11 @@ let rec eval x =
 
   | Call(IdSpecial((ArithOp(Plus | Concat) | ConcatString _), _), args)->
     let literals = args |> Common.map_filter (fun (arg) ->
-      match arg with 
+      match arg with
         | Arg e -> eval e
         | _ -> None
-    ) in 
-    let strs = literals |> Common.map_filter (fun (lit) -> 
+    ) in
+    let strs = literals |> Common.map_filter (fun (lit) ->
       match lit with
         | String (s1, _) -> Some s1
         | _ -> None

--- a/semgrep-core/matching/Normalize_generic.mli
+++ b/semgrep-core/matching/Normalize_generic.mli
@@ -1,8 +1,8 @@
 (*s: semgrep/matching/Normalize_generic.mli *)
 
 (*s: signature [[Normalize_generic.normalize_import_opt]] *)
-val normalize_import_opt: 
-  bool -> AST_generic.directive -> 
+val normalize_import_opt:
+  bool -> AST_generic.directive ->
   (AST_generic.tok * AST_generic.module_name) option
 (*e: signature [[Normalize_generic.normalize_import_opt]] *)
 

--- a/semgrep-core/matching/Semgrep_generic.ml
+++ b/semgrep-core/matching/Semgrep_generic.ml
@@ -8,7 +8,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -56,28 +56,28 @@ type ('a, 'b) matcher = 'a -> 'b ->
 (*****************************************************************************)
 (* Matchers *)
 (*****************************************************************************)
- 
+
 (*s: function [[Semgrep_generic.match_e_e]] *)
-let match_e_e pattern e = 
+let match_e_e pattern e =
   let env = Matching_generic.empty_environment () in
   GG.m_expr pattern e env
 (*e: function [[Semgrep_generic.match_e_e]] *)
 
 (*s: function [[Semgrep_generic.match_st_st]] *)
-let match_st_st pattern e = 
+let match_st_st pattern e =
   let env = Matching_generic.empty_environment () in
   GG.m_stmt pattern e env
 (*e: function [[Semgrep_generic.match_st_st]] *)
 
 (*s: function [[Semgrep_generic.match_sts_sts]] *)
-let match_sts_sts pattern e = 
+let match_sts_sts pattern e =
   let env = Matching_generic.empty_environment () in
   GG.m_stmts_deep pattern e env
 (*e: function [[Semgrep_generic.match_sts_sts]] *)
 
 (*s: function [[Semgrep_generic.match_any_any]] *)
 (* for unit testing *)
-let match_any_any pattern e = 
+let match_any_any pattern e =
   let env = Matching_generic.empty_environment () in
   GG.m_any pattern e env
 (*e: function [[Semgrep_generic.match_any_any]] *)
@@ -99,16 +99,16 @@ let match_e_e_for_equivalences a b =
 (* Substituters *)
 (*****************************************************************************)
 (*s: function [[Semgrep_generic.subst_e]] *)
-let subst_e (bindings: MV.metavars_binding) e = 
+let subst_e (bindings: MV.metavars_binding) e =
   let visitor = M.mk_visitor { M.default_visitor with
-    M.kexpr = (fun (k, _) x -> 
+    M.kexpr = (fun (k, _) x ->
       match x with
       | AST.Id ((str,_tok), _id_info) when MV.is_metavar_name str ->
           (match List.assoc_opt str bindings with
-          | Some (AST.E e) -> 
+          | Some (AST.E e) ->
               (* less: abstract-line? *)
               e
-          | Some _ -> 
+          | Some _ ->
              failwith (spf "incompatible metavar: %s, was expecting an expr"
                       str)
           | None ->
@@ -117,7 +117,7 @@ let subst_e (bindings: MV.metavars_binding) e =
           )
       | _ -> k x
     );
-   } 
+   }
   in
   visitor.M.vexpr e
 (*e: function [[Semgrep_generic.subst_e]] *)
@@ -133,15 +133,15 @@ let apply_equivalences equivs any =
 
   equivs |> List.iter (fun {Eq. left; op; right; _ } ->
     match left, op, right with
-    | E l, Eq.Equiv, E r -> 
+    | E l, Eq.Equiv, E r ->
           Common.push (l, r) expr_rules;
           Common.push (r, l) expr_rules;
-    | E l, Eq.Imply, E r -> 
+    | E l, Eq.Imply, E r ->
           Common.push (l, r) expr_rules;
-    | S l, Eq.Equiv, S r -> 
+    | S l, Eq.Equiv, S r ->
           Common.push (l, r) stmt_rules;
           Common.push (r, l) stmt_rules;
-    | S l, Eq.Imply, S r -> 
+    | S l, Eq.Imply, S r ->
           Common.push (l, r) stmt_rules;
     | _ -> failwith "only expr and stmt equivalence patterns are supported"
   );
@@ -150,13 +150,13 @@ let apply_equivalences equivs any =
   let _stmt_rulesTODO = List.rev !stmt_rules in
 
   let visitor = M.mk_visitor { M.default_visitor with
-    M.kexpr = (fun (k, _) x -> 
+    M.kexpr = (fun (k, _) x ->
        (* transform the children *)
        let x' = k x in
 
        let rec aux xs =
          match xs with
-         | [] -> x' 
+         | [] -> x'
          | (l, r)::xs ->
            (* look for a match on original x, not x' *)
            let matches_with_env = match_e_e_for_equivalences l x in
@@ -194,7 +194,7 @@ let check2 ~hook rules equivs file lang ast =
 
   let matches = ref [] in
 
-  (* rewrite code, e.g., A != B is rewritten as !(A == B) 
+  (* rewrite code, e.g., A != B is rewritten as !(A == B)
    * update: this is less necessary once you have user-defined
    * code equivalences (see Equivalence.ml).
    *)
@@ -224,7 +224,7 @@ let check2 ~hook rules equivs file lang ast =
       (* this could be quite slow ... we match many sgrep patterns
        * against an expression recursively
        *)
-      !expr_rules |> List.iter (fun (pattern, rule) -> 
+      !expr_rules |> List.iter (fun (pattern, rule) ->
          let matches_with_env = match_e_e pattern x in
          if matches_with_env <> []
          then (* Found a match *)
@@ -242,7 +242,7 @@ let check2 ~hook rules equivs file lang ast =
     (*x: [[Semgrep_generic.check2()]] visitor fields *)
     (* mostly copy paste of expr code but with the _st functions *)
     V.kstmt = (fun (k, _) x ->
-      !stmt_rules |> List.iter (fun (pattern, rule) -> 
+      !stmt_rules |> List.iter (fun (pattern, rule) ->
          let matches_with_env = match_st_st pattern x in
          if matches_with_env <> []
          then (* Found a match *)
@@ -262,7 +262,7 @@ let check2 ~hook rules equivs file lang ast =
        * the pattern will filter lots of sequences so we need to do
        * the heavy stuff (e.g., handling '...' between statements) rarely.
        *)
-      !stmts_rules |> List.iter (fun (pattern, rule) -> 
+      !stmts_rules |> List.iter (fun (pattern, rule) ->
          let matches_with_env = match_sts_sts pattern x in
          if matches_with_env <> []
          then (* Found a match *)

--- a/semgrep-core/matching/Semgrep_generic.mli
+++ b/semgrep-core/matching/Semgrep_generic.mli
@@ -1,7 +1,7 @@
 (*s: semgrep/matching/Semgrep_generic.mli *)
 
 (*s: signature [[Semgrep_generic.check]] *)
-val check: 
+val check:
   hook:(Metavars_generic.metavars_binding -> Parse_info.t list Lazy.t -> unit)
   ->
   Rule.rules ->

--- a/semgrep-core/matching/Unit_matcher.ml
+++ b/semgrep-core/matching/Unit_matcher.ml
@@ -13,20 +13,20 @@ let unittest ~any_gen_of_string =
     (* spec: pattern string, code string, should_match boolean *)
     let triples = [
       (* right now any_gen_of_string use the Python sgrep_spatch_pattern
-       * parser so the syntax below must be valid Python code  
+       * parser so the syntax below must be valid Python code
        *)
 
       (* ------------ *)
-      (* spacing *)  
+      (* spacing *)
       (* ------------ *)
-   
+
       (* basic string-match of course *)
       "foo(1,2)", "foo(1,2)", true;
       "foo(1,3)", "foo(1,2)", false;
 
       (* matches even when space or newline differs *)
       "foo(1,2)", "foo(1,     2)", true;
-      "foo(1,2)", "foo(1,     
+      "foo(1,2)", "foo(1,
                         2)", true;
       (* matches even when have comments in the middle *)
       "foo(1,2)", "foo(1, #foo
@@ -141,7 +141,7 @@ let unittest ~any_gen_of_string =
     ]
     in
     triples |> List.iter (fun (spattern, scode, should_match) ->
-     try 
+     try
       let pattern = any_gen_of_string spattern in
       let code    = any_gen_of_string scode in
       let matches_with_env = Semgrep_generic.match_any_any pattern code in
@@ -153,7 +153,7 @@ let unittest ~any_gen_of_string =
         assert_bool (spf "pattern:|%s| should not match |%s" spattern scode)
           (matches_with_env = [])
      with
-      Parsing.Parse_error -> 
+      Parsing.Parse_error ->
               failwith (spf "problem parsing %s or %s" spattern scode)
     )
   )

--- a/semgrep-core/matching/Unit_matcher.mli
+++ b/semgrep-core/matching/Unit_matcher.mli
@@ -1,12 +1,12 @@
 (*s: semgrep/matching/Unit_matcher.mli *)
 
 (*s: signature [[Unit_matcher.unittest]] *)
-(* Returns the testsuite for this directory To be concatenated by 
- * the caller (e.g. in pfff/main_test.ml ) with other testsuites and 
- * run via OUnit.run_test_tt 
+(* Returns the testsuite for this directory To be concatenated by
+ * the caller (e.g. in pfff/main_test.ml ) with other testsuites and
+ * run via OUnit.run_test_tt
  *)
-val unittest: 
-  any_gen_of_string:(string -> AST_generic.any) -> 
+val unittest:
+  any_gen_of_string:(string -> AST_generic.any) ->
   OUnit.test
 (*e: signature [[Unit_matcher.unittest]] *)
 (*e: semgrep/matching/Unit_matcher.mli *)

--- a/semgrep-core/old/lang_php/flag_matcher_php.ml
+++ b/semgrep-core/old/lang_php/flag_matcher_php.ml
@@ -1,3 +1,2 @@
 
 let verbose = ref false
-

--- a/semgrep-core/old/lang_php/matching_php.ml
+++ b/semgrep-core/old/lang_php/matching_php.ml
@@ -6,7 +6,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -36,27 +36,27 @@ let pr2, _pr2_once = Common2.mk_pr2_wrappers Flag_matcher_php.verbose
 
 module XMATCH = struct
   (* ------------------------------------------------------------------------*)
-  (* Combinators history *) 
+  (* Combinators history *)
   (* ------------------------------------------------------------------------*)
   (*
-   * version0: 
+   * version0:
    *   type ('a, 'b) matcher = 'a -> 'b -> bool
-   * 
+   *
    *   This just lets you know if you matched something.
-   * 
+   *
    * version1:
    *   type ('a, 'b) matcher = 'a -> 'b -> unit -> ('a, 'b) option
-   * 
+   *
    *   The Maybe monad.
-   * 
+   *
    * version2:
    *   type ('a, 'b) matcher = 'a -> 'b -> binding -> binding list
-   * 
+   *
    *   Why not returning a binding option ? because I may need at some
    *   point to return multiple possible bindings for one matching code.
    *   For instance with the pattern do 'f(..., X, ...)', X could be binded
    *   to different parts of the code.
-   * 
+   *
    *   Note that the empty list means a match failure.
    *)
 
@@ -65,9 +65,9 @@ module XMATCH = struct
   type ('a, 'b) matcher = 'a -> 'b  -> tin -> ('a * 'b) tout
 
   let ((>>=):
-          (tin -> ('a * 'b) tout)  -> 
-          (('a * 'b) -> (tin -> ('c * 'd) tout)) -> 
-          (tin -> ('c * 'd) tout)) = 
+          (tin -> ('a * 'b) tout)  ->
+          (('a * 'b) -> (tin -> ('c * 'd) tout)) ->
+          (tin -> ('c * 'd) tout)) =
     fun m1 m2 ->
       fun tin ->
         (* old:
@@ -76,13 +76,13 @@ module XMATCH = struct
            | Some (a,b) ->
            m2 (a, b) tin
         *)
-        (* let's get a list of possible environment match (could be 
+        (* let's get a list of possible environment match (could be
          * the empty list when it didn't match, playing the role None
          * had before)
          *)
         let xs = m1 tin in
         (* try m2 on each possible returned bindings *)
-        let xxs = xs |> List.map (fun ((a,b), binding) -> 
+        let xxs = xs |> List.map (fun ((a,b), binding) ->
           m2 (a, b) binding
         ) in
         List.flatten xxs
@@ -98,17 +98,17 @@ module XMATCH = struct
     (* opti? use set instead of list *)
     m1 tin @ m2 tin
 
-           
+
   let return (a,b) = fun tin ->
     (* old: Some (a,b) *)
     [(a,b), tin]
-      
+
   let fail = fun _tin ->
     (* old: None *)
     []
 
   (* ------------------------------------------------------------------------*)
-  (* Environment *) 
+  (* Environment *)
   (* ------------------------------------------------------------------------*)
 
   (* pre: both 'a' and 'b' contains only regular PHP code. There is no
@@ -119,8 +119,8 @@ module XMATCH = struct
   let equal_ast_binded_code a b =
     match a, b with
     | Ast.Ident2 _, Ast.Ident2 _
-    | Ast.Expr _, Ast.Expr _ 
-    | Ast.XhpAttrValue _, Ast.XhpAttrValue _ 
+    | Ast.Expr _, Ast.Expr _
+    | Ast.XhpAttrValue _, Ast.XhpAttrValue _
     | Ast.Argument _, Ast.Argument _
       ->
         (* Note that because we want to retain the position information
@@ -129,16 +129,16 @@ module XMATCH = struct
          * generic '=' OCaml operator as 'a' and 'b' may represent
          * the same code but they will contain leaves in their AST
          * with different position information. So before doing
-         * the comparison we just need to remove/abstract-away 
+         * the comparison we just need to remove/abstract-away
          * the line number information in each ASTs.
-         * 
+         *
          * todo: optimize by caching the abstract_lined ?
          *)
         let a = Lib_parsing_php.abstract_position_info_any a in
         let b = Lib_parsing_php.abstract_position_info_any b in
         a =*= b
-        
-    | _, _ -> 
+
+    | _, _ ->
         false
 
   let check_and_add_metavar_binding((mvar:Metavars_php.mvar), valu) = fun tin ->
@@ -176,13 +176,13 @@ module XMATCH = struct
         pr2 (spf "envf2: success, %s" mvar);
         return ((mvar, imvar), (any1, any2)) new_binding
 
-  let tokenf a b = 
+  let tokenf a b =
     (* dont care about position, space/indent/comment isomorphism *)
     return (a, b)
 end
 
 (*****************************************************************************)
-(* Entry point  *) 
+(* Entry point  *)
 (*****************************************************************************)
 
 module MATCH  = Php_vs_php.PHP_VS_PHP (XMATCH)
@@ -194,17 +194,17 @@ let empty_environment () = []
 
 let (extract_bindings: 'a XMATCH.tout -> MV.metavars_binding list) = fun tout ->
   tout |> List.map (fun (_term, env) -> env)
-  
+
 (* todo: should maybe have a match_any_any *)
-let match_e_e pattern e = 
+let match_e_e pattern e =
   let env = empty_environment () in
   MATCH.m_expr pattern e env |> extract_bindings
 
-let match_st_st pattern e = 
+let match_st_st pattern e =
   let env = empty_environment () in
   MATCH.m_stmt pattern e env |> extract_bindings
 
-let match_xhp_xhp pattern e = 
+let match_xhp_xhp pattern e =
   let env = empty_environment () in
   MATCH.m_xhp_html pattern e env |> extract_bindings
 

--- a/semgrep-core/old/lang_php/matching_php.mli
+++ b/semgrep-core/old/lang_php/matching_php.mli
@@ -4,8 +4,8 @@
  * is empty (because your pattern didn't contain any metavariable for
  * instance).
  *)
-type ('a, 'b) matcher = 
-  'a -> 'b -> 
+type ('a, 'b) matcher =
+  'a -> 'b ->
   Metavars_php.metavars_binding list
 
 (* right now it does not do side effects on the first argument

--- a/semgrep-core/old/lang_php/metavars_php.ml
+++ b/semgrep-core/old/lang_php/metavars_php.ml
@@ -6,7 +6,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -30,38 +30,38 @@ module V = Visitor_php
 (* todo? could want to remember the position in the pattern of the metavar
  * for error reporting ? so use a 'string Ast_php.wrap' ?
  *)
-type mvar = string 
+type mvar = string
 
 type metavars_binding = (mvar, Cst_php.any) Common.assoc
 
 (* bugfix: don't forget \\b, otherwise a string like FBredirect would
  * match such regexp (the starting F) even if it's not a metavar at all.
- * 
+ *
  * examples: X, X1, X1_ILOVEPUPPIES
  *)
-let metavar_regexp_string = 
+let metavar_regexp_string =
   "\\b\\([A-Z][0-9]?\\(_[A-Z0-9]*\\)?\\)\\b"
 
 (* example: MANY_ARGS1 *)
-let metavar_manyargs_regexp_string = 
+let metavar_manyargs_regexp_string =
   "\\b\\(MANYARGS[0-9]?\\([_A-Z0-9]*\\)?\\)\\b"
 
 (* examples: $X *)
-let metavar_variable_regexp_string = 
+let metavar_variable_regexp_string =
   "\\(\\$[A-Z]\\)\\b"
 
-(* 
+(*
  * Hacks abusing existing PHP constructs to encode extra constructions.
  * One day we will have a pattern_php_ast.ml that mimics mostly
  * ast_php.ml and extends it with sgrep special constructs.
  *)
-let is_metavar_name s = 
+let is_metavar_name s =
   s =~ metavar_regexp_string
 
-let is_metavar_variable_name s = 
+let is_metavar_variable_name s =
   s =~ metavar_variable_regexp_string
 
-let is_metavar_manyargs_name s = 
+let is_metavar_manyargs_name s =
   s =~ metavar_manyargs_regexp_string
 
 (*****************************************************************************)

--- a/semgrep-core/old/lang_php/metavars_php.mli
+++ b/semgrep-core/old/lang_php/metavars_php.mli
@@ -1,5 +1,5 @@
 
-type mvar = string 
+type mvar = string
 
 type metavars_binding = (mvar, Cst_php.any) Common.assoc
 
@@ -10,7 +10,7 @@ val is_metavar_manyargs_name: string -> bool
 val metavar_regexp_string: string
 val metavar_variable_regexp_string: string
 
-(* will throw a Failure if the pattern contains some legacy code 
+(* will throw a Failure if the pattern contains some legacy code
  * (e.g. the old lvalue metavariables $V)
  *)
 val check_pattern: Cst_php.any -> Cst_php.any

--- a/semgrep-core/old/lang_php/php_vs_php.ml
+++ b/semgrep-core/old/lang_php/php_vs_php.ml
@@ -2515,7 +2515,7 @@ and m_hint_type a b =
       return (A.HintTypeConst(a1, a2, a3),
               B.HintTypeConst(b1, b2, b3)
       ))))
-  | A.HintVariadic (a1, a2), B.HintVariadic (b1, b2) -> 
+  | A.HintVariadic (a1, a2), B.HintVariadic (b1, b2) ->
     m_tok a1 b1 >>= (fun (a1, b1) ->
     m_option m_hint_type a2 b2 >>= (fun (a2, b2) ->
       return (

--- a/semgrep-core/old/lang_php/php_vs_php.mli
+++ b/semgrep-core/old/lang_php/php_vs_php.mli
@@ -2,19 +2,19 @@
 (* PHP vs PHP *)
 (*****************************************************************************)
 
-module type PARAM = 
-  sig 
+module type PARAM =
+  sig
     type tin
     type 'x tout
     type ('a, 'b) matcher = 'a -> 'b  -> tin -> ('a * 'b) tout
-    val (>>=): 
-      (tin -> ('a * 'b) tout)  -> 
-      ('a * 'b -> (tin -> ('c * 'd) tout)) -> 
+    val (>>=):
+      (tin -> ('a * 'b) tout)  ->
+      ('a * 'b -> (tin -> ('c * 'd) tout)) ->
       (tin -> ('c * 'd) tout)
 
-    val (>||>) : 
+    val (>||>) :
       (tin -> 'x tout) ->
-      (tin -> 'x tout) -> 
+      (tin -> 'x tout) ->
       (tin -> 'x tout)
 
     (* The classical monad combinators *)
@@ -34,7 +34,7 @@ module type PARAM =
     (* Environment manipulation. Extract info from tin, the "something" *)
     (* -------------------------------------------------------------------- *)
     val envf : (Metavars_php.mvar Cst_php.wrap, Cst_php.any) matcher
-    val envf2 : 
+    val envf2 :
       (Metavars_php.mvar Cst_php.wrap, Cst_php.any * Cst_php.any) matcher
   end
 
@@ -49,7 +49,7 @@ val case_sensitive: bool ref
 (*****************************************************************************)
 
 module PHP_VS_PHP :
-  functor (X : PARAM) -> 
+  functor (X : PARAM) ->
     sig
       type ('a, 'b) matcher = 'a -> 'b -> X.tin -> ('a * 'b) X.tout
 
@@ -58,7 +58,7 @@ module PHP_VS_PHP :
       val m_xhp_html : (Cst_php.xhp_html, Cst_php.xhp_html) matcher
       val m_hint_type : (Cst_php.hint_type, Cst_php.hint_type) matcher
 
-      (* there are far more functions in this functor but they 
-       * do not have to be exported 
+      (* there are far more functions in this functor but they
+       * do not have to be exported
        *)
     end

--- a/semgrep-core/old/lang_php/refactoring_code_php.ml
+++ b/semgrep-core/old/lang_php/refactoring_code_php.ml
@@ -34,7 +34,7 @@ let tok_pos_equal_refactor_pos tok refactoring_opt =
   | Some refactoring ->
     PI.line_of_info tok = refactoring.R.line &&
     PI.col_of_info tok = refactoring.R.col
-  
+
 let string_of_class_var_modifier modifiers =
   match modifiers with
   | NoModifiers _ -> "var"
@@ -50,7 +50,7 @@ let last_token_classes classnames =
     let any = Cst_php.Hint2 classname in
     let toks = Lib_parsing_php.ii_of_any any in
     Common2.list_last toks
-      
+
 (*****************************************************************************)
 (* Main entry point *)
 (*****************************************************************************)
@@ -227,22 +227,22 @@ let refactor refactorings (ast, tokens) =
                 failwith "no interface to remove"
               | Some (tok, interfaces) ->
                 (match interfaces with
-                | [Left classname] 
+                | [Left classname]
                   when Ast.str_of_class_name classname =$= interface ->
                   tok.PI.transfo <- PI.Remove;
-                  (Hint2 classname) 
-                  |> Lib_parsing_php.ii_of_any 
+                  (Hint2 classname)
+                  |> Lib_parsing_php.ii_of_any
                   |> List.iter (fun tok -> tok.PI.transfo <- PI.Remove);
                   was_modifed := true;
                 | xs ->
-                  let rec aux xs = 
+                  let rec aux xs =
                     match xs with
                     | [] -> failwith "no interface to remove"
-                    | Left classname::Right comma::_rest 
+                    | Left classname::Right comma::_rest
                     | Right comma::Left classname::_rest
                       when Ast.str_of_class_name classname =$= interface ->
-                        (Hint2 classname) 
-                        |> Lib_parsing_php.ii_of_any 
+                        (Hint2 classname)
+                        |> Lib_parsing_php.ii_of_any
                         |> List.iter (fun tok -> tok.PI.transfo <- PI.Remove);
                         comma.PI.transfo <- PI.Remove;
                         was_modifed := true;

--- a/semgrep-core/old/lang_php/refactoring_code_php.mli
+++ b/semgrep-core/old/lang_php/refactoring_code_php.mli
@@ -1,5 +1,5 @@
 
-val refactor: 
-  Refactoring_code.refactoring list -> 
-  Parse_php.program_with_comments -> 
+val refactor:
+  Refactoring_code.refactoring list ->
+  Parse_php.program_with_comments ->
   string

--- a/semgrep-core/old/lang_php/sgrep_php.ml
+++ b/semgrep-core/old/lang_php/sgrep_php.ml
@@ -6,7 +6,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -20,7 +20,7 @@ module V = Visitor_php
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* See https://github.com/facebook/pfff/wiki/Sgrep 
+(* See https://github.com/facebook/pfff/wiki/Sgrep
  *
  * todo? many things are easier in sgrep than in spatch. For instance
  * many isomorphisms are ok to do in sgrep but would result in badly
@@ -48,7 +48,7 @@ type pattern = Cst_php.any
 (* We can't have Flag_parsing_php.case_sensitive set to false here
  * because metavariables in sgrep patterns are in uppercase
  * and we don't want to lowercase them.
- * 
+ *
  * We actually can't use Flag_parsing_php.case_sensitive at all
  * because we also want the Foo() pattern to match foo() code
  * so we have anyway to do some case insensitive string
@@ -64,7 +64,7 @@ let parse str =
 (*****************************************************************************)
 
 let sgrep_ast ?(case_sensitive=false) ~hook pattern ast =
-  (* coupling: copy paste with lang_php/matcher/spatch_php.ml 
+  (* coupling: copy paste with lang_php/matcher/spatch_php.ml
    * coupling: copy paste with sgrep_lint
    *)
   let hook =
@@ -158,8 +158,8 @@ let sgrep_ast ?(case_sensitive=false) ~hook pattern ast =
   )
 
 let sgrep ?(case_sensitive=false) ~hook pattern file =
-  let ast = 
-    try 
+  let ast =
+    try
       Parse_php.parse_program file
     with Parse_php.Parse_error _err ->
       (* we usually do sgrep on a set of files or directories,
@@ -170,4 +170,3 @@ let sgrep ?(case_sensitive=false) ~hook pattern file =
       []
   in
   sgrep_ast ~case_sensitive ~hook pattern ast
-

--- a/semgrep-core/old/lang_php/sgrep_php.mli
+++ b/semgrep-core/old/lang_php/sgrep_php.mli
@@ -2,10 +2,10 @@
 (* but right now only Expr and Stmt are supported *)
 type pattern = Cst_php.any
 
-val parse: 
+val parse:
   string -> pattern
 
-val sgrep:   
+val sgrep:
   ?case_sensitive: bool ->
   hook:(Metavars_php.metavars_binding -> Cst_php.info list -> unit) ->
   Cst_php.any -> Common.filename -> unit

--- a/semgrep-core/old/lang_php/spatch_php.mli
+++ b/semgrep-core/old/lang_php/spatch_php.mli
@@ -2,12 +2,11 @@
 (* right now only Expr and Stmt are supported *)
 type pattern = Cst_php.any
 
-val parse: 
+val parse:
  Common.filename -> pattern
-val parse_string: 
+val parse_string:
  string -> pattern
 
-val spatch: 
+val spatch:
   ?case_sensitive: bool ->
   pattern -> Common.filename -> string option
-

--- a/semgrep-core/old/lang_php/transforming_php.mli
+++ b/semgrep-core/old/lang_php/transforming_php.mli
@@ -1,14 +1,14 @@
 
-type ('a, 'b) transformer = 
-  'a -> 'b -> 
+type ('a, 'b) transformer =
+  'a -> 'b ->
   Metavars_php.metavars_binding list
 
 (* this works by side effect on the second argument and its .transfo field *)
 val transform_e_e :
   Cst_php.expr -> Cst_php.expr -> Metavars_php.metavars_binding -> unit
-val transform_st_st : 
+val transform_st_st :
   Cst_php.stmt -> Cst_php.stmt  -> Metavars_php.metavars_binding -> unit
-val transform_xhp_xhp : 
+val transform_xhp_xhp :
   Cst_php.xhp_html -> Cst_php.xhp_html  -> Metavars_php.metavars_binding -> unit
 val transform_hint_hint :
   Cst_php.hint_type -> Cst_php.hint_type  -> Metavars_php.metavars_binding -> unit

--- a/semgrep-core/old/lang_php/unit_matcher_php.ml
+++ b/semgrep-core/old/lang_php/unit_matcher_php.ml
@@ -10,7 +10,7 @@ open Cst_php
 (* See https://github.com/facebook/pfff/wiki/Sgrep *)
 
 (* run by sgrep -test *)
-let sgrep_unittest = 
+let sgrep_unittest =
   "sgrep php" >::: [
 
   "sgrep features" >:: (fun () ->
@@ -18,7 +18,7 @@ let sgrep_unittest =
     let triples = [
 
       (* ------------ *)
-      (* spacing *)  
+      (* spacing *)
       (* ------------ *)
 
       (* basic string match of course *)
@@ -113,7 +113,7 @@ let sgrep_unittest =
       (* interaction of ... and trailing comma *)
       "foo(A, ...);", "foo(1);", true;
       "foo(A, ...);", "foo(1,);", true;
-  
+
       (* we want sgrep/spatch to be case insensitive, like PHP *)
       "foo(...);", "Foo(true);", true;
       "Foo(...);", "foo(true);", true;
@@ -134,23 +134,23 @@ let sgrep_unittest =
       (* ------------ *)
 
       (* order does not matter *)
-      "return <x:frag border=\"1\" foo=\"2\" ></x:frag>;", 
-      "return <x:frag foo=\"2\" border=\"1\" ></x:frag>;", 
+      "return <x:frag border=\"1\" foo=\"2\" ></x:frag>;",
+      "return <x:frag foo=\"2\" border=\"1\" ></x:frag>;",
       true;
-      "return <x:frag border=\"1\" foo=\"2\" ></x:frag>;", 
-      "return <x:frag foo=\"3\" border=\"1\" ></x:frag>;", 
+      "return <x:frag border=\"1\" foo=\"2\" ></x:frag>;",
+      "return <x:frag foo=\"3\" border=\"1\" ></x:frag>;",
       false;
 
       (* concrete code can have more fields *)
-      "return <x:frag border=\"1\"></x:frag>;", 
-      "return <x:frag foo=\"2\" border=\"1\" ></x:frag>;", 
+      "return <x:frag border=\"1\"></x:frag>;",
+      "return <x:frag foo=\"2\" border=\"1\" ></x:frag>;",
       true;
 
       "return <x:frag />;", "return <x:frag border=\"1\" />;", true;
 
       (* concrete code can have a body *)
-      "return <x:frag border=\"1\"></x:frag>;", 
-      "return <x:frag border=\"1\" >this is text</x:frag>;", 
+      "return <x:frag border=\"1\"></x:frag>;",
+      "return <x:frag border=\"1\" >this is text</x:frag>;",
       true;
 
       (* metavariable on xhp tag *)
@@ -171,8 +171,8 @@ let sgrep_unittest =
 *)
       (* TODO:
        *  Xhp should also match XhpSingleton or optional closing tag
-       * "return <x:frag></x:frag>;", "return <x:frag />;", true; 
-       * "return <x:frag></x:frag>;", "return <x:frag></>;", true; 
+       * "return <x:frag></x:frag>;", "return <x:frag />;", true;
+       * "return <x:frag></x:frag>;", "return <x:frag></>;", true;
        *)
     ] in
     triples |> List.iter (fun (spattern, scode, should_match) ->
@@ -235,7 +235,7 @@ let spatch_unittest =
 
     let testdir = Filename.concat Config_pfff.path "tests/php/spatch/" in
     let expfiles = Common2.glob (testdir ^ "*.exp") in
-  
+
     expfiles |> List.iter (fun expfile ->
       (* todo: this regexp should just be .*? but ocaml regexp do not
        * have the greedy feature :( Also note that expfile is a fullpath
@@ -245,16 +245,16 @@ let spatch_unittest =
         let (prefix, variant) = Common.matched2 expfile in
         let spatchfile = prefix ^ ".spatch" in
         let phpfile = prefix ^ variant ^ ".php" in
-        
+
         let pattern = Spatch_php.parse spatchfile in
-        let resopt = 
-          try Spatch_php.spatch pattern phpfile 
+        let resopt =
+          try Spatch_php.spatch pattern phpfile
           with Failure s ->
             assert_failure (spf "spatch on %s have resulted in exn = %s"
                                phpfile s)
         in
-        
-        let file_res = 
+
+        let file_res =
           match resopt with
           | None -> phpfile
           | Some s ->
@@ -266,11 +266,11 @@ let spatch_unittest =
         diff |> List.iter pr;
         if List.length diff > 1
         then assert_failure
-          (spf "spatch %s on %s should have resulted in %s" 
+          (spf "spatch %s on %s should have resulted in %s"
               (Filename.basename spatchfile)
               (Filename.basename phpfile)
               (Filename.basename expfile))
-      end 
+      end
       else failwith ("wrong format for expfile: " ^ expfile)
     )
   )
@@ -282,7 +282,7 @@ let refactoring_unittest =
   "refactoring php" >::: [
     "adding return type" >:: (fun () ->
     let file_content = "function foo() { }" in
-    let refactoring = Refactoring_code.AddReturnType "int", 
+    let refactoring = Refactoring_code.AddReturnType "int",
       Some { Refactoring_code.
         file = "";
         (* line 2 because tmp_php_file_from_string below add a leading
@@ -326,7 +326,7 @@ let refactoring_unittest =
    *)
   "adding return type and closure" >:: (fun () ->
     let file_content = "function foo() { $x = function() { }; }" in
-    let refactoring = Refactoring_code.AddReturnType "int", Some 
+    let refactoring = Refactoring_code.AddReturnType "int", Some
       { Refactoring_code.
         file = ""; line = 2; col = 9;
       }
@@ -371,7 +371,7 @@ class X {
     let ast_and_toks = Parse_php.ast_and_tokens file in
     let res = Refactoring_code_php.refactor [refactoring] ast_and_toks in
     assert_equal res "<?php\nclass X implements B, I { }";
-  );    
+  );
   "remove interface" >:: (fun () ->
     let file_content = "class X implements I { }" in
     let refactoring = Refactoring_code.RemoveInterface (Some "X", "I"), None in
@@ -402,12 +402,12 @@ let unparser_unittest =
     let file_content = "function foo() { $x = printf(\"%s %d\", ); }" in
     let file = Parse_php.tmp_php_file_from_string file_content in
     let (ast, toks) = Parse_php.ast_and_tokens file in
-    toks |> List.iter (fun tok -> 
+    toks |> List.iter (fun tok ->
       match tok with
       | Parser_php.TCPAR info when (Parse_info.str_of_info info = ")") ->
         info.Parse_info.transfo <- Parse_info.AddArgsBefore ["str"; "1"]
       | _ -> ());
-    let res = Unparse_php.string_of_program_with_comments_using_transfo 
+    let res = Unparse_php.string_of_program_with_comments_using_transfo
       (ast, toks) in
     assert_equal
       "<?php\nfunction foo(str, 1) { $x = printf(\"%s %d\", str, 1); }"
@@ -417,7 +417,7 @@ let unparser_unittest =
     let file_content = "$x = <div a=\"1\" b=\"2\">foo</div>;" in
     let file = Parse_php.tmp_php_file_from_string file_content in
     let (ast, toks) = Parse_php.ast_and_tokens file in
-    let res = Unparse_php.string_of_program_with_comments_using_transfo 
+    let res = Unparse_php.string_of_program_with_comments_using_transfo
       (ast, toks) in
     assert_equal
       "<?php\n$x = <div a=\"1\" b=\"2\">foo</div>;"
@@ -429,10 +429,10 @@ let unparser_unittest =
     let e = Parse_php.expr_of_string str in
     let str2 = Unparse_php.string_of_expr e in
     assert_equal str str2;
-  );      
+  );
 
  ]
-  
+
 (*****************************************************************************)
 (* Final suite *)
 (*****************************************************************************)

--- a/semgrep-core/old/lang_php/unit_matcher_php.mli
+++ b/semgrep-core/old/lang_php/unit_matcher_php.mli
@@ -1,7 +1,7 @@
 
-(* Returns the testsuite for matcher/. To be concatenated by 
- * the caller (e.g. in pfff/main_test.ml ) with other testsuites and 
- * run via OUnit.run_test_tt 
+(* Returns the testsuite for matcher/. To be concatenated by
+ * the caller (e.g. in pfff/main_test.ml ) with other testsuites and
+ * run via OUnit.run_test_tt
  *)
 val unittest: OUnit.test
 

--- a/semgrep-core/parsing/Parse_equivalences.ml
+++ b/semgrep-core/parsing/Parse_equivalences.ml
@@ -62,7 +62,7 @@ let parse file =
                  | x::_xs -> x
                in
                let left, op, right =
-                 let xs = Str.full_split 
+                 let xs = Str.full_split
                                 (Str.regexp "<==>\\|==>") str in
                  match xs with
                  | [Str.Text a; Str.Delim "<==>"; Str.Text b] ->
@@ -71,13 +71,13 @@ let parse file =
                     a, Eq.Imply, b
                  | _ -> error (spf "could not parse the equivalence: %s" str)
                in
-               let left = 
+               let left =
                  try Parse_generic.parse_pattern lang left
                  with exn ->
                   error (spf "could not parse the left pattern: %s (exn = %s)"
                             left (Common.exn_to_s exn))
                in
-               let right = 
+               let right =
                  try Parse_generic.parse_pattern lang right
                  with exn ->
                   error (spf "could not parse the right pattern: %s (exn = %s)"

--- a/semgrep-core/parsing/Parse_rules.ml
+++ b/semgrep-core/parsing/Parse_rules.ml
@@ -39,7 +39,7 @@ exception InvalidYamlException of string
 
 (*s: function [[Parse_rules.parse_severity]] *)
 (* also used in Parse_tainting_rules.ml *)
-let parse_severity ~id s = 
+let parse_severity ~id s =
   match s with
  | "ERROR" -> R.Error
  | "WARNING" -> R.Warning
@@ -52,12 +52,12 @@ let parse_pattern ~id ~lang pattern =
   (* todo? call Normalize_ast.normalize here? *)
   try Check_semgrep.parse_check_pattern lang pattern
   with exn ->
-   raise (InvalidPatternException (id, pattern, (Lang.string_of_lang lang), 
+   raise (InvalidPatternException (id, pattern, (Lang.string_of_lang lang),
           (Common.exn_to_s exn)))
 (*e: function [[Parse_rules.parse_pattern]] *)
 
 (*s: function [[Parse_rules.parse_languages]] *)
-let parse_languages ~id langs = 
+let parse_languages ~id langs =
   let languages = langs |> List.map (function
     | `String s ->
       (match Lang.lang_of_string_opt s with
@@ -65,7 +65,7 @@ let parse_languages ~id langs =
       | Some l -> l
       )
     | _ -> raise (InvalidRuleException (id, (spf "expecting a string for languages")))
-   ) 
+   )
   in
   let lang =
     match languages with

--- a/semgrep-core/parsing/Parse_tainting_rules.ml
+++ b/semgrep-core/parsing/Parse_tainting_rules.ml
@@ -25,7 +25,7 @@ open Parse_rules (* for the exns *)
 (*****************************************************************************)
 
 (*s: function [[Parse_tainting_rules.parse_patterns]] *)
-let parse_patterns ~id ~lang xs = 
+let parse_patterns ~id ~lang xs =
   xs |> List.map (function
    | `String s -> Parse_rules.parse_pattern ~id ~lang s
    | x ->
@@ -71,32 +71,32 @@ let parse file =
 
             (* ugly: use sort so id/languages are before the source/sink/...
              * which need an id and lang set
-             *) 
+             *)
              xs |> Common.sort_by_key_lowfirst |> List.iter (fun x ->
                match x with
-               | "id", `String s -> 
+               | "id", `String s ->
                   id := Some s
                | "languages", `A langs ->
-                  let a, b = 
+                  let a, b =
                      Parse_rules.parse_languages ~id:(current_id()) langs
                   in
                   languages := Some a;
                   lang := Some b;
-               | "message", `String s -> 
+               | "message", `String s ->
                   message := s
-               | "severity", `String s -> 
-                  severity := Some 
+               | "severity", `String s ->
+                  severity := Some
                       (Parse_rules.parse_severity ~id:(current_id()) s)
                | "pattern-sources", `A xs ->
-                  sources := parse_patterns 
+                  sources := parse_patterns
                               ~id:(current_id()) ~lang:(current_lang()) xs
                | "pattern-sinks", `A xs ->
-                  sinks := parse_patterns 
+                  sinks := parse_patterns
                               ~id:(current_id()) ~lang:(current_lang()) xs
                | "pattern-sanitizers", `A xs ->
-                  sanitizers := parse_patterns 
+                  sanitizers := parse_patterns
                               ~id:(current_id()) ~lang:(current_lang()) xs
-               | x -> 
+               | x ->
                  pr2_gen x;
                  raise (InvalidYamlException "wrong rule field")
 
@@ -109,11 +109,11 @@ let parse file =
              let severity = match !severity with Some x -> x | None ->
                           raise Todo in
              let source = match !sources with _::_ -> !sources | [] ->
-                    raise Todo in 
+                    raise Todo in
              let sink = match !sinks with _::_ -> !sinks | [] ->
                     raise Todo in
              let sanitizer = !sanitizers in
-             { R.id; message; languages; severity; 
+             { R.id; message; languages; severity;
                 source; sink; sanitizer }
 
           | x ->

--- a/semgrep-core/reporting/JSON_report.ml
+++ b/semgrep-core/reporting/JSON_report.ml
@@ -103,7 +103,7 @@ let json_range min max =
 (*e: function [[JSON_report.json_range]] *)
 
 (*s: function [[JSON_report.range_of_any]] *)
-let range_of_any any = 
+let range_of_any any =
   let ii = Lib_AST.ii_of_any any in
   let ii = ii |> List.filter PI.is_origintok in
   let (min, max) = PI.min_max_ii_by_pos ii in
@@ -113,11 +113,11 @@ let range_of_any any =
 
 (*s: function [[JSON_report.json_metavar]] *)
 let json_metavar x startp (s, any) =
-  let (startp, endp) = 
-    try 
-      range_of_any any 
+  let (startp, endp) =
+    try
+      range_of_any any
     with Parse_info.NoTokenLocation exn ->
-     failwith (spf 
+     failwith (spf
       "NoTokenLocation %s exn while processing %s for rule %s, with metavar %s, close location = %s"
         exn x.file x.rule.R.id  s (Json_io.string_of_json startp))
   in
@@ -128,13 +128,13 @@ let json_metavar x startp (s, any) =
       any
       |> Lib_AST.ii_of_any |> List.filter PI.is_origintok
       |> List.sort Parse_info.compare_pos
-      |> List.map PI.str_of_info 
+      |> List.map PI.str_of_info
       |> Matching_report.join_with_space_if_needed
     );
   "unique_id", unique_id any
   ]
 (*e: function [[JSON_report.json_metavar]] *)
-  
+
 
 (*s: function [[JSON_report.match_to_json]] *)
 (* similar to pfff/h_program-lang/R2c.ml *)
@@ -157,7 +157,7 @@ let match_to_json x =
 (* Error *)
 (*****************************************************************************)
 (*s: function [[JSON_report.error]] *)
-(* this is used only in the testing code, to reuse the 
+(* this is used only in the testing code, to reuse the
  * Error_code.compare_actual_to_expected
  *)
 let error tok rule =
@@ -171,7 +171,7 @@ let error tok rule =
 (*e: function [[JSON_report.error]] *)
 
 (*s: function [[JSON_report.match_to_error]] *)
-let match_to_error x = 
+let match_to_error x =
   let toks = Lib_AST.ii_of_any x.code |> List.filter PI.is_origintok in
   let tok = List.hd toks in
   error tok x.rule

--- a/semgrep-core/reporting/Matching_report.ml
+++ b/semgrep-core/reporting/Matching_report.ml
@@ -7,7 +7,7 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
@@ -51,12 +51,12 @@ type match_format =
  * '$x = print FOO' would then be transformed into $x=printFOO, hence
  * this function
  *)
-let rec join_with_space_if_needed xs = 
+let rec join_with_space_if_needed xs =
   match xs with
   | [] -> ""
   | [x] -> x
   | x::y::xs ->
-      if x =~ ".*[a-zA-Z0-9_]$" && 
+      if x =~ ".*[a-zA-Z0-9_]$" &&
          y =~ "^[a-zA-Z0-9_]"
       then x ^ " " ^ (join_with_space_if_needed (y::xs))
       else x ^ (join_with_space_if_needed (y::xs))
@@ -66,15 +66,15 @@ let rec join_with_space_if_needed xs =
 (* Entry point *)
 (*****************************************************************************)
 (*s: function [[Matching_report.print_match]] *)
-let print_match ?(format = Normal) ii = 
+let print_match ?(format = Normal) ii =
  try
   let (mini, maxi) = PI.min_max_ii_by_pos ii in
-  let (file, line) = 
+  let (file, line) =
     PI.file_of_info mini, PI.line_of_info mini in
   let prefix = spf "%s:%d" file line in
   let arr = Common2.cat_array file in
   let lines = Common2.enum (PI.line_of_info mini) (PI.line_of_info maxi) in
-  
+
   (match format with
   | Normal ->
       pr prefix;
@@ -83,7 +83,7 @@ let print_match ?(format = Normal) ii =
   | Emacs ->
       pr (prefix ^ ": " ^ arr.(List.hd lines))
   | OneLine ->
-      pr (prefix ^ ": " ^ (ii |> List.map PI.str_of_info 
+      pr (prefix ^ ": " ^ (ii |> List.map PI.str_of_info
                             |> join_with_space_if_needed))
   )
  with Failure "get_pos: Ab or FakeTok" ->

--- a/semgrep-core/tainting/Tainting_generic.ml
+++ b/semgrep-core/tainting/Tainting_generic.ml
@@ -61,12 +61,12 @@ let match_pat_instr pat =
 
 
 (*s: function [[Tainting_generic.config_of_rule]] *)
-let config_of_rule found_tainted_sink rule = 
+let config_of_rule found_tainted_sink rule =
   { Dataflow_tainting.
     is_source = match_pat_instr rule.R.source;
     is_sanitizer = match_pat_instr rule.R.sanitizer;
     is_sink = match_pat_instr rule.R.sink;
-    
+
     found_tainted_sink;
   }
 (*e: function [[Tainting_generic.config_of_rule]] *)
@@ -81,7 +81,7 @@ let check2 rules file ast =
 
   let v = V.mk_visitor { V.default_visitor with
       V.kfunction_definition = (fun (_k, _) def ->
-          let xs = AST_to_IL.stmt def.AST.fbody in 
+          let xs = AST_to_IL.stmt def.AST.fbody in
           let flow = CFG_build.cfg_of_stmts xs in
 
           rules |> List.iter (fun rule ->

--- a/semgrep-core/tainting/Tainting_generic.mli
+++ b/semgrep-core/tainting/Tainting_generic.mli
@@ -1,6 +1,6 @@
 (*s: semgrep/tainting/Tainting_generic.mli *)
 (*s: signature [[Tainting_generic.check]] *)
-val check: 
+val check:
   Tainting_rule.rules ->  Common.filename -> AST_generic.program ->
   Match_result.t list
 (*e: signature [[Tainting_generic.check]] *)

--- a/semgrep-core/typing/Typechecking_generic.ml
+++ b/semgrep-core/typing/Typechecking_generic.ml
@@ -22,7 +22,7 @@ open AST_generic
 (*****************************************************************************)
 (* Poor's man typechecker on literals (for now).
  *
- * todo: 
+ * todo:
  *  - local type inference on AST generic? good coverage?
  *  - we could allow metavars on the type itself, as in
  *    foo($X: $T) ... $T x; ...


### PR DESCRIPTION
semgrep-core subdir was not being linted. This removes the ignores for this dir
and removes all the trailing whitespaces that were autofixed by pre-commit