### PR TITLE
Update conditions when progress bar displays.

### DIFF
--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -125,8 +125,11 @@ def progress_bar(
     #   is a hack, so it will only show the progress bar if there is more than 1 rule to run.
     # not DEBUG - don't show progress bar with debug
     # not QUIET - don't show progress bar with quiet
-    if file.isatty() and len(list(iterable)) > 1 and not DEBUG and not QUIET:
+    listified = list(
+        iterable
+    )  # Consume iterable once so we can check length and then use in tqdm.
+    if file.isatty() and len(listified) > 1 and not DEBUG and not QUIET:
         # mypy doesn't seem to want to follow tqdm imports. Do this to placate.
-        wrapped: Iterable[T] = tqdm(iterable, file=file, **kwargs)
+        wrapped: Iterable[T] = tqdm(listified, file=file, **kwargs)
         return wrapped
-    return iterable
+    return listified

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -119,7 +119,13 @@ def progress_bar(
     Return tqdm-wrapped iterable if output stream is a tty;
     else return iterable without tqdm.
     """
-    if file.isatty():
+    # Conditions:
+    # file.isatty() - only show bar if this is an interactive terminal
+    # len(iterable) > 1 - don't show progress bar when using -e on command-line. This
+    #   is a hack, so it will only show the progress bar if there is more than 1 rule to run.
+    # not DEBUG - don't show progress bar with debug
+    # not QUIET - don't show progress bar with quiet
+    if file.isatty() and len(list(iterable)) > 1 and not DEBUG and not QUIET:
         # mypy doesn't seem to want to follow tqdm imports. Do this to placate.
         wrapped: Iterable[T] = tqdm(iterable, file=file, **kwargs)
         return wrapped


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/1050.

Progress bar will now only display under these conditions:
- Semgrep is running in an interactive terminal
- Semgrep is running more than 1 rule. This prevents the progress bar
    from displaying when using --pattern on the command line.
- Semgrep is NOT running in debug mode ('-v' flag).
- Semgrep iS NOT running in quiet mode ('-q' flag).