### PR TITLE
Do not install core in windows

### DIFF
--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -2,6 +2,7 @@
 import contextlib
 import distutils.util
 import os
+import platform
 
 import setuptools
 from setuptools import setup
@@ -68,6 +69,9 @@ class PostInstallCommand(install):
     """Post-installation for installation mode."""
 
     def run(self):
+        if platform.system() == 'Windows':
+            print("Not attempting to install binary while running under windows")
+            return
         if "TOX_ENV_NAME" in os.environ:
             print("Not attempting to install binary while running under tox")
             return

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -69,7 +69,7 @@ class PostInstallCommand(install):
     """Post-installation for installation mode."""
 
     def run(self):
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             print("Not attempting to install binary while running under windows")
             return
         if "TOX_ENV_NAME" in os.environ:


### PR DESCRIPTION
Semgrep on windows throws an exception while installing.  Until semgrep supports Windows, allow graceful installation since other tools that uses semgrep might be cross-platform compliant.

Errors Python 3.6.8 Windows 10.
```
    Running setup.py install for semgrep: started
    Running setup.py install for semgrep: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: 'c:\python36\python.exe' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\travis\\AppData\\Local\\Temp\\pip-install-wmybtpv9\\semgrep\\setup.py'"'"'; __file__='"'"'C:\\Users\\travis\\AppData\\Local\\Temp\\pip-install-wmybtpv9\\semgrep\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record 'C:\Users\travis\AppData\Local\Temp\pip-record-7clboa0w\install-record.txt' --single-version-externally-managed --compile --install-headers 'c:\python36\Include\semgrep'
         cwd: C:\Users\travis\AppData\Local\Temp\pip-install-wmybtpv9\semgrep\
    Complete output (173 lines):
    running install
    The system cannot find the path specified.
    running build
    running build_py
    creating build
    creating build\lib
    creating build\lib\semgrep
    copying semgrep\autofix.py -> build\lib\semgrep
    copying semgrep\cli.py -> build\lib\semgrep
    copying semgrep\config_resolver.py -> build\lib\semgrep
    copying semgrep\constants.py -> build\lib\semgrep
    copying semgrep\core_exception.py -> build\lib\semgrep
    copying semgrep\core_runner.py -> build\lib\semgrep
    copying semgrep\dump_ast.py -> build\lib\semgrep
    copying semgrep\equivalences.py -> build\lib\semgrep
    copying semgrep\error.py -> build\lib\semgrep
    copying semgrep\evaluation.py -> build\lib\semgrep
    copying semgrep\output.py -> build\lib\semgrep
    copying semgrep\pattern.py -> build\lib\semgrep
    copying semgrep\pattern_match.py -> build\lib\semgrep
    copying semgrep\rule.py -> build\lib\semgrep
    copying semgrep\rule_lang.py -> build\lib\semgrep
    copying semgrep\rule_match.py -> build\lib\semgrep
    copying semgrep\semgrep_main.py -> build\lib\semgrep
    copying semgrep\semgrep_types.py -> build\lib\semgrep
    copying semgrep\synthesize_patterns.py -> build\lib\semgrep
    copying semgrep\target_manager.py -> build\lib\semgrep
    copying semgrep\test.py -> build\lib\semgrep
    copying semgrep\util.py -> build\lib\semgrep
    copying semgrep\version.py -> build\lib\semgrep
    copying semgrep\__init__.py -> build\lib\semgrep
    copying semgrep\__main__.py -> build\lib\semgrep
    creating build\lib\tests
    copying tests\conftest.py -> build\lib\tests
    copying tests\public_repos.py -> build\lib\tests
    copying tests\__init__.py -> build\lib\tests
    creating build\lib\tests\e2e
    copying tests\e2e\test_api.py -> build\lib\tests\e2e
    copying tests\e2e\test_autofix.py -> build\lib\tests\e2e
    copying tests\e2e\test_check.py -> build\lib\tests\e2e
    copying tests\e2e\test_equivalence.py -> build\lib\tests\e2e
    copying tests\e2e\test_exclude_include.py -> build\lib\tests\e2e
    copying tests\e2e\test_generate_config.py -> build\lib\tests\e2e
    copying tests\e2e\test_metavariable_matching.py -> build\lib\tests\e2e
    copying tests\e2e\test_paths.py -> build\lib\tests\e2e
    copying tests\e2e\test_rule_parser.py -> build\lib\tests\e2e
    copying tests\e2e\test_semgrep_core_parse_error.py -> build\lib\tests\e2e
    copying tests\e2e\test_semgrep_rules_repo.py -> build\lib\tests\e2e
    copying tests\e2e\test_synthesize_patterns.py -> build\lib\tests\e2e
    copying tests\e2e\__init__.py -> build\lib\tests\e2e
    creating build\lib\tests\performance
    copying tests\performance\test_check_perf.py -> build\lib\tests\performance
    copying tests\performance\test_ci_perf.py -> build\lib\tests\performance
    copying tests\performance\test_semgrep_rules_repo_perf.py -> build\lib\tests\performance
    copying tests\performance\__init__.py -> build\lib\tests\performance
    creating build\lib\tests\qa
    copying tests\qa\test_public_repos.py -> build\lib\tests\qa
    copying tests\qa\__init__.py -> build\lib\tests\qa
    running install_lib
    creating c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\autofix.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\cli.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\config_resolver.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\constants.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\core_exception.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\core_runner.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\dump_ast.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\equivalences.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\error.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\evaluation.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\output.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\pattern.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\pattern_match.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\rule.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\rule_lang.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\rule_match.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\semgrep_main.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\semgrep_types.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\synthesize_patterns.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\target_manager.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\test.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\util.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\version.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\__init__.py -> c:\python36\Lib\site-packages\semgrep
    copying build\lib\semgrep\__main__.py -> c:\python36\Lib\site-packages\semgrep
    creating c:\python36\Lib\site-packages\tests
    copying build\lib\tests\conftest.py -> c:\python36\Lib\site-packages\tests
    creating c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_api.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_autofix.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_check.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_equivalence.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_exclude_include.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_generate_config.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_metavariable_matching.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_paths.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_rule_parser.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_semgrep_core_parse_error.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_semgrep_rules_repo.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\test_synthesize_patterns.py -> c:\python36\Lib\site-packages\tests\e2e
    copying build\lib\tests\e2e\__init__.py -> c:\python36\Lib\site-packages\tests\e2e
    creating c:\python36\Lib\site-packages\tests\performance
    copying build\lib\tests\performance\test_check_perf.py -> c:\python36\Lib\site-packages\tests\performance
    copying build\lib\tests\performance\test_ci_perf.py -> c:\python36\Lib\site-packages\tests\performance
    copying build\lib\tests\performance\test_semgrep_rules_repo_perf.py -> c:\python36\Lib\site-packages\tests\performance
    copying build\lib\tests\performance\__init__.py -> c:\python36\Lib\site-packages\tests\performance
    copying build\lib\tests\public_repos.py -> c:\python36\Lib\site-packages\tests
    creating c:\python36\Lib\site-packages\tests\qa
    copying build\lib\tests\qa\test_public_repos.py -> c:\python36\Lib\site-packages\tests\qa
    copying build\lib\tests\qa\__init__.py -> c:\python36\Lib\site-packages\tests\qa
    copying build\lib\tests\__init__.py -> c:\python36\Lib\site-packages\tests
    byte-compiling c:\python36\Lib\site-packages\semgrep\autofix.py to autofix.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\cli.py to cli.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\config_resolver.py to config_resolver.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\constants.py to constants.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\core_exception.py to core_exception.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\core_runner.py to core_runner.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\dump_ast.py to dump_ast.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\equivalences.py to equivalences.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\error.py to error.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\evaluation.py to evaluation.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\output.py to output.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\pattern.py to pattern.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\pattern_match.py to pattern_match.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\rule.py to rule.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\rule_lang.py to rule_lang.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\rule_match.py to rule_match.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\semgrep_main.py to semgrep_main.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\semgrep_types.py to semgrep_types.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\synthesize_patterns.py to synthesize_patterns.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\target_manager.py to target_manager.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\test.py to test.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\util.py to util.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\version.py to version.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\__init__.py to __init__.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\semgrep\__main__.py to __main__.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\conftest.py to conftest.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_api.py to test_api.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_autofix.py to test_autofix.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_check.py to test_check.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_equivalence.py to test_equivalence.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_exclude_include.py to test_exclude_include.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_generate_config.py to test_generate_config.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_metavariable_matching.py to test_metavariable_matching.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_paths.py to test_paths.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_rule_parser.py to test_rule_parser.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_semgrep_core_parse_error.py to test_semgrep_core_parse_error.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_semgrep_rules_repo.py to test_semgrep_rules_repo.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\test_synthesize_patterns.py to test_synthesize_patterns.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\e2e\__init__.py to __init__.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\performance\test_check_perf.py to test_check_perf.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\performance\test_ci_perf.py to test_ci_perf.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\performance\test_semgrep_rules_repo_perf.py to test_semgrep_rules_repo_perf.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\performance\__init__.py to __init__.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\public_repos.py to public_repos.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\qa\test_public_repos.py to test_public_repos.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\qa\__init__.py to __init__.cpython-36.pyc
    byte-compiling c:\python36\Lib\site-packages\tests\__init__.py to __init__.cpython-36.pyc
    running install_egg_info
    running egg_info
    writing semgrep.egg-info\PKG-INFO
    writing dependency_links to semgrep.egg-info\dependency_links.txt
    writing entry points to semgrep.egg-info\entry_points.txt
    writing requirements to semgrep.egg-info\requires.txt
    writing top-level names to semgrep.egg-info\top_level.txt
    reading manifest file 'semgrep.egg-info\SOURCES.txt'
    writing manifest file 'semgrep.egg-info\SOURCES.txt'
    Copying semgrep.egg-info to c:\python36\Lib\site-packages\semgrep-0.16.0-py3.6.egg-info
    running install_scripts
    Installing semgrep-script.py script to c:\python36\Scripts
    Installing semgrep.exe script to c:\python36\Scripts
    writing list of installed files to 'C:\Users\travis\AppData\Local\Temp\pip-record-7clboa0w\install-record.txt'
    error: can't copy 'C:\Users\travis\AppData\Local\Temp\pip-install-wmybtpv9\semgrep-files/semgrep-core': doesn't exist or not a regular file
    ----------------------------------------
ERROR: Command errored out with exit status 1: 'c:\python36\python.exe' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\travis\\AppData\\Local\\Temp\\pip-install-wmybtpv9\\semgrep\\setup.py'"'"'; __file__='"'"'C:\\Users\\travis\\AppData\\Local\\Temp\\pip-install-wmybtpv9\\semgrep\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record 'C:\Users\travis\AppData\Local\Temp\pip-record-7clboa0w\install-record.txt' --single-version-externally-managed --compile --install-headers 'c:\python36\Include\semgrep' Check the logs for full command output.
The command "pip3 install -r requirements.txt" failed and exited with 1 during .
```