### PR TITLE
adding support for running multiple YAML urls with flag 'configs'

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -59,7 +59,6 @@ def cli() -> None:
         "-f",
         "--config",
         nargs='+',
-        type=str,
         help=(
             "YAML configuration file, directory of YAML files ending in "
             ".yml|.yaml, URL of a configuration file, or semgrep registry entry "

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -48,6 +48,13 @@ def cli() -> None:
     config = parser.add_argument_group("config")
     config_ex = config.add_mutually_exclusive_group()
     config_ex.add_argument(
+        "--configs",
+        help=("List of configuration files seperated by comma. The type of permitted files is "
+              "specified in the help section of --config."
+              "Separate like \"<url1>,<url2>\" with no space in between."),
+    )
+
+    config_ex.add_argument(
         "-g",
         "--generate-config",
         action="store_true",
@@ -378,4 +385,5 @@ def cli() -> None:
                 max_memory=args.max_memory,
                 timeout_threshold=args.timeout_threshold,
                 skip_unknown_extensions=args.skip_unknown_extensions,
+                configs=args.configs
             )

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -234,7 +234,7 @@ def invoke_semgrep(config: Path, targets: List[Path], **kwargs: Any) -> Any:
         target=[str(t) for t in targets],
         pattern="",
         lang="",
-        config=[str(config)],
+        config=str(config),
         **kwargs,
     )
     output_handler.close()
