### PR TITLE
Match filenames in metavars as literal strings

### DIFF
--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -161,10 +161,11 @@ let m_qualified_name a b =
 let m_module_name_prefix a b =
   match a, b with
   (* metavariable case *)
-  | A.FileName((a_str, _) as a1), B.FileName(_) as b_file
-    when MV.is_metavar_name a_str ->
-    let (b_file1, _) = b_file in
-    envf a1 (B.Modn b_file1)
+  | A.FileName((a_str, _) as a1), B.FileName(b1) when MV.is_metavar_name a_str ->
+    (* Bind as a literal string expression so that pretty-printing works.
+     * This also means that this metavar can match both literal strings and filenames
+     * with the same string content. *)
+    envf a1 (B.E (B.L (B.String b1)))
   | A.FileName(a1), B.FileName(b1) ->
     (* TODO figure out what prefix support means here *)
     (m_wrap m_string_prefix) a1 b1

--- a/semgrep-core/tests/go/imports2.sgrep
+++ b/semgrep-core/tests/go/imports2.sgrep
@@ -1,0 +1,7 @@
+rules:
+  - id: foo
+    pattern: |
+      import "$X"
+    languages: ["go"]
+    message: imported $X
+    severity: INFO


### PR DESCRIPTION
Previous work (8cc2954a) added the ability to match metavars to file
names within directives. This work was done specifically to enable
matching and reporting of Go imports.

However, reporting was incomplete here, as pretty-printing has not been
implemented for directives or their tributary AST nodes.

Here I instead bind a literal string expression to the metavariable,
rather than a FileName node. Since we have pretty-printing for such
expressions, reporting now works.

A side effect of this change is that the following pattern:

```go
  import "$X"

  x = $X
```

will match

```go
  import "fmt"

  x = "fmt"
```

with `$X` bound to `"fmt"`, which is a tad odd. This doesn't seem
particularly awful, and is particularly unlikely, so it's left as
a dangling edge case for now.

I've added a test pattern that can be used to verify functionality:

```bash
  semgrep --config semgrep-core/tests/go/imports2.sgrep \
    semgrep-core/tests/go/imports.go
```

Fixes #638 