### PR TITLE
target_manager: handle all file filtering in python instead of ocaml

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -199,31 +199,22 @@ class CoreRunner:
         yaml.dump({"equivalences": [e.to_json() for e in equivalences]}, fp)
         fp.flush()
 
-    def _run_rules(
-        self, rules: List[Rule], targets: List[Path]
-    ) -> Tuple[Dict[Rule, Dict[Path, List[PatternMatch]]], List[Any]]:
+    def _run_rule(
+        self, rule: Rule, targets: List[Path]
+    ) -> Tuple[List[RuleMatch], List[Dict[str, Any]], List[Any]]:
         """
             Run all rules on targets and return list of all places that match patterns, ... todo errors
         """
         outputs: List[PatternMatch] = []  # multiple invocations per language
         errors: List[Any] = []
-
-        # This will need to be addressed in the future. Since we flatten all the patterns,
-        # there's no way to tell semgrep which equivalences apply to which rules.
-        # So, my approach here is a naive implementation which likewise flattens all equivalences...
-        # Here there be dragons.... :-(
-        #  .>   )\;`a__
-        # (  _ _)/ /-." ~~
-        #  `( )_ )/
-        #   <_  <_ sb/dwb
-        equivalences = self._flatten_all_equivalences(rules)
+        equivalences = rule.equivalences
         with tempfile.NamedTemporaryFile("w") as equiv_fout:
 
             if equivalences:
                 self._write_equivalences_file(equiv_fout, equivalences)
 
             for language, all_patterns_for_language in self._group_patterns_by_language(
-                rules
+                [rule]
             ).items():
                 # semgrep-core doesn't know about OPERATORS.REGEX - this is
                 # strictly a semgrep Python feature. Regex filtering is
@@ -312,23 +303,11 @@ class CoreRunner:
         ] = collections.defaultdict(lambda: collections.defaultdict(list))
 
         for pattern_match in outputs:
-            rule_index = pattern_match.rule_index
-            rule = rules[rule_index]
             by_rule_index[rule][pattern_match.path].append(pattern_match)
 
-        return by_rule_index, errors
-
-    def _resolve_output(
-        self, outputs: Dict[Rule, Dict[Path, List[PatternMatch]]]
-    ) -> Tuple[Dict[Rule, List[RuleMatch]], Dict[Rule, List[Dict[str, Any]]]]:
-        """
-            Takes output of all running all patterns and rules and returns Findings
-        """
-        findings_by_rule: Dict[Rule, List[RuleMatch]] = {}
-        debugging_steps_by_rule: Dict[Rule, List[Dict[str, Any]]] = {}
-
-        for rule, paths in outputs.items():
-            findings = []
+        findings = []
+        debugging_steps: List[Any] = []
+        for rule, paths in by_rule_index.items():
             for filepath, pattern_matches in paths.items():
                 if not rule.globs.match_path(filepath):
                     continue
@@ -338,10 +317,37 @@ class CoreRunner:
                     rule, pattern_matches, self._allow_exec
                 )
                 findings.extend(findings_for_rule)
-                # debugging steps are only tracked for a single file, just overwrite
-                debugging_steps_by_rule[rule] = debugging_steps
 
-            findings_by_rule[rule] = dedup_output(findings)
+        findings = dedup_output(findings)
+
+        # debugging steps are only tracked for a single file, just overwrite
+        return findings, debugging_steps, errors
+
+    def _run_rules(
+        self, rules: List[Rule], target: List[Path]
+    ) -> Tuple[
+        Dict[Rule, List[RuleMatch]], Dict[Rule, List[Dict[str, Any]]], List[Any]
+    ]:
+        findings_by_rule: Dict[Rule, List[RuleMatch]] = {}
+        debugging_steps_by_rule: Dict[Rule, List[Dict[str, Any]]] = {}
+        all_errors = []
+
+        for rule in rules:
+            rule_matches, debugging_steps, errors = self._run_rule(rule, target)
+            findings_by_rule[rule] = rule_matches
+            debugging_steps_by_rule[rule] = debugging_steps
+            all_errors.extend(errors)
+
+        return findings_by_rule, debugging_steps_by_rule, all_errors
+
+    def _resolve_output(
+        self, outputs: Dict[Rule, Dict[Path, List[PatternMatch]]]
+    ) -> Tuple[Dict[Rule, List[RuleMatch]], Dict[Rule, List[Dict[str, Any]]]]:
+        """
+            Takes output of all running all patterns and rules and returns Findings
+        """
+        findings_by_rule: Dict[Rule, List[RuleMatch]] = {}
+        debugging_steps_by_rule: Dict[Rule, List[Dict[str, Any]]] = {}
 
         return findings_by_rule, debugging_steps_by_rule
 
