### PR TITLE
jsonschema: allow metavariable-regex in pattern-either

### DIFF
--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -21,6 +21,7 @@ definitions:
       - $ref: '#/definitions/pattern-inside'
       - $ref: '#/definitions/pattern'
       - $ref: '#/definitions/pattern-regex'
+      - $ref: '#/definitions/metavariable-regex'
   taint-content:
     type: array
     items:


### PR DESCRIPTION
It is useful to specify multiple metavar regex in a pattern-either. It is different
from adding an or to the regex since you might want to match a different metavariable

See https://github.com/dgryski/semgrep-go/blob/master/hostport.yml