### PR TITLE
Add ability to read target contents from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## NEXT VERSION
 
+### Added
+- Ability to read target contents from stdin by specifying "-" target.
+
 ## [0.22.0](https://github.com/returntocorp/semgrep/releases/tag/v0.22.0) - 2020-09-01
 
 ### Added

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -1,4 +1,8 @@
+import contextlib
+import os
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
 from typing import Collection
 from typing import Dict
@@ -68,6 +72,23 @@ def lang_to_exts(language: Language) -> List[FileExtension]:
         return [FileExtension("*")]
     else:
         raise _UnknownLanguageError(f"Unsupported Language: {language}")
+
+
+@contextlib.contextmanager
+def optional_stdin_target(target: List[str]) -> List[str]:
+    """
+    Read target input from stdin if "-" is specified
+    """
+    if target == ["-"]:
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as fd:
+                fd.write(sys.stdin.buffer.read())
+                target = fd.name
+            yield [target]
+        finally:
+            os.remove(target)
+    else:
+        yield target
 
 
 @attr.s(auto_attribs=True)


### PR DESCRIPTION
This is a quality of life improvement that should make our lives easier in a few different ways.

1.) Easier to do a quick demo:

```
$ echo 'if 1 == 1: print("Useless comparison")' | python -m semgrep --lang python --pattern '$X == $X' -
/tmp/tmph4om0cbb
1:if 1 == 1: print("Useless comparison")
```

This will be great for README tutorials and quick demos.

2.) Easier to test a working Semgrep installation. We end up having tests like this all over the place:

```
echo "def silly_eq(a, b):" >> test.py
echo " return a + b == a + b" >> test.py

docker run -v "${PWD}:/src" returntocorp/semgrep:"$docker_tag" ./test.py -l python -e '$X == $X' | tee output

grep 'a + b == a + b' output
echo "Docker image OK!"
```

Now we can accomplish this without have to manually create a temporary file:

```
$ echo 'if 1 == 1: print("Installed correctly")' | python -m semgrep --lang python --pattern '$X == $X' -
/tmp/tmphvmb6np1
1:if 1 == 1: print("Installed correctly")
```