### PR TITLE
Proof of concept of semgrep_core -eval <jsonfile> for pattern-where-python

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -924,6 +924,8 @@ let all_actions () = [
   Common.mk_action_2_arg Datalog_experiment.gen_facts;
   "-dump_il", " <file>",
   Common.mk_action_1_arg Datalog_experiment.dump_il;
+  "-eval", " <JSON file>",
+  Common.mk_action_1_arg Eval_generic.eval_json_file;
  ]
 
 (*e: function [[Main_semgrep_core.all_actions]] *)

--- a/semgrep-core/matching/Eval_generic.ml
+++ b/semgrep-core/matching/Eval_generic.ml
@@ -159,7 +159,8 @@ and eval_op op values code =
   | G.Div, [Int i1; Int i2] -> Int (i1 / i2)
   | G.Mod, [Int i1; Int i2] -> Int (i1 mod i2)
 
-  | G.Eq, [String s1; String s2] -> Bool (s1 = s2)
+  | G.Eq, [v1; v2] -> Bool (v1 = v2)
+  | G.NotEq, [v1; v2] -> Bool (v1 <> v2)
 
   | _ -> raise (NotHandled code)
 

--- a/semgrep-core/matching/Eval_generic.ml
+++ b/semgrep-core/matching/Eval_generic.ml
@@ -1,0 +1,146 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2019-2020 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+open Common
+module G = AST_generic
+
+module MV = Metavars_generic
+module J = JSON
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* A simple interpreter for a simple subset of the generic AST.
+ *
+ * This can be used to safely execute a subset of pattern-where-python:
+ * expressions.
+ *)
+
+[@@@warning "-37"]
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+(* This is the (partially parsed) content of a metavariable *)
+type value =
+  | Int of int
+  | Bool of bool
+  (* less: Float? *)
+  | String of string (* string without the enclosing '"' *)
+  (* default case where we don't really have good builtin operations.
+   * This should be a AST_generic.any once parsed.
+   * See JSON_report.json_metavar().
+   *)
+  | AST of string (* any AST, e.g., "x+1" *)
+  (* lesS: Id of string (* simpler to merge with AST *) *)
+
+type env = (MV.mvar, value) Hashtbl.t
+
+(* we restrict ourselves to simple expression for now *)
+type code = AST_generic.expr
+
+exception NotHandled
+
+(*****************************************************************************)
+(* Parsing *)
+(*****************************************************************************)
+let parse_metavar s =
+  match s with
+  | "true" | "True" -> Bool (true)
+  | "false" | "False" -> Bool (false)
+  | _ when s =~ "^[0-9]+" -> Int (int_of_string s)
+  | _ when s =~ "^\"\\(.*\\)\"$" -> String (Common.matched1 s)
+  | _ -> AST s
+
+let parse_json file =
+  let json = JSON.load_json file in
+  match json with
+  | J.Object [
+      "metavars", J.Object xs;
+      "language", J.String lang;
+      "code", J.String code;
+      ] ->
+      let lang = Hashtbl.find Lang.lang_of_string_map lang in
+      (* less: could also use Parse_pattern *)
+      let code =
+        match Parse_generic.parse_pattern lang code with
+        | G.E e -> e
+        | _ -> failwith "only expressions are supported"
+      in
+      let metavars = xs |> List.map (fun (s, json) ->
+            match json with
+            | J.String s2 -> s, parse_metavar s2
+            | _ -> failwith "wrong json format for metavar"
+       ) in
+      Common.hash_of_list metavars, code
+
+  | _ -> failwith "wrong json format"
+
+(*****************************************************************************)
+(* Reporting *)
+(*****************************************************************************)
+
+(* less: could use exit code, or return JSON *)
+let print_result xopt =
+  match xopt  with
+  | None -> pr "NONE"
+  | Some v ->
+      (match v with
+      | Bool b -> pr (string_of_bool b)
+      (* allow to abuse int to encode boolean ... ugly C tradition *)
+      | Int 0 -> pr (string_of_bool false)
+      | Int _ -> pr (string_of_bool true)
+      | _ -> pr "NONE"
+      )
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let rec eval env code =
+  match code with
+  | G.L x ->
+      (match x with
+      | G.Bool (b, _t) -> Bool (b)
+      | G.Int (s, _t) -> Int (int_of_string s)
+      | G.String (s, _t) -> String s
+      | _ -> raise NotHandled
+      )
+  | G.Id ((s, _t), _idinfo) ->
+      Hashtbl.find env s
+  | G.Call (G.IdSpecial (G.Op op, _t), (_, args, _)) ->
+      let values = args |> List.map (function
+            | G.Arg e -> eval env e
+            | _ -> raise NotHandled
+        ) in
+      eval_op op values
+  | _ -> raise NotHandled
+
+and eval_op op values =
+  match op, values with
+  | G.Gt, [Int i1; Int i2] -> Bool (i1 > i2)
+  | G.And, [Bool b1; Bool b2] -> Bool (b1 && b2)
+  | G.Eq, [String s1; String s2] -> Bool (s1 = s2)
+  | _ -> raise NotHandled
+
+let debug = ref true
+
+let eval_json_file file =
+  try
+    let (env, code) = parse_json file in
+    let res = eval env code in
+    print_result (Some res)
+  with _exn when not !debug ->
+    print_result None