@@ -370,8 +376,7 @@ class CoreRunner:
         """
         start = datetime.now()
 
-        outputs, errors = self._run_rules(rules, targets)
-        findings_by_rule, debug_steps_by_rule = self._resolve_output(outputs)
+        findings_by_rule, debug_steps_by_rule, errors = self._run_rules(rules, targets)
 
         debug_print(f"semgrep ran in {datetime.now() - start}")
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -332,6 +332,7 @@ class CoreRunner:
             debugging_steps_by_rule[rule] = debugging_steps
             all_errors.extend(errors)
 
+        all_errors = dedup_errors(all_errors)
         return findings_by_rule, debugging_steps_by_rule, all_errors
 
     def _resolve_output(
@@ -366,6 +367,24 @@ class CoreRunner:
 
 def dedup_output(outputs: List[RuleMatch]) -> List[RuleMatch]:
     return list({uniq_id(r): r for r in outputs}.values())
+
+
+def dedup_errors(errors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def uniq_error_id(
+        error: Dict[str, Any]
+    ) -> Tuple[str, str, Optional[int], Optional[int], Optional[int], Optional[int]]:
+        start = error.get("start", {})
+        end = error.get("end", {})
+        return (
+            error.get("check_id"),  # type: ignore
+            error.get("path"),
+            start.get("line"),
+            start.get("col"),
+            end.get("line"),
+            end.get("col"),
+        )
+
+    return list({uniq_error_id(r): r for r in errors}.values())
 
 
 def uniq_id(

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -180,3 +180,7 @@ class ErrorWithSpan(SemgrepError):
         else:
             help_str = ""
         return f"{header}\n{snippet_str}\n{help_str}\n{with_color(Fore.RED, self.long_msg or '')}\n"
+
+
+class NotGitProjectError(SemgrepError):
+    pass

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -184,3 +184,7 @@ class ErrorWithSpan(SemgrepError):
 
 class NotGitProjectError(SemgrepError):
     pass
+
+
+class UnknownLanguageError(SemgrepError):
+    pass

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -2,8 +2,10 @@ import subprocess
 from pathlib import Path
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Set
+
+from semgrep.error import NotGitProjectError
+from semgrep.util import partition_set
 
 
 class TargetManager:
@@ -12,45 +14,77 @@ class TargetManager:
         includes: List[str],
         excludes: List[str],
         targets: List[str],
-        git_ignore_file: Optional[Path] = None,
+        visible_to_git_only: bool = True,
     ) -> None:
         """
             Handles all file include/exclude logic for semgrep
