### PR TITLE
Guess typescript dialect (ts or tsx) from file extension, unless forced.

### DIFF
--- a/semgrep-core/parsing/Check_semgrep.ml
+++ b/semgrep-core/parsing/Check_semgrep.ml
@@ -11,7 +11,7 @@ let lang_has_no_dollar_ids = Lang.(function
   | JSON
   | Csharp
   -> true
-  | Javascript | Ruby | Typescript | TSX | PHP
+  | Javascript | Ruby | Typescript | PHP
   -> false)
 (*e: constant [[Check_semgrep.lang_has_no_dollar_ids]] *)
 

--- a/semgrep-core/parsing/Parse_code.ml
+++ b/semgrep-core/parsing/Parse_code.ml
@@ -124,15 +124,7 @@ let just_parse_with_lang lang file =
   | Lang.Typescript ->
       let ast =
         run file [
-          TreeSitter, Parse_typescript_tree_sitter.parse `Typescript
-        ]
-      in
-      Js_to_generic.program ast
-
-  | Lang.TSX ->
-      let ast =
-        run file [
-          TreeSitter, Parse_typescript_tree_sitter.parse `TSX
+          TreeSitter, Parse_typescript_tree_sitter.parse ?dialect:None
         ]
       in
       Js_to_generic.program ast

--- a/semgrep-core/parsing/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_typescript_tree_sitter.ml
@@ -2550,8 +2550,18 @@ let program (env : env) ((v1, v2) : CST.program) : program =
 
 type dialect = [ `Typescript | `TSX ]
 
-let parse dialect file =
+let guess_dialect opt_dialect file : dialect =
+  match opt_dialect with
+  | Some x -> x
+  | None ->
+      if file =~ ".*\\.tsx" then
+        `TSX
+      else
+        `Typescript
+
+let parse ?dialect file =
   let debug = false in
+  let dialect = guess_dialect dialect file in
   let cst =
     Parallel.backtrace_when_exn := false;
     match dialect with

--- a/semgrep-core/parsing/Parse_typescript_tree_sitter.mli
+++ b/semgrep-core/parsing/Parse_typescript_tree_sitter.mli
@@ -10,4 +10,9 @@
 
 type dialect = [ `Typescript | `TSX ]
 
-val parse : dialect -> string -> Ast_js.program
+(*
+   Parse a file as pure typescript or as TSX. If unspecified, the
+   dialect is guessed from the file extension. Pure typescript is the fallback
+   if the extension is unknown.
+*)
+val parse : ?dialect:dialect -> string -> Ast_js.program

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -65,7 +65,7 @@ let print_bool env = function
          | Lang.Python | Lang.Python2 | Lang.Python3
           -> "True"
          | Lang.Java | Lang.Go | Lang.C | Lang.JSON | Lang.Javascript
-         | Lang.OCaml | Lang.Ruby | Lang.Typescript | Lang.TSX
+         | Lang.OCaml | Lang.Ruby | Lang.Typescript
          | Lang.Csharp | Lang.PHP
           -> "true")
   | false ->
@@ -73,7 +73,7 @@ let print_bool env = function
          | Lang.Python | Lang.Python2 | Lang.Python3
           -> "False"
          | Lang.Java | Lang.Go | Lang.C | Lang.JSON | Lang.Javascript
-         | Lang.OCaml | Lang.Ruby | Lang.Typescript | Lang.TSX
+         | Lang.OCaml | Lang.Ruby | Lang.Typescript
          | Lang.Csharp | Lang.PHP
           -> "false")
 
