### PR TITLE
Refactor config validation interactions with output_manager

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -292,7 +292,7 @@ def cli() -> None:
             dump_parsed_ast(args.json, args.lang, args.pattern, args.target)
         elif args.validate:
             _, invalid_configs = semgrep.semgrep_main.get_config(
-                args.pattern, args.lang, args.config, output_handler=output_handler
+                args.pattern, args.lang, args.config
             )
             if invalid_configs:
                 raise SemgrepError(

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -291,12 +291,12 @@ def cli() -> None:
         if args.dump_ast:
             dump_parsed_ast(args.json, args.lang, args.pattern, args.target)
         elif args.validate:
-            _, invalid_configs = semgrep.semgrep_main.get_config(
+            _, config_errors = semgrep.semgrep_main.get_config(
                 args.pattern, args.lang, args.config
             )
-            if invalid_configs:
+            if config_errors:
                 raise SemgrepError(
-                    f"run with --validate and there were {len(invalid_configs)} errors loading configs"
+                    f"run with --validate and there were {len(config_errors)} errors loading configs"
                 )
             else:
                 print_msg("Config is valid")

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -98,7 +98,7 @@ def validate_configs(
 
             try:
                 rule = validate_single_rule(config_id, rule_dict)
-            except (InvalidRuleSchemaError, InvalidPatternNameError) as ex:
+            except InvalidRuleSchemaError as ex:
                 errors.append(ex)
             else:
                 valid_rules.append(rule)

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.json
@@ -1,6 +1,11 @@
 {
   "errors": [
     {
+      "code": 5,
+      "message": "Invalid yaml file rules/syntax/invalid.yaml:\n\tmapping values are not allowed here\n\t  in \"<file>\", line 2, column 7",
+      "type": "SemgrepError"
+    },
+    {
       "code": 7,
       "message": "run with --strict and there were 1 errors loading configs",
       "type": "SemgrepError"


### PR DESCRIPTION
Instead of passing output_manager all the way down we instead raise exceptions that are then handled further up and passed to the output_manager.

Fixed up some unnecessary optionals