### PR TITLE
On the way to beautiful errors

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -221,6 +221,12 @@ def cli() -> None:
         "--version", action="store_true", help="Show the version and exit."
     )
 
+    parser.add_argument(
+        "--force-color",
+        action="store_true",
+        help="Always include ANSI color in the output, even if not writing to a TTY",
+    )
+
     ### Parse and validate
     args = parser.parse_args()
     if args.version:
@@ -234,7 +240,7 @@ def cli() -> None:
         parser.error("--dump-ast and -l/--lang must both be specified")
 
     # set the flags
-    semgrep.util.set_flags(args.verbose, args.quiet)
+    semgrep.util.set_flags(args.verbose, args.quiet, args.force_color)
 
     # change cwd if using docker
     semgrep.config_resolver.adjust_for_docker(args.precommit)

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -1,3 +1,15 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
+
+from colorama import Fore
+
+from semgrep.constants import OutputFormat
+from semgrep.rule_lang import Span
+from semgrep.rule_lang import SpanBuilder
+
 OK_EXIT_CODE = 0
 FINDINGS_EXIT_CODE = 1
 FATAL_EXIT_CODE = 2
@@ -32,3 +44,108 @@ class InvalidPatternNameError(SemgrepError):
 
 class UnknownOperatorError(SemgrepError):
     pass
+
+
+class ErrorWithContext(SemgrepError):
+    """
+    Error which will print context from the Span. You should provide the most specific span possible,
+    eg. if the error is an invalid key, provide exactly the span for that key. You can then expand what's printed
+    with span.with_context(...)
+    """
+
+    def __init__(
+        self,
+        short_msg: str,
+        long_msg: Optional[str],
+        level: str,
+        spans: List[Span],
+        help: Optional[str] = None,
+        cause: Optional[Exception] = None,
+    ):
+        self.short_msg = short_msg
+        self.long_msg = long_msg
+        self.level = level
+        self.spans = spans
+        self.help = help
+        self.__cause__ = cause
+
+    @staticmethod
+    def _line_number_width(span: Span) -> int:
+        return len(str((span.context_end or span.end).line + 1)) + 1
+
+    @staticmethod
+    def _format_line_number(span: Span, line_number: Optional[int]) -> str:
+        # line numbers are 0 indexed
+        width = ErrorWithContext._line_number_width(span)
+        if line_number is not None:
+            base_str = str(line_number + 1)
+            assert len(base_str) < width
+            return with_color(Fore.LIGHTBLUE_EX, base_str.ljust(width) + "| ")
+        else:
+            return with_color(Fore.LIGHTBLUE_EX, "".ljust(width) + "| ")
+
+    def _code_segment(
+        self, start_line: int, end_line: int, source: List[str], span: Span
+    ) -> List[str]:
+        code_segment = source[start_line : end_line + 1]
+        snippet = []
+        for line_num, line in zip(range(start_line, end_line + 1), code_segment):
+            snippet.append(f"{self._format_line_number(span, line_num)}{line}")
+        return snippet
+
+    def emit_str(self) -> str:
+        header = f"{with_color(Fore.RED, self.level)}: {self.short_msg}"
+        snippets = []
+        for span in self.spans:
+            location_hint = f"  --> {span.file}:{span.start.line + 1}"
+            snippet = [location_hint]
+            source = SpanBuilder().source(span.source_hash)
+            if span.context_start:
+                snippet += self._code_segment(
+                    span.context_start.line, span.start.line - 1, source, span
+                )
+            snippet += self._code_segment(span.start.line, span.end.line, source, span)
+            # Currently, only span highlighting if it's a one line span
+            if span.start.line == span.end.line:
+                error = with_color(
+                    Fore.RED, (span.end.column - span.start.column) * "^"
+                )
+                snippet.append(
+                    self._format_line_number(span, None)
+                    + " " * span.start.column
+                    + error
+                )
+            if span.context_end:
+                snippet += self._code_segment(
+                    span.end.line + 1, span.context_end.line, source, span
+                )
+
+            snippets.append("\n".join(snippet))
+        snippet_str = "\n".join(snippets)
+        if self.help:
+            help_str = f"= {with_color(Fore.CYAN, 'help', bold=True)}: {self.help}"
+        else:
+            help_str = ""
+        return f"{header}\n{snippet_str}\n{help_str}\n{with_color(Fore.RED, self.long_msg or '')}\n"
+
+    def emit(self, output_format: OutputFormat) -> Union[Dict[str, Any], str]:
+        if output_format in {OutputFormat.JSON, OutputFormat.JSON_DEBUG}:
+            return dict(
+                short_msg=self.short_msg,
+                long_msg=self.long_msg,
+                level=self.level,
+                spans=[span.as_dict() for span in self.spans],
+            )
+        else:
+            return self.emit_str()
+
+
+def with_color(color: str, text: str, bold: bool = False) -> str:
+    """
+    Wrap text in color & reset
+    """
+    reset = Fore.RESET
+    if bold:
+        color = color + "\033[1m"
+        reset += "\033[0m"
+    return f"{color}{text}{reset}"

