### PR TITLE
Do not consider .mly and .mll as ml files for semgrep

### DIFF
--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -27,8 +27,6 @@ RUBY_EXTENSIONS = [FileExtension("rb")]
 ML_EXTENSIONS = [
     FileExtension("mli"),
     FileExtension("ml"),
-    FileExtension("mly"),
-    FileExtension("mll"),
 ]
 JSON_EXTENSIONS = [FileExtension("json")]
 ALL_EXTENSIONS = (


### PR DESCRIPTION
We do not parse correctly the .mly and .mll so there's no point
considering them for semgrep.

Test plan:
pipenv shell
cd ~/pfff
semgrep -f semgrep.yml does not report anymore stuff on the .mly and .mll
inside pfff