### PR TITLE
Clean up CLI flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Next
 
 ### Fixed 
-
 - Support "print expr," in Python 2.X
 - Support "async" keyword on inner arrow functions for ECMAScript 7+
 - Support optional catch bindings for ECMAScript 2019+
 - Support non-ASCII Unicode whitespace code points as lexical whitespace in JavaScript code
 - Support assignment expressions in Python 3.8
+
+### Removed
+- `--exclude-tests` flag - prefer `--exclude` or `--exclude-dir`
+- `--r2c` flag - this was completely unused
 
 ## [0.8.1](https://github.com/returntocorp/semgrep/releases/tag/v0.8.1) - 2020-05-26
 

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -119,11 +119,6 @@ def cli() -> None:
     )
 
     config.add_argument(
-        "--exclude-tests",
-        action="store_true",
-        help="Exclude tests, documentation, and examples based on filename/path.",
-    )
-    config.add_argument(
         "--precommit", action="store_true", help=argparse.SUPPRESS,
     )
     config.add_argument(
@@ -181,11 +176,6 @@ def cli() -> None:
         "--test-ignore-todo",
         action="store_true",
         help="Ignore rules marked as '#todoruleid:' in test files.",
-    )
-    output.add_argument(
-        "--r2c",
-        action="store_true",
-        help="Output json in r2c platform format (https://app.r2c.dev).",
     )
     output.add_argument(
         "--dump-ast",
@@ -275,7 +265,6 @@ def cli() -> None:
                 include_dir=args.include_dir,
                 exclude=args.exclude,
                 exclude_dir=args.exclude_dir,
-                exclude_tests=args.exclude_tests,
                 json_format=args.json,
                 sarif=args.sarif,
                 output_destination=args.output,

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -200,13 +200,6 @@ def flatten_configs(transformed_configs: Dict[str, Any]) -> List[Rule]:
     ]
 
 
-def should_exclude_this_path(path: Path) -> bool:
-    """
-        Return true if "test" or "example" are anywhere in path
-    """
-    return any("test" in p or "example" in p for p in path.parts)
-
-
 def main(
     target: List[str],
     pattern: str,
@@ -219,7 +212,6 @@ def main(
     include_dir: List[str],
     exclude: List[str],
     exclude_dir: List[str],
-    exclude_tests: bool,
     json_format: bool,
     sarif: bool,
     output_destination: str,
@@ -281,23 +273,6 @@ def main(
         exclude_dir=exclude_dir,
         include_dir=include_dir,
     ).invoke_semgrep(targets, all_rules)
-
-    if exclude_tests:
-        ignored_in_tests = 0
-        filtered_findings_by_rule = {}
-        for rule, rule_matches in rule_matches_by_rule.items():
-            filtered = []
-            for rule_match in rule_matches:
-                if should_exclude_this_path(Path(rule_match.path)):
-                    ignored_in_tests += 1
-                else:
-                    filtered.append(rule_match)
-            filtered_findings_by_rule[rule] = filtered
-        rule_matches_by_rule = filtered_findings_by_rule
-        if ignored_in_tests > 0:
-            print_error(
-                f"warning: ignored {ignored_in_tests} results in tests due to --exclude-tests option"
-            )
 
     for finding in semgrep_errors:
         print_error(f"semgrep: {finding['path']}: {finding['check_id']}")

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -184,7 +184,6 @@ def invoke_semgrep(
             include_dir=[],
             exclude=[],
             exclude_dir=[],
-            exclude_tests=False,
             json_format=True,
             sarif=False,
             output_destination="",


### PR DESCRIPTION
The `--exclude-tests` flag predates `--exclude` and `--exclude-dir` but is pointless now that we have them. The following can be used in place of `--exclude-tests`: `--exclude-dir="*test*" --exclude-dir="*example*"`.

The `--r2c` flag is completely unused. I believe this was originally intended to output in Platform analyzer JSON format. Instead we should prefer to implement this logic in the analyzer image itself instead of bundling it with all `semgrep` installs, should the functionality ever be needed.