### PR TITLE
Fix Parse_tree_sitter_helpers.combine_infos

### DIFF
--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -141,8 +141,8 @@ let string_literal (env : env) (x : CST.string_literal) =
       in
       let v3 = token env v3 (* "\"" *) in
       let str = v2 |> List.map fst |> String.concat "" in
-      let toks = [v1] @ (v2 |> List.map snd) @ [v3] in
-      str, H.combine_infos env toks
+      let toks = (v2 |> List.map snd) @ [v3] in
+      str, H.combine_infos env v1 toks
   )
 
 let import_spec (env : env) ((v1, v2) : CST.import_spec) =

--- a/semgrep-core/parsing/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/parsing/Parse_tree_sitter_helpers.ml
@@ -92,8 +92,6 @@ let combine_tokens env xs =
       let t = token env x in
       t
 
-let combine_infos _env xs =
-  match xs with
-  | [] -> failwith "combine_infos: empty list"
-  | x::_xsTODO ->
-      x
+let combine_infos _env x xs =
+  let str = xs |> List.map PI.str_of_info |> String.concat "" in
+  PI.tok_add_s str x

--- a/semgrep-core/parsing/Parse_tree_sitter_helpers.mli
+++ b/semgrep-core/parsing/Parse_tree_sitter_helpers.mli
@@ -12,4 +12,4 @@ val token: env -> Tree_sitter_run.Token.t -> Parse_info.t
 val str: env -> Tree_sitter_run.Token.t -> string * Parse_info.t
 
 val combine_tokens: env -> Tree_sitter_run.Token.t list -> Parse_info.t
-val combine_infos: env -> Parse_info.t list -> Parse_info.t
+val combine_infos: env -> Parse_info.t -> Parse_info.t list -> Parse_info.t


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1609

We were not generating the right Parse_info.t (aka token info) in
tree-sitter when we had to combine multiple tokens in one.
Indeed, in pfff we currently parse certain strings as a single
token, but in tree-sitter this was decomposed in 3 tokens, one for the
opening ", one for the content, and one for the closing ".
Before this diff, we were generating the right literal content, but
the token associated with it was just the token for the opening ".
This led to some issues in the editor when a message was mentioning
a metavariable that was bound to a string, because we are using the
tokens to pretty print its content.

test plan:
+ /home/pad/github/semgrep/semgrep-core/_build/default/bin/Main.exe -full_token_info -diff_pfff_tree_sitter string.go
NOTE: consider using -full_token_info to get also diff on tokens

No more diff!