### PR TITLE
Use latest pfff and new [@@profiling] attribute

### DIFF
--- a/semgrep-core/matching/Apply_equivalences.ml
+++ b/semgrep-core/matching/Apply_equivalences.ml
@@ -65,7 +65,7 @@ let subst_e (bindings: MV.metavars_binding) e =
 (*e: function [[Apply_equivalences.subst_e]] *)
 
 (*s: function [[Apply_equivalences.apply]] *)
-let apply2 equivs any =
+let apply equivs any =
   let expr_rules = ref [] in
   let stmt_rules = ref [] in
 
@@ -121,9 +121,7 @@ let apply2 equivs any =
     );
    } in
   visitor.M.vany any
+[@@profiling]
 (*e: function [[Apply_equivalences.apply]] *)
-let apply a b =
-  Common.profile_code "Apply_equivalences.apply" (fun () ->
-      apply2 a b)
 
 (*e: semgrep/matching/Apply_equivalences.ml *)

--- a/semgrep-core/matching/dune
+++ b/semgrep-core/matching/dune
@@ -13,4 +13,5 @@
    semgrep_core
    semgrep_typing
  )
+ (preprocess (pps ppx_deriving.show ppx_profiling))
 )


### PR DESCRIPTION
test plan:
you can see the Apply_equivalences.apply below when running with -profile

d@yrax:~/semgrep$ yy -lang js -profile -e 'FOO' tests/js/concrete_syntax.js
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -lang js -profile -e FOO tests/js/concrete_syntax.js
Profile mode On
disabling -j when in profiling mode
---------------------
profiling result
---------------------
Main total                               :      0.010 sec          1 count
Parallel.invoke                          :      0.000 sec          1 count
Common.=~                                :      0.000 sec         26 count
Semgrep.check                            :      0.000 sec          1 count
Semgrep.match_e_e                        :      0.000 sec         16 count
file_type_of_file                        :      0.000 sec          1 count
rule:-e/-f                               :      0.000 sec         16 count
Parse_js.tokens                          :      0.000 sec          1 count
Naming_ast.resolve                       :      0.000 sec          1 count
Constant_propagation.xxx                 :      0.000 sec          1 count
Common.full_charpos_to_pos_large         :      0.000 sec          1 count
Apply_equivalences.apply                 :      0.000 sec          1 count
Unix.stat                                :      0.000 sec          2 count