### PR TITLE
Upgrade ocaml-tree-sitter runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #
 .PHONY: build
 build:
-	$(MAKE) -C build-core
+	$(MAKE) build-core
 	cd semgrep && python3 -m pipenv install --dev
 
 .PHONY: build-core

--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -131,7 +131,7 @@ let import_spec (env : env) ((v1, v2) : CST.import_spec) =
 
 let rec declaration (env : env) (x : CST.declaration) =
   (match x with
-  | `Decl_const_decl (v1, v2) ->
+  | `Const_decl (v1, v2) ->
       let v1 = token env v1 (* "const" *) in
       let v2 =
         (match v2 with
@@ -155,7 +155,7 @@ let rec declaration (env : env) (x : CST.declaration) =
         )
       in
       todo env (v1, v2)
-  | `Decl_type_decl (v1, v2) ->
+  | `Type_decl (v1, v2) ->
       let v1 = token env v1 (* "type" *) in
       let v2 =
         (match v2 with
@@ -185,7 +185,7 @@ let rec declaration (env : env) (x : CST.declaration) =
         )
       in
       todo env (v1, v2)
-  | `Decl_var_decl (v1, v2) ->
+  | `Var_decl (v1, v2) ->
       let v1 = token env v1 (* "var" *) in
       let v2 =
         (match v2 with
@@ -409,9 +409,9 @@ and parenthesized_type (env : env) ((v1, v2, v3) : CST.parenthesized_type) =
 
 and simple_type (env : env) (x : CST.simple_type) =
   (match x with
-  | `Simple_type_id tok -> token env tok (* identifier *)
-  | `Simple_type_qual_type x -> qualified_type env x
-  | `Simple_type_poin_type (v1, v2) ->
+  | `Id tok -> token env tok (* identifier *)
+  | `Qual_type x -> qualified_type env x
+  | `Poin_type (v1, v2) ->
       let v1 = token env v1 (* "*" *) in
       let v2 =
         (match v2 with
@@ -420,16 +420,16 @@ and simple_type (env : env) (x : CST.simple_type) =
         )
       in
       todo env (v1, v2)
-  | `Simple_type_stru_type x -> struct_type env x
-  | `Simple_type_inte_type (v1, v2) ->
+  | `Stru_type x -> struct_type env x
+  | `Inte_type (v1, v2) ->
       let v1 = token env v1 (* "interface" *) in
       let v2 = method_spec_list env v2 in
       todo env (v1, v2)
-  | `Simple_type_array_type x -> array_type env x
-  | `Simple_type_slice_type x -> slice_type env x
-  | `Simple_type_map_type x -> map_type env x
-  | `Simple_type_chan_type x -> channel_type env x
-  | `Simple_type_func_type (v1, v2, v3) ->
+  | `Array_type x -> array_type env x
+  | `Slice_type x -> slice_type env x
+  | `Map_type x -> map_type env x
+  | `Chan_type x -> channel_type env x
+  | `Func_type (v1, v2, v3) ->
       let v1 = token env v1 (* "func" *) in
       let v2 = parameter_list env v2 in
       let v3 =
@@ -651,7 +651,7 @@ and map_type (env : env) ((v1, v2, v3, v4, v5) : CST.map_type) =
 
 and channel_type (env : env) (x : CST.channel_type) =
   (match x with
-  | `Chan_type_chan_choice_simple_type (v1, v2) ->
+  | `Chan_choice_simple_type (v1, v2) ->
       let v1 = token env v1 (* "chan" *) in
       let v2 =
         (match v2 with
@@ -660,7 +660,7 @@ and channel_type (env : env) (x : CST.channel_type) =
         )
       in
       todo env (v1, v2)
-  | `Chan_type_chan_LTDASH_choice_simple_type (v1, v2, v3) ->
+  | `Chan_LTDASH_choice_simple_type (v1, v2, v3) ->
       let v1 = token env v1 (* "chan" *) in
       let v2 = token env v2 (* "<-" *) in
       let v3 =
@@ -670,7 +670,7 @@ and channel_type (env : env) (x : CST.channel_type) =
         )
       in
       todo env (v1, v2, v3)
-  | `Chan_type_LTDASH_chan_choice_simple_type (v1, v2, v3) ->
+  | `LTDASH_chan_choice_simple_type (v1, v2, v3) ->
       let v1 = token env v1 (* "<-" *) in
       let v2 = token env v2 (* "chan" *) in
       let v3 =
@@ -696,7 +696,7 @@ and block (env : env) ((v1, v2, v3) : CST.block) =
 
 and statement_list (env : env) (x : CST.statement_list) =
   (match x with
-  | `Stmt_list_stmt_rep_choice_LF_stmt_opt_choice_LF_opt_empty_labe_stmt (v1, v2, v3) ->
+  | `Stmt_rep_choice_LF_stmt_opt_choice_LF_opt_empty_labe_stmt (v1, v2, v3) ->
       let v1 = statement env v1 in
       let v2 =
         List.map (fun (v1, v2) ->
@@ -728,16 +728,16 @@ and statement_list (env : env) (x : CST.statement_list) =
         | None -> todo env ())
       in
       todo env (v1, v2, v3)
-  | `Stmt_list_empty_labe_stmt x ->
+  | `Empty_labe_stmt x ->
       empty_labeled_statement env x
   )
 
 
 and statement (env : env) (x : CST.statement) =
   (match x with
-  | `Stmt_decl x -> declaration env x
-  | `Stmt_simple_stmt x -> simple_statement env x
-  | `Stmt_ret_stmt (v1, v2) ->
+  | `Decl x -> declaration env x
+  | `Simple_stmt x -> simple_statement env x
+  | `Ret_stmt (v1, v2) ->
       let v1 = token env v1 (* "return" *) in
       let v2 =
         (match v2 with
@@ -745,16 +745,16 @@ and statement (env : env) (x : CST.statement) =
         | None -> todo env ())
       in
       todo env (v1, v2)
-  | `Stmt_go_stmt (v1, v2) ->
+  | `Go_stmt (v1, v2) ->
       let v1 = token env v1 (* "go" *) in
       let v2 = expression env v2 in
       todo env (v1, v2)
-  | `Stmt_defer_stmt (v1, v2) ->
+  | `Defer_stmt (v1, v2) ->
       let v1 = token env v1 (* "defer" *) in
       let v2 = expression env v2 in
       todo env (v1, v2)
-  | `Stmt_if_stmt x -> if_statement env x
-  | `Stmt_for_stmt (v1, v2, v3) ->
+  | `If_stmt x -> if_statement env x
+  | `For_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "for" *) in
       let v2 =
         (match v2 with
@@ -768,7 +768,7 @@ and statement (env : env) (x : CST.statement) =
       in
       let v3 = block env v3 in
       todo env (v1, v2, v3)
-  | `Stmt_exp_swit_stmt (v1, v2, v3, v4, v5, v6) ->
+  | `Exp_swit_stmt (v1, v2, v3, v4, v5, v6) ->
       let v1 = token env v1 (* "switch" *) in
       let v2 =
         (match v2 with
@@ -794,7 +794,7 @@ and statement (env : env) (x : CST.statement) =
       in
       let v6 = token env v6 (* "}" *) in
       todo env (v1, v2, v3, v4, v5, v6)
-  | `Stmt_type_swit_stmt (v1, v2, v3, v4, v5) ->
+  | `Type_swit_stmt (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "switch" *) in
       let v2 = type_switch_header env v2 in
       let v3 = token env v3 (* "{" *) in
@@ -808,7 +808,7 @@ and statement (env : env) (x : CST.statement) =
       in
       let v5 = token env v5 (* "}" *) in
       todo env (v1, v2, v3, v4, v5)
-  | `Stmt_sele_stmt (v1, v2, v3, v4) ->
+  | `Sele_stmt (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "select" *) in
       let v2 = token env v2 (* "{" *) in
       let v3 =
@@ -821,13 +821,13 @@ and statement (env : env) (x : CST.statement) =
       in
       let v4 = token env v4 (* "}" *) in
       todo env (v1, v2, v3, v4)
-  | `Stmt_labe_stmt (v1, v2, v3) ->
+  | `Labe_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* identifier *) in
       let v2 = token env v2 (* ":" *) in
       let v3 = statement env v3 in
       todo env (v1, v2, v3)
-  | `Stmt_fall_stmt tok -> token env tok (* "fallthrough" *)
-  | `Stmt_brk_stmt (v1, v2) ->
+  | `Fall_stmt tok -> token env tok (* "fallthrough" *)
+  | `Brk_stmt (v1, v2) ->
       let v1 = token env v1 (* "break" *) in
       let v2 =
         (match v2 with
@@ -835,7 +835,7 @@ and statement (env : env) (x : CST.statement) =
         | None -> todo env ())
       in
       todo env (v1, v2)
-  | `Stmt_cont_stmt (v1, v2) ->
+  | `Cont_stmt (v1, v2) ->
       let v1 = token env v1 (* "continue" *) in
       let v2 =
         (match v2 with
@@ -843,28 +843,28 @@ and statement (env : env) (x : CST.statement) =
         | None -> todo env ())
       in
       todo env (v1, v2)
-  | `Stmt_goto_stmt (v1, v2) ->
+  | `Goto_stmt (v1, v2) ->
       let v1 = token env v1 (* "goto" *) in
       let v2 = token env v2 (* identifier *) in
       todo env (v1, v2)
-  | `Stmt_blk x -> block env x
-  | `Stmt_empty_stmt tok -> token env tok (* ";" *)
+  | `Blk x -> block env x
+  | `Empty_stmt tok -> token env tok (* ";" *)
   )
 
 
 and simple_statement (env : env) (x : CST.simple_statement) =
   (match x with
-  | `Simple_stmt_exp x -> expression env x
-  | `Simple_stmt_send_stmt x -> send_statement env x
-  | `Simple_stmt_inc_stmt (v1, v2) ->
+  | `Exp x -> expression env x
+  | `Send_stmt x -> send_statement env x
+  | `Inc_stmt (v1, v2) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "++" *) in
       todo env (v1, v2)
-  | `Simple_stmt_dec_stmt (v1, v2) ->
+  | `Dec_stmt (v1, v2) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "--" *) in
       todo env (v1, v2)
-  | `Simple_stmt_assign_stmt (v1, v2, v3) ->
+  | `Assign_stmt (v1, v2, v3) ->
       let v1 = expression_list env v1 in
       let v2 =
         (match v2 with
@@ -884,7 +884,7 @@ and simple_statement (env : env) (x : CST.simple_statement) =
       in
       let v3 = expression_list env v3 in
       todo env (v1, v2, v3)
-  | `Simple_stmt_short_var_decl (v1, v2, v3) ->
+  | `Short_var_decl (v1, v2, v3) ->
       let v1 = expression_list env v1 in
       let v2 = token env v2 (* ":=" *) in
       let v3 = expression_list env v3 in
@@ -1081,7 +1081,7 @@ and communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
 
 and expression (env : env) (x : CST.expression) =
   (match x with
-  | `Exp_un_exp (v1, v2) ->
+  | `Un_exp (v1, v2) ->
       let v1 =
         (match v1 with
         | `PLUS tok -> token env tok (* "+" *)
@@ -1095,19 +1095,19 @@ and expression (env : env) (x : CST.expression) =
       in
       let v2 = expression env v2 in
       todo env (v1, v2)
-  | `Exp_bin_exp x -> binary_expression env x
-  | `Exp_sele_exp (v1, v2, v3) ->
+  | `Bin_exp x -> binary_expression env x
+  | `Sele_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "." *) in
       let v3 = token env v3 (* identifier *) in
       todo env (v1, v2, v3)
-  | `Exp_index_exp (v1, v2, v3, v4) ->
+  | `Index_exp (v1, v2, v3, v4) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "[" *) in
       let v3 = expression env v3 in
       let v4 = token env v4 (* "]" *) in
       todo env (v1, v2, v3, v4)
-  | `Exp_slice_exp (v1, v2, v3, v4) ->
+  | `Slice_exp (v1, v2, v3, v4) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "[" *) in
       let v3 =
@@ -1140,8 +1140,8 @@ and expression (env : env) (x : CST.expression) =
       in
       let v4 = token env v4 (* "]" *) in
       todo env (v1, v2, v3, v4)
-  | `Exp_call_exp x -> call_expression env x
-  | `Exp_type_asse_exp (v1, v2, v3, v4, v5) ->
+  | `Call_exp x -> call_expression env x
+  | `Type_asse_exp (v1, v2, v3, v4, v5) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "." *) in
       let v3 = token env v3 (* "(" *) in
@@ -1153,7 +1153,7 @@ and expression (env : env) (x : CST.expression) =
       in
       let v5 = token env v5 (* ")" *) in
       todo env (v1, v2, v3, v4, v5)
-  | `Exp_type_conv_exp (v1, v2, v3, v4, v5) ->
+  | `Type_conv_exp (v1, v2, v3, v4, v5) ->
       let v1 =
         (match v1 with
         | `Simple_type x -> simple_type env x
@@ -1169,13 +1169,13 @@ and expression (env : env) (x : CST.expression) =
       in
       let v5 = token env v5 (* ")" *) in
       todo env (v1, v2, v3, v4, v5)
-  | `Exp_id tok -> token env tok (* identifier *)
-  | `Exp_choice_new x ->
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_new x ->
       (match x with
       | `New tok -> token env tok (* "new" *)
       | `Make tok -> token env tok (* "make" *)
       )
-  | `Exp_comp_lit (v1, v2) ->
+  | `Comp_lit (v1, v2) ->
       let v1 =
         (match v1 with
         | `Map_type x -> map_type env x
@@ -1190,7 +1190,7 @@ and expression (env : env) (x : CST.expression) =
       in
       let v2 = literal_value env v2 in
       todo env (v1, v2)
-  | `Exp_func_lit (v1, v2, v3, v4) ->
+  | `Func_lit (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "func" *) in
       let v2 = parameter_list env v2 in
       let v3 =
@@ -1204,19 +1204,19 @@ and expression (env : env) (x : CST.expression) =
       in
       let v4 = block env v4 in
       todo env (v1, v2, v3, v4)
-  | `Exp_choice_raw_str_lit x ->
+  | `Choice_raw_str_lit x ->
       (match x with
       | `Raw_str_lit tok -> token env tok (* raw_string_literal *)
       | `Inte_str_lit x -> interpreted_string_literal env x
       )
-  | `Exp_int_lit tok -> token env tok (* int_literal *)
-  | `Exp_float_lit tok -> token env tok (* float_literal *)
-  | `Exp_imag_lit tok -> token env tok (* imaginary_literal *)
-  | `Exp_rune_lit tok -> token env tok (* rune_literal *)
-  | `Exp_nil tok -> token env tok (* "nil" *)
-  | `Exp_true tok -> token env tok (* "true" *)
-  | `Exp_false tok -> token env tok (* "false" *)
-  | `Exp_paren_exp (v1, v2, v3) ->
+  | `Int_lit tok -> token env tok (* int_literal *)
+  | `Float_lit tok -> token env tok (* float_literal *)
+  | `Imag_lit tok -> token env tok (* imaginary_literal *)
+  | `Rune_lit tok -> token env tok (* rune_literal *)
+  | `Nil tok -> token env tok (* "nil" *)
+  | `True tok -> token env tok (* "true" *)
+  | `False tok -> token env tok (* "false" *)
+  | `Paren_exp (v1, v2, v3) ->
       let v1 = token env v1 (* "(" *) in
       let v2 = expression env v2 in
       let v3 = token env v3 (* ")" *) in
@@ -1370,14 +1370,14 @@ and keyed_element (env : env) ((v1, v2) : CST.keyed_element) =
 
 and element (env : env) (x : CST.element) =
   (match x with
-  | `Elem_exp x -> expression env x
-  | `Elem_lit_value x -> literal_value env x
+  | `Exp x -> expression env x
+  | `Lit_value x -> literal_value env x
   )
 
 
 and binary_expression (env : env) (x : CST.binary_expression) =
   (match x with
-  | `Bin_exp_exp_choice_STAR_exp (v1, v2, v3) ->
+  | `Exp_choice_STAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 =
         (match v2 with
@@ -1392,7 +1392,7 @@ and binary_expression (env : env) (x : CST.binary_expression) =
       in
       let v3 = expression env v3 in
       todo env (v1, v2, v3)
-  | `Bin_exp_exp_choice_PLUS_exp (v1, v2, v3) ->
+  | `Exp_choice_PLUS_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 =
         (match v2 with
@@ -1404,7 +1404,7 @@ and binary_expression (env : env) (x : CST.binary_expression) =
       in
       let v3 = expression env v3 in
       todo env (v1, v2, v3)
-  | `Bin_exp_exp_choice_EQEQ_exp (v1, v2, v3) ->
+  | `Exp_choice_EQEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 =
         (match v2 with
@@ -1418,12 +1418,12 @@ and binary_expression (env : env) (x : CST.binary_expression) =
       in
       let v3 = expression env v3 in
       todo env (v1, v2, v3)
-  | `Bin_exp_exp_AMPAMP_exp (v1, v2, v3) ->
+  | `Exp_AMPAMP_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "&&" *) in
       let v3 = expression env v3 in
       todo env (v1, v2, v3)
-  | `Bin_exp_exp_BARBAR_exp (v1, v2, v3) ->
+  | `Exp_BARBAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "||" *) in
       let v3 = expression env v3 in

--- a/semgrep-core/parsing/Parse_java_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_java_tree_sitter.ml
@@ -57,24 +57,24 @@ let identifier (env : env) (tok : CST.identifier) =
 
 let floating_point_type (env : env) (x : CST.floating_point_type) =
   (match x with
-  | `Floa_point_type_float tok -> TBasic ("float", token env tok) (* "float" *)
-  | `Floa_point_type_doub tok -> TBasic ("double", token env tok) (* "double" *)
+  | `Float tok -> TBasic ("float", token env tok) (* "float" *)
+  | `Doub tok -> TBasic ("double", token env tok) (* "double" *)
   )
 
 let integral_type (env : env) (x : CST.integral_type) =
   (match x with
-  | `Inte_type_byte tok -> TBasic (str env tok) (* "byte" *)
-  | `Inte_type_short tok -> TBasic (str env tok) (* "short" *)
-  | `Inte_type_int tok -> TBasic (str env tok) (* "int" *)
-  | `Inte_type_long tok -> TBasic (str env tok) (* "long" *)
-  | `Inte_type_char tok -> TBasic (str env tok) (* "char" *)
+  | `Byte tok -> TBasic (str env tok) (* "byte" *)
+  | `Short tok -> TBasic (str env tok) (* "short" *)
+  | `Int tok -> TBasic (str env tok) (* "int" *)
+  | `Long tok -> TBasic (str env tok) (* "long" *)
+  | `Char tok -> TBasic (str env tok) (* "char" *)
   )
 
 
 let requires_modifier (env : env) (x : CST.requires_modifier) =
   (match x with
-  | `Requis_modi_tran tok -> token env tok (* "transitive" *)
-  | `Requis_modi_stat tok -> token env tok (* "static" *)
+  | `Tran tok -> token env tok (* "transitive" *)
+  | `Stat tok -> token env tok (* "static" *)
   )
 
 let id_extra env = function
@@ -116,23 +116,23 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
 
 let literal (env : env) (x : CST.literal) =
   (match x with
-  | `Lit_deci_int_lit tok ->
+  | `Deci_int_lit tok ->
       Int (str env tok) (* decimal_integer_literal *)
-  | `Lit_hex_int_lit tok ->
+  | `Hex_int_lit tok ->
       Int (str env tok) (* hex_integer_literal *)
-  | `Lit_octal_int_lit tok ->
+  | `Octal_int_lit tok ->
       Int (str env tok) (* octal_integer_literal *)
-  | `Lit_bin_int_lit tok ->
+  | `Bin_int_lit tok ->
       Int (str env tok) (* binary_integer_literal *)
-  | `Lit_deci_floa_point_lit tok ->
+  | `Deci_floa_point_lit tok ->
       Float (str env tok) (* decimal_floating_point_literal *)
-  | `Lit_hex_floa_point_lit tok ->
+  | `Hex_floa_point_lit tok ->
       Float (str env tok) (* hex_floating_point_literal *)
-  | `Lit_true tok -> Bool (true, token env tok) (* "true" *)
-  | `Lit_false tok -> Bool (false, token env tok) (* "false" *)
-  | `Lit_char_lit tok -> Char (str env tok) (* character_literal *)
-  | `Lit_str_lit tok -> String (str env tok) (* string_literal *)
-  | `Lit_null_lit tok -> Null (token env tok) (* "null" *)
+  | `True tok -> Bool (true, token env tok) (* "true" *)
+  | `False tok -> Bool (false, token env tok) (* "false" *)
+  | `Char_lit tok -> Char (str env tok) (* character_literal *)
+  | `Str_lit tok -> String (str env tok) (* string_literal *)
+  | `Null_lit tok -> Null (token env tok) (* "null" *)
   )
 
 let module_directive (env : env) ((v1, v2) : CST.module_directive) =
@@ -219,7 +219,7 @@ let module_body (env : env) ((v1, v2, v3) : CST.module_body) =
 
 let rec expression (env : env) (x : CST.expression) =
   (match x with
-  | `Exp_assign_exp (v1, v2, v3) ->
+  | `Assign_exp (v1, v2, v3) ->
       let v1 =
         (match v1 with
         | `Id tok -> name_of_id env tok (* pattern [a-zA-Z_]\w* *)
@@ -253,13 +253,13 @@ let rec expression (env : env) (x : CST.expression) =
       | Left (), t -> Assign (v1, t, v3)
       | Right op, t -> AssignOp (v1, (op, t), v3)
       )
-  | `Exp_bin_exp x -> binary_expression env x
-  | `Exp_inst_exp (v1, v2, v3) ->
+  | `Bin_exp x -> binary_expression env x
+  | `Inst_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let _v2 = token env v2 (* "instanceof" *) in
       let v3 = type_ env v3 in
       InstanceOf (v1, v3)
-  | `Exp_lamb_exp (v1, v2, v3) ->
+  | `Lamb_exp (v1, v2, v3) ->
       let v1 =
         (match v1 with
         | `Id tok ->
@@ -281,17 +281,17 @@ let rec expression (env : env) (x : CST.expression) =
       in
       Lambda (v1, v3)
 
-  | `Exp_tern_exp (v1, v2, v3, v4, v5) ->
+  | `Tern_exp (v1, v2, v3, v4, v5) ->
       let v1 = expression env v1 in
       let _v2 = token env v2 (* "?" *) in
       let v3 = expression env v3 in
       let _v4 = token env v4 (* ":" *) in
       let v5 = expression env v5 in
       Conditional (v1, v3, v5)
-  | `Exp_upda_exp x -> update_expression env x
-  | `Exp_prim x -> primary env x
-  | `Exp_un_exp x -> unary_expression env x
-  | `Exp_cast_exp (v1, v2, v3, v4, v5) ->
+  | `Upda_exp x -> update_expression env x
+  | `Prim x -> primary env x
+  | `Un_exp x -> unary_expression env x
+  | `Cast_exp (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "(" *) in
       let v2 = type_ env v2 in
       let v3 =
@@ -309,97 +309,97 @@ let rec expression (env : env) (x : CST.expression) =
 
 and binary_expression (env : env) (x : CST.binary_expression) =
   (match x with
-  | `Bin_exp_exp_GT_exp (v1, v2, v3) ->
+  | `Exp_GT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Gt, v2), v3)
-  | `Bin_exp_exp_LT_exp (v1, v2, v3) ->
+  | `Exp_LT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "<" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Lt, v2), v3)
-  | `Bin_exp_exp_EQEQ_exp (v1, v2, v3) ->
+  | `Exp_EQEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "==" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Eq, v2), v3)
-  | `Bin_exp_exp_GTEQ_exp (v1, v2, v3) ->
+  | `Exp_GTEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">=" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.GtE, v2), v3)
-  | `Bin_exp_exp_LTEQ_exp (v1, v2, v3) ->
+  | `Exp_LTEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "<=" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.LtE, v2), v3)
-  | `Bin_exp_exp_BANGEQ_exp (v1, v2, v3) ->
+  | `Exp_BANGEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "!=" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.NotEq, v2), v3)
-  | `Bin_exp_exp_AMPAMP_exp (v1, v2, v3) ->
+  | `Exp_AMPAMP_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "&&" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.And, v2), v3)
-  | `Bin_exp_exp_BARBAR_exp (v1, v2, v3) ->
+  | `Exp_BARBAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "||" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Or, v2), v3)
-  | `Bin_exp_exp_PLUS_exp (v1, v2, v3) ->
+  | `Exp_PLUS_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "+" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Plus, v2), v3)
-  | `Bin_exp_exp_DASH_exp (v1, v2, v3) ->
+  | `Exp_DASH_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "-" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Minus, v2), v3)
-  | `Bin_exp_exp_STAR_exp (v1, v2, v3) ->
+  | `Exp_STAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "*" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Mult, v2), v3)
-  | `Bin_exp_exp_SLASH_exp (v1, v2, v3) ->
+  | `Exp_SLASH_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "/" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Div, v2), v3)
-  | `Bin_exp_exp_AMP_exp (v1, v2, v3) ->
+  | `Exp_AMP_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "&" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.BitAnd, v2), v3)
-  | `Bin_exp_exp_BAR_exp (v1, v2, v3) ->
+  | `Exp_BAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "|" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.BitOr, v2), v3)
-  | `Bin_exp_exp_HAT_exp (v1, v2, v3) ->
+  | `Exp_HAT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "^" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.BitXor, v2), v3)
-  | `Bin_exp_exp_PERC_exp (v1, v2, v3) ->
+  | `Exp_PERC_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "%" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.Mod, v2), v3)
-  | `Bin_exp_exp_LTLT_exp (v1, v2, v3) ->
+  | `Exp_LTLT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "<<" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.LSL, v2), v3)
-  | `Bin_exp_exp_GTGT_exp (v1, v2, v3) ->
+  | `Exp_GTGT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">>" *) in
       let v3 = expression env v3 in
       Infix (v1, (G.LSR, v2), v3)
-  | `Bin_exp_exp_GTGTGT_exp (v1, v2, v3) ->
+  | `Exp_GTGTGT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">>>" *) in
       let v3 = expression env v3 in
@@ -409,19 +409,19 @@ and binary_expression (env : env) (x : CST.binary_expression) =
 
 and unary_expression (env : env) (x : CST.unary_expression) =
   (match x with
-  | `Un_exp_PLUS_exp (v1, v2) ->
+  | `PLUS_exp (v1, v2) ->
       let v1 = token env v1 (* "+" *) in
       let v2 = expression env v2 in
       Unary ((G.Plus, v1), v2)
-  | `Un_exp_DASH_exp (v1, v2) ->
+  | `DASH_exp (v1, v2) ->
       let v1 = token env v1 (* "-" *) in
       let v2 = expression env v2 in
       Unary ((G.Minus, v1), v2)
-  | `Un_exp_BANG_exp (v1, v2) ->
+  | `BANG_exp (v1, v2) ->
       let v1 = token env v1 (* "!" *) in
       let v2 = expression env v2 in
       Unary ((G.Not, v1), v2)
-  | `Un_exp_TILDE_exp (v1, v2) ->
+  | `TILDE_exp (v1, v2) ->
       let v1 = token env v1 (* "~" *) in
       let v2 = expression env v2 in
       Unary ((G.BitNot, v1), v2)
@@ -482,26 +482,26 @@ and new_id env tok =
 
 and primary (env : env) (x : CST.primary) =
   (match x with
-  | `Prim_lit x -> Literal (literal env x)
-  | `Prim_class_lit (v1, v2, v3) ->
+  | `Lit x -> Literal (literal env x)
+  | `Class_lit (v1, v2, v3) ->
       let v1 = unannotated_type env v1 in
       let _v2 = token env v2 (* "." *) in
       let _v3 = token env v3 (* "class" *) in
       ClassLiteral v1
-  | `Prim_this tok -> this env tok (* "this" *)
-  | `Prim_id tok -> name_of_id env tok (* pattern [a-zA-Z_]\w* *)
+  | `This tok -> this env tok (* "this" *)
+  | `Id tok -> name_of_id env tok (* pattern [a-zA-Z_]\w* *)
 
-  | `Prim_choice_open x ->
+  | `Choice_open x ->
       (match x with
       | `Open tok -> name_of_id env tok (* "open" *)
       | `Modu tok -> name_of_id env tok (* "module" *)
       )
-  | `Prim_paren_exp x -> parenthesized_expression env x
-  | `Prim_obj_crea_exp x ->
+  | `Paren_exp x -> parenthesized_expression env x
+  | `Obj_crea_exp x ->
       object_creation_expression env x
-  | `Prim_field_acce x -> field_access env x
-  | `Prim_array_acce x -> array_access env x
-  | `Prim_meth_invo (v1, v2) ->
+  | `Field_acce x -> field_access env x
+  | `Array_acce x -> array_access env x
+  | `Meth_invo (v1, v2) ->
       let v1 =
         (match v1 with
         | `Choice_id x ->
@@ -537,7 +537,7 @@ and primary (env : env) (x : CST.primary) =
       in
       let v2 = argument_list env v2 in
       Call (v1, v2)
-  | `Prim_meth_ref (v1, v2, v3, v4) ->
+  | `Meth_ref (v1, v2, v3, v4) ->
       let v1 =
         (match v1 with
         | `Type x -> let t = type_ env x in
@@ -559,7 +559,7 @@ and primary (env : env) (x : CST.primary) =
         )
       in
       MethodRef (v1, v2, v3, v4)
-  | `Prim_array_crea_exp (v1, v2, v3) ->
+  | `Array_crea_exp (v1, v2, v3) ->
       let v1 = token env v1 (* "new" *) in
       let v2 = basic_type_extra env v2 in
       let (exprs, dims, init) =
@@ -607,12 +607,12 @@ and parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expre
 
 and object_creation_expression (env : env) (x : CST.object_creation_expression) =
   (match x with
-  | `Obj_crea_exp_unqu_obj_crea_exp x ->
+  | `Unqu_obj_crea_exp x ->
       let (tnew, _targsTODO, typ, args, body_opt) =
             unqualified_object_creation_expression env x in
       NewClass (tnew, typ, args, body_opt)
 
-  | `Obj_crea_exp_prim_DOT_unqu_obj_crea_exp (v1, v2, v3) ->
+  | `Prim_DOT_unqu_obj_crea_exp (v1, v2, v3) ->
       let v1 = primary env v1 in
       let v2 = token env v2 (* "." *) in
       let v3 =
@@ -742,11 +742,11 @@ and wildcard (env : env) ((v1, v2, v3) : CST.wildcard) =
 
 and wildcard_bounds (env : env) (x : CST.wildcard_bounds) =
   (match x with
-  | `Wild_bounds_extens_type (v1, v2) ->
+  | `Extens_type (v1, v2) ->
       let _v1 = token env v1 (* "extends" *) in
       let v2 = type_ env v2 in
       false, v2
-  | `Wild_bounds_super_type (v1, v2) ->
+  | `Super_type (v1, v2) ->
       let _v1 = token env v1 (* "super" *) in
       let v2 = type_ env v2 in
       true, v2
@@ -764,17 +764,17 @@ and statement (env : env) (x : CST.statement) : Ast_java.stmt =
 
 and statement_aux env x : Ast_java.stmt list =
   (match x with
-  | `Stmt_decl x -> [declaration env x]
-  | `Stmt_exp_stmt (v1, v2) ->
+  | `Decl x -> [declaration env x]
+  | `Exp_stmt (v1, v2) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ";" *) in
       [Expr (v1, v2)]
-  | `Stmt_labe_stmt (v1, v2, v3) ->
+  | `Labe_stmt (v1, v2, v3) ->
       let v1 = identifier env v1 (* pattern [a-zA-Z_]\w* *) in
       let _v2 = token env v2 (* ":" *) in
       let v3 = statement env v3 in
       [Label (v1, v3)]
-  | `Stmt_if_stmt (v1, v2, v3, v4) ->
+  | `If_stmt (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "if" *) in
       let v2 = parenthesized_expression env v2 in
       let v3 = statement env v3 in
@@ -787,12 +787,12 @@ and statement_aux env x : Ast_java.stmt list =
         | None -> None)
       in
       [If (v1, v2, v3, v4)]
-  | `Stmt_while_stmt (v1, v2, v3) ->
+  | `While_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "while" *) in
       let v2 = parenthesized_expression env v2 in
       let v3 = statement env v3 in
       [While (v1, v2, v3)]
-  | `Stmt_for_stmt (v1, v2, v3, v4, v5, v6, v7, v8) ->
+  | `For_stmt (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 = token env v1 (* "for" *) in
       let _v2 = token env v2 (* "(" *) in
       let v3 =
@@ -842,7 +842,7 @@ and statement_aux env x : Ast_java.stmt list =
       let _v7 = token env v7 (* ")" *) in
       let v8 = statement env v8 in
       [For (v1, ForClassic (v3, v4, v6), v8)]
-  | `Stmt_enha_for_stmt (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
+  | `Enha_for_stmt (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
       let v1 = token env v1 (* "for" *) in
       let _v2 = token env v2 (* "(" *) in
       let v3 =
@@ -859,24 +859,24 @@ and statement_aux env x : Ast_java.stmt list =
       let vdef = canon_var v3 (Some v4) v5 in
       [For (v1, Foreach (vdef, v7), v9)]
 
-  | `Stmt_blk x -> [block env x]
-  | `Stmt_SEMI tok ->
+  | `Blk x -> [block env x]
+  | `SEMI tok ->
         let t = token env tok (* ";" *) in [EmptyStmt t]
-  | `Stmt_asse_stmt x ->
+  | `Asse_stmt x ->
         [assert_statement env x]
-  | `Stmt_swit_stmt (v1, v2, v3) ->
+  | `Swit_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "switch" *) in
       let v2 = parenthesized_expression env v2 in
       let v3 = switch_block env v3 in
       [Switch (v1, v2, v3)]
-  | `Stmt_do_stmt (v1, v2, v3, v4, v5) ->
+  | `Do_stmt (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "do" *) in
       let v2 = statement env v2 in
       let _v3 = token env v3 (* "while" *) in
       let v4 = parenthesized_expression env v4 in
       let _v5 = token env v5 (* ";" *) in
       [Do (v1, v2, v4)]
-  | `Stmt_brk_stmt (v1, v2, v3) ->
+  | `Brk_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "break" *) in
       let v2 =
         (match v2 with
@@ -885,7 +885,7 @@ and statement_aux env x : Ast_java.stmt list =
       in
       let _v3 = token env v3 (* ";" *) in
       [Break (v1, v2)]
-  | `Stmt_cont_stmt (v1, v2, v3) ->
+  | `Cont_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "continue" *) in
       let v2 =
         (match v2 with
@@ -894,7 +894,7 @@ and statement_aux env x : Ast_java.stmt list =
       in
       let _v3 = token env v3 (* ";" *) in
       [Continue (v1, v2)]
-  | `Stmt_ret_stmt (v1, v2, v3) ->
+  | `Ret_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "return" *) in
       let v2 =
         (match v2 with
@@ -903,20 +903,20 @@ and statement_aux env x : Ast_java.stmt list =
       in
       let _v3 = token env v3 (* ";" *) in
       [Return (v1, v2)]
-  | `Stmt_sync_stmt (v1, v2, v3) ->
+  | `Sync_stmt (v1, v2, v3) ->
       let _v1 = token env v1 (* "synchronized" *) in
       let v2 = parenthesized_expression env v2 in
       let v3 = block env v3 in
       [Sync (v2, v3)]
-  | `Stmt_local_var_decl x ->
+  | `Local_var_decl x ->
       let xs = local_variable_declaration env x in
       xs |> List.map (fun x -> LocalVar x)
-  | `Stmt_throw_stmt (v1, v2, v3) ->
+  | `Throw_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "throw" *) in
       let v2 = expression env v2 in
       let _v3 = token env v3 (* ";" *) in
       [Throw (v1, v2)]
-  | `Stmt_try_stmt (v1, v2, v3) ->
+  | `Try_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "try" *) in
       let v2 = block env v2 in
       let v3 =
@@ -930,7 +930,7 @@ and statement_aux env x : Ast_java.stmt list =
       in
       let (v3a, v3b) = v3 in
       [Try (v1, None, v2, v3a, v3b)]
-  | `Stmt_try_with_resous_stmt (v1, v2, v3, v4, v5) ->
+  | `Try_with_resous_stmt (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "try" *) in
       let v2 = resource_specification env v2 in
       let v3 = block env v3 in
@@ -953,12 +953,12 @@ and block (env : env) ((v1, v2, v3) : CST.block) =
 
 and assert_statement (env : env) (x : CST.assert_statement) =
   (match x with
-  | `Asse_stmt_asse_exp_SEMI (v1, v2, v3) ->
+  | `Asse_exp_SEMI (v1, v2, v3) ->
       let v1 = token env v1 (* "assert" *) in
       let v2 = expression env v2 in
       let _v3 = token env v3 (* ";" *) in
       Assert (v1, v2, None)
-  | `Asse_stmt_asse_exp_COLON_exp_SEMI (v1, v2, v3, v4, v5) ->
+  | `Asse_exp_COLON_exp_SEMI (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "assert" *) in
       let v2 = expression env v2 in
       let _v3 = token env v3 (* ":" *) in
@@ -998,12 +998,12 @@ and switch_block (env : env) ((v1, v2, v3) : CST.switch_block) =
 
 and switch_label (env : env) (x : CST.switch_label) =
   (match x with
-  | `Swit_label_case_exp_COLON (v1, v2, v3) ->
+  | `Case_exp_COLON (v1, v2, v3) ->
       let v1 = token env v1 (* "case" *) in
       let v2 = expression env v2 in
       let _v3 = token env v3 (* ":" *) in
       Case (v1, v2)
-  | `Swit_label_defa_COLON (v1, v2) ->
+  | `Defa_COLON (v1, v2) ->
       let v1 = token env v1 (* "default" *) in
       let _v2 = token env v2 (* ":" *) in
       Default v1
@@ -1070,7 +1070,7 @@ and resource_specification (env : env) ((v1, v2, v3, v4, v5) : CST.resource_spec
 
 and resource (env : env) (x : CST.resource) =
   (match x with
-  | `Reso_opt_modifs_unan_type_var_decl_id_EQ_exp (v1, v2, v3, v4, v5) ->
+  | `Opt_modifs_unan_type_var_decl_id_EQ_exp (v1, v2, v3, v4, v5) ->
       let v1 =
         (match v1 with
         | Some x -> modifiers env x
@@ -1082,21 +1082,21 @@ and resource (env : env) (x : CST.resource) =
       let v5 = expression env v5 in
       let vdef = canon_var v1 (Some v2) v3 in
       Left { f_var = vdef; f_init = Some (ExprInit v5) }
-  | `Reso_id tok ->
+  | `Id tok ->
         let x = name_of_id env tok (* pattern [a-zA-Z_]\w* *) in
         Right x
-  | `Reso_field_acce x ->
+  | `Field_acce x ->
      Right (field_access env x)
   )
 
 
 and annotation (env : env) (x : CST.annotation) : tok * annotation =
   (match x with
-  | `Anno_mark_anno (v1, v2) ->
+  | `Mark_anno (v1, v2) ->
       let v1 = token env v1 (* "@" *) in
       let v2 = qualifier_extra env v2 in
       v1, (v1, (v2 |> List.map (fun id -> Id id)), None)
-  | `Anno_anno_ (v1, v2, v3) ->
+  | `Anno_ (v1, v2, v3) ->
       let v1 = token env v1 (* "@" *) in
       let v2 = qualifier_extra env v2 in
       let v3 = annotation_argument_list env v3 in
@@ -1717,8 +1717,8 @@ and array_initializer (env : env) ((v1, v2, v3, v4) : CST.array_initializer) =
 
 and type_ (env : env) (x : CST.type_) : typ =
   (match x with
-  | `Type_unan_type x -> unannotated_type env x
-  | `Type_anno_type (v1, v2) ->
+  | `Unan_type x -> unannotated_type env x
+  | `Anno_type (v1, v2) ->
       let _v1 = List.map (annotation env) v1 in
       let v2 = unannotated_type env v2 in
       v2
@@ -1727,9 +1727,9 @@ and type_ (env : env) (x : CST.type_) : typ =
 
 and unannotated_type (env : env) (x : CST.unannotated_type) : typ =
   (match x with
-  | `Unan_type_choice_void_type x ->
+  | `Choice_void_type x ->
         basic_type_extra env x
-  | `Unan_type_array_type (v1, v2) ->
+  | `Array_type (v1, v2) ->
       let v1 = unannotated_type env v1 in
       let v2 = dimensions env v2 in
       List.fold_left (fun acc _e -> TArray acc) v1 v2

--- a/semgrep-core/parsing/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_ruby_tree_sitter.ml
@@ -65,60 +65,60 @@ let blank () = ()
 
 let false_ (x : CST.false_) : bool wrap =
   (match x with
-  | `False_false tok -> false, token2 tok
-  | `False_FALSE tok -> false, token2 tok
+  | `False tok -> false, token2 tok
+  | `FALSE tok -> false, token2 tok
   )
 
 let true_ (x : CST.true_) : bool wrap =
   (match x with
-  | `True_true tok -> true, token2 tok
-  | `True_TRUE tok -> true, token2 tok
+  | `True tok -> true, token2 tok
+  | `TRUE tok -> true, token2 tok
   )
 
 let nil (x : CST.nil) : tok =
   (match x with
-  | `Nil_nil tok -> token2 tok
-  | `Nil_NIL tok -> token2 tok
+  | `Nil tok -> token2 tok
+  | `NIL tok -> token2 tok
   )
 
 
 let operator (x : CST.operator) =
   (match x with
 
-  | `Op_DOTDOT tok -> Left Op_DOT2, (token2 tok)
-  | `Op_BAR tok -> Left Op_BOR, (token2 tok)
-  | `Op_HAT tok -> Left Op_XOR, (token2 tok)
-  | `Op_AMP tok -> Left Op_BAND, (token2 tok)
+  | `DOTDOT tok -> Left Op_DOT2, (token2 tok)
+  | `BAR tok -> Left Op_BOR, (token2 tok)
+  | `HAT tok -> Left Op_XOR, (token2 tok)
+  | `AMP tok -> Left Op_BAND, (token2 tok)
 
-  | `Op_LTEQGT tok -> Left Op_CMP, (token2 tok)
-  | `Op_EQEQ tok -> Left Op_EQ, (token2 tok)
-  | `Op_EQEQEQ tok -> Left Op_EQQ, (token2 tok)
-  | `Op_EQTILDE tok -> Left Op_MATCH, (token2 tok)
-  | `Op_GT tok -> Left Op_GT, (token2 tok)
-  | `Op_GTEQ tok -> Left Op_GEQ, (token2 tok)
-  | `Op_LT tok -> Left Op_LT, (token2 tok)
-  | `Op_LTEQ tok -> Left Op_LEQ, (token2 tok)
+  | `LTEQGT tok -> Left Op_CMP, (token2 tok)
+  | `EQEQ tok -> Left Op_EQ, (token2 tok)
+  | `EQEQEQ tok -> Left Op_EQQ, (token2 tok)
+  | `EQTILDE tok -> Left Op_MATCH, (token2 tok)
+  | `GT tok -> Left Op_GT, (token2 tok)
+  | `GTEQ tok -> Left Op_GEQ, (token2 tok)
+  | `LT tok -> Left Op_LT, (token2 tok)
+  | `LTEQ tok -> Left Op_LEQ, (token2 tok)
 
-  | `Op_PLUS tok -> Left Op_PLUS, (token2 tok)
-  | `Op_DASH tok -> Left Op_MINUS, (token2 tok)
-  | `Op_STAR tok -> Left Op_TIMES, (token2 tok)
-  | `Op_SLASH tok -> Left Op_DIV, (token2 tok)
-  | `Op_PERC tok -> Left Op_REM, (token2 tok)
-  | `Op_BANGTILDE tok -> Left Op_NMATCH, (token2 tok)
-  | `Op_STARSTAR tok -> Left Op_POW, (token2 tok)
-  | `Op_LTLT tok -> Left Op_LSHIFT, (token2 tok)
-  | `Op_GTGT tok -> Left Op_RSHIFT, (token2 tok)
-  | `Op_LBRACKRBRACK tok -> Left Op_AREF, (token2 tok)
-  | `Op_LBRACKRBRACKEQ tok -> Left Op_ASET, (token2 tok)
+  | `PLUS tok -> Left Op_PLUS, (token2 tok)
+  | `DASH tok -> Left Op_MINUS, (token2 tok)
+  | `STAR tok -> Left Op_TIMES, (token2 tok)
+  | `SLASH tok -> Left Op_DIV, (token2 tok)
+  | `PERC tok -> Left Op_REM, (token2 tok)
+  | `BANGTILDE tok -> Left Op_NMATCH, (token2 tok)
+  | `STARSTAR tok -> Left Op_POW, (token2 tok)
+  | `LTLT tok -> Left Op_LSHIFT, (token2 tok)
+  | `GTGT tok -> Left Op_RSHIFT, (token2 tok)
+  | `LBRACKRBRACK tok -> Left Op_AREF, (token2 tok)
+  | `LBRACKRBRACKEQ tok -> Left Op_ASET, (token2 tok)
 
-  | `Op_PLUSAT tok -> Right Op_UPlus, token2 tok
-  | `Op_DASHAT tok -> Right Op_UMinus, token2 tok
+  | `PLUSAT tok -> Right Op_UPlus, token2 tok
+  | `DASHAT tok -> Right Op_UMinus, token2 tok
 
-  | `Op_TILDE tok -> Right Op_UTilde, token2 tok
-  | `Op_BANG tok -> Right Op_UBang, token2 tok
+  | `TILDE tok -> Right Op_UTilde, token2 tok
+  | `BANG tok -> Right Op_UBang, token2 tok
 
   (* TODO *)
-  | `Op_BQUOT tok ->
+  | `BQUOT tok ->
         pr2_gen tok;
         failwith "Op_BQUOT???"
   )
@@ -126,8 +126,8 @@ let operator (x : CST.operator) =
 
 let terminator (x : CST.terminator) : unit =
   (match x with
-  | `Term_line_brk _tok -> ()
-  | `Term_SEMI _tok -> ()
+  | `Line_brk _tok -> ()
+  | `SEMI _tok -> ()
   )
 
 let variable (x : CST.variable) : AST.variable =
@@ -151,13 +151,13 @@ let variable (x : CST.variable) : AST.variable =
 
 let do_ (x : CST.do_) : unit =
   (match x with
-  | `Do_do _tok -> ()
-  | `Do_term x -> terminator x
+  | `Do _tok -> ()
+  | `Term x -> terminator x
   )
 
 let rec statements (x : CST.statements) : AST.stmts =
   (match x with
-  | `Stmts_rep1_choice_stmt_term_opt_stmt (v1, v2) ->
+  | `Rep1_choice_stmt_term_opt_stmt (v1, v2) ->
       let v1 =
         v1 |> List.map (fun x ->
           (match x with
@@ -176,12 +176,12 @@ let rec statements (x : CST.statements) : AST.stmts =
         | None -> [])
       in
       v1 @ v2
-  | `Stmts_stmt x -> [statement x]
+  | `Stmt x -> [statement x]
   )
 
 and statement (x : CST.statement) : AST.expr (* TODO AST.stmt at some point *)=
   (match x with
-  | `Stmt_undef (v1, v2, v3) ->
+  | `Undef (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 = method_name v2 in
       let v3 =
@@ -192,34 +192,34 @@ and statement (x : CST.statement) : AST.expr (* TODO AST.stmt at some point *)=
         ) v3
       in
       D (Undef (v1, (v2::v3)))
-  | `Stmt_alias (v1, v2, v3) ->
+  | `Alias (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 = method_name v2 in
       let v3 = method_name v3 in
       D (Alias (v1, v2, v3))
-  | `Stmt_if_modi (v1, v2, v3) ->
+  | `If_modi (v1, v2, v3) ->
       let v1 = statement v1 in
       let v2 = token2 v2 in
       let v3 = expression v3 in
       S (If (v2, v3, [v1], None))
-  | `Stmt_unle_modi (v1, v2, v3) ->
+  | `Unle_modi (v1, v2, v3) ->
       let v1 = statement v1 in
       let v2 = token2 v2 in
       let v3 = expression v3 in
       S (Unless (v2, v3, [v1], None))
-  | `Stmt_while_modi (v1, v2, v3) ->
+  | `While_modi (v1, v2, v3) ->
       let v1 = statement v1 in
       let v2 = token2 v2 in
       let v3 = expression v3 in
       let b = true (* ?? *) in
       S (While (v2, b, v3, [v1]))
-  | `Stmt_until_modi (v1, v2, v3) ->
+  | `Until_modi (v1, v2, v3) ->
       let v1 = statement v1 in
       let v2 = token2 v2 in
       let v3 = expression v3 in
       S (Until (v2, true, v3, [v1]))
 
-  | `Stmt_resc_modi (v1, v2, v3) ->
+  | `Resc_modi (v1, v2, v3) ->
       let v1 = statement v1 in
       let v2 = token2 v2 in
       let v3 = expression v3 in
@@ -231,7 +231,7 @@ and statement (x : CST.statement) : AST.expr (* TODO AST.stmt at some point *)=
         }))
 
 
-  | `Stmt_begin_blk (v1, v2, v3, v4) ->
+  | `Begin_blk (v1, v2, v3, v4) ->
       let v1 = token2 v1 in
       let v2 = token2 v2 in
       let v3 =
@@ -241,7 +241,7 @@ and statement (x : CST.statement) : AST.expr (* TODO AST.stmt at some point *)=
       in
       let v4 = token2 v4 in
       D (BeginBlock (v1, (v2, v3, v4)))
-  | `Stmt_end_blk (v1, v2, v3, v4) ->
+  | `End_blk (v1, v2, v3, v4) ->
       let v1 = token2 v1 in
       let v2 = token2 v2 in
       let v3 =
@@ -251,7 +251,7 @@ and statement (x : CST.statement) : AST.expr (* TODO AST.stmt at some point *)=
       in
       let v4 = token2 v4 in
       D (EndBlock (v1, (v2, v3, v4)))
-  | `Stmt_exp x -> expression x
+  | `Exp x -> expression x
   )
 
 and method_rest ((v1, v2, v3) : CST.method_rest) =
@@ -351,19 +351,19 @@ and block_parameters ((v1, v2, v3, v4, v5) : CST.block_parameters) :
 
 and formal_parameter (x : CST.formal_parameter) : AST.formal_param =
   (match x with
-  | `Form_param_simple_form_param x ->
+  | `Simple_form_param x ->
       simple_formal_parameter x
-  | `Form_param_params x ->
+  | `Params x ->
         let (lp, xs, rp) = parameters x in
         Formal_tuple ((lp, xs, rp))
   )
 
 and simple_formal_parameter (x : CST.simple_formal_parameter) : AST.formal_param =
   (match x with
-  | `Simple_form_param_id tok ->
+  | `Id tok ->
         let id = str tok in
         Formal_id ((id))
-  | `Simple_form_param_splat_param (v1, v2) ->
+  | `Splat_param (v1, v2) ->
       let v1 = token2 v1 in
         (match v2 with
         | Some tok -> let id = str tok in
@@ -371,7 +371,7 @@ and simple_formal_parameter (x : CST.simple_formal_parameter) : AST.formal_param
         | None ->
            Formal_rest v1
         )
-  | `Simple_form_param_hash_splat_param (v1, v2) ->
+  | `Hash_splat_param (v1, v2) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -379,11 +379,11 @@ and simple_formal_parameter (x : CST.simple_formal_parameter) : AST.formal_param
         | None -> None)
       in
       Formal_hash_splat (v1, v2)
-  | `Simple_form_param_blk_param (v1, v2) ->
+  | `Blk_param (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = str v2 in
       Formal_amp (v1, v2)
-  | `Simple_form_param_kw_param (v1, v2, v3) ->
+  | `Kw_param (v1, v2, v3) ->
       let v1 = str v1 in
       let v2 = token2 v2 in
       let v3 =
@@ -392,7 +392,7 @@ and simple_formal_parameter (x : CST.simple_formal_parameter) : AST.formal_param
         | None -> None)
       in
       Formal_kwd (v1, v2, v3)
-  | `Simple_form_param_opt_param (v1, v2, v3) ->
+  | `Opt_param (v1, v2, v3) ->
       let v1 = str v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
@@ -429,8 +429,8 @@ and when_ ((v1, v2, v3, v4) : CST.when_) =
 
 and pattern (x : CST.pattern) : AST.pattern =
   (match x with
-  | `Pat_arg x -> arg x
-  | `Pat_splat_arg x -> splat_argument x
+  | `Arg x -> arg x
+  | `Splat_arg x -> splat_argument x
   )
 
 and elsif ((v1, v2, v3, v4) : CST.elsif) : AST.tok * AST.stmt =
@@ -471,11 +471,11 @@ and else_ ((v1, v2, v3) : CST.else_) : (AST.tok * AST.stmts) =
 
 and then_ (x : CST.then_) : AST.stmts =
   (match x with
-  | `Then_term_stmts (v1, v2) ->
+  | `Term_stmts (v1, v2) ->
       let _v1 = terminator v1 in
       let v2 = statements v2 in
       v2
-  | `Then_opt_term_then_opt_stmts (v1, v2, v3) ->
+  | `Opt_term_then_opt_stmts (v1, v2, v3) ->
       let _v1 =
         (match v1 with
         | Some x -> terminator x
@@ -582,7 +582,7 @@ and body_statement ((v1, v2, v3) : CST.body_statement) :
 
 and expression (x : CST.expression) : AST.expr =
   (match x with
-  | `Exp_cmd_bin (v1, v2, v3) ->
+  | `Cmd_bin (v1, v2, v3) ->
       let v1 = expression v1 in
       let v2 =
         (match v2 with
@@ -592,8 +592,8 @@ and expression (x : CST.expression) : AST.expr =
       in
       let v3 = expression v3 in
       Binop (v1, v2, v3)
-  | `Exp_cmd_assign x -> command_assignment x
-  | `Exp_cmd_op_assign (v1, v2, v3) ->
+  | `Cmd_assign x -> command_assignment x
+  | `Cmd_op_assign (v1, v2, v3) ->
       let v1 = lhs v1 in
       let (op, tok) =
         (match v2 with
@@ -614,31 +614,31 @@ and expression (x : CST.expression) : AST.expr =
       in
       let v3 = expression v3 in
       Binop (v1, (Op_OP_ASGN op, tok), v3)
-  | `Exp_cmd_call x -> command_call x
-  | `Exp_ret_cmd (v1, v2) ->
+  | `Cmd_call x -> command_call x
+  | `Ret_cmd (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = command_argument_list v2 in
       S (Return (v1, v2))
-  | `Exp_yield_cmd (v1, v2) ->
+  | `Yield_cmd (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = command_argument_list v2 in
       S (Yield (v1, v2))
-  | `Exp_brk_cmd (v1, v2) ->
+  | `Brk_cmd (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = command_argument_list v2 in
       S (Break (v1, v2))
-  | `Exp_next_cmd (v1, v2) ->
+  | `Next_cmd (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = command_argument_list v2 in
       S (Next (v1, v2))
-  | `Exp_arg x -> arg x
+  | `Arg x -> arg x
   )
 
 and arg (x : CST.arg) : AST.expr =
   (match x with
-  | `Arg_prim x -> primary x
-  | `Arg_assign x -> assignment x
-  | `Arg_op_assign (v1, v2, v3) ->
+  | `Prim x -> primary x
+  | `Assign x -> assignment x
+  | `Op_assign (v1, v2, v3) ->
       let v1 = lhs v1 in
       let (op, tok) =
         (match v2 with
@@ -659,14 +659,14 @@ and arg (x : CST.arg) : AST.expr =
       in
       let v3 = arg v3 in
       Binop (v1, (Op_OP_ASGN op, tok), v3)
-  | `Arg_cond (v1, v2, v3, v4, v5) ->
+  | `Cond (v1, v2, v3, v4, v5) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
       let v4 = token2 v4 in
       let v5 = arg v5 in
       Ternary (v1, v2, v3, v4, v5)
-  | `Arg_range (v1, v2, v3) ->
+  | `Range (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 =
         (match v2 with
@@ -676,17 +676,17 @@ and arg (x : CST.arg) : AST.expr =
       in
       let v3 = arg v3 in
       Binop (v1, v2, v3)
-  | `Arg_bin x -> binary x
-  | `Arg_un x -> unary x
+  | `Bin x -> binary x
+  | `Un x -> unary x
   )
 
 and primary (x : CST.primary) : AST.expr =
   (match x with
-  | `Prim_paren_stmts x ->
+  | `Paren_stmts x ->
         let (lp, xs, rp) = parenthesized_statements x in
         S (Block (lp, xs, rp))
-  | `Prim_lhs x -> lhs x
-  | `Prim_array (v1, v2, v3) ->
+  | `Lhs x -> lhs x
+  | `Array (v1, v2, v3) ->
       let lb = token2 v1 in
       let v2 =
         (match v2 with
@@ -696,7 +696,7 @@ and primary (x : CST.primary) : AST.expr =
       let rb = token2 v3 in
       Array (lb, v2, rb)
   (* ?? *)
-  | `Prim_str_array (v1, v2, v3, v4, v5) ->
+  | `Str_array (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let _v2 =
         (match v2 with
@@ -724,7 +724,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v5 = token2 v5 in
       Literal (String (Double (v3 |> List.flatten), v1)) (* Double? *)
-  | `Prim_symb_array (v1, v2, v3, v4, v5) ->
+  | `Symb_array (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let _v2 =
         (match v2 with
@@ -752,7 +752,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v5 = token2 v5 in
       Literal (Atom (v3 |> List.flatten, v1))
-  | `Prim_hash (v1, v2, v3) ->
+  | `Hash (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -785,7 +785,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let v3 = token2 v3 in
       Hash (true, (v1, v2, v3))
-  | `Prim_subs (v1, v2, v3) ->
+  | `Subs (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -794,20 +794,20 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v3 = token2 v3 in
       Literal (String (Tick v2, v1)) (* Tick? *)
-  | `Prim_symb x -> Literal (Atom (symbol x))
-  | `Prim_int tok -> Literal (Num (str tok))
-  | `Prim_float tok -> Literal (Float (str tok))
-  | `Prim_comp tok -> Literal (Complex (str tok))
-  | `Prim_rati (v1, v2) ->
+  | `Symb x -> Literal (Atom (symbol x))
+  | `Int tok -> Literal (Num (str tok))
+  | `Float tok -> Literal (Float (str tok))
+  | `Comp tok -> Literal (Complex (str tok))
+  | `Rati (v1, v2) ->
       let v1 = str v1 in
       let v2 = token2 v2 in
       Literal (Rational (v1, v2))
-  | `Prim_str x ->
+  | `Str x ->
         let (t1, xs, _t2) = string_ x in
         Literal (String (Double xs, t1))
-  | `Prim_char tok ->
+  | `Char tok ->
         Literal (Char (str tok))
-  | `Prim_chai_str (v1, v2) ->
+  | `Chai_str (v1, v2) ->
       let (t1, v1, _) = string_ v1 in
       let v2 = List.map (fun x ->
               let (_lp, x, _) = string_ x in
@@ -816,7 +816,7 @@ and primary (x : CST.primary) : AST.expr =
         in
       Literal (String (Double (v1 @ v2), t1))
 
-  | `Prim_regex (v1, v2, v3) ->
+  | `Regex (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -825,7 +825,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v3 = token2 v3 in
       Literal (Regexp ((v2, "??"), v1))
-  | `Prim_lamb (v1, v2, v3) ->
+  | `Lamb (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -844,11 +844,11 @@ and primary (x : CST.primary) : AST.expr =
       in
       let b = false in (* should have a third option for lambdas *)
       CodeBlock ((v1, b, v1), v2, [v3])
-  | `Prim_meth (v1, v2) ->
+  | `Meth (v1, v2) ->
       let v1 = token2 v1 in
       let (n, params, body_exn) = method_rest v2 in
       D (MethodDef (v1, M n, params, body_exn))
-  | `Prim_sing_meth (v1, v2, v3, v4) ->
+  | `Sing_meth (v1, v2, v3, v4) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -871,7 +871,7 @@ and primary (x : CST.primary) : AST.expr =
       let (n, params, body_exn) = method_rest v4 in
       let n = v3 v2 n in
       D (MethodDef (v1, SingletonM n, params, body_exn))
-  | `Prim_class (v1, v2, v3, v4, v5) ->
+  | `Class (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -887,14 +887,14 @@ and primary (x : CST.primary) : AST.expr =
       let _v4 = terminator v4 in
       let (v5, _tend) = body_statement v5 in
       D (ClassDef (v1, C (v2, v3), v5))
-  | `Prim_sing_class (v1, v2, v3, v4, v5) ->
+  | `Sing_class (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
       let _v4 = terminator v4 in
       let (v5, _tend) = body_statement v5 in
       D (ClassDef (v1, SingletonC (v2, v3), v5))
-  | `Prim_modu (v1, v2, v3) ->
+  | `Modu (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -912,7 +912,7 @@ and primary (x : CST.primary) : AST.expr =
         )
       in
       D (ModuleDef (v1, v2, v3))
-  | `Prim_begin (v1, v2, v3) ->
+  | `Begin (v1, v2, v3) ->
       let tbegin = token2 v1 in
       let _v2 =
         (match v2 with
@@ -921,7 +921,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let (v3, tend) = body_statement v3 in
       S (Block (tbegin, [S (ExnBlock (v3))], tend))
-  | `Prim_while (v1, v2, v3, v4, v5) ->
+  | `While (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let v2 = arg v2 in
       let _v3 = do_ v3 in
@@ -932,7 +932,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _tend = token2 v5 in
       S (While (v1, true, v2, v4))
-  | `Prim_until (v1, v2, v3, v4, v5) ->
+  | `Until (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let v2 = arg v2 in
       let _v3 = do_ v3 in
@@ -943,7 +943,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _tend = token2 v5 in
       S (Until (v1, true, v2, v4))
-  | `Prim_if (v1, v2, v3, v4, v5) ->
+  | `If (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let v2 = statement v2 in
       let v3 =
@@ -965,7 +965,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v5 = token2 v5 in
       S (If (v1, v2, v3, v4))
-  | `Prim_unle (v1, v2, v3, v4, v5) ->
+  | `Unle (v1, v2, v3, v4, v5) ->
       let v1 = token2 v1 in
       let v2 = statement v2 in
       let v3 =
@@ -987,7 +987,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v5 = token2 v5 in
       S (Unless (v1, v2, v3, v4))
-  | `Prim_for (v1, v2, v3, v4, v5, v6) ->
+  | `For (v1, v2, v3, v4, v5, v6) ->
       let v1 = token2 v1 in
       let v2 = mlhs v2 in
       let (t, e) = in_ v3 in
@@ -999,7 +999,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v6 = token2 v6 in
       S (For (v1, v2 |> list_to_maybe_tuple, t, e, v5))
-  | `Prim_case (v1, v2, v3, v4, v5, v6, v7) ->
+  | `Case (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1016,7 +1016,7 @@ and primary (x : CST.primary) : AST.expr =
       in
       let _v7 = token2 v7 in
       S (Case (v1, { case_guard = v2; case_whens = v5; case_else = v6}))
-  | `Prim_ret (v1, v2) ->
+  | `Ret (v1, v2) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1024,7 +1024,7 @@ and primary (x : CST.primary) : AST.expr =
         | None -> [])
       in
       S (Return (v1, v2))
-  | `Prim_yield (v1, v2) ->
+  | `Yield (v1, v2) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1032,7 +1032,7 @@ and primary (x : CST.primary) : AST.expr =
         | None -> [])
       in
       S (Yield (v1, v2))
-  | `Prim_brk (v1, v2) ->
+  | `Brk (v1, v2) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1040,7 +1040,7 @@ and primary (x : CST.primary) : AST.expr =
         | None -> [])
       in
       S (Break (v1, v2))
-  | `Prim_next (v1, v2) ->
+  | `Next (v1, v2) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1048,7 +1048,7 @@ and primary (x : CST.primary) : AST.expr =
         | None -> [])
       in
       S (Next (v1, v2))
-  | `Prim_redo (v1, v2) ->
+  | `Redo (v1, v2) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1056,7 +1056,7 @@ and primary (x : CST.primary) : AST.expr =
         | None -> [])
       in
       S (Redo (v1, v2))
-  | `Prim_retry (v1, v2) ->
+  | `Retry (v1, v2) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1064,7 +1064,7 @@ and primary (x : CST.primary) : AST.expr =
         | None -> [])
       in
       S (Retry (v1, v2))
-  | `Prim_paren_un (v1, v2) ->
+  | `Paren_un (v1, v2) ->
       let v1 =
         (match v1 with
         | `Defi tok -> Op_DefinedQuestion, token2 tok
@@ -1074,7 +1074,7 @@ and primary (x : CST.primary) : AST.expr =
       let (lp, v2, rp) = parenthesized_statements v2 in
       let block = S (Block (lp, v2, rp)) in
       Unary (v1, block)
-  | `Prim_un_lit (v1, v2) ->
+  | `Un_lit (v1, v2) ->
       let v1 =
         (match v1 with
         | `Un_minus tok -> U Op_UMinus, (token2 tok)
@@ -1088,7 +1088,7 @@ and primary (x : CST.primary) : AST.expr =
         )
       in
       Unary (v1, v2)
-  | `Prim_here_begin tok ->
+  | `Here_begin tok ->
     let (s, tok) = str tok in
     Literal (String (Single s, tok))
   )
@@ -1147,7 +1147,7 @@ and call ((v1, v2, v3) : CST.call) =
 
 and command_call (x : CST.command_call) : AST.expr =
   (match x with
-  | `Cmd_call_choice_var_cmd_arg_list (v1, v2) ->
+  | `Choice_var_cmd_arg_list (v1, v2) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1157,7 +1157,7 @@ and command_call (x : CST.command_call) : AST.expr =
       in
       let v2 = command_argument_list v2 in
       Call (v1, v2, None)
-  | `Cmd_call_choice_var_cmd_arg_list_blk (v1, v2, v3) ->
+  | `Choice_var_cmd_arg_list_blk (v1, v2, v3) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1168,7 +1168,7 @@ and command_call (x : CST.command_call) : AST.expr =
       let v2 = command_argument_list v2 in
       let v3 = block v3 in
       Call (v1, v2, Some v3)
-  | `Cmd_call_choice_var_cmd_arg_list_do_blk (v1, v2, v3) ->
+  | `Choice_var_cmd_arg_list_do_blk (v1, v2, v3) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1183,7 +1183,7 @@ and command_call (x : CST.command_call) : AST.expr =
 
 and method_call (x : CST.method_call) : AST.expr =
   (match x with
-  | `Meth_call_choice_var_arg_list (v1, v2) ->
+  | `Choice_var_arg_list (v1, v2) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1193,7 +1193,7 @@ and method_call (x : CST.method_call) : AST.expr =
       in
       let v2 = argument_list v2 |> G.unbracket in
       Call (v1, v2, None)
-  | `Meth_call_choice_var_arg_list_blk (v1, v2, v3) ->
+  | `Choice_var_arg_list_blk (v1, v2, v3) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1204,7 +1204,7 @@ and method_call (x : CST.method_call) : AST.expr =
       let v2 = argument_list v2 |> G.unbracket in
       let v3 = block v3 in
       Call (v1, v2, Some v3)
-  | `Meth_call_choice_var_arg_list_do_blk (v1, v2, v3) ->
+  | `Choice_var_arg_list_do_blk (v1, v2, v3) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1215,7 +1215,7 @@ and method_call (x : CST.method_call) : AST.expr =
       let v2 = argument_list v2 |> G.unbracket in
       let v3 = do_block v3 in
       Call (v1, v2, Some v3)
-  | `Meth_call_choice_var_blk (v1, v2) ->
+  | `Choice_var_blk (v1, v2) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1225,7 +1225,7 @@ and method_call (x : CST.method_call) : AST.expr =
       in
       let v2 = block v2 in
       Call (v1, [], Some v2)
-  | `Meth_call_choice_var_do_blk (v1, v2) ->
+  | `Choice_var_do_blk (v1, v2) ->
       let v1 =
         (match v1 with
         | `Var x -> Id (variable x)
@@ -1239,7 +1239,7 @@ and method_call (x : CST.method_call) : AST.expr =
 
 and command_argument_list (x : CST.command_argument_list) : AST.expr list =
   (match x with
-  | `Cmd_arg_list_arg_rep_COMMA_arg (v1, v2) ->
+  | `Arg_rep_COMMA_arg (v1, v2) ->
       let v1 = argument v1 in
       let v2 =
         List.map (fun (v1, v2) ->
@@ -1249,7 +1249,7 @@ and command_argument_list (x : CST.command_argument_list) : AST.expr list =
         ) v2
       in
       v1::v2
-  | `Cmd_arg_list_cmd_call x -> [command_call x]
+  | `Cmd_call x -> [command_call x]
   )
 
 and argument_list ((v1, v2, v3) : CST.argument_list) : AST.expr list AST.bracket =
@@ -1280,14 +1280,14 @@ and argument_list_with_trailing_comma ((v1, v2, v3) : CST.argument_list_with_tra
 
 and argument (x : CST.argument) : AST.expr =
   (match x with
-  | `Arg_arg x -> arg x
-  | `Arg_splat_arg x -> splat_argument x
-  | `Arg_hash_splat_arg x -> hash_splat_argument x
-  | `Arg_blk_arg (v1, v2) ->
+  | `Arg x -> arg x
+  | `Splat_arg x -> splat_argument x
+  | `Hash_splat_arg x -> hash_splat_argument x
+  | `Blk_arg (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = arg v2 in
       Unary ((Op_UAmper, v1), v2)
-  | `Arg_pair x -> pair x
+  | `Pair x -> pair x
   )
 
 and splat_argument ((v1, v2) : CST.splat_argument) =
@@ -1374,27 +1374,27 @@ and command_assignment (x : CST.command_assignment) =
 
 and binary (x : CST.binary) =
   (match x with
-  | `Bin_arg_and_arg (v1, v2, v3) ->
+  | `Arg_and_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
       Binop (v1, (Op_kAND, v2), v3)
-  | `Bin_arg_or_arg (v1, v2, v3) ->
+  | `Arg_or_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
       Binop (v1, (Op_kOR, v2), v3)
-  | `Bin_arg_BARBAR_arg (v1, v2, v3) ->
+  | `Arg_BARBAR_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
       Binop (v1, (Op_OR, v2), v3)
-  | `Bin_arg_AMPAMP_arg (v1, v2, v3) ->
+  | `Arg_AMPAMP_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
       Binop (v1, (Op_AND, v2), v3)
-  | `Bin_arg_choice_LTLT_arg (v1, v2, v3) ->
+  | `Arg_choice_LTLT_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 =
         (match v2 with
@@ -1404,7 +1404,7 @@ and binary (x : CST.binary) =
       in
       let v3 = arg v3 in
       Binop (v1, v2, v3)
-  | `Bin_arg_choice_LT_arg (v1, v2, v3) ->
+  | `Arg_choice_LT_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 =
         (match v2 with
@@ -1416,12 +1416,12 @@ and binary (x : CST.binary) =
       in
       let v3 = arg v3 in
       Binop (v1, v2, v3)
-  | `Bin_arg_AMP_arg (v1, v2, v3) ->
+  | `Arg_AMP_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
       Binop (v1, (Op_kAND, v2), v3)
-  | `Bin_arg_choice_HAT_arg (v1, v2, v3) ->
+  | `Arg_choice_HAT_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 =
         (match v2 with
@@ -1431,7 +1431,7 @@ and binary (x : CST.binary) =
       in
       let v3 = arg v3 in
       Binop (v1, v2, v3)
-  | `Bin_arg_choice_PLUS_arg (v1, v2, v3) ->
+  | `Arg_choice_PLUS_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 =
         (match v2 with
@@ -1441,7 +1441,7 @@ and binary (x : CST.binary) =
       in
       let v3 = arg v3 in
       Binop (v1, v2, v3)
-  | `Bin_arg_choice_SLASH_arg (v1, v2, v3) ->
+  | `Arg_choice_SLASH_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 =
         (match v2 with
@@ -1452,7 +1452,7 @@ and binary (x : CST.binary) =
       in
       let v3 = arg v3 in
       Binop (v1, v2, v3)
-  | `Bin_arg_choice_EQEQ_arg (v1, v2, v3) ->
+  | `Arg_choice_EQEQ_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 =
         (match v2 with
@@ -1466,7 +1466,7 @@ and binary (x : CST.binary) =
       in
       let v3 = arg v3 in
       Binop (v1, v2, v3)
-  | `Bin_arg_STARSTAR_arg (v1, v2, v3) ->
+  | `Arg_STARSTAR_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in
       let v3 = arg v3 in
@@ -1475,15 +1475,15 @@ and binary (x : CST.binary) =
 
 and unary (x : CST.unary) =
   (match x with
-  | `Un_defi_arg (v1, v2) ->
+  | `Defi_arg (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = arg v2 in
       Unary ((Op_DefinedQuestion, v1), v2)
-  | `Un_not_arg (v1, v2) ->
+  | `Not_arg (v1, v2) ->
       let v1 = token2 v1 in
       let v2 = arg v2 in
       Unary ((Op_UNot, v1), v2)
-  | `Un_choice_un_minus_arg (v1, v2) ->
+  | `Choice_un_minus_arg (v1, v2) ->
       let v1 =
         (match v1 with
         | `Un_minus tok -> U Op_UMinus, token2 tok
@@ -1492,7 +1492,7 @@ and unary (x : CST.unary) =
       in
       let v2 = arg v2 in
       Unary (v1, v2)
-  | `Un_choice_BANG_arg (v1, v2) ->
+  | `Choice_BANG_arg (v1, v2) ->
       let v1 =
         (match v1 with
         | `BANG tok -> U Op_UBang, token2 tok
@@ -1595,21 +1595,21 @@ and lhs (x : CST.lhs) : AST.expr =
 
 and method_name (x : CST.method_name) : AST.method_name =
   (match x with
-  | `Meth_name_id tok -> MethodId (str tok, ID_Lowercase)
-  | `Meth_name_cst tok -> MethodId (str tok, ID_Uppercase)
-  | `Meth_name_sett (v1, v2) ->
+  | `Id tok -> MethodId (str tok, ID_Lowercase)
+  | `Cst tok -> MethodId (str tok, ID_Uppercase)
+  | `Sett (v1, v2) ->
       let v1 = str v1 in
       let v2 = token2 v2 in
       MethodIdAssign (v1, v2, ID_Lowercase)
-  | `Meth_name_symb x -> MethodAtom (symbol x)
-  | `Meth_name_op x -> let op = operator x in
+  | `Symb x -> MethodAtom (symbol x)
+  | `Op x -> let op = operator x in
         (match op with
         | Left bin, t -> MethodOperator (bin ,t)
         | Right un, t -> MethodUOperator (un, t)
         )
-  | `Meth_name_inst_var tok -> MethodId (str tok, ID_Instance)
-  | `Meth_name_class_var tok -> MethodId (str tok, ID_Class)
-  | `Meth_name_glob_var tok -> MethodId (str tok, ID_Global)
+  | `Inst_var tok -> MethodId (str tok, ID_Instance)
+  | `Class_var tok -> MethodId (str tok, ID_Class)
+  | `Glob_var tok -> MethodId (str tok, ID_Global)
   )
 
 and interpolation ((v1, v2, v3) : CST.interpolation) : AST.expr AST.bracket =
@@ -1630,9 +1630,9 @@ and string_ ((v1, v2, v3) : CST.string_) : AST.string_contents list bracket =
 
 and symbol (x : CST.symbol) : AST.atom =
   (match x with
-  | `Symb_simple_symb tok -> let (s, t) = str tok in
+  | `Simple_symb tok -> let (s, t) = str tok in
         ([StrChars s], t)
-  | `Symb_symb_start_opt_lit_content_str_end (v1, v2, v3) ->
+  | `Symb_start_opt_lit_content_str_end (v1, v2, v3) ->
       let v1 = token2 v1 in
       let v2 =
         (match v2 with
@@ -1660,12 +1660,12 @@ and literal_contents (xs : CST.literal_contents) : AST.string_contents list =
 
 and pair (x : CST.pair) =
   (match x with
-  | `Pair_arg_EQGT_arg (v1, v2, v3) ->
+  | `Arg_EQGT_arg (v1, v2, v3) ->
       let v1 = arg v1 in
       let v2 = token2 v2 in  (* => *)
       let v3 = arg v3 in
       Binop(v1, (Op_ASSOC, v2), v3)
-  | `Pair_choice_id_hash_key_COLON_arg (v1, v2, v3) ->
+  | `Choice_id_hash_key_COLON_arg (v1, v2, v3) ->
       let v1 =
         (match v1 with
         | `Id_hash_key tok -> Id (str tok, ID_Lowercase)


### PR DESCRIPTION
This comes with a renaming of polymorphic variants. It wasn't tricky, just slightly tedious.

This upgrades the ocaml-tree-sitter runtime, and in particular the matching/backtracking engine. I expect this to be less efficient than before but hopefully it's negligible.
