### PR TITLE
fix --skip-unknown-extensions skipping known extensions

### DIFF
--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -260,17 +260,21 @@ class TargetManager:
         targets = self.filter_includes(targets, self.includes)
         targets = self.filter_excludes(targets, self.excludes)
 
+        # Remove explicit_files with known extensions
+        explicit_files_with_lang_extension = set(
+            f
+            for f in explicit_files
+            if (any(f.match(f"*.{ext}") for ext in lang_to_exts(lang)))
+        )
+        targets = targets.union(explicit_files_with_lang_extension)
+
         if not self.skip_unknown_extensions:
-            # Remove explicit_files with known extensions
-            explicit_files = set(
+            explicit_files_with_unknown_extensions = set(
                 f
                 for f in explicit_files
-                if (
-                    any(f.match(f"*.{ext}") for ext in lang_to_exts(lang))
-                    or not any(f.match(f"*.{ext}") for ext in ALL_EXTENSIONS)
-                )
+                if not any(f.match(f"*.{ext}") for ext in ALL_EXTENSIONS)
             )
-            targets = targets.union(explicit_files)
+            targets = targets.union(explicit_files_with_unknown_extensions)
 
         self._filtered_targets[lang] = targets
         return self._filtered_targets[lang]

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -395,6 +395,9 @@ def test_explicit_path(tmp_path, monkeypatch):
     assert foo_a in TargetManager(
         [], [], ["foo/a.py"], False, defaulthandler, False
     ).get_files(python_language, [], [])
+    assert foo_a in TargetManager(
+        [], [], ["foo/a.py"], False, defaulthandler, True
+    ).get_files(python_language, [], [])
 
     # Should include explicitly passed python file even if is in excludes
     assert foo_a not in TargetManager(
@@ -430,4 +433,14 @@ def test_explicit_path(tmp_path, monkeypatch):
             )
         ),
         set(),
+    )
+
+    # Should include explicitly passed file with correct extension even if skip_unknown_extensions=True
+    assert cmp_path_sets(
+        set(
+            TargetManager(
+                [], [], ["foo/noext", "foo/a.py"], False, defaulthandler, True
+            ).get_files(python_language, [], [])
+        ),
+        {foo_a},
     )


### PR DESCRIPTION
When files of the correct extension were being passed to semgrep
with the --skip-unknown-extensions flag, we were skipping even those
files. This commit fixes the issue.