### PR TITLE
Use easy_logging to log information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ semgrep-core/bin/version.ml
 /semgrep-core/layer_bottomup.json
 /semgrep-core/layer_graphcode_stats.json
 /semgrep-core/layer_topdown.json
+/semgrep-core/log_config.json

--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -21,7 +21,7 @@ module J = JSON
 (*****************************************************************************)
 (* A semantic grep. https://semgrep.dev/
  * Right now there is good support for Python, Javascript (and JSON), Java,
- * Go, and C and partial support for PHP, C++, and OCaml.
+ * Go, and C and partial support for Typescript, Ruby, PHP, C++, and OCaml.
  *
  * opti: git grep foo | xargs semgrep -e 'foo(...)'
  *
@@ -54,6 +54,9 @@ module J = JSON
  *)
 let env_debug = "SEMGREP_CORE_DEBUG"
 let env_profile = "SEMGREP_CORE_PROFILE"
+
+let logger = Logging.get_logger [__MODULE__]
+let log_config_file = ref "log_config.json"
 
 (* see also verbose/... flags in Flag_semgrep.ml *)
 (* to test things *)
@@ -306,7 +309,7 @@ let cache_computation file cache_file_of_file f =
       let file_cache = cache_file_of_file file in
       if Sys.file_exists file_cache && filemtime file_cache >= filemtime file
       then begin
