### PR TITLE
Skeleton for Parse_javascript_tree_sitter.ml

### DIFF
--- a/semgrep-core/parsing/Parse_code.ml
+++ b/semgrep-core/parsing/Parse_code.ml
@@ -59,6 +59,18 @@ let just_parse_with_lang lang file =
       in
       Go_to_generic.program ast
 
+  | Lang.Javascript ->
+      let ast =
+        try unless_tree_sitter
+            (fun file ->
+              let cst = Parse_js.parse_program file in
+              Ast_js_build.program cst
+            )
+            file
+        with _exn -> Parse_javascript_tree_sitter.parse file
+      in
+      Js_to_generic.program ast
+
   | Lang.Csharp ->
       Parse_csharp_tree_sitter.parse file
 

--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -50,6 +50,7 @@ let rev = false
    to another type of tree.
 *)
 
+(* TODO: use H.combine_tokens *)
 let combine_tokens_and_strings v1 _v2 _v3 =
   "TODO", v1
 

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -58,19 +58,19 @@ let blank (env : env) () = ()
 let todo (env : env) _ =
    failwith "not implemented"
 
-let map_regex_pattern (env : env) (tok : CST.regex_pattern) =
+let regex_pattern (env : env) (tok : CST.regex_pattern) =
   token env tok (* regex_pattern *)
 
-let map_identifier (env : env) (tok : CST.identifier) =
+let identifier (env : env) (tok : CST.identifier) =
   token env tok (* identifier *)
 
-let map_number (env : env) (tok : CST.number) =
+let number (env : env) (tok : CST.number) =
   token env tok (* number *)
 
-let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
+let escape_sequence (env : env) (tok : CST.escape_sequence) =
   token env tok (* escape_sequence *)
 
-let map_reserved_identifier (env : env) (x : CST.reserved_identifier) =
+let reserved_identifier (env : env) (x : CST.reserved_identifier) =
   (match x with
   | `Get tok -> token env tok (* "get" *)
   | `Set tok -> token env tok (* "set" *)
@@ -78,51 +78,51 @@ let map_reserved_identifier (env : env) (x : CST.reserved_identifier) =
   | `Static tok -> token env tok (* "static" *)
   )
 
-let map_jsx_identifier (env : env) (tok : CST.jsx_identifier) =
+let jsx_identifier (env : env) (tok : CST.jsx_identifier) =
   token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
 
-let map_regex_flags (env : env) (tok : CST.regex_flags) =
+let regex_flags (env : env) (tok : CST.regex_flags) =
   token env tok (* pattern [a-z]+ *)
 
-let map_anon_choice_PLUSPLUS (env : env) (x : CST.anon_choice_PLUSPLUS) =
+let anon_choice_PLUSPLUS (env : env) (x : CST.anon_choice_PLUSPLUS) =
   (match x with
   | `PLUSPLUS tok -> token env tok (* "++" *)
   | `DASHDASH tok -> token env tok (* "--" *)
   )
 
-let map_template_chars (env : env) (tok : CST.template_chars) =
+let template_chars (env : env) (tok : CST.template_chars) =
   token env tok (* template_chars *)
 
-let map_import (env : env) (tok : CST.import) =
+let import (env : env) (tok : CST.import) =
   token env tok (* import *)
 
-let map_hash_bang_line (env : env) (tok : CST.hash_bang_line) =
+let hash_bang_line (env : env) (tok : CST.hash_bang_line) =
   token env tok (* pattern #!.* *)
 
-let map_jsx_text (env : env) (tok : CST.jsx_text) =
+let jsx_text (env : env) (tok : CST.jsx_text) =
   token env tok (* pattern [^{}<>]+ *)
 
-let map_automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
+let automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
   token env tok (* automatic_semicolon *)
 
-let map_namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
+let namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
   let v1 = token env v1 (* "*" *) in
   let v2 = token env v2 (* "as" *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let rec map_nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
+let rec nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
   let v1 =
     (match v1 with
     | `Id tok -> token env tok (* identifier *)
-    | `Nested_id x -> map_nested_identifier env x
+    | `Nested_id x -> nested_identifier env x
     )
   in
   let v2 = token env v2 (* "." *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-let map_import_export_specifier (env : env) ((v1, v2) : CST.import_export_specifier) =
+let import_export_specifier (env : env) ((v1, v2) : CST.import_export_specifier) =
   let v1 = token env v1 (* identifier *) in
   let v2 =
     (match v2 with
@@ -134,87 +134,87 @@ let map_import_export_specifier (env : env) ((v1, v2) : CST.import_export_specif
   in
   todo env (v1, v2)
 
-let map_anon_choice_blank (env : env) (x : CST.anon_choice_blank) =
+let anon_choice_blank (env : env) (x : CST.anon_choice_blank) =
   (match x with
   | `Blank () -> todo env ()
   | `Esc_seq tok -> token env tok (* escape_sequence *)
   )
 
-let map_anon_choice_rese_id (env : env) (x : CST.anon_choice_rese_id) =
+let anon_choice_rese_id (env : env) (x : CST.anon_choice_rese_id) =
   (match x with
-  | `Choice_get x -> map_reserved_identifier env x
+  | `Choice_get x -> reserved_identifier env x
   | `Id tok -> token env tok (* identifier *)
   )
 
-let map_identifier_reference (env : env) (x : CST.identifier_reference) =
+let identifier_reference (env : env) (x : CST.identifier_reference) =
   (match x with
   | `Id tok -> token env tok (* identifier *)
-  | `Choice_get x -> map_reserved_identifier env x
+  | `Choice_get x -> reserved_identifier env x
   )
 
-let map_jsx_identifier_ (env : env) (x : CST.jsx_identifier_) =
+let jsx_identifier_ (env : env) (x : CST.jsx_identifier_) =
   (match x with
   | `Jsx_id tok ->
       token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
   | `Id tok -> token env tok (* identifier *)
   )
 
-let map_semicolon (env : env) (x : CST.semicolon) =
+let semicolon (env : env) (x : CST.semicolon) =
   (match x with
   | `Auto_semi tok -> token env tok (* automatic_semicolon *)
   | `SEMI tok -> token env tok (* ";" *)
   )
 
-let map_anon_import_export_spec_rep_COMMA_import_export_spec (env : env) ((v1, v2) : CST.anon_import_export_spec_rep_COMMA_import_export_spec) =
-  let v1 = map_import_export_specifier env v1 in
+let anon_import_export_spec_rep_COMMA_import_export_spec (env : env) ((v1, v2) : CST.anon_import_export_spec_rep_COMMA_import_export_spec) =
+  let v1 = import_export_specifier env v1 in
   let v2 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 = map_import_export_specifier env v2 in
+      let v2 = import_export_specifier env v2 in
       todo env (v1, v2)
     ) v2
   in
   todo env (v1, v2)
 
-let map_string_ (env : env) (x : CST.string_) =
+let string_ (env : env) (x : CST.string_) =
   (match x with
   | `DQUOT_rep_choice_blank_DQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "\"" *) in
-      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v2 = List.map (anon_choice_blank env) v2 in
       let v3 = token env v3 (* "\"" *) in
       todo env (v1, v2, v3)
   | `SQUOT_rep_choice_blank_SQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "'" *) in
-      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v2 = List.map (anon_choice_blank env) v2 in
       let v3 = token env v3 (* "'" *) in
       todo env (v1, v2, v3)
   )
 
-let rec map_decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
-  let v1 = map_anon_choice_id_ref env v1 in
+let rec decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
+  let v1 = anon_choice_id_ref env v1 in
   let v2 = token env v2 (* "." *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-and map_anon_choice_id_ref (env : env) (x : CST.anon_choice_id_ref) =
+and anon_choice_id_ref (env : env) (x : CST.anon_choice_id_ref) =
   (match x with
-  | `Choice_id x -> map_identifier_reference env x
+  | `Choice_id x -> identifier_reference env x
   | `Deco_member_exp x ->
-      map_decorator_member_expression env x
+      decorator_member_expression env x
   )
 
-let map_jsx_namespace_name (env : env) ((v1, v2, v3) : CST.jsx_namespace_name) =
-  let v1 = map_jsx_identifier_ env v1 in
+let jsx_namespace_name (env : env) ((v1, v2, v3) : CST.jsx_namespace_name) =
+  let v1 = jsx_identifier_ env v1 in
   let v2 = token env v2 (* ":" *) in
-  let v3 = map_jsx_identifier_ env v3 in
+  let v3 = jsx_identifier_ env v3 in
   todo env (v1, v2, v3)
 
-let map_export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
+let export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some x ->
-        map_anon_import_export_spec_rep_COMMA_import_export_spec env x
+        anon_import_export_spec_rep_COMMA_import_export_spec env x
     | None -> todo env ())
   in
   let v3 =
@@ -225,12 +225,12 @@ let map_export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
   let v4 = token env v4 (* "}" *) in
   todo env (v1, v2, v3, v4)
 
-let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
+let named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some x ->
-        map_anon_import_export_spec_rep_COMMA_import_export_spec env x
+        anon_import_export_spec_rep_COMMA_import_export_spec env x
     | None -> todo env ())
   in
   let v3 =
@@ -241,28 +241,28 @@ let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   let v4 = token env v4 (* "}" *) in
   todo env (v1, v2, v3, v4)
 
-let map_from_clause (env : env) ((v1, v2) : CST.from_clause) =
+let from_clause (env : env) ((v1, v2) : CST.from_clause) =
   let v1 = token env v1 (* "from" *) in
-  let v2 = map_string_ env v2 in
+  let v2 = string_ env v2 in
   todo env (v1, v2)
 
-let map_jsx_attribute_name (env : env) (x : CST.jsx_attribute_name) =
+let jsx_attribute_name (env : env) (x : CST.jsx_attribute_name) =
   (match x with
-  | `Choice_jsx_id x -> map_jsx_identifier_ env x
-  | `Jsx_name_name x -> map_jsx_namespace_name env x
+  | `Choice_jsx_id x -> jsx_identifier_ env x
+  | `Jsx_name_name x -> jsx_namespace_name env x
   )
 
-let map_jsx_element_name (env : env) (x : CST.jsx_element_name) =
+let jsx_element_name (env : env) (x : CST.jsx_element_name) =
   (match x with
-  | `Choice_jsx_id x -> map_jsx_identifier_ env x
-  | `Nested_id x -> map_nested_identifier env x
-  | `Jsx_name_name x -> map_jsx_namespace_name env x
+  | `Choice_jsx_id x -> jsx_identifier_ env x
+  | `Nested_id x -> nested_identifier env x
+  | `Jsx_name_name x -> jsx_namespace_name env x
   )
 
-let map_import_clause (env : env) (x : CST.import_clause) =
+let import_clause (env : env) (x : CST.import_clause) =
   (match x with
-  | `Name_import x -> map_namespace_import env x
-  | `Named_imports x -> map_named_imports env x
+  | `Name_import x -> namespace_import env x
+  | `Named_imports x -> named_imports env x
   | `Id_opt_COMMA_choice_name_import (v1, v2) ->
       let v1 = token env v1 (* identifier *) in
       let v2 =
@@ -271,8 +271,8 @@ let map_import_clause (env : env) (x : CST.import_clause) =
             let v1 = token env v1 (* "," *) in
             let v2 =
               (match v2 with
-              | `Name_import x -> map_namespace_import env x
-              | `Named_imports x -> map_named_imports env x
+              | `Name_import x -> namespace_import env x
+              | `Named_imports x -> named_imports env x
               )
             in
             todo env (v1, v2)
@@ -281,46 +281,46 @@ let map_import_clause (env : env) (x : CST.import_clause) =
       todo env (v1, v2)
   )
 
-let map_jsx_closing_element (env : env) ((v1, v2, v3, v4) : CST.jsx_closing_element) =
+let jsx_closing_element (env : env) ((v1, v2, v3, v4) : CST.jsx_closing_element) =
   let v1 = token env v1 (* "<" *) in
   let v2 = token env v2 (* "/" *) in
-  let v3 = map_jsx_element_name env v3 in
+  let v3 = jsx_element_name env v3 in
   let v4 = token env v4 (* ">" *) in
   todo env (v1, v2, v3, v4)
 
-let rec map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
+let rec parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
   let v1 = token env v1 (* "(" *) in
-  let v2 = map_expressions env v2 in
+  let v2 = expressions env v2 in
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-and map_jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element) =
+and jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = map_jsx_element_name env v2 in
-  let v3 = List.map (map_jsx_attribute_ env) v3 in
+  let v2 = jsx_element_name env v2 in
+  let v3 = List.map (jsx_attribute_ env) v3 in
   let v4 = token env v4 (* ">" *) in
   todo env (v1, v2, v3, v4)
 
-and map_destructuring_pattern (env : env) (x : CST.destructuring_pattern) =
+and destructuring_pattern (env : env) (x : CST.destructuring_pattern) =
   (match x with
-  | `Obj x -> map_object_ env x
-  | `Array x -> map_array_ env x
+  | `Obj x -> object_ env x
+  | `Array x -> array_ env x
   )
 
-and map_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.variable_declaration) =
+and variable_declaration (env : env) ((v1, v2, v3, v4) : CST.variable_declaration) =
   let v1 = token env v1 (* "var" *) in
-  let v2 = map_variable_declarator env v2 in
+  let v2 = variable_declarator env v2 in
   let v3 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 = map_variable_declarator env v2 in
+      let v2 = variable_declarator env v2 in
       todo env (v1, v2)
     ) v3
   in
-  let v4 = map_semicolon env v4 in
+  let v4 = semicolon env v4 in
   todo env (v1, v2, v3, v4)
 
-and map_function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
+and function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
   let v1 =
     (match v1 with
     | Some tok -> token env tok (* "async" *)
@@ -332,195 +332,195 @@ and map_function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
     | Some tok -> token env tok (* identifier *)
     | None -> todo env ())
   in
-  let v4 = map_formal_parameters env v4 in
-  let v5 = map_statement_block env v5 in
+  let v4 = formal_parameters env v4 in
+  let v5 = statement_block env v5 in
   todo env (v1, v2, v3, v4, v5)
 
-and map_anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
+and anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
   (match x with
-  | `Exp x -> map_expression env x
-  | `Spread_elem x -> map_spread_element env x
+  | `Exp x -> expression env x
+  | `Spread_elem x -> spread_element env x
   )
 
-and map_switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
+and switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
   let v1 = token env v1 (* "default" *) in
   let v2 = token env v2 (* ":" *) in
-  let v3 = List.map (map_statement env) v3 in
+  let v3 = List.map (statement env) v3 in
   todo env (v1, v2, v3)
 
