### PR TITLE
tests: make perf test less flakey

### DIFF
--- a/semgrep/tests/performance/test_ci_perf.py
+++ b/semgrep/tests/performance/test_ci_perf.py
@@ -47,4 +47,4 @@ def test_perf(clone_github_repo):
     )
     duration = time.time() - start
     print(duration)
-    assert duration < 275
+    assert duration < 300


### PR DESCRIPTION
timing is very flakey. Increase timeout of this canary until a stricter
test that is less affected by change in hardware.

In https://github.com/returntocorp/semgrep/pull/1513 will time published version of semgrep and compare to that