### PR TITLE
Show parse semgrep-core parse errors in semgrep-cli

### DIFF
--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -7,7 +7,6 @@ from typing import Union
 
 import pytest
 
-
 TESTS_PATH = Path(__file__).parent
 
 MASKED_KEYS = [

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -1,0 +1,6 @@
+Syntax error
+--> targets/bad/invalid_python.py:1
+def foo(a)
+          ^
+= note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev
+run with --strict and 1 errors occurred during semgrep run; exiting

--- a/semgrep/tests/e2e/targets/bad/invalid_python.py
+++ b/semgrep/tests/e2e/targets/bad/invalid_python.py
@@ -1,0 +1,3 @@
+def foo(a)
+    tree = ElementTree.parse('country_data.xml')
+    root = tree.getroot()

--- a/semgrep/tests/e2e/test_semgrep_core_parse_error.py
+++ b/semgrep/tests/e2e/test_semgrep_core_parse_error.py
@@ -1,0 +1,17 @@
+from subprocess import CalledProcessError
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "filename", ["invalid_python.py",],
+)
+def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):
+    with pytest.raises(CalledProcessError) as excinfo:
+        run_semgrep_in_tmp(
+            config="rules/eqeq.yaml",
+            target_name=f"bad/{filename}",
+            output_format="text",
+            stderr=True,
+        )
+    snapshot.assert_match(excinfo.value.output, "error.txt")


### PR DESCRIPTION
Nothing fancy (eg. displaying colored errors w/ context), just rendering exactly what we get from semgrep-core.

cc #746 