### PR TITLE
Don't try to parse an inline pattern as YAML

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -18,7 +18,6 @@ from semgrep.constants import YML_EXTENSIONS
 from semgrep.error import SemgrepError
 from semgrep.error import UNPARSEABLE_YAML_EXIT_CODE
 from semgrep.rule_lang import parse_yaml_preserve_spans
-from semgrep.rule_lang import SourceTracker
 from semgrep.rule_lang import Span
 from semgrep.rule_lang import YamlTree
 from semgrep.util import debug_print

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -18,6 +18,8 @@ from semgrep.constants import YML_EXTENSIONS
 from semgrep.error import SemgrepError
 from semgrep.error import UNPARSEABLE_YAML_EXIT_CODE
 from semgrep.rule_lang import parse_yaml_preserve_spans
+from semgrep.rule_lang import SourceTracker
+from semgrep.rule_lang import Span
 from semgrep.rule_lang import YamlTree
 from semgrep.util import debug_print
 from semgrep.util import is_url
@@ -39,7 +41,8 @@ DEFAULT_REGISTRY_KEY = "r2c"
 
 def manual_config(pattern: str, lang: str) -> Dict[str, YamlTree]:
     # TODO remove when using sgrep -e ... -l ... instead of this hacked config
-    pattern_tree = parse_yaml_preserve_spans(pattern, filename=None)
+    pattern_span = Span.from_string(pattern, filename="CLI Input")
+    pattern_tree = YamlTree[str](value=pattern, span=pattern_span)
     error_span = parse_yaml_preserve_spans(
         f"Semgrep bug generating manual config {PLEASE_FILE_ISSUE_TEXT}", filename=None
     ).span

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -178,7 +178,7 @@ class CoreRunner:
 
             raise InvalidPatternError(
                 short_msg=error_type,
-                long_msg=f"Pattern could not be parsed as {error_json['language']}",
+                long_msg=f"Pattern could not be parsed as a {error_json['language']} semgrep pattern",
                 spans=[matching_span],
                 level="error",
                 help=None,

--- a/semgrep/semgrep/rule_lang.py
+++ b/semgrep/semgrep/rule_lang.py
@@ -93,6 +93,14 @@ class Span:
         end = Position(line=node.end_mark.line + 1, col=node.end_mark.column + 1)
         return Span(start=start, end=end, file=filename, source_hash=source_hash).fix()
 
+    @classmethod
+    def from_string(cls, s: str, filename: Optional[str] = None) -> "Span":
+        src_hash = SourceTracker.add_source(s)
+        start = Position(1, 1)
+        lines = s.splitlines()
+        end = Position(line=len(lines), col=len(lines[-1]))
+        return Span(start=start, end=end, file=filename, source_hash=src_hash)
+
     def fix(self) -> "Span":
         # some issues in ruamel lead to bad spans
         # correct empty spans by rewinding to the last non-whitespace character:
@@ -322,7 +330,7 @@ def parse_yaml_preserve_spans(contents: str, filename: Optional[str]) -> YamlTre
     data = yaml.load(StringIO(contents))
     if not isinstance(data, YamlTree):
         raise Exception(
-            f"Something went wrong parsing Yaml (expected a YamlTree as output): {PLEASE_FILE_ISSUE_TEXT}"
+            f"Something went wrong parsing Yaml (expected a YamlTree as output, but got {type(data).__name__}): {PLEASE_FILE_ISSUE_TEXT}"
         )
     return data
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
@@ -4,5 +4,5 @@ running 1 rules...
 [94m4 | [39m      - pattern: $X == $X 3
 [94m  | [39m                 [31m^^^^^^^^^^[39m
 
-[31mPattern could not be parsed as Python[39m
+[31mPattern could not be parsed as a Python semgrep pattern[39m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -3,7 +3,7 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "Pattern could not be parsed as Python",
+      "long_msg": "Pattern could not be parsed as a Python semgrep pattern",
       "short_msg": "invalid pattern",
       "spans": [
         {

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.txt
@@ -4,5 +4,5 @@ error: invalid pattern
 4 |       - pattern: $X == $X 3
   |                  ^^^^^^^^^^
 
-Pattern could not be parsed as Python
+Pattern could not be parsed as a Python semgrep pattern
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -3,18 +3,18 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "Pattern could not be parsed as C",
+      "long_msg": "Pattern could not be parsed as a C semgrep pattern",
       "short_msg": "invalid pattern",
       "spans": [
         {
           "context_end": null,
           "context_start": null,
           "end": {
-            "col": 11,
+            "col": 23,
             "line": 1
           },
           "file": "CLI Input",
-          "source_hash": "420525e8e16fbbef2e5558f91905d129b6d1e8c9d818204b3a823e4829196719",
+          "source_hash": "7efe89db58e7a4017c5cd63dd547745a14f3e4c1fc32fd5e2051b53858d9e85d",
           "start": {
             "col": 1,
             "line": 1

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -1,0 +1,28 @@
+{
+  "errors": [
+    {
+      "code": 4,
+      "level": "error",
+      "long_msg": "Pattern could not be parsed as C",
+      "short_msg": "invalid pattern",
+      "spans": [
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 11,
+            "line": 1
+          },
+          "file": "CLI Input",
+          "source_hash": "420525e8e16fbbef2e5558f91905d129b6d1e8c9d818204b3a823e4829196719",
+          "start": {
+            "col": 1,
+            "line": 1
+          }
+        }
+      ],
+      "type": "InvalidPatternError"
+    }
+  ],
+  "results": []
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
@@ -1,7 +1,7 @@
 error: invalid pattern
   --> CLI Input:1
-1 | #include $X
-  | ^^^^^^^^^^
+1 | #include<asdf><<>>><$X>
+  | ^^^^^^^^^^^^^^^^^^^^^^
 
-Pattern could not be parsed as C
+Pattern could not be parsed as a C semgrep pattern
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
@@ -1,0 +1,7 @@
+error: invalid pattern
+  --> CLI Input:1
+1 | #include $X
+  | ^^^^^^^^^^
+
+Pattern could not be parsed as C
+

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -44,3 +44,16 @@ def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, file
 
     if excinfo_in_color.value.stderr != excinfo.value.stderr:
         snapshot.assert_match(excinfo_in_color.value.stderr, "error-in-color.txt")
+
+
+# https://github.com/returntocorp/semgrep/issues/1095
+def test_rule_parser_cli_pattern(run_semgrep_in_tmp, snapshot):
+    # This test should eventually pass once this pattern is handled by semgrep-core, but for now,
+    # getting a proper error from semgrep-core is an improvement
+    with pytest.raises(CalledProcessError) as excinfo:
+        run_semgrep_in_tmp(options=["-e", "#include $X", "-l", "c"])
+    snapshot.assert_match(excinfo.value.stderr, "error.txt")
+    json_output = json.loads(excinfo.value.stdout)
+    snapshot.assert_match(
+        json.dumps(json_output, indent=2, sort_keys=True), "error.json"
+    )

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -48,10 +48,8 @@ def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, file
 
 # https://github.com/returntocorp/semgrep/issues/1095
 def test_rule_parser_cli_pattern(run_semgrep_in_tmp, snapshot):
-    # This test should eventually pass once this pattern is handled by semgrep-core, but for now,
-    # getting a proper error from semgrep-core is an improvement
     with pytest.raises(CalledProcessError) as excinfo:
-        run_semgrep_in_tmp(options=["-e", "#include $X", "-l", "c"])
+        run_semgrep_in_tmp(options=["-e", "#include<asdf><<>>><$X>", "-l", "c"])
     snapshot.assert_match(excinfo.value.stderr, "error.txt")
     json_output = json.loads(excinfo.value.stdout)
     snapshot.assert_match(


### PR DESCRIPTION
To build an error span, we were attempting to parse the argument to `-e` as YAML, but this breaks if eg. it starts with `#` as in #1095. Instead, build a YamlTree[str] directly.