### PR TITLE
Skeleton to use the Go tree-sitter parser

### DIFF
--- a/semgrep-core/parsing/Parse_code.ml
+++ b/semgrep-core/parsing/Parse_code.ml
@@ -46,6 +46,12 @@ let just_parse_with_lang lang file =
         with _exn -> Parse_java_tree_sitter.parse file
        in
        Java_to_generic.program ast
+  | Lang.Go ->
+      let ast =
+        try Parse_go.parse_program file
+        with _exn -> Parse_go_tree_sitter.parse file
+      in
+      Go_to_generic.program ast
 
   | _ -> Parse_generic.parse_with_lang lang file
 

--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -28,44 +28,44 @@ let blank (env : env) () =
 let todo (env : env) _ =
    failwith "not implemented"
 
-let map_int_literal (env : env) (tok : CST.int_literal) =
+let int_literal (env : env) (tok : CST.int_literal) =
   token env tok (* int_literal *)
 
-let map_identifier (env : env) (tok : CST.identifier) =
+let identifier (env : env) (tok : CST.identifier) =
   token env tok (* identifier *)
 
-let map_raw_string_literal (env : env) (tok : CST.raw_string_literal) =
+let raw_string_literal (env : env) (tok : CST.raw_string_literal) =
   token env tok (* raw_string_literal *)
 
-let map_rune_literal (env : env) (tok : CST.rune_literal) =
+let rune_literal (env : env) (tok : CST.rune_literal) =
   token env tok (* rune_literal *)
 
-let map_float_literal (env : env) (tok : CST.float_literal) =
+let float_literal (env : env) (tok : CST.float_literal) =
   token env tok (* float_literal *)
 
-let map_imaginary_literal (env : env) (tok : CST.imaginary_literal) =
+let imaginary_literal (env : env) (tok : CST.imaginary_literal) =
   token env tok (* imaginary_literal *)
 
-let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
+let escape_sequence (env : env) (tok : CST.escape_sequence) =
   token env tok (* escape_sequence *)
 
