### PR TITLE
Remove confusing line about only 1 pattern-inside

### DIFF
--- a/docs/configuration-files.md
+++ b/docs/configuration-files.md
@@ -233,7 +233,7 @@ See the [`patterns`](configuration-files.md#patterns) example above.
 
 ### `pattern-inside`
 
-The `pattern-inside` operator keeps matched findings that reside within its expression. This is useful for finding code inside other pieces of code like functions or if blocks. At the moment, your rule can have at most one pattern-inside clause.
+The `pattern-inside` operator keeps matched findings that reside within its expression. This is useful for finding code inside other pieces of code like functions or if blocks.
 
 **Example**
 


### PR DESCRIPTION
Nobody seems to know why it was there and the following examples that use more than one `pattern-inside` both work:
https://semgrep.dev/chmccreery:auto_attribs
https://semgrep.dev/y9eO/