### PR TITLE
Display severities during 'bad severity' error

### DIFF
--- a/semgrep-core/parsing/Parse_rules.ml
+++ b/semgrep-core/parsing/Parse_rules.ml
@@ -44,7 +44,7 @@ let parse_severity ~id s =
  | "ERROR" -> R.Error
  | "WARNING" -> R.Warning
  | "INFO" -> R.Info
- | s -> raise (InvalidRuleException (id, (spf "Bad severity: %s" s)))
+ | s -> raise (InvalidRuleException (id, (spf "Bad severity: %s (expected ERROR, WARNING or INFO)" s)))
 (*e: function [[Parse_rules.parse_severity]] *)
 
 (*s: function [[Parse_rules.parse_pattern]] *)


### PR DESCRIPTION
tl;dr it would be nice to be presented with available severities when the passed severity is incorrect.
```
$ semgrep
running 1 rules...
an internal error occured while invoking semgrep-core:
	invalid rule: Bad severity: info
An error occurred while invoking the semgrep engine; please help us fix this by creating an issue at https://semgrep.dev
```