-and map_binary_expression (env : env) (x : CST.binary_expression) =
+and binary_expression (env : env) (x : CST.binary_expression) =
   (match x with
   | `Exp_AMPAMP_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "&&" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_BARBAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "||" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_GTGT_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* ">>" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_GTGTGT_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* ">>>" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_LTLT_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "<<" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_AMP_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "&" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_HAT_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "^" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_BAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "|" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_PLUS_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "+" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_DASH_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "-" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_STAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "*" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_SLASH_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "/" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_PERC_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "%" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_STARSTAR_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "**" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_LT_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "<" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_LTEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "<=" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_EQEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "==" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_EQEQEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "===" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_BANGEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "!=" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_BANGEQEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "!==" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_GTEQ_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* ">=" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_GT_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* ">" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_QMARKQMARK_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "??" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_inst_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "instanceof" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Exp_in_exp (v1, v2, v3) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "in" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   )
 
-and map_arguments (env : env) ((v1, v2, v3) : CST.arguments) =
+and arguments (env : env) ((v1, v2, v3) : CST.arguments) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
-    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+    anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
   in
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-and map_variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
-  let v1 = map_anon_choice_id env v1 in
+and variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
+  let v1 = anon_choice_id env v1 in
   let v2 =
     (match v2 with
-    | Some x -> map_initializer_ env x
+    | Some x -> initializer_ env x
     | None -> todo env ())
   in
   todo env (v1, v2)
 
-and map_sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
-  let v1 = map_expression env v1 in
+and sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
+  let v1 = expression env v1 in
   let v2 = token env v2 (* "," *) in
   let v3 =
     (match v3 with
-    | `Seq_exp x -> map_sequence_expression env x
-    | `Exp x -> map_expression env x
+    | `Seq_exp x -> sequence_expression env x
+    | `Exp x -> expression env x
     )
   in
   todo env (v1, v2, v3)
 
-and map_jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) =
+and jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) =
   let v1 = token env v1 (* "<" *) in
   let v2 = token env v2 (* ">" *) in
-  let v3 = List.map (map_jsx_child env) v3 in
+  let v3 = List.map (jsx_child env) v3 in
   let v4 = token env v4 (* "<" *) in
   let v5 = token env v5 (* "/" *) in
   let v6 = token env v6 (* ">" *) in
   todo env (v1, v2, v3, v4, v5, v6)
 
-and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
+and class_body (env : env) ((v1, v2, v3) : CST.class_body) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     List.map (fun x ->
       (match x with
       | `Meth_defi_opt_SEMI (v1, v2) ->
-          let v1 = map_method_definition env v1 in
+          let v1 = method_definition env v1 in
           let v2 =
             (match v2 with
             | Some tok -> token env tok (* ";" *)
@@ -528,8 +528,8 @@ and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
           in
           todo env (v1, v2)
       | `Public_field_defi_choice_auto_semi (v1, v2) ->
-          let v1 = map_public_field_definition env v1 in
-          let v2 = map_semicolon env v2 in
+          let v1 = public_field_definition env v1 in
+          let v2 = semicolon env v2 in
           todo env (v1, v2)
       )
     ) v2
@@ -537,83 +537,83 @@ and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-and map_member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
+and member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
   let v1 =
     (match v1 with
-    | `Exp x -> map_expression env x
+    | `Exp x -> expression env x
     | `Id tok -> token env tok (* identifier *)
     | `Super tok -> token env tok (* "super" *)
-    | `Choice_get x -> map_reserved_identifier env x
+    | `Choice_get x -> reserved_identifier env x
     )
   in
   let v2 = token env v2 (* "." *) in
   let v3 = token env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
-and map_assignment_pattern (env : env) ((v1, v2, v3) : CST.assignment_pattern) =
+and assignment_pattern (env : env) ((v1, v2, v3) : CST.assignment_pattern) =
   let v1 =
     (match v1 with
-    | `Choice_choice_get x -> map_anon_choice_rese_id env x
-    | `Choice_obj x -> map_destructuring_pattern env x
+    | `Choice_choice_get x -> anon_choice_rese_id env x
+    | `Choice_obj x -> destructuring_pattern env x
     )
   in
   let v2 = token env v2 (* "=" *) in
-  let v3 = map_expression env v3 in
+  let v3 = expression env v3 in
   todo env (v1, v2, v3)
 
-and map_jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) =
+and jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some x ->
         (match x with
-        | `Exp x -> map_expression env x
-        | `Seq_exp x -> map_sequence_expression env x
-        | `Spread_elem x -> map_spread_element env x
+        | `Exp x -> expression env x
+        | `Seq_exp x -> sequence_expression env x
+        | `Spread_elem x -> spread_element env x
         )
     | None -> todo env ())
   in
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-and map_anon_choice_pair (env : env) (x : CST.anon_choice_pair) =
+and anon_choice_pair (env : env) (x : CST.anon_choice_pair) =
   (match x with
   | `Pair (v1, v2, v3) ->
-      let v1 = map_property_name env v1 in
+      let v1 = property_name env v1 in
       let v2 = token env v2 (* ":" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
-  | `Spread_elem x -> map_spread_element env x
-  | `Meth_defi x -> map_method_definition env x
-  | `Assign_pat x -> map_assignment_pattern env x
-  | `Choice_id x -> map_identifier_reference env x
+  | `Spread_elem x -> spread_element env x
+  | `Meth_defi x -> method_definition env x
+  | `Assign_pat x -> assignment_pattern env x
+  | `Choice_id x -> identifier_reference env x
   )
 
-and map_subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
+and subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
   let v1 =
     (match v1 with
-    | `Exp x -> map_expression env x
+    | `Exp x -> expression env x
     | `Super tok -> token env tok (* "super" *)
     )
   in
   let v2 = token env v2 (* "[" *) in
-  let v3 = map_expressions env v3 in
+  let v3 = expressions env v3 in
   let v4 = token env v4 (* "]" *) in
   todo env (v1, v2, v3, v4)
 
-and map_initializer_ (env : env) ((v1, v2) : CST.initializer_) =
+and initializer_ (env : env) ((v1, v2) : CST.initializer_) =
   let v1 = token env v1 (* "=" *) in
-  let v2 = map_expression env v2 in
+  let v2 = expression env v2 in
   todo env (v1, v2)
 
-and map_constructable_expression (env : env) (x : CST.constructable_expression) =
+and constructable_expression (env : env) (x : CST.constructable_expression) =
   (match x with
   | `This tok -> token env tok (* "this" *)
   | `Id tok -> token env tok (* identifier *)
-  | `Choice_get x -> map_reserved_identifier env x
+  | `Choice_get x -> reserved_identifier env x
   | `Num tok -> token env tok (* number *)
-  | `Str x -> map_string_ env x
-  | `Temp_str x -> map_template_string env x
+  | `Str x -> string_ env x
+  | `Temp_str x -> template_string env x
   | `Regex (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "/" *) in
       let v2 = token env v2 (* regex_pattern *) in
@@ -629,9 +629,9 @@ and map_constructable_expression (env : env) (x : CST.constructable_expression) 
   | `Null tok -> token env tok (* "null" *)
   | `Unde tok -> token env tok (* "undefined" *)
   | `Import tok -> token env tok (* import *)
-  | `Obj x -> map_object_ env x
-  | `Array x -> map_array_ env x
-  | `Func x -> map_function_ env x
+  | `Obj x -> object_ env x
+  | `Array x -> array_ env x
+  | `Func x -> function_ env x
   | `Arrow_func (v1, v2, v3, v4) ->
       let v1 =
         (match v1 with
@@ -640,15 +640,15 @@ and map_constructable_expression (env : env) (x : CST.constructable_expression) 
       in
       let v2 =
         (match v2 with
-        | `Choice_choice_get x -> map_anon_choice_rese_id env x
-        | `Formal_params x -> map_call_signature env x
+        | `Choice_choice_get x -> anon_choice_rese_id env x
+        | `Formal_params x -> call_signature env x
         )
       in
       let v3 = token env v3 (* "=>" *) in
       let v4 =
         (match v4 with
-        | `Exp x -> map_expression env x
-        | `Stmt_blk x -> map_statement_block env x
+        | `Exp x -> expression env x
+        | `Stmt_blk x -> statement_block env x
         )
       in
       todo env (v1, v2, v3, v4)
@@ -665,11 +665,11 @@ and map_constructable_expression (env : env) (x : CST.constructable_expression) 
         | Some tok -> token env tok (* identifier *)
         | None -> todo env ())
       in
-      let v5 = map_formal_parameters env v5 in
-      let v6 = map_statement_block env v6 in
+      let v5 = formal_parameters env v5 in
+      let v6 = statement_block env v6 in
       todo env (v1, v2, v3, v4, v5, v6)
   | `Class (v1, v2, v3, v4, v5) ->
-      let v1 = List.map (map_decorator env) v1 in
+      let v1 = List.map (decorator env) v1 in
       let v2 = token env v2 (* "class" *) in
       let v3 =
         (match v3 with
@@ -678,14 +678,14 @@ and map_constructable_expression (env : env) (x : CST.constructable_expression) 
       in
       let v4 =
         (match v4 with
-        | Some x -> map_class_heritage env x
+        | Some x -> class_heritage env x
         | None -> todo env ())
       in
-      let v5 = map_class_body env v5 in
+      let v5 = class_body env v5 in
       todo env (v1, v2, v3, v4, v5)
-  | `Paren_exp x -> map_parenthesized_expression env x
-  | `Subs_exp x -> map_subscript_expression env x
-  | `Member_exp x -> map_member_expression env x
+  | `Paren_exp x -> parenthesized_expression env x
+  | `Subs_exp x -> subscript_expression env x
+  | `Member_exp x -> member_expression env x
   | `Meta_prop (v1, v2, v3) ->
       let v1 = token env v1 (* "new" *) in
       let v2 = token env v2 (* "." *) in
@@ -693,89 +693,89 @@ and map_constructable_expression (env : env) (x : CST.constructable_expression) 
       todo env (v1, v2, v3)
   | `New_exp (v1, v2, v3) ->
       let v1 = token env v1 (* "new" *) in
-      let v2 = map_constructable_expression env v2 in
+      let v2 = constructable_expression env v2 in
       let v3 =
         (match v3 with
-        | Some x -> map_arguments env x
+        | Some x -> arguments env x
         | None -> todo env ())
       in
       todo env (v1, v2, v3)
   )
 
-and map_jsx_attribute_ (env : env) (x : CST.jsx_attribute_) =
+and jsx_attribute_ (env : env) (x : CST.jsx_attribute_) =
   (match x with
   | `Jsx_attr (v1, v2) ->
-      let v1 = map_jsx_attribute_name env v1 in
+      let v1 = jsx_attribute_name env v1 in
       let v2 =
         (match v2 with
         | Some (v1, v2) ->
             let v1 = token env v1 (* "=" *) in
-            let v2 = map_jsx_attribute_value env v2 in
+            let v2 = jsx_attribute_value env v2 in
             todo env (v1, v2)
         | None -> todo env ())
       in
       todo env (v1, v2)
-  | `Jsx_exp x -> map_jsx_expression env x
+  | `Jsx_exp x -> jsx_expression env x
   )
 
-and map_expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
-  let v1 = map_expressions env v1 in
-  let v2 = map_semicolon env v2 in
+and expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
+  let v1 = expressions env v1 in
+  let v2 = semicolon env v2 in
   todo env (v1, v2)
 
-and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) =
+and catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) =
   let v1 = token env v1 (* "catch" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
         let v1 = token env v1 (* "(" *) in
-        let v2 = map_anon_choice_id env v2 in
+        let v2 = anon_choice_id env v2 in
         let v3 = token env v3 (* ")" *) in
         todo env (v1, v2, v3)
     | None -> todo env ())
   in
-  let v3 = map_statement_block env v3 in
+  let v3 = statement_block env v3 in
   todo env (v1, v2, v3)
 
-and map_template_string (env : env) ((v1, v2, v3) : CST.template_string) =
+and template_string (env : env) ((v1, v2, v3) : CST.template_string) =
   let v1 = token env v1 (* "`" *) in
   let v2 =
     List.map (fun x ->
       (match x with
       | `Temp_chars tok -> token env tok (* template_chars *)
       | `Esc_seq tok -> token env tok (* escape_sequence *)
-      | `Temp_subs x -> map_template_substitution env x
+      | `Temp_subs x -> template_substitution env x
       )
     ) v2
   in
   let v3 = token env v3 (* "`" *) in
   todo env (v1, v2, v3)
 
-and map_decorator (env : env) ((v1, v2) : CST.decorator) =
+and decorator (env : env) ((v1, v2) : CST.decorator) =
   let v1 = token env v1 (* "@" *) in
   let v2 =
     (match v2 with
-    | `Choice_id x -> map_identifier_reference env x
+    | `Choice_id x -> identifier_reference env x
     | `Deco_member_exp x ->
-        map_decorator_member_expression env x
-    | `Deco_call_exp x -> map_decorator_call_expression env x
+        decorator_member_expression env x
+    | `Deco_call_exp x -> decorator_call_expression env x
     )
   in
   todo env (v1, v2)
 
-and map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp (env : env) (opt : CST.anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp) =
+and anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp (env : env) (opt : CST.anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp) =
   (match opt with
   | Some (v1, v2) ->
       let v1 =
         (match v1 with
-        | Some x -> map_anon_choice_exp env x
+        | Some x -> anon_choice_exp env x
         | None -> todo env ())
       in
-      let v2 = map_anon_rep_COMMA_opt_choice_exp env v2 in
+      let v2 = anon_rep_COMMA_opt_choice_exp env v2 in
       todo env (v1, v2)
   | None -> todo env ())
 
-and map_for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
+and for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
@@ -787,35 +787,35 @@ and map_for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
         )
     | None -> todo env ())
   in
-  let v3 = map_anon_choice_paren_exp env v3 in
+  let v3 = anon_choice_paren_exp env v3 in
   let v4 =
     (match v4 with
     | `In tok -> token env tok (* "in" *)
     | `Of tok -> token env tok (* "of" *)
     )
   in
-  let v5 = map_expressions env v5 in
+  let v5 = expressions env v5 in
   let v6 = token env v6 (* ")" *) in
   todo env (v1, v2, v3, v4, v5, v6)
 
-and map_expression (env : env) (x : CST.expression) =
+and expression (env : env) (x : CST.expression) =
   (match x with
-  | `Choice_this x -> map_constructable_expression env x
-  | `Choice_jsx_elem x -> map_jsx_element_ env x
-  | `Jsx_frag x -> map_jsx_fragment env x
+  | `Choice_this x -> constructable_expression env x
+  | `Choice_jsx_elem x -> jsx_element_ env x
+  | `Jsx_frag x -> jsx_fragment env x
   | `Assign_exp (v1, v2, v3) ->
-      let v1 = map_anon_choice_paren_exp env v1 in
+      let v1 = anon_choice_paren_exp env v1 in
       let v2 = token env v2 (* "=" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Augm_assign_exp (v1, v2, v3) ->
       let v1 =
         (match v1 with
-        | `Member_exp x -> map_member_expression env x
-        | `Subs_exp x -> map_subscript_expression env x
-        | `Choice_get x -> map_reserved_identifier env x
+        | `Member_exp x -> member_expression env x
+        | `Subs_exp x -> subscript_expression env x
+        | `Choice_get x -> reserved_identifier env x
         | `Id tok -> token env tok (* identifier *)
-        | `Paren_exp x -> map_parenthesized_expression env x
+        | `Paren_exp x -> parenthesized_expression env x
         )
       in
       let v2 =
@@ -834,34 +834,34 @@ and map_expression (env : env) (x : CST.expression) =
         | `STARSTAREQ tok -> token env tok (* "**=" *)
         )
       in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       todo env (v1, v2, v3)
   | `Await_exp (v1, v2) ->
       let v1 = token env v1 (* "await" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
-  | `Un_exp x -> map_unary_expression env x
-  | `Bin_exp x -> map_binary_expression env x
+  | `Un_exp x -> unary_expression env x
+  | `Bin_exp x -> binary_expression env x
   | `Tern_exp (v1, v2, v3, v4, v5) ->
-      let v1 = map_expression env v1 in
+      let v1 = expression env v1 in
       let v2 = token env v2 (* "?" *) in
-      let v3 = map_expression env v3 in
+      let v3 = expression env v3 in
       let v4 = token env v4 (* ":" *) in
-      let v5 = map_expression env v5 in
+      let v5 = expression env v5 in
       todo env (v1, v2, v3, v4, v5)
-  | `Update_exp x -> map_update_expression env x
+  | `Update_exp x -> update_expression env x
   | `Call_exp (v1, v2) ->
       let v1 =
         (match v1 with
-        | `Exp x -> map_expression env x
+        | `Exp x -> expression env x
         | `Super tok -> token env tok (* "super" *)
-        | `Func x -> map_function_ env x
+        | `Func x -> function_ env x
         )
       in
       let v2 =
         (match v2 with
-        | `Args x -> map_arguments env x
-        | `Temp_str x -> map_template_string env x
+        | `Args x -> arguments env x
+        | `Temp_str x -> template_string env x
         )
       in
       todo env (v1, v2)
@@ -871,65 +871,65 @@ and map_expression (env : env) (x : CST.expression) =
         (match v2 with
         | `STAR_exp (v1, v2) ->
             let v1 = token env v1 (* "*" *) in
-            let v2 = map_expression env v2 in
+            let v2 = expression env v2 in
             todo env (v1, v2)
         | `Opt_exp opt ->
             (match opt with
-            | Some x -> map_expression env x
+            | Some x -> expression env x
             | None -> todo env ())
         )
       in
       todo env (v1, v2)
   )
 
-and map_anon_choice_paren_exp (env : env) (x : CST.anon_choice_paren_exp) =
+and anon_choice_paren_exp (env : env) (x : CST.anon_choice_paren_exp) =
   (match x with
-  | `Paren_exp x -> map_parenthesized_expression env x
-  | `Choice_member_exp x -> map_lhs_expression env x
+  | `Paren_exp x -> parenthesized_expression env x
+  | `Choice_member_exp x -> lhs_expression env x
   )
 
-and map_unary_expression (env : env) (x : CST.unary_expression) =
+and unary_expression (env : env) (x : CST.unary_expression) =
   (match x with
   | `BANG_exp (v1, v2) ->
       let v1 = token env v1 (* "!" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   | `TILDE_exp (v1, v2) ->
       let v1 = token env v1 (* "~" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   | `DASH_exp (v1, v2) ->
       let v1 = token env v1 (* "-" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   | `PLUS_exp (v1, v2) ->
       let v1 = token env v1 (* "+" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   | `Typeof_exp (v1, v2) ->
       let v1 = token env v1 (* "typeof" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   | `Void_exp (v1, v2) ->
       let v1 = token env v1 (* "void" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   | `Delete_exp (v1, v2) ->
       let v1 = token env v1 (* "delete" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   )
 
-and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
+and formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2, v3) ->
-        let v1 = map_formal_parameter env v1 in
+        let v1 = formal_parameter env v1 in
         let v2 =
           List.map (fun (v1, v2) ->
             let v1 = token env v1 (* "," *) in
-            let v2 = map_formal_parameter env v2 in
+            let v2 = formal_parameter env v2 in
             todo env (v1, v2)
           ) v2
         in
@@ -944,84 +944,84 @@ and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
   let v3 = token env v3 (* ")" *) in
   todo env (v1, v2, v3)
 
-and map_switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
+and switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     List.map (fun x ->
       (match x with
-      | `Switch_case x -> map_switch_case env x
-      | `Switch_defa x -> map_switch_default env x
+      | `Switch_case x -> switch_case env x
+      | `Switch_defa x -> switch_default env x
       )
     ) v2
   in
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-and map_statement (env : env) (x : CST.statement) =
+and statement (env : env) (x : CST.statement) =
   (match x with
-  | `Export_stmt x -> map_export_statement env x
+  | `Export_stmt x -> export_statement env x
   | `Import_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "import" *) in
       let v2 =
         (match v2 with
         | `Import_clause_from_clause (v1, v2) ->
-            let v1 = map_import_clause env v1 in
-            let v2 = map_from_clause env v2 in
+            let v1 = import_clause env v1 in
+            let v2 = from_clause env v2 in
             todo env (v1, v2)
-        | `Str x -> map_string_ env x
+        | `Str x -> string_ env x
         )
       in
-      let v3 = map_semicolon env v3 in
+      let v3 = semicolon env v3 in
       todo env (v1, v2, v3)
   | `Debu_stmt (v1, v2) ->
       let v1 = token env v1 (* "debugger" *) in
-      let v2 = map_semicolon env v2 in
+      let v2 = semicolon env v2 in
       todo env (v1, v2)
-  | `Exp_stmt x -> map_expression_statement env x
-  | `Decl x -> map_declaration env x
-  | `Stmt_blk x -> map_statement_block env x
+  | `Exp_stmt x -> expression_statement env x
+  | `Decl x -> declaration env x
+  | `Stmt_blk x -> statement_block env x
   | `If_stmt (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "if" *) in
-      let v2 = map_parenthesized_expression env v2 in
-      let v3 = map_statement env v3 in
+      let v2 = parenthesized_expression env v2 in
+      let v3 = statement env v3 in
       let v4 =
         (match v4 with
         | Some (v1, v2) ->
             let v1 = token env v1 (* "else" *) in
-            let v2 = map_statement env v2 in
+            let v2 = statement env v2 in
             todo env (v1, v2)
         | None -> todo env ())
       in
       todo env (v1, v2, v3, v4)
   | `Switch_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "switch" *) in
-      let v2 = map_parenthesized_expression env v2 in
-      let v3 = map_switch_body env v3 in
+      let v2 = parenthesized_expression env v2 in
+      let v3 = switch_body env v3 in
       todo env (v1, v2, v3)
   | `For_stmt (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 = token env v1 (* "for" *) in
       let v2 = token env v2 (* "(" *) in
       let v3 =
         (match v3 with
-        | `Lexi_decl x -> map_lexical_declaration env x
-        | `Var_decl x -> map_variable_declaration env x
-        | `Exp_stmt x -> map_expression_statement env x
+        | `Lexi_decl x -> lexical_declaration env x
+        | `Var_decl x -> variable_declaration env x
+        | `Exp_stmt x -> expression_statement env x
         | `Empty_stmt tok -> token env tok (* ";" *)
         )
       in
       let v4 =
         (match v4 with
-        | `Exp_stmt x -> map_expression_statement env x
+        | `Exp_stmt x -> expression_statement env x
         | `Empty_stmt tok -> token env tok (* ";" *)
         )
       in
       let v5 =
         (match v5 with
-        | Some x -> map_expressions env x
+        | Some x -> expressions env x
         | None -> todo env ())
       in
       let v6 = token env v6 (* ")" *) in
-      let v7 = map_statement env v7 in
+      let v7 = statement env v7 in
       todo env (v1, v2, v3, v4, v5, v6, v7)
   | `For_in_stmt (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "for" *) in
@@ -1030,39 +1030,39 @@ and map_statement (env : env) (x : CST.statement) =
         | Some tok -> token env tok (* "await" *)
         | None -> todo env ())
       in
-      let v3 = map_for_header env v3 in
-      let v4 = map_statement env v4 in
+      let v3 = for_header env v3 in
+      let v4 = statement env v4 in
       todo env (v1, v2, v3, v4)
   | `While_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "while" *) in
-      let v2 = map_parenthesized_expression env v2 in
-      let v3 = map_statement env v3 in
+      let v2 = parenthesized_expression env v2 in
+      let v3 = statement env v3 in
       todo env (v1, v2, v3)
   | `Do_stmt (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "do" *) in
-      let v2 = map_statement env v2 in
+      let v2 = statement env v2 in
       let v3 = token env v3 (* "while" *) in
-      let v4 = map_parenthesized_expression env v4 in
-      let v5 = map_semicolon env v5 in
+      let v4 = parenthesized_expression env v4 in
+      let v5 = semicolon env v5 in
       todo env (v1, v2, v3, v4, v5)
   | `Try_stmt (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "try" *) in
-      let v2 = map_statement_block env v2 in
+      let v2 = statement_block env v2 in
       let v3 =
         (match v3 with
-        | Some x -> map_catch_clause env x
+        | Some x -> catch_clause env x
         | None -> todo env ())
       in
       let v4 =
         (match v4 with
-        | Some x -> map_finally_clause env x
+        | Some x -> finally_clause env x
         | None -> todo env ())
       in
       todo env (v1, v2, v3, v4)
   | `With_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "with" *) in
-      let v2 = map_parenthesized_expression env v2 in
-      let v3 = map_statement env v3 in
+      let v2 = parenthesized_expression env v2 in
+      let v3 = statement env v3 in
       todo env (v1, v2, v3)
   | `Brk_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "break" *) in
@@ -1071,7 +1071,7 @@ and map_statement (env : env) (x : CST.statement) =
         | Some tok -> token env tok (* identifier *)
         | None -> todo env ())
       in
-      let v3 = map_semicolon env v3 in
+      let v3 = semicolon env v3 in
       todo env (v1, v2, v3)
   | `Cont_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "continue" *) in
@@ -1080,32 +1080,32 @@ and map_statement (env : env) (x : CST.statement) =
         | Some tok -> token env tok (* identifier *)
         | None -> todo env ())
       in
-      let v3 = map_semicolon env v3 in
+      let v3 = semicolon env v3 in
       todo env (v1, v2, v3)
   | `Ret_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "return" *) in
       let v2 =
         (match v2 with
-        | Some x -> map_expressions env x
+        | Some x -> expressions env x
         | None -> todo env ())
       in
-      let v3 = map_semicolon env v3 in
+      let v3 = semicolon env v3 in
       todo env (v1, v2, v3)
   | `Throw_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "throw" *) in
-      let v2 = map_expressions env v2 in
-      let v3 = map_semicolon env v3 in
+      let v2 = expressions env v2 in
+      let v3 = semicolon env v3 in
       todo env (v1, v2, v3)
   | `Empty_stmt tok -> token env tok (* ";" *)
   | `Labe_stmt (v1, v2, v3) ->
-      let v1 = map_identifier_reference env v1 in
+      let v1 = identifier_reference env v1 in
       let v2 = token env v2 (* ":" *) in
-      let v3 = map_statement env v3 in
+      let v3 = statement env v3 in
       todo env (v1, v2, v3)
   )
 
-and map_method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.method_definition) =
-  let v1 = List.map (map_decorator env) v1 in
+and method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.method_definition) =
+  let v1 = List.map (decorator env) v1 in
   let v2 =
     (match v2 with
     | Some tok -> token env tok (* "static" *)
@@ -1126,20 +1126,20 @@ and map_method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.method
         )
     | None -> todo env ())
   in
