### PR TITLE
Filter rules not containing any specific strings contained in the source

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -975,6 +975,8 @@ let options () =
     (*e: [[Main_semgrep_core.options]] other cases *)
     "-use_parsing_cache", Arg.Set_string use_parsing_cache,
     " <dir> save and use parsed ASTs in a cache at given directory. Caller responsiblity to clear cache";
+    "-no_filter_rules_regexp", Arg.Clear Flag.filter_rules_regexp,
+    " do not filter rules using regexp optimization";
     "-debug", Arg.Set Flag.debug,
     " add debugging information in the output (tracing)";
     "-debug_matching", Arg.Set Flag.debug_matching,

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -975,8 +975,10 @@ let options () =
     (*e: [[Main_semgrep_core.options]] other cases *)
     "-use_parsing_cache", Arg.Set_string use_parsing_cache,
     " <dir> save and use parsed ASTs in a cache at given directory. Caller responsiblity to clear cache";
-    "-no_filter_rules_regexp", Arg.Clear Flag.filter_rules_regexp,
-    " do not filter rules using regexp optimization";
+    "-filter_irrelevant_rules", Arg.Set Flag.filter_irrelevant_rules,
+    " filter rules not containing any strings in target file";
+    "-no_filter_irrelevant_rules", Arg.Clear Flag.filter_irrelevant_rules,
+    " do not filter rules";
     "-debug", Arg.Set Flag.debug,
     " add debugging information in the output (tracing)";
     "-debug_matching", Arg.Set Flag.debug_matching,

--- a/semgrep-core/core/Flag_semgrep.ml
+++ b/semgrep-core/core/Flag_semgrep.ml
@@ -30,6 +30,8 @@ let go_deeper_stmt = ref true
 let go_really_deeper_stmt = ref true
 (*e: constant [[Flag_semgrep.go_really_deeper_stmt]] *)
 
