### PR TITLE
Dockerfile: Ensure /src exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ COPY semgrep /semgrep
 RUN HOMEBREW_SYSTEM='NOCORE' python -m pip install /semgrep
 RUN semgrep --version
 
+RUN mkdir -p /src
+RUN chmod 777 /src
 RUN mkdir -p /tmp/.cache
 RUN chmod 777 /tmp/.cache
 


### PR DESCRIPTION
Because we now run without root as the user, we need to create this
directory first.

We should release 0.19.2 after this in order to unblock CI users.