### PR TITLE
fix: ocaml open override and python raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Changed
+
+### Fixed
+- Parsing Ocaml open overriding
+- Parse raise in Python2 can take up to three arguments
+
+### Changed
 - More clear Parse error message
 
 ## [0.12.0](https://github.com/returntocorp/semgrep/releases/tag/v0.12.0) - 2020-06-23


### PR DESCRIPTION
update pfff to fix open! in ocaml and able to pass 3 arguments to
raise in python2