### PR TITLE
Remove 'setuptools_scm_git_archive' files that are no longer used

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,0 @@
-ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-.git_archival.txt  export-subst


### PR DESCRIPTION
These files were required for [`setuptools-scm-git-archive`](https://pypi.org/project/setuptools-scm-git-archive/). This functionality was removed in https://github.com/returntocorp/semgrep/pull/836 so we no longer need these files.