### PR TITLE
Const propagation examples for Java final and Python globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Add version check to recommend upgrading when applicable
 
 ### Fixed
+- Const propagation now works with Java 'final' keyword and for Python globals
+  which were assigned only once in the program
 - The range of function calls and statement blocks now includes the closing
   `}` and `)`. The range for expression statements now includes the closing
   ';' when there's one. The range of decorators now includes '@'.

--- a/semgrep-core/tests/java/equivalence_constant_propagation.java
+++ b/semgrep-core/tests/java/equivalence_constant_propagation.java
@@ -1,0 +1,29 @@
+public class SemgrepTest
+{
+	public static final String MD5_1 = "MD5";
+	public final String MD5_2 = "MD5";
+
+public static void main(String[] args) throws NoSuchAlgorithmException, IOException
+	{
+
+		if (args.length != 1)
+		{
+			throw new IOException("Wrong number of arguments");
+		}
+
+        //ERROR: match
+		MessageDigest md1 = MessageDigest.getInstance("MD5");
+
+        //ERROR: match
+		MessageDigest md2 = MessageDigest.getInstance(MD5_1);
+
+        //ERROR: match
+		MessageDigest md3 = MessageDigest.getInstance(MD5_2);	
+
+		int stam1 = 0;
+		if (stam1 == stam1)
+			throw new IOException("Bad place");
+
+	}
+
+}

--- a/semgrep-core/tests/java/equivalence_constant_propagation.sgrep
+++ b/semgrep-core/tests/java/equivalence_constant_propagation.sgrep
@@ -1,0 +1,1 @@
+MessageDigest $VAR = $MD.getInstance("MD5");

--- a/semgrep-core/tests/python/equivalence_constant_propagation.py
+++ b/semgrep-core/tests/python/equivalence_constant_propagation.py
@@ -1,0 +1,13 @@
+CONST_GLOBAL = "secret"
+
+# this is modifed somewhere, so not inferred as a constant
+GLOBAL = "secret"
+
+def foo():
+    # ERROR: match
+    bar(CONST_GLOBAL)
+
+
+def bar():
+    global GLOBAL
+    GLOBAL="x"

--- a/semgrep-core/tests/python/equivalence_constant_propagation.sgrep
+++ b/semgrep-core/tests/python/equivalence_constant_propagation.sgrep
@@ -1,0 +1,1 @@
+bar("secret")


### PR DESCRIPTION
This shows that #1088 works now and that #349 is partially solved.

Test plan:
test files included