-        if !Flag.debug then pr2 ("using cache: " ^ file_cache);
+        logger#info "using cache: %s" file_cache;
         let (version, file2, res) = Common2.get_value file_cache in
         if version <> Version.version
         then failwith (spf "Version mismatch! Clean the cache file %s"
@@ -349,7 +352,7 @@ let timeout_function = fun f ->
   let timeout = !timeout in
   if timeout <= 0.
   then f ()
-  else Common.timeout_function_float ~verbose:!Flag.debug timeout f
+  else Common.timeout_function_float ~verbose:false timeout f
 
 (* from https://discuss.ocaml.org/t/todays-trick-memory-limits-with-gc-alarms/4431 *)
 let run_with_memory_limit limit_mb f =
@@ -361,8 +364,7 @@ let run_with_memory_limit limit_mb f =
       let mem = (Gc.quick_stat ()).Gc.heap_words in
       if mem > limit / (Sys.word_size / 8)
       then begin
-          if !Flag.debug
-          then pr2 (spf "maxout allocated memory: %d" (mem*(Sys.word_size/8)));
+          logger#info "maxout allocated memory: %d" (mem*(Sys.word_size/8));
           raise Out_of_memory
         end
     in
@@ -562,9 +564,8 @@ let get_final_files xs =
 let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
   let matches_and_errors =
     files |> map (fun file ->
-       if !Flag.debug then pr2 (spf "Analyzing %s" file);
+       logger#info "Analyzing %s" file;
        let lang = lang_of_string !lang in
-       if !Flag.debug then pr2 (spf "PARSING: %s" file);
        try
          run_with_memory_limit !max_memory (fun () ->
          timeout_function (fun () ->
@@ -617,8 +618,7 @@ let print_matches_and_errors files matches errs =
      "stats", stats
   ] in
   let s = J.string_of_json json in
-  if !Flag.debug
-  then pr2 ("returned JSON: "^ s);
+  logger#debug "returned JSON: %s" s;
   pr s
 (*e: function [[Main_semgrep_core.print_matches_and_errors]] *)
 
@@ -663,8 +663,7 @@ let semgrep_with_one_pattern xs =
 
   files |> List.iter (fun file ->
     (*s: [[Main_semgrep_core.semgrep_with_one_pattern()]] if [[verbose]] *)
-    if !Flag.debug
-    then pr2 (spf "processing: %s" file);
+    logger#info "processing: %s" file;
     (*e: [[Main_semgrep_core.semgrep_with_one_pattern()]] if [[verbose]] *)
     let process file =
         timeout_function (fun () ->
@@ -700,7 +699,7 @@ let semgrep_with_one_pattern xs =
  *)
 let semgrep_with_rules rules_file xs =
   (*s: [[Main_semgrep_core.semgrep_with_rules()]] if [[verbose]] *)
-  if !Flag.debug then pr2 (spf "Parsing %s" rules_file);
+  logger#info "Parsing %s" rules_file;
   (*e: [[Main_semgrep_core.semgrep_with_rules()]] if [[verbose]] *)
   let rules = Parse_rules.parse rules_file in
   let files = get_final_files xs in
@@ -736,7 +735,7 @@ module TR = Tainting_rule
 
 (*s: function [[Main_semgrep_core.tainting_with_rules]] *)
 let tainting_with_rules rules_file xs =
-  if !Flag.debug then pr2 (spf "Parsing %s" rules_file);
+  logger#info "Parsing %s" rules_file;
   let rules = Parse_tainting_rules.parse rules_file in
 
   let files = get_final_files xs in
@@ -912,8 +911,7 @@ let all_actions () = [
   Common.mk_action_2_arg Test_synthesizing.synthesize_patterns;
 
   "-test_parse_lang", " <files or dirs>",
-  Common.mk_action_n_arg
-    (Test_parsing.test_parse_lang !Flag.debug !lang get_final_files);
+  Common.mk_action_n_arg (Test_parsing.test_parse_lang !lang get_final_files);
   "-dump_tree_sitter_cst", " <file>",
   Common.mk_action_1_arg Test_parsing.dump_tree_sitter_cst;
   "-dump_ast_pfff", " <file>",
@@ -994,10 +992,10 @@ let options () =
     " do not filter rules";
     "-tree_sitter_only", Arg.Set Flag.tree_sitter_only,
     " only use tree-sitter-based parsers";
-    "-debug", Arg.Set Flag.debug,
-    " add debugging information in the output (tracing)";
     "-debug_matching", Arg.Set Flag.debug_matching,
-    " add more debugging information on matching";
+    " raise an exception at the first match failure";
+    "-log_config_file", Arg.Set_string log_config_file,
+    " <file> logging configuration file";
     "-test", Arg.Set test,
     " (internal) set test context";
     "-target_file", Arg.Set_string target_file,
@@ -1099,14 +1097,17 @@ let main () =
   end
   in
 
-  if !Flag.debug then begin
-    pr2 "Debug mode On";
-    pr2 (spf "Executed as: %s" (Sys.argv|>Array.to_list|> String.concat " "));
-    pr2 version;
+  if Sys.file_exists !log_config_file
+  then begin
+      Logging.load_config_file !log_config_file;
+      logger#info "loaded %s" !log_config_file;
   end;
+
+  logger#info "Executed as: %s" (Sys.argv|>Array.to_list|> String.concat " ");
+  logger#info "Version: %s" version;
   if !profile then begin
-    pr2 "Profile mode On";
-    pr2 "disabling -j when in profiling mode";
+    logger#info "Profile mode On";
+    logger#info "disabling -j when in profiling mode";
     ncores := 1;
   end;
 
@@ -1136,7 +1137,8 @@ let main () =
                semgrep_with_rules !rules_file (x::xs);
                if !profile then save_rules_file_in_tmp ();
             with exn -> begin
-             if !Flag.debug then save_rules_file_in_tmp ();
+             logger#debug "exn before exit %s" (Common.exn_to_s exn);
+             (* if !Flag.debug then save_rules_file_in_tmp (); *)
              pr (format_output_exception exn);
              exit 2
              end

--- a/semgrep-core/bin/dune
+++ b/semgrep-core/bin/dune
@@ -30,6 +30,7 @@
     tree-sitter-lang.java
 
     ; internal deps
+    semgrep_utils
     semgrep_core
     semgrep_fuzzy
     semgrep_finding

--- a/semgrep-core/core/Flag_semgrep.ml
+++ b/semgrep-core/core/Flag_semgrep.ml
@@ -1,10 +1,6 @@
 (*s: semgrep/core/Flag_semgrep.ml *)
 (*s: constant [[Flag_semgrep.verbose]] *)
-(* unused for now *)
-let _verbose = ref false
 (*e: constant [[Flag_semgrep.verbose]] *)
-
-let debug = ref false
 
 (*s: constant [[Flag_semgrep.debug]] *)
 (* note that this will stop at the first fail(), but if you restrict

--- a/semgrep-core/log_config.json.ex1
+++ b/semgrep-core/log_config.json.ex1
@@ -1,0 +1,18 @@
+{
+    "loggers":
+        [
+            { "name": "Main", "level": "debug",
+              "handlers": [ {"cli_err": {"level" : "debug"}} ]
+            },
+            { "name": "Main.Dune__exe__Main", "level": "debug" },
+            { "name": "Main.Eval_generic", "level": "debug" },
+            { "name": "Main.Rules_filter", "level": "debug" },
+            { "name": "Main.Test_parsing", "level": "debug" },
+            { "name": "Main.Generic_vs_generic", "level": "debug" },
+            { "name": "Main.Matching_generic", "level": "debug" },
+            { "name": "XXX", "level": "error" }
+        ],
+   "handlers": {
+        "file_handlers": { "logs_folder" : "logs", "truncate" : false }
+    }
+}

--- a/semgrep-core/log_config.json.ex2
+++ b/semgrep-core/log_config.json.ex2
@@ -1,0 +1,18 @@
+{
+    "loggers":
+        [
+            { "name": "Main", "level": "debug",
+              "handlers": [ {"file": {"filename": "semgrep.log", "level" : "info"}} ]
+            },
+            { "name": "Main.Dune__exe__Main", "level": "debug" },
+            { "name": "Main.Eval_generic", "level": "debug" },
+            { "name": "Main.Rules_filter", "level": "debug" },
+            { "name": "Main.Test_parsing", "level": "debug" },
+            { "name": "Main.Generic_vs_generic", "level": "debug" },
+            { "name": "Main.Matching_generic", "level": "debug" },
+            { "name": "XXX", "level": "error" }
+        ],
+   "handlers": {
+        "file_handlers": { "logs_folder" : "logs", "truncate" : false }
+    }
+}

--- a/semgrep-core/matching/Eval_generic.ml
+++ b/semgrep-core/matching/Eval_generic.ml
@@ -174,5 +174,6 @@ let eval_json_file file =
    | NotHandled e ->
       logger#sdebug (G.show_any (G.E e));
       print_result None
-   | _exn ->
-    print_result None
+   | exn ->
+      logger#debug "exn: %s" (Common.exn_to_s exn);
+      print_result None

--- a/semgrep-core/matching/Eval_generic.ml
+++ b/semgrep-core/matching/Eval_generic.ml
@@ -27,7 +27,7 @@ module J = JSON
  * expressions.
  *)
 
-[@@@warning "-37"]
+let logger = Logging.get_logger [__MODULE__]
 
 (*****************************************************************************)
 (* Types *)
@@ -165,16 +165,14 @@ and eval_op op values code =
 
   | _ -> raise (NotHandled code)
 
-let debug = ref false
-
 let eval_json_file file =
   try
     let (env, code) = parse_json file in
     let res = eval env code in
     print_result (Some res)
   with
-   | NotHandled e when !debug ->
-      pr2 (G.show_any (G.E e));
-      raise (NotHandled e)
-   | _exn when not !debug ->
+   | NotHandled e ->
+      logger#sdebug (G.show_any (G.E e));
+      print_result None
+   | _exn ->
     print_result None

--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -34,6 +34,8 @@ module Flag = Flag_semgrep
 
 open Matching_generic
 
+let logger = Logging.get_logger [__MODULE__]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -1355,8 +1357,7 @@ and _m_stmts (xsa: A.stmt list) (xsb: A.stmt list) =
 (*s: function [[Generic_vs_generic.m_list__m_stmt]] *)
 and m_list__m_stmt (xsa: A.stmt list) (xsb: A.stmt list) =
   (*s: [[Generic_vs_generic.m_list__m_stmt]] if [[debug]] *)
-  if !Flag.debug_matching
-  then pr2 (spf "%d vs %d" (List.length xsa) (List.length xsb));
+  logger#debug "%d vs %d" (List.length xsa) (List.length xsb);
   (*e: [[Generic_vs_generic.m_list__m_stmt]] if [[debug]] *)
   match xsa, xsb with
   | [], [] ->

--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -24,6 +24,8 @@ module Lib = Lib_AST
 module AST = AST_generic
 module Flag = Flag_semgrep
 
+let logger = Logging.get_logger [__MODULE__]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -106,7 +108,7 @@ type ('a, 'b) matcher = 'a -> 'b -> tin -> tout
 (*****************************************************************************)
 (*s: function [[Matching_generic.str_of_any]] *)
 let str_of_any any =
-  if !Flag.debug_matching && !Flag.debug_with_full_position
+  if !Flag.debug_with_full_position
   then Meta_parse_info._current_precision :=
     { Meta_parse_info.default_dumper_precision with Meta_parse_info.
       full_info = true };
@@ -242,12 +244,9 @@ let rec equal_ast_binded_code (a: AST.any) (b: AST.any) : bool = (
       false
   ) in
 
-  if !Flag.debug_matching && not res
-  then begin
-    pr2 (spf "A = %s" (str_of_any a));
-    pr2 (spf "B = %s" (str_of_any b));
-  end;
-
+  if not res
+  then logger#ldebug (lazy (spf "A = %s\nB = %s\n"
+                (str_of_any a) (str_of_any b)));
   res
 )
 (*e: function [[Matching_generic.equal_ast_binded_code]] *)
@@ -275,14 +274,12 @@ let (envf: (MV.mvar AST.wrap, AST.any) matcher) =
   match check_and_add_metavar_binding (mvar, any) tin with
   | None ->
       (*s: [[Matching_generic.envf]] if [[verbose]] when fail *)
-      if !Flag.debug_matching
-      then pr2 (spf "envf: fail, %s (%s)" mvar (str_of_any any));
+      logger#ldebug (lazy (spf "envf: fail, %s (%s)" mvar (str_of_any any)));
       (*e: [[Matching_generic.envf]] if [[verbose]] when fail *)
       fail tin
   | Some new_binding ->
       (*s: [[Matching_generic.envf]] if [[verbose]] when success *)
-      if !Flag.debug_matching
-      then pr2 (spf "envf: success, %s (%s)" mvar (str_of_any any));
+      logger#ldebug (lazy (spf "envf: success, %s (%s)" mvar(str_of_any any)));
       (*e: [[Matching_generic.envf]] if [[verbose]] when success *)
       return new_binding
 (*e: function [[Matching_generic.envf]] *)

--- a/semgrep-core/matching/Rules_filter.ml
+++ b/semgrep-core/matching/Rules_filter.ml
@@ -12,7 +12,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
  *)
-open Common
 module Flag = Flag_semgrep
 module R = Rule
 module V = Visitor_AST
@@ -40,6 +39,7 @@ open AST_generic
  *  - we could even avoid parsing the file by using a lazy AST
  *    in Semgrep_generic.check.
  *)
+let logger = Logging.get_logger [__MODULE__]
 
 (*****************************************************************************)
 (* Helpers  *)
@@ -144,8 +144,8 @@ let filter_rules_relevant_to_file_using_regexp rules lang file =
     )
 
     in
