### PR TITLE
Resolve run-time mypy conflict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         args: [--config, mypy.ini]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.761"
+    rev: "v0.782"
     hooks:
       - id: mypy
         alias: mypy-test

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -37,6 +37,7 @@ def _evaluate_single_expression(
     results_for_pattern = [
         x.range for x in pattern_ids_to_pattern_matches.get(expression.pattern_id, [])
     ]
+    output_ranges: Set[Range] = set()
 
     if expression.operator == OPERATORS.AND:
         # remove all ranges that don't equal the ranges for this pattern
@@ -56,7 +57,6 @@ def _evaluate_single_expression(
         return output_ranges
     elif expression.operator == OPERATORS.AND_INSIDE:
         # remove all ranges (not enclosed by) or (not equal to) the inside ranges
-        output_ranges = set()
         for arange in ranges_left:
             for keep_inside_this_range in results_for_pattern:
                 is_enclosed = keep_inside_this_range.is_enclosing_or_eq(arange)
@@ -99,7 +99,6 @@ def _evaluate_single_expression(
             )
         assert expression.operand, "must have operand for this operator type"
 
-        output_ranges = set()
         # Look through every range that hasn't been filtered yet
         for pattern_match in list(flatten(pattern_ids_to_pattern_matches.values())):
             # Only need to check where-python clause if the range hasn't already been filtered

--- a/semgrep/tests/unit/test_evaluation.py
+++ b/semgrep/tests/unit/test_evaluation.py
@@ -26,12 +26,15 @@ def evaluate_expression(
 ) -> Set[Range]:
     # convert it to an implicit and
     e = BooleanRuleExpression(OPERATORS.AND_ALL, None, exprs, None)
-    return raw_evaluate_expression(e, pattern_ids_to_pattern_matches, [], flags)
+    result: Set[Range] = raw_evaluate_expression(
+        e, pattern_ids_to_pattern_matches, [], flags
+    )
+    return result
 
 
 def PatternMatchMock(
     start: int, end: int, metavars: Optional[Dict[str, Any]] = None
-) -> MagicMock:
+) -> PatternMatch:
     mock = MagicMock()
     range_property = PropertyMock(return_value=Range(start, end, metavars or {}))
     type(mock).range = range_property
@@ -100,7 +103,7 @@ def testB() -> None:
         and-or (P2, P3) -->  remove any ranges not exactly == P2 or P3. (R2 stays)
         OUTPUT: R2
     """
-    results = {
+    results: Dict[PatternId, List[PatternMatch]] = {
         PatternId("pattern1"): [PatternMatchMock(0, 100)],
         PatternId("pattern2"): [PatternMatchMock(30, 70), PatternMatchMock(0, 100)],
         PatternId("pattern3"): [],


### PR DESCRIPTION
Conflict appeared between commit e14ab83c, which rev'd the version of
mypy we were using on mainline code, and commit 2fb1d8e57, which added
a stripped-down mypy configuration for tests.

Here I rev the version of mypy used in tests.

However, doing this revealed some untyped declarations in
semgrep/evaluation.py, which are fixed here.