-  let v5 = map_property_name env v5 in
-  let v6 = map_formal_parameters env v6 in
-  let v7 = map_statement_block env v7 in
+  let v5 = property_name env v5 in
+  let v6 = formal_parameters env v6 in
+  let v7 = statement_block env v7 in
   todo env (v1, v2, v3, v4, v5, v6, v7)
 
-and map_array_ (env : env) ((v1, v2, v3) : CST.array_) =
+and array_ (env : env) ((v1, v2, v3) : CST.array_) =
   let v1 = token env v1 (* "[" *) in
   let v2 =
-    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+    anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
   in
   let v3 = token env v3 (* "]" *) in
   todo env (v1, v2, v3)
 
-and map_export_statement (env : env) (x : CST.export_statement) =
+and export_statement (env : env) (x : CST.export_statement) =
   (match x with
   | `Export_choice_STAR_from_clause_choice_auto_semi (v1, v2) ->
       let v1 = token env v1 (* "export" *) in
@@ -1147,177 +1147,177 @@ and map_export_statement (env : env) (x : CST.export_statement) =
         (match v2 with
         | `STAR_from_clause_choice_auto_semi (v1, v2, v3) ->
             let v1 = token env v1 (* "*" *) in
-            let v2 = map_from_clause env v2 in
-            let v3 = map_semicolon env v3 in
+            let v2 = from_clause env v2 in
+            let v3 = semicolon env v3 in
             todo env (v1, v2, v3)
         | `Export_clause_from_clause_choice_auto_semi (v1, v2, v3) ->
-            let v1 = map_export_clause env v1 in
-            let v2 = map_from_clause env v2 in
-            let v3 = map_semicolon env v3 in
+            let v1 = export_clause env v1 in
+            let v2 = from_clause env v2 in
+            let v3 = semicolon env v3 in
             todo env (v1, v2, v3)
         | `Export_clause_choice_auto_semi (v1, v2) ->
-            let v1 = map_export_clause env v1 in
-            let v2 = map_semicolon env v2 in
+            let v1 = export_clause env v1 in
+            let v2 = semicolon env v2 in
             todo env (v1, v2)
         )
       in
       todo env (v1, v2)
   | `Rep_deco_export_choice_decl (v1, v2, v3) ->
-      let v1 = List.map (map_decorator env) v1 in
+      let v1 = List.map (decorator env) v1 in
       let v2 = token env v2 (* "export" *) in
       let v3 =
         (match v3 with
-        | `Decl x -> map_declaration env x
+        | `Decl x -> declaration env x
         | `Defa_exp_choice_auto_semi (v1, v2, v3) ->
             let v1 = token env v1 (* "default" *) in
-            let v2 = map_expression env v2 in
-            let v3 = map_semicolon env v3 in
+            let v2 = expression env v2 in
+            let v3 = semicolon env v3 in
             todo env (v1, v2, v3)
         )
       in
       todo env (v1, v2, v3)
   )
 
-and map_anon_rep_COMMA_opt_choice_exp (env : env) (xs : CST.anon_rep_COMMA_opt_choice_exp) =
+and anon_rep_COMMA_opt_choice_exp (env : env) (xs : CST.anon_rep_COMMA_opt_choice_exp) =
   List.map (fun (v1, v2) ->
     let v1 = token env v1 (* "," *) in
     let v2 =
       (match v2 with
-      | Some x -> map_anon_choice_exp env x
+      | Some x -> anon_choice_exp env x
       | None -> todo env ())
     in
     todo env (v1, v2)
   ) xs
 
-and map_decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_expression) =
-  let v1 = map_anon_choice_id_ref env v1 in
-  let v2 = map_arguments env v2 in
+and decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_expression) =
+  let v1 = anon_choice_id_ref env v1 in
+  let v2 = arguments env v2 in
   todo env (v1, v2)
 
-and map_update_expression (env : env) (x : CST.update_expression) =
+and update_expression (env : env) (x : CST.update_expression) =
   (match x with
   | `Exp_choice_PLUSPLUS (v1, v2) ->
-      let v1 = map_expression env v1 in
-      let v2 = map_anon_choice_PLUSPLUS env v2 in
+      let v1 = expression env v1 in
+      let v2 = anon_choice_PLUSPLUS env v2 in
       todo env (v1, v2)
   | `Choice_PLUSPLUS_exp (v1, v2) ->
-      let v1 = map_anon_choice_PLUSPLUS env v1 in
-      let v2 = map_expression env v2 in
+      let v1 = anon_choice_PLUSPLUS env v1 in
+      let v2 = expression env v2 in
       todo env (v1, v2)
   )
 
-and map_public_field_definition (env : env) ((v1, v2, v3) : CST.public_field_definition) =
+and public_field_definition (env : env) ((v1, v2, v3) : CST.public_field_definition) =
   let v1 =
     (match v1 with
     | Some tok -> token env tok (* "static" *)
     | None -> todo env ())
   in
-  let v2 = map_property_name env v2 in
+  let v2 = property_name env v2 in
   let v3 =
     (match v3 with
-    | Some x -> map_initializer_ env x
+    | Some x -> initializer_ env x
     | None -> todo env ())
   in
   todo env (v1, v2, v3)
 
-and map_lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration) =
+and lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration) =
   let v1 =
     (match v1 with
     | `Let tok -> token env tok (* "let" *)
     | `Const tok -> token env tok (* "const" *)
     )
   in
