### PR TITLE
Add a flag --dryrun for autofixes.

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -212,6 +212,16 @@ def cli() -> None:
         ),
     )
     output.add_argument(
+        "--dryrun",
+        action="store_true",
+        help=(
+            "Do autofixes, but don't write them to a file. "
+            "This will print the changes to the console. "
+            "This lets you see the changes before you commit to them. "
+            "Only works with the --autofix flag. Otherwise does nothing."
+        ),
+    )
+    output.add_argument(
         "--disable-nosem",
         action="store_true",
         help=(
@@ -315,6 +325,7 @@ def cli() -> None:
                 exclude_dir=args.exclude_dir,
                 strict=args.strict,
                 autofix=args.autofix,
+                dryrun=args.dryrun,
                 disable_nosem=args.disable_nosem,
                 dangerously_allow_arbitrary_code_execution_from_rules=args.dangerously_allow_arbitrary_code_execution_from_rules,
                 no_git_ignore=args.no_git_ignore,

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -59,7 +59,8 @@ def finding_to_line(rule_match: RuleMatch, color_output: bool) -> Iterator[str]:
     start_col = rule_match.start.get("col")
     end_col = rule_match.end.get("col")
     if path:
-        for i, line in enumerate(rule_match.lines):
+        lines = rule_match.extra.get("fixed_lines") or rule_match.lines
+        for i, line in enumerate(lines):
             line = line.rstrip()
             line_number = ""
             if start_line:
@@ -118,6 +119,9 @@ def build_normal_output(
         yield from finding_to_line(rule_match, color_output)
         if fix:
             yield f"{BLUE_COLOR}autofix:{RESET_COLOR} {fix}"
+        elif rule_match.fix_regex:
+            fix_regex = rule_match.fix_regex
+            yield f"{BLUE_COLOR}autofix:{RESET_COLOR} s/{fix_regex.get('regex')}/{fix_regex.get('replacement')}/{fix_regex.get('count', 'g')}"
 
 
 def build_output_json(

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -298,6 +298,7 @@ def main(
     exclude_dir: List[str],
     strict: bool,
     autofix: bool,
+    dryrun: bool,
     disable_nosem: bool,
     dangerously_allow_arbitrary_code_execution_from_rules: bool,
     no_git_ignore: bool,
@@ -380,4 +381,4 @@ def main(
             )
 
     if autofix:
-        apply_fixes(rule_matches_by_rule)
+        apply_fixes(rule_matches_by_rule, dryrun)

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -198,6 +198,7 @@ def invoke_semgrep(
         exclude_dir=[],
         strict=strict,
         autofix=False,
+        dryrun=False,
         disable_nosem=False,
         dangerously_allow_arbitrary_code_execution_from_rules=unsafe,
         no_git_ignore=True,


### PR DESCRIPTION
Added a flag --dryrun for autofixes.
When this flag is set:
- autofixes are not applied directly to the file.
- the autofix is applied to the output to demonstrate what the change would be.

This enables easier debugging of autofixes, including when future autofix methods land.