+
+            If visible_to_git_only is true then will only consider files that are
+            tracked or (untracked but not ignored) by git
         """
         self._targets = targets
         self._includes = includes
         self._excludes = excludes
-        self._git_ignore_file = git_ignore_file
-        self._filtered_targets: Dict[str, List[Path]] = {}
+        self._visible_to_git_only = visible_to_git_only
+
+        self._filtered_targets: Dict[str, Set[Path]] = {}
 
     @staticmethod
-    def resolve_targets(targets: List[str]) -> List[Path]:
+    def resolve_targets(targets: List[str]) -> Set[Path]:
         """
             Return list of Path objects appropriately resolving relative paths
             (relative to cwd) if necessary
         """
         base_path = Path(".")
-        return [
+        return set(
             Path(target) if Path(target).is_absolute() else base_path.joinpath(target)
             for target in targets
-        ]
+        )
 
-    @staticmethod
-    def _expand_dir(curr_dir: Path, lang: str) -> Set[Path]:
+    def _expand_dir(self, curr_dir: Path, lang: str) -> Set[Path]:
         """
             Recursively go through a directory and return list of all files with
             default file extention of language
         """
         ext = "py"
-        output = subprocess.run(
-            ["find", curr_dir, "-type", "f", "-name", f"*.{ext}"],
-            encoding="utf-8",
-            stdout=subprocess.PIPE,
-        )
-        return set(Path(elem) for elem in output.stdout.strip().split("\n"))
+        if self._visible_to_git_only:
+            try:
+                # Tracked files
+                tracked_output = subprocess.check_output(
+                    ["git", "ls-files", f"*.{ext}"],
+                    cwd=curr_dir.resolve(),
+                    encoding="utf-8",
+                    stderr=subprocess.DEVNULL,
+                )
 
-    @staticmethod
-    def expand_targets(targets: List[Path], lang: str) -> List[Path]:
+                # Untracked but not ignored files
+                untracked_output = subprocess.check_output(
+                    ["git", "ls-files", "--other", "--exclude-standard", f"*.{ext}"],
+                    cwd=curr_dir.resolve(),
+                    encoding="utf-8",
+                    stderr=subprocess.DEVNULL,
+                )
+            except subprocess.CalledProcessError:
+                raise NotGitProjectError(
+                    f"{curr_dir.resolve()} is not a git repository."
+                )
+
+            tracked = set(Path(elem) for elem in tracked_output.strip().split("\n"))
+            untracked_unignored = set(
+                Path(elem) for elem in untracked_output.strip().split("\n")
+            )
+            return tracked.union(untracked_unignored)
+
+        else:
+            output = subprocess.run(
+                ["find", curr_dir, "-type", "f", "-name", f"*.{ext}"],
+                encoding="utf-8",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            return set(Path(elem) for elem in output.stdout.strip().split("\n"))
+
+    def expand_targets(self, targets: Set[Path], lang: str) -> Set[Path]:
         """
             Explore all directories. Remove duplicates
         """
@@ -60,11 +94,11 @@ class TargetManager:
                 continue
 
             if target.is_dir():
-                expanded.update(TargetManager._expand_dir(target, lang))
+                expanded.update(self._expand_dir(target, lang))
             else:
                 expanded.add(target)
 
-        return list(expanded)
+        return expanded
 
     @staticmethod
     def match_glob(path: Path, globs: List[str]) -> bool:
@@ -75,7 +109,7 @@ class TargetManager:
         return any(p.match(glob) for p in subpaths for glob in globs)
 
     @staticmethod
-    def filter_includes(arr: List[Path], includes: List[str]) -> List[Path]:
+    def filter_includes(arr: Set[Path], includes: List[str]) -> Set[Path]:
         """
             Returns all elements in arr that match any includes pattern
 
@@ -84,41 +118,56 @@ class TargetManager:
         if not includes:
             return arr
 
-        return [elem for elem in arr if TargetManager.match_glob(elem, includes)]
+        return set(elem for elem in arr if TargetManager.match_glob(elem, includes))
 
     @staticmethod
-    def filter_excludes(arr: List[Path], excludes: List[str]) -> List[Path]:
+    def filter_excludes(arr: Set[Path], excludes: List[str]) -> Set[Path]:
         """
             Returns all elements in arr that do not match any excludes excludes
         """
-        return [elem for elem in arr if not TargetManager.match_glob(elem, excludes)]
+        return set(elem for elem in arr if not TargetManager.match_glob(elem, excludes))
 
-    def filtered_files(self, lang: str) -> List[Path]:
+    def filtered_files(self, lang: str) -> Set[Path]:
+        """
+            Return all files that are decendants of any directory in TARGET that have
+            an extension matching LANG that match any pattern in INCLUDES and do not
+            match any pattern in EXCLUDES. Any file in TARGET bypasses excludes and includes.
+        """
         if lang in self._filtered_targets:
             return self._filtered_targets[lang]
 
         targets = self.resolve_targets(self._targets)
-        targets = self.expand_targets(targets, lang)
+        explicit_files, directories = partition_set(lambda p: not p.is_dir(), targets)
+        targets = self.expand_targets(directories, lang)
         targets = self.filter_includes(targets, self._includes)
         targets = self.filter_excludes(targets, self._excludes)
 
