### PR TITLE
core_exception: Fix crash when an error exists on a binary file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Next
+
+### Fixed
+
+- Fixed a crash when running over a directory with binary files in it.
+
 ## [0.14.0](https://github.com/returntocorp/semgrep/releases/tag/v0.14.0) - 2020-07-07
 
 ### Changed

--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -66,7 +66,7 @@ class CoreException:
         )
 
     def into_semgrep_error(self) -> SemgrepError:
-        with open(self._path) as f:
+        with open(self._path, errors="replace") as f:
             file_hash = SourceTracker.add_source(f.read())
         error_span = Span(
             start=self._start,


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/1247

Output is now

```
$ semgrep -l py -e 0 /tmp/cat.jpg
warn: parse error
  --> cat.jpg:1
1 | ����JFIF``��;CREATOR: gd-jpeg v1.0 (using IJG JPEG v62), quality = 65
  | ^
= help: If the code appears to be valid, this may be a semgrep bug.
Could not parse cat.jpg as py
```