### PR TITLE
Better Timeout error indicating the ruleid of the offending rule

### DIFF
--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -253,13 +253,13 @@ let (envf: (MV.mvar AST.wrap, AST.any) matcher) =
   match check_and_add_metavar_binding (mvar, any) tin with
   | None ->
       (*s: [[Matching_generic.envf]] if [[verbose]] when fail *)
-      if !Flag.debug
+      if !Flag.debug_matching
       then pr2 (spf "envf: fail, %s (%s)" mvar (str_of_any any));
       (*e: [[Matching_generic.envf]] if [[verbose]] when fail *)
       fail tin
   | Some new_binding ->
       (*s: [[Matching_generic.envf]] if [[verbose]] when success *)
-      if !Flag.debug
+      if !Flag.debug_matching
       then pr2 (spf "envf: success, %s (%s)" mvar (str_of_any any));
       (*e: [[Matching_generic.envf]] if [[verbose]] when success *)
       return new_binding

--- a/semgrep-core/matching/Semgrep_generic.mli
+++ b/semgrep-core/matching/Semgrep_generic.mli
@@ -12,6 +12,8 @@ val check:
   Match_result.t list
 (*e: signature [[Semgrep_generic.check]] *)
 
+val last_matched_rule: Rule.t option ref
+
 (*s: type [[Semgrep_generic.matcher]] *)
 type ('a, 'b) matcher = 'a -> 'b ->
   Metavars_generic.metavars_binding list
@@ -20,7 +22,7 @@ type ('a, 'b) matcher = 'a -> 'b ->
 (* used by tainting *)
 
 (*s: signature [[Semgrep_generic.match_e_e]] *)
-val match_e_e: string -> (AST_generic.expr, AST_generic.expr) matcher
+val match_e_e: Rule.t -> (AST_generic.expr, AST_generic.expr) matcher
 (*e: signature [[Semgrep_generic.match_e_e]] *)
 
 (*s: signature [[Semgrep_generic.match_any_any]] *)

--- a/semgrep-core/tainting/Tainting_generic.ml
+++ b/semgrep-core/tainting/Tainting_generic.ml
@@ -54,8 +54,11 @@ let match_pat_instr pat =
     let pat = Common2.foldl1 (fun x acc -> AST.DisjExpr (x, acc)) xs in
     (fun instr ->
        let eorig = instr.IL.iorig in
-       let matches_with_env = Semgrep_generic.match_e_e "<tainting>" pat eorig
-          in
+       (* the rule is just used by match_e_e for profiling stats *)
+       let rule = { Rule.id = "<tainting>"; pattern = AST.E pat; message = "";
+          severity = Rule.Error; languages = []; } in
+
+       let matches_with_env = Semgrep_generic.match_e_e rule pat eorig in
        matches_with_env <> []
     )
 (*e: function [[Tainting_generic.match_pat_instr]] *)


### PR DESCRIPTION
This will help diagnose more quickly issues like
https://github.com/returntocorp/semgrep/issues/1361

Test plan:
you need some modifs to core_runner.py to not capture stderr (should
be fixed hopefully soon), and then you can do:

(semgrep) pad@yrax:~/semgrep/tests/PERF$ export SEMGREP_CORE_DEBUG=1
(semgrep) pad@yrax:~/semgrep/tests/PERF$ semgrep -v -f ajin2.yaml three.js
loaded 1 configs in 0.020273208618164062
running 2 rules from 1 config ajin2.yaml
running 2 rules...
Running rule node_nosqli_js_injection
Debug mode On
Executed as: semgrep-core -lang javascript -rules_file /tmp/tmp1aheu78p -j 8 -target_file /tmp/tmp8qu5slnl -use_parsing_cache /tmp/tmpy3k0oivh
Profile mode On
disabling -j when in profiling mode
Parsing /tmp/tmp1aheu78p
Analyzing three.js
PARSING: three.js
timeout (we abort)
returned JSON: {
  "matches": [],
  "errors": [
    {
      "check_id": "Timeout",
      "path": "three.js",
      "start": { "line": 1, "col": 1 },
      "end": { "line": 1, "col": 1 },
      "extra": {
        "message": "Timeout: with ruleid: 0..0.0.10",
        "line": "/**"
      }
    }
  ],