### PR TITLE
Determine whether to use static linking from the name of the opam switch

### DIFF
--- a/semgrep-core/bin/flags.sh
+++ b/semgrep-core/bin/flags.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  echo "( :standard )" > flags.sexp
-else
+#
+# Use static linking if platform allows.
+#
+set -eu
+
+# Expect an opam switch name like '4.10.0+musl+static+flambda'
+if [[ "$(opam switch show)" == *+static* ]]; then
   echo "(-ccopt -static)" > flags.sexp
+else
+  echo "( :standard )" > flags.sexp
 fi


### PR DESCRIPTION
This will allow me to build on ubuntu with default, dynamic linking of C libraries. Everything should work as before on other platforms (alpine, darwin).

~~Note that I tried and failed to build semgrep under the `4.10.0+musl+static+flambda` opam switch on ubuntu. Could be an easy fix, I don't know. It's not something we need at the moment, I think.~~ (nevermind, it works perfectly!)