### PR TITLE
Remove sdist from pypi release

### DIFF
--- a/release-scripts/build-wheels.sh
+++ b/release-scripts/build-wheels.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 pip install setuptools wheel
-cd semgrep && python setup.py sdist bdist_wheel
+cd semgrep && python setup.py bdist_wheel
 # Zipping for a stable name to upload as an artifact
 zip -r dist.zip dist


### PR DESCRIPTION
We currently do not include ocaml packaging/building tools in pypi sdist
release so users cannot actually install semgrep this way. Removing sdist
for now to avoid confusion.