### PR TITLE
Remove benchmark, don't run tests on MD changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,8 +7,6 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
     # Don't benchmark changes to markdown files
-    paths-ignore:
-      - '**.md'
 name: Incorporate Benchmark Data
 #     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 # This string is matched in `latest-artifact-for-branch.py`:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,6 @@ on:
       - "master"
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
-    # Don't benchmark changes to markdown files
 name: Incorporate Benchmark Data
 #     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 # This string is matched in `latest-artifact-for-branch.py`:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,11 +6,12 @@ on:
       - "master"
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
-  pull_request:
-    branches: ["develop"]
-
-      # This string is matched in `latest-artifact-for-branch.py`
+    # Don't benchmark changes to markdown files
+    paths-ignore:
+      - '**.md'
 name: Incorporate Benchmark Data
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+# This string is matched in `latest-artifact-for-branch.py`:
 jobs:
   build-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - develop
   pull_request:
-  paths-ignore:
-  - '**.md'
+    paths-ignore:
+    - '**.md'
 
 jobs:
   docker-build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - develop
   pull_request:
+  paths-ignore:
+  - '**.md'
 
 jobs:
   docker-build:

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -2,10 +2,11 @@ name: Env Tests
 
 on:
   pull_request:
+    paths-ignore:
+    - '**.md'
   push:
     branches: [master, develop]
-  paths-ignore:
-  - '**.md'
+  
 
 jobs:
   build-core:

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -6,8 +6,6 @@ on:
     - '**.md'
   push:
     branches: [master, develop]
-  
-
 jobs:
   build-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [master, develop]
+  paths-ignore:
+  - '**.md'
 
 jobs:
   build-core:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,10 @@ name: Tests
 
 on:
   pull_request:
+    paths-ignore:
+    - '**.md'
   push:
     branches: [master, develop]
-  paths-ignore:
-  - '**.md'
 
 jobs:
   build-core:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [master, develop]
+  paths-ignore:
+  - '**.md'
 
 jobs:
   build-core:


### PR DESCRIPTION
We can do a lot more smart filtering of what tests we run when, but this a conservative change just to test out the machinery.