### PR TITLE
Add flag to ignore explicit files with unknown extensions

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -109,9 +109,9 @@ def cli() -> None:
         help="Scan all files even those ignored by a projects gitignore(s)",
     )
     parser.add_argument(
-        "--ignore_unknown_extentions",
+        "--skip-unknown-extensions",
         action="store_true",
-        help="By default, explicity passed targets with an extension semgrep does not understand is treated as if it matches all languages. Setting this flag will have semgrep ignore such files.",
+        help="Scan only known file extensions, even if unrecognized ones are explicitly targeted.",
     )
 
     config.add_argument(
@@ -370,5 +370,5 @@ def cli() -> None:
                 timeout=args.timeout,
                 max_memory=args.max_memory,
                 timeout_threshold=args.timeout_threshold,
-                keep_explicit_unknown_extentions=(not args.ignore_unknown_extentions),
+                skip_unknown_extensions=args.skip_unknown_extensions,
             )

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -108,6 +108,11 @@ def cli() -> None:
         action="store_true",
         help="Scan all files even those ignored by a projects gitignore(s)",
     )
+    parser.add_argument(
+        "--ignore_unknown_extentions",
+        action="store_true",
+        help="By default, explicity passed targets with an extension semgrep does not understand is treated as if it matches all languages. Setting this flag will have semgrep ignore such files.",
+    )
 
     config.add_argument(
         RCE_RULE_FLAG,
@@ -365,4 +370,5 @@ def cli() -> None:
                 timeout=args.timeout,
                 max_memory=args.max_memory,
                 timeout_threshold=args.timeout_threshold,
+                keep_explicit_unknown_extentions=(not args.ignore_unknown_extentions),
             )

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -295,6 +295,7 @@ def main(
     timeout: int = 0,
     max_memory: int = 0,
     timeout_threshold: int = 0,
+    keep_explicit_unknown_extentions: bool = True,
 ) -> None:
     if include is None:
         include = []
@@ -348,6 +349,7 @@ def main(
         targets=target,
         respect_git_ignore=respect_git_ignore,
         output_handler=output_handler,
+        keep_explicit_unknown_extentions=keep_explicit_unknown_extentions,
     )
 
     # actually invoke semgrep

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -295,7 +295,7 @@ def main(
     timeout: int = 0,
     max_memory: int = 0,
     timeout_threshold: int = 0,
-    keep_explicit_unknown_extentions: bool = True,
+    skip_unknown_extensions: bool = False,
 ) -> None:
     if include is None:
         include = []
@@ -349,7 +349,7 @@ def main(
         targets=target,
         respect_git_ignore=respect_git_ignore,
         output_handler=output_handler,
-        keep_explicit_unknown_extentions=keep_explicit_unknown_extentions,
+        skip_unknown_extensions=skip_unknown_extensions,
     )
 
     # actually invoke semgrep

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -77,7 +77,7 @@ class TargetManager:
         If respect_git_ignore is true then will only consider files that are
         tracked or (untracked but not ignored) by git
 
