### PR TITLE
Match generic unbraced blocks to single-statement blocks

### DIFF
--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -1466,9 +1466,9 @@ and m_stmt a b =
     m_tok a0 b0 >>= (fun () ->
     (* too many regressions doing m_expr_deep by default; Use DeepEllipsis *)
     m_expr a1 b1 >>= (fun () ->
-    m_stmt a2 b2 >>= (fun () ->
+    m_block a2 b2 >>= (fun () ->
     (* less-is-more: *)
-    m_option_none_can_match_some m_stmt a3 b3
+    m_option_none_can_match_some m_block a3 b3
     )))
 
   | A.While(a0, a1, a2), B.While(b0, b1, b2) ->
@@ -1569,6 +1569,17 @@ and m_for_header a b =
   | A.ForClassic _, _  | A.ForEach _, _
    -> fail ()
 (*e: function [[Generic_vs_generic.m_for_header]] *)
+
+and m_block a b =
+  match a, b with
+  | A.Block _, B.Block _ ->
+    m_stmt a b
+  | A.Block (_, [a_stmt], _), _ ->
+    m_stmt a_stmt b
+  | _, B.Block (_, [b_stmt], _) ->
+    m_stmt a b_stmt
+  | _, _ ->
+    m_stmt a b
 
 (*s: function [[Generic_vs_generic.m_for_var_or_expr]] *)
 and m_for_var_or_expr a b =

--- a/semgrep-core/tests/GENERIC/misc_else_blocks_brace.sgrep
+++ b/semgrep-core/tests/GENERIC/misc_else_blocks_brace.sgrep
@@ -1,0 +1,3 @@
+if (conditional) {} else {
+  return x;
+}

--- a/semgrep-core/tests/GENERIC/misc_else_blocks_no_brace.sgrep
+++ b/semgrep-core/tests/GENERIC/misc_else_blocks_no_brace.sgrep
@@ -1,0 +1,1 @@
+if (conditional) {} else return x;

--- a/semgrep-core/tests/GENERIC/misc_if_blocks_brace.sgrep
+++ b/semgrep-core/tests/GENERIC/misc_if_blocks_brace.sgrep
@@ -1,0 +1,3 @@
+if (condition) {
+  return x;
+}

--- a/semgrep-core/tests/GENERIC/misc_if_blocks_no_brace.sgrep
+++ b/semgrep-core/tests/GENERIC/misc_if_blocks_no_brace.sgrep
@@ -1,0 +1,2 @@
+if (condition)
+  return x;

--- a/semgrep-core/tests/js/misc_else_blocks_brace.js
+++ b/semgrep-core/tests/js/misc_else_blocks_brace.js
@@ -1,0 +1,8 @@
+//ERROR: match
+if (conditional) {
+} else {
+  return x;
+}
+
+//ERROR: match
+if (conditional) {} else return x;

--- a/semgrep-core/tests/js/misc_else_blocks_no_brace.js
+++ b/semgrep-core/tests/js/misc_else_blocks_no_brace.js
@@ -1,0 +1,8 @@
+//ERROR: match
+if (conditional) {
+} else {
+  return x;
+}
+
+//ERROR: match
+if (conditional) {} else return x;

--- a/semgrep-core/tests/js/misc_if_blocks_brace.js
+++ b/semgrep-core/tests/js/misc_if_blocks_brace.js
@@ -1,0 +1,8 @@
+//ERROR: match
+if (condition)
+  return x;
+
+//ERROR: match
+if (condition) {
+  return x;
+}

--- a/semgrep-core/tests/js/misc_if_blocks_no_brace.js
+++ b/semgrep-core/tests/js/misc_if_blocks_no_brace.js
@@ -1,0 +1,8 @@
+//ERROR: match
+if (condition)
+  return x;
+
+//ERROR: match
+if (condition) {
+  return x;
+}


### PR DESCRIPTION
This fixes a regression from returntocorp/pfff@53808c5690, which
explicitly identified blocks on conditionals.

This previous change was necessary to distinguish between conditionals
with no else block, and conditionals with an empty else block.

However, as a side effect it caused us to no longer match
single-statement blocks with unbraced if blocks.

This commit adds that equivalence in the Semgrep layer.

Fixes #1548.