### PR TITLE
Improve 'pattern-where-python' error messages

### DIFF
--- a/docs/pattern-features.md
+++ b/docs/pattern-features.md
@@ -449,7 +449,7 @@ public class Example {
 **Go:**
 
 ```text
-pattern: "$X == ($Y : str)"
+pattern: "$X == ($Y : string)"
 ```
 
 ```go

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -208,14 +208,18 @@ def _where_python_statement_matches(
         exec(to_eval, scope)  # nosem: contrib.dlint.dlint-equivalent.insecure-exec-use, python.lang.security.audit.exec-detected.exec-detected
         # fmt: on
         result = scope[RETURN_VAR]  # type: ignore
+    except KeyError as ex:
+        logger.error(
+            f"could not find metavariable {ex} while evaluating where-python expression '{where_expression}', consider case where metavariable is missing"
+        )
     except Exception as ex:
         logger.error(
-            f"error evaluating a where-python expression: `{where_expression}`: {ex}"
+            f"received error '{repr(ex)}' while evaluating where-python expression '{where_expression}'"
         )
 
     if not isinstance(result, bool):
         raise SemgrepError(
-            f"python where expression needs boolean output but got: {result} for {where_expression}"
+            f"where-python expression '{where_expression}' needs boolean output but got {result}"
         )
     return result
 


### PR DESCRIPTION
From #1256. Before and after:

```
$ python -m semgrep --dangerously-allow-arbitrary-code-execution-from-rules --config test.yml test.go
running 1 rules...
error evaluating a where-python expression: `vars['$ERR1'] != vars['$ERR'].split(' ')[-1]`: '$ERR1'
```

```
$ python -m semgrep --dangerously-allow-arbitrary-code-execution-from-rules --config test.yml test.go
running 1 rules...
could not find metavariable '$ERR1' while evaluating where-python expression 'vars['$ERR1'] != vars['$ERR'].split(' ')[-1]', consider case where metavariable is missing
```