### PR TITLE
Allow pattern to be inferred from expressions and statements (and later, statement lists?)

### DIFF
--- a/semgrep-core/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/synthesizing/Pattern_from_Code.ml
@@ -236,6 +236,7 @@ and generalize_if s_in =
   let rec dots_in_body s =
     match s with
       | If (tok, e, s, sopt) -> If (tok, e, dots_in_body s, opt dots_in_body sopt)
+      | Block (t1, [If _ as x], t2) -> Block(t1, [dots_in_body x], t2)
       | Block (t1, _, t2) -> Block(t1, [ExprStmt (Ellipsis fk, fk)], t2)
       | _ -> ExprStmt (Ellipsis fk, fk)
   in

--- a/semgrep-core/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/synthesizing/Pattern_from_Code.ml
@@ -221,13 +221,31 @@ and generalize_exp e env =
   | Assign _ -> generalize_assign env e
   | _ -> []
 
-let generalize e =
-  (generalize_exp e { count = 1; mapping = []; has_type = false })
+(* All statements *)
+and generalize_exprstmt (e, tok) env =
+  List.map (fun x -> match x with | (s, E e') -> (s, S (ExprStmt(e', tok)))
+                                  | _ -> raise (UnexpectedCase "Must pass in an any of form E x"))
+           (generalize_exp e env)
+
+and generalize_stmt s env =
+  match s with
+  | ExprStmt (e, tok) -> generalize_exprstmt (e, tok) env
+  | _ -> []
+
+(* All *)
+and generalize_any a env =
+   match a with
+   | E e -> generalize_exp e env
+   | S s -> generalize_stmt s env
+   | _ -> []
+
+let generalize a =
+  (generalize_any a { count = 1; mapping = []; has_type = false })
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
-let from_expr e =
-  ("exact match", E e)::
-  generalize e
+let from_any a =
+  ("exact match", a)::
+  generalize a

--- a/semgrep-core/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/synthesizing/Pattern_from_Code.ml
@@ -52,6 +52,8 @@ in
 (* Helpers *)
 (*****************************************************************************)
 let fk = Parse_info.fake_info "fake"
+let fk_stmt = ExprStmt (Ellipsis fk, fk)
+let body_ellipsis t1 t2 = Block(t1, [fk_stmt], t2)
 let _bk f (lp,x,rp) = (lp, f x, rp)
 
 let default_id str =
@@ -225,7 +227,7 @@ and add_expr e f env =
            (generalize_exp e env)
 
 and generalize_exprstmt (e, tok) env =
-  add_expr e (fun (s, e') -> (s, S (ExprStmt (e', tok)))) env
+  add_expr e (fun (str, e') -> (str, S (ExprStmt (e', tok)))) env
 
 and generalize_if s_in =
   let opt f so =
@@ -237,18 +239,28 @@ and generalize_if s_in =
     match s with
       | If (tok, e, s, sopt) -> If (tok, e, dots_in_body s, opt dots_in_body sopt)
       | Block (t1, [If _ as x], t2) -> Block(t1, [dots_in_body x], t2)
-      | Block (t1, _, t2) -> Block(t1, [ExprStmt (Ellipsis fk, fk)], t2)
-      | _ -> ExprStmt (Ellipsis fk, fk)
+      | Block (t1, _, t2) -> body_ellipsis t1 t2
+      | _ -> fk_stmt
   in
   let rec dots_in_cond s =
     match s with
       | If (tok, _, s, sopt) -> If (tok, Ellipsis fk, s, opt dots_in_cond sopt)
-      | Block (t1, [If _ as x], t2) -> Block(t1, [dots_in_cond x], t2)
+      | Block (t1, [If _ as x], t2) -> Block (t1, [dots_in_cond x], t2)
       | x -> x
   in
   ["dots in body", S (dots_in_body s_in); "dots in cond", S (dots_in_cond s_in)]
 