-  let v2 = map_variable_declarator env v2 in
+  let v2 = variable_declarator env v2 in
   let v3 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 = map_variable_declarator env v2 in
+      let v2 = variable_declarator env v2 in
       todo env (v1, v2)
     ) v3
   in
-  let v4 = map_semicolon env v4 in
+  let v4 = semicolon env v4 in
   todo env (v1, v2, v3, v4)
 
-and map_class_heritage (env : env) ((v1, v2) : CST.class_heritage) =
+and class_heritage (env : env) ((v1, v2) : CST.class_heritage) =
   let v1 = token env v1 (* "extends" *) in
-  let v2 = map_expression env v2 in
+  let v2 = expression env v2 in
   todo env (v1, v2)
 
-and map_property_name (env : env) (x : CST.property_name) =
+and property_name (env : env) (x : CST.property_name) =
   (match x with
-  | `Choice_id x -> map_identifier_reference env x
-  | `Str x -> map_string_ env x
+  | `Choice_id x -> identifier_reference env x
+  | `Str x -> string_ env x
   | `Num tok -> token env tok (* number *)
   | `Comp_prop_name (v1, v2, v3) ->
       let v1 = token env v1 (* "[" *) in
-      let v2 = map_expression env v2 in
+      let v2 = expression env v2 in
       let v3 = token env v3 (* "]" *) in
       todo env (v1, v2, v3)
   )
 
-and map_jsx_child (env : env) (x : CST.jsx_child) =
+and jsx_child (env : env) (x : CST.jsx_child) =
   (match x with
   | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
-  | `Choice_jsx_elem x -> map_jsx_element_ env x
-  | `Jsx_exp x -> map_jsx_expression env x
+  | `Choice_jsx_elem x -> jsx_element_ env x
+  | `Jsx_exp x -> jsx_expression env x
   )
 
-and map_switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
+and switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
   let v1 = token env v1 (* "case" *) in
-  let v2 = map_expressions env v2 in
+  let v2 = expressions env v2 in
   let v3 = token env v3 (* ":" *) in
-  let v4 = List.map (map_statement env) v4 in
+  let v4 = List.map (statement env) v4 in
   todo env (v1, v2, v3, v4)
 
-and map_spread_element (env : env) ((v1, v2) : CST.spread_element) =
+and spread_element (env : env) ((v1, v2) : CST.spread_element) =
   let v1 = token env v1 (* "..." *) in
-  let v2 = map_expression env v2 in
+  let v2 = expression env v2 in
   todo env (v1, v2)
 
-and map_expressions (env : env) (x : CST.expressions) =
+and expressions (env : env) (x : CST.expressions) =
   (match x with
-  | `Exp x -> map_expression env x
-  | `Seq_exp x -> map_sequence_expression env x
+  | `Exp x -> expression env x
+  | `Seq_exp x -> sequence_expression env x
   )
 
-and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
+and finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
   let v1 = token env v1 (* "finally" *) in
-  let v2 = map_statement_block env v2 in
+  let v2 = statement_block env v2 in
   todo env (v1, v2)
 
-and map_jsx_element_ (env : env) (x : CST.jsx_element_) =
+and jsx_element_ (env : env) (x : CST.jsx_element_) =
   (match x with
   | `Jsx_elem (v1, v2, v3) ->
-      let v1 = map_jsx_opening_element env v1 in
-      let v2 = List.map (map_jsx_child env) v2 in
-      let v3 = map_jsx_closing_element env v3 in
+      let v1 = jsx_opening_element env v1 in
+      let v2 = List.map (jsx_child env) v2 in
+      let v3 = jsx_closing_element env v3 in
       todo env (v1, v2, v3)
   | `Jsx_self_clos_elem (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "<" *) in
-      let v2 = map_jsx_element_name env v2 in
-      let v3 = List.map (map_jsx_attribute_ env) v3 in
+      let v2 = jsx_element_name env v2 in
+      let v3 = List.map (jsx_attribute_ env) v3 in
       let v4 = token env v4 (* "/" *) in
       let v5 = token env v5 (* ">" *) in
       todo env (v1, v2, v3, v4, v5)
   )
 
-and map_anon_choice_id (env : env) (x : CST.anon_choice_id) =
+and anon_choice_id (env : env) (x : CST.anon_choice_id) =
   (match x with
   | `Id tok -> token env tok (* identifier *)
-  | `Choice_obj x -> map_destructuring_pattern env x
+  | `Choice_obj x -> destructuring_pattern env x
   )
 
-and map_call_signature (env : env) (v1 : CST.call_signature) =
-  map_formal_parameters env v1
+and call_signature (env : env) (v1 : CST.call_signature) =
+  formal_parameters env v1
 
-and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
+and object_ (env : env) ((v1, v2, v3) : CST.object_) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
     (match v2 with
     | Some (v1, v2) ->
         let v1 =
           (match v1 with
-          | Some x -> map_anon_choice_pair env x
+          | Some x -> anon_choice_pair env x
           | None -> todo env ())
         in
         let v2 =
@@ -1325,7 +1325,7 @@ and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
             let v1 = token env v1 (* "," *) in
             let v2 =
               (match v2 with
-              | Some x -> map_anon_choice_pair env x
+              | Some x -> anon_choice_pair env x
               | None -> todo env ())
             in
             todo env (v1, v2)
@@ -1337,18 +1337,18 @@ and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-and map_lhs_expression (env : env) (x : CST.lhs_expression) =
+and lhs_expression (env : env) (x : CST.lhs_expression) =
   (match x with
-  | `Member_exp x -> map_member_expression env x
-  | `Subs_exp x -> map_subscript_expression env x
+  | `Member_exp x -> member_expression env x
+  | `Subs_exp x -> subscript_expression env x
   | `Id tok -> token env tok (* identifier *)
-  | `Choice_get x -> map_reserved_identifier env x
-  | `Choice_obj x -> map_destructuring_pattern env x
+  | `Choice_get x -> reserved_identifier env x
+  | `Choice_obj x -> destructuring_pattern env x
   )
 
