### PR TITLE
Update CLI help messages with path to appropriate docs

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -60,14 +60,14 @@ def cli() -> None:
         help=(
             "YAML configuration file, directory of YAML files ending in "
             ".yml|.yaml, URL of a configuration file, or semgrep registry entry "
-            "name. See docs/configuration-files.md for information on configuration file format."
+            "name. See https://github.com/returntocorp/semgrep/blob/develop/docs/configuration-files.md for information on configuration file format."
         ),
     )
 
     config_ex.add_argument(
         "-e",
         "--pattern",
-        help="Code search pattern. See docs/pattern-features.md for information on pattern features.",
+        help="Code search pattern. See https://github.com/returntocorp/semgrep/blob/develop/docs/pattern-features.md for information on pattern features.",
     )
     config.add_argument(
         "-l",

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -60,14 +60,14 @@ def cli() -> None:
         help=(
             "YAML configuration file, directory of YAML files ending in "
             ".yml|.yaml, URL of a configuration file, or semgrep registry entry "
-            "name. See README for information on configuration file format."
+            "name. See docs/configuration-files.md for information on configuration file format."
         ),
     )
 
     config_ex.add_argument(
         "-e",
         "--pattern",
-        help="Code search pattern. See README for information on pattern features.",
+        help="Code search pattern. See docs/pattern-features.md for information on pattern features.",
     )
     config.add_argument(
         "-l",


### PR DESCRIPTION
Just updating the path we spit out in the Semgrep CLI on where to learn more, now that we've slimmed the README.