### PR TITLE
Add JSON errors for various parse errors

### DIFF
--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -40,6 +40,9 @@ class OutputFormat(Enum):
     JSON_DEBUG = auto()
     SARIF = auto()
 
+    def is_json(self) -> bool:
+        return self == OutputFormat.JSON or self == OutputFormat.JSON_DEBUG
+
 
 # Inline 'noqa' implementation modified from flake8:
 # https://github.com/PyCQA/flake8/blob/master/src/flake8/defaults.py

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -47,7 +47,7 @@ def validate_single_rule(
         missing_keys = YAML_MUST_HAVE_KEYS - rule_keys
         # TODO(https://github.com/returntocorp/semgrep/issues/746): return the error messages instead of
         #  immediately printing them so we can emit nice JSON errors to semgrep.live
-        output_handler.handle_semgrep_rule_errors(
+        output_handler.handle_semgrep_error(
             InvalidRuleSchemaError(
                 short_msg="missing keys",
                 long_msg=f"{config_id} is missing required keys {missing_keys}",
@@ -60,7 +60,7 @@ def validate_single_rule(
         extra_keys: Set[str] = rule_keys - YAML_ALL_VALID_RULE_KEYS
         extra_key_spans = sorted([rule.key_tree(k) for k in extra_keys])
 
-        output_handler.handle_semgrep_rule_errors(
+        output_handler.handle_semgrep_error(
             InvalidRuleSchemaError(
                 short_msg="extra top-level key",
                 long_msg=f"{config_id} has an invalid top-level rule key: {sorted([k for k in extra_keys])}",
@@ -73,7 +73,7 @@ def validate_single_rule(
     try:
         return Rule.from_yamltree(rule_yaml)
     except InvalidRuleSchemaError as ex:
-        output_handler.handle_semgrep_rule_errors(ex)
+        output_handler.handle_semgrep_error(ex)
         return None
     except InvalidPatternNameError as ex:
         rule_id = rule.get("id")
@@ -82,7 +82,7 @@ def validate_single_rule(
         else:
             rule_id_str = rule_id.value
         rule_id_err_msg = f"{rule_id_str}"
-        output_handler.handle_semgrep_rule_errors(
+        output_handler.handle_semgrep_error(
             SemgrepError(
                 f"{config_id}: inside rule id {rule_id_err_msg}, pattern fields can't look like this: {ex}"
             )
@@ -110,7 +110,7 @@ def validate_configs(
             continue
         rules = config.get(RULES_KEY)
         if rules is None:
-            output_handler.handle_semgrep_rule_errors(
+            output_handler.handle_semgrep_error(
                 InvalidRuleSchemaError(
                     short_msg="missing keys",
                     long_msg=f"{config_id} is missing `{RULES_KEY}` as top-level key",

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -83,7 +83,7 @@ def _run_semgrep(
     output = subprocess.check_output(
         ["python3", "-m", "semgrep", *options, Path("targets") / target_name],
         encoding="utf-8",
-        stderr=subprocess.STDOUT if stderr else None,
+        stderr=subprocess.STDOUT if stderr else subprocess.PIPE,
     )
 
     if output_format in {"json", "sarif"} and not stderr:

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__implicit/error.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__implicit/error.json
@@ -1,0 +1,1 @@
+{"results": [], "errors": [{"type": "SemgrepError", "code": 2, "message": "No config given and .semgrep.yml was not found. Try running with --help to debug or if you want to download a default config, try running with --config r2c"}]}

--- a/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule__invalid_id/error.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule__invalid_id/error.json
@@ -1,0 +1,1 @@
+{"results": [], "errors": [{"type": "SemgrepError", "code": 2, "message": "found 'nosem' comment with id 'rules.test-nosem-invalid', but no corresponding rule trying 'rules.test-nosem'"}]}

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__invalid_expression/error.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__invalid_expression/error.json
@@ -1,0 +1,1 @@
+{"results": [], "errors": [{"type": "SemgrepError", "code": 2, "message": "invalid regular expression specified: missing ), unterminated subpattern at position 0"}]}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
@@ -1,0 +1,36 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "operand for pattern-inside must be a string, but instead was list",
+      "short_msg": "invalid operand",
+      "spans": [
+        {
+          "context_end": {
+            "col": 7,
+            "line": 12
+          },
+          "context_start": null,
+          "end": {
+            "col": 23,
+            "line": 4
+          },
+          "file": "rules/syntax/bad1.yaml",
+          "source_hash": "2eb1bb9f87d22d182e19161640dcf8c967f142004c395a4ffb5c97e5909c5f7a",
+          "start": {
+            "col": 9,
+            "line": 4
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
@@ -1,0 +1,40 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "help": "Only ['equivalences', 'fix', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys",
+      "level": "error",
+      "long_msg": "rules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside']",
+      "short_msg": "extra top-level key",
+      "spans": [
+        {
+          "context_end": {
+            "col": 0,
+            "line": 5
+          },
+          "context_start": {
+            "col": 0,
+            "line": 1
+          },
+          "end": {
+            "col": 19,
+            "line": 3
+          },
+          "file": "rules/syntax/bad2.yaml",
+          "source_hash": "6ebef770ea281e5e811acfd1d5b219adb3a0ae87f6613ae0a8cfc593ad126dd2",
+          "start": {
+            "col": 5,
+            "line": 3
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
@@ -1,0 +1,39 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "type of `pattern` must be a string, but it was a list",
+      "short_msg": "invalid operand",
+      "spans": [
+        {
+          "context_end": {
+            "col": 0,
+            "line": 6
+          },
+          "context_start": {
+            "col": 0,
+            "line": 3
+          },
+          "end": {
+            "col": 5,
+            "line": 5
+          },
+          "file": "rules/syntax/bad3.yaml",
+          "source_hash": "b5c10ec06e8348dfbfe2dc7fe5431da300c68b6cbdb249519596ac9e96f0cee1",
+          "start": {
+            "col": 9,
+            "line": 4
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
@@ -1,0 +1,37 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "help": "perhaps your YAML is missing a `-` on line 4?",
+      "level": "error",
+      "long_msg": "invalid type for patterns; expected a list, but found dict",
+      "short_msg": "invalid patterns",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": {
+            "col": 0,
+            "line": 3
+          },
+          "end": {
+            "col": 5,
+            "line": 8
+          },
+          "file": "rules/syntax/bad4.yaml",
+          "source_hash": "156e59613c09e6fd9edd1e4c4240b15559a486bcfae658b3afc13989701f5391",
+          "start": {
+            "col": 9,
+            "line": 4
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
@@ -1,0 +1,34 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "help": "Did you mean `pattern: 4`?",
+      "level": "error",
+      "long_msg": "invalid type for pattern expected dict but found str",
+      "short_msg": "invalid pattern",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 12,
+            "line": 5
+          },
+          "file": "rules/syntax/bad5.yaml",
+          "source_hash": "5c4f00f11940b0b9526ec7832ba2b1b539877e705bc7d73a4421db5a7006eba9",
+          "start": {
+            "col": 9,
+            "line": 5
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
@@ -1,0 +1,36 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "operator pattern-either must have children",
+      "short_msg": "missing children",
+      "spans": [
+        {
+          "context_end": {
+            "col": 35,
+            "line": 5
+          },
+          "context_start": null,
+          "end": {
+            "col": 23,
+            "line": 5
+          },
+          "file": "rules/syntax/bad6.yaml",
+          "source_hash": "ebcad6ecc6d2264e00fcdeeee54e8997c92b2862d3fb66a0066b2bbdde796b2e",
+          "start": {
+            "col": 9,
+            "line": 5
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
@@ -1,0 +1,33 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "rule id must be a string, but was int",
+      "short_msg": "invalid id",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 12,
+            "line": 3
+          },
+          "file": "rules/syntax/bad7.yaml",
+          "source_hash": "99c414681ffa893e6d96ca71e262787fd058d3da094abe7425e470a21879205c",
+          "start": {
+            "col": 9,
+            "line": 3
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
@@ -1,0 +1,33 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "missing a pattern type in rule, expected one of ['patterns', 'pattern-either', 'pattern-regex', 'pattern']",
+      "short_msg": "missing key",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 1,
+            "line": 7
+          },
+          "file": "rules/syntax/bad8.yaml",
+          "source_hash": "f821234ba9175efc8d66b3226996144ba05bdc0aea35a50321cbb9c6f349f6a0",
+          "start": {
+            "col": 5,
+            "line": 2
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
@@ -1,0 +1,40 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "help": "valid pattern names are ['equivalences', 'fix', 'pattern', 'pattern-either', 'pattern-inside', 'pattern-not', 'pattern-not-inside', 'pattern-regex', 'pattern-where-python', 'patterns']",
+      "level": "error",
+      "long_msg": "invalid pattern name: patter",
+      "short_msg": "invalid pattern name",
+      "spans": [
+        {
+          "context_end": {
+            "col": 0,
+            "line": 5
+          },
+          "context_start": {
+            "col": 0,
+            "line": 3
+          },
+          "end": {
+            "col": 15,
+            "line": 4
+          },
+          "file": "rules/syntax/bad9.yaml",
+          "source_hash": "22b38817e2ddc7b6ad25b80aaf6a01451159c7a0233eaef3ed58642355a05379",
+          "start": {
+            "col": 9,
+            "line": 4
+          }
+        }
+      ],
+      "type": "InvalidPatternNameError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -1,0 +1,34 @@
+{
+  "errors": [
+    {
+      "code": 8,
+      "level": "error",
+      "long_msg": "unsupported language rust",
+      "short_msg": "invalid language",
+      "spans": [
+        {
+          "context_end": {
+            "col": 0,
+            "line": 8
+          },
+          "context_start": {
+            "col": 0,
+            "line": 6
+          },
+          "end": {
+            "col": 22,
+            "line": 7
+          },
+          "file": "rules/syntax/badlanguage.yaml",
+          "source_hash": "f6b249e5598500966b21d2584b6c6ec9385fceee05c5efb3f90f4a012d1c0163",
+          "start": {
+            "col": 16,
+            "line": 7
+          }
+        }
+      ],
+      "type": "UnknownLanguageError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
@@ -1,0 +1,37 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "help": "remove the `-` to convert the list into a mapping",
+      "level": "error",
+      "long_msg": "the `paths:` targeting rules must be an object with at least one of ('include', 'exclude')",
+      "short_msg": "invalid paths",
+      "spans": [
+        {
+          "context_end": {
+            "col": 5,
+            "line": 10
+          },
+          "context_start": null,
+          "end": {
+            "col": 10,
+            "line": 6
+          },
+          "file": "rules/syntax/badpaths1.yaml",
+          "source_hash": "5f729ef631099eaddf81dca6b10c2e399989ff7c923ac53ab0e4e51b6124d1a1",
+          "start": {
+            "col": 5,
+            "line": 6
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
@@ -1,0 +1,39 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "the `paths:` targeting rules must each be one of ('include', 'exclude')",
+      "short_msg": "invalid targeting rules",
+      "spans": [
+        {
+          "context_end": {
+            "col": 0,
+            "line": 9
+          },
+          "context_start": {
+            "col": 0,
+            "line": 7
+          },
+          "end": {
+            "col": 15,
+            "line": 8
+          },
+          "file": "rules/syntax/badpaths2.yaml",
+          "source_hash": "e8a29e15677c634a77353a6099e2c0acf18909672c87d06292a1caece7cd4d3c",
+          "start": {
+            "col": 7,
+            "line": 8
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -1,0 +1,28 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "Pattern could not be parsed as Python",
+      "short_msg": "invalid pattern",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 28,
+            "line": 4
+          },
+          "file": "rules/syntax/badpattern.yaml",
+          "source_hash": "3721310e28daac277c2fc5496749be9e60441abcb6d2e3a99542a30f34628ee3",
+          "start": {
+            "col": 18,
+            "line": 4
+          }
+        }
+      ],
+      "type": "InvalidPatternError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
@@ -1,0 +1,33 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "rules/syntax/missing-field.yaml is missing required keys {'severity'}",
+      "short_msg": "missing keys",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 0,
+            "line": 8
+          },
+          "file": "rules/syntax/missing-field.yaml",
+          "source_hash": "52c8055ff5d4555128113f2ad1b4f03c1227c339ee9b6992d9bbc18548d4e645",
+          "start": {
+            "col": 3,
+            "line": 3
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
@@ -1,0 +1,33 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "rules/syntax/missing-toplevel.yaml is missing `rules` as top-level key",
+      "short_msg": "missing keys",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 0,
+            "line": 7
+          },
+          "file": "rules/syntax/missing-toplevel.yaml",
+          "source_hash": "c72a97211dabcaa3065612fb9c52d6a344855414a6d9f1eb5adea4305d4c47da",
+          "start": {
+            "col": 1,
+            "line": 2
+          }
+        }
+      ],
+      "type": "InvalidRuleSchemaError"
+    },
+    {
+      "code": 7,
+      "message": "run with --strict and there were 1 errors loading configs",
+      "type": "SemgrepError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -78,9 +78,10 @@ def test_hidden_rule__explicit(run_semgrep_in_tmp, snapshot):
 
 def test_hidden_rule__implicit(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
-        run_semgrep_in_tmp("rules/hidden", stderr=True)
+        run_semgrep_in_tmp("rules/hidden")
     assert excinfo.value.returncode == 2
-    snapshot.assert_match(excinfo.value.output, "error.txt")
+    snapshot.assert_match(excinfo.value.stderr, "error.txt")
+    snapshot.assert_match(excinfo.value.stdout, "error.json")
 
 
 def test_default_rule__file(run_semgrep_in_tmp, snapshot):
@@ -105,9 +106,10 @@ def test_regex_rule__child(run_semgrep_in_tmp, snapshot):
 
 def test_regex_rule__invalid_expression(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
-        run_semgrep_in_tmp("rules/regex-invalid.yaml", stderr=True)
+        run_semgrep_in_tmp("rules/regex-invalid.yaml")
     assert excinfo.value.returncode == 2
-    snapshot.assert_match(excinfo.value.output, "error.txt")
+    snapshot.assert_match(excinfo.value.stderr, "error.txt")
+    snapshot.assert_match(excinfo.value.stdout, "error.json")
 
 
 def test_nested_patterns_rule(run_semgrep_in_tmp, snapshot):
@@ -122,8 +124,7 @@ def test_nosem_rule(run_semgrep_in_tmp, snapshot):
 
 def test_nosem_rule__invalid_id(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
-        run_semgrep_in_tmp(
-            "rules/nosem.yaml", target_name="nosem_invalid_id", stderr=True
-        )
+        run_semgrep_in_tmp("rules/nosem.yaml", target_name="nosem_invalid_id")
     assert excinfo.value.returncode == 2
-    snapshot.assert_match(excinfo.value.output, "error.txt")
+    snapshot.assert_match(excinfo.value.stderr, "error.txt")
+    snapshot.assert_match(excinfo.value.stdout, "error.json")


### PR DESCRIPTION
A long time coming. SemgrepError now defines a standard JSON serialization. All SemgrepErrors will be included in the JSON output when requested. Individual exceptions should override `to_dict_base` to provide a custom JSON serialization other than `str(ex)`.

I also split out stdout and stderr from the snapshot tests which trigger known errors -- hopefully this makes the snapshot tests less brittle as well as ensuring that all output is going to the right place!

Everything else is just rudimentary refactoring moving a bits of code around.

With this change, we can now include errors for rule schemas in semgrep.live! 