### PR TITLE
Convert tree-sitter parse error exn to Parse_info.Parsing_error

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -582,17 +582,6 @@ let get_final_files xs =
   Common2.uniq_eff (files @ explicit_files)
 (*e: function [[Main_semgrep_core.get_final_files]] *)
 
-let mk_tree_sitter_error (err : Tree_sitter_run.Tree_sitter_error.t) =
-  let start = err.start_pos in
-  let loc = {
-    PI.str = err.substring;
-    charpos = 0; (* fake *)
-    line = start.row + 1;
-    column = start.column;
-    file = err.file.name;
-  } in
-  Error_code.({ loc; typ = ParseError; sev = Error })
-
 (*s: function [[Main_semgrep_core.iter_generic_ast_of_files_and_get_matches_and_exn_to_errors]] *)
 let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
   let matches_and_errors =
@@ -632,8 +621,6 @@ let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
               | Out_of_memory -> Error_code.OutOfMemory str_opt
               | _ -> raise Impossible
               )]
-        | Tree_sitter_run.Tree_sitter_error.Error ts_error ->
-            [], [mk_tree_sitter_error ts_error]
         | exn ->
             [], [Error_code.exn_to_error file exn]
     )

--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -2219,6 +2219,7 @@ and declaration (env : env) (x : CST.declaration) =
 (* Entry point *)
 (*****************************************************************************)
 let parse file =
+ H.convert_tree_sitter_exn_to_pfff_exn (fun () ->
   let ast =
     Parallel.backtrace_when_exn := false;
     Parallel.invoke Tree_sitter_csharp.Parse.file file ()
@@ -2236,3 +2237,4 @@ let parse file =
       pr2 "Original backtrace:";
       pr2 s;
       raise exn
+ )

--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -1317,6 +1317,7 @@ let source_file (env : env) (xs : CST.source_file) : program =
 (*****************************************************************************)
 
 let parse file =
+ H.convert_tree_sitter_exn_to_pfff_exn (fun () ->
   let ast =
     Parallel.backtrace_when_exn := false;
     Parallel.invoke Tree_sitter_go.Parse.file file ()
@@ -1324,3 +1325,4 @@ let parse file =
   let env = { H.file; conv = H.line_col_to_pos file } in
   let x = source_file env ast in
   x
+ )

--- a/semgrep-core/parsing/Parse_java_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_java_tree_sitter.ml
@@ -1929,9 +1929,11 @@ let program (env : env) (xs : CST.program) =
 (*****************************************************************************)
 
 let parse file =
+ H.convert_tree_sitter_exn_to_pfff_exn (fun () ->
   let ast =
     Parallel.backtrace_when_exn := false;
     Parallel.invoke Tree_sitter_java.Parse.file file ()
   in
   let env = { H.file; conv = H.line_col_to_pos file } in
   program env ast
+ )

--- a/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_javascript_tree_sitter.ml
@@ -1783,6 +1783,7 @@ let program (env : env) ((v1, v2) : CST.program) : program =
 (* Entry point *)
 (*****************************************************************************)
 let parse file =
+ H.convert_tree_sitter_exn_to_pfff_exn (fun () ->
   let ast =
     Parallel.backtrace_when_exn := false;
     Parallel.invoke Tree_sitter_javascript.Parse.file file ()
@@ -1790,3 +1791,4 @@ let parse file =
   let env = { H.file; conv = H.line_col_to_pos file } in
 
   program env ast
+ )

--- a/semgrep-core/parsing/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_ruby_tree_sitter.ml
@@ -1686,6 +1686,7 @@ let program ((v1, _v2interpreted) : CST.program) : AST.stmts  =
 (*****************************************************************************)
 
 let parse file =
+ H.convert_tree_sitter_exn_to_pfff_exn (fun () ->
   (* TODO: tree-sitter bindings are buggy so we cheat and fork to
    * avoid segfaults to popup. See Main.ml test_parse_ruby function.
    *)
@@ -1709,3 +1710,4 @@ let parse file =
    global_file := file;
    global_conv := H.line_col_to_pos file;
    program cst
+ )

--- a/semgrep-core/parsing/Parse_tree_sitter_helpers.mli
+++ b/semgrep-core/parsing/Parse_tree_sitter_helpers.mli
@@ -12,3 +12,5 @@ val token: env -> Tree_sitter_run.Token.t -> Parse_info.t
 val str: env -> Tree_sitter_run.Token.t -> string * Parse_info.t
 
 val combine_tokens: env -> Tree_sitter_run.Token.t list -> Parse_info.t
+
+val convert_tree_sitter_exn_to_pfff_exn: (unit -> 'a) -> 'a

--- a/semgrep-core/parsing/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_typescript_tree_sitter.ml
@@ -2620,6 +2620,7 @@ let guess_dialect opt_dialect file : dialect =
         `Typescript
 
 let parse ?dialect file =
+ H.convert_tree_sitter_exn_to_pfff_exn (fun () ->
   let debug = false in
   let dialect = guess_dialect dialect file in
   let cst =
@@ -2640,3 +2641,4 @@ let parse ?dialect file =
   );
 
   program env cst
+ )

--- a/semgrep-core/tests/OTHER/parsing_errors/err.ts
+++ b/semgrep-core/tests/OTHER/parsing_errors/err.ts
@@ -1,0 +1,3 @@
+function foo() {
+         return 1+
+}


### PR DESCRIPTION
There is already some code to automatically intercept Parse_info exns
to display their location, so better to use a consistent scheme
across pfff and tree-sitter parsers.

test plan:
```
(semgrep) pad@yrax:~/semgrep/tests/OTHER/parsing_errors$ semgrep -l ts -e 'FOO' .
warn: parse error
  --> err.ts:2
2 |          return 1+
  |          ^^^^^^^^^
= help: If the code appears to be valid, this may be a semgrep bug.
Could not parse err.ts as ts

Warnings exist. Run with `--strict` to turn warnings into errors.
```

better than the previous error that was always reported on the first line.
This also improves error location for the errors reported in
https://github.com/returntocorp/semgrep/issues/1713