+let filter_rules_regexp = ref true
+
 (*s: constant [[Flag_semgrep.equivalence_mode]] *)
 (* special mode to set before using generic_vs_generic to match
  * code equivalences.

--- a/semgrep-core/core/Flag_semgrep.ml
+++ b/semgrep-core/core/Flag_semgrep.ml
@@ -30,7 +30,7 @@ let go_deeper_stmt = ref true
 let go_really_deeper_stmt = ref true
 (*e: constant [[Flag_semgrep.go_really_deeper_stmt]] *)
 
-let filter_rules_regexp = ref true
+let filter_irrelevant_rules = ref false
 
 (*s: constant [[Flag_semgrep.equivalence_mode]] *)
 (* special mode to set before using generic_vs_generic to match

--- a/semgrep-core/matching/Rules_filter.ml
+++ b/semgrep-core/matching/Rules_filter.ml
@@ -1,0 +1,155 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+open Common
+module Flag = Flag_semgrep
+module R = Rule
+module V = Visitor_AST
+open AST_generic
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Rules filtering using regexps.
+ *
+ * It is useless to run the engine on rules containing specific IDs
+ * (e.g., eval) that are never mentioned in the file.
+ *
+ * We did something similar in Coccinelle I think. This also has been
+ * mentioned many times (by Clint, HN, etc.).
+ *
+ * notes: I tried to use the ocaml-re (Re) regexp libray instead of Str
+ * because I thought it would be faster, and because it offers regexp
+ * combinators (alt, rep, etc.) which might be useful at some point to
+ * handle patterns containing explicit DisjExpr. However when running
+ * on Zulip codebase with zulip semgrep rules, Str is actually faster
+ * than Re.
+ *
+ * todo:
+ *  - we could even avoid parsing the file by using a lazy AST
+ *    in Semgrep_generic.check.
+ *)
+
+(*****************************************************************************)
+(* Helpers  *)
+(*****************************************************************************)
+
+(* Those functions using Re instead of Str are actually slower on
+ * Zulip.
+let regexp_matching_str s =
+  Re.str s
+let compile_regexp t =
+  Common.profile_code "Re.compile_regexp" (fun () -> Re.compile t)
+let run_regexp re str =
+  Common.profile_code "Re.run_regexp" (fun () -> Re.execp re str)
+*)
+
+let regexp_matching_str s =
+  Str.regexp_string s
+let compile_regexp t =
+  Common.profile_code "Re.compile_regexp" (fun () -> t)
+let run_regexp re str =
+  Common.profile_code "Re.run_regexp" (fun () ->
+   (* bugfix:
+    * this does not work!:  Str.string_match re str 0
+    * because you need to add ".*" in front to make it work,
+    * (but then you can not use regexp_string above)
+    * => use Str.search_forward instead.
+    *)
+   try
+     Str.search_forward re str 0 |> ignore; true
+   with Not_found -> false
+  )
+
+let reserved_id lang str =
+  Metavars_generic.is_metavar_name str ||
+  (* in JS field names can be regexps *)
+  (lang = Lang.Javascript && Matching_generic.is_regexp_string str) ||
+  (* ugly hack that we then need to handle also here *)
+  str = AST_generic.special_multivardef_pattern ||
+  (* ugly: because ast_js_build introduce some extra "!default" ids *)
+  (lang = Lang.Javascript && str = Ast_js.default_entity) ||
+  (* parser_js.mly inserts some implicit this *)
+  (lang = Lang.Java && str = "this")
+
+let reserved_str str =
+  str = "..." ||
+  Matching_generic.is_regexp_string str
+
+(*****************************************************************************)
+(* ID extractor  *)
+(*****************************************************************************)
+let extract_specific_strings lang any =
+  let res = ref [] in
+  let visitor = V.mk_visitor {V.default_visitor with
+     V.kident = (fun (_k, _) (str, _tok) ->
+       if not (reserved_id lang str)
+       then Common.push str res
+     );
+     V.kexpr = (fun (k, _) x ->
+       (match x with
+       (* less: we could extract strings for the other literals too?
+        * atoms, chars, even int?
+        *)
+       | L (String (str, _tok)) ->
+         if not (reserved_str str)
+         then Common.push str res
+       (* do not recurse there, the type does not have to be in the source *)
+       | TypedMetavar _ ->
+          ()
+       | _ -> k x
+       );
+     );
+  } in
+  visitor any;
+  !res
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let filter_rules_relevant_to_file_using_regexp2 rules lang file =
+  let str = Common.read_file file in
+  rules |> List.filter (fun rule ->
+    let pat = rule.R.pattern in
+    let xs = extract_specific_strings lang pat in
+    (* pr2_gen xs; *)
+    let match_ =
+    (* we could avoid running multiple regexps on the same file
+     * by first orring them and do the and only of the or succeed,
+     * but probably not worth the opti.
+      let t = xs |> List.map (fun x -> regexp_matching_str x) |> Re.alt in
+      let re = compile_regexp t in
+      run_regexp re str
+      *)
+      (* Note that right now we do a for_all but it mighe be incorrect
+       * at some point if the pattern contains DisjExpr for example, in
+       * which case we will need extract_specific_strings to directly
+       * extract a complex regexp instead handling itself disjunction.
+       *)
+      xs |> List.for_all (fun x ->
+         let t = regexp_matching_str x in
+         let re = compile_regexp t in
+         run_regexp re str
+    )
+
+    in
+    if !Flag.debug && not match_
+    then pr2 (spf "filtering rule %s" rule.R.id);
+    match_
+    )
+
+let filter_rules_relevant_to_file_using_regexp a b =
+  Common.profile_code "Rules_filter.filter" (fun () ->
+      filter_rules_relevant_to_file_using_regexp2 a b)

--- a/semgrep-core/matching/Rules_filter.mli
+++ b/semgrep-core/matching/Rules_filter.mli
@@ -1,0 +1,3 @@
+
+val filter_rules_relevant_to_file_using_regexp:
+  Rule.t list -> Lang.t -> Common.filename -> Rule.t list

--- a/semgrep-core/matching/Semgrep_generic.ml
+++ b/semgrep-core/matching/Semgrep_generic.ml
@@ -152,7 +152,17 @@ let match_any_any pattern e =
 (*****************************************************************************)
 
 (*s: function [[Semgrep_generic.check2]] *)
-let check2 ~hook rules equivs file _lang ast =
+let check2 ~hook rules equivs file lang ast =
+
+  let rules =
+    if !Flag.filter_rules_regexp
+    then Rules_filter.filter_rules_relevant_to_file_using_regexp
+           rules lang file
+    else rules
+  in
+  if rules = []
+  then []
+  else begin
 
   let matches = ref [] in
 
@@ -256,6 +266,7 @@ let check2 ~hook rules equivs file _lang ast =
   visitor prog;
 
   !matches |> List.rev
+  end
 (*e: function [[Semgrep_generic.check2]] *)
 
 (*s: function [[Semgrep_generic.check]] *)

--- a/semgrep-core/matching/Semgrep_generic.ml
+++ b/semgrep-core/matching/Semgrep_generic.ml
@@ -155,7 +155,7 @@ let match_any_any pattern e =
 let check2 ~hook rules equivs file lang ast =
 
   let rules =
-    if !Flag.filter_rules_regexp
+    if !Flag.filter_irrelevant_rules
     then Rules_filter.filter_rules_relevant_to_file_using_regexp
            rules lang file
     else rules

--- a/semgrep-core/matching/dune
+++ b/semgrep-core/matching/dune
@@ -7,6 +7,7 @@
    pfff-config
    pfff-h_program-lang
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
+   pfff-lang_js pfff-lang_js-analyze
 
 
    semgrep_core


### PR DESCRIPTION
It's useless to run the matching engine on a file not containing
the 'eval' string if your rule mentions 'eval'.

This seems to improve the speed on semgrep on Zulip and Ajin
"benchmarks".

Test plan:
make test still works!

(semgrep) pad@yrax:~/work/semgrep/zulip$
(semgrep) pad@yrax:~/work/semgrep/zulip$ time semgrep --dangerously-allow-arbitrary-code-execution-from-rules --config tools/semgrep.yml .
running 9 rules...
100%|                                                                                                                                                    |9/9

real	0m5.479s
user	0m24.776s
sys	0m3.019s

(semgrep) pad@yrax:~/work/semgrep/zulip$ export SEMGREP_CORE_EXTRA=''
(semgrep) pad@yrax:~/work/semgrep/zulip$ time semgrep --dangerously-allow-arbitrary-code-execution-from-rules --config tools/semgrep.yml .
running 9 rules...
100%|                                                                                                                                                    |9/9

real	0m4.415s
user	0m16.017s
sys	0m3.082s

On juice-shop with Ajin rules I got from 8m52 to 7m52, and more importantly
got from 50 Timeout errors to just 18 or so.