### PR TITLE
Support pattern errors in text and JSON

### DIFF
--- a/semgrep/semgrep/pattern.py
+++ b/semgrep/semgrep/pattern.py
@@ -1,7 +1,9 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
+from semgrep.rule_lang import Span
 from semgrep.semgrep_types import BooleanRuleExpression
 
 
@@ -16,6 +18,7 @@ class Pattern:
         expression: BooleanRuleExpression,
         severity: str,
         languages: List[str],
+        span: Optional[Span],
     ) -> None:
         self._id = f"{rule_index}.{expression.pattern_id}"
         # if we don't copy an array (like `languages`), the yaml file will refer to it by reference (with an anchor)
@@ -25,6 +28,11 @@ class Pattern:
         self._expression = expression
         self._pattern = expression.operand
         self._message = "<internalonly>"
+        self._span = span
+
+    @property
+    def span(self) -> Optional[Span]:
+        return self._span
 
     @property
     def languages(self) -> List[str]:

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -80,6 +80,8 @@ def _run_semgrep(
     elif output_format == "sarif":
         options.append("--sarif")
 
+    # helpful for debugging failed tests
+    print("Semgrep run with options: ", options)
     output = subprocess.check_output(
         ["python3", "-m", "semgrep", *options, Path("targets") / target_name],
         encoding="utf-8",

--- a/semgrep/tests/e2e/rules/syntax/badlanguage.yaml
+++ b/semgrep/tests/e2e/rules/syntax/badlanguage.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: arg-reassign
+    pattern-either:
+      - pattern: $X = 1
+      - pattern: $X = 2
+    message: "$X is being assigned to one or two"
+    languages: [rust]
+    severity: WARNING

--- a/semgrep/tests/e2e/rules/syntax/badpattern.yaml
+++ b/semgrep/tests/e2e/rules/syntax/badpattern.yaml
@@ -2,6 +2,7 @@ rules:
   - id: eqeq-is-bad
     patterns:
       - pattern: $X == $X 3
+      - pattern: $X 4
     message: "yeah this pattern doesn't work"
     languages: [python]
     severity: ERROR

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
@@ -117,5 +117,6 @@
         "line": 6
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
@@ -77,5 +77,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
@@ -77,5 +77,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
@@ -77,5 +77,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
@@ -77,5 +77,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
@@ -77,5 +77,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
@@ -77,5 +77,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
@@ -39,5 +39,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
@@ -38,5 +38,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
@@ -19,5 +19,6 @@
         "line": 2
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
@@ -19,5 +19,6 @@
         "line": 2
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -77,5 +77,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_url_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_url_rule/results.json
@@ -112,5 +112,6 @@
         "line": 12
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
@@ -75,5 +75,6 @@
         "line": 14
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-exclude/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-exclude/results.json
@@ -1,4 +1,5 @@
 {
   "errors": [],
-  "results": []
+  "results": [],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-dir-and-exclude-dir/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-dir-and-exclude-dir/results.json
@@ -1,4 +1,5 @@
 {
   "errors": [],
-  "results": []
+  "results": [],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-dir-and-include/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-dir-and-include/results.json
@@ -40,5 +40,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-dir/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-dir/results.json
@@ -79,5 +79,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude/results.json
@@ -79,5 +79,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include/results.json
@@ -157,5 +157,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-dir-and-exclude/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-dir-and-exclude/results.json
@@ -40,5 +40,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-dir-and-include-dir/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-dir-and-include-dir/results.json
@@ -157,5 +157,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-dir/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-dir/results.json
@@ -79,5 +79,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include/results.json
@@ -79,5 +79,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
@@ -40,5 +40,6 @@
         "line": 4
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
+++ b/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
@@ -547,5 +547,6 @@
         "line": 3
       }
     }
-  ]
+  ],
+  "structured_errors": []
 }

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.txt
@@ -1,2 +1,3 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "SemgrepError", "message": "rules/syntax/bad1.yaml: inside rule id eqeq-is-bad, pattern fields can't look like this: operand pattern-inside must be a string, but instead was list", "code": 2}]}
 rules/syntax/bad1.yaml: inside rule id eqeq-is-bad, pattern fields can't look like this: operand pattern-inside must be a string, but instead was list
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error-in-color.txt
@@ -1,3 +1,4 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "RuleLangError", "short_msg": "extra top-level key", "long_msg": "rules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside']", "level": "error", "help": "Only ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys", "spans": [{"start": {"line": 3, "col": 5}, "end": {"line": 3, "col": 19}, "source_hash": "6ebef770ea281e5e811acfd1d5b219adb3a0ae87f6613ae0a8cfc593ad126dd2", "file": "rules/syntax/bad2.yaml", "context_start": {"line": 1, "col": 0}, "context_end": {"line": 5, "col": 0}}]}]}
 [31merror[39m: extra top-level key
   --> rules/syntax/bad2.yaml:3
 [94m1 | [39mrules:

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
@@ -1,3 +1,4 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "RuleLangError", "short_msg": "extra top-level key", "long_msg": "rules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside']", "level": "error", "help": "Only ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys", "spans": [{"start": {"line": 3, "col": 5}, "end": {"line": 3, "col": 19}, "source_hash": "6ebef770ea281e5e811acfd1d5b219adb3a0ae87f6613ae0a8cfc593ad126dd2", "file": "rules/syntax/bad2.yaml", "context_start": {"line": 1, "col": 0}, "context_end": {"line": 5, "col": 0}}]}]}
 error: extra top-level key
   --> rules/syntax/bad2.yaml:3
 1 | rules:

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.txt
@@ -1,2 +1,3 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "SemgrepError", "message": "rules/syntax/bad3.yaml: inside rule id test-pattern, pattern fields can't look like this: type of `pattern` must be a string, but it was a list", "code": 2}]}
 rules/syntax/bad3.yaml: inside rule id test-pattern, pattern fields can't look like this: type of `pattern` must be a string, but it was a list
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.txt
@@ -1,2 +1,3 @@
-rules/syntax/bad4.yaml: inside rule id arg-reassign, pattern fields can't look like this: invalid type for patterns in rule: <class 'dict'> is not a list; perhaps your YAML is missing a `-` before {'pattern-inside': 'def foo($X):\n    ...\n', 'pattern': '$X = 1'}?
+{"results": [], "errors": [], "structured_errors": [{"type": "SemgrepError", "message": "rules/syntax/bad4.yaml: inside rule id arg-reassign, pattern fields can't look like this: invalid type for patterns in rule: dict is not a list; perhaps your YAML is missing a `-` before {'pattern-inside': 'def foo($X):\\n    ...\\n', 'pattern': '$X = 1'}?", "code": 2}]}
+rules/syntax/bad4.yaml: inside rule id arg-reassign, pattern fields can't look like this: invalid type for patterns in rule: dict is not a list; perhaps your YAML is missing a `-` before {'pattern-inside': 'def foo($X):\n    ...\n', 'pattern': '$X = 1'}?
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -1,0 +1,10 @@
+running 1 rules...
+[31merror[39m: invalid language
+  --> rules/syntax/badlanguage.yaml:7
+[94m6 | [39m    message: "$X is being assigned to one or two"
+[94m7 | [39m    languages: [rust]
+[94m  | [39m               [31m^^^^^^[39m
+[94m8 | [39m    severity: WARNING
+
+[31munsupported language rust[39m
+

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.txt
@@ -1,0 +1,10 @@
+running 1 rules...
+error: invalid language
+  --> rules/syntax/badlanguage.yaml:7
+6 |     message: "$X is being assigned to one or two"
+7 |     languages: [rust]
+  |                ^^^^^^
+8 |     severity: WARNING
+
+unsupported language rust
+

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.txt
@@ -1,2 +1,3 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "SemgrepError", "message": "rules/syntax/badpaths1.yaml: inside rule id arg-reassign, pattern fields can't look like this: the `paths:` targeting rules must be an object with at least one of ('include', 'exclude')", "code": 2}]}
 rules/syntax/badpaths1.yaml: inside rule id arg-reassign, pattern fields can't look like this: the `paths:` targeting rules must be an object with at least one of ('include', 'exclude')
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.txt
@@ -1,2 +1,3 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "SemgrepError", "message": "rules/syntax/badpaths2.yaml: inside rule id arg-reassign, pattern fields can't look like this: the `paths:` targeting rules must each be one of ('include', 'exclude')", "code": 2}]}
 rules/syntax/badpaths2.yaml: inside rule id arg-reassign, pattern fields can't look like this: the `paths:` targeting rules must each be one of ('include', 'exclude')
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
@@ -1,0 +1,8 @@
+running 1 rules...
+[31merror[39m: invalid pattern
+  --> rules/syntax/badpattern.yaml:4
+[94m4 | [39m      - pattern: $X == $X 3
+[94m  | [39m                 [31m^^^^^^^^^^[39m
+
+[31mPattern could not be parsed as Python[39m
+

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.txt
@@ -1,4 +1,8 @@
 running 1 rules...
-non-zero return code while invoking semgrep-core:
-	invalid pattern "$X == $X 3": Parsing.Parse_error
-An error occurred while invoking the semgrep engine; please help us fix this by creating an issue at https://semgrep.dev
+error: invalid pattern
+  --> rules/syntax/badpattern.yaml:4
+4 |       - pattern: $X == $X 3
+  |                  ^^^^^^^^^^
+
+Pattern could not be parsed as Python
+

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error-in-color.txt
@@ -1,3 +1,4 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "RuleLangError", "short_msg": "missing keys", "long_msg": "rules/syntax/missing-field.yaml is missing required keys {'severity'}", "level": "error", "help": null, "spans": [{"start": {"line": 3, "col": 3}, "end": {"line": 8, "col": 0}, "source_hash": "52c8055ff5d4555128113f2ad1b4f03c1227c339ee9b6992d9bbc18548d4e645", "file": "rules/syntax/missing-field.yaml", "context_start": null, "context_end": null}]}]}
 [31merror[39m: missing keys
   --> rules/syntax/missing-field.yaml:3
 [94m3 | [39m- id: flask-secure-set-cookie

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.txt
@@ -1,3 +1,4 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "RuleLangError", "short_msg": "missing keys", "long_msg": "rules/syntax/missing-field.yaml is missing required keys {'severity'}", "level": "error", "help": null, "spans": [{"start": {"line": 3, "col": 3}, "end": {"line": 8, "col": 0}, "source_hash": "52c8055ff5d4555128113f2ad1b4f03c1227c339ee9b6992d9bbc18548d4e645", "file": "rules/syntax/missing-field.yaml", "context_start": null, "context_end": null}]}]}
 error: missing keys
   --> rules/syntax/missing-field.yaml:3
 3 | - id: flask-secure-set-cookie

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error-in-color.txt
@@ -1,3 +1,4 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "RuleLangError", "short_msg": "missing keys", "long_msg": "rules/syntax/missing-toplevel.yaml is missing `rules` as top-level key", "level": "error", "help": null, "spans": [{"start": {"line": 2, "col": 1}, "end": {"line": 7, "col": 0}, "source_hash": "c72a97211dabcaa3065612fb9c52d6a344855414a6d9f1eb5adea4305d4c47da", "file": "rules/syntax/missing-toplevel.yaml", "context_start": null, "context_end": null}]}]}
 [31merror[39m: missing keys
   --> rules/syntax/missing-toplevel.yaml:2
 [94m2 | [39mrule:

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.txt
@@ -1,3 +1,4 @@
+{"results": [], "errors": [], "structured_errors": [{"type": "RuleLangError", "short_msg": "missing keys", "long_msg": "rules/syntax/missing-toplevel.yaml is missing `rules` as top-level key", "level": "error", "help": null, "spans": [{"start": {"line": 2, "col": 1}, "end": {"line": 7, "col": 0}, "source_hash": "c72a97211dabcaa3065612fb9c52d6a344855414a6d9f1eb5adea4305d4c47da", "file": "rules/syntax/missing-toplevel.yaml", "context_start": null, "context_end": null}]}]}
 error: missing keys
   --> rules/syntax/missing-toplevel.yaml:2
 2 | rule:

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -38,15 +38,18 @@ def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
         "invalid",
         "missing-toplevel",
         "missing-field",
+        "badlanguage",
     ],
 )
 def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):
     with pytest.raises(CalledProcessError) as excinfo:
-        run_semgrep_in_tmp(f"rules/syntax/{filename}.yaml", stderr=True)
+        run_semgrep_in_tmp(
+            f"rules/syntax/{filename}.yaml", stderr=True,
+        )
 
     with pytest.raises(CalledProcessError) as excinfo_in_color:
         run_semgrep_in_tmp(
-            f"rules/syntax/{filename}.yaml", options=["--force-color"], stderr=True
+            f"rules/syntax/{filename}.yaml", options=["--force-color"], stderr=True,
         )
     snapshot.assert_match(excinfo.value.output, "error.txt")
 

--- a/semgrep/tests/unit/test_rule_lang.py
+++ b/semgrep/tests/unit/test_rule_lang.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import attr
+
 from semgrep.rule_lang import parse_yaml
 from semgrep.rule_lang import parse_yaml_preserve_spans
 from semgrep.rule_lang import Position
@@ -21,21 +23,21 @@ def test_span_tracking():
     data = parse_yaml_preserve_spans(test_yaml, Path("filename"))
 
     def test_span(start: Position, end: Position) -> Span:
-        return data.span._replace(start=start, end=end)
+        return attr.evolve(data.span, start=start, end=end)
 
     # basic spans
     assert data.span == test_span(
-        start=Position(line=2, column=1), end=Position(line=10, column=1),
+        start=Position(line=2, col=1), end=Position(line=10, col=1),
     )
 
     # values act like dictionaries
     assert data.value["a"].span == test_span(
-        start=Position(line=3, column=3), end=Position(line=10, column=1),
+        start=Position(line=3, col=3), end=Position(line=10, col=1),
     )
 
     # values act like lists
     assert data.value["a"].value[1].span == test_span(
-        start=Position(line=4, column=5), end=Position(line=4, column=6),
+        start=Position(line=4, col=5), end=Position(line=4, col=6),
     )
 
     assert data.value["a"].value[1].value == 2
@@ -44,7 +46,7 @@ def test_span_tracking():
     kvs = list(data.value.items())
     key, value = kvs[0]
     assert key.span == test_span(
-        start=Position(line=2, column=1), end=Position(line=2, column=2),
+        start=Position(line=2, col=1), end=Position(line=2, col=2),
     )
 
     # unrolling is equivalent


### PR DESCRIPTION
![Selection_015](https://user-images.githubusercontent.com/492903/84547253-278e4900-acd1-11ea-8af2-160209a30d68.png)
![Selection_014](https://user-images.githubusercontent.com/492903/84546923-696abf80-acd0-11ea-941c-8e52d1f1c063.png)
This commit builds on all of the previous error handling work to do 2 things:
- Adds `structured_errors` to the JSON output. This exists for backwards compatibility with Semgrep live since these new errors will be in a new, structured format
- Matches `pattern_id` returned from semgrep-core errors against rules to find a matching span
- Track the span for each pattern object when building rules

This required a few semi-related changes:
- Switch Spans / Positions from `NamedTuple` to attr for more flexibility
- Rule building operates on `YamlTree` instead of on `Dict[str, Any]` to track spans for patterns. This will also facilitate changing all the errors currently in `Rule.py` to rules with context in a subsequent diff
- `Position.column` => `Position.col` to match the output of semgrep-core for the convenience of semgrep.live
