### PR TITLE
Benchmark CI Job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,56 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    branches:
+      - "develop"
+      - "master"
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Incorporate Benchmark Data
+jobs:
+  benchmark-persist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+        # TODO: once the job is working, build semgrep-core from source
+      - name: Install semgrep-core from develop
+        run: sudo -E ./install-scripts/latest-artifact-for-branch.py
+        env:
+          SEMGREP_CORE: "y"
+          AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Retrieve the latest performance run
+        run: ./install-scripts/latest-artifact-for-branch.py
+        env:
+          AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCHMARK: "y"
+          # TODO: don't hardcode
+          BRANCH: "develop"
+          OUT_DIR: "semgrep/benchmarks"
+      - name: Previous benches
+        run: find semgrep/benchmarks
+      - name: Check status
+        run: ls -l
+      - name: Install Tox and any other packages
+        run: pip install pipenv==2018.11.26 wheel==0.34.2
+      - name: Install semgrep
+        run: |
+          cd semgrep
+          pipenv install --dev
+      - name: check semgrep
+        run: |
+          cd semgrep
+          pipenv run semgrep --version
+      - name: run benchmarks
+        run: |
+          cd semgrep
+          pipenv run pytest -k test_ci_perf tests/ --benchmark-only --benchmark-autosave --benchmark-storage benchmarks --benchmark-compare
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v1
+        with:
+          name: benchmarks
+          path: semgrep/benchmarks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
         run: sudo -E ./install-scripts/latest-artifact-for-branch.py
         env:
           AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMGREP_CORE: y
       - name: Install Tox and any other packages
         run: pip install pipenv==2018.11.26 wheel==0.34.2 tox==3.15.0
       - name: Run Tox

--- a/install-scripts/latest-artifact-for-branch.py
+++ b/install-scripts/latest-artifact-for-branch.py
@@ -7,6 +7,7 @@ import tempfile
 import urllib.request
 from pathlib import Path
 from shutil import copyfile
+from shutil import move
 from typing import Any
 from typing import List
 from typing import Optional
@@ -28,12 +29,13 @@ def download_json(url: str) -> Any:
     return json.load(urllib.request.urlopen(request))
 
 
-def get_latest_artifact_url(branch: str, workflow: str) -> Optional[str]:
+def get_latest_artifact_url(
+    branch: str, workflow: str, artifact_name: Optional[str]
+) -> Optional[str]:
     workflows = download_json("/actions/workflows")["workflows"]
     workflow_objs = [w for w in workflows if w["name"] == workflow]
     if not workflow_objs:
