### PR TITLE
New -dump_tree_sitter_cst to dump the tree-sitter CST

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -432,10 +432,17 @@ let parse_equivalences () =
 (*e: function [[Main_semgrep_core.parse_equivalences]] *)
 
 (*s: function [[Main_semgrep_core.unsupported_language_message]] *)
-let unsupported_language_message some_lang =
-  spf "unsupported language: %s; supported language tags are: %s"
-      some_lang supported_langs
+let unsupported_language_message lang =
+  if lang = "unset"
+  then "no language specified; use -lang"
+  else spf "unsupported language: %s; supported language tags are: %s"
+      lang supported_langs
 (*e: function [[Main_semgrep_core.unsupported_language_message]] *)
+
+let lang_of_string s =
+  match Lang.lang_of_string_opt s with
+  | Some x -> x
+  | None -> failwith (unsupported_language_message s)
 
 (*****************************************************************************)
 (* Language specific *)
@@ -559,11 +566,7 @@ let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
   let matches_and_errors =
     files |> map (fun file ->
        if !Flag.debug then pr2 (spf "Analyzing %s" file);
-       let lang =
-          match Lang.lang_of_string_opt !lang with
-          | Some lang -> lang
-          | _ -> failwith (spf "no language specified")
-       in
+       let lang = lang_of_string !lang in
        if !Flag.debug then pr2 (spf "PARSING: %s" file);
        try
          run_with_memory_limit !max_memory (fun () ->
@@ -827,16 +830,13 @@ let dump_v_to_format (v: OCaml.v) =
 let dump_pattern (file: Common.filename) =
   let s = Common.read_file file in
   (* mostly copy-paste of parse_pattern above, but with better error report *)
-  match Lang.lang_of_string_opt !lang with
-  | Some lang ->
+  let lang = lang_of_string !lang in
     E.try_with_print_exn_and_reraise file (fun () ->
       let any = Parse_pattern.parse_pattern lang s in
       let v = Meta_AST.vof_any any in
       let s = dump_v_to_format v in
       pr s
-    )
-  | None ->
-     failwith (unsupported_language_message !lang)
+  )
 (*e: function [[Main_semgrep_core.dump_pattern]] *)
 
 (*s: function [[Main_semgrep_core.dump_ast]] *)
@@ -913,6 +913,8 @@ let all_actions () = [
   "-test_parse_lang", " <files or dirs>",
   Common.mk_action_n_arg
     (Test_parsing.test_parse_lang !Flag.debug !lang get_final_files);
+  "-dump_tree_sitter_cst", " <file>",
+  Common.mk_action_1_arg Test_parsing.dump_tree_sitter_cst;
   "-datalog_experiment", " <file> <dir>",
   Common.mk_action_2_arg Datalog_experiment.gen_facts;
   "-dump_il", " <file>",

--- a/semgrep-core/parsing/Test_parsing.mli
+++ b/semgrep-core/parsing/Test_parsing.mli
@@ -2,3 +2,5 @@
 val test_parse_lang: bool -> string ->
   (Common.filename list -> Common.filename list) -> Common.filename list ->
   unit
+
+val dump_tree_sitter_cst: Common.filename -> unit


### PR DESCRIPTION
This helps to debug issues.

test plan:
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -dump_tree_sitter_cst string.js
|   | Exp_stmt
|   |   | Exp
|   |   |   Assign_exp
|   |   |   |   Choice_member_exp
|   |   |   |   | Id
|   |   |   |   | a
|   |   |   | "="
|   |   |   |   Choice_this
|   |   |   |   | Str
|   |   |   |   |   DQUOT_rep_choice_blank_DQUOT
|   |   |   |   |   | "\""
|   |   |   |   |   |   | Blank
|   |   |   |   |   | "\""
|   |   | Auto_semi
|   |   | ""

Note that it shows a bug with the Blank above instead of the content
of the actual string.