-        # TODO filter out gitignore
-
-        self._filtered_targets[lang] = targets
-        return targets
+        self._filtered_targets[lang] = targets.union(explicit_files)
+        return self._filtered_targets[lang]
 
     def get_files(
         self, lang: str, includes: List[str], excludes: List[str]
     ) -> List[Path]:
         """
-            per rule include and excludes
+            Returns list of files that should be analyzed for a LANG
+
+            Given this object's TARGET, self.INCLUDE, and self.EXCLUDE will return list
+            of all descendant files of directories in TARGET that end in extension
+            typical for LANG. If self.INCLUDES is non empty then all files will have an ancestor
+            that matches a pattern in self.INCLUDES. Will not include any file that has
+            an ancestor that matches a pattern in self.EXCLUDES. Any explcilty named files
+            in TARGET will bypass this global INCLUDE/EXCLUDE filter. The local INCLUDE/EXCLUDE
+            filter is then applied.
         """
         targets = self.filtered_files(lang)
         targets = self.filter_includes(targets, includes)
         targets = self.filter_excludes(targets, excludes)
-        return targets
+        return list(targets)
 
 
 if __name__ == "__main__":
-    target_manager = TargetManager(includes=[], excludes=[], targets=["."])
-    target_manager.get_files("python", [], [])
+    try:
+        target_manager = TargetManager(includes=[], excludes=["tests"], targets=["."])
+        target_manager.get_files("python", [], [])
+    except Exception as e:
+        print(str(e))

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -1,0 +1,124 @@
+import subprocess
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+
+
+class TargetManager:
+    def __init__(
+        self,
+        includes: List[str],
+        excludes: List[str],
+        targets: List[str],
+        git_ignore_file: Optional[Path] = None,
+    ) -> None:
+        """
+            Handles all file include/exclude logic for semgrep
+        """
+        self._targets = targets
+        self._includes = includes
+        self._excludes = excludes
+        self._git_ignore_file = git_ignore_file
+        self._filtered_targets: Dict[str, List[Path]] = {}
+
+    @staticmethod
+    def resolve_targets(targets: List[str]) -> List[Path]:
+        """
+            Return list of Path objects appropriately resolving relative paths
+            (relative to cwd) if necessary
+        """
+        base_path = Path(".")
+        return [
+            Path(target) if Path(target).is_absolute() else base_path.joinpath(target)
+            for target in targets
+        ]
+
+    @staticmethod
+    def _expand_dir(curr_dir: Path, lang: str) -> Set[Path]:
+        """
+            Recursively go through a directory and return list of all files with
+            default file extention of language
+        """
+        ext = "py"
+        output = subprocess.run(
+            ["find", curr_dir, "-type", "f", "-name", f"*.{ext}"],
+            encoding="utf-8",
+            stdout=subprocess.PIPE,
+        )
+        return set(Path(elem) for elem in output.stdout.strip().split("\n"))
+
+    @staticmethod
+    def expand_targets(targets: List[Path], lang: str) -> List[Path]:
+        """
+            Explore all directories. Remove duplicates
+        """
+        expanded = set()
+        for target in targets:
+            if not target.exists():
+                continue
+
+            if target.is_dir():
+                expanded.update(TargetManager._expand_dir(target, lang))
+            else:
+                expanded.add(target)
+
+        return list(expanded)
+
+    @staticmethod
+    def match_glob(path: Path, globs: List[str]) -> bool:
+        """
+            Return true if path or any parent of path matches any glob in globs
+        """
+        subpaths = [path, *path.parents]
+        return any(p.match(glob) for p in subpaths for glob in globs)
+
+    @staticmethod
+    def filter_includes(arr: List[Path], includes: List[str]) -> List[Path]:
+        """
+            Returns all elements in arr that match any includes pattern
+
+            If includes is empty, returns arr unchanged
+        """
+        if not includes:
+            return arr
+
+        return [elem for elem in arr if TargetManager.match_glob(elem, includes)]
+
+    @staticmethod
+    def filter_excludes(arr: List[Path], excludes: List[str]) -> List[Path]:
+        """
+            Returns all elements in arr that do not match any excludes excludes
+        """
+        return [elem for elem in arr if not TargetManager.match_glob(elem, excludes)]
+
+    def filtered_files(self, lang: str) -> List[Path]:
+        if lang in self._filtered_targets:
+            return self._filtered_targets[lang]
+
+        targets = self.resolve_targets(self._targets)
+        targets = self.expand_targets(targets, lang)
+        targets = self.filter_includes(targets, self._includes)
+        targets = self.filter_excludes(targets, self._excludes)
+
+        # TODO filter out gitignore
+
+        self._filtered_targets[lang] = targets
+        return targets
+
+    def get_files(
+        self, lang: str, includes: List[str], excludes: List[str]
+    ) -> List[Path]:
+        """
+            per rule include and excludes
+        """
+        targets = self.filtered_files(lang)
+        targets = self.filter_includes(targets, includes)
+        targets = self.filter_excludes(targets, excludes)
+        return targets
+
+
+if __name__ == "__main__":
+    target_manager = TargetManager(includes=[], excludes=[], targets=["."])
+    target_manager.get_files("python", [], [])

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Callable
 from typing import Iterable
 from typing import List
