### PR TITLE
semgrep-core tests: force-run the tests when doing 'make test'

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -7,7 +7,7 @@ all:
 clean:
 	dune clean
 test:
-	dune runtest
+	dune runtest -f
 e2etest:
 	python3 tests/e2e/test_target_file.py
 install:


### PR DESCRIPTION
Our setup causes `dune runtest` to cache test results excessively, disregarding changes in test cases. This change forces the tests to run with every invocation of `make test`.
