### PR TITLE
Make error classes frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 - Parse nested object properties in parameter destructuring in JavaScript
 - Parse binding patterns in ECMAScript 2021 catch expressions
+- Was mistakenly reporting only one of each type of issue even if multiple issues exist
 
 ## [0.15.0](https://github.com/returntocorp/semgrep/releases/tag/v0.15.0) - 2020-07-14
 

--- a/semgrep-local.yaml
+++ b/semgrep-local.yaml
@@ -16,3 +16,15 @@ rules:
       Move the import inside the function that needs it.
     languages: [python]
     severity: ERROR
+
+  - id: attr-manual-hash-set
+    pattern: |
+      @attr.s(..., hash=True, ...)
+      class $X(...):
+        ...
+    message: >
+      Setting hash explicitly can lead to unintended consequences. attrs
+      will do the right thing depending on how other flags are set. See
+      https://www.attrs.org/en/stable/hashing.html for more info.
+    languages: [python]
+    severity: ERROR

--- a/semgrep/tests/unit/test_error.py
+++ b/semgrep/tests/unit/test_error.py
@@ -1,0 +1,27 @@
+from semgrep.error import SourceParseError
+
+
+def test_different_hash():
+    # SemgrepErrors with differing fields have different hash
+    error_1 = SourceParseError(short_msg="1", long_msg="2", spans=[], help="4",)
+
+    error_2 = SourceParseError(short_msg="not 1", long_msg="2", spans=[], help="4",)
+
+    assert error_1.__hash__() != error_2.__hash__()
+
+    errors = set()
+    errors.add(error_1)
+    assert error_2 not in errors
+
+
+def test_same_hash():
+    # SemgrepErrors with all same fields have the same hash
+    error_1 = SourceParseError(short_msg="1", long_msg="2", spans=[], help="4",)
+
+    error_2 = SourceParseError(short_msg="1", long_msg="2", spans=[], help="4",)
+
+    assert error_1.__hash__() == error_2.__hash__()
+
+    errors = set()
+    errors.add(error_1)
+    assert error_2 in errors


### PR DESCRIPTION
Prior to this commit, it looked like only one error was being reported and other errors were
being silently hidden: https://github.com/returntocorp/semgrep/issues/1221. Root cause was that
all errors of the same type had the same hash and were considered duplicate errors https://github.com/returntocorp/semgrep/blob/develop/semgrep/semgrep/output.py#L242

There are issues with non frozen attr objects generating hashes. For more information: https://www.attrs.org/en/stable/hashing.html

This PR converts our error objects into frozen attr objects and removes explicit attr hash flags.
Adds a test that verifies an Error object hashes as expected and added semgrep-rule to check
for explicit hash flag setting.