### PR TITLE
add a debugging json flag for use on semgrep live

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -167,6 +167,11 @@ def cli() -> None:
         "--json", action="store_true", help="Output results in JSON format."
     )
     output.add_argument(
+        "--debugging-json",
+        action="store_true",
+        help="Output JSON with extra debugging information.",
+    )
+    output.add_argument(
         "--sarif", action="store_true", help="Output results in SARIF format."
     )
     output.add_argument("--test", action="store_true", help="Run test suite.")
@@ -263,6 +268,7 @@ def cli() -> None:
             exclude=args.exclude,
             exclude_dir=args.exclude_dir,
             json_format=args.json,
+            debugging_json=args.debugging_json,
             sarif=args.sarif,
             output_destination=args.output,
             quiet=args.quiet,

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -36,4 +36,5 @@ SEMGREP_PATH = compute_semgrep_path()
 class OutputFormat(Enum):
     TEXT = auto()
     JSON = auto()
+    JSON_DEBUG = auto()
     SARIF = auto()

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -312,11 +312,12 @@ class CoreRunner:
 
     def _resolve_output(
         self, outputs: Dict[Rule, Dict[Path, List[PatternMatch]]]
-    ) -> Dict[Rule, List[RuleMatch]]:
+    ) -> Tuple[Dict[Rule, List[RuleMatch]], Dict[Rule, List[Dict[str, Any]]]]:
         """
             Takes output of all running all patterns and rules and returns Findings
         """
         findings_by_rule: Dict[Rule, List[RuleMatch]] = {}
+        debugging_steps_by_rule: Dict[Rule, List[Dict[str, Any]]] = {}
 
         for rule, paths in outputs.items():
             findings = []
@@ -325,11 +326,16 @@ class CoreRunner:
                     continue
                 debug_print(f"-------- rule ({rule.id} ------ filepath: {filepath}")
 
-                findings.extend(evaluate(rule, pattern_matches, self._allow_exec))
+                findings_for_rule, debugging_steps = evaluate(
+                    rule, pattern_matches, self._allow_exec
+                )
+                findings.extend(findings_for_rule)
+                # debugging steps are only tracked for a single file, just overwrite
+                debugging_steps_by_rule[rule] = debugging_steps
 
             findings_by_rule[rule] = dedup_output(findings)
 
-        return findings_by_rule
+        return findings_by_rule, debugging_steps_by_rule
 
     @property
     def targeting_options(self) -> Iterator[str]:
@@ -348,18 +354,20 @@ class CoreRunner:
 
     def invoke_semgrep(
         self, targets: List[Path], rules: List[Rule]
-    ) -> Tuple[Dict[Rule, List[RuleMatch]], List[Any]]:
+    ) -> Tuple[
+        Dict[Rule, List[RuleMatch]], Dict[Rule, List[Dict[str, Any]]], List[Any]
+    ]:
         """
             Takes in rules and targets and retuns object with findings
         """
         start = datetime.now()
 
         outputs, errors = self._run_rules(rules, targets)
-        findings_by_rule = self._resolve_output(outputs)
+        findings_by_rule, debug_steps_by_rule = self._resolve_output(outputs)
 
         debug_print(f"semgrep ran in {datetime.now() - start}")
 
-        return findings_by_rule, errors
+        return findings_by_rule, debug_steps_by_rule, errors
 
 
 def dedup_output(outputs: List[RuleMatch]) -> List[RuleMatch]:

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -5,6 +5,7 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Set
+from typing import Tuple
 
 from semgrep.constants import RCE_RULE_FLAG
 from semgrep.error import NEED_ARBITRARY_CODE_EXEC_EXIT_CODE
@@ -27,6 +28,7 @@ def _evaluate_single_expression(
     expression: BooleanRuleExpression,
     pattern_ids_to_pattern_matches: Dict[PatternId, List[PatternMatch]],
     ranges_left: Set[Range],
+    steps_for_debugging: List[Dict[str, Any]],
     flags: Optional[Dict[str, Any]] = None,
 ) -> Set[Range]:
 
