### PR TITLE
3 Error refactorings

### DIFF
--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -160,13 +160,9 @@ class ErrorWithSpan(SemgrepError):
             snippet += self._format_code_segment(span.start, span.end, source, span)
             # Currently, only span highlighting if it's a one line span
             if span.start.line == span.end.line:
-                error = with_color(
-                    Fore.RED, (span.end.column - span.start.column) * "^"
-                )
+                error = with_color(Fore.RED, (span.end.col - span.start.col) * "^")
                 snippet.append(
-                    self._format_line_number(span, None)
-                    + " " * span.start.column
-                    + error
+                    self._format_line_number(span, None) + " " * span.start.col + error
                 )
             if span.context_end:
                 snippet += self._format_code_segment(

--- a/semgrep/semgrep/rule_lang.py
+++ b/semgrep/semgrep/rule_lang.py
@@ -54,7 +54,7 @@ class Position(NamedTuple):
     """
 
     line: int
-    column: int
+    col: int
 
     def next_line(self) -> "Position":
         return self._replace(line=self.line + 1)
@@ -63,7 +63,7 @@ class Position(NamedTuple):
         return self._replace(line=self.line - 1)
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} line={self.line} column={self.column}>"
+        return f"<{self.__class__.__name__} line={self.line} col={self.col}>"
 
 
 class Span(NamedTuple):
@@ -83,10 +83,8 @@ class Span(NamedTuple):
     def from_node(
         cls, node: Node, source_hash: SourceFileHash, filename: Optional[str]
     ) -> "Span":
-        start = Position(
-            line=node.start_mark.line + 1, column=node.start_mark.column + 1
-        )
-        end = Position(line=node.end_mark.line + 1, column=node.end_mark.column + 1)
+        start = Position(line=node.start_mark.line + 1, col=node.start_mark.column + 1)
+        end = Position(line=node.end_mark.line + 1, col=node.end_mark.column + 1)
         return Span(start=start, end=end, file=filename, source_hash=source_hash)
 
     def truncate(self, lines: int) -> "Span":
@@ -97,7 +95,7 @@ class Span(NamedTuple):
         """
         if self.end.line - self.start.line > lines:
             return self._replace(
-                end=Position(line=self.start.line + lines, column=0), context_end=None
+                end=Position(line=self.start.line + lines, col=0), context_end=None
             )
         return self
 
@@ -110,13 +108,13 @@ class Span(NamedTuple):
         new = self
         if before is not None:
             new = new._replace(
-                context_start=Position(column=0, line=max(0, self.start.line - before))
+                context_start=Position(col=0, line=max(0, self.start.line - before))
             )
 
         if after is not None:
             new = new._replace(
                 context_end=Position(
-                    column=0,
+                    col=0,
                     line=min(
                         len(SourceTracker.source(self.source_hash)),
                         self.end.line + after,

--- a/semgrep/tests/unit/test_rule_lang.py
+++ b/semgrep/tests/unit/test_rule_lang.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import attr
+
 from semgrep.rule_lang import parse_yaml
 from semgrep.rule_lang import parse_yaml_preserve_spans
 from semgrep.rule_lang import Position
@@ -21,7 +23,7 @@ def test_span_tracking():
     data = parse_yaml_preserve_spans(test_yaml, Path("filename"))
 
     def test_span(start: Position, end: Position) -> Span:
-        return data.span._replace(start=start, end=end)
+        return attr.evolve(data.span, start=start, end=end)
 
     # basic spans
     assert data.span == test_span(

--- a/semgrep/tests/unit/test_rule_lang.py
+++ b/semgrep/tests/unit/test_rule_lang.py
@@ -25,17 +25,17 @@ def test_span_tracking():
 
     # basic spans
     assert data.span == test_span(
-        start=Position(line=2, column=1), end=Position(line=10, column=1),
+        start=Position(line=2, col=1), end=Position(line=10, col=1),
     )
 
     # values act like dictionaries
     assert data.value["a"].span == test_span(
-        start=Position(line=3, column=3), end=Position(line=10, column=1),
+        start=Position(line=3, col=3), end=Position(line=10, col=1),
     )
 
     # values act like lists
     assert data.value["a"].value[1].span == test_span(
-        start=Position(line=4, column=5), end=Position(line=4, column=6),
+        start=Position(line=4, col=5), end=Position(line=4, col=6),
     )
 
     assert data.value["a"].value[1].value == 2
@@ -44,7 +44,7 @@ def test_span_tracking():
     kvs = list(data.value.items())
     key, value = kvs[0]
     assert key.span == test_span(
-        start=Position(line=2, column=1), end=Position(line=2, column=2),
+        start=Position(line=2, col=1), end=Position(line=2, col=2),
     )
 
     # unrolling is equivalent


### PR DESCRIPTION
3 completely independent refactorings (should review commit-by-commit)
1: basic rename of column to col
2. NamedTuple -> attr
3. Remove bothersome (and potentially dangerous) hack in YamlTree. YamlTree delegated eq and hash to enable it to act like a regular map but it always made me queasy. I created a separate `YamlMap` class which is more code, but much more explicit about how everything works and should prevent unexpected behavior.