### PR TITLE
Fix 'pattern_id' when using nested pattern operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Value of `pattern_id` when using nested pattern operators [#828](https://github.com/returntocorp/semgrep/issues/828)
+
 ## [0.10.0](https://github.com/returntocorp/semgrep/releases/tag/v0.10.0) - 2020-06-09
 
 ### Fixed

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -331,7 +331,7 @@ class CoreRunner:
             for filepath, pattern_matches in paths.items():
                 if not rule.globs.match_path(filepath):
                     continue
-                debug_print(f"-------- rule ({rule.id} ------ filepath: {filepath}")
+                debug_print(f"----- rule ({rule.id}) ----- filepath: {filepath}")
 
                 findings_for_rule, debugging_steps = evaluate(
                     rule, pattern_matches, self._allow_exec

--- a/semgrep/semgrep/pattern.py
+++ b/semgrep/semgrep/pattern.py
@@ -42,3 +42,6 @@ class Pattern:
             "languages": self._languages,
             "message": self._message,
         }
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} id={self._id}>"

--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -37,7 +37,7 @@ class PatternMatch:
     @property
     def vars(self) -> Dict[str, Any]:
         metavars = {v: data.get("unique_id", {}) for v, data in self.metavars.items()}
-        return {v: uid.get("sid", "md5sum") for v, uid in metavars.items()}
+        return {v: uid.get("sid", uid.get("md5sum")) for v, uid in metavars.items()}
 
     @property
     def range(self) -> Range:
@@ -63,5 +63,5 @@ class PatternMatch:
             del end["offset"]
         return end
 
-    # def __repr__(self) -> str:
-    #     return f"{self.range}-{self.metavars}"
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} id={self.id} range={self.range}>"

--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 
-from semgrep.error import SemgrepError
 from semgrep.semgrep_types import PatternId
 from semgrep.semgrep_types import Range
 
@@ -37,16 +36,8 @@ class PatternMatch:
 
     @property
     def vars(self) -> Dict[str, Any]:
-        def get_identifier(metavariable: str, uid: Dict) -> str:
-            try:
-                return uid.get("sid", uid["md5sum"])
-            except KeyError:
-                raise SemgrepError(
-                    f"metavariable missing unique identifier: {metavariable}"
-                )
-
         metavars = {v: data.get("unique_id", {}) for v, data in self.metavars.items()}
-        return {v: get_identifier(v, uid) for v, uid in metavars.items()}
+        return {v: uid.get("sid", uid.get("md5sum")) for v, uid in metavars.items()}
 
     @property
     def range(self) -> Range:

--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 
+from semgrep.error import SemgrepError
 from semgrep.semgrep_types import PatternId
 from semgrep.semgrep_types import Range
 
@@ -36,8 +37,16 @@ class PatternMatch:
 
     @property
     def vars(self) -> Dict[str, Any]:
+        def get_identifier(metavariable: str, uid: Dict) -> str:
+            try:
+                return uid.get("sid", uid["md5sum"])
+            except KeyError:
+                raise SemgrepError(
+                    f"metavariable missing unique identifier: {metavariable}"
+                )
+
         metavars = {v: data.get("unique_id", {}) for v, data in self.metavars.items()}
-        return {v: uid.get("sid", uid.get("md5sum")) for v, uid in metavars.items()}
+        return {v: get_identifier(v, uid) for v, uid in metavars.items()}
 
     @property
     def range(self) -> Range:

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from typing import Dict
 from typing import Iterator
@@ -38,7 +37,7 @@ class Rule:
             raise InvalidRuleSchemaError(
                 f"invalid type for patterns in rule: {type(rule_patterns)} is not a list; perhaps your YAML is missing a `-` before {rule_patterns}?"
             )