-    if !Flag.debug && not match_
-    then pr2 (spf "filtering rule %s" rule.R.id);
+    if not match_
+    then logger#info "filtering rule %s" rule.R.id;
     match_
     )
 [@@profiling "Rules_filter.filter"]

--- a/semgrep-core/matching/dune
+++ b/semgrep-core/matching/dune
@@ -7,9 +7,9 @@
    pfff-config
    pfff-h_program-lang
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
-   pfff-lang_js pfff-lang_js-analyze
+   pfff-lang_js pfff-lang_js-analyze  ; for Ast_js.default_entity
 
-
+   semgrep_utils
    semgrep_core
    semgrep_typing
  )

--- a/semgrep-core/parsing/Test_parsing.ml
+++ b/semgrep-core/parsing/Test_parsing.ml
@@ -16,6 +16,8 @@ open Common
 module PI = Parse_info
 module G = AST_generic
 
+let logger = Logging.get_logger [__MODULE__]
+
 (* less: could infer lang from filename *)
 let dump_tree_sitter_cst_lang lang file =
    match lang with
@@ -59,7 +61,7 @@ let dump_ast_pfff file =
 (* mostly a copy paste of Test_parsing_ruby.test_parse in pfff but using
  * the tree-sitter Ruby parser instead.
  *)