-and generalize_while _ = []
+and generalize_while (tok, e, s) env =
+  let body_dots =
+    match s with
+      | Block (t1, _, t2) -> body_ellipsis t1 t2
+      | _ -> fk_stmt
+  in
+  let dots_in_cond = ("dots in condition", S (While (tok, Ellipsis fk, s))) in
+  let dots_in_body = ("dots in body", S (While (tok, e, body_dots))) in
+  let expr_choices_in_cond =
+    add_expr e (fun (str, e') -> ("condition " ^ str, S (While (tok, e', body_dots)))) env in
+  dots_in_cond :: dots_in_body :: expr_choices_in_cond
 
 and generalize_block ss =
   let rec get_last = function
@@ -258,14 +270,14 @@ and generalize_block ss =
   in
   match ss with
   | [] | _::[] -> ss
-  | x::_::[] -> x::(ExprStmt(Ellipsis fk, fk))::[]
-  | x::y::z::zs -> x::(ExprStmt(Ellipsis fk, fk))::(get_last (y::z::zs))
+  | x::_::[] -> x::(fk_stmt)::[]
+  | x::y::z::zs -> x::(fk_stmt)::(get_last (y::z::zs))
 
 and generalize_stmt s env =
   match s with
   | ExprStmt (e, tok) -> generalize_exprstmt (e, tok) env
   | If _ -> generalize_if s
-  | While _ -> generalize_while s
+  | While (tok, e, s) -> generalize_while (tok, e, s) env
   | Block (t1, ss, t2) -> ["dots", S (Block ((t1, generalize_block ss, t2)))]
   | _ -> []
 

--- a/semgrep-core/synthesizing/Pattern_from_Code.mli
+++ b/semgrep-core/synthesizing/Pattern_from_Code.mli
@@ -1,4 +1,33 @@
 
