### PR TITLE
Use new python rule to detect wrong string concatenation in sets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,7 @@ jobs:
     working_directory: /src
     steps:
       - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            apk add git
-            git submodule init
-            git submodule update --remote
-      - run: semgrep --config semgrep-core/semgrep.yml --error --strict --exclude ocaml --exclude TODO --exclude _build semgrep-core
+      - run: semgrep --config semgrep.yml --error --strict --exclude tests --exclude TODO --exclude _build .
 
 workflows:
   version: 2

--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -49,7 +49,7 @@ merge:
 check:
 	@semgrep --version
 	@semgrep-core -version
-	semgrep --config semgrep.yml --error --strict --exclude tests/ocaml .
+	semgrep --config ../semgrep.yml --error --strict --exclude tests ..
 
 index:
 	codegraph_build -lang cmt -derived_data .

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -34,3 +34,10 @@ rules:
        - Test.ml
        - Matching_report.ml
        - Unit_*.ml
+
+  - id: string-missing-comma
+    pattern: |
+      {..., "..." "...", ...}
+    message: You probably forgot a comma
+    languages: [python]
+    severity: ERROR

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -58,7 +58,7 @@ def lang_to_exts(language: Language) -> List[FileExtension]:
         return PYTHON_EXTENSIONS
     elif language in {"js", "jsx", "javascript"}:
         return JAVASCRIPT_EXTENSIONS
-    elif language in {"ts", "tsx" "typescript"}:
+    elif language in {"ts", "tsx", "typescript"}:
         return TYPESCRIPT_EXTENSIONS
     elif language in {"java"}:
         return JAVA_EXTENSIONS


### PR DESCRIPTION
This should help detect bugs like the one reported in
 https://github.com/returntocorp/semgrep/issues/1705

test plan:
make check
wait for CI to see if circleCI spot the reported bug above.