### PR TITLE
Match arbitrary content with f"..."

### DIFF
--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -1065,11 +1065,13 @@ and m_arguments_concat a b =
   match a,b with
   | [], [] ->
       return ()
+
   (*s: [[Generic_vs_generic.m_arguments_concat()]] ellipsis cases *)
-  (* dots '...' for string literal, can also match no argument *)
-  | [A.Arg (A.L (A.String("...", _a)))], [] ->
+  (* dots '...' for string literal, can match any number of arguments *)
+  | [A.Arg (A.L (A.String("...", _)))], _xsb ->
       return ()
 
+  (* specific case: f"...{$X}..." will properly extract $X from f"foo {bar} baz" *)
   | A.Arg (A.L (A.String("...", a)))::xsa, B.Arg(bexpr)::xsb ->
     (match Normalize_generic.constant_propagation_and_evaluate_literal bexpr
      with
@@ -1081,6 +1083,7 @@ and m_arguments_concat a b =
       | None ->
         (m_arguments_concat xsa (B.Arg(bexpr)::xsb))
       )
+
   (*e: [[Generic_vs_generic.m_arguments_concat()]] ellipsis cases *)
   (* the general case *)
   | xa::aas, xb::bbs ->

--- a/semgrep-core/tests/python/dots_fstring.py
+++ b/semgrep-core/tests/python/dots_fstring.py
@@ -2,6 +2,9 @@ def foo():
   #ERROR: match
   print(f"this is good")
 
+  # ERROR: match
+  print(f"this should {match}")
+
   print("hello")
 
   print("hello" "world")

--- a/semgrep-core/tests/python/equivalence_f_string_2.py
+++ b/semgrep-core/tests/python/equivalence_f_string_2.py
@@ -10,8 +10,7 @@ def foo2():
   query = f"{select} from foo " + f"where name={name}"
 
 def foo2a():
-  # TODO:
-  # OK:
+  # ERROR:
   select = "select * "
   name = "foo"
   query = f"{select} from foo where name={name}"

--- a/semgrep-core/tests/python/equivalence_f_string_3.py
+++ b/semgrep-core/tests/python/equivalence_f_string_3.py
@@ -4,8 +4,7 @@ def foo1():
   query = f"{select} from foo"
 
 def foo2():
-  # TODO
-  # OK:
+  # ERROR:
   select = "select * "
   # TODO:
   # OK:
@@ -41,9 +40,10 @@ def foo10():
   # TODO: 
   # OK:
   ww = "foo"
-  # TODO: 
+  # TODO:
   # OK:
   ww = "foo"
+  # ERROR:
   www = "bar"
   query = f"SELECT {www} and {ww}"
 


### PR DESCRIPTION
This will now match any arbitrary inclusion of interpolated string
content.

It also sort-of implements some additional use cases, as trailing
ellipses in patterns like f"...{$X}..." can now match arbitrary content
as well.

Definitely not perfect, and some thoughts about what the appropriate API
is here are in order.

Fixes returntocorp/semgrep#979.