### PR TITLE
Match against destructured parameters with metavariables in js

### DIFF
--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -221,6 +221,14 @@ let rec equal_ast_binded_code (a: AST.any) (b: AST.any) : bool = (
       a =*= b
   | A.I _, A.E (A.Id (b_id, _)) ->
     (* Allow identifier nodes to match pure identifier expressions *)
+
+    (* You should prefer to add metavar as expression (A.E), not id (A.I),
+     * (see Generic_vs_generic.m_ident_and_id_info_add_in_env_Expr)
+     * but in some cases you have no choice and you need to match an expression
+     * metavar with an id metavar.
+     * For example, we want the pattern 'const $X = foo.$X' to match 'const bar = foo.bar'
+     * (this is useful in the Javascript transpilation context of complex pattern parameter).
+     *)
       equal_ast_binded_code a (A.I b_id)
   | _, _ ->
       false

--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -198,8 +198,8 @@ let (fail : tin -> tout) = fun _tin ->
 (* pre: both 'a' and 'b' contains only regular code; there are no
  * metavariables inside them.
  *)
-let equal_ast_binded_code (a: AST.any) (b: AST.any) : bool =
-  match a, b with
+let rec equal_ast_binded_code (a: AST.any) (b: AST.any) : bool = (
+  let res = (match a, b with
   | A.I _, A.I _
   | A.N _, A.N _
   | A.E _, A.E _
@@ -218,16 +218,22 @@ let equal_ast_binded_code (a: AST.any) (b: AST.any) : bool =
        *)
       let a = Lib.abstract_position_info_any a in
       let b = Lib.abstract_position_info_any b in
-      let res = a =*= b in
-      if !Flag.debug_matching && not res
-      then begin
-        pr2 (spf "A = %s" (str_of_any a));
-        pr2 (spf "B = %s" (str_of_any b));
-      end;
-      res
-
+      a =*= b
+  | A.I _, A.E (A.Id (b_id, _)) ->
+    (* Allow identifier nodes to match pure identifier expressions *)
+      equal_ast_binded_code a (A.I b_id)
   | _, _ ->
       false
+  ) in
+
+  if !Flag.debug_matching && not res
+  then begin
+    pr2 (spf "A = %s" (str_of_any a));
+    pr2 (spf "B = %s" (str_of_any b));
+  end;
+
+  res
+)
 (*e: function [[Matching_generic.equal_ast_binded_code]] *)
 
 (*s: function [[Matching_generic.check_and_add_metavar_binding]] *)

--- a/semgrep-core/tests/js/misc_destructuring_2.js
+++ b/semgrep-core/tests/js/misc_destructuring_2.js
@@ -1,0 +1,4 @@
+//ERROR: match
+function test({foo}) {
+    console.log(foo);
+}

--- a/semgrep-core/tests/js/misc_destructuring_2.sgrep
+++ b/semgrep-core/tests/js/misc_destructuring_2.sgrep
@@ -1,0 +1,3 @@
+function $F ({$FOO}) {
+  ...
+}

--- a/semgrep-core/tests/js/misc_destructuring_2.sgrep
+++ b/semgrep-core/tests/js/misc_destructuring_2.sgrep
@@ -1,3 +1,3 @@
-function $F ({$FOO}) {
+function $F ({$FOO}, ...) {
   ...
 }


### PR DESCRIPTION
Previously, we could not match these, as we could not reuse the symbol
in

  let $FOO = arg.$FOO

when matching

  let foo = arg.foo

Here we add the ability to match pure identifier nodes against
identifier expressions, allowing this match.

Fixes #1005.