### PR TITLE
Fix autofix eating square brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## NEXT VERSION
+
+### Fixed
+- `fix` does a better job handling square brackets. [Link: Issue](https://github.com/returntocorp/semgrep/issues/1285)
+
 ## [0.20.0]() - 2020-08-18
 
 ### Added

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -305,14 +305,13 @@ def evaluate(
     for pattern_match in pattern_matches:
         if pattern_match.range in valid_ranges_to_output:
             message = interpolate_message_metavariables(rule, pattern_match)
-            fix = interpolate_fix_metavariables(rule, pattern_match)
             rule_match = RuleMatch(
                 rule.id,
                 pattern_match,
                 message=message,
                 metadata=rule.metadata,
                 severity=rule.severity,
-                fix=fix,
+                fix=rule.fix,
                 fix_regex=rule.fix_regex,
             )
             output.append(rule_match)
@@ -325,17 +324,6 @@ def interpolate_message_metavariables(rule: Rule, pattern_match: PatternMatch) -
     for metavar, contents in pattern_match.metavars.items():
         msg_text = msg_text.replace(metavar, contents.get("abstract_content", ""))
     return msg_text
-
-
-def interpolate_fix_metavariables(
-    rule: Rule, pattern_match: PatternMatch
-) -> Optional[str]:
-    fix_str = rule.fix
-    if fix_str is None:
-        return None
-    for metavar, contents in pattern_match.metavars.items():
-        fix_str = fix_str.replace(metavar, contents.get("abstract_content", ""))
-    return fix_str
 
 
 def evaluate_expression(

--- a/semgrep/tests/e2e/rules/autofix/issue1285.yaml
+++ b/semgrep/tests/e2e/rules/autofix/issue1285.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: simple-assert
+  pattern: |
+    self.assertEqual($X, $Y)
+  message: |
+    Simple assert statements are friendlier to pytest than self.assertEqual
+  fix: |
+    assert $X==$Y
+  severity: WARNING
+  languages:
+  - python

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py/results.json
@@ -1,0 +1,121 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.autofix.use-dict-get",
+      "end": {
+        "col": 11,
+        "line": 5
+      },
+      "extra": {
+        "fix": "inputs.get(x)",
+        "lines": "  inputs[x] = 1",
+        "message": "Use `.get()` method to avoid a KeyNotFound error",
+        "metadata": {},
+        "metavars": {
+          "$DICT": {
+            "abstract_content": "inputs",
+            "end": {
+              "col": 9,
+              "line": 5,
+              "offset": 51
+            },
+            "start": {
+              "col": 3,
+              "line": 5,
+              "offset": 45
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "inputs"
+            }
+          },
+          "$KEY": {
+            "abstract_content": "x",
+            "end": {
+              "col": 11,
+              "line": 5,
+              "offset": 53
+            },
+            "start": {
+              "col": 10,
+              "line": 5,
+              "offset": 52
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 2,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/autofix.py",
+      "start": {
+        "col": 3,
+        "line": 5
+      }
+    },
+    {
+      "check_id": "rules.autofix.use-dict-get",
+      "end": {
+        "col": 18,
+        "line": 6
+      },
+      "extra": {
+        "fix": "inputs.get(x+1)",
+        "lines": "  if inputs[x + 1] == True:",
+        "message": "Use `.get()` method to avoid a KeyNotFound error",
+        "metadata": {},
+        "metavars": {
+          "$DICT": {
+            "abstract_content": "inputs",
+            "end": {
+              "col": 12,
+              "line": 6,
+              "offset": 70
+            },
+            "start": {
+              "col": 6,
+              "line": 6,
+              "offset": 64
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "inputs"
+            }
+          },
+          "$KEY": {
+            "abstract_content": "x+1",
+            "end": {
+              "col": 18,
+              "line": 6,
+              "offset": 76
+            },
+            "start": {
+              "col": 13,
+              "line": 6,
+              "offset": 71
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/autofix.py",
+      "start": {
+        "col": 6,
+        "line": 6
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py/results.json
@@ -8,7 +8,7 @@
         "line": 5
       },
       "extra": {
-        "fix": "inputs.get(x)",
+        "fix": "$DICT.get($KEY)",
         "lines": "  inputs[x] = 1",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
         "metadata": {},
@@ -67,7 +67,7 @@
         "line": 6
       },
       "extra": {
-        "fix": "inputs.get(x+1)",
+        "fix": "$DICT.get($KEY)",
         "lines": "  if inputs[x + 1] == True:",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixissue1285.yaml-autofixissue1285.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixissue1285.yaml-autofixissue1285.py/results.json
@@ -8,7 +8,7 @@
         "line": 5
       },
       "extra": {
-        "fix": "assert foo()==1\n",
+        "fix": "assert $X==$Y\n",
         "lines": "    self.assertEqual(foo(), 1)",
         "message": "Simple assert statements are friendlier to pytest than self.assertEqual\n",
         "metadata": {},
@@ -63,7 +63,7 @@
         "line": 6
       },
       "extra": {
-        "fix": "assert foo'bar'==1\n",
+        "fix": "assert $X==$Y\n",
         "lines": "    self.assertEqual(foo['bar'], 1)",
         "message": "Simple assert statements are friendlier to pytest than self.assertEqual\n",
         "metadata": {},
@@ -118,8 +118,8 @@
         "line": 15
       },
       "extra": {
-        "fix": "assert response.json()'response'=={'a'1'b'2'c'[1 2 3]2}\n",
-        "lines": "    self.assertEqual(\n\n        response.json()['response'],\n\n        {\n\n            'a': 1,\n\n            'b': 2,\n\n            'c': [1,2,3][2],\n\n        }\n\n    )",
+        "fix": "assert $X==$Y\n",
+        "lines": "    self.assertEqual(\n        response.json()['response'],\n        {\n            'a': 1,\n            'b': 2,\n            'c': [1,2,3][2],\n        }\n    )",
         "message": "Simple assert statements are friendlier to pytest than self.assertEqual\n",
         "metadata": {},
         "metavars": {

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixissue1285.yaml-autofixissue1285.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixissue1285.yaml-autofixissue1285.py/results.json
@@ -1,0 +1,170 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.autofix.simple-assert",
+      "end": {
+        "col": 31,
+        "line": 5
+      },
+      "extra": {
+        "fix": "assert foo()==1\n",
+        "lines": "    self.assertEqual(foo(), 1)",
+        "message": "Simple assert statements are friendlier to pytest than self.assertEqual\n",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "foo()",
+            "end": {
+              "col": 27,
+              "line": 5,
+              "offset": 63
+            },
+            "start": {
+              "col": 22,
+              "line": 5,
+              "offset": 58
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$Y": {
+            "abstract_content": "1",
+            "end": {
+              "col": 30,
+              "line": 5,
+              "offset": 66
+            },
+            "start": {
+              "col": 29,
+              "line": 5,
+              "offset": 65
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/autofix/issue1285.py",
+      "start": {
+        "col": 5,
+        "line": 5
+      }
+    },
+    {
+      "check_id": "rules.autofix.simple-assert",
+      "end": {
+        "col": 36,
+        "line": 6
+      },
+      "extra": {
+        "fix": "assert foo'bar'==1\n",
+        "lines": "    self.assertEqual(foo['bar'], 1)",
+        "message": "Simple assert statements are friendlier to pytest than self.assertEqual\n",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "foo'bar'",
+            "end": {
+              "col": 31,
+              "line": 6,
+              "offset": 98
+            },
+            "start": {
+              "col": 22,
+              "line": 6,
+              "offset": 89
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$Y": {
+            "abstract_content": "1",
+            "end": {
+              "col": 35,
+              "line": 6,
+              "offset": 102
+            },
+            "start": {
+              "col": 34,
+              "line": 6,
+              "offset": 101
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/autofix/issue1285.py",
+      "start": {
+        "col": 5,
+        "line": 6
+      }
+    },
+    {
+      "check_id": "rules.autofix.simple-assert",
+      "end": {
+        "col": 6,
+        "line": 15
+      },
+      "extra": {
+        "fix": "assert response.json()'response'=={'a'1'b'2'c'[1 2 3]2}\n",
+        "lines": "    self.assertEqual(\n\n        response.json()['response'],\n\n        {\n\n            'a': 1,\n\n            'b': 2,\n\n            'c': [1,2,3][2],\n\n        }\n\n    )",
+        "message": "Simple assert statements are friendlier to pytest than self.assertEqual\n",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "response.json()'response'",
+            "end": {
+              "col": 35,
+              "line": 9,
+              "offset": 165
+            },
+            "start": {
+              "col": 9,
+              "line": 9,
+              "offset": 139
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$Y": {
+            "abstract_content": "{'a'1'b'2'c'[1 2 3]2}",
+            "end": {
+              "col": 10,
+              "line": 14,
+              "offset": 256
+            },
+            "start": {
+              "col": 9,
+              "line": 10,
+              "offset": 176
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/autofix/issue1285.py",
+      "start": {
+        "col": 5,
+        "line": 8
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
@@ -12,7 +12,7 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
-        "lines": "        new_password = request.data.get(\"password\", \"\")\n\n        validate_password(new_password, user=user)\n\n        user.set_password(new_password)\n\n        user.save()",
+        "lines": "        new_password = request.data.get(\"password\", \"\")\n        validate_password(new_password, user=user)\n        user.set_password(new_password)\n        user.save()",
         "message": "'new_password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
         "metadata": {
           "cwe": "CWE-521: Weak Password Requirements",
@@ -114,7 +114,7 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
-        "lines": "    def create_user(self, email, password=\"\"):\n\n        \"\"\"\n\n        Creates and saves a Poster with the given email and password.\n\n        \"\"\"\n\n        if not email:\n\n            raise ValueError('Users must have an email address')\n\n\n\n        user = self.model(email=self.normalize_email(email))\n\n        user.set_password(password)\n\n        user.save(using=self._db)\n\n        return user",
+        "lines": "    def create_user(self, email, password=\"\"):\n        \"\"\"\n        Creates and saves a Poster with the given email and password.\n        \"\"\"\n        if not email:\n            raise ValueError('Users must have an email address')\n\n        user = self.model(email=self.normalize_email(email))\n        user.set_password(password)\n        user.save(using=self._db)\n        return user",
         "message": "'password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
         "metadata": {
           "cwe": "CWE-521: Weak Password Requirements",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
@@ -12,7 +12,7 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
-        "lines": "        new_password = request.data.get(\"password\", \"\")\n        validate_password(new_password, user=user)\n        user.set_password(new_password)\n        user.save()",
+        "lines": "        new_password = request.data.get(\"password\", \"\")\n\n        validate_password(new_password, user=user)\n\n        user.set_password(new_password)\n\n        user.save()",
         "message": "'new_password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
         "metadata": {
           "cwe": "CWE-521: Weak Password Requirements",
@@ -114,7 +114,7 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
-        "lines": "    def create_user(self, email, password=\"\"):\n        \"\"\"\n        Creates and saves a Poster with the given email and password.\n        \"\"\"\n        if not email:\n            raise ValueError('Users must have an email address')\n\n        user = self.model(email=self.normalize_email(email))\n        user.set_password(password)\n        user.save(using=self._db)\n        return user",
+        "lines": "    def create_user(self, email, password=\"\"):\n\n        \"\"\"\n\n        Creates and saves a Poster with the given email and password.\n\n        \"\"\"\n\n        if not email:\n\n            raise ValueError('Users must have an email address')\n\n\n\n        user = self.model(email=self.normalize_email(email))\n\n        user.set_password(password)\n\n        user.save(using=self._db)\n\n        return user",
         "message": "'password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
         "metadata": {
           "cwe": "CWE-521: Weak Password Requirements",

--- a/semgrep/tests/e2e/targets/autofix/issue1285.py
+++ b/semgrep/tests/e2e/targets/autofix/issue1285.py
@@ -1,0 +1,15 @@
+def foo():
+    return 1
+
+def test():
+    self.assertEqual(foo(), 1)
+    self.assertEqual(foo['bar'], 1)
+    
+    self.assertEqual(
+        response.json()['response'],
+        {
+            'a': 1,
+            'b': 2,
+            'c': [1,2,3][2],
+        }
+    )

--- a/semgrep/tests/e2e/test_autofix.py
+++ b/semgrep/tests/e2e/test_autofix.py
@@ -4,12 +4,16 @@ from pathlib import Path
 import pytest
 
 
-def test_autofix(run_semgrep_in_tmp, snapshot):
+@pytest.mark.parametrize(
+    "rule,target",
+    [
+        ("rules/autofix/autofix.yaml", "autofix/autofix.py"),
+        ("rules/autofix/issue1285.yaml", "autofix/issue1285.py"),
+    ],
+)
+def test_autofix(run_semgrep_in_tmp, snapshot, rule, target):
     snapshot.assert_match(
-        run_semgrep_in_tmp(
-            "rules/autofix/autofix.yaml", target_name="autofix/autofix.py"
-        ),
-        "results.json",
+        run_semgrep_in_tmp(rule, target_name=target), "results.json",
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/1285.

However, we lose metavariable interpolation in the autofix suggestion in the CLI.