### PR TITLE
Revert "Remove sdist from pypi release"

### DIFF
--- a/release-scripts/build-wheels.sh
+++ b/release-scripts/build-wheels.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 pip install setuptools wheel
-cd semgrep && python setup.py bdist_wheel
+cd semgrep && python setup.py sdist bdist_wheel
 # Zipping for a stable name to upload as an artifact
 zip -r dist.zip dist


### PR DESCRIPTION
Reverts returntocorp/semgrep#1263

The original issue was that `pip install --no-build-isolation --no-binary :all: semgrep` would fail with a 'semgrep-core not found' error.

After this commit, running the same command will still fail with the same error as before, because pip will download the last release with an sdist available. So I'd argue this commit was not an improvement.

If you run `pip install --no-build-isolation --no-binary :all: semgrep==0.15.0` with the version pinned, you get `ERROR: Could not find a version that satisfies the requirement semgrep==0.15.0` which I'd say is a worse, more confusing error message than `semgrep-core not found`.

Created https://github.com/returntocorp/semgrep/issues/1295 for a more long term solution.