### PR TITLE
tests: tox test use latest develop build artifact

### DIFF
--- a/install-scripts/latest-artifact-for-branch.py
+++ b/install-scripts/latest-artifact-for-branch.py
@@ -41,11 +41,7 @@ def get_latest_artifact_url(
     workflow_runs = download_json(f"/actions/workflows/{workflow_obj['id']}/runs")[
         "workflow_runs"
     ]
-    successful_runs = [
-        run
-        for run in workflow_runs
-        if run["conclusion"] == "success" and run["head_branch"] == branch
-    ]
+    successful_runs = [run for run in workflow_runs if run["head_branch"] == branch]
     if not successful_runs:
         return None
 

--- a/semgrep/tox.ini
+++ b/semgrep/tox.ini
@@ -5,7 +5,7 @@ envlist = py36, py37, py38
 [testenv]
 commands =
     pipenv install --sequential --dev
-    pipenv run pytest tests --qa
+    pipenv run pytest -v --tb=short tests/ --qa
 setenv =
     # suppress a pipenv warning
     PIPENV_VERBOSITY = -1


### PR DESCRIPTION
tox tests were only using a build artifact from a workflow that was successful but
since tox tests and ubuntu-build are in the same workflow this means that a failing
tox test due to a changed semgrep-core will never use the new built image.