### PR TITLE
ci: osx wheel name fix

### DIFF
--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -42,7 +42,7 @@ class bdist_wheel(_bdist_wheel):
         abi = "none"
 
         if "macosx" in plat:
-            plat = f"macosx_{MIN_OSX_VERSION}_x86_64.whl"
+            plat = f"macosx_{MIN_OSX_VERSION}_x86_64"
 
         # The binary we build is statically linked & manylinux compatible, so change platform
         # accordingly


### PR DESCRIPTION
Artifact of osx wheel has extension .whl.whl
This removes the duplicated .whl