### PR TITLE
Add target_file flag to semgrep-core

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install semgrep-core
         run: eval $(opam  env --root /home/opam/.opam --set-root) && cd semgrep-core && opam install --deps-only -y . && make all && make install
       - name: Test semgrep-core
-        run: eval $(opam  env --root /home/opam/.opam --set-root) && cd semgrep-core && make test
+        run: eval $(opam  env --root /home/opam/.opam --set-root) && cd semgrep-core && make test && make e2etest
       - name: Install semgrep
         run: eval $(opam  env --root /home/opam/.opam --set-root) && cd semgrep && export PATH=/github/home/.local/bin:$PATH && pip3 install pipenv && pipenv install --dev && make test && make qa-test
       - name: Test semgrep

--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -8,6 +8,8 @@ clean:
 	dune clean
 test:
 	dune runtest
+e2etest:
+	python3 tests/e2e/test_target_file.py
 install:
 	dune install
 dump:

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -882,9 +882,8 @@ let main () =
   in
 
   (* does side effect on many global flags *)
-  let _args_tmp = Common.parse_options (options()) usage_msg (Array.of_list argv) in
-
-  let args = if !target_file="" then _args_tmp else
+  let args = Common.parse_options (options()) usage_msg (Array.of_list argv) in
+  let args = if !target_file="" then args else
   begin
     let s = Common.read_file !target_file in
     String.split_on_char '\n' s

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -136,6 +136,8 @@ let supported_langs: string = String.concat ", " keys
 let ncores = ref 1
 (*e: constant [[Main_semgrep_core.ncores]] *)
 
+let target_file = ref ""
+
 (*s: constant [[Main_semgrep_core.action]] *)
 (* action mode *)
 let action = ref ""
@@ -801,6 +803,8 @@ let options () =
     " ";
     "-debug", Arg.Set debug,
     " add debugging information in the output (e.g., tracing)";
+    "-target_file", Arg.Set_string target_file,
+    " <file> obtain list of targets to run patterns on";
   ] @
   (*s: [[Main_semgrep_core.options]] concatenated flags *)
   Flag_parsing_cpp.cmdline_flags_macrofile () @
@@ -878,7 +882,14 @@ let main () =
   in
 
   (* does side effect on many global flags *)
-  let args = Common.parse_options (options()) usage_msg (Array.of_list argv) in
+  let _args_tmp = Common.parse_options (options()) usage_msg (Array.of_list argv) in
+
+  let args = if !target_file="" then _args_tmp else
+  begin
+    let s = Common.read_file !target_file in
+    String.split_on_char '\n' s
+  end
+  in
 
   if !debug then begin
     pr2 "Debug mode On";

--- a/semgrep-core/tests/e2e/target
+++ b/semgrep-core/tests/e2e/target
@@ -1,0 +1,1 @@
+tests/e2e/targets/basic.py

--- a/semgrep-core/tests/e2e/targets/basic.py
+++ b/semgrep-core/tests/e2e/targets/basic.py
@@ -1,0 +1,12 @@
+def foo(a, b):
+    # ERROR: stupid $X == $X
+    return a + b == a + b
+
+
+def __eq__(a, b):
+    # ERROR: stupid $X == $X (linter knows ok because method is named eq)
+    x == x
+
+
+# ERROR: stupid $X == $X (linter knows ok because method is assertTrue)
+assertTrue(x == x)

--- a/semgrep-core/tests/e2e/test_target_file.py
+++ b/semgrep-core/tests/e2e/test_target_file.py
@@ -1,0 +1,15 @@
+import subprocess
+
+
+def test_target_file():
+    """
+        Check that output of passing in file is the same
+        as having that file in -target-file flag
+    """
+    output = subprocess.check_output(["semgrep-core", "-e", "$X==$X", "-lang", "python", "tests/e2e/targets/basic.py"], encoding="utf-8")
+    output2 = subprocess.check_output(["semgrep-core", "-e", "$X==$X", "-lang", "python", "-target_file", "tests/e2e/target"], encoding="utf-8")
+    assert output == output2
+
+
+if __name__ == "__main__":
+    test_target_file()


### PR DESCRIPTION
Allows us to pass a newline delimited list of files to semgrep-core
instead of using the cli so we can get around shell character limits