### PR TITLE
Allow multiple configs

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -58,6 +58,7 @@ def cli() -> None:
         "-f",
         "--config",
         action="append",
+        default=[],
         help=(
             "YAML configuration file, directory of YAML files ending in "
             ".yml|.yaml, URL of a configuration file, or semgrep registry entry "

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -57,6 +57,7 @@ def cli() -> None:
     config_ex.add_argument(
         "-f",
         "--config",
+        action="append",
         help=(
             "YAML configuration file, directory of YAML files ending in "
             ".yml|.yaml, URL of a configuration file, or semgrep registry entry "
@@ -352,9 +353,9 @@ def cli() -> None:
                 args.pattern, args.lang, args.config
             )
             valid_str = "invalid" if config_errors else "valid"
-            rule_count = sum(len(rules) for rules in configs.values())
+            rule_count = len(configs.get_rules(True))
             logger.info(
-                f"Configuration is {valid_str} - found {len(configs)} valid configuration(s), {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
+                f"Configuration is {valid_str} - found {len(configs.valid)} valid configuration(s), {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
             )
             if config_errors:
                 for error in config_errors:
@@ -368,7 +369,7 @@ def cli() -> None:
                 target=target,
                 pattern=args.pattern,
                 lang=args.lang,
-                config=args.config,
+                configs=args.config,
                 no_rewrite_rule_ids=args.no_rewrite_rule_ids,
                 jobs=args.jobs,
                 include=args.include,

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -200,13 +200,13 @@ def main(
             f"running {len(all_rules)} rules from {len(configs_obj.valid)} config{plural} {config_id_if_single} {invalid_msg}"
         )
 
-        notify_user_of_work(all_rules, include, exclude)
-
         if len(configs_obj.valid) == 0:
             raise SemgrepError(
                 f"no valid configuration file found ({len(errors)} configs were invalid)",
                 code=MISSING_CONFIG_EXIT_CODE,
             )
+
+        notify_user_of_work(all_rules, include, exclude)
 
     respect_git_ignore = not no_git_ignore
     target_manager = TargetManager(

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -30,94 +30,10 @@ from semgrep.target_manager import TargetManager
 
 logger = logging.getLogger(__name__)
 
-MISSING_RULE_ID = "no-rule-id"
-
-
-def validate_single_rule(
-    config_id: str, rule_yaml: YamlTree[YamlMap]
-) -> Optional[Rule]:
-    """
-        Validate that a rule dictionary contains all necessary keys
-        and can be correctly parsed.
-    """
-    rule: YamlMap = rule_yaml.value
-
-    # Defaults to search mode if mode is not specified
-    return Rule.from_yamltree(rule_yaml)
-
-
-def validate_configs(
-    configs: Dict[str, YamlTree],
-) -> Tuple[Dict[str, List[Rule]], List[SemgrepError]]:
-    """
-        Take configs and separate into valid and list of errors parsing the invalid ones
-    """
-    errors: List[SemgrepError] = []
-    valid: Dict[str, Any] = {}
-    for config_id, config_yaml_tree in configs.items():
-        config = config_yaml_tree.value
-        if not isinstance(config, YamlMap):
-            errors.append(SemgrepError(f"{config_id} was not a mapping"))
-            continue
-
-        rules = config.get(RULES_KEY)
-        if rules is None:
-            errors.append(
-                InvalidRuleSchemaError(
-                    short_msg="missing keys",
-                    long_msg=f"{config_id} is missing `{RULES_KEY}` as top-level key",
-                    spans=[config_yaml_tree.span.truncate(lines=5)],
-                )
-            )
-            continue
-        valid_rules = []
-        for rule_dict in rules.value:
-
-            try:
-                rule = validate_single_rule(config_id, rule_dict)
-            except InvalidRuleSchemaError as ex:
-                errors.append(ex)
-            else:
-                valid_rules.append(rule)
-
-        if valid_rules:
-            valid[config_id] = valid_rules
-    return valid, errors
-
-
-def safe_relative_to(a: Path, b: Path) -> Path:
-    try:
-        return a.relative_to(b)
-    except ValueError:
-        # paths had no common prefix; not possible to relativize
-        return a
-
-
-def convert_config_id_to_prefix(config_id: str) -> str:
-    at_path = Path(config_id)
-    at_path = safe_relative_to(at_path, Path.cwd())
-
-    prefix = ".".join(at_path.parts[:-1]).lstrip("./").lstrip(".")
-    if len(prefix):
-        prefix += "."
-    return prefix
-
-
-def rename_rule_ids(valid_configs: Dict[str, List[Rule]]) -> Dict[str, List[Rule]]:
-    transformed = {}
-    for config_id, rules in valid_configs.items():
-        transformed[config_id] = [
-            rule.with_id(
-                f"{convert_config_id_to_prefix(config_id)}{rule.id or MISSING_RULE_ID}"
-            )
-            for rule in rules
-        ]
-    return transformed
-
 
 def get_config(
-    pattern: str, lang: str, config: str
-) -> Tuple[Dict[str, List[Rule]], List[SemgrepError]]:
+    pattern: str, lang: str, config_strs: List[str]
+) -> Tuple[semgrep.config_resolver.Config, List[SemgrepError]]:
     # let's check for a pattern
     if pattern:
         # and a language
@@ -125,26 +41,18 @@ def get_config(
             raise SemgrepError("language must be specified when a pattern is passed")
 
         # TODO for now we generate a manual config. Might want to just call semgrep -e ... -l ...
-        configs = semgrep.config_resolver.manual_config(pattern, lang)
+        config, errors = semgrep.config_resolver.Config.from_pattern_lang(pattern, lang)
     else:
         # else let's get a config. A config is a dict from config_id -> config. Config Id is not well defined at this point.
-        try:
-            configs = semgrep.config_resolver.resolve_config(config)
-        except SemgrepError as e:
-            return {}, [e]
+        config, errors = semgrep.config_resolver.Config.from_config_list(config_strs)
 
     # if we can't find a config, use default r2c rules
-    if not configs:
+    if not config:
         raise SemgrepError(
             f"No config given and {DEFAULT_CONFIG_FILE} was not found. Try running with --help to debug or if you want to download a default config, try running with --config r2c"
         )
 
-    valid_configs, error = validate_configs(configs)
-    return valid_configs, error
-
-
-def flatten_configs(transformed_configs: Dict[str, List[Rule]]) -> List[Rule]:
-    return [rule for rules in transformed_configs.values() for rule in rules]
+    return config, errors
 
 
 def notify_user_of_work(
@@ -234,7 +142,7 @@ def invoke_semgrep(config: Path, targets: List[Path], **kwargs: Any) -> Any:
         target=[str(t) for t in targets],
         pattern="",
         lang="",
-        config=str(config),
+        configs=[str(config)],
         **kwargs,
     )
     output_handler.close()
@@ -246,7 +154,7 @@ def main(
     target: List[str],
     pattern: str,
     lang: str,
-    config: str,
+    configs: List[str],
     no_rewrite_rule_ids: bool = False,
     jobs: int = 1,
     include: Optional[List[str]] = None,
@@ -269,42 +177,34 @@ def main(
     if exclude is None:
         exclude = []
 
-    valid_configs, config_errors = get_config(pattern, lang, config)
+    configs_obj, errors = get_config(pattern, lang, configs)
+    all_rules = configs_obj.get_rules(no_rewrite_rule_ids)
 
-    output_handler.handle_semgrep_errors(config_errors)
+    output_handler.handle_semgrep_errors(errors)
 
-    if config_errors and strict:
+    if errors and strict:
         raise SemgrepError(
-            f"run with --strict and there were {len(config_errors)} errors loading configs",
+            f"run with --strict and there were {len(errors)} errors loading configs",
             code=MISSING_CONFIG_EXIT_CODE,
         )
 
-    if not no_rewrite_rule_ids:
-        # re-write the configs to have the hierarchical rule ids
-        valid_configs = rename_rule_ids(valid_configs)
-
-    # extract just the rules from valid configs
-    all_rules = flatten_configs(valid_configs)
-
     if not pattern:
-        plural = "s" if len(valid_configs) > 1 else ""
+        plural = "s" if len(configs_obj.valid) > 1 else ""
         config_id_if_single = (
-            list(valid_configs.keys())[0] if len(valid_configs) == 1 else ""
+            list(configs_obj.valid.keys())[0] if len(configs_obj.valid) == 1 else ""
         )
         invalid_msg = (
-            f"({len(config_errors)} config files were invalid)"
-            if len(config_errors)
-            else ""
+            f"({len(errors)} config files were invalid)" if len(errors) else ""
         )
         logger.debug(
-            f"running {len(all_rules)} rules from {len(valid_configs)} config{plural} {config_id_if_single} {invalid_msg}"
+            f"running {len(all_rules)} rules from {len(configs_obj.valid)} config{plural} {config_id_if_single} {invalid_msg}"
         )
 
         notify_user_of_work(all_rules, include, exclude)
 
-        if len(valid_configs) == 0:
+        if len(configs_obj.valid) == 0:
             raise SemgrepError(
-                f"no valid configuration file found ({len(config_errors)} configs were invalid)",
+                f"no valid configuration file found ({len(errors)} configs were invalid)",
                 code=MISSING_CONFIG_EXIT_CODE,
             )
 

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__implicit/error.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__implicit/error.json
@@ -1,1 +1,1 @@
-{"results": [], "errors": [{"type": "SemgrepError", "code": 2, "message": "No config given and .semgrep.yml was not found. Try running with --help to debug or if you want to download a default config, try running with --config r2c"}]}
+{"results": [], "errors": [{"type": "SemgrepError", "code": 7, "message": "no valid configuration file found (0 configs were invalid)"}]}

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__implicit/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__implicit/error.txt
@@ -1,1 +1,1 @@
-No config given and .semgrep.yml was not found. Try running with --help to debug or if you want to download a default config, try running with --config r2c
+no valid configuration file found (0 configs were invalid)

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -103,12 +103,12 @@ def test_hidden_rule__explicit(run_semgrep_in_tmp, snapshot):
 def test_hidden_rule__implicit(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/hidden")
-    assert excinfo.value.returncode == 2
+    assert excinfo.value.returncode == 7
     snapshot.assert_match(excinfo.value.stdout, "error.json")
 
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/hidden", output_format="normal")
-    assert excinfo.value.returncode == 2
+    assert excinfo.value.returncode == 7
     snapshot.assert_match(excinfo.value.stderr, "error.txt")
 
 

--- a/semgrep/tests/unit/test_yaml_parsing.py
+++ b/semgrep/tests/unit/test_yaml_parsing.py
@@ -1,6 +1,6 @@
 from semgrep.config_resolver import parse_config_string
+from semgrep.config_resolver import validate_single_rule
 from semgrep.constants import RULES_KEY
-from semgrep.semgrep_main import validate_single_rule
 
 
 def test_parse_taint_rules():


### PR DESCRIPTION
Multiple config files can now be passed to semgrep cli `semgrep --config foo.yaml --config bar.yaml`

Also refactors config handling logic to it's own class