### PR TITLE
Improve --validate info and message

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -331,15 +331,17 @@ def cli() -> None:
         if args.dump_ast:
             dump_parsed_ast(args.json, args.lang, args.pattern, args.target)
         elif args.validate:
-            _, config_errors = semgrep.semgrep_main.get_config(
+            configs, config_errors = semgrep.semgrep_main.get_config(
                 args.pattern, args.lang, args.config
             )
+            valid_str = "invalid" if config_errors else "valid"
+            print_msg(
+                f"Configuration is {valid_str} - found {len(configs)} valid configuration(s) and {len(config_errors)} configuration error(s)."
+            )
             if config_errors:
-                raise SemgrepError(
-                    f"run with --validate and there were {len(config_errors)} errors loading configs"
-                )
-            else:
-                print_msg("Config is valid")
+                for error in config_errors:
+                    output_handler.handle_semgrep_error(error)
+                raise SemgrepError("Please fix the above errors and try again.")
         elif args.generate_config:
             semgrep.config_resolver.generate_config()
         else:

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -110,7 +110,7 @@ def parse_config_string(
         return {config_id: data}
     except YAMLError as se:
         raise SemgrepError(
-            f"Invalid yaml file {config_id}:\n{indent(str(se))}",
+            f"Invalid YAML file {config_id}:\n{indent(str(se))}",
             code=UNPARSEABLE_YAML_EXIT_CODE,
         )
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.json
@@ -2,7 +2,7 @@
   "errors": [
     {
       "code": 5,
-      "message": "Invalid yaml file rules/syntax/invalid.yaml:\n\tmapping values are not allowed here\n\t  in \"<file>\", line 2, column 7",
+      "message": "Invalid YAML file rules/syntax/invalid.yaml:\n\tmapping values are not allowed here\n\t  in \"<file>\", line 2, column 7",
       "type": "SemgrepError"
     },
     {

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/invalid/error.txt
@@ -1,4 +1,4 @@
-Invalid yaml file rules/syntax/invalid.yaml:
+Invalid YAML file rules/syntax/invalid.yaml:
 	mapping values are not allowed here
 	  in "<file>", line 2, column 7
 run with --strict and there were 1 errors loading configs


### PR DESCRIPTION
E.g.

```
$ python -m semgrep --validate --config ~/r2c/sgrep-rules/contrib/
Configuration is invalid - found 0 valid configuration(s) and 1 configuration error(s).
Invalid YAML file ~/r2c/sgrep-rules/contrib/dlint/dlint-equivalent.yaml:
	while parsing a block mapping
	  in "<file>", line 2, column 3
	expected <block end>, but found '-'
	  in "<file>", line 8, column 3
Please fix the above errors and try again.
$ echo $?
2
$ python -m semgrep --validate --config ~/r2c/sgrep-rules/contrib/
Configuration is valid - found 34 valid configuration(s) and 0 configuration error(s).
$ echo $?
0
```