### PR TITLE
Show language file being parsed as when printing parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Changed
+- More clear Parse error message
+
 ## [0.12.0](https://github.com/returntocorp/semgrep/releases/tag/v0.12.0) - 2020-06-23
 
 ### Added

--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from typing import Any
+from typing import Dict
+
+from semgrep.rule_lang import Position
+
+
+class CoreException:
+    def __init__(
+        self,
+        check_id: str,
+        path: Path,
+        start: Position,
+        end: Position,
+        extra: Dict[str, Any],
+        language: str,
+    ):
+        """
+            Object that encapsulates exception information returned by
+            semgrep-core
+        """
+        self._check_id = check_id
+        self._path = path
+        self._start = start
+        self._end = end
+        self._language = language
+
+        if "message" not in extra or "line" not in extra:
+            # in pfff/h_program-lang/R2c.ml these fields always exist
+            raise ValueError("SemgrepCore error extra field missing information")
+        self._extra = extra
+
+    @classmethod
+    def from_json(  # type: ignore
+        cls, json_obj: Dict[str, Any], language: str
+    ) -> "CoreException":
+        if {"check_id", "path", "start", "end", "extra"}.difference(
+            json_obj.keys()
+        ) != set():
+            raise ValueError(f"cannot parse {json_obj} as {cls.__name__}")
+
+        start = json_obj["start"]
+        end = json_obj["end"]
+        if (
+            "line" not in start
+            or "col" not in start
+            or "line" not in end
+            or "col" not in end
+        ):
+            raise ValueError(f"cannot parse {json_obj} as {cls.__name__}")
+
+        start_pos = Position(start["line"], start["col"])
+        end_pos = Position(end["line"], end["col"])
+
+        return cls(
+            json_obj["check_id"],
+            Path(json_obj["path"]),
+            start_pos,
+            end_pos,
+            json_obj["extra"],
+            language,
+        )
+
+    def __str__(self) -> str:
+        header = (
+            f"--> Failed to parse {self._path}:{self._start.line} as {self._language}"
+        )
+        line_1 = self._extra["line"]
+        start_col = self._start.col
+        line_2 = " " * (start_col - 1) + "^"
+        return "\n".join([header, line_1, line_2])

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -19,6 +19,7 @@ import semgrep.util
 from semgrep import config_resolver
 from semgrep.constants import __VERSION__
 from semgrep.constants import OutputFormat
+from semgrep.core_exception import CoreException
 from semgrep.error import SemgrepError
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
@@ -217,28 +218,28 @@ class OutputHandler:
         self.rule_matches: List[RuleMatch] = []
         self.debug_steps_by_rule: Dict[Rule, List[Dict[str, Any]]] = {}
         self.rules: FrozenSet[Rule] = frozenset()
-        self.semgrep_core_errors: List[Dict[str, Any]] = []
+        self.semgrep_core_errors: List[CoreException] = []
         self.semgrep_structured_errors: List[SemgrepError] = []
         self.has_output = False
 
         self.final_error: Optional[Exception] = None
 
-    def handle_semgrep_core_errors(self, semgrep_errors: List[Dict[str, Any]]) -> None:
+    def handle_semgrep_core_errors(self, semgrep_errors: List[CoreException]) -> None:
         """
         Report errors coming directly from semgrep-core (raw JSON objects)
         """
         self.semgrep_core_errors += semgrep_errors
         if self.settings.output_format == OutputFormat.TEXT:
             parse_errors, other_errors = partition(
-                lambda e: e["check_id"] == "ParseError", semgrep_errors
+                lambda e: e._check_id == "ParseError", semgrep_errors
             )
 
             for error in other_errors:
-                print_stderr(pretty_error(error))
+                print_stderr(str(error))
 
             if len(parse_errors) > 0:
                 files_with_parse_errors: Set[str] = set(
-                    e.get("path") for e in parse_errors if "path" in e
+                    str(e._path) for e in parse_errors
                 )
 
                 print_stderr(
@@ -248,7 +249,7 @@ class OutputHandler:
                 if semgrep.util.DEBUG:
                     debug_print("ParseErrors:")
                     for error in parse_errors:
-                        debug_print(pretty_error(error))
+                        debug_print(str(error))
                     debug_print(
                         "= note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev"
                     )
@@ -353,17 +354,3 @@ class OutputHandler:
             raise RuntimeError(
                 f"Unhandled output format: {type(output_format).__name__}"
             )
-
-
-def pretty_error(error: Dict[str, Any]) -> str:
-    try:
-        if {"path", "start", "end", "extra"}.difference(error.keys()) == set():
-            header = f"--> {error['path']}:{error['start']['line']}"
-            line_1 = error["extra"]["line"]
-            start_col = error["start"]["col"]
-            line_2 = " " * (start_col - 1) + "^"
-            return "\n".join([header, line_1, line_2])
-        else:
-            return f"semgrep-core error: {json.dumps(error, indent=2)}"
-    except KeyError:
-        return f"semgrep-core error: {json.dumps(error, indent=2)}"

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -231,7 +231,7 @@ class OutputHandler:
         self.semgrep_core_errors += semgrep_errors
         if self.settings.output_format == OutputFormat.TEXT:
             parse_errors, other_errors = partition(
-                lambda e: e._check_id == "ParseError", semgrep_errors
+                lambda e: e._check_id in {"ParseError", "FatalError"}, semgrep_errors
             )
 
             for error in other_errors:

--- a/semgrep/semgrep/pattern.py
+++ b/semgrep/semgrep/pattern.py
@@ -1,6 +1,5 @@
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Optional
 
 from semgrep.rule_lang import Span
@@ -17,17 +16,14 @@ class Pattern:
         rule_index: int,
         expression: BooleanRuleExpression,
         severity: str,
-        languages: List[str],
+        language: str,
         span: Optional[Span],
     ) -> None:
         self._id = f"{rule_index}.{expression.pattern_id}"
-        # if we don't copy an array (like `languages`), the yaml file will refer to it by reference (with an anchor)
-        # which is nice and all but the semgrep YAML parser doesn't support that
-        self._languages = languages.copy()
+        self._language = language
         self._severity = severity
         self._expression = expression
         self._pattern = expression.operand
-        self._message = "<internalonly>"
         self._span = span
 
     @property
@@ -35,20 +31,21 @@ class Pattern:
         return self._span
 
     @property
-    def languages(self) -> List[str]:
-        return self._languages
+    def language(self) -> str:
+        return self._language
 
     @property
     def expression(self) -> BooleanRuleExpression:
         return self._expression
 
     def to_json(self) -> Dict[str, Any]:
+        # Note languages is a list as this is what semgrep-core expects
         return {
             "id": self._id,
             "pattern": self._pattern,
             "severity": self._severity,
-            "languages": self._languages,
-            "message": self._message,
+            "languages": [self._language],
+            "message": "<internalonly>",
         }
 
     def __repr__(self) -> str:

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages_verbose/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages_verbose/invalid_python.py/error.txt
@@ -1,6 +1,6 @@
 1 file(s) failed to parse: targets/bad/invalid_python.py
 ParseErrors:
---> targets/bad/invalid_python.py:1
+--> Failed to parse targets/bad/invalid_python.py:1 as python
 def foo(a)
           ^
 = note: If the code is correct, this could be a semgrep bug -- please help us fix this by filing an an issue at https://semgrep.dev


### PR DESCRIPTION
Old error message was confusing when valid javascript files were being parsed as python. This PR makes it more clear what language a file is being parsed with