### PR TITLE
Fix timeout handling on languages using tree-sitter and pfff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## NEXT VERSION
 
 ### Added
+- Experimental support for Typescript (with -lang ts). You can currently
+  mainly use the Javascript subset of Typescript in patterns, as well
+  as type annotations in variable declarations or parameters.
 - Ability to read target contents from stdin by specifying "-" target.
+
+### Changed
+- You can now specify timeouts using floats instead of integers 
+  (e.g., semgrep -timeout 0.5 will timeout after half a second)
+
+### Fixed
+- We now respect the -timeout when analyzing languages which have
+  both a Tree-sitter and pfff parser (e.g., Javascript, Go).
 
 ## [0.22.0](https://github.com/returntocorp/semgrep/releases/tag/v0.22.0) - 2020-09-01
 

--- a/semgrep-core/parsing/Parse_code.ml
+++ b/semgrep-core/parsing/Parse_code.ml
@@ -42,7 +42,9 @@ let rec (run_either: Common.filename -> 'ast parser list ->
       in
       let res =
         try Left (f file)
-        with exn -> Right exn
+        with
+        | Timeout -> raise Timeout
+        | exn -> Right exn
       in
       match res with
       | Left ast -> Left ast


### PR DESCRIPTION
This also switches to float for specifying timeout (easier to test things).

We were incorrectly capturing the Timeout exn in Parse_code
when the first parser (usually the tree-sitter one) was timing out.
This then caused to use the second parser (usually the pfff one) without
any more timeout.

test plan:
  semgrep -l js --timeout 0.5 -e 'FOO' tests/PERF/timeout.js
now finishes quickly and does not invoke the pfff parser.