+from typing import Set
 from typing import Tuple
 from urllib.parse import urlparse
 
@@ -82,6 +83,12 @@ def partition(pred: Callable, iterable: Iterable) -> Tuple[List, List]:
     """E.g. partition(is_odd, range(10)) -> 1 3 5 7 9  and  0 2 4 6 8"""
     i1, i2 = itertools.tee(iterable)
     return list(filter(pred, i1)), list(itertools.filterfalse(pred, i2))
+
+
+def partition_set(pred: Callable, iterable: Iterable) -> Tuple[Set, Set]:
+    """E.g. partition(is_odd, range(10)) -> 1 3 5 7 9  and  0 2 4 6 8"""
+    i1, i2 = itertools.tee(iterable)
+    return set(filter(pred, i1)), set(itertools.filterfalse(pred, i2))
 
 
 def with_color(color: str, text: str, bold: bool = False) -> str:

--- a/semgrep/tests/e2e/rules/paths.yaml
+++ b/semgrep/tests/e2e/rules/paths.yaml
@@ -1,7 +1,8 @@
 rules:
   - id: file-excluded
     paths:
-      exclude: excluded.*
+      exclude:
+        - excluded.*
     patterns:
       - pattern: "$X == $X"
     message: "possibly useless comparison but in eq function"
@@ -9,7 +10,8 @@ rules:
     severity: ERROR
   - id: file-included
     paths:
-      include: included.*
+      include:
+        - included.*
     patterns:
       - pattern: "$X == $X"
     message: "possibly useless comparison but in eq function"
@@ -17,7 +19,8 @@ rules:
     severity: ERROR
   - id: directory-excluded
     paths:
-      exclude: excluded/
+      exclude:
+        - excluded/
     patterns:
       - pattern: "$X == $X"
     message: "possibly useless comparison but in eq function"
@@ -25,7 +28,8 @@ rules:
     severity: ERROR
   - id: directory-included
     paths:
-      include: included/
+      include:
+        - included/
     patterns:
       - pattern: "$X == $X"
     message: "possibly useless comparison but in eq function"
@@ -53,8 +57,10 @@ rules:
     severity: ERROR
   - id: file-excluded-directory-included
     paths:
-      exclude: excluded.*
-      include: included/
+      exclude:
+        - excluded.*
+      include:
+        - included/
     patterns:
       - pattern: "$X == $X"
     message: "possibly useless comparison but in eq function"
@@ -62,8 +68,10 @@ rules:
     severity: ERROR
   - id: directory-excluded-file-included
     paths:
-      exclude: excluded/
-      include: included.*
+      exclude:
+        - excluded/
+      include:
+        - included.*
     patterns:
       - pattern: "$X == $X"
     message: "possibly useless comparison but in eq function"