--- a/semgrep-core/matching/Eval_generic.ml
+++ b/semgrep-core/matching/Eval_generic.ml
@@ -60,7 +60,7 @@ let parse_metavar s =
   match s with
   | "true" | "True" -> Bool (true)
   | "false" | "False" -> Bool (false)
-  | _ when s =~ "^[0-9]+" -> Int (int_of_string s)
+  | _ when s =~ "^[0-9]+$" -> Int (int_of_string s)
   | _ when s =~ "^\"\\(.*\\)\"$" -> String (Common.matched1 s)
   | _ -> AST s
 
@@ -92,7 +92,7 @@ let parse_json file =
 (* Reporting *)
 (*****************************************************************************)
 
-(* less: could use exit code, or return JSON *)
+(* alt: could use exit code, or return JSON *)
 let print_result xopt =
   match xopt  with
   | None -> pr "NONE"

--- a/semgrep-core/matching/Eval_generic.ml
+++ b/semgrep-core/matching/Eval_generic.ml
@@ -105,6 +105,7 @@ let print_result xopt =
       | Int _ -> pr (string_of_bool true)
       | _ -> pr "NONE"
       )
+[@@action]
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/matching/Eval_generic.mli
+++ b/semgrep-core/matching/Eval_generic.mli
@@ -1,0 +1,14 @@
+
+type value
+type env
+type code = AST_generic.expr
+
+val parse_json: Common.filename -> env * code
+
+exception NotHandled
+
+(* raise NotHandled if the code is outside the subset of expressions allowed *)
+val eval: env -> code -> value
+
+(* entry point for -eval *)
+val eval_json_file: Common.filename -> unit

--- a/semgrep-core/matching/Eval_generic.mli
+++ b/semgrep-core/matching/Eval_generic.mli
@@ -3,6 +3,7 @@ type value =
   | Int of int
   | Bool of bool
   | String of string (* string without the enclosing '"' *)
+  | List of value list
   | AST of string (* any AST, e.g., "x+1" *)
 
 type env
@@ -10,7 +11,7 @@ type code = AST_generic.expr
 
 val parse_json: Common.filename -> env * code
 
-exception NotHandled
+exception NotHandled of code
 
 (* raise NotHandled if the code is outside the subset of expressions allowed *)
 val eval: env -> code -> value

--- a/semgrep-core/matching/Eval_generic.mli
+++ b/semgrep-core/matching/Eval_generic.mli
@@ -1,5 +1,10 @@
 
-type value
+type value =
+  | Int of int
+  | Bool of bool
+  | String of string (* string without the enclosing '"' *)
+  | AST of string (* any AST, e.g., "x+1" *)
+
 type env
 type code = AST_generic.expr
 

--- a/semgrep-core/tests/EVAL/in_list.json
+++ b/semgrep-core/tests/EVAL/in_list.json
@@ -1,0 +1,7 @@
+{
+  "metavars": {
+    "$X": "2"
+  },
+  "language": "python",
+  "code": "$X in [1,2,3]"
+}

--- a/semgrep-core/tests/EVAL/simple_expr.json
+++ b/semgrep-core/tests/EVAL/simple_expr.json
@@ -1,0 +1,9 @@
+{
+  "metavars": {
+    "$X": "42",
+    "$Y": "\"foo\"",
+    "$Z": "x+1"
+  },
+  "language": "python",
+  "code": "$X > 0 and $Y == \"foo\""
+}

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -225,6 +225,18 @@ let lint_regression_tests =
   )
 (*e: constant [[Test.lint_regression_tests]] *)
 
+let eval_regression_tests = 
+  "eval regression resting" >:: (fun () ->
+      let dir = Filename.concat tests_path "EVAL" in
+      let files = Common2.glob (spf "%s/*.json" dir) in
+      files |> List.iter (fun file ->
+        let (env, code) = Eval_generic.parse_json file in
+        let res = Eval_generic.eval env code in
+        OUnit.assert_equal ~msg:"it should evaluate to true"
+          (Eval_generic.Bool true) res
+      )
+  )
+
 (*****************************************************************************)
 (* Main action *)
 (*****************************************************************************)
@@ -247,6 +259,7 @@ let test regexp =
       (* TODO Unit_matcher.spatch_unittest ~xxx *)
       (* TODO Unit_matcher_php.unittest; (* sgrep, spatch, refactoring, unparsing *) *)
       lint_regression_tests;
+      eval_regression_tests;
       Unit_files.unittest;
     ]
   in


### PR DESCRIPTION
This is a possible solution to https://github.com/returntocorp/semgrep/issues/1724

test plan:
```
$ cat simple_expr.json
{
  "metavars": {
    "$X": "42",
    "$Y": "\"foo\"",
    "$Z": "x+1"
  },
  "language": "python",
  "code": "$X > 0 and $Y == \"foo\""
}
$ /home/pad/semgrep/_build/default/bin/Main.exe -eval simple_expr.json
true