### PR TITLE
Allow failures on CI changelog reminder

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,7 @@ jobs:
   changelog-reminder:
     name: Changelog Reminder
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
   changelog-reminder:
     name: Changelog Reminder
     runs-on: ubuntu-latest
-    continue-on-error: true
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error

The changelog reminder keeps failure our CI runs. This isn't a crucial task that should fail runs, in my opinion.