### PR TITLE
Support matching of qualified identifiers to imported entities

### DIFF
--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -358,6 +358,11 @@ and m_expr a b =
                          | B.ImportedModule (B.DottedName dotted)
                          ), _sid)}; _}) ->
     m_expr a (make_dotted dotted)
+  (* Put this before the next case to prevent overly eager dealiasing *)
+  | A.IdQualified(a1, a2), B.IdQualified(b1, b2) ->
+    m_name a1 b1 >>= (fun () ->
+    m_id_info a2 b2
+    )
   (* Matches pattern
    *   a.b.C.x
    * to code
@@ -505,10 +510,6 @@ and m_expr a b =
       return ())
     | A.AnonClass(a1), B.AnonClass(b1) ->
       m_class_definition a1 b1
-    | A.IdQualified(a1, a2), B.IdQualified(b1, b2) ->
-      m_name a1 b1 >>= (fun () ->
-      m_id_info a2 b2
-      )
     | A.IdSpecial(a1), B.IdSpecial(b1) ->
       m_wrap m_special a1 b1
 

--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -357,8 +357,16 @@ and m_expr a b =
       {contents = Some ( ( B.ImportedEntity dotted
                          | B.ImportedModule (B.DottedName dotted)
                          ), _sid)}; _}) ->
-
     m_expr a (make_dotted dotted)
+  (* Matches pattern
+   *   a.b.C.x
+   * to code
+   *   import a.b.C
+   *   C.x
+   *)
+  | A.IdQualified ((alabel, { A.name_qualifier = Some(names); _ }), _id_info), b ->
+    let full = names @ [alabel] in
+    m_expr (make_dotted full) b
   (*e: [[Generic_vs_generic.m_expr()]] resolving alias case *)
   (*s: [[Generic_vs_generic.m_expr()]] metavariable case *)
   (*s: [[Generic_vs_generic.m_expr()]] forbidden metavariable case *)

--- a/semgrep-core/tests/java/aliasing_qualified.java
+++ b/semgrep-core/tests/java/aliasing_qualified.java
@@ -1,0 +1,8 @@
+package testcode.crypto;
+
+import javax.crypto.Cipher;
+
+class Foo {
+    //ERROR:
+    Cipher c = Cipher.getInstance("DES/ECB/PKCS5Padding");
+}

--- a/semgrep-core/tests/java/aliasing_qualified.sgrep
+++ b/semgrep-core/tests/java/aliasing_qualified.sgrep
@@ -1,0 +1,1 @@
+javax.crypto.Cipher.getInstance("...");

--- a/semgrep-core/tests/java/id_qualified.java
+++ b/semgrep-core/tests/java/id_qualified.java
@@ -1,0 +1,11 @@
+class javax {
+  static class crypto {
+    static class Cipher {
+      public static Cipher getInstance(java.lang.String s) {
+        return new Cipher();
+      }
+    }
+  }
+  //ERROR:
+  javax.crypto.Cipher instance = javax.crypto.Cipher.getInstance("hi");
+}

--- a/semgrep-core/tests/java/id_qualified.sgrep
+++ b/semgrep-core/tests/java/id_qualified.sgrep
@@ -1,0 +1,1 @@
+javax.crypto.Cipher.getInstance("...");


### PR DESCRIPTION
In certain languages (viz., Java), a qualified pattern is parsed into an
IdQualified object, rather than an Id with a named_entity. In this case,
we want to match this qualified object to the latter.

A good example is contained in the accompanying test case.

Fixes #733.