### PR TITLE
Switch YAML parsing to Ruamel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     hooks:
       - id: check-yaml
         args: [--allow-multiple-documents]
+        exclude: ^semgrep/tests/.+$
       - id: end-of-file-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]

--- a/semgrep/Pipfile.lock
+++ b/semgrep/Pipfile.lock
@@ -51,28 +51,44 @@
             ],
             "version": "==2.9"
         },
-        "pyyaml": {
-            "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
-                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
-                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
-                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
-                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
-                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
-                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
-            ],
-            "version": "==5.3.1"
-        },
         "requests": {
             "hashes": [
                 "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
                 "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
             "version": "==2.23.0"
+        },
+        "ruamel.yaml": {
+            "hashes": [
+                "sha256:0962fd7999e064c4865f96fb1e23079075f4a2a14849bcdc5cdba53a24f9759b",
+                "sha256:099c644a778bf72ffa00524f78dd0b6476bca94a1da344130f4bf3381ce5b954"
+            ],
+            "version": "==0.16.10"
+        },
+        "ruamel.yaml.clib": {
+            "hashes": [
+                "sha256:1e77424825caba5553bbade750cec2277ef130647d685c2b38f68bc03453bac6",
+                "sha256:392b7c371312abf27fb549ec2d5e0092f7ef6e6c9f767bfb13e83cb903aca0fd",
+                "sha256:4d55386129291b96483edcb93b381470f7cd69f97585829b048a3d758d31210a",
+                "sha256:550168c02d8de52ee58c3d8a8193d5a8a9491a5e7b2462d27ac5bf63717574c9",
+                "sha256:57933a6986a3036257ad7bf283529e7c19c2810ff24c86f4a0cfeb49d2099919",
+                "sha256:615b0396a7fad02d1f9a0dcf9f01202bf9caefee6265198f252c865f4227fcc6",
+                "sha256:77556a7aa190be9a2bd83b7ee075d3df5f3c5016d395613671487e79b082d784",
+                "sha256:7aee724e1ff424757b5bd8f6c5bbdb033a570b2b4683b17ace4dbe61a99a657b",
+                "sha256:8073c8b92b06b572e4057b583c3d01674ceaf32167801fe545a087d7a1e8bf52",
+                "sha256:9c6d040d0396c28d3eaaa6cb20152cb3b2f15adf35a0304f4f40a3cf9f1d2448",
+                "sha256:a0ff786d2a7dbe55f9544b3f6ebbcc495d7e730df92a08434604f6f470b899c5",
+                "sha256:b1b7fcee6aedcdc7e62c3a73f238b3d080c7ba6650cd808bce8d7761ec484070",
+                "sha256:b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c",
+                "sha256:be018933c2f4ee7de55e7bd7d0d801b3dfb09d21dad0cce8a97995fd3e44be30",
+                "sha256:d0d3ac228c9bbab08134b4004d748cf9f8743504875b3603b3afbb97e3472947",
+                "sha256:d10e9dd744cf85c219bf747c75194b624cc7a94f0c80ead624b06bfa9f61d3bc",
+                "sha256:ea4362548ee0cbc266949d8a441238d9ad3600ca9910c3fe4e82ee3a50706973",
+                "sha256:ed5b3698a2bb241b7f5cbbe277eaa7fe48b07a58784fba4f75224fd066d253ad",
+                "sha256:f9dcc1ae73f36e8059589b601e8e4776b9976effd76c21ad6a855a74318efd6e"
+            ],
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.9'",
+            "version": "==0.2.0"
         },
         "semgrep": {
             "editable": true,
@@ -131,10 +147,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "version": "==20.3"
+            "version": "==20.4"
         },
         "pluggy": {
             "hashes": [
@@ -165,11 +181,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
-                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
+                "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1",
+                "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"
             ],
             "index": "pypi",
-            "version": "==5.4.2"
+            "version": "==5.4.3"
         },
         "pytest-benchmark": {
             "hashes": [
@@ -189,10 +205,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "version": "==1.15.0"
         },
         "toml": {
             "hashes": [
@@ -203,25 +219,25 @@
         },
         "tox": {
             "hashes": [
-                "sha256:8d97bfaf70053ed3db56f57377288621f1bcc7621446d301927d18df93b1c4c3",
-                "sha256:af09c19478e8fc7ce7555b3d802ddf601b82684b874812c5857f774b8aee1b67"
+                "sha256:322dfdf007d7d53323f767badcb068a5cfa7c44d8aabb698d131b28cf44e62c4",
+                "sha256:8c9ad9b48659d291c5bc78bcabaa4d680d627687154b812fa52baedaa94f9f83"
             ],
             "index": "pypi",
-            "version": "==3.15.0"
+            "version": "==3.15.1"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:b4c14d4d73a0c23db267095383c4276ef60e161f94fde0427f2f21a0132dde74",
-                "sha256:fd0e54dec8ac96c1c7c87daba85f0a59a7c37fe38748e154306ca21c73244637"
+                "sha256:a116629d4e7f4d03433b8afa27f43deba09d48bc48f5ecefa4f015a178efb6cf",
+                "sha256:a730548b27366c5e6cbdf6f97406d861cccece2e22275e8e1a757aeff5e00c70"
             ],
-            "version": "==20.0.20"
+            "version": "==20.0.21"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+                "sha256:980fbf4f3c196c0f329cdcd1e84c554d6a211f18e252e525a0cf4223154a41d6",
+                "sha256:edbc2b718b4db6cdf393eefe3a420183947d6aa312505ce6754516f458ff8830"
             ],
-            "version": "==0.1.9"
+            "version": "==0.2.3"
         },
         "wheel": {
             "hashes": [

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -18,7 +18,6 @@ from semgrep.constants import ID_KEY
 from semgrep.constants import RULES_KEY
 from semgrep.constants import SEMGREP_USER_AGENT
 from semgrep.constants import YML_EXTENSIONS
-from semgrep.rule_lang import parse_yaml
 from semgrep.rule_lang import parse_yaml_preserve_spans
 from semgrep.rule_lang import YamlTree
 from semgrep.util import debug_print

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -9,6 +9,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from ruamel.yaml import YAMLError
+
 from semgrep.constants import DEFAULT_CONFIG_FILE
 from semgrep.constants import DEFAULT_CONFIG_FOLDER
 from semgrep.constants import DEFAULT_SEMGREP_CONFIG_NAME
@@ -16,6 +18,9 @@ from semgrep.constants import ID_KEY
 from semgrep.constants import RULES_KEY
 from semgrep.constants import SEMGREP_USER_AGENT
 from semgrep.constants import YML_EXTENSIONS
+from semgrep.rule_lang import parse_yaml
+from semgrep.rule_lang import parse_yaml_preserve_spans
+from semgrep.rule_lang import YamlTree
 from semgrep.util import debug_print
 from semgrep.util import is_url
 from semgrep.util import print_error
@@ -82,36 +87,32 @@ def indent(msg: str) -> str:
 
 def parse_config_at_path(
     loc: Path, base_path: Optional[Path] = None
-) -> Dict[str, Optional[Dict[str, Any]]]:
+) -> Dict[str, Optional[YamlTree]]:
     config_id = str(loc)
     if base_path:
         config_id = str(loc).replace(str(base_path), "")
     try:
         with loc.open() as f:
-            return parse_config_string(config_id, f.read())
+            return parse_config_string(config_id, f.read(), str(loc))
     except FileNotFoundError:
         print_error(f"YAML file at {loc} not found")
         return {str(loc): None}
 
 
 def parse_config_string(
-    config_id: str, contents: str
-) -> Dict[str, Optional[Dict[str, Any]]]:
-    import yaml  # here for faster startup times
-
+    config_id: str, contents: str, filename: Optional[str]
+) -> Dict[str, Optional[YamlTree]]:
     try:
-        return {config_id: yaml.safe_load(contents)}
-    except yaml.parser.ParserError as se:
-        print_error(f"Invalid yaml file {config_id}:\n{indent(str(se))}")
-        return {config_id: None}
-    except yaml.scanner.ScannerError as se:
+        data = parse_yaml_preserve_spans(contents, filename)
+        return {config_id: data}
+    except YAMLError as se:
         print_error(f"Invalid yaml file {config_id}:\n{indent(str(se))}")
         return {config_id: None}
 
 
 def parse_config_folder(
     loc: Path, relative: bool = False
-) -> Dict[str, Optional[Dict[str, Any]]]:
+) -> Dict[str, Optional[YamlTree]]:
     configs = {}
     for l in loc.rglob("*"):
         # Allow manually specified paths with ".", but don't auto-expand them