-and map_statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
+and statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = List.map (map_statement env) v2 in
+  let v2 = List.map (statement env) v2 in
   let v3 = token env v3 (* "}" *) in
   let v4 =
     (match v4 with
@@ -1357,13 +1357,13 @@ and map_statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
   in
   todo env (v1, v2, v3, v4)
 
-and map_template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =
+and template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =
   let v1 = token env v1 (* "${" *) in
-  let v2 = map_expressions env v2 in
+  let v2 = expressions env v2 in
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-and map_declaration (env : env) (x : CST.declaration) =
+and declaration (env : env) (x : CST.declaration) =
   (match x with
   | `Func_decl (v1, v2, v3, v4, v5, v6) ->
       let v1 =
@@ -1373,8 +1373,8 @@ and map_declaration (env : env) (x : CST.declaration) =
       in
       let v2 = token env v2 (* "function" *) in
       let v3 = token env v3 (* identifier *) in
-      let v4 = map_formal_parameters env v4 in
-      let v5 = map_statement_block env v5 in
+      let v4 = formal_parameters env v4 in
+      let v5 = statement_block env v5 in
       let v6 =
         (match v6 with
         | Some tok -> token env tok (* automatic_semicolon *)
@@ -1390,8 +1390,8 @@ and map_declaration (env : env) (x : CST.declaration) =
       let v2 = token env v2 (* "function" *) in
       let v3 = token env v3 (* "*" *) in
       let v4 = token env v4 (* identifier *) in
-      let v5 = map_formal_parameters env v5 in
-      let v6 = map_statement_block env v6 in
+      let v5 = formal_parameters env v5 in
+      let v6 = statement_block env v6 in
       let v7 =
         (match v7 with
         | Some tok -> token env tok (* automatic_semicolon *)
@@ -1399,52 +1399,52 @@ and map_declaration (env : env) (x : CST.declaration) =
       in
       todo env (v1, v2, v3, v4, v5, v6, v7)
   | `Class_decl (v1, v2, v3, v4, v5, v6) ->
-      let v1 = List.map (map_decorator env) v1 in
+      let v1 = List.map (decorator env) v1 in
       let v2 = token env v2 (* "class" *) in
       let v3 = token env v3 (* identifier *) in
       let v4 =
         (match v4 with
-        | Some x -> map_class_heritage env x
+        | Some x -> class_heritage env x
         | None -> todo env ())
       in
-      let v5 = map_class_body env v5 in
+      let v5 = class_body env v5 in
       let v6 =
         (match v6 with
         | Some tok -> token env tok (* automatic_semicolon *)
         | None -> todo env ())
       in
       todo env (v1, v2, v3, v4, v5, v6)
-  | `Lexi_decl x -> map_lexical_declaration env x
-  | `Var_decl x -> map_variable_declaration env x
+  | `Lexi_decl x -> lexical_declaration env x
+  | `Var_decl x -> variable_declaration env x
   )
 
-and map_formal_parameter (env : env) (x : CST.formal_parameter) =
+and formal_parameter (env : env) (x : CST.formal_parameter) =
   (match x with
   | `Id tok -> token env tok (* identifier *)
-  | `Choice_get x -> map_reserved_identifier env x
-  | `Choice_obj x -> map_destructuring_pattern env x
-  | `Assign_pat x -> map_assignment_pattern env x
+  | `Choice_get x -> reserved_identifier env x
+  | `Choice_obj x -> destructuring_pattern env x
+  | `Assign_pat x -> assignment_pattern env x
   | `Rest_param (v1, v2) ->
       let v1 = token env v1 (* "..." *) in
-      let v2 = map_anon_choice_id env v2 in
+      let v2 = anon_choice_id env v2 in
       todo env (v1, v2)
   )
 
-and map_jsx_attribute_value (env : env) (x : CST.jsx_attribute_value) =
+and jsx_attribute_value (env : env) (x : CST.jsx_attribute_value) =
   (match x with
-  | `Str x -> map_string_ env x
-  | `Jsx_exp x -> map_jsx_expression env x
-  | `Choice_jsx_elem x -> map_jsx_element_ env x
-  | `Jsx_frag x -> map_jsx_fragment env x
+  | `Str x -> string_ env x
+  | `Jsx_exp x -> jsx_expression env x
+  | `Choice_jsx_elem x -> jsx_element_ env x
+  | `Jsx_frag x -> jsx_fragment env x
   )
 
-let map_program (env : env) ((v1, v2) : CST.program) =
+let program (env : env) ((v1, v2) : CST.program) =
   let v1 =
     (match v1 with
     | Some tok -> token env tok (* pattern #!.* *)
     | None -> todo env ())
   in
-  let v2 = List.map (map_statement env) v2 in
+  let v2 = List.map (statement env) v2 in
   todo env (v1, v2)
 
 
@@ -1459,7 +1459,7 @@ let parse file =
   let env = { H.file; conv = H.line_col_to_pos file } in
 
   try
-    map_program env ast
+    program env ast
   with
     (Failure "not implemented") as exn ->
       let s = Printexc.get_backtrace () in

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -1,0 +1,1471 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License (GPL)
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * file license.txt for more details.
+ *)
+open Common
+module CST = Tree_sitter_javascript.CST
+module AST = Ast_js
+module H = Parse_tree_sitter_helpers
+(*open Ast_js*)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Javascript parser using ocaml-tree-sitter-lang/javascript and converting
+ * directly to pfff/lang_js/analyze/ast_js.ml
+ *
+ *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+[@@@warning "-32"]
+
+type env = H.env
+let _fake = AST_generic.fake
+let token = H.token
+let str = H.str
+
+(*****************************************************************************)
+(* Boilerplate converter *)
+(*****************************************************************************)
+(* This was started from ocaml-tree-sitter-lang/javascript/Boilerplate.ml *)
+
+(**
+   Boilerplate to be used as a template when mapping the javascript CST
+   to another type of tree.
+*)
+
+(* Disable warnings against unused variables *)
+[@@@warning "-26-27"]
+
+(* Disable warning against unused 'rec' *)
+[@@@warning "-39"]
+
+
+let blank (env : env) () = ()
+
+let todo (env : env) _ =
+   failwith "not implemented"
+
+let map_regex_pattern (env : env) (tok : CST.regex_pattern) =
+  token env tok (* regex_pattern *)
+
+let map_identifier (env : env) (tok : CST.identifier) =
+  token env tok (* identifier *)
+
+let map_number (env : env) (tok : CST.number) =
+  token env tok (* number *)
+
+let map_escape_sequence (env : env) (tok : CST.escape_sequence) =
+  token env tok (* escape_sequence *)
+
+let map_reserved_identifier (env : env) (x : CST.reserved_identifier) =
+  (match x with
+  | `Get tok -> token env tok (* "get" *)
+  | `Set tok -> token env tok (* "set" *)
+  | `Async tok -> token env tok (* "async" *)
+  | `Static tok -> token env tok (* "static" *)
+  )
+
+let map_jsx_identifier (env : env) (tok : CST.jsx_identifier) =
+  token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+
+let map_regex_flags (env : env) (tok : CST.regex_flags) =
+  token env tok (* pattern [a-z]+ *)
+
+let map_anon_choice_PLUSPLUS (env : env) (x : CST.anon_choice_PLUSPLUS) =
+  (match x with
+  | `PLUSPLUS tok -> token env tok (* "++" *)
+  | `DASHDASH tok -> token env tok (* "--" *)
+  )
+
+let map_template_chars (env : env) (tok : CST.template_chars) =
+  token env tok (* template_chars *)
+
+let map_import (env : env) (tok : CST.import) =
+  token env tok (* import *)
+
+let map_hash_bang_line (env : env) (tok : CST.hash_bang_line) =
+  token env tok (* pattern #!.* *)
+
+let map_jsx_text (env : env) (tok : CST.jsx_text) =
+  token env tok (* pattern [^{}<>]+ *)
+
+let map_automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
+  token env tok (* automatic_semicolon *)
+
+let map_namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
+  let v1 = token env v1 (* "*" *) in
+  let v2 = token env v2 (* "as" *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+let rec map_nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
+  let v1 =
+    (match v1 with
+    | `Id tok -> token env tok (* identifier *)
+    | `Nested_id x -> map_nested_identifier env x
+    )
+  in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+let map_import_export_specifier (env : env) ((v1, v2) : CST.import_export_specifier) =
+  let v1 = token env v1 (* identifier *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 = token env v1 (* "as" *) in
+        let v2 = token env v2 (* identifier *) in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  todo env (v1, v2)
+
+let map_anon_choice_blank (env : env) (x : CST.anon_choice_blank) =
+  (match x with
+  | `Blank () -> todo env ()
+  | `Esc_seq tok -> token env tok (* escape_sequence *)
+  )
+
+let map_anon_choice_rese_id (env : env) (x : CST.anon_choice_rese_id) =
+  (match x with
+  | `Choice_get x -> map_reserved_identifier env x
+  | `Id tok -> token env tok (* identifier *)
+  )
+
+let map_identifier_reference (env : env) (x : CST.identifier_reference) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_reserved_identifier env x
+  )
+
+let map_jsx_identifier_ (env : env) (x : CST.jsx_identifier_) =
+  (match x with
+  | `Jsx_id tok ->
+      token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
+  | `Id tok -> token env tok (* identifier *)
+  )
+
+let map_semicolon (env : env) (x : CST.semicolon) =
+  (match x with
+  | `Auto_semi tok -> token env tok (* automatic_semicolon *)
+  | `SEMI tok -> token env tok (* ";" *)
+  )
+
+let map_anon_import_export_spec_rep_COMMA_import_export_spec (env : env) ((v1, v2) : CST.anon_import_export_spec_rep_COMMA_import_export_spec) =
+  let v1 = map_import_export_specifier env v1 in
+  let v2 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_import_export_specifier env v2 in
+      todo env (v1, v2)
+    ) v2
+  in
+  todo env (v1, v2)
+
+let map_string_ (env : env) (x : CST.string_) =
+  (match x with
+  | `DQUOT_rep_choice_blank_DQUOT (v1, v2, v3) ->
+      let v1 = token env v1 (* "\"" *) in
+      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v3 = token env v3 (* "\"" *) in
+      todo env (v1, v2, v3)
+  | `SQUOT_rep_choice_blank_SQUOT (v1, v2, v3) ->
+      let v1 = token env v1 (* "'" *) in
+      let v2 = List.map (map_anon_choice_blank env) v2 in
+      let v3 = token env v3 (* "'" *) in
+      todo env (v1, v2, v3)
+  )
+
+let rec map_decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
+  let v1 = map_anon_choice_id_ref env v1 in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_id_ref (env : env) (x : CST.anon_choice_id_ref) =
+  (match x with
+  | `Choice_id x -> map_identifier_reference env x
+  | `Deco_member_exp x ->
+      map_decorator_member_expression env x
+  )
+
+let map_jsx_namespace_name (env : env) ((v1, v2, v3) : CST.jsx_namespace_name) =
+  let v1 = map_jsx_identifier_ env v1 in
+  let v2 = token env v2 (* ":" *) in
+  let v3 = map_jsx_identifier_ env v3 in
+  todo env (v1, v2, v3)
+
+let map_export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        map_anon_import_export_spec_rep_COMMA_import_export_spec env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  let v4 = token env v4 (* "}" *) in
+  todo env (v1, v2, v3, v4)
+
+let map_named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        map_anon_import_export_spec_rep_COMMA_import_export_spec env x
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "," *)
+    | None -> todo env ())
+  in
+  let v4 = token env v4 (* "}" *) in
+  todo env (v1, v2, v3, v4)
+
+let map_from_clause (env : env) ((v1, v2) : CST.from_clause) =
+  let v1 = token env v1 (* "from" *) in
+  let v2 = map_string_ env v2 in
+  todo env (v1, v2)
+
+let map_jsx_attribute_name (env : env) (x : CST.jsx_attribute_name) =
+  (match x with
+  | `Choice_jsx_id x -> map_jsx_identifier_ env x
+  | `Jsx_name_name x -> map_jsx_namespace_name env x
+  )
+
+let map_jsx_element_name (env : env) (x : CST.jsx_element_name) =
+  (match x with
+  | `Choice_jsx_id x -> map_jsx_identifier_ env x
+  | `Nested_id x -> map_nested_identifier env x
+  | `Jsx_name_name x -> map_jsx_namespace_name env x
+  )
+
+let map_import_clause (env : env) (x : CST.import_clause) =
+  (match x with
+  | `Name_import x -> map_namespace_import env x
+  | `Named_imports x -> map_named_imports env x
+  | `Id_opt_COMMA_choice_name_import (v1, v2) ->
+      let v1 = token env v1 (* identifier *) in
+      let v2 =
+        (match v2 with
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 =
+              (match v2 with
+              | `Name_import x -> map_namespace_import env x
+              | `Named_imports x -> map_named_imports env x
+              )
+            in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  )
+
+let map_jsx_closing_element (env : env) ((v1, v2, v3, v4) : CST.jsx_closing_element) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = token env v2 (* "/" *) in
+  let v3 = map_jsx_element_name env v3 in
+  let v4 = token env v4 (* ">" *) in
+  todo env (v1, v2, v3, v4)
+
+let rec map_parenthesized_expression (env : env) ((v1, v2, v3) : CST.parenthesized_expression) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 = map_expressions env v2 in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = map_jsx_element_name env v2 in
+  let v3 = List.map (map_jsx_attribute_ env) v3 in
+  let v4 = token env v4 (* ">" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_destructuring_pattern (env : env) (x : CST.destructuring_pattern) =
+  (match x with
+  | `Obj x -> map_object_ env x
+  | `Array x -> map_array_ env x
+  )
+
+and map_variable_declaration (env : env) ((v1, v2, v3, v4) : CST.variable_declaration) =
+  let v1 = token env v1 (* "var" *) in
+  let v2 = map_variable_declarator env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_variable_declarator env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 = map_semicolon env v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
+  let v1 =
+    (match v1 with
+    | Some tok -> token env tok (* "async" *)
+    | None -> todo env ())
+  in
+  let v2 = token env v2 (* "function" *) in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* identifier *)
+    | None -> todo env ())
+  in
+  let v4 = map_formal_parameters env v4 in
+  let v5 = map_statement_block env v5 in
+  todo env (v1, v2, v3, v4, v5)
+
+and map_anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Spread_elem x -> map_spread_element env x
+  )
+
+and map_switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
+  let v1 = token env v1 (* "default" *) in
+  let v2 = token env v2 (* ":" *) in
+  let v3 = List.map (map_statement env) v3 in
+  todo env (v1, v2, v3)
+
+and map_binary_expression (env : env) (x : CST.binary_expression) =
+  (match x with
+  | `Exp_AMPAMP_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "&&" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_BARBAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "||" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_GTGT_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* ">>" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_GTGTGT_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* ">>>" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_LTLT_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "<<" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_AMP_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "&" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_HAT_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "^" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_BAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "|" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_PLUS_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "+" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_DASH_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "-" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_STAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "*" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_SLASH_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "/" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_PERC_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "%" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_STARSTAR_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "**" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_LT_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "<" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_LTEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "<=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_EQEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "==" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_EQEQEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "===" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_BANGEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "!=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_BANGEQEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "!==" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_GTEQ_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* ">=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_GT_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* ">" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_QMARKQMARK_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "??" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_inst_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "instanceof" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Exp_in_exp (v1, v2, v3) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "in" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_arguments (env : env) ((v1, v2, v3) : CST.arguments) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
+  let v1 = map_anon_choice_id env v1 in
+  let v2 =
+    (match v2 with
+    | Some x -> map_initializer_ env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2)
+
+and map_sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
+  let v1 = map_expression env v1 in
+  let v2 = token env v2 (* "," *) in
+  let v3 =
+    (match v3 with
+    | `Seq_exp x -> map_sequence_expression env x
+    | `Exp x -> map_expression env x
+    )
+  in
+  todo env (v1, v2, v3)
+
+and map_jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) =
+  let v1 = token env v1 (* "<" *) in
+  let v2 = token env v2 (* ">" *) in
+  let v3 = List.map (map_jsx_child env) v3 in
+  let v4 = token env v4 (* "<" *) in
+  let v5 = token env v5 (* "/" *) in
+  let v6 = token env v6 (* ">" *) in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_class_body (env : env) ((v1, v2, v3) : CST.class_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Meth_defi_opt_SEMI (v1, v2) ->
+          let v1 = map_method_definition env v1 in
+          let v2 =
+            (match v2 with
+            | Some tok -> token env tok (* ";" *)
+            | None -> todo env ())
+          in
+          todo env (v1, v2)
+      | `Public_field_defi_choice_auto_semi (v1, v2) ->
+          let v1 = map_public_field_definition env v1 in
+          let v2 = map_semicolon env v2 in
+          todo env (v1, v2)
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
+  let v1 =
+    (match v1 with
+    | `Exp x -> map_expression env x
+    | `Id tok -> token env tok (* identifier *)
+    | `Super tok -> token env tok (* "super" *)
+    | `Choice_get x -> map_reserved_identifier env x
+    )
+  in
+  let v2 = token env v2 (* "." *) in
+  let v3 = token env v3 (* identifier *) in
+  todo env (v1, v2, v3)
+
+and map_assignment_pattern (env : env) ((v1, v2, v3) : CST.assignment_pattern) =
+  let v1 =
+    (match v1 with
+    | `Choice_choice_get x -> map_anon_choice_rese_id env x
+    | `Choice_obj x -> map_destructuring_pattern env x
+    )
+  in
+  let v2 = token env v2 (* "=" *) in
+  let v3 = map_expression env v3 in
+  todo env (v1, v2, v3)
+
+and map_jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        (match x with
+        | `Exp x -> map_expression env x
+        | `Seq_exp x -> map_sequence_expression env x
+        | `Spread_elem x -> map_spread_element env x
+        )
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_anon_choice_pair (env : env) (x : CST.anon_choice_pair) =
+  (match x with
+  | `Pair (v1, v2, v3) ->
+      let v1 = map_property_name env v1 in
+      let v2 = token env v2 (* ":" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Spread_elem x -> map_spread_element env x
+  | `Meth_defi x -> map_method_definition env x
+  | `Assign_pat x -> map_assignment_pattern env x
+  | `Choice_id x -> map_identifier_reference env x
+  )
+
+and map_subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
+  let v1 =
+    (match v1 with
+    | `Exp x -> map_expression env x
+    | `Super tok -> token env tok (* "super" *)
+    )
+  in
+  let v2 = token env v2 (* "[" *) in
+  let v3 = map_expressions env v3 in
+  let v4 = token env v4 (* "]" *) in
+  todo env (v1, v2, v3, v4)
+
+and map_initializer_ (env : env) ((v1, v2) : CST.initializer_) =
+  let v1 = token env v1 (* "=" *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
+
+and map_constructable_expression (env : env) (x : CST.constructable_expression) =
+  (match x with
+  | `This tok -> token env tok (* "this" *)
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_reserved_identifier env x
+  | `Num tok -> token env tok (* number *)
+  | `Str x -> map_string_ env x
+  | `Temp_str x -> map_template_string env x
+  | `Regex (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "/" *) in
+      let v2 = token env v2 (* regex_pattern *) in
+      let v3 = token env v3 (* "/" *) in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* pattern [a-z]+ *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `True tok -> token env tok (* "true" *)
+  | `False tok -> token env tok (* "false" *)
+  | `Null tok -> token env tok (* "null" *)
+  | `Unde tok -> token env tok (* "undefined" *)
+  | `Import tok -> token env tok (* import *)
+  | `Obj x -> map_object_ env x
+  | `Array x -> map_array_ env x
+  | `Func x -> map_function_ env x
+  | `Arrow_func (v1, v2, v3, v4) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 =
+        (match v2 with
+        | `Choice_choice_get x -> map_anon_choice_rese_id env x
+        | `Formal_params x -> map_call_signature env x
+        )
+      in
+      let v3 = token env v3 (* "=>" *) in
+      let v4 =
+        (match v4 with
+        | `Exp x -> map_expression env x
+        | `Stmt_blk x -> map_statement_block env x
+        )
+      in
+      todo env (v1, v2, v3, v4)
+  | `Gene_func (v1, v2, v3, v4, v5, v6) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* "*" *) in
+      let v4 =
+        (match v4 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v5 = map_formal_parameters env v5 in
+      let v6 = map_statement_block env v6 in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Class (v1, v2, v3, v4, v5) ->
+      let v1 = List.map (map_decorator env) v1 in
+      let v2 = token env v2 (* "class" *) in
+      let v3 =
+        (match v3 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_class_heritage env x
+        | None -> todo env ())
+      in
+      let v5 = map_class_body env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Paren_exp x -> map_parenthesized_expression env x
+  | `Subs_exp x -> map_subscript_expression env x
+  | `Member_exp x -> map_member_expression env x
+  | `Meta_prop (v1, v2, v3) ->
+      let v1 = token env v1 (* "new" *) in
+      let v2 = token env v2 (* "." *) in
+      let v3 = token env v3 (* "target" *) in
+      todo env (v1, v2, v3)
+  | `New_exp (v1, v2, v3) ->
+      let v1 = token env v1 (* "new" *) in
+      let v2 = map_constructable_expression env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3)
+  )
+
+and map_jsx_attribute_ (env : env) (x : CST.jsx_attribute_) =
+  (match x with
+  | `Jsx_attr (v1, v2) ->
+      let v1 = map_jsx_attribute_name env v1 in
+      let v2 =
+        (match v2 with
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "=" *) in
+            let v2 = map_jsx_attribute_value env v2 in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2)
+  | `Jsx_exp x -> map_jsx_expression env x
+  )
+
+and map_expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
+  let v1 = map_expressions env v1 in
+  let v2 = map_semicolon env v2 in
+  todo env (v1, v2)
+
+and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) =
+  let v1 = token env v1 (* "catch" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 = token env v1 (* "(" *) in
+        let v2 = map_anon_choice_id env v2 in
+        let v3 = token env v3 (* ")" *) in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = map_statement_block env v3 in
+  todo env (v1, v2, v3)
+
+and map_template_string (env : env) ((v1, v2, v3) : CST.template_string) =
+  let v1 = token env v1 (* "`" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Temp_chars tok -> token env tok (* template_chars *)
+      | `Esc_seq tok -> token env tok (* escape_sequence *)
+      | `Temp_subs x -> map_template_substitution env x
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "`" *) in
+  todo env (v1, v2, v3)
+
+and map_decorator (env : env) ((v1, v2) : CST.decorator) =
+  let v1 = token env v1 (* "@" *) in
+  let v2 =
+    (match v2 with
+    | `Choice_id x -> map_identifier_reference env x
+    | `Deco_member_exp x ->
+        map_decorator_member_expression env x
+    | `Deco_call_exp x -> map_decorator_call_expression env x
+    )
+  in
+  todo env (v1, v2)
+
+and map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp (env : env) (opt : CST.anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp) =
+  (match opt with
+  | Some (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | Some x -> map_anon_choice_exp env x
+        | None -> todo env ())
+      in
+      let v2 = map_anon_rep_COMMA_opt_choice_exp env v2 in
+      todo env (v1, v2)
+  | None -> todo env ())
+
+and map_for_header (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_header) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some x ->
+        (match x with
+        | `Var tok -> token env tok (* "var" *)
+        | `Let tok -> token env tok (* "let" *)
+        | `Const tok -> token env tok (* "const" *)
+        )
+    | None -> todo env ())
+  in
+  let v3 = map_anon_choice_paren_exp env v3 in
+  let v4 =
+    (match v4 with
+    | `In tok -> token env tok (* "in" *)
+    | `Of tok -> token env tok (* "of" *)
+    )
+  in
+  let v5 = map_expressions env v5 in
+  let v6 = token env v6 (* ")" *) in
+  todo env (v1, v2, v3, v4, v5, v6)
+
+and map_expression (env : env) (x : CST.expression) =
+  (match x with
+  | `Choice_this x -> map_constructable_expression env x
+  | `Choice_jsx_elem x -> map_jsx_element_ env x
+  | `Jsx_frag x -> map_jsx_fragment env x
+  | `Assign_exp (v1, v2, v3) ->
+      let v1 = map_anon_choice_paren_exp env v1 in
+      let v2 = token env v2 (* "=" *) in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Augm_assign_exp (v1, v2, v3) ->
+      let v1 =
+        (match v1 with
+        | `Member_exp x -> map_member_expression env x
+        | `Subs_exp x -> map_subscript_expression env x
+        | `Choice_get x -> map_reserved_identifier env x
+        | `Id tok -> token env tok (* identifier *)
+        | `Paren_exp x -> map_parenthesized_expression env x
+        )
+      in
+      let v2 =
+        (match v2 with
+        | `PLUSEQ tok -> token env tok (* "+=" *)
+        | `DASHEQ tok -> token env tok (* "-=" *)
+        | `STAREQ tok -> token env tok (* "*=" *)
+        | `SLASHEQ tok -> token env tok (* "/=" *)
+        | `PERCEQ tok -> token env tok (* "%=" *)
+        | `HATEQ tok -> token env tok (* "^=" *)
+        | `AMPEQ tok -> token env tok (* "&=" *)
+        | `BAREQ tok -> token env tok (* "|=" *)
+        | `GTGTEQ tok -> token env tok (* ">>=" *)
+        | `GTGTGTEQ tok -> token env tok (* ">>>=" *)
+        | `LTLTEQ tok -> token env tok (* "<<=" *)
+        | `STARSTAREQ tok -> token env tok (* "**=" *)
+        )
+      in
+      let v3 = map_expression env v3 in
+      todo env (v1, v2, v3)
+  | `Await_exp (v1, v2) ->
+      let v1 = token env v1 (* "await" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Un_exp x -> map_unary_expression env x
+  | `Bin_exp x -> map_binary_expression env x
+  | `Tern_exp (v1, v2, v3, v4, v5) ->
+      let v1 = map_expression env v1 in
+      let v2 = token env v2 (* "?" *) in
+      let v3 = map_expression env v3 in
+      let v4 = token env v4 (* ":" *) in
+      let v5 = map_expression env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Update_exp x -> map_update_expression env x
+  | `Call_exp (v1, v2) ->
+      let v1 =
+        (match v1 with
+        | `Exp x -> map_expression env x
+        | `Super tok -> token env tok (* "super" *)
+        | `Func x -> map_function_ env x
+        )
+      in
+      let v2 =
+        (match v2 with
+        | `Args x -> map_arguments env x
+        | `Temp_str x -> map_template_string env x
+        )
+      in
+      todo env (v1, v2)
+  | `Yield_exp (v1, v2) ->
+      let v1 = token env v1 (* "yield" *) in
+      let v2 =
+        (match v2 with
+        | `STAR_exp (v1, v2) ->
+            let v1 = token env v1 (* "*" *) in
+            let v2 = map_expression env v2 in
+            todo env (v1, v2)
+        | `Opt_exp opt ->
+            (match opt with
+            | Some x -> map_expression env x
+            | None -> todo env ())
+        )
+      in
+      todo env (v1, v2)
+  )
+
+and map_anon_choice_paren_exp (env : env) (x : CST.anon_choice_paren_exp) =
+  (match x with
+  | `Paren_exp x -> map_parenthesized_expression env x
+  | `Choice_member_exp x -> map_lhs_expression env x
+  )
+
+and map_unary_expression (env : env) (x : CST.unary_expression) =
+  (match x with
+  | `BANG_exp (v1, v2) ->
+      let v1 = token env v1 (* "!" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `TILDE_exp (v1, v2) ->
+      let v1 = token env v1 (* "~" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `DASH_exp (v1, v2) ->
+      let v1 = token env v1 (* "-" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `PLUS_exp (v1, v2) ->
+      let v1 = token env v1 (* "+" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Typeof_exp (v1, v2) ->
+      let v1 = token env v1 (* "typeof" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Void_exp (v1, v2) ->
+      let v1 = token env v1 (* "void" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  | `Delete_exp (v1, v2) ->
+      let v1 = token env v1 (* "delete" *) in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  )
+
+and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
+  let v1 = token env v1 (* "(" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2, v3) ->
+        let v1 = map_formal_parameter env v1 in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 = map_formal_parameter env v2 in
+            todo env (v1, v2)
+          ) v2
+        in
+        let v3 =
+          (match v3 with
+          | Some tok -> token env tok (* "," *)
+          | None -> todo env ())
+        in
+        todo env (v1, v2, v3)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and map_switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    List.map (fun x ->
+      (match x with
+      | `Switch_case x -> map_switch_case env x
+      | `Switch_defa x -> map_switch_default env x
+      )
+    ) v2
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_statement (env : env) (x : CST.statement) =
+  (match x with
+  | `Export_stmt x -> map_export_statement env x
+  | `Import_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "import" *) in
+      let v2 =
+        (match v2 with
+        | `Import_clause_from_clause (v1, v2) ->
+            let v1 = map_import_clause env v1 in
+            let v2 = map_from_clause env v2 in
+            todo env (v1, v2)
+        | `Str x -> map_string_ env x
+        )
+      in
+      let v3 = map_semicolon env v3 in
+      todo env (v1, v2, v3)
+  | `Debu_stmt (v1, v2) ->
+      let v1 = token env v1 (* "debugger" *) in
+      let v2 = map_semicolon env v2 in
+      todo env (v1, v2)
+  | `Exp_stmt x -> map_expression_statement env x
+  | `Decl x -> map_declaration env x
+  | `Stmt_blk x -> map_statement_block env x
+  | `If_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "if" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_statement env v3 in
+      let v4 =
+        (match v4 with
+        | Some (v1, v2) ->
+            let v1 = token env v1 (* "else" *) in
+            let v2 = map_statement env v2 in
+            todo env (v1, v2)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `Switch_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "switch" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_switch_body env v3 in
+      todo env (v1, v2, v3)
+  | `For_stmt (v1, v2, v3, v4, v5, v6, v7) ->
+      let v1 = token env v1 (* "for" *) in
+      let v2 = token env v2 (* "(" *) in
+      let v3 =
+        (match v3 with
+        | `Lexi_decl x -> map_lexical_declaration env x
+        | `Var_decl x -> map_variable_declaration env x
+        | `Exp_stmt x -> map_expression_statement env x
+        | `Empty_stmt tok -> token env tok (* ";" *)
+        )
+      in
+      let v4 =
+        (match v4 with
+        | `Exp_stmt x -> map_expression_statement env x
+        | `Empty_stmt tok -> token env tok (* ";" *)
+        )
+      in
+      let v5 =
+        (match v5 with
+        | Some x -> map_expressions env x
+        | None -> todo env ())
+      in
+      let v6 = token env v6 (* ")" *) in
+      let v7 = map_statement env v7 in
+      todo env (v1, v2, v3, v4, v5, v6, v7)
+  | `For_in_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "for" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* "await" *)
+        | None -> todo env ())
+      in
+      let v3 = map_for_header env v3 in
+      let v4 = map_statement env v4 in
+      todo env (v1, v2, v3, v4)
+  | `While_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "while" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_statement env v3 in
+      todo env (v1, v2, v3)
+  | `Do_stmt (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "do" *) in
+      let v2 = map_statement env v2 in
+      let v3 = token env v3 (* "while" *) in
+      let v4 = map_parenthesized_expression env v4 in
+      let v5 = map_semicolon env v5 in
+      todo env (v1, v2, v3, v4, v5)
+  | `Try_stmt (v1, v2, v3, v4) ->
+      let v1 = token env v1 (* "try" *) in
+      let v2 = map_statement_block env v2 in
+      let v3 =
+        (match v3 with
+        | Some x -> map_catch_clause env x
+        | None -> todo env ())
+      in
+      let v4 =
+        (match v4 with
+        | Some x -> map_finally_clause env x
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4)
+  | `With_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "with" *) in
+      let v2 = map_parenthesized_expression env v2 in
+      let v3 = map_statement env v3 in
+      todo env (v1, v2, v3)
+  | `Brk_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "break" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v3 = map_semicolon env v3 in
+      todo env (v1, v2, v3)
+  | `Cont_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "continue" *) in
+      let v2 =
+        (match v2 with
+        | Some tok -> token env tok (* identifier *)
+        | None -> todo env ())
+      in
+      let v3 = map_semicolon env v3 in
+      todo env (v1, v2, v3)
+  | `Ret_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "return" *) in
+      let v2 =
+        (match v2 with
+        | Some x -> map_expressions env x
+        | None -> todo env ())
+      in
+      let v3 = map_semicolon env v3 in
+      todo env (v1, v2, v3)
+  | `Throw_stmt (v1, v2, v3) ->
+      let v1 = token env v1 (* "throw" *) in
+      let v2 = map_expressions env v2 in
+      let v3 = map_semicolon env v3 in
+      todo env (v1, v2, v3)
+  | `Empty_stmt tok -> token env tok (* ";" *)
+  | `Labe_stmt (v1, v2, v3) ->
+      let v1 = map_identifier_reference env v1 in
+      let v2 = token env v2 (* ":" *) in
+      let v3 = map_statement env v3 in
+      todo env (v1, v2, v3)
+  )
+
+and map_method_definition (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.method_definition) =
+  let v1 = List.map (map_decorator env) v1 in
+  let v2 =
+    (match v2 with
+    | Some tok -> token env tok (* "static" *)
+    | None -> todo env ())
+  in
+  let v3 =
+    (match v3 with
+    | Some tok -> token env tok (* "async" *)
+    | None -> todo env ())
+  in
+  let v4 =
+    (match v4 with
+    | Some x ->
+        (match x with
+        | `Get tok -> token env tok (* "get" *)
+        | `Set tok -> token env tok (* "set" *)
+        | `STAR tok -> token env tok (* "*" *)
+        )
+    | None -> todo env ())
+  in
+  let v5 = map_property_name env v5 in
+  let v6 = map_formal_parameters env v6 in
+  let v7 = map_statement_block env v7 in
+  todo env (v1, v2, v3, v4, v5, v6, v7)
+
+and map_array_ (env : env) ((v1, v2, v3) : CST.array_) =
+  let v1 = token env v1 (* "[" *) in
+  let v2 =
+    map_anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
+  in
+  let v3 = token env v3 (* "]" *) in
+  todo env (v1, v2, v3)
+
+and map_export_statement (env : env) (x : CST.export_statement) =
+  (match x with
+  | `Export_choice_STAR_from_clause_choice_auto_semi (v1, v2) ->
+      let v1 = token env v1 (* "export" *) in
+      let v2 =
+        (match v2 with
+        | `STAR_from_clause_choice_auto_semi (v1, v2, v3) ->
+            let v1 = token env v1 (* "*" *) in
+            let v2 = map_from_clause env v2 in
+            let v3 = map_semicolon env v3 in
+            todo env (v1, v2, v3)
+        | `Export_clause_from_clause_choice_auto_semi (v1, v2, v3) ->
+            let v1 = map_export_clause env v1 in
+            let v2 = map_from_clause env v2 in
+            let v3 = map_semicolon env v3 in
+            todo env (v1, v2, v3)
+        | `Export_clause_choice_auto_semi (v1, v2) ->
+            let v1 = map_export_clause env v1 in
+            let v2 = map_semicolon env v2 in
+            todo env (v1, v2)
+        )
+      in
+      todo env (v1, v2)
+  | `Rep_deco_export_choice_decl (v1, v2, v3) ->
+      let v1 = List.map (map_decorator env) v1 in
+      let v2 = token env v2 (* "export" *) in
+      let v3 =
+        (match v3 with
+        | `Decl x -> map_declaration env x
+        | `Defa_exp_choice_auto_semi (v1, v2, v3) ->
+            let v1 = token env v1 (* "default" *) in
+            let v2 = map_expression env v2 in
+            let v3 = map_semicolon env v3 in
+            todo env (v1, v2, v3)
+        )
+      in
+      todo env (v1, v2, v3)
+  )
+
+and map_anon_rep_COMMA_opt_choice_exp (env : env) (xs : CST.anon_rep_COMMA_opt_choice_exp) =
+  List.map (fun (v1, v2) ->
+    let v1 = token env v1 (* "," *) in
+    let v2 =
+      (match v2 with
+      | Some x -> map_anon_choice_exp env x
+      | None -> todo env ())
+    in
+    todo env (v1, v2)
+  ) xs
+
+and map_decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_expression) =
+  let v1 = map_anon_choice_id_ref env v1 in
+  let v2 = map_arguments env v2 in
+  todo env (v1, v2)
+
+and map_update_expression (env : env) (x : CST.update_expression) =
+  (match x with
+  | `Exp_choice_PLUSPLUS (v1, v2) ->
+      let v1 = map_expression env v1 in
+      let v2 = map_anon_choice_PLUSPLUS env v2 in
+      todo env (v1, v2)
+  | `Choice_PLUSPLUS_exp (v1, v2) ->
+      let v1 = map_anon_choice_PLUSPLUS env v1 in
+      let v2 = map_expression env v2 in
+      todo env (v1, v2)
+  )
+
+and map_public_field_definition (env : env) ((v1, v2, v3) : CST.public_field_definition) =
+  let v1 =
+    (match v1 with
+    | Some tok -> token env tok (* "static" *)
+    | None -> todo env ())
+  in
+  let v2 = map_property_name env v2 in
+  let v3 =
+    (match v3 with
+    | Some x -> map_initializer_ env x
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3)
+
+and map_lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration) =
+  let v1 =
+    (match v1 with
+    | `Let tok -> token env tok (* "let" *)
+    | `Const tok -> token env tok (* "const" *)
+    )
+  in
+  let v2 = map_variable_declarator env v2 in
+  let v3 =
+    List.map (fun (v1, v2) ->
+      let v1 = token env v1 (* "," *) in
+      let v2 = map_variable_declarator env v2 in
+      todo env (v1, v2)
+    ) v3
+  in
+  let v4 = map_semicolon env v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_class_heritage (env : env) ((v1, v2) : CST.class_heritage) =
+  let v1 = token env v1 (* "extends" *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
+
+and map_property_name (env : env) (x : CST.property_name) =
+  (match x with
+  | `Choice_id x -> map_identifier_reference env x
+  | `Str x -> map_string_ env x
+  | `Num tok -> token env tok (* number *)
+  | `Comp_prop_name (v1, v2, v3) ->
+      let v1 = token env v1 (* "[" *) in
+      let v2 = map_expression env v2 in
+      let v3 = token env v3 (* "]" *) in
+      todo env (v1, v2, v3)
+  )
+
+and map_jsx_child (env : env) (x : CST.jsx_child) =
+  (match x with
+  | `Jsx_text tok -> token env tok (* pattern [^{}<>]+ *)
+  | `Choice_jsx_elem x -> map_jsx_element_ env x
+  | `Jsx_exp x -> map_jsx_expression env x
+  )
+
+and map_switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
+  let v1 = token env v1 (* "case" *) in
+  let v2 = map_expressions env v2 in
+  let v3 = token env v3 (* ":" *) in
+  let v4 = List.map (map_statement env) v4 in
+  todo env (v1, v2, v3, v4)
+
+and map_spread_element (env : env) ((v1, v2) : CST.spread_element) =
+  let v1 = token env v1 (* "..." *) in
+  let v2 = map_expression env v2 in
+  todo env (v1, v2)
+
+and map_expressions (env : env) (x : CST.expressions) =
+  (match x with
+  | `Exp x -> map_expression env x
+  | `Seq_exp x -> map_sequence_expression env x
+  )
+
+and map_finally_clause (env : env) ((v1, v2) : CST.finally_clause) =
+  let v1 = token env v1 (* "finally" *) in
+  let v2 = map_statement_block env v2 in
+  todo env (v1, v2)
+
+and map_jsx_element_ (env : env) (x : CST.jsx_element_) =
+  (match x with
+  | `Jsx_elem (v1, v2, v3) ->
+      let v1 = map_jsx_opening_element env v1 in
+      let v2 = List.map (map_jsx_child env) v2 in
+      let v3 = map_jsx_closing_element env v3 in
+      todo env (v1, v2, v3)
+  | `Jsx_self_clos_elem (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "<" *) in
+      let v2 = map_jsx_element_name env v2 in
+      let v3 = List.map (map_jsx_attribute_ env) v3 in
+      let v4 = token env v4 (* "/" *) in
+      let v5 = token env v5 (* ">" *) in
+      todo env (v1, v2, v3, v4, v5)
+  )
+
+and map_anon_choice_id (env : env) (x : CST.anon_choice_id) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_obj x -> map_destructuring_pattern env x
+  )
+
+and map_call_signature (env : env) (v1 : CST.call_signature) =
+  map_formal_parameters env v1
+
+and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 =
+    (match v2 with
+    | Some (v1, v2) ->
+        let v1 =
+          (match v1 with
+          | Some x -> map_anon_choice_pair env x
+          | None -> todo env ())
+        in
+        let v2 =
+          List.map (fun (v1, v2) ->
+            let v1 = token env v1 (* "," *) in
+            let v2 =
+              (match v2 with
+              | Some x -> map_anon_choice_pair env x
+              | None -> todo env ())
+            in
+            todo env (v1, v2)
+          ) v2
+        in
+        todo env (v1, v2)
+    | None -> todo env ())
+  in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_lhs_expression (env : env) (x : CST.lhs_expression) =
+  (match x with
+  | `Member_exp x -> map_member_expression env x
+  | `Subs_exp x -> map_subscript_expression env x
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_reserved_identifier env x
+  | `Choice_obj x -> map_destructuring_pattern env x
+  )
+
+and map_statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
+  let v1 = token env v1 (* "{" *) in
+  let v2 = List.map (map_statement env) v2 in
+  let v3 = token env v3 (* "}" *) in
+  let v4 =
+    (match v4 with
+    | Some tok -> token env tok (* automatic_semicolon *)
+    | None -> todo env ())
+  in
+  todo env (v1, v2, v3, v4)
+
+and map_template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =
+  let v1 = token env v1 (* "${" *) in
+  let v2 = map_expressions env v2 in
+  let v3 = token env v3 (* "}" *) in
+  todo env (v1, v2, v3)
+
+and map_declaration (env : env) (x : CST.declaration) =
+  (match x with
+  | `Func_decl (v1, v2, v3, v4, v5, v6) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 = map_formal_parameters env v4 in
+      let v5 = map_statement_block env v5 in
+      let v6 =
+        (match v6 with
+        | Some tok -> token env tok (* automatic_semicolon *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Gene_func_decl (v1, v2, v3, v4, v5, v6, v7) ->
+      let v1 =
+        (match v1 with
+        | Some tok -> token env tok (* "async" *)
+        | None -> todo env ())
+      in
+      let v2 = token env v2 (* "function" *) in
+      let v3 = token env v3 (* "*" *) in
+      let v4 = token env v4 (* identifier *) in
+      let v5 = map_formal_parameters env v5 in
+      let v6 = map_statement_block env v6 in
+      let v7 =
+        (match v7 with
+        | Some tok -> token env tok (* automatic_semicolon *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4, v5, v6, v7)
+  | `Class_decl (v1, v2, v3, v4, v5, v6) ->
+      let v1 = List.map (map_decorator env) v1 in
+      let v2 = token env v2 (* "class" *) in
+      let v3 = token env v3 (* identifier *) in
+      let v4 =
+        (match v4 with
+        | Some x -> map_class_heritage env x
+        | None -> todo env ())
+      in
+      let v5 = map_class_body env v5 in
+      let v6 =
+        (match v6 with
+        | Some tok -> token env tok (* automatic_semicolon *)
+        | None -> todo env ())
+      in
+      todo env (v1, v2, v3, v4, v5, v6)
+  | `Lexi_decl x -> map_lexical_declaration env x
+  | `Var_decl x -> map_variable_declaration env x
+  )
+
+and map_formal_parameter (env : env) (x : CST.formal_parameter) =
+  (match x with
+  | `Id tok -> token env tok (* identifier *)
+  | `Choice_get x -> map_reserved_identifier env x
+  | `Choice_obj x -> map_destructuring_pattern env x
+  | `Assign_pat x -> map_assignment_pattern env x
+  | `Rest_param (v1, v2) ->
+      let v1 = token env v1 (* "..." *) in
+      let v2 = map_anon_choice_id env v2 in
+      todo env (v1, v2)
+  )
+
+and map_jsx_attribute_value (env : env) (x : CST.jsx_attribute_value) =
+  (match x with
+  | `Str x -> map_string_ env x
+  | `Jsx_exp x -> map_jsx_expression env x
+  | `Choice_jsx_elem x -> map_jsx_element_ env x
+  | `Jsx_frag x -> map_jsx_fragment env x
+  )
+
+let map_program (env : env) ((v1, v2) : CST.program) =
+  let v1 =
+    (match v1 with
+    | Some tok -> token env tok (* pattern #!.* *)
+    | None -> todo env ())
+  in
+  let v2 = List.map (map_statement env) v2 in
+  todo env (v1, v2)
+
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+let parse file =
+  let ast =
+    Parallel.backtrace_when_exn := false;
+    Parallel.invoke Tree_sitter_javascript.Parse.file file ()
+  in
+  let env = { H.file; conv = H.line_col_to_pos file } in
+
+  try
+    map_program env ast
+  with
+    (Failure "not implemented") as exn ->
+      let s = Printexc.get_backtrace () in
+      pr2 "Some constructs are not handled yet";
+      pr2 "CST was:";
+      CST.dump_tree ast;
+      pr2 "Original backtrace:";
+      pr2 s;
+      raise exn

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -108,27 +108,27 @@ let automatic_semicolon (env : env) (tok : CST.automatic_semicolon) =
 let namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
   let v1 = token env v1 (* "*" *) in
   let v2 = token env v2 (* "as" *) in
-  let v3 = token env v3 (* identifier *) in
+  let v3 = identifier env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
 let rec nested_identifier (env : env) ((v1, v2, v3) : CST.nested_identifier) =
   let v1 =
     (match v1 with
-    | `Id tok -> token env tok (* identifier *)
+    | `Id tok -> identifier env tok (* identifier *)
     | `Nested_id x -> nested_identifier env x
     )
   in
   let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
+  let v3 = identifier env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
 let import_export_specifier (env : env) ((v1, v2) : CST.import_export_specifier) =
-  let v1 = token env v1 (* identifier *) in
+  let v1 = identifier env v1 (* identifier *) in
   let v2 =
     (match v2 with
     | Some (v1, v2) ->
         let v1 = token env v1 (* "as" *) in
-        let v2 = token env v2 (* identifier *) in
+        let v2 = identifier env v2 (* identifier *) in
         todo env (v1, v2)
     | None -> todo env ())
   in
@@ -143,12 +143,12 @@ let anon_choice_blank (env : env) (x : CST.anon_choice_blank) =
 let anon_choice_rese_id (env : env) (x : CST.anon_choice_rese_id) =
   (match x with
   | `Choice_get x -> reserved_identifier env x
-  | `Id tok -> token env tok (* identifier *)
+  | `Id tok -> identifier env tok (* identifier *)
   )
 
 let identifier_reference (env : env) (x : CST.identifier_reference) =
   (match x with
-  | `Id tok -> token env tok (* identifier *)
+  | `Id tok -> identifier env tok (* identifier *)
   | `Choice_get x -> reserved_identifier env x
   )
 
@@ -156,7 +156,7 @@ let jsx_identifier_ (env : env) (x : CST.jsx_identifier_) =
   (match x with
   | `Jsx_id tok ->
       token env tok (* pattern [a-zA-Z_$][a-zA-Z\d_$]*-[a-zA-Z\d_$\-]* *)
-  | `Id tok -> token env tok (* identifier *)
+  | `Id tok -> identifier env tok (* identifier *)
   )
 
 let semicolon (env : env) (x : CST.semicolon) =
@@ -193,7 +193,7 @@ let string_ (env : env) (x : CST.string_) =
 let rec decorator_member_expression (env : env) ((v1, v2, v3) : CST.decorator_member_expression) =
   let v1 = anon_choice_id_ref env v1 in
   let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
+  let v3 = identifier env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
 and anon_choice_id_ref (env : env) (x : CST.anon_choice_id_ref) =
@@ -264,7 +264,7 @@ let import_clause (env : env) (x : CST.import_clause) =
   | `Name_import x -> namespace_import env x
   | `Named_imports x -> named_imports env x
   | `Id_opt_COMMA_choice_name_import (v1, v2) ->
-      let v1 = token env v1 (* identifier *) in
+      let v1 = identifier env v1 (* identifier *) in
       let v2 =
         (match v2 with
         | Some (v1, v2) ->
@@ -329,7 +329,7 @@ and function_ (env : env) ((v1, v2, v3, v4, v5) : CST.function_) =
   let v2 = token env v2 (* "function" *) in
   let v3 =
     (match v3 with
-    | Some tok -> token env tok (* identifier *)
+    | Some tok -> identifier env tok (* identifier *)
     | None -> todo env ())
   in
   let v4 = formal_parameters env v4 in
@@ -541,13 +541,13 @@ and member_expression (env : env) ((v1, v2, v3) : CST.member_expression) =
   let v1 =
     (match v1 with
     | `Exp x -> expression env x
-    | `Id tok -> token env tok (* identifier *)
+    | `Id tok -> identifier env tok (* identifier *)
     | `Super tok -> token env tok (* "super" *)
     | `Choice_get x -> reserved_identifier env x
     )
   in
   let v2 = token env v2 (* "." *) in
-  let v3 = token env v3 (* identifier *) in
+  let v3 = identifier env v3 (* identifier *) in
   todo env (v1, v2, v3)
 
 and assignment_pattern (env : env) ((v1, v2, v3) : CST.assignment_pattern) =
@@ -609,7 +609,7 @@ and initializer_ (env : env) ((v1, v2) : CST.initializer_) =
 and constructable_expression (env : env) (x : CST.constructable_expression) =
   (match x with
   | `This tok -> token env tok (* "this" *)
-  | `Id tok -> token env tok (* identifier *)
+  | `Id tok -> identifier env tok (* identifier *)
   | `Choice_get x -> reserved_identifier env x
   | `Num tok -> token env tok (* number *)
   | `Str x -> string_ env x
@@ -662,7 +662,7 @@ and constructable_expression (env : env) (x : CST.constructable_expression) =
       let v3 = token env v3 (* "*" *) in
       let v4 =
         (match v4 with
-        | Some tok -> token env tok (* identifier *)
+        | Some tok -> identifier env tok (* identifier *)
         | None -> todo env ())
       in
       let v5 = formal_parameters env v5 in
@@ -673,7 +673,7 @@ and constructable_expression (env : env) (x : CST.constructable_expression) =
       let v2 = token env v2 (* "class" *) in
       let v3 =
         (match v3 with
-        | Some tok -> token env tok (* identifier *)
+        | Some tok -> identifier env tok (* identifier *)
         | None -> todo env ())
       in
       let v4 =
@@ -814,7 +814,7 @@ and expression (env : env) (x : CST.expression) =
         | `Member_exp x -> member_expression env x
         | `Subs_exp x -> subscript_expression env x
         | `Choice_get x -> reserved_identifier env x
-        | `Id tok -> token env tok (* identifier *)
+        | `Id tok -> identifier env tok (* identifier *)
         | `Paren_exp x -> parenthesized_expression env x
         )
       in
@@ -1068,7 +1068,7 @@ and statement (env : env) (x : CST.statement) =
       let v1 = token env v1 (* "break" *) in
       let v2 =
         (match v2 with
-        | Some tok -> token env tok (* identifier *)
+        | Some tok -> identifier env tok (* identifier *)
         | None -> todo env ())
       in
       let v3 = semicolon env v3 in
@@ -1077,7 +1077,7 @@ and statement (env : env) (x : CST.statement) =
       let v1 = token env v1 (* "continue" *) in
       let v2 =
         (match v2 with
-        | Some tok -> token env tok (* identifier *)
+        | Some tok -> identifier env tok (* identifier *)
         | None -> todo env ())
       in
       let v3 = semicolon env v3 in
@@ -1303,7 +1303,7 @@ and jsx_element_ (env : env) (x : CST.jsx_element_) =
 
 and anon_choice_id (env : env) (x : CST.anon_choice_id) =
   (match x with
-  | `Id tok -> token env tok (* identifier *)
+  | `Id tok -> identifier env tok (* identifier *)
   | `Choice_obj x -> destructuring_pattern env x
   )
 
@@ -1341,7 +1341,7 @@ and lhs_expression (env : env) (x : CST.lhs_expression) =
   (match x with
   | `Member_exp x -> member_expression env x
   | `Subs_exp x -> subscript_expression env x
-  | `Id tok -> token env tok (* identifier *)
+  | `Id tok -> identifier env tok (* identifier *)
   | `Choice_get x -> reserved_identifier env x
   | `Choice_obj x -> destructuring_pattern env x
   )
@@ -1372,7 +1372,7 @@ and declaration (env : env) (x : CST.declaration) =
         | None -> todo env ())
       in
       let v2 = token env v2 (* "function" *) in
-      let v3 = token env v3 (* identifier *) in
+      let v3 = identifier env v3 (* identifier *) in
       let v4 = formal_parameters env v4 in
       let v5 = statement_block env v5 in
       let v6 =
@@ -1389,7 +1389,7 @@ and declaration (env : env) (x : CST.declaration) =
       in
       let v2 = token env v2 (* "function" *) in
       let v3 = token env v3 (* "*" *) in
-      let v4 = token env v4 (* identifier *) in
+      let v4 = identifier env v4 (* identifier *) in
       let v5 = formal_parameters env v5 in
       let v6 = statement_block env v6 in
       let v7 =
@@ -1401,7 +1401,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Class_decl (v1, v2, v3, v4, v5, v6) ->
       let v1 = List.map (decorator env) v1 in
       let v2 = token env v2 (* "class" *) in
-      let v3 = token env v3 (* identifier *) in
+      let v3 = identifier env v3 (* identifier *) in
       let v4 =
         (match v4 with
         | Some x -> class_heritage env x
@@ -1420,7 +1420,7 @@ and declaration (env : env) (x : CST.declaration) =
 
 and formal_parameter (env : env) (x : CST.formal_parameter) =
   (match x with
-  | `Id tok -> token env tok (* identifier *)
+  | `Id tok -> identifier env tok (* identifier *)
   | `Choice_get x -> reserved_identifier env x
   | `Choice_obj x -> destructuring_pattern env x
   | `Assign_pat x -> assignment_pattern env x

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -1328,16 +1328,16 @@ and decorator_call_expression (env : env) ((v1, v2) : CST.decorator_call_express
   let v2 = arguments env v2 in
   todo env (v1, v2)
 
-and update_expression (env : env) (x : CST.update_expression) =
+and update_expression (env : env) (x : CST.update_expression) : expr =
   (match x with
   | `Exp_choice_PLUSPLUS (v1, v2) ->
       let v1 = expression env v1 in
-      let v2 = anon_choice_PLUSPLUS env v2 in
-      todo env (v1, v2)
+      let (op, t) = anon_choice_PLUSPLUS env v2 in
+      Apply (IdSpecial (IncrDecr (op, G.Postfix), t), fb [v1])
   | `Choice_PLUSPLUS_exp (v1, v2) ->
-      let v1 = anon_choice_PLUSPLUS env v1 in
+      let (op, t) = anon_choice_PLUSPLUS env v1 in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (IncrDecr (op, G.Prefix), t), fb [v2])
   )
 
 and public_field_definition (env : env) ((v1, v2, v3) : CST.public_field_definition) =
@@ -1373,9 +1373,9 @@ and lexical_declaration (env : env) ((v1, v2, v3, v4) : CST.lexical_declaration)
   todo env (v1, v2, v3, v4)
 
 and class_heritage (env : env) ((v1, v2) : CST.class_heritage) =
-  let v1 = token env v1 (* "extends" *) in
+  let _v1 = token env v1 (* "extends" *) in
   let v2 = expression env v2 in
-  todo env (v1, v2)
+  v2
 
 and property_name (env : env) (x : CST.property_name) : property_name =
   (match x with

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -229,12 +229,12 @@ let export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
     (match v2 with
     | Some x ->
         anon_import_export_spec_rep_COMMA_import_export_spec env x
-    | None -> todo env ())
+    | None -> [])
   in
   let v3 =
     (match v3 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None)
   in
   let v4 = token env v4 (* "}" *) in
   todo env (v1, v2, v3, v4)
@@ -245,12 +245,12 @@ let named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
     (match v2 with
     | Some x ->
         anon_import_export_spec_rep_COMMA_import_export_spec env x
-    | None -> todo env ())
+    | None -> [])
   in
-  let v3 =
+  let _v3 =
     (match v3 with
-    | Some tok -> token env tok (* "," *)
-    | None -> todo env ())
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None)
   in
   let v4 = token env v4 (* "}" *) in
   todo env (v1, v2, v3, v4)

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -983,17 +983,21 @@ and expression (env : env) (x : CST.expression) : expr =
       let v1 = token env v1 (* "yield" *) in
       let v2 =
         (match v2 with
-        | `STAR_exp (v1, v2) ->
-            let v1 = token env v1 (* "*" *) in
+        | `STAR_exp (v1bis, v2) ->
+            let v1bis = token env v1bis (* "*" *) in
             let v2 = expression env v2 in
-            todo env (v1, v2)
+            Apply (IdSpecial (YieldStar, v1), fb [v2])
         | `Opt_exp opt ->
             (match opt with
-            | Some x -> expression env x
-            | None -> todo env ())
+            | Some x ->
+                let x = expression env x in
+                Apply (IdSpecial (Yield, v1), fb [x])
+            | None ->
+                Apply (IdSpecial (Yield, v1), fb [])
+          )
         )
       in
-      todo env (v1, v2)
+      v2
   )
 
 and anon_choice_paren_exp (env : env) (x : CST.anon_choice_paren_exp) : expr =
@@ -1007,31 +1011,31 @@ and unary_expression (env : env) (x : CST.unary_expression) : expr =
   | `BANG_exp (v1, v2) ->
       let v1 = token env v1 (* "!" *) in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (ArithOp G.Not, v1), fb [v2])
   | `TILDE_exp (v1, v2) ->
       let v1 = token env v1 (* "~" *) in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (ArithOp G.BitNot, v1), fb [v2])
   | `DASH_exp (v1, v2) ->
       let v1 = token env v1 (* "-" *) in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (ArithOp G.Minus, v1), fb [v2])
   | `PLUS_exp (v1, v2) ->
       let v1 = token env v1 (* "+" *) in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (ArithOp G.Plus, v1), fb [v2])
   | `Typeof_exp (v1, v2) ->
       let v1 = token env v1 (* "typeof" *) in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (Typeof, v1), fb [v2])
   | `Void_exp (v1, v2) ->
       let v1 = token env v1 (* "void" *) in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (Void, v1), fb [v2])
   | `Delete_exp (v1, v2) ->
       let v1 = token env v1 (* "delete" *) in
       let v2 = expression env v2 in
-      todo env (v1, v2)
+      Apply (IdSpecial (Delete, v1), fb [v2])
   )
 
 and formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) : parameter list =

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -37,6 +37,8 @@ let _fake = AST_generic.fake
 let token = H.token
 let str = H.str
 
+let fb = G.fake_bracket
+
 (*****************************************************************************)
 (* Boilerplate converter *)
 (*****************************************************************************)
@@ -383,124 +385,119 @@ and anon_choice_exp (env : env) (x : CST.anon_choice_exp) =
   | `Spread_elem x -> spread_element env x
   )
 
