### PR TITLE
Convert parse errors from SemgrepCore into SemgrepError

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -289,6 +289,7 @@ def cli() -> None:
         output_destination=args.output,
         quiet=args.quiet,
         error_on_findings=args.error,
+        strict=args.strict,
     )
 
     if not args.disable_version_check:

--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -1,8 +1,13 @@
 from pathlib import Path
 from typing import Any
 from typing import Dict
+from typing import Optional
 
+from semgrep.error import SemgrepError
+from semgrep.error import SourceParseError
 from semgrep.rule_lang import Position
+from semgrep.rule_lang import SourceTracker
+from semgrep.rule_lang import Span
 
 
 class CoreException:
@@ -61,11 +66,18 @@ class CoreException:
             language,
         )
 
-    def __str__(self) -> str:
-        header = (
-            f"--> Failed to parse {self._path}:{self._start.line} as {self._language}"
+    def into_semgrep_error(self) -> SourceParseError:
+        with open(self._path) as f:
+            file_hash = SourceTracker.add_source(f.read())
+        error_span = Span(
+            start=self._start,
+            end=self._end,
+            source_hash=file_hash,
+            file=self._path.name,
         )
-        line_1 = self._extra["line"]
-        start_col = self._start.col
-        line_2 = " " * (start_col - 1) + "^"
-        return "\n".join([header, line_1, line_2])
+        return SourceParseError(
+            short_msg="parse error",
+            long_msg=f"Could not parse {self._path.name} as {self._language}",
+            spans=[error_span],
+            help="If the code appears to be valid, this may be a semgrep bug.",
+        )

--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Any
 from typing import Dict
-from typing import Optional
 
 from semgrep.error import SemgrepError
 from semgrep.error import SourceParseError
@@ -66,7 +65,7 @@ class CoreException:
             language,
         )
 