@@ -246,7 +246,7 @@ def main(
     target: List[str],
     pattern: str,
     lang: str,
-    config: List[str],
+    config: str,
     no_rewrite_rule_ids: bool = False,
     jobs: int = 1,
     include: Optional[List[str]] = None,
@@ -262,6 +262,7 @@ def main(
     timeout_threshold: int = 0,
     skip_unknown_extensions: bool = False,
     testing: bool = False,
+    configs: Optional[List[str]] = None,
 ) -> None:
     if include is None:
         include = []
@@ -269,10 +270,10 @@ def main(
     if exclude is None:
         exclude = []
 
-    if config is None:
-        config = [None]
+    if configs is None:
+        configs = [config]
 
-    for c in config:
+    for c in configs:
         valid_configs, config_errors = get_config(pattern, lang, c)
 
         output_handler.handle_semgrep_errors(config_errors)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -262,6 +262,7 @@ def main(
     timeout_threshold: int = 0,
     skip_unknown_extensions: bool = False,
     testing: bool = False,
+    configs: Optional[List[str]] = None,
 ) -> None:
     if include is None:
         include = []
@@ -269,78 +270,87 @@ def main(
     if exclude is None:
         exclude = []
 
-    valid_configs, config_errors = get_config(pattern, lang, config)
+    if configs is None:
+        configs = []
+    else:
+        configs = configs.split(',')
 
-    output_handler.handle_semgrep_errors(config_errors)
+    if not config is None:
+        configs = [config]
 
-    if config_errors and strict:
-        raise SemgrepError(
-            f"run with --strict and there were {len(config_errors)} errors loading configs",
-            code=MISSING_CONFIG_EXIT_CODE,
-        )
+    for c in configs:
+        valid_configs, config_errors = get_config(pattern, lang, c)
 
-    if not no_rewrite_rule_ids:
-        # re-write the configs to have the hierarchical rule ids
-        valid_configs = rename_rule_ids(valid_configs)
+        output_handler.handle_semgrep_errors(config_errors)
 
-    # extract just the rules from valid configs
-    all_rules = flatten_configs(valid_configs)
-
-    if not pattern:
-        plural = "s" if len(valid_configs) > 1 else ""
-        config_id_if_single = (
-            list(valid_configs.keys())[0] if len(valid_configs) == 1 else ""
-        )
-        invalid_msg = (
-            f"({len(config_errors)} config files were invalid)"
-            if len(config_errors)
-            else ""
-        )
-        logger.debug(
-            f"running {len(all_rules)} rules from {len(valid_configs)} config{plural} {config_id_if_single} {invalid_msg}"
-        )
-
-        notify_user_of_work(all_rules, include, exclude)
-
-        if len(valid_configs) == 0:
+        if config_errors and strict:
             raise SemgrepError(
-                f"no valid configuration file found ({len(config_errors)} configs were invalid)",
+                f"run with --strict and there were {len(config_errors)} errors loading configs",
                 code=MISSING_CONFIG_EXIT_CODE,
             )
 
-    respect_git_ignore = not no_git_ignore
-    target_manager = TargetManager(
-        includes=include,
-        excludes=exclude,
-        targets=target,
-        respect_git_ignore=respect_git_ignore,
-        output_handler=output_handler,
-        skip_unknown_extensions=skip_unknown_extensions,
-    )
+        if not no_rewrite_rule_ids:
+            # re-write the configs to have the hierarchical rule ids
+            valid_configs = rename_rule_ids(valid_configs)
 
-    # actually invoke semgrep
-    rule_matches_by_rule, debug_steps_by_rule, semgrep_errors = CoreRunner(
-        allow_exec=dangerously_allow_arbitrary_code_execution_from_rules,
-        jobs=jobs,
-        timeout=timeout,
-        max_memory=max_memory,
-        timeout_threshold=timeout_threshold,
-        testing=testing,
-    ).invoke_semgrep(target_manager, all_rules)
+        # extract just the rules from valid configs
+        all_rules = flatten_configs(valid_configs)
 
-    output_handler.handle_semgrep_errors(semgrep_errors)
+        if not pattern:
+            plural = "s" if len(valid_configs) > 1 else ""
+            config_id_if_single = (
+                list(valid_configs.keys())[0] if len(valid_configs) == 1 else ""
+            )
+            invalid_msg = (
+                f"({len(config_errors)} config files were invalid)"
+                if len(config_errors)
+                else ""
+            )
+            logger.debug(
+                f"running {len(all_rules)} rules from {len(valid_configs)} config{plural} {config_id_if_single} {invalid_msg}"
+            )
 
-    if not disable_nosem:
-        rule_matches_by_rule = {
-            rule: [
-                rule_match
-                for rule_match in rule_matches
-                if not rule_match_nosem(rule_match, strict)
-            ]
-            for rule, rule_matches in rule_matches_by_rule.items()
-        }
+            notify_user_of_work(all_rules, include, exclude)
 
-    output_handler.handle_semgrep_core_output(rule_matches_by_rule, debug_steps_by_rule)
+            if len(valid_configs) == 0:
+                raise SemgrepError(
+                    f"no valid configuration file found ({len(config_errors)} configs were invalid)",
+                    code=MISSING_CONFIG_EXIT_CODE,
+                )
 
-    if autofix:
-        apply_fixes(rule_matches_by_rule, dryrun)
+        respect_git_ignore = not no_git_ignore
+        target_manager = TargetManager(
+            includes=include,
+            excludes=exclude,
+            targets=target,
+            respect_git_ignore=respect_git_ignore,
+            output_handler=output_handler,
+            skip_unknown_extensions=skip_unknown_extensions,
+        )
+
+        # actually invoke semgrep
+        rule_matches_by_rule, debug_steps_by_rule, semgrep_errors = CoreRunner(
+            allow_exec=dangerously_allow_arbitrary_code_execution_from_rules,
+            jobs=jobs,
+            timeout=timeout,
+            max_memory=max_memory,
+            timeout_threshold=timeout_threshold,
+            testing=testing,
+        ).invoke_semgrep(target_manager, all_rules)
+
+        output_handler.handle_semgrep_errors(semgrep_errors)
+
+        if not disable_nosem:
+            rule_matches_by_rule = {
+                rule: [
+                    rule_match
+                    for rule_match in rule_matches
+                    if not rule_match_nosem(rule_match, strict)
+                ]
+                for rule, rule_matches in rule_matches_by_rule.items()
+            }
+
+        output_handler.handle_semgrep_core_output(rule_matches_by_rule, debug_steps_by_rule)
+
+        if autofix:
+            apply_fixes(rule_matches_by_rule, dryrun)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -271,15 +271,12 @@ def main(
         exclude = []
 
     if configs is None:
-        configs = []
+        configs = [config]
     else:
         configs = configs.split(',')
 
-    if not config is None:
-        configs = [config]
-
     for c in configs:
-        valid_configs, config_errors = get_config(pattern, lang, c)
+        valid_configs, config_errors = get_config(pattern, lang, config)
 
         output_handler.handle_semgrep_errors(config_errors)
 

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -234,7 +234,7 @@ def invoke_semgrep(config: Path, targets: List[Path], **kwargs: Any) -> Any:
         target=[str(t) for t in targets],
         pattern="",
         lang="",
-        config=str(config),
+        config=[str(config)],
         **kwargs,
     )
     output_handler.close()
@@ -246,7 +246,7 @@ def main(
     target: List[str],
     pattern: str,
     lang: str,
-    config: str,
+    config: List[str],
     no_rewrite_rule_ids: bool = False,
     jobs: int = 1,
     include: Optional[List[str]] = None,
@@ -262,7 +262,6 @@ def main(
     timeout_threshold: int = 0,
     skip_unknown_extensions: bool = False,
     testing: bool = False,
-    configs: Optional[List[str]] = None,
 ) -> None:
     if include is None:
         include = []
@@ -270,12 +269,10 @@ def main(
     if exclude is None:
         exclude = []
 
-    if configs is None:
-        configs = [config]
-    else:
-        configs = configs.split(',')
+    if config is None:
+        config = [None]
 
-    for c in configs:
+    for c in config:
         valid_configs, config_errors = get_config(pattern, lang, c)
 
         output_handler.handle_semgrep_errors(config_errors)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -276,7 +276,7 @@ def main(
         configs = configs.split(',')
 
     for c in configs:
-        valid_configs, config_errors = get_config(pattern, lang, config)
+        valid_configs, config_errors = get_config(pattern, lang, c)
 
         output_handler.handle_semgrep_errors(config_errors)
 


### PR DESCRIPTION
Feature request addition for issue #1237. 

Added a flag, --configs that allows you to input a list of configuration files separated by a comma (NO SPACE AFTER). 

**Test Plan**
Can test with python -m semgrep --configs \<rule1\> \<rule2\> \<rule3\> ...:
Ex:  python -m semgrep --configs https://semgrep.dev/s/0gZr https://semgrep.dev/s/NxvL