-let map_qualified_type (env : env) ((v1, v2, v3) : CST.qualified_type) =
+let qualified_type (env : env) ((v1, v2, v3) : CST.qualified_type) =
   let v1 = token env v1 (* identifier *) in
   let v2 = token env v2 (* "." *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let map_package_clause (env : env) ((v1, v2) : CST.package_clause) =
+let package_clause (env : env) ((v1, v2) : CST.package_clause) =
   let v1 = token env v1 (* "package" *) in
   let v2 = token env v2 (* identifier *) in
   todo env (v1, v2)
 
-let map_empty_labeled_statement (env : env) ((v1, v2) : CST.empty_labeled_statement) =
+let empty_labeled_statement (env : env) ((v1, v2) : CST.empty_labeled_statement) =
   let v1 = token env v1 (* identifier *) in
   let v2 = token env v2 (* ":" *) in
   todo env (v1, v2)
 
-let map_interpreted_string_literal (env : env) ((v1, v2, v3) : CST.interpreted_string_literal) =
+let interpreted_string_literal (env : env) ((v1, v2, v3) : CST.interpreted_string_literal) =
   let v1 = token env v1 (* "\"" *) in
   let v2 =
     List.map (fun x ->
@@ -78,7 +78,7 @@ let map_interpreted_string_literal (env : env) ((v1, v2, v3) : CST.interpreted_s
   let v3 = token env v3 (* "\"" *) in
   todo env (v1, v2, v3)
 
-let map_import_spec (env : env) ((v1, v2) : CST.import_spec) =
+let import_spec (env : env) ((v1, v2) : CST.import_spec) =
   let v1 =
     (match v1 with
     | Some x ->
@@ -92,23 +92,23 @@ let map_import_spec (env : env) ((v1, v2) : CST.import_spec) =
   let v2 =
     (match v2 with
     | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
-    | `Inte_str_lit x -> map_interpreted_string_literal env x
+    | `Inte_str_lit x -> interpreted_string_literal env x
     )
   in
   todo env (v1, v2)
 
-let rec map_declaration (env : env) (x : CST.declaration) =
+let rec declaration (env : env) (x : CST.declaration) =
   (match x with
   | `Decl_const_decl (v1, v2) ->
       let v1 = token env v1 (* "const" *) in
       let v2 =
         (match v2 with
-        | `Const_spec x -> map_const_spec env x
+        | `Const_spec x -> const_spec env x
         | `LPAR_rep_const_spec_choice_LF_RPAR (v1, v2, v3) ->
             let v1 = token env v1 (* "(" *) in
             let v2 =
               List.map (fun (v1, v2) ->
-                let v1 = map_const_spec env v1 in
+                let v1 = const_spec env v1 in
                 let v2 =
                   (match v2 with
                   | `LF tok -> token env tok (* "\n" *)
@@ -127,16 +127,16 @@ let rec map_declaration (env : env) (x : CST.declaration) =
       let v1 = token env v1 (* "type" *) in
       let v2 =
         (match v2 with
-        | `Type_spec x -> map_type_spec env x
-        | `Type_alias x -> map_type_alias env x
+        | `Type_spec x -> type_spec env x
+        | `Type_alias x -> type_alias env x
         | `LPAR_rep_choice_type_spec_choice_LF_RPAR (v1, v2, v3) ->
             let v1 = token env v1 (* "(" *) in
             let v2 =
               List.map (fun (v1, v2) ->
                 let v1 =
                   (match v1 with
-                  | `Type_spec x -> map_type_spec env x
-                  | `Type_alias x -> map_type_alias env x
+                  | `Type_spec x -> type_spec env x
+                  | `Type_alias x -> type_alias env x
                   )
                 in
                 let v2 =
@@ -157,12 +157,12 @@ let rec map_declaration (env : env) (x : CST.declaration) =
       let v1 = token env v1 (* "var" *) in
       let v2 =
         (match v2 with
-        | `Var_spec x -> map_var_spec env x
+        | `Var_spec x -> var_spec env x
         | `LPAR_rep_var_spec_choice_LF_RPAR (v1, v2, v3) ->
             let v1 = token env v1 (* "(" *) in
             let v2 =
               List.map (fun (v1, v2) ->
-                let v1 = map_var_spec env v1 in
+                let v1 = var_spec env v1 in
                 let v2 =
                   (match v2 with
                   | `LF tok -> token env tok (* "\n" *)
@@ -180,7 +180,7 @@ let rec map_declaration (env : env) (x : CST.declaration) =
   )
 
 
-and map_const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
+and const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
   let v1 = token env v1 (* identifier *) in
   let v2 =
     List.map (fun (v1, v2) ->
@@ -196,20 +196,20 @@ and map_const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
           (match v1 with
           | Some x ->
               (match x with
-              | `Simple_type x -> map_simple_type env x
-              | `Paren_type x -> map_parenthesized_type env x
+              | `Simple_type x -> simple_type env x
+              | `Paren_type x -> parenthesized_type env x
               )
           | None -> todo env ())
         in
         let v2 = token env v2 (* "=" *) in
-        let v3 = map_expression_list env v3 in
+        let v3 = expression_list env v3 in
         todo env (v1, v2, v3)
     | None -> todo env ())
   in
   todo env (v1, v2, v3)
 
 
-and map_var_spec (env : env) ((v1, v2, v3) : CST.var_spec) =
+and var_spec (env : env) ((v1, v2, v3) : CST.var_spec) =
   let v1 = token env v1 (* identifier *) in
   let v2 =
     List.map (fun (v1, v2) ->
@@ -223,29 +223,29 @@ and map_var_spec (env : env) ((v1, v2, v3) : CST.var_spec) =
     | `Choice_simple_type_opt_EQ_exp_list (v1, v2) ->
         let v1 =
           (match v1 with
-          | `Simple_type x -> map_simple_type env x
-          | `Paren_type x -> map_parenthesized_type env x
+          | `Simple_type x -> simple_type env x
+          | `Paren_type x -> parenthesized_type env x
           )
         in
         let v2 =
           (match v2 with
           | Some (v1, v2) ->
               let v1 = token env v1 (* "=" *) in
-              let v2 = map_expression_list env v2 in
+              let v2 = expression_list env v2 in
               todo env (v1, v2)
           | None -> todo env ())
         in
         todo env (v1, v2)
     | `EQ_exp_list (v1, v2) ->
         let v1 = token env v1 (* "=" *) in
-        let v2 = map_expression_list env v2 in
+        let v2 = expression_list env v2 in
         todo env (v1, v2)
     )
   in
   todo env (v1, v2, v3)
 
 
-and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
+and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
@@ -255,9 +255,9 @@ and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
           | Some (v1, v2) ->
               let v1 =
                 (match v1 with
-                | `Param_decl x -> map_parameter_declaration env x
+                | `Param_decl x -> parameter_declaration env x
                 | `Vari_param_decl x ->
-                    map_variadic_parameter_declaration env x
+                    variadic_parameter_declaration env x
                 )
               in
               let v2 =
@@ -265,9 +265,9 @@ and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
                   let v1 = token env v1 (* "," *) in
                   let v2 =
                     (match v2 with
-                    | `Param_decl x -> map_parameter_declaration env x
+                    | `Param_decl x -> parameter_declaration env x
                     | `Vari_param_decl x ->
-                        map_variadic_parameter_declaration env x
+                        variadic_parameter_declaration env x
                     )
                   in
                   todo env (v1, v2)
@@ -288,7 +288,7 @@ and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
   todo env (v1, v2, v3)
 
 
-and map_parameter_declaration (env : env) ((v1, v2) : CST.parameter_declaration) =
+and parameter_declaration (env : env) ((v1, v2) : CST.parameter_declaration) =
   let v1 =
     (match v1 with
     | Some (v1, v2) ->
@@ -305,14 +305,14 @@ and map_parameter_declaration (env : env) ((v1, v2) : CST.parameter_declaration)
   in
   let v2 =
     (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2)
 
 
-and map_variadic_parameter_declaration (env : env) ((v1, v2, v3) : CST.variadic_parameter_declaration) =
+and variadic_parameter_declaration (env : env) ((v1, v2, v3) : CST.variadic_parameter_declaration) =
   let v1 =
     (match v1 with
     | Some tok -> token env tok (* identifier *)
@@ -321,91 +321,91 @@ and map_variadic_parameter_declaration (env : env) ((v1, v2, v3) : CST.variadic_
   let v2 = token env v2 (* "..." *) in
   let v3 =
     (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2, v3)
 
 
-and map_type_alias (env : env) ((v1, v2, v3) : CST.type_alias) =
+and type_alias (env : env) ((v1, v2, v3) : CST.type_alias) =
   let v1 = token env v1 (* identifier *) in
   let v2 = token env v2 (* "=" *) in
   let v3 =
     (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2, v3)
 
 
-and map_type_spec (env : env) ((v1, v2) : CST.type_spec) =
+and type_spec (env : env) ((v1, v2) : CST.type_spec) =
   let v1 = token env v1 (* identifier *) in
   let v2 =
     (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2)
 
 
-and map_expression_list (env : env) ((v1, v2) : CST.expression_list) =
-  let v1 = map_expression env v1 in
+and expression_list (env : env) ((v1, v2) : CST.expression_list) =
+  let v1 = expression env v1 in
   let v2 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
     ) v2
   in
   todo env (v1, v2)
 
 
-and map_parenthesized_type (env : env) ((v1, v2, v3) : CST.parenthesized_type) =
+and parenthesized_type (env : env) ((v1, v2, v3) : CST.parenthesized_type) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
 
-and map_simple_type (env : env) (x : CST.simple_type) =
+and simple_type (env : env) (x : CST.simple_type) =
   (match x with
   | `Simple_type_id tok -> token env tok (* identifier *)
-  | `Simple_type_qual_type x -> map_qualified_type env x
+  | `Simple_type_qual_type x -> qualified_type env x
   | `Simple_type_poin_type (v1, v2) ->
       let v1 = token env v1 (* "*" *) in
       let v2 =
         (match v2 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Simple_type x -> simple_type env x
+        | `Paren_type x -> parenthesized_type env x
         )
       in
       todo env (v1, v2)
-  | `Simple_type_stru_type x -> map_struct_type env x
+  | `Simple_type_stru_type x -> struct_type env x
   | `Simple_type_inte_type (v1, v2) ->
       let v1 = token env v1 (* "interface" *) in
-      let v2 = map_method_spec_list env v2 in
+      let v2 = method_spec_list env v2 in
       todo env (v1, v2)
-  | `Simple_type_array_type x -> map_array_type env x
-  | `Simple_type_slice_type x -> map_slice_type env x
-  | `Simple_type_map_type x -> map_map_type env x
-  | `Simple_type_chan_type x -> map_channel_type env x
+  | `Simple_type_array_type x -> array_type env x
+  | `Simple_type_slice_type x -> slice_type env x
+  | `Simple_type_map_type x -> map_type env x
+  | `Simple_type_chan_type x -> channel_type env x
   | `Simple_type_func_type (v1, v2, v3) ->
       let v1 = token env v1 (* "func" *) in
-      let v2 = map_parameter_list env v2 in
+      let v2 = parameter_list env v2 in
       let v3 =
         (match v3 with
         | Some x ->
             (match x with
-            | `Param_list x -> map_parameter_list env x
-            | `Simple_type x -> map_simple_type env x
+            | `Param_list x -> parameter_list env x
+            | `Simple_type x -> simple_type env x
             )
         | None -> todo env ())
       in
@@ -413,56 +413,56 @@ and map_simple_type (env : env) (x : CST.simple_type) =
   )
 
 
-and map_array_type (env : env) ((v1, v2, v3, v4) : CST.array_type) =
+and array_type (env : env) ((v1, v2, v3, v4) : CST.array_type) =
   let v1 = token env v1 (* "[" *) in
-  let v2 = map_expression env v2 in
+  let v2 = expression env v2 in
   let v3 = token env v3 (* "]" *) in
   let v4 =
     (match v4 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2, v3, v4)
 
 
-and map_implicit_length_array_type (env : env) ((v1, v2, v3, v4) : CST.implicit_length_array_type) =
+and implicit_length_array_type (env : env) ((v1, v2, v3, v4) : CST.implicit_length_array_type) =
   let v1 = token env v1 (* "[" *) in
   let v2 = token env v2 (* "..." *) in
   let v3 = token env v3 (* "]" *) in
   let v4 =
     (match v4 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2, v3, v4)
 
 
-and map_slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
+and slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
   let v1 = token env v1 (* "[" *) in
   let v2 = token env v2 (* "]" *) in
   let v3 =
     (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2, v3)
 
 
-and map_struct_type (env : env) ((v1, v2) : CST.struct_type) =
+and struct_type (env : env) ((v1, v2) : CST.struct_type) =
   let v1 = token env v1 (* "struct" *) in
-  let v2 = map_field_declaration_list env v2 in
+  let v2 = field_declaration_list env v2 in
   todo env (v1, v2)
 
 
-and map_field_declaration_list (env : env) ((v1, v2, v3) : CST.field_declaration_list) =
+and field_declaration_list (env : env) ((v1, v2, v3) : CST.field_declaration_list) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
-        let v1 = map_field_declaration env v1 in
+        let v1 = field_declaration env v1 in
         let v2 =
           List.map (fun (v1, v2) ->
             let v1 =
@@ -471,7 +471,7 @@ and map_field_declaration_list (env : env) ((v1, v2, v3) : CST.field_declaration
               | `SEMI tok -> token env tok (* ";" *)
               )
             in
-            let v2 = map_field_declaration env v2 in
+            let v2 = field_declaration env v2 in
             todo env (v1, v2)
           ) v2
         in
@@ -491,7 +491,7 @@ and map_field_declaration_list (env : env) ((v1, v2, v3) : CST.field_declaration
   todo env (v1, v2, v3)
 
 
-and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
+and field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
   let v1 =
     (match v1 with
     | `Id_rep_COMMA_id_choice_simple_type (v1, v2, v3) ->
@@ -505,8 +505,8 @@ and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
         in
         let v3 =
           (match v3 with
-          | `Simple_type x -> map_simple_type env x
-          | `Paren_type x -> map_parenthesized_type env x
+          | `Simple_type x -> simple_type env x
+          | `Paren_type x -> parenthesized_type env x
           )
         in
         todo env (v1, v2, v3)
@@ -519,7 +519,7 @@ and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
         let v2 =
           (match v2 with
           | `Id tok -> token env tok (* identifier *)
-          | `Qual_type x -> map_qualified_type env x
+          | `Qual_type x -> qualified_type env x
           )
         in
         todo env (v1, v2)
@@ -530,14 +530,14 @@ and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
     | Some x ->
         (match x with
         | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
-        | `Inte_str_lit x -> map_interpreted_string_literal env x
+        | `Inte_str_lit x -> interpreted_string_literal env x
         )
     | None -> todo env ())
   in
   todo env (v1, v2)
 
 
-and map_method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
+and method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
@@ -545,8 +545,8 @@ and map_method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
         let v1 =
           (match v1 with
           | `Id tok -> token env tok (* identifier *)
-          | `Qual_type x -> map_qualified_type env x
-          | `Meth_spec x -> map_method_spec env x
+          | `Qual_type x -> qualified_type env x
+          | `Meth_spec x -> method_spec env x
           )
         in
         let v2 =
@@ -560,8 +560,8 @@ and map_method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
             let v2 =
               (match v2 with
               | `Id tok -> token env tok (* identifier *)
-              | `Qual_type x -> map_qualified_type env x
-              | `Meth_spec x -> map_method_spec env x
+              | `Qual_type x -> qualified_type env x
+              | `Meth_spec x -> method_spec env x
               )
             in
             todo env (v1, v2)
@@ -583,48 +583,48 @@ and map_method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
   todo env (v1, v2, v3)
 
 
-and map_method_spec (env : env) ((v1, v2, v3) : CST.method_spec) =
+and method_spec (env : env) ((v1, v2, v3) : CST.method_spec) =
   let v1 = token env v1 (* identifier *) in
-  let v2 = map_parameter_list env v2 in
+  let v2 = parameter_list env v2 in
   let v3 =
     (match v3 with
     | Some x ->
         (match x with
-        | `Param_list x -> map_parameter_list env x
-        | `Simple_type x -> map_simple_type env x
+        | `Param_list x -> parameter_list env x
+        | `Simple_type x -> simple_type env x
         )
     | None -> todo env ())
   in
   todo env (v1, v2, v3)
 
 
-and map_map_type (env : env) ((v1, v2, v3, v4, v5) : CST.map_type) =
+and map_type (env : env) ((v1, v2, v3, v4, v5) : CST.map_type) =
   let v1 = token env v1 (* "map" *) in
   let v2 = token env v2 (* "[" *) in
   let v3 =
     (match v3 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   let v4 = token env v4 (* "]" *) in
   let v5 =
     (match v5 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   todo env (v1, v2, v3, v4, v5)
 
 
-and map_channel_type (env : env) (x : CST.channel_type) =
+and channel_type (env : env) (x : CST.channel_type) =
   (match x with
   | `Chan_type_chan_choice_simple_type (v1, v2) ->
       let v1 = token env v1 (* "chan" *) in
       let v2 =
         (match v2 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Simple_type x -> simple_type env x
+        | `Paren_type x -> parenthesized_type env x
         )
       in
       todo env (v1, v2)
@@ -633,8 +633,8 @@ and map_channel_type (env : env) (x : CST.channel_type) =
       let v2 = token env v2 (* "<-" *) in
       let v3 =
         (match v3 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Simple_type x -> simple_type env x
+        | `Paren_type x -> parenthesized_type env x
         )
       in
       todo env (v1, v2, v3)
@@ -643,29 +643,29 @@ and map_channel_type (env : env) (x : CST.channel_type) =
       let v2 = token env v2 (* "chan" *) in
       let v3 =
         (match v3 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Simple_type x -> simple_type env x
+        | `Paren_type x -> parenthesized_type env x
         )
       in
       todo env (v1, v2, v3)
   )
 
 
-and map_block (env : env) ((v1, v2, v3) : CST.block) =
+and block (env : env) ((v1, v2, v3) : CST.block) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
-    | Some x -> map_statement_list env x
+    | Some x -> statement_list env x
     | None -> todo env ())
   in
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
 
-and map_statement_list (env : env) (x : CST.statement_list) =
+and statement_list (env : env) (x : CST.statement_list) =
   (match x with
   | `Stmt_list_stmt_rep_choice_LF_stmt_opt_choice_LF_opt_empty_labe_stmt (v1, v2, v3) ->
-      let v1 = map_statement env v1 in
+      let v1 = statement env v1 in
       let v2 =
         List.map (fun (v1, v2) ->
           let v1 =
@@ -674,7 +674,7 @@ and map_statement_list (env : env) (x : CST.statement_list) =
             | `SEMI tok -> token env tok (* ";" *)
             )
           in
-          let v2 = map_statement env v2 in
+          let v2 = statement env v2 in
           todo env (v1, v2)
         ) v2
       in
@@ -689,7 +689,7 @@ and map_statement_list (env : env) (x : CST.statement_list) =
             in
             let v2 =
               (match v2 with
-              | Some x -> map_empty_labeled_statement env x
+              | Some x -> empty_labeled_statement env x
               | None -> todo env ())
             in
             todo env (v1, v2)
@@ -697,66 +697,66 @@ and map_statement_list (env : env) (x : CST.statement_list) =
       in
       todo env (v1, v2, v3)
   | `Stmt_list_empty_labe_stmt x ->
-      map_empty_labeled_statement env x
+      empty_labeled_statement env x
   )
 
 
-and map_statement (env : env) (x : CST.statement) =
+and statement (env : env) (x : CST.statement) =
   (match x with
-  | `Stmt_decl x -> map_declaration env x
-  | `Stmt_simple_stmt x -> map_simple_statement env x
+  | `Stmt_decl x -> declaration env x
+  | `Stmt_simple_stmt x -> simple_statement env x
   | `Stmt_ret_stmt (v1, v2) ->
       let v1 = token env v1 (* "return" *) in
       let v2 =
         (match v2 with
-        | Some x -> map_expression_list env x
+        | Some x -> expression_list env x
         | None -> todo env ())
       in
       todo env (v1, v2)
   | `Stmt_go_stmt (v1, v2) ->
       let v1 = token env v1 (* "go" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   | `Stmt_defer_stmt (v1, v2) ->
       let v1 = token env v1 (* "defer" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
-  | `Stmt_if_stmt x -> map_if_statement env x
+  | `Stmt_if_stmt x -> if_statement env x
   | `Stmt_for_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "for" *) in
       let v2 =
         (match v2 with
         | Some x ->
             (match x with
-            | `Exp x -> map_expression env x
-            | `For_clau x -> map_for_clause env x
-            | `Range_clau x -> map_range_clause env x
+            | `Exp x -> expression env x
+            | `For_clau x -> for_clause env x
+            | `Range_clau x -> range_clause env x
             )
         | None -> todo env ())
       in
-      let v3 = map_block env v3 in
+      let v3 = block env v3 in
       todo env (v1, v2, v3)
   | `Stmt_exp_swit_stmt (v1, v2, v3, v4, v5, v6) ->
       let v1 = token env v1 (* "switch" *) in
       let v2 =
         (match v2 with
         | Some (v1, v2) ->
-            let v1 = map_simple_statement env v1 in
+            let v1 = simple_statement env v1 in
             let v2 = token env v2 (* ";" *) in
             todo env (v1, v2)
         | None -> todo env ())
       in
       let v3 =
         (match v3 with
-        | Some x -> map_expression env x
+        | Some x -> expression env x
         | None -> todo env ())
       in
       let v4 = token env v4 (* "{" *) in
       let v5 =
         List.map (fun x ->
           (match x with
-          | `Exp_case x -> map_expression_case env x
-          | `Defa_case x -> map_default_case env x
+          | `Exp_case x -> expression_case env x
+          | `Defa_case x -> default_case env x
           )
         ) v5
       in
@@ -764,13 +764,13 @@ and map_statement (env : env) (x : CST.statement) =
       todo env (v1, v2, v3, v4, v5, v6)
   | `Stmt_type_swit_stmt (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "switch" *) in
-      let v2 = map_type_switch_header env v2 in
+      let v2 = type_switch_header env v2 in
       let v3 = token env v3 (* "{" *) in
       let v4 =
         List.map (fun x ->
           (match x with
-          | `Type_case x -> map_type_case env x
-          | `Defa_case x -> map_default_case env x
+          | `Type_case x -> type_case env x
+          | `Defa_case x -> default_case env x
           )
         ) v4
       in
@@ -782,8 +782,8 @@ and map_statement (env : env) (x : CST.statement) =
       let v3 =
         List.map (fun x ->
           (match x with
-          | `Comm_case x -> map_communication_case env x
-          | `Defa_case x -> map_default_case env x
+          | `Comm_case x -> communication_case env x
+          | `Defa_case x -> default_case env x
           )
         ) v3
       in
@@ -792,7 +792,7 @@ and map_statement (env : env) (x : CST.statement) =
   | `Stmt_labe_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* identifier *) in
       let v2 = token env v2 (* ":" *) in
-      let v3 = map_statement env v3 in
+      let v3 = statement env v3 in
       todo env (v1, v2, v3)
   | `Stmt_fall_stmt tok -> token env tok (* "fallthrough" *)
   | `Stmt_brk_stmt (v1, v2) ->
@@ -815,25 +815,25 @@ and map_statement (env : env) (x : CST.statement) =
       let v1 = token env v1 (* "goto" *) in
       let v2 = token env v2 (* identifier *) in
       todo env (v1, v2)
-  | `Stmt_blk x -> map_block env x
+  | `Stmt_blk x -> block env x
   | `Stmt_empty_stmt tok -> token env tok (* ";" *)
   )
 
 
-and map_simple_statement (env : env) (x : CST.simple_statement) =
+and simple_statement (env : env) (x : CST.simple_statement) =
   (match x with
-  | `Simple_stmt_exp x -> map_expression env x
-  | `Simple_stmt_send_stmt x -> map_send_statement env x
+  | `Simple_stmt_exp x -> expression env x
+  | `Simple_stmt_send_stmt x -> send_statement env x
   | `Simple_stmt_inc_stmt (v1, v2) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "++" *) in
       todo env (v1, v2)
   | `Simple_stmt_dec_stmt (v1, v2) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "--" *) in
       todo env (v1, v2)
   | `Simple_stmt_assign_stmt (v1, v2, v3) ->
-      let v1 = map_expression_list env v1 in
+      let v1 = expression_list env v1 in
       let v2 =
         (match v2 with
         | `STAREQ tok -> token env tok (* "*=" *)
@@ -850,28 +850,28 @@ and map_simple_statement (env : env) (x : CST.simple_statement) =
         | `EQ tok -> token env tok (* "=" *)
         )
       in
-      let v3 = map_expression_list env v3 in
+      let v3 = expression_list env v3 in
       todo env (v1, v2, v3)
   | `Simple_stmt_short_var_decl (v1, v2, v3) ->
-      let v1 = map_expression_list env v1 in
+      let v1 = expression_list env v1 in
       let v2 = token env v2 (* ":=" *) in
-      let v3 = map_expression_list env v3 in
+      let v3 = expression_list env v3 in
       todo env (v1, v2, v3)
   )
 
 
-and map_send_statement (env : env) ((v1, v2, v3) : CST.send_statement) =
-  let v1 = map_expression env v1 in
+and send_statement (env : env) ((v1, v2, v3) : CST.send_statement) =
+  let v1 = expression env v1 in
   let v2 = token env v2 (* "<-" *) in
-  let v3 = map_expression env v3 in
+  let v3 = expression env v3 in
   todo env (v1, v2, v3)
 
 
-and map_receive_statement (env : env) ((v1, v2) : CST.receive_statement) =
+and receive_statement (env : env) ((v1, v2) : CST.receive_statement) =
   let v1 =
     (match v1 with
     | Some (v1, v2) ->
-        let v1 = map_expression_list env v1 in
+        let v1 = expression_list env v1 in
         let v2 =
           (match v2 with
           | `EQ tok -> token env tok (* "=" *)
@@ -881,30 +881,30 @@ and map_receive_statement (env : env) ((v1, v2) : CST.receive_statement) =
         todo env (v1, v2)
     | None -> todo env ())
   in
-  let v2 = map_expression env v2 in
+  let v2 = expression env v2 in
   todo env (v1, v2)
 
 
-and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
+and if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
   let v1 = token env v1 (* "if" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2) ->
-        let v1 = map_simple_statement env v1 in
+        let v1 = simple_statement env v1 in
         let v2 = token env v2 (* ";" *) in
         todo env (v1, v2)
     | None -> todo env ())
   in
-  let v3 = map_expression env v3 in
-  let v4 = map_block env v4 in
+  let v3 = expression env v3 in
+  let v4 = block env v4 in
   let v5 =
     (match v5 with
     | Some (v1, v2) ->
         let v1 = token env v1 (* "else" *) in
         let v2 =
           (match v2 with
-          | `Blk x -> map_block env x
-          | `If_stmt x -> map_if_statement env x
+          | `Blk x -> block env x
+          | `If_stmt x -> if_statement env x
           )
         in
         todo env (v1, v2)
@@ -913,32 +913,32 @@ and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
   todo env (v1, v2, v3, v4, v5)
 
 
-and map_for_clause (env : env) ((v1, v2, v3, v4, v5) : CST.for_clause) =
+and for_clause (env : env) ((v1, v2, v3, v4, v5) : CST.for_clause) =
   let v1 =
     (match v1 with
-    | Some x -> map_simple_statement env x
+    | Some x -> simple_statement env x
     | None -> todo env ())
   in
   let v2 = token env v2 (* ";" *) in
   let v3 =
     (match v3 with
-    | Some x -> map_expression env x
+    | Some x -> expression env x
     | None -> todo env ())
   in
   let v4 = token env v4 (* ";" *) in
   let v5 =
     (match v5 with
-    | Some x -> map_simple_statement env x
+    | Some x -> simple_statement env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4, v5)
 
 
-and map_range_clause (env : env) ((v1, v2, v3) : CST.range_clause) =
+and range_clause (env : env) ((v1, v2, v3) : CST.range_clause) =
   let v1 =
     (match v1 with
     | Some (v1, v2) ->
-        let v1 = map_expression_list env v1 in
+        let v1 = expression_list env v1 in
         let v2 =
           (match v2 with
           | `EQ tok -> token env tok (* "=" *)
@@ -949,38 +949,38 @@ and map_range_clause (env : env) ((v1, v2, v3) : CST.range_clause) =
     | None -> todo env ())
   in
   let v2 = token env v2 (* "range" *) in
-  let v3 = map_expression env v3 in
+  let v3 = expression env v3 in
   todo env (v1, v2, v3)
 
 
-and map_expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
+and expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
   let v1 = token env v1 (* "case" *) in
-  let v2 = map_expression_list env v2 in
+  let v2 = expression_list env v2 in
   let v3 = token env v3 (* ":" *) in
   let v4 =
     (match v4 with
-    | Some x -> map_statement_list env x
+    | Some x -> statement_list env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4)
 
 
-and map_default_case (env : env) ((v1, v2, v3) : CST.default_case) =
+and default_case (env : env) ((v1, v2, v3) : CST.default_case) =
   let v1 = token env v1 (* "default" *) in
   let v2 = token env v2 (* ":" *) in
   let v3 =
     (match v3 with
-    | Some x -> map_statement_list env x
+    | Some x -> statement_list env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3)
 
 
-and map_type_switch_header (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.type_switch_header) =
+and type_switch_header (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.type_switch_header) =
   let v1 =
     (match v1 with
     | Some (v1, v2) ->
-        let v1 = map_simple_statement env v1 in
+        let v1 = simple_statement env v1 in
         let v2 = token env v2 (* ";" *) in
         todo env (v1, v2)
     | None -> todo env ())
@@ -988,12 +988,12 @@ and map_type_switch_header (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.type_
   let v2 =
     (match v2 with
     | Some (v1, v2) ->
-        let v1 = map_expression_list env v1 in
+        let v1 = expression_list env v1 in
         let v2 = token env v2 (* ":=" *) in
         todo env (v1, v2)
     | None -> todo env ())
   in
-  let v3 = map_expression env v3 in
+  let v3 = expression env v3 in
   let v4 = token env v4 (* "." *) in
   let v5 = token env v5 (* "(" *) in
   let v6 = token env v6 (* "type" *) in
@@ -1001,12 +1001,12 @@ and map_type_switch_header (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.type_
   todo env (v1, v2, v3, v4, v5, v6, v7)
 
 
-and map_type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
+and type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
   let v1 = token env v1 (* "case" *) in
   let v2 =
     (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   let v3 =
@@ -1014,8 +1014,8 @@ and map_type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
       let v1 = token env v1 (* "," *) in
       let v2 =
         (match v2 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Simple_type x -> simple_type env x
+        | `Paren_type x -> parenthesized_type env x
         )
       in
       todo env (v1, v2)
@@ -1024,30 +1024,30 @@ and map_type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
   let v4 = token env v4 (* ":" *) in
   let v5 =
     (match v5 with
-    | Some x -> map_statement_list env x
+    | Some x -> statement_list env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4, v5)
 
 
-and map_communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
+and communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
   let v1 = token env v1 (* "case" *) in
   let v2 =
     (match v2 with
-    | `Send_stmt x -> map_send_statement env x
-    | `Rece_stmt x -> map_receive_statement env x
+    | `Send_stmt x -> send_statement env x
+    | `Rece_stmt x -> receive_statement env x
     )
   in
   let v3 = token env v3 (* ":" *) in
   let v4 =
     (match v4 with
-    | Some x -> map_statement_list env x
+    | Some x -> statement_list env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4)
 
 
-and map_expression (env : env) (x : CST.expression) =
+and expression (env : env) (x : CST.expression) =
   (match x with
   | `Exp_un_exp (v1, v2) ->
       let v1 =
@@ -1061,62 +1061,62 @@ and map_expression (env : env) (x : CST.expression) =
         | `LTDASH tok -> token env tok (* "<-" *)
         )
       in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
-  | `Exp_bin_exp x -> map_binary_expression env x
+  | `Exp_bin_exp x -> binary_expression env x
   | `Exp_sele_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "." *) in
       let v3 = token env v3 (* identifier *) in
       todo env (v1, v2, v3)
   | `Exp_index_exp (v1, v2, v3, v4) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "[" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       let v4 = token env v4 (* "]" *) in
       todo env (v1, v2, v3, v4)
   | `Exp_slice_exp (v1, v2, v3, v4) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "[" *) in
       let v3 =
         (match v3 with
         | `Opt_exp_COLON_opt_exp (v1, v2, v3) ->
             let v1 =
               (match v1 with
-              | Some x -> map_expression env x
+              | Some x -> expression env x
               | None -> todo env ())
             in
             let v2 = token env v2 (* ":" *) in
             let v3 =
               (match v3 with
-              | Some x -> map_expression env x
+              | Some x -> expression env x
               | None -> todo env ())
             in
             todo env (v1, v2, v3)
         | `Opt_exp_COLON_exp_COLON_exp (v1, v2, v3, v4, v5) ->
             let v1 =
               (match v1 with
-              | Some x -> map_expression env x
+              | Some x -> expression env x
               | None -> todo env ())
             in
             let v2 = token env v2 (* ":" *) in
-            let v3 = map_expression env v3 in
+            let v3 = expression env v3 in
             let v4 = token env v4 (* ":" *) in
-            let v5 = map_expression env v5 in
+            let v5 = expression env v5 in
             todo env (v1, v2, v3, v4, v5)
         )
       in
       let v4 = token env v4 (* "]" *) in
       todo env (v1, v2, v3, v4)
-  | `Exp_call_exp x -> map_call_expression env x
+  | `Exp_call_exp x -> call_expression env x
   | `Exp_type_asse_exp (v1, v2, v3, v4, v5) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "." *) in
       let v3 = token env v3 (* "(" *) in
       let v4 =
         (match v4 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Simple_type x -> simple_type env x
+        | `Paren_type x -> parenthesized_type env x
         )
       in
       let v5 = token env v5 (* ")" *) in
@@ -1124,12 +1124,12 @@ and map_expression (env : env) (x : CST.expression) =
   | `Exp_type_conv_exp (v1, v2, v3, v4, v5) ->
       let v1 =
         (match v1 with
-        | `Simple_type x -> map_simple_type env x
-        | `Paren_type x -> map_parenthesized_type env x
+        | `Simple_type x -> simple_type env x
+        | `Paren_type x -> parenthesized_type env x
         )
       in
       let v2 = token env v2 (* "(" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       let v4 =
         (match v4 with
         | Some tok -> token env tok (* "," *)
@@ -1146,36 +1146,36 @@ and map_expression (env : env) (x : CST.expression) =
   | `Exp_comp_lit (v1, v2) ->
       let v1 =
         (match v1 with
-        | `Map_type x -> map_map_type env x
-        | `Slice_type x -> map_slice_type env x
-        | `Array_type x -> map_array_type env x
+        | `Map_type x -> map_type env x
+        | `Slice_type x -> slice_type env x
+        | `Array_type x -> array_type env x
         | `Impl_len_array_type x ->
-            map_implicit_length_array_type env x
-        | `Stru_type x -> map_struct_type env x
+            implicit_length_array_type env x
+        | `Stru_type x -> struct_type env x
         | `Id tok -> token env tok (* identifier *)
-        | `Qual_type x -> map_qualified_type env x
+        | `Qual_type x -> qualified_type env x
         )
       in
-      let v2 = map_literal_value env v2 in
+      let v2 = literal_value env v2 in
       todo env (v1, v2)
   | `Exp_func_lit (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "func" *) in
-      let v2 = map_parameter_list env v2 in
+      let v2 = parameter_list env v2 in
       let v3 =
         (match v3 with
         | Some x ->
             (match x with
-            | `Param_list x -> map_parameter_list env x
-            | `Simple_type x -> map_simple_type env x
+            | `Param_list x -> parameter_list env x
+            | `Simple_type x -> simple_type env x
             )
         | None -> todo env ())
       in
-      let v4 = map_block env v4 in
+      let v4 = block env v4 in
       todo env (v1, v2, v3, v4)
   | `Exp_choice_raw_str_lit x ->
       (match x with
       | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
-      | `Inte_str_lit x -> map_interpreted_string_literal env x
+      | `Inte_str_lit x -> interpreted_string_literal env x
       )
   | `Exp_int_lit tok -> token env tok (* int_literal *)
   | `Exp_float_lit tok -> token env tok (* float_literal *)
@@ -1186,13 +1186,13 @@ and map_expression (env : env) (x : CST.expression) =
   | `Exp_false tok -> token env tok (* "false" *)
   | `Exp_paren_exp (v1, v2, v3) ->
       let v1 = token env v1 (* "(" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       let v3 = token env v3 (* ")" *) in
       todo env (v1, v2, v3)
   )
 
 
-and map_call_expression (env : env) (x : CST.call_expression) =
+and call_expression (env : env) (x : CST.call_expression) =
   (match x with
   | `Choice_new_spec_arg_list (v1, v2) ->
       let v1 =
@@ -1201,33 +1201,33 @@ and map_call_expression (env : env) (x : CST.call_expression) =
         | `Make tok -> token env tok (* "make" *)
         )
       in
-      let v2 = map_special_argument_list env v2 in
+      let v2 = special_argument_list env v2 in
       todo env (v1, v2)
   | `Exp_arg_list (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = map_argument_list env v2 in
+      let v1 = expression env v1 in
+      let v2 = argument_list env v2 in
       todo env (v1, v2)
   )
 
 
-and map_variadic_argument (env : env) ((v1, v2) : CST.variadic_argument) =
-  let v1 = map_expression env v1 in
+and variadic_argument (env : env) ((v1, v2) : CST.variadic_argument) =
+  let v1 = expression env v1 in
   let v2 = token env v2 (* "..." *) in
   todo env (v1, v2)
 
 
-and map_special_argument_list (env : env) ((v1, v2, v3, v4, v5) : CST.special_argument_list) =
+and special_argument_list (env : env) ((v1, v2, v3, v4, v5) : CST.special_argument_list) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
-    | `Simple_type x -> map_simple_type env x
-    | `Paren_type x -> map_parenthesized_type env x
+    | `Simple_type x -> simple_type env x
+    | `Paren_type x -> parenthesized_type env x
     )
   in
   let v3 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
     ) v3
   in
@@ -1240,15 +1240,15 @@ and map_special_argument_list (env : env) ((v1, v2, v3, v4, v5) : CST.special_ar
   todo env (v1, v2, v3, v4, v5)
 
 
-and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
+and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
         let v1 =
           (match v1 with
-          | `Exp x -> map_expression env x
-          | `Vari_arg x -> map_variadic_argument env x
+          | `Exp x -> expression env x
+          | `Vari_arg x -> variadic_argument env x
           )
         in
         let v2 =
@@ -1256,8 +1256,8 @@ and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
             let v1 = token env v1 (* "," *) in
             let v2 =
               (match v2 with
-              | `Exp x -> map_expression env x
-              | `Vari_arg x -> map_variadic_argument env x
+              | `Exp x -> expression env x
+              | `Vari_arg x -> variadic_argument env x
               )
             in
             todo env (v1, v2)
@@ -1275,15 +1275,15 @@ and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
   todo env (v1, v2, v3)
 
 
-and map_literal_value (env : env) ((v1, v2, v3) : CST.literal_value) =
+and literal_value (env : env) ((v1, v2, v3) : CST.literal_value) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
         let v1 =
           (match v1 with
-          | `Elem x -> map_element env x
-          | `Keyed_elem x -> map_keyed_element env x
+          | `Elem x -> element env x
+          | `Keyed_elem x -> keyed_element env x
           )
         in
         let v2 =
@@ -1291,8 +1291,8 @@ and map_literal_value (env : env) ((v1, v2, v3) : CST.literal_value) =
             let v1 = token env v1 (* "," *) in
             let v2 =
               (match v2 with
-              | `Elem x -> map_element env x
-              | `Keyed_elem x -> map_keyed_element env x
+              | `Elem x -> element env x
+              | `Keyed_elem x -> keyed_element env x
               )
             in
             todo env (v1, v2)
@@ -1310,15 +1310,15 @@ and map_literal_value (env : env) ((v1, v2, v3) : CST.literal_value) =
   todo env (v1, v2, v3)
 
 
-and map_keyed_element (env : env) ((v1, v2) : CST.keyed_element) =
+and keyed_element (env : env) ((v1, v2) : CST.keyed_element) =
   let v1 =
     (match v1 with
     | `Exp_COLON (v1, v2) ->
-        let v1 = map_expression env v1 in
+        let v1 = expression env v1 in
         let v2 = token env v2 (* ":" *) in
         todo env (v1, v2)
     | `Lit_value_COLON (v1, v2) ->
-        let v1 = map_literal_value env v1 in
+        let v1 = literal_value env v1 in
         let v2 = token env v2 (* ":" *) in
         todo env (v1, v2)
     | `Id_COLON (v1, v2) ->
@@ -1329,24 +1329,24 @@ and map_keyed_element (env : env) ((v1, v2) : CST.keyed_element) =
   in
   let v2 =
     (match v2 with
-    | `Exp x -> map_expression env x
-    | `Lit_value x -> map_literal_value env x
+    | `Exp x -> expression env x
+    | `Lit_value x -> literal_value env x
     )
   in
   todo env (v1, v2)
 
 
-and map_element (env : env) (x : CST.element) =
+and element (env : env) (x : CST.element) =
   (match x with
-  | `Elem_exp x -> map_expression env x
-  | `Elem_lit_value x -> map_literal_value env x
+  | `Elem_exp x -> expression env x
+  | `Elem_lit_value x -> literal_value env x
   )
 
 
-and map_binary_expression (env : env) (x : CST.binary_expression) =
+and binary_expression (env : env) (x : CST.binary_expression) =
   (match x with
   | `Bin_exp_exp_choice_STAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 =
         (match v2 with
         | `STAR tok -> token env tok (* "*" *)
@@ -1358,10 +1358,10 @@ and map_binary_expression (env : env) (x : CST.binary_expression) =
         | `AMPHAT tok -> token env tok (* "&^" *)
         )
       in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Bin_exp_exp_choice_PLUS_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 =
         (match v2 with
         | `PLUS tok -> token env tok (* "+" *)
@@ -1370,10 +1370,10 @@ and map_binary_expression (env : env) (x : CST.binary_expression) =
         | `HAT tok -> token env tok (* "^" *)
         )
       in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Bin_exp_exp_choice_EQEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 =
         (match v2 with
         | `EQEQ tok -> token env tok (* "==" *)
@@ -1384,25 +1384,25 @@ and map_binary_expression (env : env) (x : CST.binary_expression) =
         | `GTEQ tok -> token env tok (* ">=" *)
         )
       in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Bin_exp_exp_AMPAMP_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "&&" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Bin_exp_exp_BARBAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "||" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   )
 
-let map_import_spec_list (env : env) ((v1, v2, v3) : CST.import_spec_list) =
+let import_spec_list (env : env) ((v1, v2, v3) : CST.import_spec_list) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     List.map (fun (v1, v2) ->
-      let v1 = map_import_spec env v1 in
+      let v1 = import_spec env v1 in
       let v2 =
         (match v2 with
         | `LF tok -> token env tok (* "\n" *)
@@ -1415,62 +1415,62 @@ let map_import_spec_list (env : env) ((v1, v2, v3) : CST.import_spec_list) =
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-let map_method_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.method_declaration) =
+let method_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.method_declaration) =
   let v1 = token env v1 (* "func" *) in
-  let v2 = map_parameter_list env v2 in
+  let v2 = parameter_list env v2 in
   let v3 = token env v3 (* identifier *) in
-  let v4 = map_parameter_list env v4 in
+  let v4 = parameter_list env v4 in
   let v5 =
     (match v5 with
     | Some x ->
         (match x with
-        | `Param_list x -> map_parameter_list env x
-        | `Simple_type x -> map_simple_type env x
+        | `Param_list x -> parameter_list env x
+        | `Simple_type x -> simple_type env x
         )
     | None -> todo env ())
   in
   let v6 =
     (match v6 with
-    | Some x -> map_block env x
+    | Some x -> block env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4, v5, v6)
 
-let map_function_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.function_declaration) =
+let function_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.function_declaration) =
   let v1 = token env v1 (* "func" *) in
   let v2 = token env v2 (* identifier *) in
-  let v3 = map_parameter_list env v3 in
+  let v3 = parameter_list env v3 in
   let v4 =
     (match v4 with
     | Some x ->
         (match x with
-        | `Param_list x -> map_parameter_list env x
-        | `Simple_type x -> map_simple_type env x
+        | `Param_list x -> parameter_list env x
+        | `Simple_type x -> simple_type env x
         )
     | None -> todo env ())
   in
   let v5 =
     (match v5 with
-    | Some x -> map_block env x
+    | Some x -> block env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3, v4, v5)
 
-let map_import_declaration (env : env) ((v1, v2) : CST.import_declaration) =
+let import_declaration (env : env) ((v1, v2) : CST.import_declaration) =
   let v1 = token env v1 (* "import" *) in
   let v2 =
     (match v2 with
-    | `Impo_spec x -> map_import_spec env x
-    | `Impo_spec_list x -> map_import_spec_list env x
+    | `Impo_spec x -> import_spec env x
+    | `Impo_spec_list x -> import_spec_list env x
     )
   in
   todo env (v1, v2)
 
-let map_source_file (env : env) (xs : CST.source_file) =
+let source_file (env : env) (xs : CST.source_file) =
   List.map (fun x ->
     (match x with
     | `Stmt_choice_LF (v1, v2) ->
-        let v1 = map_statement env v1 in
+        let v1 = statement env v1 in
         let v2 =
           (match v2 with
           | `LF tok -> token env tok (* "\n" *)
@@ -1481,10 +1481,10 @@ let map_source_file (env : env) (xs : CST.source_file) =
     | `Choice_pack_clau_opt_choice_LF (v1, v2) ->
         let v1 =
           (match v1 with
-          | `Pack_clau x -> map_package_clause env x
-          | `Func_decl x -> map_function_declaration env x
-          | `Meth_decl x -> map_method_declaration env x
-          | `Impo_decl x -> map_import_declaration env x
+          | `Pack_clau x -> package_clause env x
+          | `Func_decl x -> function_declaration env x
+          | `Meth_decl x -> method_declaration env x
+          | `Impo_decl x -> import_declaration env x
           )
         in
         let v2 =

--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -1,0 +1,1501 @@
+module CST = Tree_sitter_go.CST
+[@@@warning "-32"]
+
+let parse _file =
+  raise Common.Todo
+
+(* This was started by copying ocaml-tree-sitter-lang/go/.../Boilerplate.ml *)
+(**
+   Boilerplate to be used as a template when mapping the go CST
+   to another type of tree.
+*)
+
+(* Disable warnings against unused variables *)
+[@@@warning "-26-27"]
+
+(* Disable warning against unused 'rec' *)
+[@@@warning "-39"]
+
+
+type env = unit
+
+let token (env : env) (_tok : Tree_sitter_run.Token.t) =
+  failwith "not implemented"
+
+let blank (env : env) () =
+  failwith "not implemented"
+
+let todo (env : env) _ =
+   failwith "not implemented"
+
+let map_int_literal (env : env) (tok : CST.int_literal) =
+  token env tok (* int_literal *)
+
+let map_identifier (env : env) (tok : CST.identifier) =
+  token env tok (* identifier *)
+
+let map_raw_string_literal (env : env) (tok : CST.raw_string_literal) =
+  token env tok (* raw_string_literal *)
+
+let map_rune_literal (env : env) (tok : CST.rune_literal) =
+  token env tok (* rune_literal *)
+
+let map_float_literal (env : env) (tok : CST.float_literal) =
+  token env tok (* float_literal *)
+
+let map_imaginary_literal (env : env) (tok : CST.imaginary_literal) =
+  token env tok (* imaginary_literal *)
+
+let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
+  token env tok (* escape_sequence *)
+
+let map_qualified_type (env : env) ((v1, v2, v3) : CST.qualified_type) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+let map_package_clause (env : env) ((v1, v2) : CST.package_clause) =
+  let v1 = token env v1 (* "package" *) in
+  let v2 = token env v2 (* identifier *) in
+  todo env (v1, v2)
+
+let map_empty_labeled_statement (env : env) ((v1, v2) : CST.empty_labeled_statement) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 = token env v2 (* ":" *) in
+  todo env (v1, v2)
+
+let map_interpreted_string_literal (env : env) ((v1, v2, v3) : CST.interpreted_string_literal) =
+  let v1 = token env v1 (* "\"" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Blank () -> todo env ()
+      | `Esc_seq tok -> token env tok (* escape_sequence *)
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "\"" *) in
+  todo env (v1, v2, v3)
+
+let map_import_spec (env : env) ((v1, v2) : CST.import_spec) =
+  let v1 =
+    (match v1 with
+    | Some x ->
+        (match x with
+        | `Dot tok -> token env tok (* "." *)
+        | `Blank_id tok -> token env tok (* "_" *)
+        | `Id tok -> token env tok (* identifier *)
+        )
+    | None -> todo env ())
+  in
+  let v2 =
+    (match v2 with
+    | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
+    | `Inte_str_lit x -> map_interpreted_string_literal env x
+    )
+  in
+  todo env (v1, v2)
+
+let rec map_declaration (env : env) (x : CST.declaration) =
+  (match x with
+  | `Decl_const_decl (v1, v2) ->
+      let v1 = token env v1 (* "const" *) in
+      let v2 =
+        (match v2 with
+        | `Const_spec x -> map_const_spec env x
+        | `LPAR_rep_const_spec_choice_LF_RPAR (v1, v2, v3) ->
+            let v1 = token env v1 (* "(" *) in
+            let v2 =
+              List.map (fun (v1, v2) ->
+                let v1 = map_const_spec env v1 in
+                let v2 =
+                  (match v2 with
+                  | `LF tok -> token env tok (* "\n" *)
+                  | `SEMI tok -> token env tok (* ";" *)
+                  )
+                in
+                todo env (v1, v2)
+              ) v2
+            in
+            let v3 = token env v3 (* ")" *) in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2)
+  | `Decl_type_decl (v1, v2) ->
+      let v1 = token env v1 (* "type" *) in
+      let v2 =
+        (match v2 with
+        | `Type_spec x -> map_type_spec env x
+        | `Type_alias x -> map_type_alias env x
+        | `LPAR_rep_choice_type_spec_choice_LF_RPAR (v1, v2, v3) ->
+            let v1 = token env v1 (* "(" *) in
+            let v2 =
+              List.map (fun (v1, v2) ->
+                let v1 =
+                  (match v1 with
+                  | `Type_spec x -> map_type_spec env x
+                  | `Type_alias x -> map_type_alias env x
+                  )
+                in
+                let v2 =
+                  (match v2 with
+                  | `LF tok -> token env tok (* "\n" *)
+                  | `SEMI tok -> token env tok (* ";" *)
+                  )
+                in
+                todo env (v1, v2)
+              ) v2
+            in
+            let v3 = token env v3 (* ")" *) in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2)
+  | `Decl_var_decl (v1, v2) ->
+      let v1 = token env v1 (* "var" *) in
+      let v2 =
+        (match v2 with
+        | `Var_spec x -> map_var_spec env x
+        | `LPAR_rep_var_spec_choice_LF_RPAR (v1, v2, v3) ->
+            let v1 = token env v1 (* "(" *) in
+            let v2 =
+              List.map (fun (v1, v2) ->
+                let v1 = map_var_spec env v1 in
+                let v2 =
+                  (match v2 with
+                  | `LF tok -> token env tok (* "\n" *)
+                  | `SEMI tok -> token env tok (* ";" *)
+                  )
+                in
+                todo env (v1, v2)
+              ) v2
+            in
+            let v3 = token env v3 (* ")" *) in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2)
+  )
+
+
+and map_const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = token env v2 (* identifier *) in
+      todo env (v1, v2)
+    ) v2
+  in
+  let v3 =
+    (match v3 with
+    | Some (v1, v2, v3) ->
+        let v1 =
+          (match v1 with
+          | Some x ->
+              (match x with
+              | `Simple_type x -> map_simple_type env x
+              | `Paren_type x -> map_parenthesized_type env x
+              )
+          | None -> todo env ())
+        in
+        let v2 = token env v2 (* "=" *) in
+        let v3 = map_expression_list env v3 in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+
+and map_var_spec (env : env) ((v1, v2, v3) : CST.var_spec) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = token env v2 (* identifier *) in
+      todo env (v1, v2)
+    ) v2
+  in
+  let v3 =
+    (match v3 with
+    | `Choice_simple_type_opt_EQ_exp_list (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | `Simple_type x -> map_simple_type env x
+          | `Paren_type x -> map_parenthesized_type env x
+          )
+        in
+        let v2 =
+          (match v2 with
+          | Some (v1, v2) ->
+              let v1 = token env v1 (* "=" *) in
+              let v2 = map_expression_list env v2 in
+              todo env (v1, v2)
+          | None -> todo env ())
+        in
+        todo env (v1, v2)
+    | `EQ_exp_list (v1, v2) ->
+        let v1 = token env v1 (* "=" *) in
+        let v2 = map_expression_list env v2 in
+        todo env (v1, v2)
+    )
+  in
+  todo env (v1, v2, v3)
+
+
+and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | Some (v1, v2) ->
+              let v1 =
+                (match v1 with
+                | `Param_decl x -> map_parameter_declaration env x
+                | `Vari_param_decl x ->
+                    map_variadic_parameter_declaration env x
+                )
+              in
+              let v2 =
+                List.map (fun (v1, v2) ->
+                  let v1 = token env v1 (* "," *) in
+                  let v2 =
+                    (match v2 with
+                    | `Param_decl x -> map_parameter_declaration env x
+                    | `Vari_param_decl x ->
+                        map_variadic_parameter_declaration env x
+                    )
+                  in
+                  todo env (v1, v2)
+                ) v2
+              in
+              todo env (v1, v2)
+          | None -> todo env ())
+        in
+        let v2 =
+          (match v2 with
+          | Some tok -> token env tok (* "," *)
+          | None -> todo env ())
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+
+and map_parameter_declaration (env : env) ((v1, v2) : CST.parameter_declaration) =
+  let v1 =
+    (match v1 with
+    | Some (v1, v2) ->
+        let v1 = token env v1 (* identifier *) in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = token env v2 (* identifier *) in
+            todo env (v1, v2)
+          ) v2
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v2 =
+    (match v2 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2)
+
+
+and map_variadic_parameter_declaration (env : env) ((v1, v2, v3) : CST.variadic_parameter_declaration) =
+  let v1 =
+    (match v1 with
+    | Some tok -> token env tok (* identifier *)
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "..." *) in
+  let v3 =
+    (match v3 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2, v3)
+
+
+and map_type_alias (env : env) ((v1, v2, v3) : CST.type_alias) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 = token env v2 (* "=" *) in
+  let v3 =
+    (match v3 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2, v3)
+
+
+and map_type_spec (env : env) ((v1, v2) : CST.type_spec) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 =
+    (match v2 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2)
+
+
+and map_expression_list (env : env) ((v1, v2) : CST.expression_list) =
+  let v1 = map_expression env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+
+and map_parenthesized_type (env : env) ((v1, v2, v3) : CST.parenthesized_type) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+
+and map_simple_type (env : env) (x : CST.simple_type) =
+  (match x with
+  | `Simple_type_id tok -> token env tok (* identifier *)
+  | `Simple_type_qual_type x -> map_qualified_type env x
+  | `Simple_type_poin_type (v1, v2) ->
+      let v1 = token env v1 (* "*" *) in
+      let v2 =
+        (match v2 with
+        | `Simple_type x -> map_simple_type env x
+        | `Paren_type x -> map_parenthesized_type env x
+        )
+      in
+      todo env (v1, v2)
+  | `Simple_type_stru_type x -> map_struct_type env x
+  | `Simple_type_inte_type (v1, v2) ->
+      let v1 = token env v1 (* "interface" *) in
+      let v2 = map_method_spec_list env v2 in
+      todo env (v1, v2)
+  | `Simple_type_array_type x -> map_array_type env x
+  | `Simple_type_slice_type x -> map_slice_type env x
+  | `Simple_type_map_type x -> map_map_type env x
+  | `Simple_type_chan_type x -> map_channel_type env x
+  | `Simple_type_func_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "func" *) in
+      let v2 = map_parameter_list env v2 in
+      let v3 =
+        (match v3 with
+        | Some x ->
+            (match x with
+            | `Param_list x -> map_parameter_list env x
+            | `Simple_type x -> map_simple_type env x
+            )
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  )
+
+
+and map_array_type (env : env) ((v1, v2, v3, v4) : CST.array_type) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 = map_expression env v2 in
+  let v3 = token env v3 (* "]" *) in
+  let v4 =
+    (match v4 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2, v3, v4)
+
+
+and map_implicit_length_array_type (env : env) ((v1, v2, v3, v4) : CST.implicit_length_array_type) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 = token env v2 (* "..." *) in
+  let v3 = token env v3 (* "]" *) in
+  let v4 =
+    (match v4 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2, v3, v4)
+
+
+and map_slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 = token env v2 (* "]" *) in
+  let v3 =
+    (match v3 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2, v3)
+
+
+and map_struct_type (env : env) ((v1, v2) : CST.struct_type) =
+  let v1 = token env v1 (* "struct" *) in
+  let v2 = map_field_declaration_list env v2 in
+  todo env (v1, v2)
+
+
+and map_field_declaration_list (env : env) ((v1, v2, v3) : CST.field_declaration_list) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 = map_field_declaration env v1 in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 =
+              (match v1 with
+              | `LF tok -> token env tok (* "\n" *)
+              | `SEMI tok -> token env tok (* ";" *)
+              )
+            in
+            let v2 = map_field_declaration env v2 in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | Some x ->
+              (match x with
+              | `LF tok -> token env tok (* "\n" *)
+              | `SEMI tok -> token env tok (* ";" *)
+              )
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+
+and map_field_declaration (env : env) ((v1, v2) : CST.field_declaration) =
+  let v1 =
+    (match v1 with
+    | `Id_rep_COMMA_id_choice_simple_type (v1, v2, v3) ->
+        let v1 = token env v1 (* identifier *) in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = token env v2 (* identifier *) in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | `Simple_type x -> map_simple_type env x
+          | `Paren_type x -> map_parenthesized_type env x
+          )
+        in
+        todo env (v1, v2, v3)
+    | `Opt_STAR_choice_id (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | Some tok -> token env tok (* "*" *)
+          | None -> todo env ())
+        in
+        let v2 =
+          (match v2 with
+          | `Id tok -> token env tok (* identifier *)
+          | `Qual_type x -> map_qualified_type env x
+          )
+        in
+        todo env (v1, v2)
+    )
+  in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        (match x with
+        | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
+        | `Inte_str_lit x -> map_interpreted_string_literal env x
+        )
+    | None -> todo env ())
+  in
+  todo env (v1, v2)
+
+
+and map_method_spec_list (env : env) ((v1, v2, v3) : CST.method_spec_list) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 =
+          (match v1 with
+          | `Id tok -> token env tok (* identifier *)
+          | `Qual_type x -> map_qualified_type env x
+          | `Meth_spec x -> map_method_spec env x
+          )
+        in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 =
+              (match v1 with
+              | `LF tok -> token env tok (* "\n" *)
+              | `SEMI tok -> token env tok (* ";" *)
+              )
+            in
+            let v2 =
+              (match v2 with
+              | `Id tok -> token env tok (* identifier *)
+              | `Qual_type x -> map_qualified_type env x
+              | `Meth_spec x -> map_method_spec env x
+              )
+            in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | Some x ->
+              (match x with
+              | `LF tok -> token env tok (* "\n" *)
+              | `SEMI tok -> token env tok (* ";" *)
+              )
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+
+and map_method_spec (env : env) ((v1, v2, v3) : CST.method_spec) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 = map_parameter_list env v2 in
+  let v3 =
+    (match v3 with
+    | Some x ->
+        (match x with
+        | `Param_list x -> map_parameter_list env x
+        | `Simple_type x -> map_simple_type env x
+        )
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+
+and map_map_type (env : env) ((v1, v2, v3, v4, v5) : CST.map_type) =
+  let v1 = token env v1 (* "map" *) in
+  let v2 = token env v2 (* "[" *) in
+  let v3 =
+    (match v3 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  let v4 = token env v4 (* "]" *) in
+  let v5 =
+    (match v5 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  todo env (v1, v2, v3, v4, v5)
+
+
+and map_channel_type (env : env) (x : CST.channel_type) =
+  (match x with
+  | `Chan_type_chan_choice_simple_type (v1, v2) ->
+      let v1 = token env v1 (* "chan" *) in
+      let v2 =
+        (match v2 with
+        | `Simple_type x -> map_simple_type env x
+        | `Paren_type x -> map_parenthesized_type env x
+        )
+      in
+      todo env (v1, v2)
+  | `Chan_type_chan_LTDASH_choice_simple_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "chan" *) in
+      let v2 = token env v2 (* "<-" *) in
+      let v3 =
+        (match v3 with
+        | `Simple_type x -> map_simple_type env x
+        | `Paren_type x -> map_parenthesized_type env x
+        )
+      in
+      todo env (v1, v2, v3)
+  | `Chan_type_LTDASH_chan_choice_simple_type (v1, v2, v3) ->
+      let v1 = token env v1 (* "<-" *) in
+      let v2 = token env v2 (* "chan" *) in
+      let v3 =
+        (match v3 with
+        | `Simple_type x -> map_simple_type env x
+        | `Paren_type x -> map_parenthesized_type env x
+        )
+      in
+      todo env (v1, v2, v3)
+  )
+
+
+and map_block (env : env) ((v1, v2, v3) : CST.block) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some x -> map_statement_list env x
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+
+and map_statement_list (env : env) (x : CST.statement_list) =
+  (match x with
+  | `Stmt_list_stmt_rep_choice_LF_stmt_opt_choice_LF_opt_empty_labe_stmt (v1, v2, v3) ->
+      let v1 = map_statement env v1 in
+      let v2 =
+        List.map (fun (v1, v2) ->
+          let v1 =
+            (match v1 with
+            | `LF tok -> token env tok (* "\n" *)
+            | `SEMI tok -> token env tok (* ";" *)
+            )
+          in
+          let v2 = map_statement env v2 in
+          todo env (v1, v2)
+        ) v2
+      in
+      let v3 =
+        (match v3 with
+        | Some (v1, v2) ->
+            let v1 =
+              (match v1 with
+              | `LF tok -> token env tok (* "\n" *)
+              | `SEMI tok -> token env tok (* ";" *)
+              )
+            in
+            let v2 =
+              (match v2 with
+              | Some x -> map_empty_labeled_statement env x
+              | None -> todo env ())
+            in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  | `Stmt_list_empty_labe_stmt x ->
+      map_empty_labeled_statement env x
+  )
+
+
+and map_statement (env : env) (x : CST.statement) =
+  (match x with
+  | `Stmt_decl x -> map_declaration env x
+  | `Stmt_simple_stmt x -> map_simple_statement env x
+  | `Stmt_ret_stmt (v1, v2) ->
+      let v1 = token env v1 (* "return" *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_expression_list env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Stmt_go_stmt (v1, v2) ->
+      let v1 = token env v1 (* "go" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Stmt_defer_stmt (v1, v2) ->
+      let v1 = token env v1 (* "defer" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Stmt_if_stmt x -> map_if_statement env x
+  | `Stmt_for_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "for" *) in
+      let v2 =
+        (match v2 with
+        | Some x ->
+            (match x with
+            | `Exp x -> map_expression env x
+            | `For_clau x -> map_for_clause env x
+            | `Range_clau x -> map_range_clause env x
+            )
+        | None -> todo env ())
+      in
+      let v3 = map_block env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_exp_swit_stmt (v1, v2, v3, v4, v5, v6) ->
+      let v1 = token env v1 (* "switch" *) in
+      let v2 =
+        (match v2 with
+        | Some (v1, v2) ->
+            let v1 = map_simple_statement env v1 in
+            let v2 = token env v2 (* ";" *) in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      let v3 =
+        (match v3 with
+        | Some x -> map_expression env x
+        | None -> todo env ())
+      in
+      let v4 = token env v4 (* "{" *) in
+      let v5 =
+        List.map (fun x ->
+          (match x with
+          | `Exp_case x -> map_expression_case env x
+          | `Defa_case x -> map_default_case env x
+          )
+        ) v5
+      in
+      let v6 = token env v6 (* "}" *) in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Stmt_type_swit_stmt (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "switch" *) in
+      let v2 = map_type_switch_header env v2 in
+      let v3 = token env v3 (* "{" *) in
+      let v4 =
+        List.map (fun x ->
+          (match x with
+          | `Type_case x -> map_type_case env x
+          | `Defa_case x -> map_default_case env x
+          )
+        ) v4
+      in
+      let v5 = token env v5 (* "}" *) in
+      todo env (v1, v2, v3, v4, v5)
+  | `Stmt_sele_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "select" *) in
+      let v2 = token env v2 (* "{" *) in
+      let v3 =
+        List.map (fun x ->
+          (match x with
+          | `Comm_case x -> map_communication_case env x
+          | `Defa_case x -> map_default_case env x
+          )
+        ) v3
+      in
+      let v4 = token env v4 (* "}" *) in
+      todo env (v1, v2, v3, v4)
+  | `Stmt_labe_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* identifier *) in
+      let v2 = token env v2 (* ":" *) in
+      let v3 = map_statement env v3 in
+      todo env (v1, v2, v3)
+  | `Stmt_fall_stmt tok -> token env tok (* "fallthrough" *)
+  | `Stmt_brk_stmt (v1, v2) ->
+      let v1 = token env v1 (* "break" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Stmt_cont_stmt (v1, v2) ->
+      let v1 = token env v1 (* "continue" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Stmt_goto_stmt (v1, v2) ->
+      let v1 = token env v1 (* "goto" *) in
+      let v2 = token env v2 (* identifier *) in
+      todo env (v1, v2)
+  | `Stmt_blk x -> map_block env x
+  | `Stmt_empty_stmt tok -> token env tok (* ";" *)
+  )
+
+
+and map_simple_statement (env : env) (x : CST.simple_statement) =
+  (match x with
+  | `Simple_stmt_exp x -> map_expression env x
+  | `Simple_stmt_send_stmt x -> map_send_statement env x
+  | `Simple_stmt_inc_stmt (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "++" *) in
+      todo env (v1, v2)
+  | `Simple_stmt_dec_stmt (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "--" *) in
+      todo env (v1, v2)
+  | `Simple_stmt_assign_stmt (v1, v2, v3) ->
+      let v1 = map_expression_list env v1 in
+      let v2 =
+        (match v2 with
+        | `STAREQ tok -> token env tok (* "*=" *)
+        | `SLASHEQ tok -> token env tok (* "/=" *)
+        | `PERCEQ tok -> token env tok (* "%=" *)
+        | `LTLTEQ tok -> token env tok (* "<<=" *)
+        | `GTGTEQ tok -> token env tok (* ">>=" *)
+        | `AMPEQ tok -> token env tok (* "&=" *)
+        | `AMPHATEQ tok -> token env tok (* "&^=" *)
+        | `PLUSEQ tok -> token env tok (* "+=" *)
+        | `DASHEQ tok -> token env tok (* "-=" *)
+        | `BAREQ tok -> token env tok (* "|=" *)
+        | `HATEQ tok -> token env tok (* "^=" *)
+        | `EQ tok -> token env tok (* "=" *)
+        )
+      in
+      let v3 = map_expression_list env v3 in
+      todo env (v1, v2, v3)
+  | `Simple_stmt_short_var_decl (v1, v2, v3) ->
+      let v1 = map_expression_list env v1 in
+      let v2 = token env v2 (* ":=" *) in
+      let v3 = map_expression_list env v3 in
+      todo env (v1, v2, v3)
+  )
+
+
+and map_send_statement (env : env) ((v1, v2, v3) : CST.send_statement) =
+  let v1 = map_expression env v1 in
+  let v2 = token env v2 (* "<-" *) in
+  let v3 = map_expression env v3 in
+  todo env (v1, v2, v3)
+
+
+and map_receive_statement (env : env) ((v1, v2) : CST.receive_statement) =
+  let v1 =
+    (match v1 with
+    | Some (v1, v2) ->
+        let v1 = map_expression_list env v1 in
+        let v2 =
+          (match v2 with
+          | `EQ tok -> token env tok (* "=" *)
+          | `COLONEQ tok -> token env tok (* ":=" *)
+          )
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
+
+
+and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
+  let v1 = token env v1 (* "if" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = map_simple_statement env v1 in
+        let v2 = token env v2 (* ";" *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = map_expression env v3 in
+  let v4 = map_block env v4 in
+  let v5 =
+    (match v5 with
+    | Some (v1, v2) ->
+        let v1 = token env v1 (* "else" *) in
+        let v2 =
+          (match v2 with
+          | `Blk x -> map_block env x
+          | `If_stmt x -> map_if_statement env x
+          )
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5)
+
+
+and map_for_clause (env : env) ((v1, v2, v3, v4, v5) : CST.for_clause) =
+  let v1 =
+    (match v1 with
+    | Some x -> map_simple_statement env x
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* ";" *) in
+  let v3 =
+    (match v3 with
+    | Some x -> map_expression env x
+    | None -> todo env ())
+  in
+  let v4 = token env v4 (* ";" *) in
+  let v5 =
+    (match v5 with
+    | Some x -> map_simple_statement env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5)
+
+
+and map_range_clause (env : env) ((v1, v2, v3) : CST.range_clause) =
+  let v1 =
+    (match v1 with
+    | Some (v1, v2) ->
+        let v1 = map_expression_list env v1 in
+        let v2 =
+          (match v2 with
+          | `EQ tok -> token env tok (* "=" *)
+          | `COLONEQ tok -> token env tok (* ":=" *)
+          )
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "range" *) in
+  let v3 = map_expression env v3 in
+  todo env (v1, v2, v3)
+
+
+and map_expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
+  let v1 = token env v1 (* "case" *) in
+  let v2 = map_expression_list env v2 in
+  let v3 = token env v3 (* ":" *) in
+  let v4 =
+    (match v4 with
+    | Some x -> map_statement_list env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4)
+
+
+and map_default_case (env : env) ((v1, v2, v3) : CST.default_case) =
+  let v1 = token env v1 (* "default" *) in
+  let v2 = token env v2 (* ":" *) in
+  let v3 =
+    (match v3 with
+    | Some x -> map_statement_list env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+
+and map_type_switch_header (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.type_switch_header) =
+  let v1 =
+    (match v1 with
+    | Some (v1, v2) ->
+        let v1 = map_simple_statement env v1 in
+        let v2 = token env v2 (* ";" *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = map_expression_list env v1 in
+        let v2 = token env v2 (* ":=" *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = map_expression env v3 in
+  let v4 = token env v4 (* "." *) in
+  let v5 = token env v5 (* "(" *) in
+  let v6 = token env v6 (* "type" *) in
+  let v7 = token env v7 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5, v6, v7)
+
+
+and map_type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
+  let v1 = token env v1 (* "case" *) in
+  let v2 =
+    (match v2 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 =
+        (match v2 with
+        | `Simple_type x -> map_simple_type env x
+        | `Paren_type x -> map_parenthesized_type env x
+        )
+      in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 = token env v4 (* ":" *) in
+  let v5 =
+    (match v5 with
+    | Some x -> map_statement_list env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5)
+
+
+and map_communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
+  let v1 = token env v1 (* "case" *) in
+  let v2 =
+    (match v2 with
+    | `Send_stmt x -> map_send_statement env x
+    | `Rece_stmt x -> map_receive_statement env x
+    )
+  in
+  let v3 = token env v3 (* ":" *) in
+  let v4 =
+    (match v4 with
+    | Some x -> map_statement_list env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4)
+
+
+and map_expression (env : env) (x : CST.expression) =
+  (match x with
+  | `Exp_un_exp (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `PLUS tok -> token env tok (* "+" *)
+        | `DASH tok -> token env tok (* "-" *)
+        | `BANG tok -> token env tok (* "!" *)
+        | `HAT tok -> token env tok (* "^" *)
+        | `STAR tok -> token env tok (* "*" *)
+        | `AMP tok -> token env tok (* "&" *)
+        | `LTDASH tok -> token env tok (* "<-" *)
+        )
+      in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Exp_bin_exp x -> map_binary_expression env x
+  | `Exp_sele_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* identifier *) in
+      todo env (v1, v2, v3)
+  | `Exp_index_exp (v1, v2, v3, v4) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "[" *) in
+      let v3 = map_expression env v3 in
+      let v4 = token env v4 (* "]" *) in
+      todo env (v1, v2, v3, v4)
+  | `Exp_slice_exp (v1, v2, v3, v4) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "[" *) in
+      let v3 =
+        (match v3 with
+        | `Opt_exp_COLON_opt_exp (v1, v2, v3) ->
+            let v1 =
+              (match v1 with
+              | Some x -> map_expression env x
+              | None -> todo env ())
+            in
+            let v2 = token env v2 (* ":" *) in
+            let v3 =
+              (match v3 with
+              | Some x -> map_expression env x
+              | None -> todo env ())
+            in
+            todo env (v1, v2, v3)
+        | `Opt_exp_COLON_exp_COLON_exp (v1, v2, v3, v4, v5) ->
+            let v1 =
+              (match v1 with
+              | Some x -> map_expression env x
+              | None -> todo env ())
+            in
+            let v2 = token env v2 (* ":" *) in
+            let v3 = map_expression env v3 in
+            let v4 = token env v4 (* ":" *) in
+            let v5 = map_expression env v5 in
+            todo env (v1, v2, v3, v4, v5)
+        )
+      in
+      let v4 = token env v4 (* "]" *) in
+      todo env (v1, v2, v3, v4)
+  | `Exp_call_exp x -> map_call_expression env x
+  | `Exp_type_asse_exp (v1, v2, v3, v4, v5) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* "(" *) in
+      let v4 =
+        (match v4 with
+        | `Simple_type x -> map_simple_type env x
+        | `Paren_type x -> map_parenthesized_type env x
+        )
+      in
+      let v5 = token env v5 (* ")" *) in
+      todo env (v1, v2, v3, v4, v5)
+  | `Exp_type_conv_exp (v1, v2, v3, v4, v5) ->
+      let v1 =
+        (match v1 with
+        | `Simple_type x -> map_simple_type env x
+        | `Paren_type x -> map_parenthesized_type env x
+        )
+      in
+      let v2 = token env v2 (* "(" *) in
+      let v3 = map_expression env v3 in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* "," *)
+        | None -> todo env ())
+      in
+      let v5 = token env v5 (* ")" *) in
+      todo env (v1, v2, v3, v4, v5)
+  | `Exp_id tok -> token env tok (* identifier *)
+  | `Exp_choice_new x ->
+      (match x with
+      | `New tok -> token env tok (* "new" *)
+      | `Make tok -> token env tok (* "make" *)
+      )
+  | `Exp_comp_lit (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `Map_type x -> map_map_type env x
+        | `Slice_type x -> map_slice_type env x
+        | `Array_type x -> map_array_type env x
+        | `Impl_len_array_type x ->
+            map_implicit_length_array_type env x
+        | `Stru_type x -> map_struct_type env x
+        | `Id tok -> token env tok (* identifier *)
+        | `Qual_type x -> map_qualified_type env x
+        )
+      in
+      let v2 = map_literal_value env v2 in
+      todo env (v1, v2)
+  | `Exp_func_lit (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "func" *) in
+      let v2 = map_parameter_list env v2 in
+      let v3 =
+        (match v3 with
+        | Some x ->
+            (match x with
+            | `Param_list x -> map_parameter_list env x
+            | `Simple_type x -> map_simple_type env x
+            )
+        | None -> todo env ())
+      in
+      let v4 = map_block env v4 in
+      todo env (v1, v2, v3, v4)
+  | `Exp_choice_raw_str_lit x ->
+      (match x with
+      | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
+      | `Inte_str_lit x -> map_interpreted_string_literal env x
+      )
+  | `Exp_int_lit tok -> token env tok (* int_literal *)
+  | `Exp_float_lit tok -> token env tok (* float_literal *)
+  | `Exp_imag_lit tok -> token env tok (* imaginary_literal *)
+  | `Exp_rune_lit tok -> token env tok (* rune_literal *)
+  | `Exp_nil tok -> token env tok (* "nil" *)
+  | `Exp_true tok -> token env tok (* "true" *)
+  | `Exp_false tok -> token env tok (* "false" *)
+  | `Exp_paren_exp (v1, v2, v3) ->
+      let v1 = token env v1 (* "(" *) in
+      let v2 = map_expression env v2 in
+      let v3 = token env v3 (* ")" *) in
+      todo env (v1, v2, v3)
+  )
+
+
+and map_call_expression (env : env) (x : CST.call_expression) =
+  (match x with
+  | `Choice_new_spec_arg_list (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `New tok -> token env tok (* "new" *)
+        | `Make tok -> token env tok (* "make" *)
+        )
+      in
+      let v2 = map_special_argument_list env v2 in
+      todo env (v1, v2)
+  | `Exp_arg_list (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = map_argument_list env v2 in
+      todo env (v1, v2)
+  )
+
+
+and map_variadic_argument (env : env) ((v1, v2) : CST.variadic_argument) =
+  let v1 = map_expression env v1 in
+  let v2 = token env v2 (* "..." *) in
+  todo env (v1, v2)
+
+
+and map_special_argument_list (env : env) ((v1, v2, v3, v4, v5) : CST.special_argument_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | `Simple_type x -> map_simple_type env x
+    | `Paren_type x -> map_parenthesized_type env x
+    )
+  in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  let v5 = token env v5 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5)
+
+
+and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 =
+          (match v1 with
+          | `Exp x -> map_expression env x
+          | `Vari_arg x -> map_variadic_argument env x
+          )
+        in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 =
+              (match v2 with
+              | `Exp x -> map_expression env x
+              | `Vari_arg x -> map_variadic_argument env x
+              )
+            in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | Some tok -> token env tok (* "," *)
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+
+and map_literal_value (env : env) ((v1, v2, v3) : CST.literal_value) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 =
+          (match v1 with
+          | `Elem x -> map_element env x
+          | `Keyed_elem x -> map_keyed_element env x
+          )
+        in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 =
+              (match v2 with
+              | `Elem x -> map_element env x
+              | `Keyed_elem x -> map_keyed_element env x
+              )
+            in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | Some tok -> token env tok (* "," *)
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+
+and map_keyed_element (env : env) ((v1, v2) : CST.keyed_element) =
+  let v1 =
+    (match v1 with
+    | `Exp_COLON (v1, v2) ->
+        let v1 = map_expression env v1 in
+        let v2 = token env v2 (* ":" *) in
+        todo env (v1, v2)
+    | `Lit_value_COLON (v1, v2) ->
+        let v1 = map_literal_value env v1 in
+        let v2 = token env v2 (* ":" *) in
+        todo env (v1, v2)
+    | `Id_COLON (v1, v2) ->
+        let v1 = token env v1 (* identifier *) in
+        let v2 = token env v2 (* ":" *) in
+        todo env (v1, v2)
+    )
+  in
+  let v2 =
+    (match v2 with
+    | `Exp x -> map_expression env x
+    | `Lit_value x -> map_literal_value env x
+    )
+  in
+  todo env (v1, v2)
+
+
+and map_element (env : env) (x : CST.element) =
+  (match x with
+  | `Elem_exp x -> map_expression env x
+  | `Elem_lit_value x -> map_literal_value env x
+  )
+
+
+and map_binary_expression (env : env) (x : CST.binary_expression) =
+  (match x with
+  | `Bin_exp_exp_choice_STAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 =
+        (match v2 with
+        | `STAR tok -> token env tok (* "*" *)
+        | `SLASH tok -> token env tok (* "/" *)
+        | `PERC tok -> token env tok (* "%" *)
+        | `LTLT tok -> token env tok (* "<<" *)
+        | `GTGT tok -> token env tok (* ">>" *)
+        | `AMP tok -> token env tok (* "&" *)
+        | `AMPHAT tok -> token env tok (* "&^" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_choice_PLUS_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 =
+        (match v2 with
+        | `PLUS tok -> token env tok (* "+" *)
+        | `DASH tok -> token env tok (* "-" *)
+        | `BAR tok -> token env tok (* "|" *)
+        | `HAT tok -> token env tok (* "^" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_choice_EQEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 =
+        (match v2 with
+        | `EQEQ tok -> token env tok (* "==" *)
+        | `BANGEQ tok -> token env tok (* "!=" *)
+        | `LT tok -> token env tok (* "<" *)
+        | `LTEQ tok -> token env tok (* "<=" *)
+        | `GT tok -> token env tok (* ">" *)
+        | `GTEQ tok -> token env tok (* ">=" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_AMPAMP_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "&&" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Bin_exp_exp_BARBAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "||" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  )
+
+let map_import_spec_list (env : env) ((v1, v2, v3) : CST.import_spec_list) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = map_import_spec env v1 in
+      let v2 =
+        (match v2 with
+        | `LF tok -> token env tok (* "\n" *)
+        | `SEMI tok -> token env tok (* ";" *)
+        )
+      in
+      todo env (v1, v2)
+    ) v2
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+let map_method_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.method_declaration) =
+  let v1 = token env v1 (* "func" *) in
+  let v2 = map_parameter_list env v2 in
+  let v3 = token env v3 (* identifier *) in
+  let v4 = map_parameter_list env v4 in
+  let v5 =
+    (match v5 with
+    | Some x ->
+        (match x with
+        | `Param_list x -> map_parameter_list env x
+        | `Simple_type x -> map_simple_type env x
+        )
+    | None -> todo env ())
+  in
+  let v6 =
+    (match v6 with
+    | Some x -> map_block env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+let map_function_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.function_declaration) =
+  let v1 = token env v1 (* "func" *) in
+  let v2 = token env v2 (* identifier *) in
+  let v3 = map_parameter_list env v3 in
+  let v4 =
+    (match v4 with
+    | Some x ->
+        (match x with
+        | `Param_list x -> map_parameter_list env x
+        | `Simple_type x -> map_simple_type env x
+        )
+    | None -> todo env ())
+  in
+  let v5 =
+    (match v5 with
+    | Some x -> map_block env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4, v5)
+
+let map_import_declaration (env : env) ((v1, v2) : CST.import_declaration) =
+  let v1 = token env v1 (* "import" *) in
+  let v2 =
+    (match v2 with
+    | `Impo_spec x -> map_import_spec env x
+    | `Impo_spec_list x -> map_import_spec_list env x
+    )
+  in
+  todo env (v1, v2)
+
+let map_source_file (env : env) (xs : CST.source_file) =
+  List.map (fun x ->
+    (match x with
+    | `Stmt_choice_LF (v1, v2) ->
+        let v1 = map_statement env v1 in
+        let v2 =
+          (match v2 with
+          | `LF tok -> token env tok (* "\n" *)
+          | `SEMI tok -> token env tok (* ";" *)
+          )
+        in
+        todo env (v1, v2)
+    | `Choice_pack_clau_opt_choice_LF (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | `Pack_clau x -> map_package_clause env x
+          | `Func_decl x -> map_function_declaration env x
+          | `Meth_decl x -> map_method_declaration env x
+          | `Impo_decl x -> map_import_declaration env x
+          )
+        in
+        let v2 =
+          (match v2 with
+          | Some x ->
+              (match x with
+              | `LF tok -> token env tok (* "\n" *)
+              | `SEMI tok -> token env tok (* ";" *)
+              )
+          | None -> todo env ())
+        in
+        todo env (v1, v2)
+    )
+  ) xs

--- a/semgrep-core/parsing/Parse_go_tree_sitter.mli
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.mli
@@ -1,0 +1,2 @@
+
+val parse: Common.filename -> Ast_go.program

--- a/semgrep-core/parsing/Parse_java_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_java_tree_sitter.ml
@@ -17,6 +17,7 @@ module CST = Tree_sitter_java.CST
 module PI = Parse_info
 (* open Ast_java *)
 module G = AST_generic
+module H = Parse_tree_sitter_helpers
 
 (*****************************************************************************)
 (* Prelude *)
@@ -50,13 +51,11 @@ module G = AST_generic
 
 [@@@warning "-32"]
 
-type env = unit
+type env = H.env
 
-let token (env : env) (_tok : Tree_sitter_run.Token.t) =
-  failwith "not implemented"
+let token (env : env) (_tok : Tree_sitter_run.Token.t) = H.token
 
-let blank (env : env) () =
-  failwith "not implemented"
+let blank (env : env) () = ()
 
 let todo (env : env) _ =
    failwith "not implemented"
@@ -2062,11 +2061,15 @@ and method_declaration (env : env) ((v1, v2, v3) : CST.method_declaration) =
 let program (env : env) (xs : CST.program) =
   List.map (statement env) xs
 
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
 
 let parse file =
-  let cst =
+  let ast =
     Parallel.backtrace_when_exn := false;
     Parallel.invoke Tree_sitter_java.Parse.file file ()
   in
-  (* TODO *)
+  let env = { H.file; conv = H.line_col_to_pos file } in
+  let _x = program env ast in
   raise Todo

--- a/semgrep-core/parsing/Test_parsing.ml
+++ b/semgrep-core/parsing/Test_parsing.ml
@@ -52,6 +52,7 @@ let test_parse_lang verbose lang get_final_files xs =
               match lang with
               | Lang.Ruby -> Tree_sitter_ruby.Parse.file file |> ignore
               | Lang.Java -> Tree_sitter_java.Parse.file file |> ignore
+              | Lang.Go   -> Tree_sitter_go.Parse.file file |> ignore
               | _ -> failwith "lang not supported by ocaml-tree-sitter"
               )
              file ()

--- a/semgrep-core/parsing/dune
+++ b/semgrep-core/parsing/dune
@@ -6,6 +6,7 @@
 
    tree-sitter-lang.ruby
    tree-sitter-lang.java
+   tree-sitter-lang.go
 
    commons commons_core
    pfff-config
@@ -13,6 +14,7 @@
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
    pfff-lang_ruby pfff-lang_ruby-analyze
    pfff-lang_java pfff-lang_java-analyze
+   pfff-lang_go pfff-lang_go-analyze
 
    semgrep_core
  )

--- a/semgrep-core/skip_list.txt
+++ b/semgrep-core/skip_list.txt
@@ -11,3 +11,6 @@ file: ocaml-tree-sitter-lang/java/lib/Parse.ml
 file: ocaml-tree-sitter-lang/typescript/lib/parser.c
 file: ocaml-tree-sitter-lang/typescript/lib/scanner.cc
 file: ocaml-tree-sitter-lang/typescript/lib/Parse.ml
+file: ocaml-tree-sitter-lang/go/lib/parser.c
+file: ocaml-tree-sitter-lang/go/lib/scanner.cc
+file: ocaml-tree-sitter-lang/go/lib/Parse.ml


### PR DESCRIPTION
This is part1 of adding support for the Go tree-sitter-based parser.
This diff just integrate the go tree-sitter library in the build system
and create a boilerplate Parse_go_tree_sitter.ml to be filled later.

Test plan:
make