### PR TITLE
Fix #1191, #438, use '/src' as Docker code volume

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         name: Semgrep Python
         types: [python]
         exclude: "^semgrep/tests/.+$|^install-scripts/.+$|^release-scripts/.+$|^semgrep/setup.py$"
-        args: ['--config', 'https://semgrep.live/p/python', '--precommit', '--error']
+        args: ['--config', 'https://semgrep.live/p/python', '--error']
 
   - repo: https://github.com/returntocorp/semgrep
     rev: 'v0.12.0'
@@ -56,7 +56,7 @@ repos:
         name: Semgrep Bandit
         types: [python]
         exclude: "^semgrep/tests/.+$|^install-scripts/.+$|^release-scripts/.+$|^semgrep/setup.py$"
-        args: ['--config', 'https://semgrep.live/p/bandit', '--precommit', '--error']
+        args: ['--config', 'https://semgrep.live/p/bandit', '--error']
 
   - repo: https://github.com/returntocorp/semgrep
     rev: 'v0.12.0'
@@ -65,7 +65,7 @@ repos:
         name: Semgrep Local
         types: [python]
         exclude: "^semgrep/tests/.+$|^install-scripts/.+$|^release-scripts/.+$|^semgrep/setup.py$"
-        args: ['--config', 'semgrep-local.yaml', '--precommit', '--error']
+        args: ['--config', 'semgrep-local.yaml', '--error']
 
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Default Docker code mount point from `/home/repo` to `/src` - this is also
+  configurable via the `SEMGREP_SRC_DIRECTORY` environment variable
+
+### Removed
+- `--precommit` flag - this is no longer necessary after defaulting to
+  `pre-commit`'s code mount point `/src`
+
 ## [0.13.0](https://github.com/returntocorp/semgrep/releases/tag/v0.13.0) - 2020-06-30
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN HOMEBREW_SYSTEM='NOCORE' python -m pip install /semgrep
 RUN semgrep --version
 
 ENV SEMGREP_IN_DOCKER=1
-ENV SEMGREP_VERSION_CACHE_PATH=/tmp/.cache/semgrep_version
+ENV SEMGREP_VERSION_CACHE_PATH=/src/.cache/semgrep_version
 ENV PYTHONIOENCODING=utf8
 ENV PYTHONUNBUFFERED=1
 ENTRYPOINT ["semgrep"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ ./semgrep-v0.13.0-ubuntu-generic.sh
 To try Semgrep without installation, you can also run it via Docker:
 
 ```
-$ docker run --rm -v "${PWD}:/home/repo" returntocorp/semgrep --help
+$ docker run --rm -v "${PWD}:/src" returntocorp/semgrep --help
 ```
 
 See [Usage](#usage) to learn about running pre-built rules and writing custom ones.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -22,7 +22,7 @@ repos:
       rev: '0.12.0'
       hooks:
           - id: semgrep
-            args: ['--config', 'https://semgrep.live/p/r2c', '--precommit', '--error']
+            args: ['--config', 'https://semgrep.live/p/r2c', '--error']
 ```
 
 ## Continuous Integration
@@ -78,7 +78,7 @@ jobs:
     build:
         docker:
             - image: returntocorp/semgrep:latest
-        working_directory: /home/repo
+        working_directory: /src
         steps:
             - checkout
             - run: semgrep --error --config https://semgrep.live/p/r2c .

--- a/release-scripts/validate-docker-release.sh
+++ b/release-scripts/validate-docker-release.sh
@@ -12,7 +12,7 @@ echo "def silly_eq(a, b):" >> test.py
 echo " return a + b == a + b" >> test.py
 
 # shellcheck disable=SC2016
-docker run -v "${PWD}:/home/repo/" returntocorp/semgrep:"$docker_tag" ./test.py -l python -e '$X == $X' | tee output
+docker run -v "${PWD}:/src" returntocorp/semgrep:"$docker_tag" ./test.py -l python -e '$X == $X' | tee output
 
 grep 'a + b == a + b' output
 

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -118,9 +118,6 @@ def cli() -> None:
     )
 
     config.add_argument(
-        "--precommit", action="store_true", help=argparse.SUPPRESS,
-    )
-    config.add_argument(
         "-j",
         "--jobs",
         action="store",
@@ -271,7 +268,7 @@ def cli() -> None:
 
     # change cwd if using docker
     try:
-        semgrep.config_resolver.adjust_for_docker(args.precommit)
+        semgrep.config_resolver.adjust_for_docker()
     except SemgrepError as e:
         print_stderr(str(e))
         raise e

--- a/semgrep/semgrep/version.py
+++ b/semgrep/semgrep/version.py
@@ -21,8 +21,7 @@ VERSION_CHECK_TIMEOUT = int(
 )
 VERSION_CACHE_PATH = Path(
     os.environ.get(
-        "SEMGREP_VERSION_CACHE_PATH",
-        Path(os.path.expanduser("~")) / ".cache" / "semgrep_version",
+        "SEMGREP_VERSION_CACHE_PATH", Path.home() / ".cache" / "semgrep_version",
     )
 )
 

--- a/semgrep/tests/run-perf-tests.sh
+++ b/semgrep/tests/run-perf-tests.sh
@@ -22,8 +22,8 @@ test_test_suite() {
 test_sample_repos() {
     rm -rf /tmp/sample && git clone --depth=1 https://github.com/apache/airflow /tmp/sample/
     cd /tmp/sample
-    SGREP_A="docker run --rm -v ${PWD}:/home/repo returntocorp/semgrep:${A_VERSION}"
-    SGREP_B="docker run --rm -v ${PWD}:/home/repo returntocorp/semgrep:${B_VERSION}"
+    SGREP_A="docker run --rm -v ${PWD}:/src returntocorp/semgrep:${A_VERSION}"
+    SGREP_B="docker run --rm -v ${PWD}:/src returntocorp/semgrep:${B_VERSION}"
 
     CMDA="${SGREP_A} --config=r2c --dangerously-allow-arbitrary-code-execution-from-rules --strict"
     CMDB="${SGREP_B} --config=r2c --dangerously-allow-arbitrary-code-execution-from-rules --strict"


### PR DESCRIPTION
Trying the old directory:

```
$ docker run --rm -v "${PWD}:/home/repo" returntocorp/semgrep:develop --config semgrep-local.yaml semgrep/setup.py
Detected Docker environment using old code volume, please use '/src' instead of '/home/repo'
```

Speedup:

```
$ time docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop --config semgrep-local.yaml semgrep/setup.py
running 1 rules...

real	0m2.239s
user	0m0.041s
sys	0m0.049s
```

```
$ time docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop --config semgrep-local.yaml semgrep/setup.py
running 1 rules...

real	0m1.456s
user	0m0.050s
sys	0m0.040s
```