### PR TITLE
Use base image for docker build

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,7 +13,7 @@ jobs:
   build-core:
     name: Build and Test semgrep-core
     runs-on: ubuntu-latest
-    container: mjambon/r2c-ocaml:alpine
+    container: returntocorp/ocaml:alpine
     steps:
       - name: Pre-checkout fixes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
   build-core:
     name: semgrep-core make test and semgrep make test/qa-test
     runs-on: ubuntu-latest
-    container: mjambon/r2c-ocaml:alpine
+    container: returntocorp/ocaml:alpine
     steps:
       - name: Pre-checkout fixes
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
   build-core:
     name: Build and Test semgrep-core
     runs-on: ubuntu-latest
-    container: mjambon/r2c-ocaml:alpine
+    container: returntocorp/ocaml:alpine
     steps:
       - name: Pre-checkout fixes
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,15 @@
 # of the 'semgrep' wrapping.
 #
 
-FROM ocaml/opam2:alpine@sha256:4c2ce9a181b4b12442a68fc221d0b753959ec80e24eae3bf788eeca4dcb9a293 as build-semgrep-core
+FROM returntocorp/ocaml:alpine as build-semgrep-core
 
-USER root
-RUN apk add --no-cache perl m4
-USER opam
+USER user
+WORKDIR /home/user
 
-WORKDIR /home/opam/opam-repository
-RUN git pull && opam update && opam switch create 4.10.0+flambda
-
-COPY --chown=opam .gitmodules /semgrep/.gitmodules
-COPY --chown=opam .git/ /semgrep/.git/
-COPY --chown=opam semgrep-core/ /semgrep/semgrep-core/
-COPY --chown=opam scripts /semgrep/scripts
+COPY --chown=user .gitmodules /semgrep/.gitmodules
+COPY --chown=user .git/ /semgrep/.git/
+COPY --chown=user semgrep-core/ /semgrep/semgrep-core/
+COPY --chown=user scripts /semgrep/scripts
 
 WORKDIR /semgrep
 
@@ -31,6 +27,8 @@ RUN git submodule update --init --recursive
 RUN eval "$(opam env)" && ./scripts/install-ocaml-tree-sitter
 RUN eval "$(opam env)" && opam install --deps-only -y semgrep-core/pfff/
 RUN eval "$(opam env)" && opam install --deps-only -y semgrep-core/ && make -C semgrep-core/ all
+
+# Sanity check
 RUN ./semgrep-core/_build/install/default/bin/semgrep-core -version
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # of the 'semgrep' wrapping.
 #
 
-FROM returntocorp/ocaml:alpine as build-semgrep-core
+FROM returntocorp/ocaml:alpine-2020-09-11 as build-semgrep-core
 
 USER user
 WORKDIR /home/user


### PR DESCRIPTION
Two changes:

* Use `returntocorp/ocaml` images instead of `mjambon/r2c-ocaml`.
* Also use this image in the dockerfile, which will speed up the build and simplify maintenance.

Background: our [ocaml-layer setup](https://github.com/returntocorp/ocaml-layer) now runs a weekly job that builds base images (alpine and ubuntu) with the desired version of ocaml and most or all external dependencies. This is meant to speed up CI jobs.

Relies on #1666 