--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
@@ -55,6 +55,23 @@
             "level": "error"
           },
           "fullDescription": {
+            "text": "possibly useless comparison but in eq function"
+          },
+          "id": "rules.assert-eqeq-is-ok",
+          "name": "rules.assert-eqeq-is-ok",
+          "properties": {
+            "precision": "very-high",
+            "tags": []
+          },
+          "shortDescription": {
+            "text": "possibly useless comparison but in eq function"
+          }
+        },
+        {
+          "defaultConfiguration": {
+            "level": "error"
+          },
+          "fullDescription": {
             "text": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
           },
           "id": "rules.eqeq-is-bad",
@@ -82,6 +99,23 @@
           },
           "shortDescription": {
             "text": "useless comparison"
+          }
+        },
+        {
+          "defaultConfiguration": {
+            "level": "error"
+          },
+          "fullDescription": {
+            "text": "this function is only available on Python 3.7+"
+          },
+          "id": "rules.python37-compatability-os-module",
+          "name": "rules.python37-compatability-os-module",
+          "properties": {
+            "precision": "very-high",
+            "tags": []
+          },
+          "shortDescription": {
+            "text": "this function is only available on Python 3.7+"
           }
         }
       ],

--- a/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
+++ b/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
@@ -2,7 +2,436 @@
   "errors": [],
   "results": [
     {
-      "check_id": "rules.directory-excluded-file-included",
+      "check_id": "rules.file-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.file-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.file-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.file-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/excluded.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/excluded.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.directory-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-excluded",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/included/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-included",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "possibly useless comparison but in eq function",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/exclude_include/excluded/included.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.paths-included",
       "end": {
         "col": 19,
         "line": 3
@@ -80,436 +509,7 @@
       }
     },
     {
-      "check_id": "rules.paths-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.paths-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.paths-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.paths-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/excluded.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/excluded.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.directory-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-included",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/included/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-excluded",
-      "end": {
-        "col": 19,
-        "line": 3
-      },
-      "extra": {
-        "lines": "console.log(x == x)",
-        "message": "possibly useless comparison but in eq function",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "x",
-            "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 25
-            },
-            "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 24
-            },
-            "unique_id": {
-              "kind": "Global",
-              "sid": 1,
-              "type": "id",
-              "value": "x"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/exclude_include/excluded/included.js",
-      "start": {
-        "col": 13,
-        "line": 3
-      }
-    },
-    {
-      "check_id": "rules.file-excluded",
+      "check_id": "rules.directory-excluded-file-included",
       "end": {
         "col": 19,
         "line": 3

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -4,9 +4,4 @@ Syntax error
 def foo(a)
           ^
 = note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev
-Syntax error
---> targets/bad/invalid_python.py:1
-def foo(a)
-          ^
-= note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev
-run with --strict and 2 errors occurred during semgrep run; exiting
+run with --strict and 1 errors occurred during semgrep run; exiting

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -4,4 +4,9 @@ Syntax error
 def foo(a)
           ^
 = note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev
-run with --strict and 1 errors occurred during semgrep run; exiting
+Syntax error
+--> targets/bad/invalid_python.py:1
+def foo(a)
+          ^
+= note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev
+run with --strict and 2 errors occurred during semgrep run; exiting

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -1,0 +1,321 @@
+import subprocess
+from pathlib import Path
+from typing import Set
+
+from semgrep.target_manager import TargetManager
+
+
+def test_filter_include():
+    all_files = [
+        "foo.py",
+        "foo.go",
+        "foo.java",
+        "foo/bar.py",
+        "foo/bar.go",
+        "bar/foo/baz/bar.go",
+        "foo/bar.java",
+        "bar/baz",
+        "baz.py",
+        "baz.go",
+        "baz.java",
+        "bar/foo/foo.py",
+        "foo",
+        "bar/baz/foo/a.py",
+        "bar/baz/foo/b.py",
+        "bar/baz/foo/c.py",
+        "bar/baz/qux/foo/a.py",
+        "/foo/bar/baz/a.py",
+    ]
+    all_files = set({Path(elem) for elem in all_files})
+
+    # All .py files
+    assert len(TargetManager.filter_includes(all_files, ["*.py"])) == 9
+
+    # All files in a foo directory ancestor
+    assert len(TargetManager.filter_includes(all_files, ["foo"])) == 11
+
+    # All files with an ancestor named bar/baz
+    assert len(TargetManager.filter_includes(all_files, ["bar/baz"])) == 6
+
+    # All go files
+    assert len(TargetManager.filter_includes(all_files, ["*.go"])) == 4
+
+    # All go and java files
+    assert len(TargetManager.filter_includes(all_files, ["*.go", "*.java"])) == 7
+
+    # All go files with a direct ancestor named foo
+    assert len(TargetManager.filter_includes(all_files, ["foo/*.go"])) == 1
+
+
+def test_filter_exclude():
+    all_files = [
+        "foo.py",
+        "foo.go",
+        "foo.java",
+        "foo/bar.py",
+        "foo/bar.go",
+        "bar/foo/baz/bar.go",
+        "foo/bar.java",
+        "bar/baz",
+        "baz.py",
+        "baz.go",
+        "baz.java",
+        "bar/foo/foo.py",
+        "foo",
+        "bar/baz/foo/a.py",
+        "bar/baz/foo/b.py",
+        "bar/baz/foo/c.py",
+        "bar/baz/qux/foo/a.py",
+        "/foo/bar/baz/a.py",
+    ]
+    all_files = set({Path(elem) for elem in all_files})
+
+    # Filter out .py files
+    assert len(TargetManager.filter_excludes(all_files, ["*.py"])) == 9
+
+    # Filter out files in a foo directory ancestor
+    assert len(TargetManager.filter_excludes(all_files, ["foo"])) == 7
+
+    # Filter out files with an ancestor named bar/baz
+    assert len(TargetManager.filter_excludes(all_files, ["bar/baz"])) == 12
+
+    # Filter out go files
+    assert len(TargetManager.filter_excludes(all_files, ["*.go"])) == 14
+
+    # Filter out go and java files
+    assert len(TargetManager.filter_excludes(all_files, ["*.go", "*.java"])) == 11
+
+    # Filter out go files with a direct ancestor named foo
+    assert len(TargetManager.filter_excludes(all_files, ["foo/*.go"])) == 17
+
+
+def test_expand_targets_git(tmp_path, monkeypatch):
+    """
+        Test TargetManager with visible_to_git_only flag on in a git repository
+        with nested .gitignores
+    """
+    foo = tmp_path / "foo"
+    foo.mkdir()
+    foo_a_go = foo / "a.go"
+    foo_a_go.touch()
+    (foo / "b.go").touch()
+    (foo / "py").touch()
+    foo_a = foo / "a.py"
+    foo_a.touch()
+    foo_b = foo / "b.py"
+    foo_b.touch()
+
+    bar = tmp_path / "bar"
+    bar.mkdir()
+    bar_a = bar / "a.py"
+    bar_a.touch()
+    bar_b = bar / "b.py"
+    bar_b.touch()
+
+    foo_bar = foo / "bar"
+    foo_bar.mkdir()
+    foo_bar_a = foo_bar / "a.py"
+    foo_bar_a.touch()
+    foo_bar_b = foo_bar / "b.py"
+    foo_bar_b.touch()
+
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"])
+    subprocess.run(["git", "add", foo_a])
+    subprocess.run(["git", "add", foo_bar_a])
+    subprocess.run(["git", "add", foo_bar_b])
+    subprocess.run(["git", "add", foo_a_go])
+    subprocess.run(["git", "commit", "-m", "first"])
+
+    # Check that all files are visible without a .gitignore
+    in_foo_bar = {foo_bar_a, foo_bar_b}
+    in_foo = {foo_a, foo_b}.union(in_foo_bar)
+    in_bar = {bar_a, bar_b}
+    in_all = in_foo.union(in_bar)
+
+    monkeypatch.chdir(tmp_path)
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path(".")], "python", True), in_all
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", True), in_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo")], "python", True), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo").resolve()], "python", True), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo/bar")], "python", True), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo/bar").resolve()], "python", True),
+        in_foo_bar,
+    )
+    monkeypatch.chdir(foo)
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path(".")], "python", True), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("./foo")], "python", True), set()
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", True), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", True), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("..")], "python", True), in_all
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("../bar")], "python", True), in_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("../foo/bar")], "python", True), in_foo_bar
+    )
+
+    # Add bar/, foo/bar/a.py, foo/b.py to gitignores
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gitignore").write_text("bar/\nfoo/bar/a.py")
+    (tmp_path / "foo" / ".gitignore").write_text("b.py")
+
+    # Reflect what should now be visible given gitignores
+    in_foo_bar = {
+        foo_bar_a,
+        foo_bar_b,
+    }  # foo/bar/a.py is gitignored but is already tracked
+    in_foo = {foo_a}.union(in_foo_bar)  # foo/b.py is gitignored with a nested gitignore
+    in_bar = set()  # bar/ is gitignored
+    in_all = in_foo.union(in_bar)
+
+    monkeypatch.chdir(tmp_path)
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path(".")], "python", True), in_all
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", True), in_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo")], "python", True), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo").resolve()], "python", True), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo/bar")], "python", True), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo/bar").resolve()], "python", True),
+        in_foo_bar,
+    )
+    monkeypatch.chdir(foo)
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path(".")], "python", True), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("./foo")], "python", True), set()
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", True), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", True), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("..")], "python", True), in_all
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("../bar")], "python", True), in_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("../foo/bar")], "python", True), in_foo_bar
+    )
+
+
+def cmp_path_sets(a: Set[Path], b: Set[Path]) -> bool:
+    """
+        Check that two sets of path contain the same paths
+    """
+    a_abs = {elem.resolve() for elem in a}
+    b_abs = {elem.resolve() for elem in b}
+    return a_abs == b_abs
+
+
+def test_expand_targets_not_git(tmp_path, monkeypatch):
+    """
+        Check that directory expansion works with relative paths, absolute paths, paths with ..
+    """
+    foo = tmp_path / "foo"
+    foo.mkdir()
+    (foo / "a.go").touch()
+    (foo / "b.go").touch()
+    (foo / "py").touch()
+    foo_a = foo / "a.py"
+    foo_a.touch()
+    foo_b = foo / "b.py"
+    foo_b.touch()
+
+    bar = tmp_path / "bar"
+    bar.mkdir()
+    bar_a = bar / "a.py"
+    bar_a.touch()
+    bar_b = bar / "b.py"
+    bar_b.touch()
+
+    foo_bar = foo / "bar"
+    foo_bar.mkdir()
+    foo_bar_a = foo_bar / "a.py"
+    foo_bar_a.touch()
+    foo_bar_b = foo_bar / "b.py"
+    foo_bar_b.touch()
+
+    in_foo_bar = {foo_bar_a, foo_bar_b}
+    in_foo = {foo_a, foo_b}.union(in_foo_bar)
+    in_bar = {bar_a, bar_b}
+    in_all = in_foo.union(in_bar)
+
+    monkeypatch.chdir(tmp_path)
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path(".")], "python", False), in_all
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", False), in_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo")], "python", False), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo").resolve()], "python", False), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo/bar")], "python", False), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("foo/bar").resolve()], "python", False),
+        in_foo_bar,
+    )
+
+    monkeypatch.chdir(foo)
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path(".")], "python", False), in_foo
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("./foo")], "python", False), set()
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", False), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("bar")], "python", False), in_foo_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("..")], "python", False), in_all
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("../bar")], "python", False), in_bar
+    )
+    assert cmp_path_sets(
+        TargetManager.expand_targets([Path("../foo/bar")], "python", False), in_foo_bar
+    )


### PR DESCRIPTION
This PR adds logic in python to manage which files to run semgrep rules on.

- Respects per rule file ignores and only runs semgrep-core on necessary files instead of post-filtering
- Regex and semgrep-core rules share logic on what files to run on
- Code in semgrep-core that handles file include/exclude was not removed
- Adds support for respecting gitignore (for now turned off. we can turn on and add a flag in a follow up PR)
- Allows cli include/exclude behavior to mimic rule path config style so we don't have two separate include/exclude syntaxes but will expose the cli changes in a follow up PR
- passing list of files to semgrep-core as a file will also do in a follow up PR