### PR TITLE
Use the new [@@profiling] ppx extension

### DIFF
--- a/semgrep-core/analyzing/dune
+++ b/semgrep-core/analyzing/dune
@@ -12,4 +12,5 @@
    semgrep_parsing
    semgrep_matching
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -298,7 +298,7 @@ let cache_computation file cache_file_of_file f =
       pr2 ("defaulting to calling the function");
       f ()
     end else begin
-    profile_code "Main.cache_computation" (fun () ->
+    Common.profile_code "Main.cache_computation" (fun () ->
 
       let file_cache = cache_file_of_file file in
       if Sys.file_exists file_cache && filemtime file_cache >= filemtime file

--- a/semgrep-core/bin/dune
+++ b/semgrep-core/bin/dune
@@ -42,6 +42,7 @@
     semgrep_reporting
     semgrep_synthesizing
  )
+ (preprocess (pps ppx_profiling))
  ; for ocamldebug
  (modes byte)
  (flags (:include flags.sexp))

--- a/semgrep-core/core/dune
+++ b/semgrep-core/core/dune
@@ -8,4 +8,5 @@
    pfff-h_program-lang
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/demos/dune
+++ b/semgrep-core/demos/dune
@@ -11,6 +11,7 @@
    pfff-h_program-lang
    pfff-lang_php
  )
+ (preprocess (pps ppx_profiling))
  ; for ocamldebug
  (modes byte)
 )

--- a/semgrep-core/finding/dune
+++ b/semgrep-core/finding/dune
@@ -5,4 +5,5 @@
    dune-glob
    commons
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/fuzzy/dune
+++ b/semgrep-core/fuzzy/dune
@@ -6,4 +6,5 @@
    pfff-config
    pfff-h_program-lang
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/matching/Rules_filter.ml
+++ b/semgrep-core/matching/Rules_filter.ml
@@ -50,17 +50,16 @@ open AST_generic
 let regexp_matching_str s =
   Re.str s
 let compile_regexp t =
-  Common.profile_code "Re.compile_regexp" (fun () -> Re.compile t)
+  Re.compile t
 let run_regexp re str =
-  Common.profile_code "Re.run_regexp" (fun () -> Re.execp re str)
+  Re.execp re str
 *)
 
 let regexp_matching_str s =
   Str.regexp_string s
-let compile_regexp t =
-  Common.profile_code "Re.compile_regexp" (fun () -> t)
+let compile_regexp t = t
+[@@profiling]
 let run_regexp re str =
-  Common.profile_code "Re.run_regexp" (fun () ->
    (* bugfix:
     * this does not work!:  Str.string_match re str 0
     * because you need to add ".*" in front to make it work,
@@ -70,7 +69,7 @@ let run_regexp re str =
    try
      Str.search_forward re str 0 |> ignore; true
    with Not_found -> false
-  )
+[@@profiling]
 
 let reserved_id lang str =
   Metavars_generic.is_metavar_name str ||
@@ -119,7 +118,7 @@ let extract_specific_strings lang any =
 (* Entry point *)
 (*****************************************************************************)
 
-let filter_rules_relevant_to_file_using_regexp2 rules lang file =
+let filter_rules_relevant_to_file_using_regexp rules lang file =
   let str = Common.read_file file in
   rules |> List.filter (fun rule ->
     let pat = rule.R.pattern in
@@ -149,7 +148,4 @@ let filter_rules_relevant_to_file_using_regexp2 rules lang file =
     then pr2 (spf "filtering rule %s" rule.R.id);
     match_
     )
-
-let filter_rules_relevant_to_file_using_regexp a b =
-  Common.profile_code "Rules_filter.filter" (fun () ->
-      filter_rules_relevant_to_file_using_regexp2 a b)
+[@@profiling "Rules_filter.filter"]

--- a/semgrep-core/matching/Semgrep_generic.ml
+++ b/semgrep-core/matching/Semgrep_generic.ml
@@ -81,10 +81,10 @@ let match_e_e2 pattern e =
   GG.m_expr pattern e env
 (*e: function [[Semgrep_generic.match_e_e]] *)
 let match_e_e rule a b =
- Common.profile_code "Semgrep.match_e_e" (fun () ->
-    Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
+     Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
      set_last_matched_rule rule (fun () ->
-      match_e_e2 a b)))
+      match_e_e2 a b))
+[@@profiling]
 
 (*s: function [[Semgrep_generic.match_st_st]] *)
 let match_st_st2 pattern e =
