### PR TITLE
Fail Semgrep rules tests on exit != 0

### DIFF
--- a/semgrep/tests/e2e/test_semgrep_rules_repo.py
+++ b/semgrep/tests/e2e/test_semgrep_rules_repo.py
@@ -3,12 +3,23 @@ import subprocess
 import pytest
 
 
+def _fail_subprocess_on_error(cmd):
+    output = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8",
+    )
+
+    if output.returncode != 0:
+        pytest.fail(f"Failed running cmd={cmd}" + output.stdout + output.stderr)
+
+
 def test_semgrep_rules_repo(run_semgrep_in_tmp):
     subprocess.check_output(
         ["git", "clone", "--depth=1", "https://github.com/returntocorp/semgrep-rules"]
     )
-    subprocess.check_output(["python3", "-m", "semgrep", "--generate-config"])
-    output = subprocess.run(
+
+    _fail_subprocess_on_error(["python3", "-m", "semgrep", "--generate-config"])
+
+    _fail_subprocess_on_error(
         [
             "python3",
             "-m",
@@ -19,12 +30,8 @@ def test_semgrep_rules_repo(run_semgrep_in_tmp):
             "--test-ignore-todo",
             "semgrep-rules",
         ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        encoding="utf-8",
     )
 
-    if output.returncode != 0:
-        pytest.fail("Regression in Semgrep-Rules Repo" + output.stdout + output.stderr)
-
-    subprocess.check_output(["python3", "-m", "semgrep", "--validate", "semgrep-rules"])
+    _fail_subprocess_on_error(
+        ["python3", "-m", "semgrep", "--validate", "--config", "semgrep-rules"]
+    )


### PR DESCRIPTION
The `subprocess.check_output` commands were broken, but it wasn't failing `pytest`.