### PR TITLE
Show repo URL in QA tests

### DIFF
--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -1,7 +1,6 @@
 import contextlib
 import json
 import os
-import random
 import shutil
 import subprocess
 from pathlib import Path
@@ -236,6 +235,6 @@ def pytest_generate_tests(metafunc):
         repos = (
             public_repos.ALL_REPOS
             if metafunc.config.getoption("--qa")
-            else random.sample(public_repos.PASSING_REPOS, non_qa_smoketest_count)
+            else public_repos.PASSING_REPOS[:non_qa_smoketest_count]
         )
         metafunc.parametrize("public_repo_url", repos, ids=lambda r: r["repo"])

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import os
+import random
 import shutil
 import subprocess
 from pathlib import Path
@@ -231,7 +232,10 @@ def pytest_runtest_setup(item):
 # Add `public_repo_url` as a parameter to your test to use this. It generates 1 test case per repo url in `ALL_REPOS`
 def pytest_generate_tests(metafunc):
     if "public_repo_url" in metafunc.fixturenames:
-        if metafunc.config.getoption("--qa"):
-            metafunc.parametrize("public_repo_url", public_repos.ALL_REPOS)
-        else:
-            metafunc.parametrize("public_repo_url", public_repos.PASSING_REPOS[:5])
+        non_qa_smoketest_count = 5  # Arbitrarily chosen
+        repos = (
+            public_repos.ALL_REPOS
+            if metafunc.config.getoption("--qa")
+            else random.sample(public_repos.PASSING_REPOS, non_qa_smoketest_count)
+        )
+        metafunc.parametrize("public_repo_url", repos, ids=lambda r: r["repo"])


### PR DESCRIPTION
The QA tests currently show something like:

```
semgrep/tests/qa/test_public_repos.py::test_semgrep_on_repo[public_repo_url7]
```

This updates them to use the `ids` kwarg to show something like:

```
semgrep/tests/qa/test_public_repos.py::test_semgrep_on_repo[https:/github.com/keybase/pykeybasebot]
```

I also updated the non-QA smoketest to choose a random sample of repos rather than the same 5 every time.