-let test_parse_lang verbose lang get_final_files xs =
+let test_parse_lang lang get_final_files xs =
   let xs = List.map Common.fullpath xs in
   let fullxs = get_final_files xs
       |> Skip_code.filter_files_if_skip_list ~root:xs
@@ -73,7 +75,7 @@ let test_parse_lang verbose lang get_final_files xs =
   let stat_list = ref [] in
   fullxs |> Console.progress (fun k -> List.iter (fun file ->
     k();
-    if verbose then pr2 (spf "processing %s" file);
+    logger#info "processing %s" file;
     let stat =
     (try
        if true

--- a/semgrep-core/parsing/Test_parsing.mli
+++ b/semgrep-core/parsing/Test_parsing.mli
@@ -1,5 +1,5 @@
 
-val test_parse_lang: bool -> string ->
+val test_parse_lang: string ->
   (Common.filename list -> Common.filename list) -> Common.filename list ->
   unit
 

--- a/semgrep-core/parsing/dune
+++ b/semgrep-core/parsing/dune
@@ -21,6 +21,7 @@
    pfff-lang_go pfff-lang_go-analyze
    pfff-lang_js pfff-lang_js-analyze
 
+   semgrep_utils
    semgrep_core
  )
  (preprocess (pps ppx_profiling ppx_sexp_conv))

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -16,6 +16,7 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 
 depends: [
   "dune"
+  "dune-build-info"
   "ocamlgraph"
   "yojson"
   "yaml"

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -16,7 +16,6 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 
 depends: [
   "dune"
-  "dune-build-info"
   "ocamlgraph"
   "yojson"
   "yaml"

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -20,6 +20,7 @@ depends: [
   "ocamlgraph"
   "yojson"
   "yaml"
+  "easy_logging_yojson"
   "grain_dypgen"
   "menhir"
   "uucp"

--- a/semgrep-core/tainting/Tainting_generic.ml
+++ b/semgrep-core/tainting/Tainting_generic.ml
@@ -28,6 +28,7 @@ module Flag = Flag_semgrep
  * Here we pass matcher functions that uses semgrep patterns to
  * describe the source/sink/sanitizers.
  *)
+let _logger = Logging.get_logger [__MODULE__]
 
 (*****************************************************************************)
 (* Helpers *)
@@ -100,8 +101,11 @@ let check rules file ast =
             ) in
             let config = config_of_rule found_tainted_sink rule in
             let mapping = Dataflow_tainting.fixpoint config flow in
-            if !Flag.debug
-            then DataflowY.display_mapping flow mapping (fun () -> "()");
+            ignore (mapping);
+(* TODO
+            logger#sdebug (DataflowY.mapping_to_str flow
+                             (fun () -> "()") mapping);
+*)
           )
       );
    } in

