### PR TITLE
Add benchmark job for PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
   build-test:
     name: semgrep-core make test and semgrep make test/qa-test
     runs-on: ubuntu-latest
-    container: returntocorp/sgrep-build:2.7
+    container: returntocorp/sgrep-build:2.8
     steps:
       - name: Adjust permissions
         run: sudo chmod -R 777 . /github
@@ -93,3 +93,60 @@ jobs:
         with:
           name: semgrep-${{ matrix.os }}-${{ github.sha }}
           path: artifacts.tar.gz
+
+  benchmark:
+    name: Benchmark PR
+    runs-on: ubuntu-latest
+    container: returntocorp/sgrep-build:2.8
+    steps:
+      - name: Adjust permissions
+        run: sudo chmod -R 777 . /github
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install submodules
+        run: git submodule update --init --recursive
+      - name: Retrieve the latest performance run
+        run: ./install-scripts/latest-artifact-for-branch.py
+        env:
+          AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCHMARK: "y"
+          BRANCH: "develop"
+          OUT_DIR: "semgrep/benchmarks"
+      - name: Install pfff
+        run: eval $(opam  env --root /home/opam/.opam --set-root) && opam install -y ./pfff
+      - name: Install semgrep-core
+        run: eval $(opam  env --root /home/opam/.opam --set-root) && cd semgrep-core && opam install --deps-only -y . && make all && make install
+      - name: Install bootstrapping packages for Python
+        run: |
+          export PATH=/github/home/.local/bin:$PATH
+          pip3 install pipenv==2018.11.26 wheel==0.34.2
+      - name: Install semgrep
+        run: |
+          cd semgrep
+          export PATH=/github/home/.local/bin:$PATH
+          pipenv install --dev
+      - name: check semgrep
+        run: |
+          cd semgrep
+          export PATH=/github/home/.local/bin:$PATH
+          pipenv run semgrep --version
+      - name: run benchmarks
+        run: |
+          cd semgrep
+          # TODO: figure out what checks we want to run on PRs
+          eval $(opam  env --root /home/opam/.opam --set-root)
+          export PATH=/github/home/.local/bin:$PATH
+          pipenv run pytest -k test_ci_perf tests/ --benchmark-min-rounds 1 --benchmark-only --benchmark-autosave --benchmark-storage benchmarks
+      - name: Compare to previous benchmark result
+        run: |
+          cd semgrep
+          eval $(opam  env --root /home/opam/.opam --set-root)
+          export PATH=/github/home/.local/bin:$PATH
+          pipenv run py.test-benchmark compare benchmarks/Linux-*/* --group-by name --sort name
+        # compare to previous runs, even if we had a timeout or a test failure
+        if: ${{ always() }}
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v1
+        with:
+          name: benchmarks
+          path: semgrep/benchmarks

--- a/install-scripts/Dockerfile.16.04
+++ b/install-scripts/Dockerfile.16.04
@@ -4,7 +4,7 @@ RUN test -n "$version"
 RUN apt-get update && apt-get install -y curl sudo ca-certificates --no-install-recommends \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-COPY ubuntu-16.04.sh ./install.sh
+COPY ubuntu-generic.sh ./install.sh
 RUN chmod +x install.sh
 COPY validate-install.sh ./validate-install.sh
 RUN chmod +x validate-install.sh


### PR DESCRIPTION
Runs the benchmark job on PR. As a next step, we'll want to make a Github comment with the benchmark results & maybe fail if the delta is too big? Both of these need a Python script to analyze the benchmark data which doesn't currently exist, but this gets us 80% of the way there.