### PR TITLE
Use stdin target instead of temp files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build the Docker image
         run: docker build -t semgrep-dev .
       - name: Check the Docker image
-        run: ./scripts/validate-docker-build semgrep-dev
+        run: ./scripts/validate-docker-build.sh semgrep-dev
       - name: Push Develop Image if on develop branch
         if: ${{ github.event_name == 'push'}}
         uses: docker/build-push-action@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,21 +119,9 @@ and run the binary from there. Another option is including it somewhere like
 `semgrep` is fully operational by running a simple analysis:
 
 ```
-$ cat << EOF > test.py
-if 5 == 5:
-    print("Useless comparison")
-EOF
-```
-
-```
-$ python test.py
-Useless comparison
-```
-
-```
-$ python -m semgrep --lang python --pattern '$X == $X' test.py
-test.py
-1:if 5 == 5:
+$ echo 'if 1 == 1: pass' | python -m semgrep --lang python --pattern '$X == $X' -
+/tmp/...
+1:if 1 == 1: pass
 ```
 
 Congratulations, you have Semgrep running locally!

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -38,11 +38,6 @@ if [[ $# -gt 0 ]]; then
   esac
 fi
 
-cat > test.py <<EOF
-def silly_eq(a, b):
-    return a + b == a + b
-EOF
-
-docker run -v "$(pwd):/src" "$image" \
-  ./test.py -l python -e '$X == $X' \
-  2>&1 | tee "$prog_name".log
+echo "if 1 == 1: pass" \
+    | docker run -i "$image" -l python -e '$X == $X' - \
+    | grep -q "1 == 1"

--- a/scripts/validate-docker-release.sh
+++ b/scripts/validate-docker-release.sh
@@ -8,7 +8,6 @@ docker_tag="${version/v/}"
 
 echo "Validating release with docker tag: $docker_tag"
 
-# shellcheck disable=SC2016
 echo "if 1 == 1: pass" \
     | docker run -i returntocorp/semgrep:"$docker_tag" -l python -e '$X == $X' - \
     | grep -q "1 == 1"

--- a/scripts/validate-docker-release.sh
+++ b/scripts/validate-docker-release.sh
@@ -8,12 +8,9 @@ docker_tag="${version/v/}"
 
 echo "Validating release with docker tag: $docker_tag"
 
-echo "def silly_eq(a, b):" >> test.py
-echo " return a + b == a + b" >> test.py
-
 # shellcheck disable=SC2016
-docker run -v "${PWD}:/src" returntocorp/semgrep:"$docker_tag" ./test.py -l python -e '$X == $X' | tee output
-
-grep 'a + b == a + b' output
+echo "if 1 == 1: pass" \
+    | docker run -i returntocorp/semgrep:"$docker_tag" -l python -e '$X == $X' - \
+    | grep -q "1 == 1"
 
 echo "Docker image OK!"


### PR DESCRIPTION
This simplifies basic testing of a Semgrep installation and avoids leaving temp files around.