### PR TITLE
tests: dynamic checking of version in sarif output

### DIFF
--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
@@ -121,7 +121,7 @@
               }
             }
           ],
-          "semanticVersion": "0.17.0"
+          "semanticVersion": "placeholder"
         }
       }
     }

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -4,6 +4,8 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from semgrep import __VERSION__
+
 
 def test_basic_rule__local(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/eqeq.yaml"), "results.json")
@@ -51,6 +53,11 @@ def test_sarif_output(run_semgrep_in_tmp, snapshot):
     sarif_output["runs"][0]["tool"]["driver"]["rules"] = sorted(
         sarif_output["runs"][0]["tool"]["driver"]["rules"], key=lambda rule: rule["id"]
     )
+
+    # Semgrep version is included in sarif output. Verify this independently so
+    # snapshot does not need to be updated on version bump
+    assert sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] == __VERSION__
+    sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] = "placeholder"
 
     snapshot.assert_match(
         json.dumps(sarif_output, indent=2, sort_keys=True), "results.sarif"


### PR DESCRIPTION
Snapshot file had to be updated everytime version was changed. This
PR checks the version string dynamically so it does not need to be
manually bumped in the expected output file.