### PR TITLE
Modified to allow metavar replacement

### DIFF
--- a/semgrep-core/matching/Matching_generic.mli
+++ b/semgrep-core/matching/Matching_generic.mli
@@ -69,9 +69,10 @@ val is_regexp_string: string -> bool
 val regexp_of_regexp_string: string -> Str.regexp
 (*e: signature [[Matching_generic.regexp_of_regexp_string]] *)
 
+val equal_ast_binded_code : AST_generic.any -> AST_generic.any -> bool
+
 (* internal:
 val str_of_any : AST_generic.any -> string
-val equal_ast_binded_code : AST_generic.any -> AST_generic.any -> bool
 *)
 
 (* generic matchers *)

--- a/semgrep-core/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/synthesizing/Pattern_from_Code.ml
@@ -28,7 +28,8 @@ open AST_generic
 type named_variants =
   (string * Pattern.t) list
 
-type global_state = { count : int; mapping : (expr * expr) list }
+type global_state = { count : int; mapping : (expr * expr) list;
+                      has_type : bool }
 
 (*****************************************************************************)
 (* State helpers *)
@@ -55,6 +56,9 @@ let default_id str =
   Id((str, fk),
    {id_resolved = ref None; id_type = ref None; id_const_literal = ref None})
 
+let default_tyvar str typ =
+  TypedMetavar((str, fk), fk, typ)
+
 let count_to_id count =
   let make_id ch = Format.sprintf "$%c" ch in
   if count = 1 then make_id 'X'
@@ -63,13 +67,28 @@ let count_to_id count =
   else if count <= 26 then make_id (Char.chr (count - 4 + Char.code 'A'))
   else Format.sprintf "$X%d" (count - 26)
 
