### PR TITLE
Handle file-not-found errors more gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ def fetch_global_const():
 - Do not convert certain parenthesized expressions in tuples in Python
 - Returned warning when improperly mounting volume in docker container
 - Correctly handle uncommited file deletions when using git aware file targeting
+- Send informative error message when user tries to use semgrep on missing files
 
 ### Changed
 - Progress bar only displays when in interactive terminal, more than one

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -1,8 +1,10 @@
 from enum import Enum
+from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 import attr
 from colorama import Fore
@@ -74,6 +76,17 @@ class SemgrepInternalError(Exception):
 
 class UnknownOperatorError(SemgrepError):
     pass
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class FilesNotFoundError(SemgrepError):
+    level = Level.ERROR
+    code = FATAL_EXIT_CODE
+    paths: Sequence[Path]
+
+    def __str__(self) -> str:
+        lines = (f"File not found: {pathname}" for pathname in self.paths)
+        return "\n".join(lines)
 
 
 @attr.s(eq=True, hash=True, init=False)  # type: ignore

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -333,6 +333,7 @@ def main(
         excludes=exclude,
         targets=target,
         respect_git_ignore=respect_git_ignore,
+        output_handler=output_handler,
     )
 
     # actually invoke semgrep

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -5,11 +5,16 @@ from typing import List
 from typing import NewType
 from typing import Set
 
+import attr
+
 from semgrep.error import _UnknownLanguageError
+from semgrep.error import FilesNotFoundError
+from semgrep.error import SemgrepError
+from semgrep.output import OutputHandler
 from semgrep.semgrep_types import Language
 from semgrep.util import partition_set
+from semgrep.util import print_stderr
 from semgrep.util import sub_check_output
-
 
 FileExtension = NewType("FileExtension", str)
 
@@ -62,26 +67,22 @@ def lang_to_exts(language: Language) -> List[FileExtension]:
         raise _UnknownLanguageError(f"Unsupported Language: {language}")
 
 
+@attr.s(auto_attribs=True)
 class TargetManager:
-    def __init__(
-        self,
-        includes: List[str],
-        excludes: List[str],
-        targets: List[str],
-        respect_git_ignore: bool,
-    ) -> None:
-        """
-            Handles all file include/exclude logic for semgrep
+    """
+        Handles all file include/exclude logic for semgrep
 
-            If respect_git_ignore is true then will only consider files that are
-            tracked or (untracked but not ignored) by git
-        """
-        self._targets = targets
-        self._includes = includes
-        self._excludes = excludes
-        self._respect_git_ignore = respect_git_ignore
+        If respect_git_ignore is true then will only consider files that are
+        tracked or (untracked but not ignored) by git
+    """
 
-        self._filtered_targets: Dict[str, Set[Path]] = {}
+    targets: List[str]
+    includes: List[str]
+    excludes: List[str]
+    respect_git_ignore: bool
+    output_handler: OutputHandler
+
+    _filtered_targets: Dict[str, Set[Path]] = {}
 
     @staticmethod
     def resolve_targets(targets: List[str]) -> Set[Path]:
@@ -237,23 +238,31 @@ class TargetManager:
         if lang in self._filtered_targets:
             return self._filtered_targets[lang]
 
-        targets = self.resolve_targets(self._targets)
-        explicit_files, directories = partition_set(lambda p: not p.is_dir(), targets)
+        targets = self.resolve_targets(self.targets)
+
+        files, directories = partition_set(lambda p: not p.is_dir(), targets)
+
+        # Error on non-existent files
+        explicit_files, nonexistent_files = partition_set(lambda p: p.is_file(), files)
+        if nonexistent_files:
+            # TODO: change to use handler instead of raise
+            self.output_handler.handle_semgrep_error(
+                FilesNotFoundError(tuple(nonexistent_files))
+            )
 
         # Remove explicit_files with known extensions. Remove non-existent files
         explicit_files = set(
             f
             for f in explicit_files
-            if f.is_file
-            and (
+            if (
                 any(f.match(f"*.{ext}") for ext in lang_to_exts(lang))
                 or not any(f.match(f"*.{ext}") for ext in ALL_EXTENSIONS)
             )
         )
 
-        targets = self.expand_targets(directories, lang, self._respect_git_ignore)
-        targets = self.filter_includes(targets, self._includes)
-        targets = self.filter_excludes(targets, self._excludes)
+        targets = self.expand_targets(directories, lang, self.respect_git_ignore)
+        targets = self.filter_includes(targets, self.includes)
+        targets = self.filter_excludes(targets, self.excludes)
 
         self._filtered_targets[lang] = targets.union(explicit_files)
         return self._filtered_targets[lang]

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -76,13 +76,13 @@ class TargetManager:
         tracked or (untracked but not ignored) by git
     """
 
-    targets: List[str]
     includes: List[str]
     excludes: List[str]
+    targets: List[str]
     respect_git_ignore: bool
     output_handler: OutputHandler
 
-    _filtered_targets: Dict[str, Set[Path]] = {}
+    _filtered_targets: Dict[str, Set[Path]] = attr.ib(factory=dict)
 
     @staticmethod
     def resolve_targets(targets: List[str]) -> Set[Path]:
@@ -245,7 +245,6 @@ class TargetManager:
         # Error on non-existent files
         explicit_files, nonexistent_files = partition_set(lambda p: p.is_file(), files)
         if nonexistent_files:
-            # TODO: change to use handler instead of raise
             self.output_handler.handle_semgrep_error(
                 FilesNotFoundError(tuple(nonexistent_files))
             )


### PR DESCRIPTION
Re-factored target manager init method to use attr.s for clarity and passed output_handler to target_manager. Fixes #706 