### PR TITLE
core_runner: use semgrep-core ast cache

### DIFF
--- a/install-scripts/latest-artifact-for-branch.py
+++ b/install-scripts/latest-artifact-for-branch.py
@@ -23,6 +23,7 @@ def download_json(url: str) -> Any:
     if not url.startswith("https"):
         url = f"{API_BASE_URL}{url}"
 
+    print(f"Downloading from {url}", file=sys.stderr)
     request = urllib.request.Request(
         url=url, headers={"authorization": f"Bearer {GITHUB_TOKEN}"}
     )
@@ -51,7 +52,10 @@ def get_latest_artifact_url(
         if artifacts:
             return str(artifacts[0]["archive_download_url"])
         else:
-            print("No artifacts found with name, looking at the previous run...")
+            print(
+                "No artifacts found with name, looking at the previous run...",
+                file=sys.stderr,
+            )
     return None
 
 
@@ -63,6 +67,7 @@ def make_executable(path: str) -> None:
 
 def download_artifact(url: str) -> str:
     tempdir = tempfile.mkdtemp()
+    print(f"Downloading from {url}", file=sys.stderr)
     request = urllib.request.Request(
         url=url, headers={"authorization": f"Bearer {GITHUB_TOKEN}"}
     )

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -319,9 +319,7 @@ let cache_computation file cache_file_of_file f =
 
 
 let cache_file_of_file filename =
-  let dir = spf "%s/semgrep_core_cache_%d"
-      (!use_parsing_cache)
-      (Unix.getuid()) in
+  let dir = !use_parsing_cache in
   if not (Sys.file_exists dir)
   then Unix.mkdir dir 0o700;
   (* hopefully there will be no collision *)
@@ -895,7 +893,7 @@ let options () =
     " do not stop at first parsing error with -e/-f";
     (*e: [[Main_semgrep_core.options]] other cases *)
     "-use_parsing_cache", Arg.Set_string use_parsing_cache,
-    " save and use parsed ASTs in a cache";
+    " <dir> save and use parsed ASTs in a cache at given directory. Caller responsiblity to clear cache";
     "-verbose", Arg.Unit (fun () ->
       verbose := true;
       Flag_semgrep.verbose := true;

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -136,7 +136,7 @@ let supported_langs: string = String.concat ", " keys
 let ncores = ref 1
 (*e: constant [[Main_semgrep_core.ncores]] *)
 
-let use_parsing_cache = ref false
+let use_parsing_cache = ref ""
 let target_file = ref ""
 let timeout = ref 0
 
@@ -282,7 +282,7 @@ let filemtime file =
  * TODO: merge in pfff/commons/Common.ml at some point
  *)
 let cache_computation file cache_file_of_file f =
-  if not !use_parsing_cache
+  if !use_parsing_cache=""
   then f ()
   else begin
     if not (Sys.file_exists file)
@@ -320,7 +320,7 @@ let cache_computation file cache_file_of_file f =
 
 let cache_file_of_file filename =
   let dir = spf "%s/semgrep_core_cache_%d"
-      (Filename.get_temp_dir_name ())
+      (!use_parsing_cache)
       (Unix.getuid()) in
   if not (Sys.file_exists dir)
   then Unix.mkdir dir 0o700;
@@ -894,7 +894,7 @@ let options () =
     ),
     " do not stop at first parsing error with -e/-f";
     (*e: [[Main_semgrep_core.options]] other cases *)
-    "-use_parsing_cache", Arg.Set use_parsing_cache,
+    "-use_parsing_cache", Arg.Set_string use_parsing_cache,
     " save and use parsed ASTs in a cache";
     "-verbose", Arg.Unit (fun () ->
       verbose := true;


### PR DESCRIPTION
    Use semgrep-core ast cache while running a set of rules. Automatically
    uses a fresh cache (and cleans it up after use) on every run of semgrep
    so there is no need to worry about cache invalidation etc.

    Change semgrep-core cache argument to take in a path to a directory
    to use as a cache. This makes it so that the caller can handle clearing
    the cache instead of hard coding a directory that semgrep-core uses.