### PR TITLE
Only respect nosem after a comment

### DIFF
--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -47,7 +47,7 @@ NOSEM_INLINE_RE = re.compile(
     # * We want multi-language support, so we cannot strictly look for
     #   Python comments that begin with '# '
     #
-    r" nosem(?::[\s]?(?P<ids>([^,\s](?:[,\s]+)?)+))?",
+    r"(?:#|\/\/|\/\*)\s+nosem(?::[\s]?(?P<ids>(?:[^,\s](?:[,\s]+)?)+))?",
     re.IGNORECASE,
 )
 COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -47,7 +47,7 @@ NOSEM_INLINE_RE = re.compile(
     # * We want multi-language support, so we cannot strictly look for
     #   Python comments that begin with '# '
     #
-    r"(?:#|\/\/|\/\*)\s+nosem(?::[\s]?(?P<ids>(?:[^,\s](?:[,\s]+)?)+))?",
+    r"(?:#|[/]{2,3}|[/][*]|[(][*])\s+nosem(?::[\s]?(?P<ids>(?:[^,\s](?:[,\s]+)?)+))?",
     re.IGNORECASE,
 )
 COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")


### PR DESCRIPTION
This avoids treating a code symbol that happens to be named "nosem" as
an indicator to disable semgrep.

Bonus: Remove spurious unused capturing group from semgrep regex.

Fixes #1053.