### PR TITLE
Add setup-ocaml as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ocaml-tree-sitter"]
 	path = ocaml-tree-sitter
 	url = https://github.com/returntocorp/ocaml-tree-sitter.git
+[submodule "setup-ocaml"]
+	path = setup-ocaml
+	url = https://github.com/returntocorp/setup-ocaml.git


### PR DESCRIPTION
 It's for building and pushing custom Docker images with most dependencies pre-installed. In particular, this includes the version of ocaml we want and pre-installed opam packages.

> https://github.com/returntocorp/setup-ocaml