-        for pattern in rule_patterns:
+        for rule_index, pattern in enumerate(rule_patterns):
             if not isinstance(pattern, dict):
                 raise InvalidRuleSchemaError(
                     f"invalid type for pattern {pattern}: {type(pattern)} is not a dict"
@@ -48,7 +47,7 @@ class Rule:
                 if operator in set(OPERATORS_WITH_CHILDREN):
                     if isinstance(pattern_text, list):
                         sub_expression = self._parse_boolean_expression(
-                            pattern_text, 0, f"{prefix}.{pattern_id}"
+                            pattern_text, 0, f"{prefix}.{rule_index}.{pattern_id}"
                         )
                         yield BooleanRuleExpression(
                             operator=operator,
@@ -251,7 +250,7 @@ class Rule:
         }
 
     def __repr__(self) -> str:
-        return json.dumps(self.to_json())
+        return f"<{self.__class__.__name__} id={self.id}>"
 
     def with_id(self, new_id: str) -> "Rule":
         new_yaml = YamlTree(value=dict(self._yaml.value), span=self._yaml.span)  # type: ignore

--- a/semgrep/semgrep/rule_lang.py
+++ b/semgrep/semgrep/rule_lang.py
@@ -18,7 +18,7 @@ class Position(NamedTuple):
     column: int
 
     def __repr__(self) -> str:
-        return f"{self.line}:{self.column}"
+        return f"<{self.__class__.__name__} line={self.line} column={self.column}>"
 
 
 class Span(NamedTuple):
@@ -33,7 +33,7 @@ class Span(NamedTuple):
         return Span(start=start, end=end, file=file)
 
     def __repr__(self) -> str:
-        return f"{self.start}-{self.end}"
+        return f"<{self.__class__.__name__} start={self.start} end={self.end}>"
 
 
 EmptySpan = Span(start=Position(0, 0), end=Position(0, 0), file=None)
@@ -58,7 +58,7 @@ class YamlTree:
         return hash(self.value)
 
     def __repr__(self) -> str:
-        return f"{self.span}: ---> {self.value}"
+        return f"<{self.__class__.__name__} span={self.span} value={self.value}>"
 
     def unroll_dict(self) -> Dict[str, Any]:
         ret = self.unroll()

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -129,3 +129,6 @@ class RuleMatch:
                 }
             ],
         }
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} id={self.id} start={str(self.start)} end={str(self.end)}>"

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -145,10 +145,13 @@ class Range(NamedTuple):
         :param rhs: The other Range
         """
         to_match = set(self.vars.keys()).intersection(rhs.vars.keys())
-        return all(self.vars[v] == rhs.vars[v] for v in to_match)
+        return all(
+            self.vars[v] and rhs.vars[v] and self.vars[v] == rhs.vars[v]
+            for v in to_match
+        )
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} start={self.start} end={self.end} vars={ {m: self.vars.get(m, 'None') for m in self.vars} }>"
+        return f"<{self.__class__.__name__} start={self.start} end={self.end} vars={self.vars}>"
 
     def __hash__(self) -> int:
         return hash((self.start, self.end))

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -148,7 +148,7 @@ class Range(NamedTuple):
         return all(self.vars[v] == rhs.vars[v] for v in to_match)
 
     def __repr__(self) -> str:
-        return f"{self.start}-{self.end} {{m: self.vars.get(m, 'None') for m in self.vars}}"
+        return f"<{self.__class__.__name__} start={self.start} end={self.end} vars={ {m: self.vars.get(m, 'None') for m in self.vars} }>"
 
     def __hash__(self) -> int:
         return hash((self.start, self.end))

--- a/semgrep/tests/e2e/rules/nested-patterns.yaml
+++ b/semgrep/tests/e2e/rules/nested-patterns.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test
+  message: test
+  severity: WARNING
+  languages: [javascript]
+  patterns:
+    - pattern-either:
+      - pattern: nested_patterns_func('foo', ...)
+      - pattern: nested_patterns_func('bar', ...)
+    - pattern-either:
+      - pattern: nested_patterns_func($X, 1, ...)
+      - pattern: nested_patterns_func($X, 2, ...)

--- a/semgrep/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
@@ -1,0 +1,43 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.test",
+      "end": {
+        "col": 34,
+        "line": 2
+      },
+      "extra": {
+        "lines": "    nested_patterns_func('foo', 1)",
+        "message": "test",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nested-patterns.js",
+      "start": {
+        "col": 5,
+        "line": 2
+      }
+    },
+    {
+      "check_id": "rules.test",
+      "end": {
+        "col": 34,
+        "line": 3
+      },
+      "extra": {
+        "lines": "    nested_patterns_func('bar', 2)",
+        "message": "test",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nested-patterns.js",
+      "start": {
+        "col": 5,
+        "line": 3
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/basic/nested-patterns.js
+++ b/semgrep/tests/e2e/targets/basic/nested-patterns.js
@@ -1,0 +1,6 @@
+function test() {
+    nested_patterns_func('foo', 1)
+    nested_patterns_func('bar', 2)
+    nested_patterns_func('bar', 3)
+    nested_patterns_func('baz', 1)
+}

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -108,3 +108,9 @@ def test_regex_rule__invalid_expression(run_semgrep_in_tmp, snapshot):
         run_semgrep_in_tmp("rules/regex-invalid.yaml", stderr=True)
     assert excinfo.value.returncode == 2
     snapshot.assert_match(excinfo.value.output, "error.txt")
+
+
+def test_nested_patterns_rule(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/nested-patterns.yaml"), "results.json"
+    )


### PR DESCRIPTION
Fixes #828.

I was also having a heck of a time debugging the problem, so I patched up some of the `__repr__` functions to make it easier. Added a few comments inline.