### PR TITLE
Remove Semgrep binary checks from ubuntu release

### DIFF
--- a/scripts/Dockerfile.16.04
+++ b/scripts/Dockerfile.16.04
@@ -4,11 +4,8 @@ RUN test -n "$version"
 RUN apt-get update && apt-get install -y curl sudo ca-certificates --no-install-recommends \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-COPY ubuntu-generic.sh ./install.sh
-RUN chmod +x install.sh
-COPY validate-install.sh ./validate-install.sh
-RUN chmod +x validate-install.sh
+COPY ubuntu-generic.sh ./ubuntu-generic.sh
+RUN chmod +x ubuntu-generic.sh
 
 ENV VERSION ${version}
-RUN ./install.sh
-RUN ./validate-install.sh
+RUN ./ubuntu-generic.sh

--- a/scripts/ubuntu-generic.sh
+++ b/scripts/ubuntu-generic.sh
@@ -9,27 +9,9 @@ sha_url=https://github.com/returntocorp/semgrep/releases/download/v$version/$tar
 
 echo "Installing tarball from $tarball_url (checksum: $sha_url)"
 
-if ! out="$(semgrep --version 2>/dev/null)" || [[ "$out" != "$version" ]]
-then
-    tmpdir="$(mktemp -d)"
-    trap 'rm -r "$tmpdir"' EXIT
-    cd "$tmpdir"
-    curl -L "$tarball_url" > "$tarball"
-    sha256=$(curl -L "$sha_url" | awk '{ print $1 }')
-    sha256sum -c <<< "$sha256  $tarball"
-    # Be gentle on `/usr/local/lib`
-    rm -rf /usr/local/lib/semgrep-files
-    sudo tar --skip-old-files -xzf  "$tarball" -C /usr/local/lib/
-    sudo ln -sf /usr/local/lib/semgrep-files/semgrep /usr/local/bin/semgrep
-    sudo ln -sf /usr/local/lib/semgrep-files/semgrep-core /usr/local/bin/semgrep-core
-fi
-
-echo "Semgrep installed! Version: $(semgrep --version)"
-
-echo "def silly_eq(a, b):" >> /tmp/test.py
-echo " return a + b == a + b" >> /tmp/test.py
-
-echo -n "Testing your semgrep installation..."
-# shellcheck disable=SC2016
-semgrep /tmp/test.py -l python -e '$X == $X' | grep 'a + b' > /dev/null || (echo "Something seems wrong with your semgrep install" && exit 1)
-echo "OK! Enjoy semgrep :-)"
+tmpdir="$(mktemp -d)"
+trap 'rm -r "$tmpdir"' EXIT
+cd "$tmpdir"
+curl -L "$tarball_url" > "$tarball"
+sha256=$(curl -L "$sha_url" | awk '{ print $1 }')
+sha256sum -c <<< "$sha256  $tarball"

--- a/scripts/validate-install.sh
+++ b/scripts/validate-install.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-echo "def silly_eq(a, b):" >> /tmp/test.py
-echo " return a + b == a + b" >> /tmp/test.py
-
-echo -n "Testing your semgrep installation..."
-# shellcheck disable=SC2016
-semgrep /tmp/test.py -l python -e '$X == $X' | grep "return a + b == a + b"
-echo "OK! Enjoy semgrep :-)"


### PR DESCRIPTION
The `0.22.0` release ubuntu verification failed: https://github.com/returntocorp/semgrep/runs/1058629525

This is because we're no longer including the `semgrep` Nuitka binary. This PR removes the checks for that binary. We're still confirming that the tarball and SHA256 hash are correct, but we're no longer confirming the `semgrep` binary works because it does not exist.

We may remove the tarball and hash altogether in the future. If that happens we can remove all the ubuntu release functionality. Removing the ubuntu release functionality simplifies our release process and lowers our maintenance burden. However, some users may find it useful to be able to download a pre-compiled `semgrep-core` artifact. This is a discussion for another time, for now let's fix the release scripts :+1: 