### PR TITLE
Debug logs were being hidden even with --verbose flag

### DIFF
--- a/semgrep-local.yaml
+++ b/semgrep-local.yaml
@@ -28,3 +28,16 @@ rules:
       https://www.attrs.org/en/stable/hashing.html for more info.
     languages: [python]
     severity: ERROR
+
+  - id: using-root-logger
+    patterns:
+      - pattern: logging.$METHOD(...)
+      - metavariable-regex:
+          metavariable: '$METHOD'
+          regex: '(debug|info|warn|warning|error)'
+    message: >
+      Make sure to send logs to the appropriate module (logging.getLogger(__name__))
+      instead of the root. Semgrep module logger does not propagate errors to root
+      logger (which is where this module helper sends logs).
+    languages: [python]
+    severity: ERROR

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -265,8 +265,7 @@ class CoreRunner:
                 cmd += ["-equivalences", equiv_file.name]
 
             core_run = sub_run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-            logging.debug(core_run.stderr.decode("utf-8", "replace"))
+            logger.debug(core_run.stderr.decode("utf-8", "replace"))
 
             if core_run.returncode != 0:
                 # see if semgrep output a JSON error that we can decode

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -147,7 +147,7 @@ def score_output_json(
             reported = all_reported - ignored
 
             new_cm = compute_confusion_matrix(reported, expected)
-            logging.debug(
+            logger.debug(
                 f"reported lines for check {check_id}: {sorted(reported)}, expected lines: {sorted(expected)} (ignored: {sorted(ignored)}, confusion matrix: {new_cm}"
             )
             expected_reported_by_check_id[check_id][file_path] = (expected, reported)

--- a/semgrep/semgrep/version.py
+++ b/semgrep/semgrep/version.py
@@ -38,18 +38,18 @@ def _fetch_latest_version(
             url, headers={"User-Agent": SEMGREP_USER_AGENT}, timeout=timeout,
         )
     except Exception as e:
-        logging.debug(f"Fetching latest version failed to connect: {e}")
+        logger.debug(f"Fetching latest version failed to connect: {e}")
         return None
     else:
         if resp.status_code != requests.codes.OK:
-            logging.debug(
+            logger.debug(
                 f"Fetching latest version received HTTP error code: {resp.status_code}"
             )
             return None
         try:
             resp_json = resp.json()
         except ValueError:
-            logging.debug("Fetching latest version received invalid JSON")
+            logger.debug("Fetching latest version received invalid JSON")
             return None
         else:
             return str(resp_json["latest"])
@@ -67,17 +67,17 @@ def _get_version_from_cache(version_cache_path: Path) -> Optional[str]:
                 # Treat time as integer seconds so no need to deal with str float conversion
                 timestamp = int(timestamp_str)
             except ValueError:
-                logging.debug(f"Version cache invalid timestamp: {timestamp_str}")
+                logger.debug(f"Version cache invalid timestamp: {timestamp_str}")
                 return None
 
             one_day = 86400
             if now - timestamp > one_day:
-                logging.debug(f"Version cache expired: {timestamp_str}:{now}")
+                logger.debug(f"Version cache expired: {timestamp_str}:{now}")
                 return None
 
             return latest_version_str
 
-    logging.debug("Version cache does not exist")
+    logger.debug("Version cache does not exist")
     return None
 
 
@@ -107,7 +107,7 @@ def is_running_latest(version_cache_path: Path = VERSION_CACHE_PATH) -> bool:
         latest_version = Version(latest_version_str)
         current_version = Version(__VERSION__)
     except InvalidVersion as e:
-        logging.debug(f"Invalid version string: {e}")
+        logger.debug(f"Invalid version string: {e}")
         return False
 
     if current_version < latest_version:


### PR DESCRIPTION
To prevent logs being handled twice semgrep does not propagate logs
from semgrep module to root logging handler so calls to logging.info/debug
were not being handled properly. Really we should not be sending logs
to the root logger and should go through the logger of the submodule.

Fixed calls to go through the correct logger and added a semgrep
rule to alert when the root logger function is used.

Closes https://github.com/returntocorp/semgrep/issues/1365