-let get_id state e =
+(* If the id is already in state, return that *)
+(* Otherwise, this depends on the with_type flag *)
+(* If with_type is true, if there is a type, try to generate a TypedMetavar *)
+(* In all other cases, generate an id *)
+(* Add to state's mapping and return it *)
+let get_id ?(with_type=false) state e =
   let id = lookup state e in
   match id with
       Some x -> (state, x)
     | None ->
-        let new_id = default_id (count_to_id state.count) in
-        ({ count = state.count + 1; mapping = (e, new_id)::(state.mapping) }, new_id)
+        let notype_id = default_id (count_to_id state.count) in
+        let has_type = state.has_type in
+        let (new_id, new_has_type) =
+        if with_type then
+          ( match e with
+              | Id (_, {id_type; _}) ->
+                 (match !id_type with | None -> (notype_id, has_type)
+                                      | Some t -> (default_tyvar (count_to_id state.count) t), true)
+              | _ -> (notype_id, has_type)
+          )
+        else (notype_id, has_type) in
+        ({ count = state.count + 1; mapping = (e, new_id)::(state.mapping); has_type = new_has_type }, new_id)
 
 let has_nested_call = List.find_opt (fun x -> match x with Arg(Call _) -> true | _ -> false)
 
@@ -96,35 +115,46 @@ let shallow_metavar (e, (lp, es, rp)) state =
   let (_, replaced_args) = map_args state es in
   ("metavars", E (Call (e, (lp, replaced_args, rp))))
 
-let rec deep_mv_call (e, (lp, es, rp)) state =
-  let (state', replaced_args) = deep_mv_args state es in
+let rec deep_mv_call (e, (lp, es, rp)) with_type state =
+  let (state', replaced_args) = deep_mv_args with_type state es in
   (state', Call (e, (lp, replaced_args, rp)))
-and deep_mv_args state = function
+and deep_mv_args with_type state = function
   | [] -> (state, [])
   | (Arg e)::xs -> (
      let (state', new_e) =
      match e with
-         | Call (e, (lp, es, rp)) -> deep_mv_call (e, (lp, es, rp)) state
-         | _ -> get_id state e
+         | Call (e, (lp, es, rp)) -> deep_mv_call (e, (lp, es, rp)) with_type state
+         | _ -> get_id ~with_type:with_type state e
      in
-     let (_, args) = deep_mv_args state' xs in
+     let (_, args) = deep_mv_args with_type state' xs in
      (state', (Arg new_e)::args)
   )
   | _ -> (state, [])
 
 let deep_metavar (e, (lp, es, rp)) state =
-  let (_, e') = deep_mv_call (e, (lp, es, rp)) state in ("deep metavars", E e')
+  let (_, e') = deep_mv_call (e, (lp, es, rp)) false state in ("deep metavars", E e')
+
+let deep_typed_metavar (e, (lp, es, rp)) state =
+  let (state', e') = deep_mv_call (e, (lp, es, rp)) true state
+  in
+  if state'.has_type then Some ("typed metavars", E e') else None
+
 
 let generalize_call state = function
   | Call (IdSpecial e1, e2) -> (shallow_metavar (IdSpecial e1, e2) state) :: []
   | Call (e, (lp, es, rp)) ->
-      (* only show the deep_metavar option if relevant *)
+      (* only show the deep_metavar and deep_typed_metavar options if relevant *)
       let d_mvar =
         match (has_nested_call es) with
             None -> []
           | Some _ -> (deep_metavar (e, (lp, es, rp)) state) :: []
-       in
-       (shallow_dots (e, (lp, rp))) :: (shallow_metavar (e, (lp, es, rp)) state) :: d_mvar
+      in
+      let optional =
+        match (deep_typed_metavar (e, (lp, es, rp)) state) with
+            None -> d_mvar
+          | Some e' -> e' :: d_mvar
+      in
+       (shallow_dots (e, (lp, rp))) :: (shallow_metavar (e, (lp, es, rp)) state) :: optional
   | _ -> []
 
 (* All expressions *)
@@ -136,7 +166,7 @@ let generalize_exp e state =
   | _ -> []
 
 let generalize e =
-  generalize_exp e { count = 1; mapping = [] }
+  (generalize_exp e { count = 1; mapping = []; has_type = false })
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/synthesizing/Pattern_from_Code.ml
@@ -34,40 +34,54 @@ type named_variants =
 let fk = Parse_info.fake_info "fake"
 let _bk f (lp,x,rp) = (lp, f x, rp)
 
+(* let fst (x, _) = x *)
+let snd (_, x) = x
+
 (*****************************************************************************)
 (* Algorithm *)
 (*****************************************************************************)
-
-let default_id count =
-    count := !count + 1;
-    Id((Format.sprintf "$%d" (!count), Parse_info.fake_info " "),
-    {id_resolved = ref None; id_type = ref None; id_const_literal = ref None})
 (* TODO: look if Call, and propose $ on each argument, ...,
  * propose also typed metavars, and resolved id in the call, etc.
  *)
 
+let default_id count =
+    (count + 1,
+     Id((Format.sprintf "$X%d" (count), Parse_info.fake_info " "),
+     {id_resolved = ref None; id_type = ref None; id_const_literal = ref None})
+    )
+
 let shallow_dots (e, (lp, rp)) =
    ("dots", E (Call (e, (lp, [Arg (Ellipsis fk)], rp))))
 
+let rec map_args count = function
+   | [] -> (count, [])
+   | _x::xs ->
+      let (c, new_id) = default_id count in
+      let (_, args) = map_args c xs in
+      (c, (Arg new_id)::args)
+
 let shallow_metavar (e, (lp, es, rp)) count =
-   let replaced_args = List.map (fun _ -> Arg (default_id count) ) es in
+   let (_, replaced_args) = map_args count es in
    ("metavars", E (Call (e, (lp, replaced_args, rp))))
 
 
 let generalize_call count = function
-  | Call (IdSpecial _, _) -> []
+  | Call (IdSpecial e1, e2) -> (shallow_metavar (IdSpecial e1, e2) count) :: []
   | Call (e, (lp, es, rp)) ->
       (shallow_dots (e, (lp, rp))) :: (shallow_metavar (e, (lp, es, rp)) count) :: []
   | _ -> []
 
-let generalize e =
-  let count = ref 0 in
+let generalize_exp e count =
   match e with
   | Call _ -> generalize_call count e
   | Id ((_s, t1), info) ->
       ["metavar", E (Id(("$X", t1), info))]
-  | L _ -> ["metavar", E (default_id count)]
+  | L _ -> ["metavar", E (snd (default_id count))]
   | _ -> []
+
+let generalize e =
+  let count = 1 in
+  generalize_exp e count
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -49,6 +49,11 @@ let token tok = Parse_info.str_of_info tok
 
 let ident (s, _) = s
 
+let print_type = function
+  | TyBuiltin (s, _) -> s
+  | TyName (id, _) -> ident id
+  | x -> todo (T x)
+
 let arithop env (op, tok) =
   match op with
       | Plus -> "+"
@@ -91,6 +96,7 @@ function
   | DotAccess (e, tok, fi) -> dot_access env (e, tok, fi)
   | Ellipsis _ -> "..."
   | Conditional (e1, e2, e3) -> cond env (e1, e2, e3)
+  | TypedMetavar (id, _, typ) -> tyvar env (id, typ)
   | x -> todo (E x)
 
 and id env (s, {id_resolved; _}) =
@@ -159,6 +165,12 @@ and field_ident env fi =
        | FId id -> ident id
        | FName (id, _) -> ident id
        | FDynamic e -> expr env e
+
+and tyvar env (id, typ) =
+  match env.lang with
+    | Lang.Java -> F.sprintf "(%s %s)" (print_type typ) (ident id)
+    | Lang.Go -> F.sprintf "(%s : %s)" (ident id) (print_type typ)
+    | _ -> failwith "Not implemented for this language"
 
 and cond env (e1, e2, e3) =
   let s1 = expr env e1 in

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -80,15 +80,13 @@ let arithop env (op, tok) =
 (* Pretty printer *)
 (*****************************************************************************)
 let rec expr env =
-let ppf = F.sprintf in
 function
   | Id ((s,_), idinfo) -> id env (s, idinfo)
   | IdSpecial (sp, tok) -> special env (sp, tok)
-  | Call (e, (_, es, _)) ->
-      ppf "%s(%s)" (expr env e) (arguments env es)
+  | Call (e1, e2) -> call env (e1, e2)
   | L x -> literal env x
-  | Tuple es -> ppf "(%s)" (tuple env es)
-  | ArrayAccess (e1, e2) -> ppf "%s[%s]" (expr env e1) (expr env e2)
+  | Tuple es -> F.sprintf "(%s)" (tuple env es)
+  | ArrayAccess (e1, e2) -> F.sprintf "%s[%s]" (expr env e1) (expr env e2)
   | SliceAccess (e, o1, o2, o3) -> slice_access env e (o1, o2) o3
   | DotAccess (e, tok, fi) -> dot_access env (e, tok, fi)
   | Ellipsis _ -> "..."
@@ -103,6 +101,12 @@ and id env (s, {id_resolved; _}) =
 and special env = function
   | (ArithOp op, tok) -> arithop env (op, tok)
   | (sp, tok) -> todo (E (IdSpecial (sp, tok)))
+
+and call env (e, (_, es, _)) =
+  let s1 = expr env e in
+  match (e, es) with
+       | (IdSpecial(_), x::y::[]) -> F.sprintf "%s %s %s" (argument env x) s1 (argument env y)
+       | _ -> F.sprintf "%s(%s)" s1 (arguments env es)
 
 and literal env = function
   | Bool ((b,_)) -> F.sprintf "%B" b
@@ -152,8 +156,8 @@ and dot_access env (e, tok, fi) =
 
 and field_ident env fi =
   match fi with
-       | FId (s, _) -> s
-       | FName ((s, _), _) -> s
+       | FId id -> ident id
+       | FName (id, _) -> ident id
        | FDynamic e -> expr env e
 
 and cond env (e1, e2, e3) =

--- a/semgrep-core/synthesizing/dune
+++ b/semgrep-core/synthesizing/dune
@@ -9,5 +9,6 @@
    pfff-lang_GENERIC
 
    semgrep_core
+   semgrep_matching
  )
 )


### PR DESCRIPTION
Split up code for call and implemented metavariables, with a count to ensure different ones

Tested with
from metrics import send
def foo():
   a.bar(var, f(var2))
   bar + send('my-report-id') + bar()
   (hi, my)
   (hi, my, bye)
   A[1]
   A[-1]
   A[1:4]
   A[1:4:-1]
   A[::-1]
   A[1:]
   if 1 == 2: foo()
   true