### PR TITLE
New -tree_sitter_only flag for semgrep-core

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -983,8 +983,8 @@ let options () =
     " filter rules not containing any strings in target file";
     "-no_filter_irrelevant_rules", Arg.Clear Flag.filter_irrelevant_rules,
     " do not filter rules";
-    "-force_tree_sitter", Arg.Set Flag.force_tree_sitter,
-    " use tree-sitter-based parsers by default";
+    "-tree_sitter_only", Arg.Set Flag.tree_sitter_only,
+    " only use tree-sitter-based parsers";
     "-debug", Arg.Set Flag.debug,
     " add debugging information in the output (tracing)";
     "-debug_matching", Arg.Set Flag.debug_matching,

--- a/semgrep-core/core/Flag_semgrep.ml
+++ b/semgrep-core/core/Flag_semgrep.ml
@@ -34,9 +34,9 @@ let go_really_deeper_stmt = ref true
 let filter_irrelevant_rules = ref false
 
 (* we usually try first with the pfff parser and then with the tree-sitter
- * parser if pfff fails. Here you can force to use tree-sitter first.
+ * parser if pfff fails. Here you can force to only use tree-sitter.
  *)
-let force_tree_sitter = ref false
+let tree_sitter_only = ref false
 
 (*s: constant [[Flag_semgrep.equivalence_mode]] *)
 (* special mode to set before using generic_vs_generic to match

--- a/semgrep-core/parsing/Parse_code.ml
+++ b/semgrep-core/parsing/Parse_code.ml
@@ -74,13 +74,12 @@ let just_parse_with_lang lang file =
        * is not great and some of the token positions may be wrong.
        *)
       let ast =
-        try
-          Parse_ruby_tree_sitter.parse file
-        with exn ->
-          if !Flag.tree_sitter_only then raise exn
+        run file [
+          TreeSitter, Parse_ruby_tree_sitter.parse;
           (* right now the parser is verbose and the token positions
            * may be wrong, but better than nothing. *)
-          else Parse_ruby.parse_program file
+          Pfff, Parse_ruby.parse_program
+        ]
       in
       Ruby_to_generic.program ast
   | Lang.Java ->


### PR DESCRIPTION
This allows to specify to only use the tree-sitter parsers.
Hopefully this will be less confusing than -force_tree_sitter.

Test plan:
/home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -tree_sitter_only -lang js -test_parse_lang .

only show tree-sitter errors.