### PR TITLE
docs/pattern-features.md: fix golang snippet

### DIFF
--- a/docs/pattern-features.md
+++ b/docs/pattern-features.md
@@ -485,7 +485,7 @@ Semgrep for Go currently does not recognize the type of all variables when decla
 same line. That is, the following will not take both `a` and `b` as `int`s:
 
 ```go
-var a, b = 1
+var a, b = 1, 2
 ```
 
 ## Limitations


### PR DESCRIPTION
I'm not 100% certain that this was the original intention behind the code
snippet, but it seems probable to me. The code that was there previously wasn't
valid.