--- a/semgrep/semgrep/rule_lang.py
+++ b/semgrep/semgrep/rule_lang.py
@@ -1,8 +1,10 @@
+import hashlib
 from io import StringIO
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import NamedTuple
+from typing import NewType
 from typing import Optional
 from typing import Union
 
@@ -11,6 +13,35 @@ from ruamel.yaml import RoundTripConstructor
 from ruamel.yaml import YAML
 
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
+
+# Do not construct directly, use `SpanBuilder().add_source`
+SourceFileHash = NewType("SourceFileHash", str)
+
+
+class SpanBuilder:
+    """
+    Singleton class tracking mapping from filehashes -> file contents to support
+    building error messages from Spans
+    """
+
+    # sources are a class variable to share state
+    sources: Dict[SourceFileHash, List[str]] = {}
+
+    @classmethod
+    def add_source(cls, source: str) -> SourceFileHash:
+        file_hash = cls._src_to_hash(source)
+        cls.sources[file_hash] = source.splitlines()
+        return file_hash
+
+    @classmethod
+    def source(cls, source_hash: SourceFileHash) -> List[str]:
+        return cls.sources[source_hash]
+
+    @staticmethod
+    def _src_to_hash(contents: Union[str, bytes]) -> SourceFileHash:
+        if isinstance(contents, str):
+            contents = contents.encode("utf-8")
+        return SourceFileHash(hashlib.sha256(contents).hexdigest())
 
 
 class Position(NamedTuple):
@@ -24,19 +55,48 @@ class Position(NamedTuple):
 class Span(NamedTuple):
     start: Position
     end: Position
+    source_hash: SourceFileHash
     file: Optional[str]
+    context_start: Optional[Position] = None
+    context_end: Optional[Position] = None
 
     @classmethod
-    def from_node(cls, node: Node, file: Optional[str]) -> "Span":
+    def from_node(
+        cls, node: Node, source_hash: SourceFileHash, filename: Optional[str]
+    ) -> "Span":
         start = Position(line=node.start_mark.line, column=node.start_mark.column)
         end = Position(line=node.end_mark.line, column=node.end_mark.column)
-        return Span(start=start, end=end, file=file)
+        return Span(start=start, end=end, file=filename, source_hash=source_hash)
+
+    def truncate(self, lines: int) -> "Span":
+        """
+        Shorten this span to at most `lines`
+        """
+        if self.end.line - self.start.line > lines:
+            return self._replace(end=Position(line=self.start.line + lines, column=0))
+        return self
+
+    def with_context(
+        self, before: Optional[int] = None, after: Optional[int] = None
+    ) -> "Span":
+        new = self
+        if before is not None:
+            new = new._replace(
+                context_start=Position(column=0, line=max(0, self.start.line - before))
+            )
+
+        if after is not None:
+            new = new._replace(
+                context_end=Position(column=0, line=self.end.line + after)
+            )
+        return new
+
+    def as_dict(self) -> Dict[str, Any]:
+        return dict(start=self.start._asdict(), end=self.end._asdict(), file=self.file)
 
     def __repr__(self) -> str:
         return f"{self.start}-{self.end}"
 
