### PR TITLE
Store whether we had a timeout on a file in the parsing cache

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -384,13 +384,13 @@ let parse_generic lang file =
   (*e: [[Main_semgrep_core.parse_generic()]] resolve names in the AST *)
   Left ast
  (* This is a bit subtle, but we now store in the cache whether we had
-  * a timeout on this file. Indeed, semgrep now calls semgrep-core
-  * per rule, and if one file timeout during parsing, it would timeout
-  * for each rule, but we don't want to wait each time 5sec for each rule.
-  * So here we store the exn in the cache, and below we reraise it
+  * an exception on this file, especially Timeout. Indeed, semgrep now calls
+  * semgrep-core per rule, and if one file timeout during parsing, it would
+  * timeout for each rule, but we don't want to wait each time 5sec for each
+  * rule. So here we store the exn in the cache, and below we reraise it
   * after we got it back from the cache.
   *)
- with Timeout -> Right Timeout
+ with exn -> Right exn
   ))
   in
   match v with

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -389,8 +389,12 @@ let parse_generic lang file =
   * timeout for each rule, but we don't want to wait each time 5sec for each
   * rule. So here we store the exn in the cache, and below we reraise it
   * after we got it back from the cache.
+  *
+  * TODO: right now we just capture Timeout, but we should capture any exn.
+  *  However this introduces some weird regressions in CI so we focus on
+  *  just Timeout for now.
   *)
- with exn -> Right exn
+ with Timeout -> Right Timeout
   ))
   in
   match v with


### PR DESCRIPTION
This should help fix #1156
See the comment in the diff for more information.

Test plan:

develop/home/pad/semgrep/tests/PERF $ rm -rf /tmp/xxx/
develop/home/pad/semgrep/tests/PERF $ time yy -use_parsing_cache /tmp/xxx -lang js -e '$X == $X' timeout.js
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -use_parsing_cache /tmp/xxx -lang js -e $X == $X timeout.js
timeout.js:1:0: Timeout

Fatal error: exception Common.Timeout
...
5.528 secs
develop/home/pad/semgrep/tests/PERF $ time yy -use_parsing_cache /tmp/xxx -lang js -e '$X == $X' timeout.js
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -use_parsing_cache /tmp/xxx -lang js -e $X == $X timeout.js
timeout.js:1:0: Fatal Error: Common.Timeout
Fatal error: exception Common.Timeout
...
0.498 secs