@@ -54,6 +56,9 @@ def _evaluate_single_expression(
                     output_ranges.add(arange)
                     break  # found a match, no need to keep going
         debug_print(f"after filter `{expression.operator}`: {output_ranges}")
+        steps_for_debugging.append(
+            {"filter": expression.operator, "ranges": list(ranges_left)}
+        )
         return output_ranges
     elif expression.operator == OPERATORS.AND_NOT_INSIDE:
         # remove all ranges enclosed by or equal to
@@ -64,6 +69,9 @@ def _evaluate_single_expression(
                     output_ranges.remove(arange)
                     break
         debug_print(f"after filter `{expression.operator}`: {output_ranges}")
+        steps_for_debugging.append(
+            {"filter": expression.operator, "ranges": list(ranges_left)}
+        )
         return output_ranges
     elif expression.operator == OPERATORS.WHERE_PYTHON:
         if not flags or flags[RCE_RULE_FLAG] != True:
@@ -87,6 +95,9 @@ def _evaluate_single_expression(
                 ):
                     output_ranges.add(pattern_match.range)
         debug_print(f"after filter `{expression.operator}`: {output_ranges}")
+        steps_for_debugging.append(
+            {"filter": expression.operator, "ranges": list(ranges_left)}
+        )
         return output_ranges
     elif expression.operator == OPERATORS.REGEX:
         # remove all ranges that don't equal the ranges for this pattern
@@ -144,24 +155,38 @@ def should_exclude_this_path(path: Path) -> bool:
 
 def evaluate(
     rule: Rule, pattern_matches: List[PatternMatch], allow_exec: bool
-) -> List[RuleMatch]:
+) -> Tuple[List[RuleMatch], List[Dict[str, Any]]]:
     """
         Takes a Rule and list of pattern matches from a single file and
         handles the boolean expression evaluation of the Rule's patterns
         Returns a list of RuleMatches.
     """
     output = []
+
     pattern_ids_to_pattern_matches = group_by_pattern_id(pattern_matches)
+    steps_for_debugging = [
+        {
+            "filter": "initial",
+            "ranges": {
+                k: [vv.range for vv in v]
+                for k, v in pattern_ids_to_pattern_matches.items()
+            },
+        }
+    ]
     debug_print(str(pattern_ids_to_pattern_matches))
     valid_ranges_to_output = evaluate_expression(
         rule.expression,
         pattern_ids_to_pattern_matches,
         flags={RCE_RULE_FLAG: allow_exec},
+        steps_for_debugging=steps_for_debugging,
     )
 
     # only output matches which are inside these offsets!
     debug_print(f"compiled result {valid_ranges_to_output}")
     debug_print("-" * 80)
+    steps_for_debugging.append(
+        {"filter": "final", "ranges": list(valid_ranges_to_output)}  # type:ignore
+    )
     for pattern_match in pattern_matches:
         if pattern_match.range in valid_ranges_to_output:
             message = interpolate_message_metavariables(rule, pattern_match)
@@ -176,7 +201,7 @@ def evaluate(
             )
             output.append(rule_match)
 
-    return output
+    return output, steps_for_debugging
 
 
 def interpolate_message_metavariables(rule: Rule, pattern_match: PatternMatch) -> str:
@@ -200,13 +225,18 @@ def interpolate_fix_metavariables(
 def evaluate_expression(
     expression: BooleanRuleExpression,
     pattern_ids_to_pattern_matches: Dict[PatternId, List[PatternMatch]],
+    steps_for_debugging: List[Dict[str, Any]],
     flags: Optional[Dict[str, Any]] = None,
 ) -> Set[Range]:
     ranges_left = set(
         [x.range for x in flatten(pattern_ids_to_pattern_matches.values())]
     )
     return _evaluate_expression(
-        expression, pattern_ids_to_pattern_matches, ranges_left, flags
+        expression,
+        pattern_ids_to_pattern_matches,
+        ranges_left,
+        steps_for_debugging,
+        flags=flags,
     )
 
 
@@ -214,6 +244,7 @@ def _evaluate_expression(
     expression: BooleanRuleExpression,
     pattern_ids_to_pattern_matches: Dict[PatternId, List[PatternMatch]],
     ranges_left: Set[Range],
+    steps_for_debugging: List[Dict[str, Any]],
     flags: Optional[Dict[str, Any]] = None,
 ) -> Set[Range]:
     if (
@@ -229,7 +260,11 @@ def _evaluate_expression(
             # remove anything that does not equal one of these ranges
             evaluated_ranges = [
                 _evaluate_expression(
-                    expr, pattern_ids_to_pattern_matches, ranges_left.copy(), flags
+                    expr,
+                    pattern_ids_to_pattern_matches,
+                    ranges_left.copy(),
+                    steps_for_debugging,
+                    flags=flags,
                 )
                 for expr in expression.children
             ]
@@ -238,17 +273,28 @@ def _evaluate_expression(
             # chain intersection eagerly; intersect for every AND'ed child
             for expr in expression.children:
                 remainining_ranges = _evaluate_expression(
-                    expr, pattern_ids_to_pattern_matches, ranges_left.copy(), flags
+                    expr,
+                    pattern_ids_to_pattern_matches,
+                    ranges_left.copy(),
+                    steps_for_debugging,
+                    flags=flags,
                 )
                 ranges_left.intersection_update(remainining_ranges)
 
         debug_print(f"after filter `{expression.operator}`: {ranges_left}")
+        steps_for_debugging.append(
+            {"filter": expression.operator, "ranges": list(ranges_left)}
+        )
     else:
         assert (
             expression.children is None
         ), f"only `{pattern_names_for_operator(OPERATORS.AND_EITHER)}` or `{pattern_names_for_operator(OPERATORS.AND_ALL)}` expressions can have multiple subpatterns"
         ranges_left = _evaluate_single_expression(
-            expression, pattern_ids_to_pattern_matches, ranges_left, flags
+            expression,
+            pattern_ids_to_pattern_matches,
+            ranges_left,
+            steps_for_debugging,
+            flags=flags,
         )
     return ranges_left
 

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import FrozenSet
 from typing import Iterator
 from typing import List
+from typing import Optional
 
 import colorama
 
@@ -104,11 +105,19 @@ def build_normal_output(
             yield f"{BLUE_COLOR}autofix:{RESET_COLOR} {fix}"
 
 
-def build_output_json(rule_matches: List[RuleMatch], semgrep_errors: List[Any]) -> str:
+def build_output_json(
+    rule_matches: List[RuleMatch],
+    semgrep_errors: List[Any],
+    debug_steps_by_rule: Optional[Dict[Rule, List[Dict[str, Any]]]] = None,
+) -> str:
     # wrap errors under "data" entry to be compatible with
     # https://docs.r2c.dev/en/latest/api/output.html#errors
     output_json = {}
     output_json["results"] = [rm.to_json() for rm in rule_matches]
+    if debug_steps_by_rule:
+        output_json["debug"] = [
+            {r.id: steps for r, steps in debug_steps_by_rule.items()}
+        ]
     output_json["errors"] = [
         {"data": e, "message": "SemgrepCoreRuntimeErrors"} for e in semgrep_errors
     ]
@@ -145,11 +154,14 @@ def build_sarif_output(
 
 def build_output(
     rule_matches: List[RuleMatch],
+    debug_steps_by_rule: Dict[Rule, List[Dict[str, Any]]],
     rules: FrozenSet[Rule],
     semgrep_errors: List[Any],
     output_format: OutputFormat,
     color_output: bool,
 ) -> str:
+    if output_format == OutputFormat.JSON_DEBUG:
+        return build_output_json(rule_matches, semgrep_errors, debug_steps_by_rule)
     if output_format == OutputFormat.JSON:
         return build_output_json(rule_matches, semgrep_errors)
     elif output_format == OutputFormat.SARIF:

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -212,6 +212,7 @@ def main(
     exclude: List[str],
     exclude_dir: List[str],
     json_format: bool,
+    debugging_json: bool,
     sarif: bool,
     output_destination: str,
     quiet: bool,
@@ -227,6 +228,8 @@ def main(
     output_format = OutputFormat.TEXT
     if json_format:
         output_format = OutputFormat.JSON
+    elif debugging_json:
+        output_format = OutputFormat.JSON_DEBUG
     elif sarif:
         output_format = OutputFormat.SARIF
 
@@ -264,7 +267,7 @@ def main(
             )
 
     # actually invoke semgrep
-    rule_matches_by_rule, semgrep_errors = CoreRunner(
+    rule_matches_by_rule, debug_steps_by_rule, semgrep_errors = CoreRunner(
         allow_exec=dangerously_allow_arbitrary_code_execution_from_rules,
         jobs=jobs,
         exclude=exclude,
@@ -287,6 +290,7 @@ def main(
         rule_matches_by_rule,
         semgrep_errors,
         output_format,
+        debug_steps_by_rule,
         quiet,
         output_destination,
         exit_on_error,
@@ -316,6 +320,7 @@ def handle_output(
     rule_matches_by_rule: Dict[Rule, List[RuleMatch]],
     semgrep_errors: List[Any],
     output_format: OutputFormat,
+    debug_steps_by_rule: Dict[Rule, List[Dict[str, Any]]],
     quiet: bool = False,
     output_destination: Optional[str] = None,
     exit_on_error: bool = False,
@@ -328,7 +333,12 @@ def handle_output(
     ]
 
     output = build_output(
-        rule_matches, rules, semgrep_errors, output_format, not output_destination
+        rule_matches,
+        debug_steps_by_rule,
+        rules,
+        semgrep_errors,
+        output_format,
+        not output_destination,
     )
     if not quiet:
         if output:

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -84,6 +84,11 @@ def operator_for_pattern_name(pattern_name: str) -> Operator:
     )
 
 
+def pattern_name_for_operator(operator: Operator) -> str:
+    # TODO
+    return pattern_names_for_operator(operator)[0]
+
+
 def pattern_names_for_operator(operator: Operator) -> List[str]:
     return OPERATOR_PATTERN_NAMES_MAP[operator]
 

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -184,6 +184,7 @@ def invoke_semgrep(
             exclude=[],
             exclude_dir=[],
             json_format=True,
+            debugging_json=False,
             sarif=False,
             output_destination="",
             quiet=True,

--- a/semgrep/tests/unit/test_evaluation.py
+++ b/semgrep/tests/unit/test_evaluation.py
@@ -26,7 +26,7 @@ def evaluate_expression(
 ) -> Set[Range]:
     # convert it to an implicit and
     e = BooleanRuleExpression(OPERATORS.AND_ALL, None, exprs, None)
-    return raw_evaluate_expression(e, pattern_ids_to_pattern_matches, flags)
+    return raw_evaluate_expression(e, pattern_ids_to_pattern_matches, [], flags)
 
 
 def PatternMatchMock(


### PR DESCRIPTION
cc @DrewDennison 

with new flag (we might want to hide this from the --help):

`$ semgrep --debugging-json --verbose --config=https://semgrep.live/c/EwkE simple.java | jq`

adds the following output:

```
  "debug": [
    {
      "find-unverified-transactions": [
        {
          "filter": "initial",
          "ranges": {
            ".1": [
              [
                276,
                399,
                {
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                1034,
                1272,
                {
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                1034,
                1272,
                {
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                1282,
                1470,
                {
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ]
            ],
            ".0": [
              [
                276,
                399,
                {
                  "$T": 1,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                411,
                509,
                {
                  "$T": 2,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                517,
                650,
                {
                  "$T": 3,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                517,
                650,
                {
                  "$T": 3,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                770,
                1021,
                {
                  "$T": 5,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                770,
                1021,
                {
                  "$T": 5,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                770,
                1021,
                {
                  "$T": 5,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                770,
                1021,
                {
                  "$T": 5,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                1034,
                1272,
                {
                  "$T": 6,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                1034,
                1272,
                {
                  "$T": 6,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ],
              [
                1282,
                1470,
                {
                  "$T": 7,
                  "$RETURN": "md5sum",
                  "$METHOD": "md5sum"
                }
              ]
            ]
          }
        },
        {
          "filter": "and_all",
          "ranges": [
            [
              770,
              1021,
              {
                "$T": 5,
                "$RETURN": "md5sum",
                "$METHOD": "md5sum"
              }
            ],
            [
              517,
              650,
              {
                "$T": 3,
                "$RETURN": "md5sum",
                "$METHOD": "md5sum"
              }
            ],
            [
              411,
              509,
              {
                "$T": 2,
                "$RETURN": "md5sum",
                "$METHOD": "md5sum"
              }
            ]
          ]
        },
        {
          "filter": "final",
          "ranges": [
            [
              770,
              1021,
              {
                "$T": 5,
                "$RETURN": "md5sum",
                "$METHOD": "md5sum"
              }
            ],
            [
              517,
              650,
              {
                "$T": 3,
                "$RETURN": "md5sum",
                "$METHOD": "md5sum"
              }
            ],
            [
              411,
              509,
              {
                "$T": 2,
                "$RETURN": "md5sum",
                "$METHOD": "md5sum"
              }
            ]
          ]
        }
      ]
```