-        If keep_explicit_unknown_extentions is True then targets with extensions that are
+        If skip_unknown_extensions is False then targets with extensions that are
         not understood by semgrep will always be returned by get_files. Else will discard
         targets with unknown extensions
     """
@@ -87,7 +87,7 @@ class TargetManager:
     targets: List[str]
     respect_git_ignore: bool
     output_handler: OutputHandler
-    keep_explicit_unknown_extentions: bool
+    skip_unknown_extensions: bool
 
     _filtered_targets: Dict[str, Set[Path]] = attr.ib(factory=dict)
 
@@ -260,7 +260,7 @@ class TargetManager:
         targets = self.filter_includes(targets, self.includes)
         targets = self.filter_excludes(targets, self.excludes)
 
-        if self.keep_explicit_unknown_extentions:
+        if not self.skip_unknown_extensions:
             # Remove explicit_files with known extensions
             explicit_files = set(
                 f

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -393,31 +393,41 @@ def test_explicit_path(tmp_path, monkeypatch):
     python_language = Language("python")
 
     assert foo_a in TargetManager(
-        [], [], ["foo/a.py"], False, defaulthandler
+        [], [], ["foo/a.py"], False, defaulthandler, True
     ).get_files(python_language, [], [])
 
     # Should include explicitly passed python file even if is in excludes
     assert foo_a not in TargetManager(
-        [], ["foo/a.py"], ["."], False, defaulthandler
+        [], ["foo/a.py"], ["."], False, defaulthandler, True
     ).get_files(python_language, [], [])
     assert foo_a in TargetManager(
-        [], ["foo/a.py"], [".", "foo/a.py"], False, defaulthandler
+        [], ["foo/a.py"], [".", "foo/a.py"], False, defaulthandler, True
     ).get_files(python_language, [], [])
 
     # Should ignore expliclty passed .go file when requesting python
     assert (
-        TargetManager([], [], ["foo/a.go"], False, defaulthandler).get_files(
+        TargetManager([], [], ["foo/a.go"], False, defaulthandler, True).get_files(
             python_language, [], []
         )
         == []
     )
 
-    # Should include explicitly passed file with unknown extension
+    # Should include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=True
     assert cmp_path_sets(
         set(
-            TargetManager([], [], ["foo/noext"], False, defaulthandler).get_files(
+            TargetManager([], [], ["foo/noext"], False, defaulthandler, True).get_files(
                 python_language, [], []
             )
         ),
         {foo_noext},
+    )
+
+    # Should not include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=False
+    assert cmp_path_sets(
+        set(
+            TargetManager(
+                [], [], ["foo/noext"], False, defaulthandler, False
+            ).get_files(python_language, [], [])
+        ),
+        set(),
     )

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -393,41 +393,41 @@ def test_explicit_path(tmp_path, monkeypatch):
     python_language = Language("python")
 
     assert foo_a in TargetManager(
-        [], [], ["foo/a.py"], False, defaulthandler, True
+        [], [], ["foo/a.py"], False, defaulthandler, False
     ).get_files(python_language, [], [])
 
     # Should include explicitly passed python file even if is in excludes
     assert foo_a not in TargetManager(
-        [], ["foo/a.py"], ["."], False, defaulthandler, True
+        [], ["foo/a.py"], ["."], False, defaulthandler, False
     ).get_files(python_language, [], [])
     assert foo_a in TargetManager(
-        [], ["foo/a.py"], [".", "foo/a.py"], False, defaulthandler, True
+        [], ["foo/a.py"], [".", "foo/a.py"], False, defaulthandler, False
     ).get_files(python_language, [], [])
 
     # Should ignore expliclty passed .go file when requesting python
     assert (
-        TargetManager([], [], ["foo/a.go"], False, defaulthandler, True).get_files(
+        TargetManager([], [], ["foo/a.go"], False, defaulthandler, False).get_files(
             python_language, [], []
         )
         == []
     )
 
-    # Should include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=True
-    assert cmp_path_sets(
-        set(
-            TargetManager([], [], ["foo/noext"], False, defaulthandler, True).get_files(
-                python_language, [], []
-            )
-        ),
-        {foo_noext},
-    )
-
-    # Should not include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=False
+    # Should include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=False
     assert cmp_path_sets(
         set(
             TargetManager(
                 [], [], ["foo/noext"], False, defaulthandler, False
             ).get_files(python_language, [], [])
+        ),
+        {foo_noext},
+    )
+
+    # Should not include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=True
+    assert cmp_path_sets(
+        set(
+            TargetManager([], [], ["foo/noext"], False, defaulthandler, True).get_files(
+                python_language, [], []
+            )
         ),
         set(),
     )

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -412,7 +412,7 @@ def test_explicit_path(tmp_path, monkeypatch):
         == []
     )
 
-    # Should include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=False
+    # Should include explicitly passed file with unknown extension if skip_unknown_extensions=False
     assert cmp_path_sets(
         set(
             TargetManager(
@@ -422,7 +422,7 @@ def test_explicit_path(tmp_path, monkeypatch):
         {foo_noext},
     )
 
-    # Should not include explicitly passed file with unknown extension if keep_explicit_unknown_extentions=True
+    # Should not include explicitly passed file with unknown extension if skip_unknown_extensions=True
     assert cmp_path_sets(
         set(
             TargetManager([], [], ["foo/noext"], False, defaulthandler, True).get_files(


### PR DESCRIPTION
By default semgrep treats explicitly passed files with unknown extension as possibly any language and so runs all rules on said files. This adds a flag so that semgrep will treat these files as if they matched no language and will so run no rules on them.

Useful for https://github.com/returntocorp/semgrep-action/issues/35