### PR TITLE
semgrep-core: don't filter out explicitly passed targets

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -407,7 +407,13 @@ let get_final_files xs =
     | Some lang -> Lang.files_of_dirs_or_files lang xs
   in
   let files = filter_files files in
-  files
+
+  let explicit_files = xs |> List.filter(fun file ->
+      Sys.file_exists file && not (Sys.is_directory file)
+    )
+  in
+
+  files @ explicit_files
 (*e: function [[Main_semgrep_core.get_final_files]] *)
 
 (*s: function [[Main_semgrep_core.iter_generic_ast_of_files_and_get_matches_and_exn_to_errors]] *)
@@ -417,18 +423,10 @@ let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
        if !verbose then pr2 (spf "Analyzing %s" file);
        try
          let lang =
-           match Lang.langs_of_filename file with
-           | [lang] -> lang
-           | x::_xs ->
-               (match Lang.lang_of_string_opt !lang with
-               | Some lang -> lang
-               | None ->
-                 pr2 (spf "no language specified, defaulting to %s for %s"
-                      (Lang.string_of_lang x) file);
-                 x
-               )
-           | [] ->
-              failwith (spf "can not extract generic AST from %s" file)
+           match Lang.lang_of_string_opt !lang with
+            | Some lang -> lang
+            | _ ->
+               failwith (spf "no language specified")
          in
          if !debug then pr2 (spf "PARSING: %s" file);
          let ast = parse_generic lang file in

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -413,7 +413,7 @@ let get_final_files xs =
     )
   in
 
-  files @ explicit_files
+  Common2.uniq_eff (files @ explicit_files)
 (*e: function [[Main_semgrep_core.get_final_files]] *)
 
 (*s: function [[Main_semgrep_core.iter_generic_ast_of_files_and_get_matches_and_exn_to_errors]] *)

--- a/semgrep/tests/e2e/rules/eqeq-python.yaml
+++ b/semgrep/tests/e2e/rules/eqeq-python.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: assert-eqeq-is-ok
+    pattern: |
+      def __eq__():
+          ...
+          $X == $X
+    message: "possibly useless comparison but in eq function"
+    languages: [python]
+    severity: ERROR
+  - id: eqeq-is-bad
+    patterns:
+      - pattern-not-inside: |
+          def __eq__(...):
+              ...
+      - pattern-not-inside: assert(...)
+      - pattern-not-inside: assertTrue(...)
+      - pattern-not-inside: assertFalse(...)
+      - pattern-either:
+        - pattern: $X == $X
+        - pattern: $X != $X
+        - patterns:
+          - pattern-inside: |
+              def __init__(...):
+                  ...
+          - pattern: self.$X == self.$X
+      - pattern-not: 1 == 1
+    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+    languages: [python]
+    severity: ERROR

--- a/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
@@ -1,0 +1,42 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.eqeq-is-bad",
+      "end": {
+        "col": 26,
+        "line": 3
+      },
+      "extra": {
+        "lines": "    return a + b == a + b",
+        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "a+b",
+            "end": {
+              "col": 17,
+              "line": 3,
+              "offset": 60
+            },
+            "start": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid_no_extension",
+      "start": {
+        "col": 12,
+        "line": 3
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/basic/stupid_no_extension
+++ b/semgrep/tests/e2e/targets/basic/stupid_no_extension
@@ -1,0 +1,12 @@
+def foo(a, b):
+    # ERROR: stupid $X == $X
+    return a + b == a + b
+
+
+def __eq__(a, b):
+    # ERROR: stupid $X == $X (linter knows ok because method is named eq)
+    x == x
+
+
+# ERROR: stupid $X == $X (linter knows ok because method is assertTrue)
+assertTrue(x == x)

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -15,6 +15,19 @@ def test_basic_rule__relative(run_semgrep_in_tmp, snapshot):
     )
 
 
+def test_noextension_filtering(run_semgrep_in_tmp, snapshot):
+    """
+        Check that semgrep does not filter out files without extensions when
+        said file is explicitly passed
+    """
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/eqeq-python.yaml", target_name="basic/stupid_no_extension"
+        ),
+        "results.json",
+    )
+
+
 def test_basic_rule__absolute(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(Path.cwd() / "rules" / "eqeq.yaml"), "results.json",

--- a/semgrep/tests/e2e/test_semgrep_core_parse_error.py
+++ b/semgrep/tests/e2e/test_semgrep_core_parse_error.py
@@ -9,7 +9,7 @@ import pytest
 def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp(
-            config="rules/eqeq.yaml",
+            config="rules/eqeq-python.yaml",
             target_name=f"bad/{filename}",
             output_format="text",
             stderr=True,


### PR DESCRIPTION
Files listed as targets for analysis are analyzed even if they do not
have an expected extension