-and switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
-  let v1 = token env v1 (* "default" *) in
-  let v2 = token env v2 (* ":" *) in
-  let v3 = List.map (statement env) v3 in
-  todo env (v1, v2, v3)
-
-and binary_expression (env : env) (x : CST.binary_expression) =
+and binary_expression (env : env) (x : CST.binary_expression) : expr =
   (match x with
   | `Exp_AMPAMP_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "&&" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.And, v2), fb [v1; v3])
   | `Exp_BARBAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "||" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Or, v2), fb [v1; v3])
   | `Exp_GTGT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">>" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.LSR, v2), fb [v1; v3])
   | `Exp_GTGTGT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">>>" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.ASR, v2), fb [v1; v3])
   | `Exp_LTLT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "<<" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.LSL, v2), fb [v1; v3])
   | `Exp_AMP_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "&" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.BitAnd, v2), fb [v1; v3])
   | `Exp_HAT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "^" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.BitXor, v2), fb [v1; v3])
   | `Exp_BAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "|" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.BitOr, v2), fb [v1; v3])
   | `Exp_PLUS_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "+" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Plus, v2), fb [v1; v3])
   | `Exp_DASH_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "-" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Minus, v2), fb [v1; v3])
   | `Exp_STAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "*" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Mult, v2), fb [v1; v3])
   | `Exp_SLASH_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "/" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Div, v2), fb [v1; v3])
   | `Exp_PERC_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "%" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Mod, v2), fb [v1; v3])
   | `Exp_STARSTAR_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "**" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Pow, v2), fb [v1; v3])
   | `Exp_LT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "<" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Lt, v2), fb [v1; v3])
   | `Exp_LTEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "<=" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.LtE, v2), fb [v1; v3])
   | `Exp_EQEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "==" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Eq, v2), fb [v1; v3])
   | `Exp_EQEQEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "===" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.PhysEq, v2), fb [v1; v3])
   | `Exp_BANGEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "!=" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.NotEq, v2), fb [v1; v3])
   | `Exp_BANGEQEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "!==" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.NotPhysEq, v2), fb [v1; v3])
   | `Exp_GTEQ_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">=" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.GtE, v2), fb [v1; v3])
   | `Exp_GT_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* ">" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (ArithOp G.Gt, v2), fb [v1; v3])
