### PR TITLE
New semgrep_core -diff_pfff_tree_sitter CLI action

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -911,6 +911,8 @@ let all_actions () = [
   Common.mk_action_1_arg Test_parsing.dump_tree_sitter_cst;
   "-dump_ast_pfff", " <file>",
   Common.mk_action_1_arg Test_parsing.dump_ast_pfff;
+  "-diff_pfff_tree_sitter", " <file>",
+  Common.mk_action_n_arg Test_parsing.diff_pfff_tree_sitter;
   "-datalog_experiment", " <file> <dir>",
   Common.mk_action_2_arg Datalog_experiment.gen_facts;
   "-dump_il", " <file>",

--- a/semgrep-core/parsing/Parse_code.mli
+++ b/semgrep-core/parsing/Parse_code.mli
@@ -4,3 +4,6 @@
  *)
 val parse_and_resolve_name_use_pfff_or_treesitter:
   Lang.t -> Common.filename -> AST_generic.program
+
+(* used only for testing purpose *)
+val just_parse_with_lang: Lang.t -> Common.filename -> AST_generic.program

--- a/semgrep-core/parsing/Test_parsing.mli
+++ b/semgrep-core/parsing/Test_parsing.mli
@@ -5,3 +5,4 @@ val test_parse_lang: bool -> string ->
 
 val dump_tree_sitter_cst: Common.filename -> unit
 val dump_ast_pfff: Common.filename -> unit
+val diff_pfff_tree_sitter: Common.filename list -> unit

--- a/semgrep-core/tests/PARSING/string.go
+++ b/semgrep-core/tests/PARSING/string.go
@@ -1,0 +1,4 @@
+package foo
+func foo() {
+     return "foo"
+}


### PR DESCRIPTION
This can help find bugs on differences between what is parsed
by pfff and tree-sitter. This is useful because right now we
use pfff to parse the pattern, and sometimes tree-sitter to parse the code,
and if they disagree on how they parse things, then we may not find matches.

test plan:
```
diff_tsitter_pfff/home/pad/semgrep/tests/PARSING $ yy -diff_pfff_tree_sitter string.go
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -diff_pfff_tree_sitter string.go
NOTE: consider using -full_token_info to get also diff on tokens
diff_tsitter_pfff/home/pad/semgrep/tests/PARSING $ yy -full_token_info -diff_pfff_tree_sitter string.go
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -full_token_info -diff_pfff_tree_sitter string.go
NOTE: consider using -full_token_info to get also diff on tokens
--- /tmp/tmp-16886-dce4d9.x	2020-09-04 10:08:31.678766347 +0200
+++ /tmp/tmp-16886-293f78.x	2020-09-04 10:08:31.678766347 +0200
@@ -46,9 +46,8 @@
                                ("foo",
                                 { token =
                                   (OriginTok
-                                     { str = "\"foo\""; charpos = 37;
-                                       line = 3; column = 12;
-                                       file = "string.go" });
+                                     { str = "\""; charpos = 37; line = 3;
+                                       column = 12; file = "string.go" });
                                   transfo = NoTransfo }))))
                    ))
                  ],
```