### PR TITLE
Add 'metavariable-regex' operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The `metavariable-regex` operator, which filters finding's by metavariable
+  value against a Python re.match compatible expression.
+
 ## [0.16.0](https://github.com/returntocorp/semgrep/releases/tag/v0.16.0) - 2020-07-21
 
 ### Added

--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -18,6 +18,7 @@ Contents:
   * [`patterns`](configuration-files.md#patterns)
   * [`pattern-either`](configuration-files.md#pattern-either)
   * [`pattern-regex`](configuration-files.md#pattern-regex)
+  * [`metavariable-regex`](configuration-files.md#metavariable-regex)
   * [`pattern-not`](configuration-files.md#pattern-not)
   * [`pattern-inside`](configuration-files.md#pattern-inside)
   * [`pattern-not-inside`](configuration-files.md#pattern-not-inside)
@@ -109,6 +110,7 @@ The below optional fields must reside underneath a `patterns` or `pattern-either
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
+| [`metavariable-regex`](configuration-files.md#metavariable-regex) | `map` | Search metavariables for [Python `re.match`](https://docs.python.org/3/library/re.html#re.match) compatible expressions. |
 | [`pattern-not`](configuration-files.md#pattern-not) | `string` | Logical NOT - remove findings matching this expression. |
 | [`pattern-inside`](configuration-files.md#pattern-inside) | `string` | Keep findings that lie inside this pattern. |
 | [`pattern-not-inside`](configuration-files.md#pattern-not-inside) | `string` | Keep findings that do not lie inside this pattern. |
@@ -196,6 +198,30 @@ rules:
 
 *Note that single (`'`) and double (`"`) quotes [behave differently](https://docs.octoprint.org/en/master/configuration/yaml.html#scalars)
 in YAML syntax. Single quotes are typically preferred when using backslashes (`\`) with `pattern-regex`.*
+
+### `metavariable-regex`
+
+The `metavariable-regex` operator searches metavariables for a [Python `re.match`](https://docs.python.org/3/library/re.html#re.match)
+compatible expression. This is useful for filtering results based on a [metavariable's](/docs/pattern-features.md#metavariables)
+value.
+
+**Example**
+
+The `metavariable-regex` operator is a mapping which requires the
+`metavariable` and `regex` keys. It can be combined with other pattern operators:
+
+```yaml
+rules:
+  - id: insecure-methods
+    patterns:
+      - pattern: module.$METHOD(...)
+      - metavariable-regex:
+          metavariable: '$METHOD'
+          regex: '(insecure1|insecure2|insecure3)'
+    message: "module using insecure method call"
+    languages: [python]
+    severity: ERROR
+```
 
 ### `pattern-not`
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -331,6 +331,16 @@ class CoreRunner:
                 if patterns_regex:
                     self.handle_regex_patterns(outputs, patterns_regex, targets)
 
+                # semgrep-core doesn't know about OPERATORS.METAVARIABLE_REGEX -
+                # this is strictly a semgrep Python feature. Metavariable regex
+                # filtering is performed purely in Python code then compared
+                # against semgrep-core's results for other patterns.
+                patterns = [
+                    pattern
+                    for pattern in patterns
+                    if pattern.expression.operator != OPERATORS.METAVARIABLE_REGEX
+                ]
+
                 patterns_json = [p.to_json() for p in patterns]
 
                 output_json = self._run_core_command(

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 from semgrep.constants import RCE_RULE_FLAG
 from semgrep.error import NEED_ARBITRARY_CODE_EXEC_EXIT_CODE
-from semgrep.error import InvalidRuleSchemaError
 from semgrep.error import SemgrepError
 from semgrep.error import UnknownOperatorError
 from semgrep.pattern_match import PatternMatch
@@ -127,7 +126,7 @@ def _evaluate_single_expression(
                 code=NEED_ARBITRARY_CODE_EXEC_EXIT_CODE,
             )
         if not isinstance(expression.operand, str):
-            raise InvalidRuleSchemaError("pattern-where-python must have a string value")
+            raise SemgrepError("pattern-where-python must have a string value")
 
         # Look through every range that hasn't been filtered yet
         for pattern_match in list(flatten(pattern_ids_to_pattern_matches.values())):
@@ -168,7 +167,7 @@ def _evaluate_single_expression(
             or "metavariable" not in expression.operand
             or "regex" not in expression.operand
         ):
-            raise InvalidRuleSchemaError(
+            raise SemgrepError(
                 "'metavariable' and 'regex' keys required when using 'metavariable-regex' operator"
             )
         output_ranges = get_re_range_matches(

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 from semgrep.constants import RCE_RULE_FLAG
 from semgrep.error import NEED_ARBITRARY_CODE_EXEC_EXIT_CODE
+from semgrep.error import InvalidRuleSchemaError
 from semgrep.error import SemgrepError
 from semgrep.error import UnknownOperatorError
 from semgrep.pattern_match import PatternMatch
@@ -126,7 +127,7 @@ def _evaluate_single_expression(
                 code=NEED_ARBITRARY_CODE_EXEC_EXIT_CODE,
             )
         if not isinstance(expression.operand, str):
-            raise SemgrepError("pattern-where-python must have a string value")
+            raise InvalidRuleSchemaError("pattern-where-python must have a string value")
 
         # Look through every range that hasn't been filtered yet
         for pattern_match in list(flatten(pattern_ids_to_pattern_matches.values())):
@@ -167,7 +168,7 @@ def _evaluate_single_expression(
             or "metavariable" not in expression.operand
             or "regex" not in expression.operand
         ):
-            raise SemgrepError(
+            raise InvalidRuleSchemaError(
                 "'metavariable' and 'regex' keys required when using 'metavariable-regex' operator"
             )
         output_ranges = get_re_range_matches(

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -25,6 +26,31 @@ from semgrep.semgrep_types import PatternId
 from semgrep.semgrep_types import Range
 from semgrep.semgrep_types import TAINT_MODE
 from semgrep.util import flatten
+
+
+def get_re_range_matches(
+    metavariable: str,
+    regex: str,
+    ranges: Set[Range],
+    pattern_matches: List[PatternMatch],
+) -> Set[Range]:
+
+    result: Set[Range] = set()
+    for _range in ranges:
+        if metavariable not in _range.vars:
+            logger.debug(f"metavariable '{metavariable}' missing in range '{_range}'")
+            continue
+
+        any_matching_ranges = any(
+            pm.range == _range
+            and metavariable in pm.metavars
+            and re.match(regex, pm.metavars[metavariable]["abstract_content"])
+            for pm in pattern_matches
+        )
+        if any_matching_ranges:
+            result.add(_range)
+
+    return result
 
 
 def _evaluate_single_expression(
@@ -99,7 +125,8 @@ def _evaluate_single_expression(
                 f"at least one rule needs to execute arbitrary code; this is dangerous! if you want to continue, enable the flag: {RCE_RULE_FLAG}",
                 code=NEED_ARBITRARY_CODE_EXEC_EXIT_CODE,
             )
-        assert expression.operand, "must have operand for this operator type"
+        if not isinstance(expression.operand, str):
+            raise SemgrepError("pattern-where-python must have a string value")
 
         # Look through every range that hasn't been filtered yet
         for pattern_match in list(flatten(pattern_ids_to_pattern_matches.values())):
@@ -125,6 +152,30 @@ def _evaluate_single_expression(
     elif expression.operator == OPERATORS.REGEX:
         # remove all ranges that don't equal the ranges for this pattern
         output_ranges = ranges_left.intersection(results_for_pattern)
+        logger.debug(f"after filter `{expression.operator}`: {output_ranges}")
+        steps_for_debugging.append(
+            {
+                "filter": pattern_name_for_operator(expression.operator),
+                "pattern_id": expression.pattern_id,
+                "ranges": list(output_ranges),
+            }
+        )
+        return output_ranges
+    elif expression.operator == OPERATORS.METAVARIABLE_REGEX:
+        if (
+            not isinstance(expression.operand, dict)
+            or "metavariable" not in expression.operand
+            or "regex" not in expression.operand
+        ):
+            raise SemgrepError(
+                "'metavariable' and 'regex' keys required when using 'metavariable-regex' operator"
+            )
+        output_ranges = get_re_range_matches(
+            expression.operand["metavariable"],
+            expression.operand["regex"],
+            ranges_left,
+            list(flatten(pattern_ids_to_pattern_matches.values())),
+        )
         logger.debug(f"after filter `{expression.operator}`: {output_ranges}")
         steps_for_debugging.append(
             {

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -183,7 +183,7 @@ class Rule:
         if not (isinstance(operand.value, str) or isinstance(operand.value, dict)):
             raise InvalidRuleSchemaError(
                 short_msg="invalid operand",
-                long_msg=f"type of `pattern` must be a string or dict, but it was a {type(operand.unroll()).__name__}",
+                long_msg=f"type of `operand` must be a string or dict, but it was a {type(operand.unroll()).__name__}",
                 spans=[operand.span.with_context(before=1, after=1)],
             )
         return operand.value
@@ -258,17 +258,6 @@ class Rule:
                 self._pattern_spans[rule_id] = pattern.span
                 return BooleanRuleExpression(
                     OPERATORS.REGEX, rule_id, None, self._validate_operand(pattern)
-                )
-
-        for pattern_name in pattern_names_for_operator(OPERATORS.METAVARIABLE_REGEX):
-            pattern = rule_raw.get(pattern_name)
-            if pattern:
-                self._pattern_spans[rule_id] = pattern.span
-                return BooleanRuleExpression(
-                    OPERATORS.METAVARIABLE_REGEX,
-                    rule_id,
-                    None,
-                    self._validate_operand(pattern),
                 )
 
         for pattern_name in pattern_names_for_operator(OPERATORS.AND_ALL):

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -4,6 +4,7 @@ from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import Union
 
 from semgrep.equivalences import Equivalence
 from semgrep.error import InvalidPatternNameError
@@ -150,7 +151,13 @@ class Rule:
                         )
                 else:
                     pattern_text, pattern_span = sub_pattern.value, sub_pattern.span
-                    if isinstance(pattern_text, str):
+
+                    if isinstance(pattern_text, YamlMap):
+                        pattern_text = {
+                            k.value: v.value for k, v in pattern_text.items()
+                        }
+
+                    if isinstance(pattern_text, str) or isinstance(pattern_text, dict):
                         pattern_id = PatternId(f"{prefix}.{pattern_id_idx}")
                         self._pattern_spans[pattern_id] = pattern_span
                         yield BooleanRuleExpression(
@@ -163,7 +170,7 @@ class Rule:
                     else:
                         raise InvalidRuleSchemaError(
                             short_msg="invalid operand",
-                            long_msg=f"operand for {boolean_operator} must be a string, but instead was {type(sub_pattern.unroll()).__name__}",
+                            long_msg=f"operand for {boolean_operator} must be a string or dict, but instead was {type(sub_pattern.unroll()).__name__}",
                             spans=[
                                 boolean_operator_yaml.span.extend_to(
                                     pattern_span
@@ -172,11 +179,11 @@ class Rule:
                         )
 
     @staticmethod
-    def _validate_operand(operand: YamlTree) -> str:  # type: ignore
-        if not isinstance(operand.value, str):
+    def _validate_operand(operand: YamlTree) -> Union[str, dict]:  # type: ignore
+        if not (isinstance(operand.value, str) or isinstance(operand.value, dict)):
             raise InvalidRuleSchemaError(
                 short_msg="invalid operand",
-                long_msg=f"type of `pattern` must be a string, but it was a {type(operand.unroll()).__name__}",
+                long_msg=f"type of `pattern` must be a string or dict, but it was a {type(operand.unroll()).__name__}",
                 spans=[operand.span.with_context(before=1, after=1)],
             )
         return operand.value
@@ -251,6 +258,17 @@ class Rule:
                 self._pattern_spans[rule_id] = pattern.span
                 return BooleanRuleExpression(
                     OPERATORS.REGEX, rule_id, None, self._validate_operand(pattern)
+                )
+
+        for pattern_name in pattern_names_for_operator(OPERATORS.METAVARIABLE_REGEX):
+            pattern = rule_raw.get(pattern_name)
+            if pattern:
+                self._pattern_spans[rule_id] = pattern.span
+                return BooleanRuleExpression(
+                    OPERATORS.METAVARIABLE_REGEX,
+                    rule_id,
+                    None,
+                    self._validate_operand(pattern),
                 )
 
         for pattern_name in pattern_names_for_operator(OPERATORS.AND_ALL):

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import NamedTuple
 from typing import NewType
 from typing import Optional
 from typing import Set
+from typing import Union
 
 import attr
 
@@ -32,6 +34,7 @@ class OPERATORS:
     FIX_REGEX: Operator = Operator("fix_regex")
     EQUIVALENCES: Operator = Operator("equivalences")
     REGEX: Operator = Operator("regex")
+    METAVARIABLE_REGEX: Operator = Operator("metavariable_regex")
 
 
 OPERATORS_WITH_CHILDREN = [OPERATORS.AND_ALL, OPERATORS.AND_EITHER]
@@ -48,6 +51,7 @@ OPERATOR_PATTERN_NAMES_MAP = {
     OPERATORS.FIX_REGEX: ["fix-regex"],
     OPERATORS.EQUIVALENCES: ["equivalences"],
     OPERATORS.REGEX: ["pattern-regex"],
+    OPERATORS.METAVARIABLE_REGEX: ["metavariable-regex"],
 }
 
 # These are the only valid top-level keys
@@ -84,7 +88,7 @@ class BooleanRuleExpression:
     operator: Operator
     pattern_id: Optional[PatternId] = None
     children: Optional[List["BooleanRuleExpression"]] = None
-    operand: Optional[str] = None
+    operand: Optional[Union[str, Dict]] = None
 
 
 def pattern_name_for_operator(operator: Operator) -> str:

--- a/semgrep/tests/e2e/rules/metavariable-regex-multi-regex.yaml
+++ b/semgrep/tests/e2e/rules/metavariable-regex-multi-regex.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: metavar-test-multi-regex
+    patterns:
+      - pattern: 'metavariable_regex_test.$X($Y)'
+      - metavariable-regex:
+          metavariable: '$X'
+          regex: 'method1'
+      - metavariable-regex:
+          metavariable: '$Y'
+          regex: 'arg1'
+    message: "Metavariable regex test multi regex"
+    languages: [python]
+    severity: ERROR

--- a/semgrep/tests/e2e/rules/metavariable-regex-multi-rule.yaml
+++ b/semgrep/tests/e2e/rules/metavariable-regex-multi-rule.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: metavar-test-multi-rule
+    patterns:
+      - pattern-inside: |
+          def func():
+              ...
+      - pattern: 'metavariable_regex_test.$X(...)'
+      - metavariable-regex:
+          metavariable: '$X'
+          regex: 'method'
+    message: "Metavariable regex test multi rule"
+    languages: [python]
+    severity: ERROR

--- a/semgrep/tests/e2e/rules/metavariable-regex.yaml
+++ b/semgrep/tests/e2e/rules/metavariable-regex.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: metavar-test
+    patterns:
+      - pattern: 'metavariable_regex_test($X)'
+      - metavariable-regex:
+          metavariable: '$X'
+          regex: '("test"|"example")'
+    message: "Metavariable regex test"
+    languages: [python]
+    severity: ERROR

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_multi_regex_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_multi_regex_rule/results.json
@@ -1,0 +1,59 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.metavar-test-multi-regex",
+      "end": {
+        "col": 38,
+        "line": 1
+      },
+      "extra": {
+        "lines": "metavariable_regex_test.method1(arg1)",
+        "message": "Metavariable regex test multi regex",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "method1",
+            "end": {
+              "col": 32,
+              "line": 1,
+              "offset": 31
+            },
+            "start": {
+              "col": 25,
+              "line": 1,
+              "offset": 24
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$Y": {
+            "abstract_content": "arg1",
+            "end": {
+              "col": 37,
+              "line": 1,
+              "offset": 36
+            },
+            "start": {
+              "col": 33,
+              "line": 1,
+              "offset": 32
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/metavariable-regex-multi-regex.py",
+      "start": {
+        "col": 1,
+        "line": 1
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_multi_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_multi_rule/results.json
@@ -1,0 +1,42 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.metavar-test-multi-rule",
+      "end": {
+        "col": 37,
+        "line": 3
+      },
+      "extra": {
+        "lines": "    metavariable_regex_test.method()",
+        "message": "Metavariable regex test multi rule",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "method",
+            "end": {
+              "col": 35,
+              "line": 3,
+              "offset": 79
+            },
+            "start": {
+              "col": 29,
+              "line": 3,
+              "offset": 73
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/metavariable-regex-multi-rule.py",
+      "start": {
+        "col": 5,
+        "line": 3
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_rule/results.json
@@ -1,0 +1,79 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.metavar-test",
+      "end": {
+        "col": 32,
+        "line": 1
+      },
+      "extra": {
+        "lines": "metavariable_regex_test(\"test\")",
+        "message": "Metavariable regex test",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "\"test\"",
+            "end": {
+              "col": 31,
+              "line": 1,
+              "offset": 30
+            },
+            "start": {
+              "col": 25,
+              "line": 1,
+              "offset": 24
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/metavariable-regex.py",
+      "start": {
+        "col": 1,
+        "line": 1
+      }
+    },
+    {
+      "check_id": "rules.metavar-test",
+      "end": {
+        "col": 35,
+        "line": 2
+      },
+      "extra": {
+        "lines": "metavariable_regex_test(\"example\")",
+        "message": "Metavariable regex test",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "\"example\"",
+            "end": {
+              "col": 34,
+              "line": 2,
+              "offset": 65
+            },
+            "start": {
+              "col": 25,
+              "line": 2,
+              "offset": 56
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/metavariable-regex.py",
+      "start": {
+        "col": 1,
+        "line": 2
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error-in-color.txt
@@ -11,6 +11,6 @@
 [94m11 | [39m          - pattern: self.$X == self.$X
 [94m12 | [39m      - pattern-not: 1 == 1
 
-[31moperand for pattern-inside must be a string, but instead was list[39m
+[31moperand for pattern-inside must be a string or dict, but instead was list[39m
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
@@ -3,7 +3,7 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "operand for pattern-inside must be a string, but instead was list",
+      "long_msg": "operand for pattern-inside must be a string or dict, but instead was list",
       "short_msg": "invalid operand",
       "spans": [
         {

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error-in-color.txt
@@ -5,6 +5,6 @@
 [94m5 | [39m    message: "test"
 [94m6 | [39m    languages: [python]
 
-[31mtype of `pattern` must be a string or dict, but it was a list[39m
+[31mtype of `operand` must be a string or dict, but it was a list[39m
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error-in-color.txt
@@ -5,6 +5,6 @@
 [94m5 | [39m    message: "test"
 [94m6 | [39m    languages: [python]
 
-[31mtype of `pattern` must be a string, but it was a list[39m
+[31mtype of `pattern` must be a string or dict, but it was a list[39m
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
@@ -3,7 +3,7 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "type of `pattern` must be a string or dict, but it was a list",
+      "long_msg": "type of `operand` must be a string or dict, but it was a list",
       "short_msg": "invalid operand",
       "spans": [
         {

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
@@ -3,7 +3,7 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "type of `pattern` must be a string, but it was a list",
+      "long_msg": "type of `pattern` must be a string or dict, but it was a list",
       "short_msg": "invalid operand",
       "spans": [
         {

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error-in-color.txt
@@ -4,7 +4,7 @@
 [94m4 | [39m      - patter: $X = 1
 [94m  | [39m        [31m^^^^^^[39m
 [94m5 | [39m      - pattern: $X = 2
-= [36m[1mhelp[39m[0m: valid pattern names are ['equivalences', 'fix', 'fix-regex', 'pattern', 'pattern-either', 'pattern-inside', 'pattern-not', 'pattern-not-inside', 'pattern-regex', 'pattern-where-python', 'patterns']
+= [36m[1mhelp[39m[0m: valid pattern names are ['equivalences', 'fix', 'fix-regex', 'metavariable-regex', 'pattern', 'pattern-either', 'pattern-inside', 'pattern-not', 'pattern-not-inside', 'pattern-regex', 'pattern-where-python', 'patterns']
 [31minvalid pattern name: patter[39m
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
@@ -2,7 +2,7 @@
   "errors": [
     {
       "code": 4,
-      "help": "valid pattern names are ['equivalences', 'fix', 'fix-regex', 'pattern', 'pattern-either', 'pattern-inside', 'pattern-not', 'pattern-not-inside', 'pattern-regex', 'pattern-where-python', 'patterns']",
+      "help": "valid pattern names are ['equivalences', 'fix', 'fix-regex', 'metavariable-regex', 'pattern', 'pattern-either', 'pattern-inside', 'pattern-not', 'pattern-not-inside', 'pattern-regex', 'pattern-where-python', 'patterns']",
       "level": "error",
       "long_msg": "invalid pattern name: patter",
       "short_msg": "invalid pattern name",

--- a/semgrep/tests/e2e/targets/basic/metavariable-regex-multi-regex.py
+++ b/semgrep/tests/e2e/targets/basic/metavariable-regex-multi-regex.py
@@ -1,0 +1,4 @@
+metavariable_regex_test.method1(arg1)
+metavariable_regex_test.method1(arg2)
+metavariable_regex_test.method2(arg1)
+metavariable_regex_test.method2(arg2)

--- a/semgrep/tests/e2e/targets/basic/metavariable-regex-multi-rule.py
+++ b/semgrep/tests/e2e/targets/basic/metavariable-regex-multi-rule.py
@@ -1,0 +1,3 @@
+metavariable_regex_test.method()
+def func():
+    metavariable_regex_test.method()

--- a/semgrep/tests/e2e/targets/basic/metavariable-regex.py
+++ b/semgrep/tests/e2e/targets/basic/metavariable-regex.py
@@ -1,0 +1,3 @@
+metavariable_regex_test("test")
+metavariable_regex_test("example")
+metavariable_regex_test(7)

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -132,3 +132,21 @@ def test_nosem_rule__invalid_id(run_semgrep_in_tmp, snapshot):
     assert excinfo.value.returncode == 2
     snapshot.assert_match(excinfo.value.stderr, "error.txt")
     snapshot.assert_match(excinfo.value.stdout, "error.json")
+
+
+def test_metavariable_regex_rule(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/metavariable-regex.yaml"), "results.json"
+    )
+
+
+def test_metavariable_regex_multi_rule(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/metavariable-regex-multi-rule.yaml"), "results.json"
+    )
+
+
+def test_metavariable_multi_regex_rule(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/metavariable-regex-multi-regex.yaml"), "results.json"
+    )


### PR DESCRIPTION
Fix #1217. The 'metavariable-regex' operator filters finding's by metavariable value against a Python re.match compatible expression.