### PR TITLE
Build semgrep-core from source for tox tests

### DIFF
--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -6,28 +6,60 @@ on:
     branches: [master, develop]
 
 jobs:
+  build-core:
+    runs-on: ubuntu-latest
+    container: returntocorp/sgrep-build:2.8
+    steps:
+      - name: Adjust permissions
+        run: |
+          sudo chmod -R 777 . /github
+          # github cache dir
+          sudo mkdir -p /__w/
+          sudo chmod -R 777 /__w/
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install submodules
+        run: git submodule update --init --recursive
+      - name: Install pfff
+        run: eval $(opam  env --root /home/opam/.opam --set-root) && opam install -y ./pfff
+      - name: Install semgrep-core
+        run: eval $(opam  env --root /home/opam/.opam --set-root) && cd semgrep-core && opam install --deps-only -y . && make all && make install
+      - name: Upload semgrep-core
+        run: |
+          mkdir -p semgrep-files
+          cp ./semgrep-core/_build/default/bin/Main.exe semgrep-files/semgrep-core
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: semgrep-core
+          path: semgrep-files/semgrep-core
   tox-tests:
     runs-on: ubuntu-latest
+    needs: [build-core]
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]
     steps:
-      - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: Install semgrep-core from develop
-        run: sudo -E ./install-scripts/latest-artifact-for-branch.py
-        env:
-          AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SEMGREP_CORE: y
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: semgrep-core
+          path: semgrep-core-dir
+      - name: Install artifact
+        run: |
+          sudo cp semgrep-core-dir/semgrep-core /usr/bin/semgrep-core
+          sudo chmod +x /usr/bin/semgrep-core
+      - name: Test semgrep-core
+        run: semgrep-core -version
       - name: Install Tox and any other packages
         run: pip install pipenv==2018.11.26 wheel==0.34.2 tox==3.15.0
       - name: Run Tox
         run: |
           cd semgrep
           tox -e py  # Run tox using the version of Python in `PATH`
-      - name: Failure hint
-        if: ${{ failure() }}
-        run: echo "This job runs with the most recent binary from the develop branch for semgrep-core. If you are using bleeding edge features, you may need to wait for a build"


### PR DESCRIPTION
I built semgrep-core in a separate job, that way we don't need the heavy docker image to actually run the tests. We can cache the semgrep-core artifact based on the hash of the semgrep-core directory.