--- a/semgrep-core/utils/Logging.ml
+++ b/semgrep-core/utils/Logging.ml
@@ -1,0 +1,64 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Small wrapper around the easy_logging library.
+ *
+ * My requirements for a logging library are:
+ *  (1) different log levels (Debug, Info, Warning, Error)
+ *  (2) easy logging calls with sprintf style formatting by default
+ *  (3) ability to log on stdout/stderr or in a file
+ *  (4) easy one-line logger creation
+ *  (5) hierarchical loggers where you can enable/disable a whole set
+ *      of loggers
+ *  (6) configurable with an external log config file
+ *
+ * There are a few OCaml logging libraries, but they usually miss one or more
+ * of the requirements above:
+ *  - Logs: popular library according to OPAM metrics. Howver, Logs is heavily
+ *    functorized (no (4)), and it requires to encapsulate your logging calls
+ *    in a closure 'Log.info (fun m -> m "xxx")' (no (2)). It also lacks
+ *    (5) and (6).
+ *  - dolog: very basic logging library, very easy to use with (1), (2),
+ *    but lacks especially (5) and (6)
+ *  - Bolt: not updated since 2013
+ *  - merlin/logging.ml: not available directly under OPAM and seems
+ *    more limited than easy_logging
+ *  - easy_logging: not really popular according to OPAM (no package depends
+ *    on it), use OCaml objects, some documentation but no good examples,
+ *    some unintuitive interfaces, some issues to compile without -42
+ *    due to ambiguous constructors, 0.8 still not in OPAM, etc.
+ *    But, it supports all the requirements if you know how to use it!
+ * => I use easy_logging (actually I use easy_logging_yojson for (6))
+ *
+ *)
+open Easy_logging_yojson
+
+(*****************************************************************************)
+(* Entry points *)
+(*****************************************************************************)
+
+(* it takes a list, so you can have a deep hierarchy like
+ * get_logger ["Generic_vs_generic"; "Env"]
+ *)
+let get_logger xs =
+  let final_name = ("Main"::xs) |> String.concat "." in
+  Logging.get_logger final_name
+
+(* see log_config.json for an example of configuration *)
+let load_config_file file =
+  Logging.load_global_config_file file