-        print(f'No workflow with name: "{workflow}"', file=sys.stderr)
-        sys.exit(1)
+        return None
     workflow_obj = workflow_objs[0]
 
     workflow_runs = download_json(f"/actions/workflows/{workflow_obj['id']}/runs")[
@@ -50,6 +52,10 @@ def get_latest_artifact_url(branch: str, workflow: str) -> Optional[str]:
     last_successful_run = successful_runs[0]
     print(f'Found a release from {last_successful_run["created_at"]}', file=sys.stderr)
     artifacts = download_json(last_successful_run["artifacts_url"])["artifacts"]
+    if artifact_name:
+        artifacts = [a for a in artifacts if a["name"].startswith(artifact_name)]
+    if not artifacts:
+        return None
     return str(artifacts[0]["archive_download_url"])
 
 
@@ -59,51 +65,95 @@ def make_executable(path: str) -> None:
     os.chmod(path, mode)
 
 
-def download_extract_install(url: str) -> None:
-    with tempfile.TemporaryDirectory() as tempdir:
-        request = urllib.request.Request(
-            url=url, headers={"authorization": f"Bearer {GITHUB_TOKEN}"}
-        )
-        response = urllib.request.urlopen(request)
-        with open("artifacts.zip", "wb") as tf:
-            tf.write(response.read())
-        with ZipFile(tf.name) as zf:
-            zf.extractall()
+def download_artifact(url: str) -> str:
+    tempdir = tempfile.mkdtemp()
+    request = urllib.request.Request(
+        url=url, headers={"authorization": f"Bearer {GITHUB_TOKEN}"}
+    )
+    response = urllib.request.urlopen(request)
+    with tempfile.TemporaryFile() as tf:
+        tf.write(response.read())
+        tf.flush()
+        with ZipFile(tf) as zf:
+            zf.extractall(path=tempdir)
             zf.close()
-        with tarfile.open("artifacts.tar.gz") as tar:
-            tar.extract("semgrep-files/semgrep-core", path=tempdir)
+    assert os.path.exists(tempdir)
+    return tempdir
 
-        binary_path = "/usr/local/bin/semgrep-core"
-        if not os.path.exists(binary_path):
-            copyfile(
-                Path(tempdir) / "semgrep-files" / "semgrep-core", binary_path,
-            )
-            make_executable(binary_path)
 
-        else:
-            print(
-                "Refusing to overwite existing file for semgrep-core!", file=sys.stderr
-            )
-            sys.exit(1)
+def install_semgrep_core(url: str) -> None:
+    tempdir = download_artifact(url)
+    with tarfile.open(Path(tempdir) / "artifacts.tar.gz") as tar:
+        tar.extract("semgrep-files/semgrep-core", path=tempdir)
+    binary_path = "/usr/local/bin/semgrep-core"
+    if not os.path.exists(binary_path):
+        copyfile(
+            Path(tempdir) / "semgrep-files" / "semgrep-core", binary_path,
+        )
+        make_executable(binary_path)
+
+    else:
+        print(
+            "Refusing to overwite existing file for semgrep-core!", file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def download_benchmarks(url: str, output: str) -> None:
+    tempdir = download_artifact(url)
+    assert os.path.exists(tempdir)
+    _mergedir(Path(tempdir), Path(output))
+
+
+def _mergedir(src: Path, target: Path) -> None:
+    if target.is_dir():
+        for path in os.listdir(src):
+            subtarget = target / path
+            if subtarget.exists():
+                _mergedir(src / path, target / path)
+            else:
+                move(str(src / path), target / path)
+    else:
+        print(f"Warning: duplicates files {target}", file=sys.stderr)
 
 
 if __name__ == "__main__":
     # If there is a HEAD_REF (this branch) use that.
     # Otherewise try to use the branch we're being merged into
     # if we're in a weird state, just use master
-    branch_options = [
-        os.environ.get("GITHUB_HEAD_REF"),
-        os.environ.get("GITHUB_BASE_REF"),
-        "develop",
-    ]
-    branches: List[str] = [b for b in branch_options if b]
-    workflow = os.environ.get("WORKFLOW", "release-ubuntu")
-    for branch in branches:
-        print(f"Downloading the semgrep-core binary for {branch}", file=sys.stderr)
-        url = get_latest_artifact_url(branch, workflow)
+    if os.environ.get("SEMGREP_CORE"):
+        branch_options = [
+            os.environ.get("GITHUB_HEAD_REF"),
+            os.environ.get("GITHUB_BASE_REF"),
+            "develop",
+        ]
+        branches: List[str] = [b for b in branch_options if b]
+        workflow = os.environ.get("WORKFLOW", "Tests")
+        for branch in branches:
+            print(f"Downloading the semgrep-core binary for {branch}", file=sys.stderr)
+            url = get_latest_artifact_url(branch, workflow, "semgrep-ubuntu")
+            if url is not None:
+                install_semgrep_core(url)
+                print(f"Installed prebuilt asset from {branch}", file=sys.stderr)
+                sys.exit(0)
+            else:
+                print(f"Tried {branch} but no prebuilt asset existed", file=sys.stderr)
+        print(
+            f"Could not find a semgrep-core asset on any of {branches}", file=sys.stderr
+        )
+        sys.exit(1)
+    elif os.environ.get("BENCHMARK"):
+        branch = os.environ["BRANCH"]
+        workflow = os.environ.get("WORKFLOW", "Incorporate Benchmark Data")
+        output = os.environ.get("OUT_DIR", "benchmarks")
+        url = get_latest_artifact_url(branch, workflow, None)
+        if not os.path.exists(output):
+            os.mkdir(output)
         if url is not None:
-            download_extract_install(url)
-            print(f"Installed prebuilt asset from {branch}", file=sys.stderr)
-            sys.exit(0)
+            download_benchmarks(url, output)
+            print(f"saved benchmark data to {output}", file=sys.stderr)
         else:
-            print(f"Tried {branch} but no prebuilt asset existed", file=sys.stderr)
+            print(f"No benchmark data found", file=sys.stderr)
+    else:
+        print("Nothing to do.", file=sys.stderr)
+        sys.exit(1)

--- a/semgrep/tests/performance/test_ci_perf.py
+++ b/semgrep/tests/performance/test_ci_perf.py
@@ -1,0 +1,47 @@
+import subprocess
+from typing import NamedTuple
+
+import pytest
+
+
+class RepoCase(NamedTuple):
+    url: str
+    sha: str
+    language: str
+
+    @property
+    def test_id(self):
+        return self.url.split("/")[-1]
+
+
+@pytest.mark.parametrize(
+    "repo_case",
+    [
+        # SHAs of May 6, 2020
+        # RepoCase("https://github.com/getsentry/sentry", "f25ea5dc", "python"),
+        RepoCase(
+            "https://github.com/coinbase/node-process-lock", "dd687bc", "javascript"
+        )
+    ],
+    ids=lambda case: case.test_id,
+)
+def test_default_packs(run_semgrep_in_tmp, benchmark, repo_case):
+    subprocess.check_output(["git", "clone", repo_case.url, "repo"])
+    subprocess.check_output(
+        ["git", "--git-dir", "repo/.git", "checkout", repo_case.sha]
+    )
+    benchmark(
+        subprocess.check_output,
+        [
+            "python3",
+            "-m",
+            "semgrep",
+            "--jobs",
+            "1",
+            "--pattern",
+            "$X = 156128578192758",
+            "--lang",
+            repo_case.language,
+            "repo",
+        ],
+    )


### PR DESCRIPTION
I kept the perf tests very simple intentionally for this PR -- a follow up PR will add a more comprehensive suite / incorporate what Bence has already written. The focus of this PR is to add a benchmark persistence and comparison workflow that:
1. Downloads the latest benchmark artifact from develop
2. Runs the benchmarks
3. Compares to the previous run of develop.
4. Upload the new benchmark artifact (which now contains 1 more file)

Building up a suite of benchmarks in one zip should make longitudinal comparison very straightforward. If it becomes a size problem eventually, we can split it up.