### PR TITLE
Remove validation from BooleanRuleExpression

### DIFF
--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -71,35 +71,8 @@ class InvalidRuleSchema(BaseException):
 class BooleanRuleExpression:
     operator: Operator
     pattern_id: Optional[PatternId] = None
-    # This is a recursive member but mypy is a half-baked dumpster fire.
-    # https://github.com/python/mypy/issues/8320
-    children: Optional[List[Any]] = None
+    children: Optional[List["BooleanRuleExpression"]] = None
     operand: Optional[str] = None
-
-    def __attrs_post_init__(self) -> None:
-        self._validate()
-
-    def _validate(self) -> None:
-        if self.operator in set(OPERATORS_WITH_CHILDREN):
-            if self.operand is not None:
-                raise InvalidRuleSchema(
-                    f"operators `{pattern_names_for_operator(self.operator)}` cannot have operand but found {self.operand}"
-                )
-        else:
-            if self.children is not None:
-                raise InvalidRuleSchema(
-                    f"only {pattern_names_for_operators(OPERATORS_WITH_CHILDREN)} operators can have children, but found `{pattern_names_for_operator(self.operator)}` with children"
-                )
-
-            if self.operand is None:
-                raise InvalidRuleSchema(
-                    f"operators `{pattern_names_for_operator(self.operator)}` must have operand"
-                )
-            else:
-                if type(self.operand) != str:
-                    raise InvalidRuleSchema(
-                        f"operand of operators `{pattern_names_for_operator(self.operator)}` must have type string, but is {type(self.operand)}: {self.operand}"
-                    )
 
 
 def operator_for_pattern_name(pattern_name: str) -> Operator:

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.txt
@@ -1,2 +1,2 @@
-rules/syntax/bad3.yaml: inside rule id test-pattern, pattern fields can't look like this: operand of operators `['pattern']` must have type string, but is <class 'list'>: [{'pattern': '$D = {}'}]
+rules/syntax/bad3.yaml: inside rule id test-pattern, pattern fields can't look like this: type of `pattern` must be a string, but it was a list
 run with --strict and there were 1 errors loading configs


### PR DESCRIPTION
This is the first in a series of diffs to track spans in Rules while keeping them isolated from `BooleanRuleExpressions`.

1. (this PR): Remove validation from `BooleanRuleExpression` and move it to Rule. This will facilitate the subsequent diffs.
1. `Rule` will be span aware, and this will support construction of clear error messages during construction of `BooleanRuleExpressions`; structurally invalid boolean rule expressions will not be created anymore. 
2. We will maintain of mapping from `pattern_id => Span`. This will exist to give good errors on parse failure coming from semgrep-core. 