+
   | `Exp_QMARKQMARK_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "??" *) in
@@ -510,12 +507,13 @@ and binary_expression (env : env) (x : CST.binary_expression) =
       let v1 = expression env v1 in
       let v2 = token env v2 (* "instanceof" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (Instanceof, v2), fb [v1; v3])
   | `Exp_in_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = token env v2 (* "in" *) in
       let v3 = expression env v3 in
-      todo env (v1, v2, v3)
+      Apply (IdSpecial (In, v2), fb [v1; v3])
+
   )
 
 and arguments (env : env) ((v1, v2, v3) : CST.arguments) : arguments =
@@ -524,7 +522,7 @@ and arguments (env : env) ((v1, v2, v3) : CST.arguments) : arguments =
     anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
   in
   let v3 = token env v3 (* ")" *) in
-  todo env (v1, v2, v3)
+  v1, v2, v3
 
 and variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) =
   let v1 = anon_choice_id env v1 in
@@ -544,17 +542,17 @@ and sequence_expression (env : env) ((v1, v2, v3) : CST.sequence_expression) =
     | `Exp x -> expression env x
     )
   in
-  todo env (v1, v2, v3)
+  Apply (IdSpecial (Seq, v2), fb [v1; v3])
 
 and jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment)
  : xml =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* ">" *) in
+  let _v2 = token env v2 (* ">" *) in
   let v3 = List.map (jsx_child env) v3 in
-  let v4 = token env v4 (* "<" *) in
-  let v5 = token env v5 (* "/" *) in
-  let v6 = token env v6 (* ">" *) in
-  todo env (v1, v2, v3, v4, v5, v6)
+  let _v4 = token env v4 (* "<" *) in
+  let _v5 = token env v5 (* "/" *) in
+  let _v6 = token env v6 (* ">" *) in
+  { xml_tag = "", v1; xml_attrs = []; xml_body = v3 }
 
 and class_body (env : env) ((v1, v2, v3) : CST.class_body) =
   let v1 = token env v1 (* "{" *) in
@@ -1026,6 +1024,12 @@ and formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) : param
     | None -> todo env ())
   in
   let v3 = token env v3 (* ")" *) in
+  todo env (v1, v2, v3)
+
+and switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
+  let v1 = token env v1 (* "default" *) in
+  let v2 = token env v2 (* ":" *) in
+  let v3 = List.map (statement env) v3 in
   todo env (v1, v2, v3)
 
 and switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -492,7 +492,7 @@ and binary_expression (env : env) (x : CST.binary_expression) =
       todo env (v1, v2, v3)
   )
 
-and arguments (env : env) ((v1, v2, v3) : CST.arguments) =
+and arguments (env : env) ((v1, v2, v3) : CST.arguments) : arguments =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp env v2
@@ -612,7 +612,7 @@ and anon_choice_pair (env : env) (x : CST.anon_choice_pair) =
         todo env id
   )
 
-and subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) =
+and subscript_expression (env : env) ((v1, v2, v3, v4) : CST.subscript_expression) : expr =
   let v1 =
     (match v1 with
     | `Exp x -> expression env x