--- a/semgrep-core/utils/dune
+++ b/semgrep-core/utils/dune
@@ -1,0 +1,8 @@
+(library
+ (public_name semgrep_utils)
+ (wrapped false)
+ (libraries
+   easy_logging_yojson
+ )
+ (preprocess (pps ppx_profiling))
+)


### PR DESCRIPTION
I was manually using some 'let debug = ref true' to enable/disable logging
which is ugly. Better to use a logging library a la Python to
log information

test plan:

$ /home/pad/semgrep/_build/default/bin/Main.exe -log_config_file log_config.json.ex1 -lang go -f tests/GENERIC/metavar_arg.sgrep tests/go/metavar_arg.go

[0.105  Info       Main.Dune__exe__Main ] loaded log_config.json.ex1
[0.105  Info       Main.Dune__exe__Main ] Executed as: /home/pad/semgrep/_build/default/bin/Main.exe -log_config_file log_config.json.ex1 -lang go -f tests/GENERIC/metavar_arg.sgrep tests/go/metavar_arg.go
[0.105  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.24.0-32-g4192ff27-dirty, pfff: 0.42
[0.106  Info       Main.Dune__exe__Main ] processing: tests/go/metavar_arg.go
[0.107  Debug      Main.Matching_generic] envf: success, $X ((E (L (Int ("1", ())))))
...

$ /home/pad/semgrep/_build/default/bin/Main.exe -log_config_file log_config.json.ex2 -lang go -f tests/GENERIC/metavar_arg.sgrep tests/go/metavar_arg.go
tests/go/metavar_arg.go:5
     foo(1,2)
tests/go/metavar_arg.go:8
     foo(a_very_long_constant_name,
         2)
tests/go/metavar_arg.go:12
     foo (unsafe(), // indeed
          2)
tests/go/metavar_arg.go:16
     foo(bar(1,3), 2)

$ cat logs/20200929_semgrep.log.log
0.089  Info       Main.Dune__exe__Main loaded log_config.json.ex2
0.089  Info       Main.Dune__exe__Main Executed as: /home/pad/semgrep/_build/default/bin/Main.exe -log_config_file log_config.json.ex2 -lang go -f tests/GENERIC/metavar_arg.sgrep tests/go/metavar_arg.go
0.089  Info       Main.Dune__exe__Main Version: semgrep-core version: v0.24.0-32-g4192ff27-dirty, pfff: 0.42
0.090  Info       Main.Dune__exe__Main processing: tests/go/metavar_arg.go
TOAMEND