### PR TITLE
Try more effective CI triggers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,14 +1,22 @@
+name: Incorporate Benchmark Data
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+# This string is matched in `latest-artifact-for-branch.py`:
+
 on:
   push:
     # Sequence of patterns matched against refs/tags
     branches:
-      - "develop"
-      - "master"
+      - develop
+      - master
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
-name: Incorporate Benchmark Data
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-# This string is matched in `latest-artifact-for-branch.py`:
+  pull_request:
+    # Don't run on pull requests into the develop branch (b/c takes too long)
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+
 jobs:
   build-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,12 +1,15 @@
-name: docker-push-pr
+name: Push Semgrep Docker Image
 
 on:
   push:
     branches:
       - develop
   pull_request:
+    # Don't run on pull requests into the develop branch (b/c takes too long)
+    branches:
+      - master
     paths-ignore:
-    - '**.md'
+      - '**.md'
 
 jobs:
   docker-build:

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -5,7 +5,8 @@ on:
     paths-ignore:
     - '**.md'
   push:
-    branches: [master, develop]
+    paths-ignore:
+    - '**.md'
 jobs:
   build-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: mjambon/r2c-ocaml:alpine
     steps:
-      # Cancel previous jobs. Useful when triggered by every push.
+      # Cancel previous jobs; Useful when triggered by every push.
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
         with:

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     container: mjambon/r2c-ocaml:alpine
     steps:
+      # Cancel previous jobs. Useful when triggered by every push.
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
       - name: Pre-checkout fixes
         run: |
           sudo chmod -R 777 /github

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: mjambon/r2c-ocaml:alpine
     steps:
-      # Cancel previous jobs; Useful when triggered by every push.
+      # Cancel previous jobs. This is useful when triggered by every push.
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: Lint
 on:
   pull_request:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,18 @@
+name: Create Draft Release
+
 on:
-  push:
-    # Sequence of patterns matched against refs/tags
+  pull_request:
+    # Don't run on pull requests into the develop branch (b/c takes too long)
     branches:
+      - master
+  push:
+    branches:
+      - master
+      - develop
+      # Sequence of patterns matched against refs/tags
       - '**-test-release'
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-
-name: Create draft release
 
 jobs:
   create_release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,15 @@ name: Tests
 
 on:
   pull_request:
+    # Don't run on pull requests into the develop branch (b/c takes too long)
+    branches:
+      - master
     paths-ignore:
     - '**.md'
   push:
-    branches: [master, develop]
+    branches:
+      - master
+      - develop
 
 jobs:
   build-core:

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,10 +1,10 @@
+name: Validate a Release
+
 on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-
-name: Validate a release
 
 jobs:
   sanity_check_release:


### PR DESCRIPTION
* Long workflows (> 10 min or so) were disabled on feature branches so as to not block PRs.
* The "env tests" workflow now runs on every push so we know if there's a problem as soon as the commit is pushed.
* The "env tests" cancels the previous run if there's one (on the same branch).

It looks like the docker.yml flow does some sort of deployment that would be useful for manual testing? I commented it out because it takes a long time.