@@ -92,10 +92,10 @@ let match_st_st2 pattern e =
   GG.m_stmt pattern e env
 (*e: function [[Semgrep_generic.match_st_st]] *)
 let match_st_st rule a b =
-  Common.profile_code "Semgrep.match_st_st" (fun () ->
     Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
      set_last_matched_rule rule (fun () ->
-      match_st_st2 a b)))
+      match_st_st2 a b))
+[@@profiling]
 
 (*s: function [[Semgrep_generic.match_sts_sts]] *)
 let match_sts_sts2 pattern e =
@@ -135,10 +135,10 @@ let match_sts_sts2 pattern e =
   )
 (*e: function [[Semgrep_generic.match_sts_sts]] *)
 let match_sts_sts rule a b =
-  Common.profile_code "Semgrep.match_sts_sts" (fun () ->
     Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
      set_last_matched_rule rule (fun () ->
-      match_sts_sts2 a b)))
+      match_sts_sts2 a b))
+[@@profiling]
 
 (*s: function [[Semgrep_generic.match_any_any]] *)
 (* for unit testing *)
@@ -151,19 +151,19 @@ let match_t_t2 pattern e =
   let env = Matching_generic.empty_environment () in
   GG.m_type_ pattern e env
 let match_t_t rule a b =
-  Common.profile_code "Semgrep.match_t_t" (fun () ->
     Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
      set_last_matched_rule rule (fun () ->
-      match_t_t2 a b)))
+      match_t_t2 a b))
+[@@profiling]
 
 let match_p_p2 pattern e =
   let env = Matching_generic.empty_environment () in
   GG.m_pattern pattern e env
 let match_p_p rule a b =
-  Common.profile_code "Semgrep.match_p_p" (fun () ->
     Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
      set_last_matched_rule rule (fun () ->
-      match_p_p2 a b)))
+      match_p_p2 a b))
+[@@profiling]
 
 (*****************************************************************************)
 (* Helpers *)
@@ -313,8 +313,8 @@ let check2 ~hook rules equivs file lang ast =
   end
 (*e: function [[Semgrep_generic.check2]] *)
 
-(*s: function [[Semgrep_generic.check]] *)
+(* TODO: cant use [@@profile] because it does not handle yet label params *)
 let check ~hook a b c d e =
   Common.profile_code "Semgrep.check" (fun () -> check2 ~hook a b c d e)
-(*e: function [[Semgrep_generic.check]] *)
+
 (*e: semgrep/matching/Semgrep_generic.ml *)

--- a/semgrep-core/matching/SubAST_generic.ml
+++ b/semgrep-core/matching/SubAST_generic.ml
@@ -32,7 +32,7 @@ module V = Visitor_AST
 
 (*s: function [[SubAST_generic.subexprs_of_expr]] *)
 (* used for deep expression matching *)
-let subexprs_of_expr2 e =
+let subexprs_of_expr e =
   match e with
   | L _
   | Id _ | IdQualified _  | IdSpecial _
@@ -80,9 +80,8 @@ let subexprs_of_expr2 e =
   | LetPattern _ | MatchPattern _
     -> []
   | DisjExpr _ -> raise Common.Impossible
+[@@profiling]
 (*e: function [[SubAST_generic.subexprs_of_expr]] *)
-let subexprs_of_expr a = Common.profile_code "Sub.subexprs_of_expr" (fun () ->
-      subexprs_of_expr2 a)
 
 (*****************************************************************************)
 (* Statements *)
@@ -212,7 +211,7 @@ let do_visit_with_ref mk_hooks = fun any ->
 (*e: function [[SubAST_generic.do_visit_with_ref]] *)
 
 (*s: function [[SubAST_generic.lambdas_in_expr]] *)
-let lambdas_in_expr2 e =
+let lambdas_in_expr e =
   do_visit_with_ref (fun aref -> { V.default_visitor with
     V.kexpr = (fun (k, _) e ->
       match e with
@@ -220,9 +219,8 @@ let lambdas_in_expr2 e =
       | _ -> k e
     );
   }) (E e)
+[@@profiling]
 (*e: function [[SubAST_generic.lambdas_in_expr]] *)