-
-EmptySpan = Span(start=Position(0, 0), end=Position(0, 0), file=None)
 
 # Actually recursive but mypy is unhelpful
 YamlValue = Union[str, int, List[Any], Dict[str, Any]]
@@ -112,10 +172,14 @@ def parse_yaml(contents: str) -> Dict[str, Any]:
 
 def parse_yaml_preserve_spans(contents: str, filename: Optional[str]) -> YamlTree:
     # this uses the `RoundTripConstructor` which inherits from `SafeConstructor`
+    source_hash = SpanBuilder().add_source(contents)
+
     class SpanPreservingRuamelConstructor(RoundTripConstructor):
         def construct_object(self, node: Node, deep: bool = False) -> YamlTree:
             r = super().construct_object(node, deep)
-            return YamlTree(r, Span.from_node(node, filename))
+            return YamlTree(
+                r, Span.from_node(node, source_hash=source_hash, filename=filename)
+            )
 
     yaml = YAML()
     yaml.Constructor = SpanPreservingRuamelConstructor
@@ -125,3 +189,6 @@ def parse_yaml_preserve_spans(contents: str, filename: Optional[str]) -> YamlTre
             f"Something went wrong parsing Yaml (expected a YamlTree as output): {PLEASE_FILE_ISSUE_TEXT}"
         )
     return data
+
+
+EmptySpan = parse_yaml_preserve_spans("a: b", None).span

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -53,7 +53,7 @@ def validate_single_rule(config_id: str, rule_yaml: YamlTree) -> Optional[Rule]:
                 long_msg=f"{config_id} is missing required keys {missing_keys}",
                 level="error",
                 spans=[rule_yaml.span.truncate(lines=5)],
-            ).emit_str()
+            ).__repr__()
         )
         return None
     if not rule_keys.issubset(YAML_ALL_VALID_RULE_KEYS):
@@ -66,7 +66,7 @@ def validate_single_rule(config_id: str, rule_yaml: YamlTree) -> Optional[Rule]:
                 help=f"Only {sorted(YAML_ALL_VALID_RULE_KEYS)} are valid keys",
                 spans=[k.span.with_context(before=2, after=2) for k in extra_keys],
                 level="error",
-            ).emit_str()
+            ).__repr__()
         )
         return None
     try:
@@ -103,7 +103,7 @@ def validate_configs(
                     long_msg=f"{config_id} is missing `{RULES_KEY}` as top-level key",
                     level="error",
                     spans=[config_yaml_tree.span.truncate(lines=5)],
-                ).emit_str()
+                ).__repr__()
             )
             errors[config_id] = config_yaml_tree.unroll()
             continue

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Tuple
 
 import semgrep.config_resolver
@@ -13,6 +14,7 @@ from semgrep.constants import DEFAULT_CONFIG_FILE
 from semgrep.constants import OutputFormat
 from semgrep.constants import RULES_KEY
 from semgrep.core_runner import CoreRunner
+from semgrep.error import ErrorWithContext
 from semgrep.error import FINDINGS_EXIT_CODE
 from semgrep.error import INVALID_CODE_EXIT_CODE
 from semgrep.error import InvalidPatternNameError
@@ -43,14 +45,27 @@ def validate_single_rule(config_id: str, rule_yaml: YamlTree) -> Optional[Rule]:
     rule_keys = set(rule.keys())
     if not rule_keys.issuperset(YAML_MUST_HAVE_KEYS):
         missing_keys = YAML_MUST_HAVE_KEYS - rule_keys
+        # TODO: return the error messages so we can emit nice JSON errors
         print_error(
-            f"{config_id} is missing required keys {missing_keys} at rule id {rule_id_err_msg}"
+            ErrorWithContext(
+                short_msg="missing keys",
+                long_msg=f"{config_id} is missing required keys {missing_keys}",
+                level="error",
+                spans=[rule_yaml.span],
+            ).emit_str()
         )
         return None
     if not rule_keys.issubset(YAML_ALL_VALID_RULE_KEYS):