-    def into_semgrep_error(self) -> SourceParseError:
+    def into_semgrep_error(self) -> SemgrepError:
         with open(self._path) as f:
             file_hash = SourceTracker.add_source(f.read())
         error_span = Span(

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -24,16 +24,12 @@ from semgrep.equivalences import Equivalence
 from semgrep.error import _UnknownLanguageError
 from semgrep.error import InvalidPatternError
 from semgrep.error import SemgrepError
-from semgrep.error import SourceParseError
 from semgrep.error import UnknownLanguageError
 from semgrep.evaluation import enumerate_patterns_in_boolean_expression
 from semgrep.evaluation import evaluate
 from semgrep.pattern import Pattern
 from semgrep.pattern_match import PatternMatch
 from semgrep.rule import Rule
-from semgrep.rule_lang import Position
-from semgrep.rule_lang import SourceTracker
-from semgrep.rule_lang import Span
 from semgrep.rule_match import RuleMatch
 from semgrep.semgrep_types import BooleanRuleExpression
 from semgrep.semgrep_types import Language

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -28,7 +28,6 @@ from semgrep.error import SourceParseError
 from semgrep.error import UnknownLanguageError
 from semgrep.evaluation import enumerate_patterns_in_boolean_expression
 from semgrep.evaluation import evaluate
-from semgrep.output import OutputHandler
 from semgrep.pattern import Pattern
 from semgrep.pattern_match import PatternMatch
 from semgrep.rule import Rule
@@ -221,28 +220,6 @@ class CoreRunner:
         yaml.representer.ignore_aliases = lambda *data: True
         yaml.dump({"equivalences": [e.to_json() for e in equivalences]}, fp)
         fp.flush()
-
-    @staticmethod
-    def _convert_semgrep_core_error(  # type: ignore
-        error: Dict[str, Any], language: str
-    ) -> Optional[SemgrepError]:
-        if {"path", "start", "end", "extra"}.difference(error.keys()) == set():
-            with open(error["path"]) as f:
-                file_hash = SourceTracker.add_source(f.read())
-            start, end = [
-                Position(line=error[k]["line"], col=error[k]["col"])
-                for k in ("start", "end")
-            ]
-            error_span = Span(
-                start=start, end=end, source_hash=file_hash, file=error["path"]
-            )
-            return SourceParseError(
-                short_msg="parse error",
-                long_msg=f'Could not parse {error["path"]} as {language}',
-                spans=[error_span],
-                help="If the code appears to be valid, this may be a semgrep bug.",
-            )
-        return None
 
     def _run_rule(
         self, rule: Rule, target_manager: TargetManager, cache_dir: str

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -26,7 +26,6 @@ from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.util import debug_print
 from semgrep.util import is_url
-from semgrep.util import partition
 from semgrep.util import print_stderr
 
 

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -269,7 +269,7 @@ class OutputHandler:
         if ex is None:
             return
         if isinstance(ex, SemgrepError):
-            if ex.level == Level.ERROR:
+            if ex.level == Level.ERROR:  # nosem: r2c.registry.latest useless-if-body
                 raise ex
             else:
                 if self.settings.strict:

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -227,25 +227,15 @@ class OutputHandler:
 
         self.final_error: Optional[Exception] = None
 
-    def handle_semgrep_core_errors(self, semgrep_errors: List[CoreException]) -> None:
-        """
-        Report errors coming directly from semgrep-core
-        """
-        self.semgrep_core_errors += semgrep_errors
-        if self.settings.output_format == OutputFormat.TEXT:
-            _, other_errors = partition(
-                lambda e: e._check_id in {"ParseError", "FatalError"}, semgrep_errors
-            )
-
-            for error in other_errors:
-                print_stderr(str(error))
+    def handle_semgrep_errors(self, errors: List[SemgrepError]) -> None:
+        for err in errors:
+            self.handle_semgrep_error(err)
 
     def handle_semgrep_error(self, error: SemgrepError) -> None:
         """
         Reports generic exceptions that extend SemgrepError
         """
         self.has_output = True
-        self.semgrep_structured_errors.append(error)
         if error not in self.error_set:
             self.semgrep_structured_errors.append(error)
             self.error_set.add(error)
@@ -365,7 +355,3 @@ class OutputHandler:
             raise RuntimeError(
                 f"Unhandled output format: {type(output_format).__name__}"
             )
-
-
-def pretty_error(error: Dict[str, Any]) -> str:
-    return f"semgrep-core error: {json.dumps(error, indent=2)}"

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -15,12 +15,12 @@ from typing import Set
 
 import colorama
 
-import semgrep.util
 from semgrep import config_resolver
-from semgrep.constants import __VERSION__
 from semgrep.constants import OutputFormat
+from semgrep.constants import __VERSION__
 from semgrep.core_exception import CoreException
 from semgrep.error import FINDINGS_EXIT_CODE
+from semgrep.error import Level
 from semgrep.error import SemgrepError
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
@@ -176,6 +176,7 @@ class OutputSettings(NamedTuple):
     output_destination: Optional[str]
     quiet: bool
     error_on_findings: bool
+    strict: bool
 
 
 @contextlib.contextmanager
@@ -221,41 +222,24 @@ class OutputHandler:
         self.rules: FrozenSet[Rule] = frozenset()
         self.semgrep_core_errors: List[CoreException] = []
         self.semgrep_structured_errors: List[SemgrepError] = []
+        self.error_set: Set[SemgrepError] = set()
         self.has_output = False
 
         self.final_error: Optional[Exception] = None
 
     def handle_semgrep_core_errors(self, semgrep_errors: List[CoreException]) -> None:
         """
-        Report errors coming directly from semgrep-core (raw JSON objects)
+        Report errors coming directly from semgrep-core
         """
         self.semgrep_core_errors += semgrep_errors
         if self.settings.output_format == OutputFormat.TEXT:
-            parse_errors, other_errors = partition(
+            _, other_errors = partition(
                 lambda e: e._check_id in {"ParseError", "FatalError"}, semgrep_errors
             )
 
             for error in other_errors:
                 print_stderr(str(error))
 
-            if len(parse_errors) > 0:
-                files_with_parse_errors: Set[str] = set(
-                    str(e._path) for e in parse_errors
-                )
-
-                print_stderr(
-                    f"{len(files_with_parse_errors)} file(s) failed to parse: {', '.join(files_with_parse_errors)}"
-                )
-
-                if semgrep.util.DEBUG:
-                    debug_print("ParseErrors:")
-                    for error in parse_errors:
-                        debug_print(str(error))
-                    debug_print(
-                        "= note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev"
-                    )
-                else:
-                    print_stderr("Run with --verbose to see parse errors")
 
     def handle_semgrep_error(self, error: SemgrepError) -> None:
         """
@@ -263,7 +247,10 @@ class OutputHandler:
         """
         self.has_output = True
         self.semgrep_structured_errors.append(error)
-        print_stderr(str(error))
+        if error not in self.error_set:
+            self.semgrep_structured_errors.append(error)
+            self.error_set.add(error)
+            print_error(str(error))
 
     def handle_semgrep_core_output(
         self,
@@ -290,6 +277,22 @@ class OutputHandler:
             self.handle_semgrep_error(ex)
         self.final_error = ex
 
+    def final_raise(self, ex: Optional[Exception]) -> None:
+        if ex is None:
+            return
+        if isinstance(ex, SemgrepError):
+            if ex.level == Level.ERROR:
+                raise ex
+            else:
+                if self.settings.strict:
+                    raise ex
+                print(
+                    "Warnings exist. Run with `--strict` to turn warnings into errors.",
+                    self.stderr,
+                )
+        else:
+            raise ex
+
     def close(self) -> None:
         """
         Close the output handler.
@@ -305,12 +308,16 @@ class OutputHandler:
             if self.settings.output_destination:
                 self.save_output(self.settings.output_destination, output)
 
+        final_error = None
         if self.final_error:
-            raise self.final_error
+            final_error = self.final_error
         elif self.rule_matches and self.settings.error_on_findings:
             # This exception won't be visiable to the user, we're just
             # using this to return a specific error code
-            raise SemgrepError("", code=FINDINGS_EXIT_CODE)
+            final_error = SemgrepError("", code=FINDINGS_EXIT_CODE)
+        elif self.semgrep_structured_errors:
+            final_error = self.semgrep_structured_errors[-1]
+        self.final_raise(final_error)
 
     @classmethod
     def save_output(cls, destination: str, output: str) -> None:
@@ -359,3 +366,7 @@ class OutputHandler:
             raise RuntimeError(
                 f"Unhandled output format: {type(output_format).__name__}"
             )
+
+
+def pretty_error(error: Dict[str, Any]) -> str:
+    return f"semgrep-core error: {json.dumps(error, indent=2)}"

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -16,8 +16,8 @@ from typing import Set
 import colorama
 
 from semgrep import config_resolver
-from semgrep.constants import OutputFormat
 from semgrep.constants import __VERSION__
+from semgrep.constants import OutputFormat
 from semgrep.core_exception import CoreException
 from semgrep.error import FINDINGS_EXIT_CODE
 from semgrep.error import Level
@@ -240,7 +240,6 @@ class OutputHandler:
             for error in other_errors:
                 print_stderr(str(error))
 
-
     def handle_semgrep_error(self, error: SemgrepError) -> None:
         """
         Reports generic exceptions that extend SemgrepError
@@ -250,7 +249,7 @@ class OutputHandler:
         if error not in self.error_set:
             self.semgrep_structured_errors.append(error)
             self.error_set.add(error)
-            print_error(str(error))
+            print_stderr(str(error))
 
     def handle_semgrep_core_output(
         self,
@@ -288,7 +287,7 @@ class OutputHandler:
                     raise ex
                 print(
                     "Warnings exist. Run with `--strict` to turn warnings into errors.",
-                    self.stderr,
+                    file=self.stderr,
                 )
         else:
             raise ex

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -1,4 +1,8 @@
 running 2 rules...
-1 file(s) failed to parse: targets/bad/invalid_python.py
-Run with --verbose to see parse errors
-run with --strict and 1 errors occurred during semgrep run; exiting
+warn: parse error
+  --> targets/bad/invalid_python.py:1
+1 | def foo(a)
+  |           ^^^^^
+= help: If the code appears to be valid, this may be a semgrep bug.
+Could not parse targets/bad/invalid_python.py as python
+

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -1,8 +1,8 @@
 running 2 rules...
 warn: parse error
-  --> targets/bad/invalid_python.py:1
+  --> invalid_python.py:1
 1 | def foo(a)
   |           ^^^^^
 = help: If the code appears to be valid, this may be a semgrep bug.
-Could not parse targets/bad/invalid_python.py as python
+Could not parse invalid_python.py as python
 

--- a/semgrep/tests/e2e/test_semgrep_core_parse_error.py
+++ b/semgrep/tests/e2e/test_semgrep_core_parse_error.py
@@ -15,23 +15,3 @@ def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, file
             stderr=True,
         )
     snapshot.assert_match(excinfo.value.output, "error.txt")
-
-
-@pytest.mark.parametrize(
-    "filename", ["invalid_python.py",],
-)
-def test_rule_parser__failure__error_messages_verbose(
-    run_semgrep_in_tmp, snapshot, filename
-):
-    with pytest.raises(CalledProcessError) as excinfo:
-        run_semgrep_in_tmp(
-            config="rules/eqeq-python.yaml",
-            target_name=f"bad/{filename}",
-            options=["--verbose"],
-            output_format="text",
-            stderr=True,
-        )
-
-    # Hack to ignore timing in verbose mode
-    output = "\n".join(excinfo.value.output.split("\n")[9:])
-    snapshot.assert_match(output, "error.txt")


### PR DESCRIPTION
I also added functionality to control which exceptions will always cause a non-zero status code, and which will only be an error when `--strict` is set.