-let lambdas_in_expr a = Common.profile_code "Sub.lambdas_in_expr" (fun () ->
-      lambdas_in_expr2 a)
 
 (* opti: using memoization speed things up a bit too
  * (but again, this is still slow when called many many times).
@@ -232,17 +230,16 @@ let lambdas_in_expr a = Common.profile_code "Sub.lambdas_in_expr" (fun () ->
  * return a unique identifier to each expression to remove the hashing cost.
  *)
 let hmemo = Hashtbl.create 101
-let lambdas_in_expr_memo2 a =
+let lambdas_in_expr_memo a =
   Common.memoized hmemo a (fun () -> lambdas_in_expr a)
-let lambdas_in_expr_memo a = Common.profile_code "Sub.lambdas_in_expr_memo"
- (fun () -> lambdas_in_expr_memo2 a)
+[@@profiling]
 
 (*****************************************************************************)
 (* Really substmts_of_stmts *)
 (*****************************************************************************)
 
 (*s: function [[SubAST_generic.flatten_substmts_of_stmts]] *)
-let flatten_substmts_of_stmts2 xs =
+let flatten_substmts_of_stmts xs =
   (* opti: using a ref, List.iter, and Common.push instead of a mix of
    * List.map, List.flatten and @ below speed things up
    * (but it is still slow when called many many times)
@@ -271,9 +268,7 @@ let flatten_substmts_of_stmts2 xs =
   in
   xs |> List.iter aux;
   List.rev !res
+[@@profiling]
 (*e: function [[SubAST_generic.flatten_substmts_of_stmts]] *)
-let flatten_substmts_of_stmts a =
-  Common.profile_code "Sub.flatten_substmts_of_stmts" (fun () ->
-      flatten_substmts_of_stmts2 a)
 
 (*e: semgrep/matching/SubAST_generic.ml *)

--- a/semgrep-core/parsing/dune
+++ b/semgrep-core/parsing/dune
@@ -21,4 +21,5 @@
 
    semgrep_core
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/reporting/dune
+++ b/semgrep-core/reporting/dune
@@ -10,4 +10,5 @@
 
    semgrep_core
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/synthesizing/dune
+++ b/semgrep-core/synthesizing/dune
@@ -11,4 +11,5 @@
    semgrep_core
    semgrep_matching
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/tainting/Tainting_generic.ml
+++ b/semgrep-core/tainting/Tainting_generic.ml
@@ -80,7 +80,7 @@ let config_of_rule found_tainted_sink rule =
 (*****************************************************************************)
 
 (*s: function [[Tainting_generic.check2]] *)
-let check2 rules file ast =
+let check rules file ast =
   let matches = ref [] in
 
   let v = V.mk_visitor { V.default_visitor with
@@ -108,11 +108,7 @@ let check2 rules file ast =
   v (AST.Pr ast);
 
    !matches
+[@@profiling]
 (*e: function [[Tainting_generic.check2]] *)
-
-(*s: function [[Tainting_generic.check]] *)
-let check a b c =
-  Common.profile_code "Tainting_generic.check" (fun () -> check2 a b c)
-(*e: function [[Tainting_generic.check]] *)
 
 (*e: semgrep/tainting/Tainting_generic.ml *)

--- a/semgrep-core/tainting/dune
+++ b/semgrep-core/tainting/dune
@@ -11,4 +11,5 @@
    semgrep_core
    semgrep_matching
  )
+ (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/typing/dune
+++ b/semgrep-core/typing/dune
@@ -8,4 +8,5 @@
    pfff-h_program-lang
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
  )
+ (preprocess (pps ppx_profiling))
 )


### PR DESCRIPTION
This removes some boilerplate code that can be autogenerated
by the ppx_profiling extension in pfff/ppx.

test plan:
You can see Semgrep_generic.match_e_e because of the
[@@profiling] attribute.

/home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -lang js -profile -e FOO tests/js/concrete_syntax.js
Profile mode On
disabling -j when in profiling mode
---------------------
profiling result
---------------------
Main total                               :      0.006 sec          1 count
Parallel.invoke                          :      0.001 sec          1 count
Semgrep.check                            :      0.000 sec          1 count
Common.=~                                :      0.000 sec         26 count
Semgrep_generic.match_e_e                :      0.000 sec         16 count
rule:-e/-f                               :      0.000 sec         16 count
file_type_of_file                        :      0.000 sec          1 count
Parse_js.tokens                          :      0.000 sec          1 count
Naming_ast.resolve                       :      0.000 sec          1 count
Constant_propagation.xxx                 :      0.000 sec          1 count
Common.full_charpos_to_pos_large         :      0.000 sec          1 count
Apply_equivalences.apply                 :      0.000 sec          1 count
Unix.stat                                :      0.000 sec          2 count