### PR TITLE
Avoid monkeypatching PYTHONPATH

### DIFF
--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -195,8 +195,6 @@ def _github_repo(repo_url: str, sha: Optional[str], repo_destination: Path):
 
 @pytest.fixture
 def run_semgrep_in_tmp(monkeypatch, tmp_path):
-    monkeypatch.setenv("PYTHONPATH", str(TESTS_PATH.parent.resolve()))
-
     (tmp_path / "targets").symlink_to(Path(TESTS_PATH / "e2e" / "targets").resolve())
     (tmp_path / "rules").symlink_to(Path(TESTS_PATH / "e2e" / "rules").resolve())
 

--- a/semgrep/tests/qa/test_public_repos.py
+++ b/semgrep/tests/qa/test_public_repos.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from ..conftest import TESTS_PATH
+
 pytestmark = pytest.mark.qa
 SENTINEL_VALUE = 87518275812375164
 
@@ -189,9 +191,8 @@ def xfail_repo(url, *, reason=None):
     ],
 )
 def test_semgrep_on_repo(monkeypatch, clone_github_repo, tmp_path, repo_url):
-    TESTS_PATH = Path(__file__).parent.parent
-    monkeypatch.setenv("PYTHONPATH", str(TESTS_PATH.parent.resolve()))
     (tmp_path / "rules").symlink_to(Path(TESTS_PATH / "qa" / "rules").resolve())
+
     monkeypatch.chdir(tmp_path)
 
     repo_path = clone_github_repo(repo_url=repo_url)


### PR DESCRIPTION
Now that `pipenv` installs `semgrep` in editable mode we can avoid monkeypatching the `PYTHONPATH` env variable: https://github.com/returntocorp/semgrep/pull/680#discussion_r419703012