### PR TITLE
core_runner: Separate calls to semgrep-core per rule

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -297,11 +297,13 @@ class CoreRunner:
 
                     # group output; we want to see all of the same rule ids on the same file path
         return (
-            [
-                r
-                for r in evaluate(rule, outputs, self._allow_exec)
-                if rule.globs.match_path(r.path)
-            ],
+            dedup_output(
+                [
+                    r
+                    for r in evaluate(rule, outputs, self._allow_exec)
+                    if rule.globs.match_path(r.path)
+                ]
+            ),
             errors,
         )
 

--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
@@ -55,6 +55,23 @@
             "level": "error"
           },
           "fullDescription": {
+            "text": "possibly useless comparison but in eq function"
+          },
+          "id": "rules.assert-eqeq-is-ok",
+          "name": "rules.assert-eqeq-is-ok",
+          "properties": {
+            "precision": "very-high",
+            "tags": []
+          },
+          "shortDescription": {
+            "text": "possibly useless comparison but in eq function"
+          }
+        },
+        {
+          "defaultConfiguration": {
+            "level": "error"
+          },
+          "fullDescription": {
             "text": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
           },
           "id": "rules.eqeq-is-bad",
@@ -82,6 +99,23 @@
           },
           "shortDescription": {
             "text": "useless comparison"
+          }
+        },
+        {
+          "defaultConfiguration": {
+            "level": "error"
+          },
+          "fullDescription": {
+            "text": "this function is only available on Python 3.7+"
+          },
+          "id": "rules.python37-compatability-os-module",
+          "name": "rules.python37-compatability-os-module",
+          "properties": {
+            "precision": "very-high",
+            "tags": []
+          },
+          "shortDescription": {
+            "text": "this function is only available on Python 3.7+"
           }
         }
       ],

--- a/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
+++ b/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
@@ -2,7 +2,436 @@
   "errors": [],
   "results": [
     {
-      "check_id": "rules.directory-excluded-file-included",
+      "check_id": "rules.file-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.file-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.file-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.file-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/excluded.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/excluded.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-included",
       "end": {
         "col": 19,
         "line": 3
@@ -80,436 +509,7 @@
       }
     },
     {
-      "check_id": "rules.paths-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.paths-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.paths-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.paths-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/excluded.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/excluded.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-excluded",
+      "check_id": "rules.directory-excluded-file-included",
       "end": {
         "col": 19,
         "line": 3

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
@@ -1,2 +1,2 @@
-rules/syntax/bad2.yaml has invalid rule key {'pattern-inside'} at rule id eqeq-is-bad, can only have: {'pattern-either', 'metadata', 'severity', 'id', 'languages', 'pattern', 'equivalences', 'fix', 'patterns', 'message', 'pattern-regex'}
+rules/syntax/bad2.yaml has invalid rule key {'pattern-inside'} at rule id eqeq-is-bad, can only have: {'pattern', 'pattern-regex', 'id', 'fix', 'metadata', 'equivalences', 'languages', 'paths', 'severity', 'pattern-either', 'message', 'patterns'}
 run with --strict and there were 1 errors loading configs


### PR DESCRIPTION
The following tickets require either per rule running of semgrep-core or passing semgrep-core some orchestration datastructure that tells it which patterns to run on which files and which equivalences apply to those patterns.

https://github.com/returntocorp/semgrep/issues/862
https://github.com/returntocorp/semgrep/issues/831
https://github.com/returntocorp/semgrep/issues/674

Per rule calls to semgrep-core is much less complex but may incur a performance regression. Hopefully some intelligent AST caching in semgrep-core should be enough to minimize this.

TODO:
- [ ] semgrep-core accepts list of files
- [ ] semgrep-core caches AST between runs