@@ -680,7 +680,9 @@ and constructable_expression (env : env) (x : CST.constructable_expression) : ex
       let v3 = token env v3 (* "=>" *) in
       let v4 =
         (match v4 with
-        | `Exp x -> expression env x
+        | `Exp x ->
+                let e = expression env x in
+                todo env e
         | `Stmt_blk x -> statement_block env x
         )
       in
@@ -897,7 +899,9 @@ and expression (env : env) (x : CST.expression) : expr =
       in
       let v2 =
         (match v2 with
-        | `Args x -> arguments env x
+        | `Args x ->
+                let args = arguments env x in
+                todo env args
         | `Temp_str x -> template_string env x
         )
       in
@@ -925,7 +929,7 @@ and anon_choice_paren_exp (env : env) (x : CST.anon_choice_paren_exp) =
   | `Choice_member_exp x -> lhs_expression env x
   )
 
-and unary_expression (env : env) (x : CST.unary_expression) =
+and unary_expression (env : env) (x : CST.unary_expression) : expr =
   (match x with
   | `BANG_exp (v1, v2) ->
       let v1 = token env v1 (* "!" *) in
@@ -994,7 +998,7 @@ and switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-and statement (env : env) (x : CST.statement) =
+and statement (env : env) (x : CST.statement) : stmt =
   (match x with
   | `Export_stmt x -> export_statement env x
   | `Import_stmt (v1, v2, v3) ->
@@ -1280,9 +1284,11 @@ and class_heritage (env : env) ((v1, v2) : CST.class_heritage) =
   let v2 = expression env v2 in
   todo env (v1, v2)
 
-and property_name (env : env) (x : CST.property_name) =
+and property_name (env : env) (x : CST.property_name) : property_name =
   (match x with
-  | `Choice_id x -> identifier_reference env x
+  | `Choice_id x ->
+        let id = identifier_reference env x in
+        todo env id
   | `Str x -> string_ env x
   | `Num tok ->
         let n = number env tok (* number *) in
@@ -1380,7 +1386,7 @@ and object_ (env : env) ((v1, v2, v3) : CST.object_) : obj_ =
   let v3 = token env v3 (* "}" *) in
   todo env (v1, v2, v3)
 
-and lhs_expression (env : env) (x : CST.lhs_expression) =
+and lhs_expression (env : env) (x : CST.lhs_expression) : expr =
   (match x with
   | `Member_exp x -> member_expression env x
   | `Subs_exp x -> subscript_expression env x
@@ -1393,7 +1399,7 @@ and lhs_expression (env : env) (x : CST.lhs_expression) =
   | `Choice_obj x -> destructuring_pattern env x
   )
 
-and statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
+and statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) : stmt =
   let v1 = token env v1 (* "{" *) in
   let v2 = List.map (statement env) v2 in
   let v3 = token env v3 (* "}" *) in
@@ -1465,7 +1471,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Var_decl x -> variable_declaration env x
   )
 
-and formal_parameter (env : env) (x : CST.formal_parameter) =
+and formal_parameter (env : env) (x : CST.formal_parameter) : parameter =
   (match x with
   | `Id tok ->
         let id = identifier env tok (* identifier *) in
@@ -1493,7 +1499,7 @@ and jsx_attribute_value (env : env) (x : CST.jsx_attribute_value) =
   | `Jsx_frag x -> jsx_fragment env x
   )
 
-let program (env : env) ((v1, v2) : CST.program) =
+let program (env : env) ((v1, v2) : CST.program) : program =
   let v1 =
     (match v1 with
     | Some tok -> token env tok (* pattern #!.* *)

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.mli
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.mli
@@ -1,0 +1,2 @@
+
+val parse: Common.filename -> Ast_js.program

--- a/semgrep-core/parsing/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/parsing/Parse_tree_sitter_helpers.ml
@@ -80,3 +80,16 @@ let token env (tok : Tree_sitter_run.Token.t) =
 let str env (tok : Tree_sitter_run.Token.t) =
   let (_, s) = tok in
   s, token env tok
+
+let combine_tokens env xs =
+  match xs with
+  | [] -> failwith "combine_tokens: empty list"
+  | x::_xsTODO ->
+      let t = token env x in
+      t
+
+let combine_infos _env xs =
+  match xs with
+  | [] -> failwith "combine_infos: empty list"
+  | x::_xsTODO ->
+      x

--- a/semgrep-core/parsing/Parse_tree_sitter_helpers.mli
+++ b/semgrep-core/parsing/Parse_tree_sitter_helpers.mli
@@ -10,3 +10,6 @@ val line_col_to_pos: Common.filename -> (int * int, int) Hashtbl.t
 val token: env -> Tree_sitter_run.Token.t -> Parse_info.t
 
 val str: env -> Tree_sitter_run.Token.t -> string * Parse_info.t
+
+val combine_tokens: env -> Tree_sitter_run.Token.t list -> Parse_info.t
+val combine_infos: env -> Parse_info.t list -> Parse_info.t

--- a/semgrep-core/parsing/Test_parsing.ml
+++ b/semgrep-core/parsing/Test_parsing.ml
@@ -56,6 +56,7 @@ let test_parse_lang verbose lang get_final_files xs =
               | Lang.Java -> Tree_sitter_java.Parse.file file |> ignore
               | Lang.Go   -> Tree_sitter_go.Parse.file file |> ignore
               | Lang.Csharp -> Tree_sitter_csharp.Parse.file file |> ignore
+              | Lang.Javascript -> Tree_sitter_javascript.Parse.file file |> ignore
               | _ -> failwith "lang not supported by ocaml-tree-sitter"
               )
              file ()

--- a/semgrep-core/parsing/dune
+++ b/semgrep-core/parsing/dune
@@ -8,6 +8,7 @@
    tree-sitter-lang.java
    tree-sitter-lang.go
    tree-sitter-lang.csharp
+   tree-sitter-lang.javascript
 
    commons commons_core
    pfff-config
@@ -16,6 +17,7 @@
    pfff-lang_ruby pfff-lang_ruby-analyze
    pfff-lang_java pfff-lang_java-analyze
    pfff-lang_go pfff-lang_go-analyze
+   pfff-lang_js pfff-lang_js-analyze
 
    semgrep_core
  )


### PR DESCRIPTION
This is the start of https://github.com/returntocorp/semgrep/issues/1525

test plan:
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -force_tree_sitter -dump_ast concrete_syntax.js
Some constructs are not handled yet
CST was:
|   | Decl
|   |   Func_decl
|   |   | function
|   |   | foo
|   |   |   "("
|   |   |   ")"
|   |   |   "{"
|   |   |   |   Exp_stmt
|   |   |   |   |   Exp
|   |   |   |   |   | Call_exp
|   |   |   |   |   |   | Exp
|   |   |   |   |   |   |   Choice_this
|   |   |   |   |   |   |   | Id
...