### PR TITLE
ci: shellcheck only run on .sh files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
         name: shellcheck
         language: docker_image
         entry: koalaman/shellcheck:v0.7.1
-        files: ".sh$"
+        files: "[.]sh$"
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
         name: shellcheck
         language: docker_image
         entry: koalaman/shellcheck:v0.7.1
-        files: ".sh"
+        files: ".sh$"
 
   - repo: local
     hooks:


### PR DESCRIPTION
shellcheck was running on files with sh anywhere in the filename