-        extra_keys = rule_keys - YAML_ALL_VALID_RULE_KEYS
+        extra_keys: Set[YamlTree] = rule_keys - YAML_ALL_VALID_RULE_KEYS  # type: ignore
+
         print_error(
-            f"{config_id} has an invalid top-level rule key {extra_keys} at rule id {rule_id_err_msg}, can only have: {sorted(YAML_ALL_VALID_RULE_KEYS)}"
+            ErrorWithContext(
+                short_msg="extra top-level key",
+                long_msg=f"{config_id} has an invalid top-level rule key: {[k.unroll() for k in extra_keys]}",
+                help=f"Only {sorted(YAML_ALL_VALID_RULE_KEYS)} are valid keys",
+                spans=[k.span.with_context(before=2, after=2) for k in extra_keys],
+                level="error",
+            ).emit_str()
         )
         return None
     try:
@@ -81,7 +96,14 @@ def validate_configs(
             continue
         rules = config.get(RULES_KEY)  # type: ignore
         if rules is None:
-            print_error(f"{config_id} is missing `{RULES_KEY}` as top-level key")
+            print_error(
+                ErrorWithContext(
+                    short_msg="missing keys",
+                    long_msg=f"{config_id} is missing `{RULES_KEY}` as top-level key",
+                    level="error",
+                    spans=[config_yaml_tree.span.truncate(lines=5)],
+                ).emit_str()
+            )  # TODO: shorten the span, we don't need to see the whole rule to see that it's missing a top level key
             errors[config_id] = config_yaml_tree.unroll()
             continue
         valid_rules = []
@@ -311,7 +333,7 @@ def pretty_error(error: Dict[str, Any]) -> str:
             line_3 = f"= note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev"
             return "\n".join([header, line_1, line_2, line_3])
         else:
-            return f"semgrep-core error: {json.dumps(error,indent=2)}"
+            return f"semgrep-core error: {json.dumps(error, indent=2)}"
     except KeyError:
         return f"semgrep-core error: {json.dumps(error, indent=2)}"
 

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -1,5 +1,7 @@
 import itertools
+import re
 import sys
+import typing
 from typing import Any
 from typing import Callable
 from typing import Iterable
@@ -7,10 +9,14 @@ from typing import List
 from typing import Tuple
 from urllib.parse import urlparse
 
+from colorama import Fore
+
 global DEBUG
 global QUIET
+global FORCE_COLOR
 DEBUG = False
 QUIET = False
+FORCE_COLOR = False
 
 
 def is_url(url: str) -> bool:
@@ -21,19 +27,31 @@ def is_url(url: str) -> bool:
         return False
 
 
+ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def tty_sensitive_print(msg: str, file: typing.IO, **kwargs: Any) -> None:
+    """
+    Strip ANSI escape sequences before printing, if `file` is not a TTY
+    """
+    if not file.isatty() and not FORCE_COLOR:
+        msg = ANSI_ESCAPE.sub("", msg)
+    print(msg, file=file, **kwargs)
+
+
 def print_error(e: str) -> None:
     if not QUIET:
-        print(e, file=sys.stderr)
+        tty_sensitive_print(e, file=sys.stderr)
 
 
 def print_msg(msg: str, **kwargs: Any) -> None:
     if not QUIET:
-        print(msg, file=sys.stderr, **kwargs)
+        tty_sensitive_print(msg, file=sys.stderr, **kwargs)
 
 
 def debug_print(msg: str) -> None:
     if DEBUG:
-        print(msg, file=sys.stderr)
+        tty_sensitive_print(msg, file=sys.stderr)
 
 
 def flatten(L: Iterable[Iterable[Any]]) -> Iterable[Any]:
@@ -42,11 +60,12 @@ def flatten(L: Iterable[Iterable[Any]]) -> Iterable[Any]:
             yield item
 
 
-def set_flags(debug: bool, quiet: bool) -> None:
+def set_flags(debug: bool, quiet: bool, force_color: bool) -> None:
     """Set the global DEBUG and QUIET flags"""
     # TODO move to a proper logging framework
     global DEBUG
     global QUIET
+    global FORCE_COLOR
     if debug:
         DEBUG = True
         debug_print("DEBUG is on")
@@ -54,8 +73,23 @@ def set_flags(debug: bool, quiet: bool) -> None:
         QUIET = True
         debug_print("QUIET is on")
 
+    if force_color:
+        FORCE_COLOR = True
+        debug_print("Output will use ANSI escapes, even if output is not a TTY")
+
 
 def partition(pred: Callable, iterable: Iterable) -> Tuple[List, List]:
     """E.g. partition(is_odd, range(10)) -> 1 3 5 7 9  and  0 2 4 6 8"""
     i1, i2 = itertools.tee(iterable)
     return list(filter(pred, i1)), list(itertools.filterfalse(pred, i2))
+
+
+def with_color(color: str, text: str, bold: bool = False) -> str:
+    """
+    Wrap text in color & reset
+    """
+    reset = Fore.RESET
+    if bold:
+        color = color + "\033[1m"
+        reset += "\033[0m"
+    return f"{color}{text}{reset}"

--- a/semgrep/tests/e2e/rules/syntax/missing-field.yaml
+++ b/semgrep/tests/e2e/rules/syntax/missing-field.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: flask-secure-set-cookie
+  languages: [python]
+  patterns:
+    - pattern-not: |
+        flask.response.set_cookie(..., httponly=True, secure=True,...)
+    - pattern: |
+        flask.response.set_cookie(....)
+  message: |
+    Flask cookies should be handled securely by setting secure=True, httponly=True, and samesite='Lax' in  response.set_cookie(...). If your situation calls for different settings, explicitly disable the setting.
+    If you want to send the cookie over http, set secure=False.  If you want to let client-side JavaScript
+    read the cookie, set httponly=False. If you want to attach cookies to requests for external sites,
+    set samesite=None.

--- a/semgrep/tests/e2e/rules/syntax/missing-field.yaml
+++ b/semgrep/tests/e2e/rules/syntax/missing-field.yaml
@@ -1,3 +1,4 @@
+## Missing rules[0].severity
 rules:
 - id: flask-secure-set-cookie
   languages: [python]

--- a/semgrep/tests/e2e/rules/syntax/missing-toplevel.yaml
+++ b/semgrep/tests/e2e/rules/syntax/missing-toplevel.yaml
@@ -1,3 +1,4 @@
+# top level key should be "rules"
 rule:
 - id: flask-secure-set-cookie
   languages: [python]

--- a/semgrep/tests/e2e/rules/syntax/missing-toplevel.yaml
+++ b/semgrep/tests/e2e/rules/syntax/missing-toplevel.yaml
@@ -1,0 +1,14 @@
+rule:
+- id: flask-secure-set-cookie
+  languages: [python]
+  patterns:
+    - pattern-not: |
+        flask.response.set_cookie(..., httponly=True, secure=True,...)
+    - pattern: |
+        flask.response.set_cookie(....)
+  message: |
+    Flask cookies should be handled securely by setting secure=True, httponly=True, and samesite='Lax' in  response.set_cookie(...). If your situation calls for different settings, explicitly disable the setting.
+    If you want to send the cookie over http, set secure=False.  If you want to let client-side JavaScript
+    read the cookie, set httponly=False. If you want to attach cookies to requests for external sites,
+    set samesite=None.
+  severity: error

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error-in-color.txt
@@ -1,0 +1,12 @@
+[31merror[39m: extra top-level key
+  --> rules/syntax/bad2.yaml:3
+[94m1 | [39mrules:
+[94m2 | [39m  - id: eqeq-is-bad
+[94m3 | [39m    pattern-inside: foo(...)
+[94m  | [39m    [31m^^^^^^^^^^^^^^[39m
+[94m4 | [39m    patterns:
+[94m5 | [39m      - pattern-not: 1 == 1
+= [36m[1mhelp[39m[0m: Only ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys
+[31mrules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside'][39m
+
+run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
@@ -1,12 +1,12 @@
-[31merror[39m: extra top-level key
+error: extra top-level key
   --> rules/syntax/bad2.yaml:3
-[94m1 | [39mrules:
-[94m2 | [39m  - id: eqeq-is-bad
-[94m3 | [39m    pattern-inside: foo(...)
-[94m  | [39m    [31m^^^^^^^^^^^^^^[39m
-[94m4 | [39m    patterns:
-[94m5 | [39m      - pattern-not: 1 == 1
-= [36m[1mhelp[39m[0m: Only ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys
-[31mrules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside'][39m
+1 | rules:
+2 |   - id: eqeq-is-bad
+3 |     pattern-inside: foo(...)
+  |     ^^^^^^^^^^^^^^
+4 |     patterns:
+5 |       - pattern-not: 1 == 1
+= help: Only ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys
+rules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside']
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
@@ -1,2 +1,12 @@
-rules/syntax/bad2.yaml has an invalid top-level rule key {'pattern-inside'} at rule id eqeq-is-bad, can only have: ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity']
+[31merror[39m: extra top-level key
+  --> rules/syntax/bad2.yaml:3
+[94m1 | [39mrules:
+[94m2 | [39m  - id: eqeq-is-bad
+[94m3 | [39m    pattern-inside: foo(...)
+[94m  | [39m    [31m^^^^^^^^^^^^^^[39m
+[94m4 | [39m    patterns:
+[94m5 | [39m      - pattern-not: 1 == 1
+= [36m[1mhelp[39m[0m: Only ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys
+[31mrules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside'][39m
+
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error-in-color.txt
@@ -1,0 +1,12 @@
+[31merror[39m: missing keys
+  --> rules/syntax/missing-field.yaml:3
+[94m3 | [39m- id: flask-secure-set-cookie
+[94m4 | [39m  languages: [python]
+[94m5 | [39m  patterns:
+[94m6 | [39m    - pattern-not: |
+[94m7 | [39m        flask.response.set_cookie(..., httponly=True, secure=True,...)
+[94m8 | [39m    - pattern: |
+
+[31mrules/syntax/missing-field.yaml is missing required keys {'severity'}[39m
+
+run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.txt
@@ -1,0 +1,18 @@
+[31merror[39m: missing keys
+  --> rules/syntax/missing-field.yaml:2
+[94m2  | [39m- id: flask-secure-set-cookie
+[94m3  | [39m  languages: [python]
+[94m4  | [39m  patterns:
+[94m5  | [39m    - pattern-not: |
+[94m6  | [39m        flask.response.set_cookie(..., httponly=True, secure=True,...)
+[94m7  | [39m    - pattern: |
+[94m8  | [39m        flask.response.set_cookie(....)
+[94m9  | [39m  message: |
+[94m10 | [39m    Flask cookies should be handled securely by setting secure=True, httponly=True, and samesite='Lax' in  response.set_cookie(...). If your situation calls for different settings, explicitly disable the setting.
+[94m11 | [39m    If you want to send the cookie over http, set secure=False.  If you want to let client-side JavaScript
+[94m12 | [39m    read the cookie, set httponly=False. If you want to attach cookies to requests for external sites,
+[94m13 | [39m    set samesite=None.
+
+[31mrules/syntax/missing-field.yaml is missing required keys {'severity'}[39m
+
+run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.txt
@@ -1,18 +1,12 @@
-[31merror[39m: missing keys
-  --> rules/syntax/missing-field.yaml:2
-[94m2  | [39m- id: flask-secure-set-cookie
-[94m3  | [39m  languages: [python]
-[94m4  | [39m  patterns:
-[94m5  | [39m    - pattern-not: |
-[94m6  | [39m        flask.response.set_cookie(..., httponly=True, secure=True,...)
-[94m7  | [39m    - pattern: |
-[94m8  | [39m        flask.response.set_cookie(....)
-[94m9  | [39m  message: |
-[94m10 | [39m    Flask cookies should be handled securely by setting secure=True, httponly=True, and samesite='Lax' in  response.set_cookie(...). If your situation calls for different settings, explicitly disable the setting.
-[94m11 | [39m    If you want to send the cookie over http, set secure=False.  If you want to let client-side JavaScript
-[94m12 | [39m    read the cookie, set httponly=False. If you want to attach cookies to requests for external sites,
-[94m13 | [39m    set samesite=None.
+error: missing keys
+  --> rules/syntax/missing-field.yaml:3
+3 | - id: flask-secure-set-cookie
+4 |   languages: [python]
+5 |   patterns:
+6 |     - pattern-not: |
+7 |         flask.response.set_cookie(..., httponly=True, secure=True,...)
+8 |     - pattern: |
 
-[31mrules/syntax/missing-field.yaml is missing required keys {'severity'}[39m
+rules/syntax/missing-field.yaml is missing required keys {'severity'}
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error-in-color.txt
@@ -1,0 +1,12 @@
+[31merror[39m: missing keys
+  --> rules/syntax/missing-toplevel.yaml:2
+[94m2 | [39mrule:
+[94m3 | [39m- id: flask-secure-set-cookie
+[94m4 | [39m  languages: [python]
+[94m5 | [39m  patterns:
+[94m6 | [39m    - pattern-not: |
+[94m7 | [39m        flask.response.set_cookie(..., httponly=True, secure=True,...)
+
+[31mrules/syntax/missing-toplevel.yaml is missing `rules` as top-level key[39m
+
+run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.txt
@@ -1,0 +1,12 @@
+[31merror[39m: missing keys
+  --> rules/syntax/missing-toplevel.yaml:1
+[94m1 | [39mrule:
+[94m2 | [39m- id: flask-secure-set-cookie
+[94m3 | [39m  languages: [python]
+[94m4 | [39m  patterns:
+[94m5 | [39m    - pattern-not: |
+[94m6 | [39m        flask.response.set_cookie(..., httponly=True, secure=True,...)
+
+[31mrules/syntax/missing-toplevel.yaml is missing `rules` as top-level key[39m
+
+run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.txt
@@ -1,12 +1,12 @@
-[31merror[39m: missing keys
-  --> rules/syntax/missing-toplevel.yaml:1
-[94m1 | [39mrule:
-[94m2 | [39m- id: flask-secure-set-cookie
-[94m3 | [39m  languages: [python]
-[94m4 | [39m  patterns:
-[94m5 | [39m    - pattern-not: |
-[94m6 | [39m        flask.response.set_cookie(..., httponly=True, secure=True,...)
+error: missing keys
+  --> rules/syntax/missing-toplevel.yaml:2
+2 | rule:
+3 | - id: flask-secure-set-cookie
+4 |   languages: [python]
+5 |   patterns:
+6 |     - pattern-not: |
+7 |         flask.response.set_cookie(..., httponly=True, secure=True,...)
 
-[31mrules/syntax/missing-toplevel.yaml is missing `rules` as top-level key[39m
+rules/syntax/missing-toplevel.yaml is missing `rules` as top-level key
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -36,6 +36,8 @@ def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
         "badpaths1",
         "badpaths2",
         "invalid",
+        "missing-toplevel",
+        "missing-field",
     ],
 )
 def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -43,4 +43,12 @@ def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
 def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp(f"rules/syntax/{filename}.yaml", stderr=True)
+
+    with pytest.raises(CalledProcessError) as excinfo_in_color:
+        run_semgrep_in_tmp(
+            f"rules/syntax/{filename}.yaml", options=["--force-color"], stderr=True
+        )
     snapshot.assert_match(excinfo.value.output, "error.txt")
+
+    if excinfo_in_color.value.output != excinfo.value.output:
+        snapshot.assert_match(excinfo_in_color.value.output, "error-in-color.txt")

--- a/semgrep/tests/unit/test_rule_lang.py
+++ b/semgrep/tests/unit/test_rule_lang.py
@@ -25,26 +25,26 @@ def test_span_tracking():
 
     # basic spans
     assert data.span == test_span(
-        start=Position(line=1, column=0), end=Position(line=9, column=0),
+        start=Position(line=2, column=1), end=Position(line=10, column=1),
     )
 
     # values act like dictionaries
     assert data.value["a"].span == test_span(
-        start=Position(line=2, column=2), end=Position(line=9, column=0),
+        start=Position(line=3, column=3), end=Position(line=10, column=1),
     )
 
     # values act like lists
-    assert data.value["a"].value[0].span == test_span(
-        start=Position(line=2, column=4), end=Position(line=2, column=5),
+    assert data.value["a"].value[1].span == test_span(
+        start=Position(line=4, column=5), end=Position(line=4, column=6),
     )
 
-    assert data.value["a"].value[0].value == 1
+    assert data.value["a"].value[1].value == 2
 
     # spans are also attached to keys
     kvs = list(data.value.items())
     key, value = kvs[0]
     assert key.span == test_span(
-        start=Position(line=1, column=0), end=Position(line=1, column=1),
+        start=Position(line=2, column=1), end=Position(line=2, column=2),
     )
 
     # unrolling is equivalent

--- a/semgrep/tests/unit/test_rule_lang.py
+++ b/semgrep/tests/unit/test_rule_lang.py
@@ -19,25 +19,23 @@ a:
 
 def test_span_tracking():
     data = parse_yaml_preserve_spans(test_yaml, Path("filename"))
+
+    def test_span(start: Position, end: Position) -> Span:
+        return data.span._replace(start=start, end=end)
+
     # basic spans
-    assert data.span == Span(
-        start=Position(line=1, column=0),
-        end=Position(line=9, column=0),
-        file=Path("filename"),
+    assert data.span == test_span(
+        start=Position(line=1, column=0), end=Position(line=9, column=0),
     )
 
     # values act like dictionaries
-    assert data.value["a"].span == Span(
-        start=Position(line=2, column=2),
-        end=Position(line=9, column=0),
-        file=Path("filename"),
+    assert data.value["a"].span == test_span(
+        start=Position(line=2, column=2), end=Position(line=9, column=0),
     )
 
     # values act like lists
-    assert data.value["a"].value[0].span == Span(
-        start=Position(line=2, column=4),
-        end=Position(line=2, column=5),
-        file=Path("filename"),
+    assert data.value["a"].value[0].span == test_span(
+        start=Position(line=2, column=4), end=Position(line=2, column=5),
     )
 
     assert data.value["a"].value[0].value == 1
@@ -45,10 +43,8 @@ def test_span_tracking():
     # spans are also attached to keys
     kvs = list(data.value.items())
     key, value = kvs[0]
-    assert key.span == Span(
-        start=Position(line=1, column=0),
-        end=Position(line=1, column=1),
-        file=Path("filename"),
+    assert key.span == test_span(
+        start=Position(line=1, column=0), end=Position(line=1, column=1),
     )
 
     # unrolling is equivalent


### PR DESCRIPTION
![Selection_011](https://user-images.githubusercontent.com/492903/84194538-278d0f80-aa6b-11ea-83dc-2242bba5a206.png)
This diff introduces `ErrorWithContext` which is an error message that can print nicely along with attached context from code. Eventually, this will output JSON errors in JSON output mode, but that isn't fully done right now. I use it in a couple of places -- a full conversion of all applicable errors into `ErrorWithContext` is coming in a later diff.

Finally getting some of the payoff of tracking the spans. Eventually, I want to refactor the error handling in `validate_configs` to return the errors instead of just logging them. For now though, I decided to just preserve the existing behavior, there are enough moving parts in this diff already.

We track span contents in a global singleton so we can look up the code a span came from posthoc.

I'm torn if the tests should include the escape sequences or not -- it's good to test that the colors don't suddenly change, but it's definitely harder to verify alignment, eg.