### PR TITLE
autofix: Handle case when no fix is requested

### DIFF
--- a/semgrep/semgrep/autofix.py
+++ b/semgrep/semgrep/autofix.py
@@ -121,6 +121,8 @@ def apply_fixes(
                     raise SemgrepError(
                         f"unable to use regex to modify file {filepath} with fix '{fix}': {e}"
                     )
+            else:
+                continue
             # endif
             if not dryrun:
                 _write_contents(rule_match.path, fixobj.fixed_contents)


### PR DESCRIPTION
I'm not sure in what case this can happen, but I saw this error in semgrep.live logs:

    UnboundLocalError: local variable 'fixobj' referenced before assignment

I think the only way that error can happen is if a rule_match without a fix is sent in to this function.

But maybe instead of this commit, we should track down why the function was called in the first place if no fix was requested.