### PR TITLE
Refactor main into OutputHandler

### DIFF
--- a/semgrep/semgrep/__main__.py
+++ b/semgrep/semgrep/__main__.py
@@ -4,7 +4,6 @@ import sys
 from semgrep.cli import cli
 from semgrep.error import OK_EXIT_CODE
 from semgrep.error import SemgrepError
-from semgrep.util import print_error
 
 
 def main() -> int:
@@ -13,7 +12,6 @@ def main() -> int:
     # Catch custom exceptions, output the right message and exit.
     # Note: this doesn't catch all Exceptions and lets them bubble up.
     except SemgrepError as e:
-        print_error(str(e))
         return e.code
     else:
         return OK_EXIT_CODE

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -262,10 +262,15 @@ def cli() -> None:
         error_on_findings=args.error,
     )
 
-    if args.dump_ast:
-        dump_parsed_ast(args.json, args.lang, args.pattern, args.target)
-    elif args.validate:
-        with managed_output(output_settings) as output_handler:
+    if args.test:
+        # the test code (which isn't a "test" per se but is actually machinery to evaluate semgrep performance)
+        # uses managed_output internally
+        semgrep.test.test_main(args)
+
+    with managed_output(output_settings) as output_handler:
+        if args.dump_ast:
+            dump_parsed_ast(args.json, args.lang, args.pattern, args.target)
+        elif args.validate:
             _, invalid_configs = semgrep.semgrep_main.get_config(
                 args.pattern, args.lang, args.config, output_handler=output_handler
             )
@@ -275,13 +280,9 @@ def cli() -> None:
                 )
             else:
                 print_msg("Config is valid")
-    elif args.generate_config:
-        semgrep.config_resolver.generate_config()
-    elif args.test:
-        semgrep.test.test_main(args)
-    else:
-
-        with managed_output(output_settings) as output_handler:
+        elif args.generate_config:
+            semgrep.config_resolver.generate_config()
+        else:
             semgrep.semgrep_main.main(
                 output_handler=output_handler,
                 target=args.target,

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -8,12 +8,14 @@ import semgrep.semgrep_main
 import semgrep.test
 from semgrep.constants import __VERSION__
 from semgrep.constants import DEFAULT_CONFIG_FILE
+from semgrep.constants import OutputFormat
 from semgrep.constants import RCE_RULE_FLAG
 from semgrep.constants import SEMGREP_URL
 from semgrep.dump_ast import dump_parsed_ast
 from semgrep.error import SemgrepError
+from semgrep.output import managed_output
+from semgrep.output import OutputSettings
 from semgrep.util import print_msg
-
 
 try:
     CPU_COUNT = multiprocessing.cpu_count()
@@ -245,41 +247,54 @@ def cli() -> None:
     # change cwd if using docker
     semgrep.config_resolver.adjust_for_docker(args.precommit)
 
+    output_format = OutputFormat.TEXT
+    if args.json:
+        output_format = OutputFormat.JSON
+    elif args.debugging_json:
+        output_format = OutputFormat.JSON_DEBUG
+    elif args.sarif:
+        output_format = OutputFormat.SARIF
+
+    output_settings = OutputSettings(
+        output_format=output_format,
+        output_destination=args.output,
+        quiet=args.quiet,
+        error_on_findings=args.error,
+    )
+
     if args.dump_ast:
         dump_parsed_ast(args.json, args.lang, args.pattern, args.target)
     elif args.validate:
-        _, invalid_configs = semgrep.semgrep_main.get_config(
-            args.pattern, args.lang, args.config
-        )
-        if invalid_configs:
-            raise SemgrepError(
-                f"run with --validate and there were {len(invalid_configs)} errors loading configs"
+        with managed_output(output_settings) as output_handler:
+            _, invalid_configs = semgrep.semgrep_main.get_config(
+                args.pattern, args.lang, args.config, output_handler=output_handler
             )
-        else:
-            print_msg("Config is valid")
+            if invalid_configs:
+                raise SemgrepError(
+                    f"run with --validate and there were {len(invalid_configs)} errors loading configs"
+                )
+            else:
+                print_msg("Config is valid")
     elif args.generate_config:
         semgrep.config_resolver.generate_config()
     elif args.test:
         semgrep.test.test_main(args)
     else:
-        semgrep.semgrep_main.main(
-            target=args.target,
-            pattern=args.pattern,
-            lang=args.lang,
-            config=args.config,
-            no_rewrite_rule_ids=args.no_rewrite_rule_ids,
-            jobs=args.jobs,
-            include=args.include,
-            include_dir=args.include_dir,
-            exclude=args.exclude,
-            exclude_dir=args.exclude_dir,
-            json_format=args.json,
-            debugging_json=args.debugging_json,
-            sarif=args.sarif,
-            output_destination=args.output,
-            quiet=args.quiet,
-            strict=args.strict,
-            exit_on_error=args.error,
-            autofix=args.autofix,
-            dangerously_allow_arbitrary_code_execution_from_rules=args.dangerously_allow_arbitrary_code_execution_from_rules,
-        )
+
+        with managed_output(output_settings) as output_handler:
+            semgrep.semgrep_main.main(
+                output_handler=output_handler,
+                target=args.target,
+                pattern=args.pattern,
+                lang=args.lang,
+                config=args.config,
+                no_rewrite_rule_ids=args.no_rewrite_rule_ids,
+                jobs=args.jobs,
+                include=args.include,
+                include_dir=args.include_dir,
+                exclude=args.exclude,
+                exclude_dir=args.exclude_dir,
+                strict=args.strict,
+                autofix=args.autofix,
+                dangerously_allow_arbitrary_code_execution_from_rules=args.dangerously_allow_arbitrary_code_execution_from_rules,
+            )

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -24,6 +24,8 @@ class SemgrepError(Exception):
 
     All Semgrep Exceptions are caught and their error messages
     are displayed to the user.
+
+    For pretty-printing, exceptions should override `__str__`.
     """
 
     def __init__(self, *args: object, code: int = FATAL_EXIT_CODE) -> None:
@@ -134,7 +136,7 @@ class ErrorWithSpan(SemgrepError):
             snippet.append(f"{self._format_line_number(part_of_span, line_num)}{line}")
         return snippet
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         """
         Format this exception into a pretty string with context and color
         """

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -200,8 +200,7 @@ def invoke_semgrep(
         autofix=False,
         dangerously_allow_arbitrary_code_execution_from_rules=unsafe,
     )
-    code = output_handler.close()
-    assert code == 0
+    output_handler.close()
     return json.loads(io_capture.getvalue())
 
 


### PR DESCRIPTION
The idea is that all output will be routed through the output handler. This will allow us to collect errors to eventually be added to the JSON, print data as it's ready, and capture output for test purposes.

Not everything is wired up to it yet, I wanted to keep this diff under control & match current behavior exactly. Future diffs will build on this to:
- remove every call to `print_error`, `print_msg`, `print_debug` outside of `OutputHandler`
- incorporate all errors in to the structured JSON output
- move all semgrep-lang parse errors into `SemgrepErrorWithSpan`
- move semgrep-core parse errors into `SemgrepErrorWithSpan`