+(*
+ * The pattern_from_code feature allows users to highlight code and
+ * autogenerate patterns that match
+ *
+ * There are three parts to pattern-from-code: taking a range and turning it
+ * into an AST, taking an AST and modifying parts to make it a pattern,
+ * and taking a pattern’s AST and outputting it.
+ *
+ * A highlighted section is turned into a range of the form row:col-row:col,
+ * which is fed as input into semgrep-core. If you’ve cloned semgrep,
+ * you can actually run it locally in semgrep/semgrep-core.
+ * An example run looks like:
+ * semgrep-core  -synthesize_patterns 8:5-8:21 tests/SYNTHESIZING/password.go
+ * The range is turned into a character position, and then the AST is visited
+ * to find the first expression in the range.
+ *
+ * Once we have an expression, we feed it into Pattern_from_code.from_expr,
+ * which makes modifications to the AST so that it’s more general.
+ * This is broken down based on what kind of expression is given.
+ * Function calls and variables are kept self contained, as the smallest
+ * “blocks” of expressions, but other expressions, like assignments,
+ * will recursively generalize their subexpressions. The guiding philosophy
+ * behind these decisions is that a pattern is only useful if it suggests
+ * a possibility for a user.
+ *
+ * Finally, we output the pattern by giving it to Pretty_print_generic.pattern_to_string,
+ * a language-aware AST-to-string converter.
+ *)
+
 (* ex:
  *  ["exact match", <metrics.send('my-report-id')>;
  *   "one argument", <metrics.send($X)>;
@@ -9,5 +38,5 @@ type named_variants =
   (string * Pattern.t) list
 
 (* limited to expressions for now *)
-val from_expr:
-  AST_generic.expr -> named_variants
+val from_any:
+  AST_generic.any -> named_variants

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -220,6 +220,7 @@ function
 and id env (s, {id_resolved; _}) =
    match !id_resolved with
        | Some (ImportedEntity ents, _) -> dotted_access env ents
+       | Some (ImportedModule (DottedName ents), _) -> dotted_access env ents
        | _ -> s
 
 and id_qualified env ((id, {name_qualifier; _}), _idinfo) =

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -109,6 +109,7 @@ function
   | Block (x) -> block env x level
   | If (tok, e, s, sopt) -> if_stmt env level (token "if" tok, e, s, sopt)
   | While (tok, e, s) -> while_stmt env level (tok, e, s)
+  | DoWhile (_tok, s, e) -> do_while stmt env level (s, e)
   | Return (tok, eopt) -> return env (tok, eopt)
   | x -> todo (S x)
 
@@ -169,6 +170,20 @@ and while_stmt env level (tok, e, s) =
    in
       while_format (token "while" tok) (expr env e) (stmt env (level + 1) s)
 
+and do_while stmt env level (s, e) =
+   let c_do_while = F.sprintf "do %s\nwhile(%s)" in
+   let do_while_format =
+    (match env.lang with
+    | Lang.Java | Lang.C | Lang.Javascript | Lang.Typescript -> c_do_while
+    | Lang.Python | Lang.Python2 | Lang.Python3
+    | Lang.Go | Lang.JSON | Lang.OCaml -> failwith "impossible; no do while"
+    | Lang.Ruby -> failwith "ruby is so weird (here, do while loop)"
+    )
+   in
+      do_while_format (stmt env (level + 1) s) (expr env e)
+
+
+  (* For of tok (* 'for', 'foreach'*) * for_header * stmt *)
 
 and return env (tok, eopt) =
   let to_return =

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -108,7 +108,7 @@ function
   | ExprStmt (e, tok) -> F.sprintf "%s%s" (expr env e) (token "" tok)
   | Block (x) -> block env x level
   | If (tok, e, s, sopt) -> if_stmt env (token "if" tok, e, s, sopt)
-  | While (tok, e, s) -> while_stmt env (tok, e, s)
+  (* | While (tok, e, s) -> while_stmt env (tok, e, s) *)
   | Return (tok, eopt) -> return env (tok, eopt)
   | x -> todo (S x)
 
@@ -152,6 +152,9 @@ and if_stmt env (tok, e, s, sopt) =
         | None -> if_stmt_prt
         | Some (Block(_, [If (_, e', s', sopt')], _)) -> F.sprintf "%s%s" if_stmt_prt (if_stmt env (elseif_str, e', s', sopt'))
         | Some (body) -> F.sprintf "%s%s" if_stmt_prt (format_block "else" (stmt env 1 body))
+
+(* and while_stmt env (tok, e, s) = *)
+
 
 and return env (tok, eopt) =
   let to_return =

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -83,6 +83,10 @@ let arithop env (op, tok) =
                 | Lang.OCaml -> "="
                 | _ -> "=="
               )
+      | Lt -> "<"
+      | LtE -> "<="
+      | Gt -> ">"
+      | GtE -> ">="
       | _ -> todo (E (IdSpecial (Op op, tok)))
       (*
       | Pow | FloorDiv | MatMult (* Python *)

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -41,9 +41,7 @@ type env = {
 (* Helpers *)
 (*****************************************************************************)
 let todo any =
-  pr ("TODO");
-  pr (show_any any);
-  failwith "TODO"
+  pr (show_any any); " TODO "
 
 let ident (s, _) = s
 
@@ -98,14 +96,43 @@ let arithop env (op, tok) =
 (*****************************************************************************)
 (* Pretty printer *)
 (*****************************************************************************)
+
+(* statements *)
+
 let rec stmt env =
 function
   | ExprStmt (e, tok) -> F.sprintf "%s%s" (expr env e) (token "" tok)
+  | Block (x) -> block env x
+  (*| If (tok, e, s, sopt) -> if_stmt env (tok, e, s, sopt) *)
   | x -> todo (S x)
+
+and block env (t1, ss, t2) =
+  let rec show_statements env =
+    function
+      | [] -> ""
+      | [x] -> F.sprintf "%s\n" (stmt env x)
+      | x::xs -> F.sprintf "%s%s" (stmt env x) (show_statements env xs)
+   in
+     F.sprintf "%s%s%s" (token "" t1) (show_statements env ss) (token "" t2)
+
+(* and if_stmt env (tok, e, s, sopt) =
+  let e_str = (expr env e) in
+  let s_str = (stmt env s) in
+  (match env.lang with
+  | Lang.Python | Lang.Python2 | Lang.Python3 ->
+        (match sopt with
+        | None -> F.sprintf "%s%s"
+        )
+  | Lang.Java | Lang.Go | Lang.C | Lang.JSON | Lang.Javascript
+  | Lang.OCaml | Lang.Ruby | Lang.Typescript ->
+        "\"" ^ s ^ "\""
+  ) *)
+
+(* expressions *)
 
 and expr env =
 function
-  | Id ((s,_), idinfo) -> id env (s, idinfo)
+  | Id ((s,_), idinfo) as x -> id env (s, idinfo)
   | IdQualified(name, idinfo) -> id_qualified env (name, idinfo)
   | IdSpecial (sp, tok) -> special env (sp, tok)
   | Call (e1, e2) -> call env (e1, e2)

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -67,9 +67,9 @@ let print_bool env = function
          | Lang.OCaml | Lang.Ruby | Lang.Typescript -> "false")
 
 let no_paren_cond = F.sprintf "%s %s"
-let paren_cond = F.sprintf "%s(%s)"
+let paren_cond = F.sprintf "%s (%s)"
 let colon_body = F.sprintf "%s:\n%s\n"
-let bracket_body = F.sprintf "%s{\n%s\n}\n"
+let bracket_body = F.sprintf "%s %s\n"
 
 let arithop env (op, tok) =
   match op with
@@ -127,7 +127,11 @@ and block env (t1, ss, t2) level =
       | [x] -> F.sprintf "%s%s" (indent level) (stmt env level x)
       | x::xs -> F.sprintf "%s%s\n%s" (indent level) (stmt env level x) (show_statements env xs)
    in
-     F.sprintf "%s%s%s%s" (indent level) (token "" t1) (show_statements env ss) (token "" t2)
+   let get_boundary t =
+     let t_str = token "" t in
+       match t_str with "" -> "" | "{" -> "{\n" | "}" -> "\n}" | _ -> t_str
+   in
+     F.sprintf "%s%s%s" (get_boundary t1) (show_statements env ss) (get_boundary t2)
 
 (* todo sorry someone is going to hate me over this at some point*)
 and if_stmt env (tok, e, s, sopt) =
@@ -144,7 +148,7 @@ and if_stmt env (tok, e, s, sopt) =
   let if_stmt_prt = format_block e_str s_str in
         match sopt with
         | None -> if_stmt_prt
-        | Some (If (_, e', s', sopt')) -> F.sprintf "%s%s" if_stmt_prt (if_stmt env (elseif_str, e', s', sopt'))
+        | Some (Block(_, [If (_, e', s', sopt')], _)) -> F.sprintf "%s%s" if_stmt_prt (if_stmt env (elseif_str, e', s', sopt'))
         | Some (body) -> F.sprintf "%s%s" if_stmt_prt (format_block "else" (stmt env 1 body))
 
 (* expressions *)

--- a/semgrep-core/synthesizing/Range_to_AST.ml
+++ b/semgrep-core/synthesizing/Range_to_AST.ml
@@ -28,7 +28,8 @@ open Range (* for the $..$ range operators *)
 (* Entry point *)
 (*****************************************************************************)
 
-exception Found of G.expr
+exception Found of G.any
+exception FoundExpr of G.expr
 
 let expr_at_range r1 ast =
 
@@ -50,7 +51,7 @@ let expr_at_range r1 ast =
          then ()
          else
            if r2 $<=$ r1
-           then raise (Found e)
+           then raise (FoundExpr e)
            (* recurse *)
            else k e
        )
@@ -60,4 +61,38 @@ let expr_at_range r1 ast =
   try
     visitor (G.Pr ast);
     None
-  with Found e -> Some e
+  with FoundExpr e -> Some e
+
+  let any_at_range r1 ast =
+
+    (* This could probably be implemented more efficiently ... but should be
+     * good enough in practice.
+     * todo? ideally every expression nodes in the AST would have range field
+     * associated with it, or at least a special id so we could memoize
+     * range for subexpressions.
+     *)
+    let visitor = V.mk_visitor { V.default_visitor with
+      V.kstmt = (fun (k, _) s ->
+         let toks = Lib.ii_of_any (G.S s) in
+         let r2_opt = Range.range_of_tokens toks in
+         (match r2_opt with
+         (* NoTokenLocation issue for the expression, should fix! *)
+         | None -> ()
+         | Some r2 ->
+           if r1 $<>$ r2
+           then ()
+           else
+             if r2 $<=$ r1
+             then raise (Found (G.S s))
+             (* recurse *)
+             else k s
+         )
+      );
+     } in
+
+    try
+      visitor (G.Pr ast);
+      match expr_at_range r1 ast with
+        | None -> None
+        | Some e -> Some (G.E e)
+    with Found a -> Some a

--- a/semgrep-core/synthesizing/Range_to_AST.mli
+++ b/semgrep-core/synthesizing/Range_to_AST.mli
@@ -5,3 +5,6 @@
  *)
 val expr_at_range:
   Range.t -> AST_generic.program -> AST_generic.expr option
+
+val any_at_range:
+  Range.t -> AST_generic.program -> AST_generic.any option

--- a/semgrep-core/synthesizing/Synthesizer.ml
+++ b/semgrep-core/synthesizing/Synthesizer.ml
@@ -5,10 +5,10 @@ let synthesize_patterns s file =
   let r = Range.range_of_linecol_spec s file in
   let ast = Parse_generic.parse_program file in
   let lang = Lang.langs_of_filename file |> List.hd in
-  let e_opt = Range_to_AST.expr_at_range r ast in
+  let a_opt = Range_to_AST.any_at_range r ast in
   Naming_AST.resolve lang ast;
-  match e_opt with
-  | Some e ->
-       let patterns = Pattern_from_Code.from_expr e in
+  match a_opt with
+  | Some a ->
+       let patterns = Pattern_from_Code.from_any a in
        List.map (fun (k, v) -> (k, Pretty_print_generic.pattern_to_string lang v)) patterns
   | None -> failwith (spf "could not find an expr at range %s in %s" s file)

--- a/semgrep-core/synthesizing/Synthesizer.ml
+++ b/semgrep-core/synthesizing/Synthesizer.ml
@@ -7,6 +7,7 @@ let synthesize_patterns s file =
   let lang = Lang.langs_of_filename file |> List.hd in
   let a_opt = Range_to_AST.any_at_range r ast in
   Naming_AST.resolve lang ast;
+  Constant_propagation.propagate lang ast;
   match a_opt with
   | Some a ->
        let patterns = Pattern_from_Code.from_any a in

--- a/semgrep-core/synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/synthesizing/Unit_synthesizer.ml
@@ -90,7 +90,7 @@ let python_tests = [
     "deep metavars", "flask.response.set_cookie($X, generate_cookie_value($Y), secure=$Z)"
    ];
 
-   (* "set_cookie.py", "8:3-8:31",
+   "set_cookie.py", "8:3-8:31",
    [
      "exact match", "a = set_cookie(1234, a, 123)";
      "dots", "a = ...";
@@ -98,7 +98,7 @@ let python_tests = [
      "righthand dots", "$X = set_cookie(...)";
      "righthand metavars", "$X = set_cookie($Y, $X, $Z, ...)";
      "righthand exact metavars", "$X = set_cookie($Y, $X, $Z)"
-   ] *)
+   ]
 ]
 
 let java_tests = [
@@ -177,15 +177,15 @@ let unittest =
         let check_pats (_, pat) =
           try
             let pattern = Parse_generic.parse_pattern lang pat in
-            let e_opt = Range_to_AST.expr_at_range r code in
+            let e_opt = Range_to_AST.any_at_range r code in
                match e_opt with
                  | Some e ->
-                    let matches_with_env = Semgrep_generic.match_any_any pattern (A.E e) in
+                    let matches_with_env = Semgrep_generic.match_any_any pattern e in
                     (* Debugging note: uses pattern_to_string for convenience, but really should *)
                     (* match the code in the given file at the given range *)
-                    pr2 (AST_generic.show_any (A.E e));
+                    pr2 (AST_generic.show_any e);
                     pr2 (AST_generic.show_any (pattern));
-                    assert_bool (spf "pattern:|%s| should match |%s" pat (PPG.pattern_to_string lang (A.E e)))
+                    assert_bool (spf "pattern:|%s| should match |%s" pat (PPG.pattern_to_string lang e))
                     (matches_with_env <> [])
                  | None -> failwith (spf "Couldn't find range %s in %s" range file)
           with

--- a/semgrep-core/synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/synthesizing/Unit_synthesizer.ml
@@ -177,11 +177,11 @@ let unittest =
         let check_pats (str, pat) =
           try
             let pattern = Parse_generic.parse_pattern lang pat in
-            let e_opt = Range_to_AST.expr_at_range r code in
+            let e_opt = Range_to_AST.any_at_range r code in
                match e_opt with
                  | Some e ->
                     let matches_with_env = Semgrep_generic.match_any_any
-                          pattern (A.E e) in
+                          pattern e in
                     (* Debugging note: uses pattern_to_string for convenience,
                      * but really should match the code in the given file at
                      * the given range *)

--- a/semgrep-core/synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/synthesizing/Unit_synthesizer.ml
@@ -99,6 +99,14 @@ let python_tests = [
      "righthand metavars", "$X = set_cookie($Y, $Z, $A, ...)";
      "righthand exact metavars", "$X = set_cookie($Y, $Z, $A)"
    ];
+
+   "import_as.py", "2:0-2:25",
+   [
+    "exact match", "exec(user_input)";
+    "dots", "exec(...)";
+    "metavars", "exec($X, ...)";
+    "exact metavars", "exec($X)"
+   ]
 ]
 
 let java_tests = [

--- a/semgrep-core/synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/synthesizing/Unit_synthesizer.ml
@@ -78,7 +78,7 @@ let python_tests = [
    "deep metavars", "f($X, b(g($X, $Y)), $Z, c($Y), $X, $Z)"
   ];
 
-  "arrays_and_funcs.py", "19:3-19:32",
+  "arrays_and_funcs.py", "19:6-19:27",
   ["exact match", "node.id == node.id";
    "exact metavars", "$X == $X"];
 
@@ -103,30 +103,30 @@ let python_tests = [
 
 let java_tests = [
   "typed_funcs.java", "6:8-6:14",
-  ["exact match", "this.foo(a)";
-   "dots", "this.foo(...)";
-   "metavars", "this.foo($X, ...)";
-   "exact metavars", "this.foo($X)";
-   "typed metavars", "this.foo((int $X))"
+  ["exact match", "this.foo(a);";
+   "dots", "this.foo(...);";
+   "metavars", "this.foo($X, ...);";
+   "exact metavars", "this.foo($X);";
+   "typed metavars", "this.foo((int $X));"
   ];
 
   "typed_funcs.java", "7:8-7:42",
-  ["exact match", "this.foo(this.bar(this.car(a)), b, this.foo(b, c), d)";
-   "dots", "this.foo(...)";
-   "metavars", "this.foo($X, $Y, $Z, $A, ...)";
-   "exact metavars", "this.foo($X, $Y, $Z, $A)";
+  ["exact match", "this.foo(this.bar(this.car(a)), b, this.foo(b, c), d);";
+   "dots", "this.foo(...);";
+   "metavars", "this.foo($X, $Y, $Z, $A, ...);";
+   "exact metavars", "this.foo($X, $Y, $Z, $A);";
    "typed metavars",
-     "this.foo(this.bar(this.car((int $X))), (String $Y), this.foo((String $Y), (bool $Z)), $A)";
-   "deep metavars", "this.foo(this.bar(this.car($X)), $Y, this.foo($Y, $Z), $A)"
+     "this.foo(this.bar(this.car((int $X))), (String $Y), this.foo((String $Y), (bool $Z)), $A);";
+   "deep metavars", "this.foo(this.bar(this.car($X)), $Y, this.foo($Y, $Z), $A);"
   ];
 
   "typed_funcs.java", "8:8-8:26",
-  ["exact match", "this.foo(this.foo(a, b), c)";
-   "dots", "this.foo(...)";
-   "metavars", "this.foo($X, $Y, ...)";
-   "exact metavars", "this.foo($X, $Y)";
-   "typed metavars", "this.foo(this.foo((int $X), (String $Y)), (bool $Z))";
-   "deep metavars", "this.foo(this.foo($X, $Y), $Z)"
+  ["exact match", "this.foo(this.foo(a, b), c);";
+   "dots", "this.foo(...);";
+   "metavars", "this.foo($X, $Y, ...);";
+   "exact metavars", "this.foo($X, $Y);";
+   "typed metavars", "this.foo(this.foo((int $X), (String $Y)), (bool $Z));";
+   "deep metavars", "this.foo(this.foo($X, $Y), $Z);"
   ];
 
    "typed_funcs.java", "6:12-6:14",
@@ -136,10 +136,10 @@ let java_tests = [
    ];
 
   "typed_funcs.java", "10:8-10:30",
-  ["exact match", "System.out.print(\"A\")";
-   "dots", "System.out.print(...)";
-   "metavars", "System.out.print($X, ...)";
-   "exact metavars", "System.out.print($X)";
+  ["exact match", "System.out.print(\"A\");";
+   "dots", "System.out.print(...);";
+   "metavars", "System.out.print($X, ...);";
+   "exact metavars", "System.out.print($X);";
   ];
 
   "typed_funcs.java", "11:20-11:47",
@@ -179,9 +179,12 @@ let unittest =
             let pattern = Parse_generic.parse_pattern lang pat in
             let e_opt = Range_to_AST.any_at_range r code in
                match e_opt with
-                 | Some e ->
+                 | Some any ->
+                    let a = match (pattern, any) with
+                              | (A.E _, A.S (A.ExprStmt (e, _))) -> A.E e
+                              | (_, x) -> x in
                     let matches_with_env = Semgrep_generic.match_any_any
-                          pattern e in
+                          pattern a in
                     (* Debugging note: uses pattern_to_string for convenience,
                      * but really should match the code in the given file at
                      * the given range *)
@@ -189,12 +192,12 @@ let unittest =
                     then begin
                       pr2 str;
                       pr2 (AST_generic.show_any (pattern));
-                      pr2 (AST_generic.show_any e);
+                      pr2 (AST_generic.show_any a);
 
                     end;
                     assert_bool (spf "pattern:|%s| should match |%s"
                               pat
-                              (PPG.pattern_to_string lang e))
+                              (PPG.pattern_to_string lang a))
                            (matches_with_env <> [])
 
                  | None ->

--- a/semgrep-core/tests/SYNTHESIZING/import_as.py
+++ b/semgrep-core/tests/SYNTHESIZING/import_as.py
@@ -1,0 +1,5 @@
+import exec as safe_function
+safe_function(user_input)
+
+exec("ls")
+

--- a/semgrep-core/tests/SYNTHESIZING/set_cookie.py
+++ b/semgrep-core/tests/SYNTHESIZING/set_cookie.py
@@ -7,6 +7,19 @@ def foo():
                        secure=True)
    a = set_cookie(1234, b, 123)
 
+   if (x == y):
+      r.set_cookie("sessionid")
+      show_again()
+      show()
+   elif (x < y):
+      do()
+   else:
+      donot()
+
    if "TOX_ENV_NAME" in os.environ:
        print("Not attempting to install binary while running under tox")
        return
+
+   while a == b:
+       do_again()
+       if a: donot()


### PR DESCRIPTION
Changed range matcher so that it will first look for a statement, then, if not found, an expression to match. This will allow pattern_from_code to handle a much wider variety of code.

Tested with arrays_and_funcs.py, set_cookie.py, typed_func.java.