### PR TITLE
Relax handling of extra keys in YAML

### DIFF
--- a/semgrep/tests/e2e/rules/syntax/bad2.yaml
+++ b/semgrep/tests/e2e/rules/syntax/bad2.yaml
@@ -1,8 +1,7 @@
 rules:
   - id: eqeq-is-bad
-    pattern-inside: foo(...)
     patterns:
       - pattern-not: 1 == 1
     message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
     languages: [python]
-    severity: ERROR
+    severit: ERROR

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error-in-color.txt
@@ -1,12 +1,15 @@
-[31merror[39m: extra top-level key
-  --> rules/syntax/bad2.yaml:3
-[94m1 | [39mrules:
+[31merror[39m: missing keys
+  --> rules/syntax/bad2.yaml:2
 [94m2 | [39m  - id: eqeq-is-bad
-[94m3 | [39m    pattern-inside: foo(...)
-[94m  | [39m    [31m^^^^^^^^^^^^^^[39m
-[94m4 | [39m    patterns:
-[94m5 | [39m      - pattern-not: 1 == 1
-= [36m[1mhelp[39m[0m: Only ['equivalences', 'fix', 'fix-regex', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys
-[31mrules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside'][39m
+[94m3 | [39m    patterns:
+[94m4 | [39m      - pattern-not: 1 == 1
+[94m5 | [39m    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+[94m6 | [39m    languages: [python]
+[94m7 | [39m    severit: ERROR
+  --> rules/syntax/bad2.yaml:7
+[94m7 | [39m    severit: ERROR
+[94m  | [39m    [31m^^^^^^^[39m
+= [36m[1mhelp[39m[0m: Unexpected keys {'severit'} found. Is one of these a typo of {'severity'}?
+[31mrules/syntax/bad2.yaml is missing required keys {'severity'}[39m
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
@@ -2,29 +2,37 @@
   "errors": [
     {
       "code": 4,
-      "help": "Only ['equivalences', 'fix', 'fix-regex', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys",
+      "help": "Unexpected keys {'severit'} found. Is one of these a typo of {'severity'}?",
       "level": "error",
-      "long_msg": "rules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside']",
-      "short_msg": "extra top-level key",
+      "long_msg": "rules/syntax/bad2.yaml is missing required keys {'severity'}",
+      "short_msg": "missing keys",
       "spans": [
         {
-          "context_end": {
-            "col": 0,
-            "line": 5
-          },
-          "context_start": {
-            "col": 0,
-            "line": 1
-          },
+          "context_end": null,
+          "context_start": null,
           "end": {
-            "col": 19,
-            "line": 3
+            "col": 0,
+            "line": 7
           },
           "file": "rules/syntax/bad2.yaml",
-          "source_hash": "6ebef770ea281e5e811acfd1d5b219adb3a0ae87f6613ae0a8cfc593ad126dd2",
+          "source_hash": "8861f46f4219927c24d0ba57521a2b46d60f7367eca308fa7efb623c5a8b17bc",
           "start": {
             "col": 5,
-            "line": 3
+            "line": 2
+          }
+        },
+        {
+          "context_end": null,
+          "context_start": null,
+          "end": {
+            "col": 12,
+            "line": 7
+          },
+          "file": "rules/syntax/bad2.yaml",
+          "source_hash": "8861f46f4219927c24d0ba57521a2b46d60f7367eca308fa7efb623c5a8b17bc",
+          "start": {
+            "col": 5,
+            "line": 7
           }
         }
       ],

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.txt
@@ -1,12 +1,15 @@
-error: extra top-level key
-  --> rules/syntax/bad2.yaml:3
-1 | rules:
+error: missing keys
+  --> rules/syntax/bad2.yaml:2
 2 |   - id: eqeq-is-bad
-3 |     pattern-inside: foo(...)
-  |     ^^^^^^^^^^^^^^
-4 |     patterns:
-5 |       - pattern-not: 1 == 1
-= help: Only ['equivalences', 'fix', 'fix-regex', 'id', 'languages', 'message', 'metadata', 'paths', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'severity'] are valid keys
-rules/syntax/bad2.yaml has an invalid top-level rule key: ['pattern-inside']
+3 |     patterns:
+4 |       - pattern-not: 1 == 1
+5 |     message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+6 |     languages: [python]
+7 |     severit: ERROR
+  --> rules/syntax/bad2.yaml:7
+7 |     severit: ERROR
+  |     ^^^^^^^
+= help: Unexpected keys {'severit'} found. Is one of these a typo of {'severity'}?
+rules/syntax/bad2.yaml is missing required keys {'severity'}
 
 run with --strict and there were 1 errors loading configs


### PR DESCRIPTION
Modified behavior to only error about extra keys if there's already something missing