@@ -136,7 +137,7 @@ def _is_hidden_config(loc: Path) -> bool:
 
 def load_config_from_local_path(
     location: Optional[str] = None,
-) -> Dict[str, Optional[Dict[str, Any]]]:
+) -> Dict[str, Optional[YamlTree]]:
     """
         Return config file(s) as dictionary object
     """
@@ -169,7 +170,7 @@ def load_config_from_local_path(
     raise Exception
 
 
-def download_config(config_url: str) -> Dict[str, Optional[Dict[str, Any]]]:
+def download_config(config_url: str) -> Dict[str, Optional[YamlTree]]:
     import requests  # here for faster startup times
 
     DOWNLOADING_MESSAGE = "downloading config..."
@@ -184,7 +185,9 @@ def download_config(config_url: str) -> Dict[str, Optional[Dict[str, Any]]]:
             content_type = r.headers.get("Content-Type")
             if content_type and "text/plain" in content_type:
                 print_msg(SCANNING_MESSAGE)
-                return parse_config_string("remote-url", r.content.decode("utf-8"))
+                return parse_config_string(
+                    "remote-url", r.content.decode("utf-8"), filename=None
+                )
             elif content_type and content_type == "application/x-gzip":
                 with tempfile.TemporaryDirectory() as fname:
                     with tarfile.open(fileobj=r.raw, mode="r:gz") as tar:
@@ -207,7 +210,7 @@ def download_config(config_url: str) -> Dict[str, Optional[Dict[str, Any]]]:
     return {config_url: None}
 
 
-def resolve_config(config_str: Optional[str]) -> Dict[str, Optional[Dict[str, Any]]]:
+def resolve_config(config_str: Optional[str]) -> Dict[str, Optional[YamlTree]]:
     """ resolves if config arg is a registry entry, a url, or a file, folder, or loads from defaults if None"""
     start_t = time.time()
     if config_str is None:

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -194,12 +194,9 @@ class CoreRunner:
     def _write_equivalences_file(self, fp: IO, equivalences: List[Equivalence]) -> None:
         # I don't even know why this is a thing.
         # cf. https://stackoverflow.com/questions/51272814/python-yaml-dumping-pointer-references
-        import yaml  # here for faster startup times
-
-        yaml.SafeDumper.ignore_aliases = (  # type: ignore
-            lambda *args: True
-        )
-        fp.write(yaml.safe_dump({"equivalences": [e.to_json() for e in equivalences]}))
+        yaml = YAML()
+        yaml.representer.ignore_aliases = lambda *data: True
+        yaml.dump({"equivalences": [e.to_json() for e in equivalences]}, fp)
         fp.flush()
 
     def _run_rules(
@@ -223,13 +220,7 @@ class CoreRunner:
         with tempfile.NamedTemporaryFile("w") as equiv_fout:
 
             if equivalences:
-                try:
-                    self._write_equivalences_file(equiv_fout, equivalences)
-                except Exception as e:
-                    print_error(
-                        f"could not write equivalences file. will continue without equivalences. {e}"
-                    )
-                    equivalences = []
+                self._write_equivalences_file(equiv_fout, equivalences)
 
             for language, all_patterns_for_language in self._group_patterns_by_language(
                 rules

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -16,6 +16,8 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+from ruamel.yaml import YAML
+
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.constants import SEMGREP_PATH
 from semgrep.equivalences import Equivalence
@@ -206,8 +208,6 @@ class CoreRunner:
         """
             Run all rules on targets and return list of all places that match patterns, ... todo errors
         """
-        import yaml  # here for faster startup times
-
         outputs: List[PatternMatch] = []  # multiple invocations per language
         errors: List[Any] = []
 
@@ -266,9 +266,9 @@ class CoreRunner:
 
                 patterns_json = [p.to_json() for p in patterns]
                 # very important not to sort keys here
-                yaml_as_str = yaml.safe_dump({"rules": patterns_json}, sort_keys=False)
                 with tempfile.NamedTemporaryFile("w") as fout:
-                    fout.write(yaml_as_str)
+                    yaml = YAML()
+                    yaml.dump({"rules": patterns_json}, fout)
                     fout.flush()
                     cmd = [SEMGREP_PATH] + [
                         "-lang",

--- a/semgrep/semgrep/rule_lang.py
+++ b/semgrep/semgrep/rule_lang.py
@@ -1,0 +1,89 @@
+from io import StringIO
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import Union
+
+from ruamel.yaml import Node
+from ruamel.yaml import RoundTripConstructor
+from ruamel.yaml import YAML
+
+
+class Position(NamedTuple):
+    line: int
+    column: int
+
+    def __repr__(self) -> str:
+        return f"{self.line}:{self.column}"
+
+
+class Span(NamedTuple):
+    start: Position
+    end: Position
+    file: Optional[str]
+
+    @classmethod
+    def from_node(cls, node: Node, file: Optional[str]) -> "Span":
+        start = Position(line=node.start_mark.line, column=node.start_mark.column)
+        end = Position(line=node.end_mark.line, column=node.end_mark.column)
+        return Span(start=start, end=end, file=file)
+
+    def __repr__(self) -> str:
+        return f"{self.start}-{self.end}"
+
+
+# Actually recursive but mypy is unhelpful
+YamlValue = Union[str, int, List[Any], Dict[str, Any]]
+LocatedYamlValue = Union[str, int, List["YamlTree"], Dict["YamlTree", "YamlTree"]]
+
+
+class YamlTree:
+    def __init__(self, value: LocatedYamlValue, span: Span):
+        self.value = value
+        self.span = span
+
+    # __eq__ and _hash__ delegate to value to support `value['a']` working properly.
+    # otherwise, since the key is _actually_ a `Located` object you'd need to give the
+    # span to pull it out of the dictionary.
+    def __eq__(self, other: Any) -> bool:
+        return self.value.__eq__(other)
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __repr__(self) -> str:
+        return f"{self.span}: ---> {self.value}"
+
+    def unroll(self) -> YamlValue:
+        """
+        Recursively expand the `self.value`, converting back to a normal datastructure
+        """
+        if isinstance(self.value, list):
+            return [x.unroll() for x in self.value]
+        elif isinstance(self.value, dict):
+            return {str(k.unroll()): v.unroll() for k, v in self.value.items()}
+        elif isinstance(self.value, YamlTree):
+            return self.value.unroll()
+        else:
+            return self.value
+
+
+def parse_yaml(contents: str) -> Dict[str, Any]:
+    yaml = YAML()
+    return yaml.load(StringIO(contents))  # type: ignore
+
+
+def parse_yaml_preserve_spans(contents: str, filename: Optional[str]) -> YamlTree:
+    class SpanPreservingRuamelConstructor(RoundTripConstructor):
+        def construct_object(self, node: Node, deep: bool = False) -> YamlTree:
+            r = super().construct_object(node, deep)
+            return YamlTree(r, Span.from_node(node, filename))
+
+    yaml = YAML()
+    yaml.Constructor = SpanPreservingRuamelConstructor
+    data = yaml.load(StringIO(contents))
+    if not isinstance(data, YamlTree):
+        raise Exception("Something has gone horribly wrong in the YAML parser")
+    return data

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -81,7 +81,10 @@ def validate_configs(
         if not config_yaml_tree:
             errors[config_id] = config_yaml_tree
             continue
-        config_any = config_yaml_tree.unroll()
+        if isinstance(config_yaml_tree, YamlTree):
+            config_any = config_yaml_tree.unroll()
+        else:
+            config_any = config_yaml_tree
         if not isinstance(config_any, dict):
             print_error(f"{config_id} was not a mapping")
             errors[config_id] = config_any

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -123,7 +123,8 @@ setup(
     url="https://github.com/returntocorp/semgrep",
     install_requires=[
         "colorama>=0.4.3",
-        "pyyaml>=5.3",
+        # exact version because of unstable API
+        "ruamel.yaml==0.16.10",
         "requests>=2.22.0",
         "attrs>=19.3.0",
     ],

--- a/semgrep/tests/e2e/rules/syntax/invalid.yaml
+++ b/semgrep/tests/e2e/rules/syntax/invalid.yaml
@@ -1,0 +1,15 @@
+rules
+  - id: eqeq-is-bad
+    patterns:
+      - pattern-inside:
+          - pattern: $X == $X
+          - pattern: $X != $X
+          - patterns:
+              - pattern-inside: |
+                  def __init__(...):
+                      ...
+              - pattern: self.$X == self.$X
+      - pattern-not: 1 == 1
+    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+    languages: [python]
+    severity: ERROR

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.txt
@@ -1,0 +1,4 @@
+Invalid yaml file rules/syntax/invalid.yaml:
+	mapping values are not allowed here
+	  in "<file>", line 2, column 7
+run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -10,7 +10,7 @@ def test_rule_parser__success(run_semgrep_in_tmp, snapshot, filename):
 
 @pytest.mark.parametrize(
     "filename",
-    ["bad1", "bad2", "bad3", "bad4", "badpattern", "badpaths1", "badpaths2"],
+    ["bad1", "bad2", "bad3", "bad4", "badpattern", "badpaths1", "badpaths2", "invalid"],
 )
 def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
     with pytest.raises(CalledProcessError) as excinfo:
@@ -35,6 +35,7 @@ def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
         "badpattern",
         "badpaths1",
         "badpaths2",
+        "invalid",
     ],
 )
 def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):

--- a/semgrep/tests/unit/test_rule_lang.py
+++ b/semgrep/tests/unit/test_rule_lang.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from semgrep.rule_lang import parse_yaml
+from semgrep.rule_lang import parse_yaml_preserve_spans
+from semgrep.rule_lang import Position
+from semgrep.rule_lang import Span
+
+test_yaml = """---
+a:
+  - 1
+  - 2
+  - "3"
+  - key: value
+  - pattern: |
+        def __eq__():
+            ...
+"""
+
+
+def test_span_tracking():
+    data = parse_yaml_preserve_spans(test_yaml, Path("filename"))
+    # basic spans
+    assert data.span == Span(
+        start=Position(line=1, column=0),
+        end=Position(line=9, column=0),
+        file=Path("filename"),
+    )
+
+    # values act like dictionaries
+    assert data.value["a"].span == Span(
+        start=Position(line=2, column=2),
+        end=Position(line=9, column=0),
+        file=Path("filename"),
+    )
+
+    # values act like lists
+    assert data.value["a"].value[0].span == Span(
+        start=Position(line=2, column=4),
+        end=Position(line=2, column=5),
+        file=Path("filename"),
+    )
+
+    assert data.value["a"].value[0].value == 1
+
+    # spans are also attached to keys
+    kvs = list(data.value.items())
+    key, value = kvs[0]
+    assert key.span == Span(
+        start=Position(line=1, column=0),
+        end=Position(line=1, column=1),
+        file=Path("filename"),
+    )
+
+    # unrolling is equivalent
+    assert data.unroll() == parse_yaml(test_yaml)

--- a/stubs/ruamel/yaml.pyi
+++ b/stubs/ruamel/yaml.pyi
@@ -14,6 +14,10 @@ class RoundTripConstructor:
 class YAML:
     Constructor: Any
     representer: Any
+
+    def __init__(self, typ: str = 'rt'):
+        ...
+
     def load(self, stream: Any) -> Any:
         ...
 

--- a/stubs/ruamel/yaml.pyi
+++ b/stubs/ruamel/yaml.pyi
@@ -1,0 +1,24 @@
+from typing import NamedTuple, Any
+class LineCol(NamedTuple):
+    line: int
+    column: int
+
+class Node(NamedTuple):
+    start_mark: LineCol
+    end_mark: LineCol
+
+class RoundTripConstructor:
+    def construct_object(self, node: Node, deep: bool = False) -> Any:
+        ...
+
+class YAML:
+    Constructor: Any
+    def load(self, stream: Any) -> Any:
+        ...
+
+    def dump(self, obj: Any, stream: Any) -> None:
+        ...
+
+
+class YAMLError(Exception):
+    ...

--- a/stubs/ruamel/yaml.pyi
+++ b/stubs/ruamel/yaml.pyi
@@ -13,6 +13,7 @@ class RoundTripConstructor:
 
 class YAML:
     Constructor: Any
+    representer: Any
     def load(self, stream: Any) -> Any:
         ...
 


### PR DESCRIPTION
- Change YAML parsing to Ruamel
- Wrap Ruamel output in `YamlTree` to preserve all the span information (Ruamel only preserves the start, not the end of spans in it's normal output)
- Coax the mypy gods into accepting this. Python is bad for ADTs...

Part of the #773 rebuild.