@@ -164,7 +164,7 @@ and if_stmt env level (tok, e, s, sopt) =
     (match env.lang with
     | Lang.Python | Lang.Python2 | Lang.Python3 -> (no_paren_cond, "elif", colon_body)
     | Lang.Java | Lang.Go | Lang.C | Lang.Csharp
-    | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.TSX
+    | Lang.JSON | Lang.Javascript | Lang.Typescript
       -> (paren_cond, "else if", bracket_body)
     | Lang.Ruby -> failwith "I don't want to deal with Ruby right now"
     | Lang.OCaml -> failwith "Impossible; if statements should be expressions"
@@ -193,7 +193,7 @@ and while_stmt env level (tok, e, s) =
       (match env.lang with
       | Lang.Python | Lang.Python2 | Lang.Python3 -> python_while
       | Lang.Java | Lang.C | Lang.Csharp
-      | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.TSX -> c_while
+      | Lang.JSON | Lang.Javascript | Lang.Typescript -> c_while
       | Lang.Go -> go_while
       | Lang.Ruby -> ruby_while
       | Lang.OCaml -> ocaml_while
@@ -207,7 +207,7 @@ and do_while stmt env level (s, e) =
    let do_while_format =
     (match env.lang with
     | Lang.Java | Lang.C | Lang.Csharp
-    | Lang.Javascript | Lang.Typescript | Lang.TSX -> c_do_while
+    | Lang.Javascript | Lang.Typescript -> c_do_while
     | Lang.Python | Lang.Python2 | Lang.Python3
     | Lang.Go | Lang.JSON | Lang.OCaml -> failwith "impossible; no do while"
     | Lang.Ruby -> failwith "ruby is so weird (here, do while loop)"
@@ -220,7 +220,7 @@ and for_stmt env level (for_tok, hdr, s) =
    let for_format =
     (match env.lang with
     | Lang.Java | Lang.C | Lang.Csharp
-    | Lang.Javascript | Lang.Typescript | Lang.TSX -> F.sprintf "%s (%s) %s"
+    | Lang.Javascript | Lang.Typescript -> F.sprintf "%s (%s) %s"
     | Lang.Go -> F.sprintf "%s %s %s"
     | Lang.Python | Lang.Python2 | Lang.Python3 -> F.sprintf "%s %s:\n%s"
     | Lang.Ruby -> F.sprintf "%s %s\ndo %s\nend"
@@ -256,7 +256,7 @@ and def_stmt env (entity, def_kind) =
        | Lang.Java | Lang.C | Lang.Csharp
           -> (fun typ id _e -> F.sprintf "%s %s;" typ id),
              (fun typ id e -> F.sprintf "%s %s = %s;" typ id e)
-       | Lang.Javascript | Lang.Typescript | Lang.TSX
+       | Lang.Javascript | Lang.Typescript
          -> (fun _typ id _e -> F.sprintf "var %s;" id),
             (fun _typ id e -> F.sprintf "var %s = %s;" id e)
        | Lang.Go -> (fun typ id _e -> F.sprintf "var %s %s" id typ),
@@ -293,7 +293,7 @@ and return env (tok, eopt) =
       -> F.sprintf "%s %s;" (token "return" tok) to_return
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
-  | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.TSX
+  | Lang.JSON | Lang.Javascript | Lang.Typescript
       -> F.sprintf "%s %s" (token "return" tok) to_return
   | Lang.PHP -> failwith "TODO: PHP"
 
@@ -310,7 +310,7 @@ and break env (tok, lbl) =
     -> F.sprintf "%s%s;" (token "break" tok) lbl_str
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
-  | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.TSX
+  | Lang.JSON | Lang.Javascript | Lang.Typescript
     -> F.sprintf "%s%s" (token "break" tok) lbl_str
   | Lang.PHP -> failwith "TODO: PHP"
 
@@ -327,7 +327,7 @@ and continue env (tok, lbl) =
     -> F.sprintf "%s%s;" (token "continue" tok) lbl_str
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
-  | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.TSX
+  | Lang.JSON | Lang.Javascript | Lang.Typescript
     -> F.sprintf "%s%s" (token "continue" tok) lbl_str
   | Lang.PHP -> failwith "TODO: PHP"
 
@@ -398,7 +398,7 @@ and literal env = function
             "'" ^ s ^ "'"
       | Lang.Java | Lang.Go | Lang.C | Lang.Csharp
       | Lang.JSON | Lang.Javascript
-      | Lang.OCaml | Lang.Ruby | Lang.Typescript | Lang.TSX ->
+      | Lang.OCaml | Lang.Ruby | Lang.Typescript ->
             "\"" ^ s ^ "\""
       | Lang.PHP -> failwith "TODO: PHP"
       )


### PR DESCRIPTION
This eliminates `Lang.TSX`. The correct parser is now picked from the file extension (tsx or other), as it's done for example to pick the ocaml parser (ml or mli) in pfff.

Depends on https://github.com/returntocorp/pfff/pull/295