### PR TITLE
Add python backed pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: "v0.782"
     hooks:
       - id: mypy
-        exclude: ^semgrep\/tests\/.+$
+        exclude: ^semgrep\/tests\/.+$|^setup.py$
         args: [--config, mypy.ini]
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,8 +4,16 @@
   language: docker_image
   entry: returntocorp/semgrep:develop
 
-- id: semgrep
+- id: semgrep-docker
   name: semgrep
   description: This hook runs semgrep
   language: docker_image
   entry: returntocorp/semgrep:latest
+
+- id: semgrep
+  name: semgrep
+  entry: semgrep
+  language: python
+  args: []
+  require_serial: false
+  additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
-- id: semgrep-develop
+- id: semgrep-docker-develop
   name: semgrep
   description: This hook runs semgrep:develop
   language: docker_image
@@ -14,6 +14,3 @@
   name: semgrep
   entry: semgrep
   language: python
-  args: []
-  require_serial: false
-  additional_dependencies: []

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 
 setup(
-    name="pre_commit_dummy_package",
+    name="semgrep_pre_commit_package",
     version="0.0.0",
     install_requires=["semgrep==0.17.0"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+# type: ignore
+# Used for pre-commit since it expects a setup.py in repo root
+# for actual setup.py see semgrep/setup.py
+from setuptools import setup
+
+setup(
+    name="pre_commit_dummy_package",
+    version="0.0.0",
+    install_requires=["semgrep==0.17.0"],
+)


### PR DESCRIPTION
Running with docker leads to slowness due to filesystem issues with
OSX. Since we have a semgrep published in pypi might as well use it.