### PR TITLE
Exclude parse error files from perf tests

### DIFF
--- a/semgrep/tests/performance/test_ci_perf.py
+++ b/semgrep/tests/performance/test_ci_perf.py
@@ -3,6 +3,8 @@ import time
 
 import pytest
 
+from semgrep import util
+
 
 @pytest.mark.qa
 def test_perf(clone_github_repo):
@@ -16,36 +18,36 @@ def test_perf(clone_github_repo):
     )
     njsscan_rules_path = str(rules_path / "njsscan/rules/semantic_grep")
 
-    # Dvna takes about 30 sec
-    target_path = clone_github_repo(
-        repo_url="https://github.com/appsecco/dvna", sha="c637437"
-    )
-    start = time.time()
-    subprocess.check_output(
-        ["python3", "-m" "semgrep", "--config", njsscan_rules_path, str(target_path),]
-    )
-    duration = time.time() - start
-    print(duration)
-    assert duration < 40
+    targets = [
+        (  # Dvna takes about ~30 sec
+            "https://github.com/appsecco/dvna",
+            "c637437d6515bd4c732e91c58e62d38e88260d3c",
+            ["jquery-3.2.1.min.js", "showdown.min.js"],
+            40,
+        ),
+        (  # Juice Shop takes about ~150 sec on 2019MBP, ~270 sec on GHA
+            "https://github.com/bkimminich/juice-shop",
+            "98633f5ef242bf943608324a562058b22eca6dfe",
+            ["three.js"],
+            300,
+        ),
+    ]
 
-    # Running on Juice Shop without three.js takes ~150 sec on 2019MBP 15"
-    # takes ~270 on GHA
-    target_path = clone_github_repo(
-        repo_url="https://github.com/bkimminich/juice-shop",
-        sha="98633f5ef242bf943608324a562058b22eca6dfe",
-    )
-    start = time.time()
-    subprocess.check_output(
-        [
+    for repo_url, sha, excludes, expected_duration in targets:
+        target_path = clone_github_repo(repo_url=repo_url, sha=sha)
+        args = [
             "python3",
-            "-m" "semgrep",
+            "-m",
+            "semgrep",
             "--config",
             njsscan_rules_path,
-            "--exclude",
-            "three.js",
             str(target_path),
         ]
-    )
-    duration = time.time() - start
-    print(duration)
-    assert duration < 300
+        args.extend(util.flatten(["--exclude", ex] for ex in excludes))
+
+        start = time.time()
+        subprocess.check_output(args)
+        duration = time.time() - start
+
+        print(duration)
+        assert duration < expected_duration


### PR DESCRIPTION
The `dvna` repository was returning parse errors for a few files. This is fine from a `semgrep` perspective, but `subprocess.check_output` was detecting a non-zero return code and failing. This PR excludes the offending files to make the `subprocess` call succeed. I also refactored a bit to make things more extensible and easier to read.