### PR TITLE
* Dockerfile: add git in semgrep docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN ./semgrep-core/_build/install/default/bin/semgrep-core -version
 FROM python:3.7.7-alpine3.11
 LABEL maintainer="support@r2c.dev"
 
+# ugly: circle CI requires a valid git command when running semgrep
+# on a repository containing submodules
+RUN apk add --no-cache git
+
 COPY --from=build-semgrep-core \
      /semgrep/semgrep-core/_build/install/default/bin/semgrep-core /usr/local/bin/semgrep-core
 RUN semgrep-core -version


### PR DESCRIPTION
This seems necessary for circleCI to be able to apply semgrep in CI
on git repositories using submodules.
See https://app.circleci.com/pipelines/github/returntocorp/semgrep/785/workflows/8bc50c5e-7891-45e6-8111-1ad8224ab79b/jobs/1418 for an example of error

test plan:
wait for it to be accepted, pushed to docker, and check if next
PR get a working circle CI