### PR TITLE
Fixing -target_file with files without newlines

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -1112,12 +1112,7 @@ let main () =
 
   (* does side effect on many global flags *)
   let args = Common.parse_options (options()) usage_msg (Array.of_list argv) in
-  let args = if !target_file="" then args else
-  begin
-    let s = Common.read_file !target_file in
-    String.split_on_char '\n' s
-  end
-  in
+  let args = if !target_file = "" then args else Common.cat !target_file in
 
   if Sys.file_exists !log_config_file
   then begin

--- a/semgrep-core/tests/OTHER/target_file/target_file.list
+++ b/semgrep-core/tests/OTHER/target_file/target_file.list
@@ -1,0 +1,1 @@
+tests/js/concrete_syntax.js

--- a/semgrep-core/tests/OTHER/target_file/target_file_newline.list
+++ b/semgrep-core/tests/OTHER/target_file/target_file_newline.list
@@ -1,0 +1,1 @@
+tests/js/concrete_syntax.js


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/1746

test plan:
$ /home/pad/semgrep/_build/default/bin/Main.exe -lang js -e FOO -target_file tests/OTHER/target_file/target_file_newline.list
[0.112  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.112  Info       Main.Dune__exe__Main ] Executed as: /home/pad/semgrep/_build/default/bin/Main.exe -lang js -e FOO -target_file tests/OTHER/target_file/target_file_newline.list
[0.112  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.24.0-35-gbe3d77e7-dirty, pfff: 0.42
[0.112  Info       Main.Dune__exe__Main ] processing: tests/js/concrete_syntax.js
[0.112  Info       Main.Parse_code      ] trying to parse with TreeSitter parser tests/js/concrete_syntax.js

$ /home/pad/semgrep/_build/default/bin/Main.exe -lang js -e FOO -target_file tests/OTHER/target_file/target_file.list
[0.077  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.077  Info       Main.Dune__exe__Main ] Executed as: /home/pad/semgrep/_build/default/bin/Main.exe -lang js -e FOO -target_file tests/OTHER/target_file/target_file.list
[0.077  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.24.0-35-gbe3d77e7-dirty, pfff: 0.42
[0.078  Info       Main.Dune__exe__Main ] processing: tests/js/concrete_syntax.js
[0.078  Info       Main.Parse_code      ] trying to parse with TreeSitter parser tests/js/concrete_syntax.js

No more exn.