### PR TITLE
Improved tags in Sarif output

### DIFF
--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -261,25 +261,9 @@ class Rule:
         Tags to display on SARIF-compliant UIs, such as GitHub security scans.
         """
         if "cwe" in self.metadata:
-            # Handling unexpected formatting of CWE meta-data
-            try:
-                # Assumed CWE format is CWE-[0-9]+[:]?.*
-                cwe_id = self.metadata["cwe"].split("CWE-")[1]
-                cwe_tag= "cwe-"
-                for char in cwe_id:
-                    if char.isdigit():
-                        cwe_tag += char
-                    else:
-                        break
-                yield cwe_tag
-            except Exception:
-                yield "cwe"
+            yield self.metadata["cwe"]
         if "owasp" in self.metadata:
-            try:
-                # Assumed OWASP format is AX: Description
-                yield "owasp-{}".format(self.metadata["owasp"].split(":")[0])
-            except Exception:
-                yield "owasp"
+            yield f"OWASP-{self.metadata['owasp']}"
 
     @property
     def languages(self) -> List[Language]:

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -267,7 +267,7 @@ class Rule:
                 cwe_id = self.metadata["cwe"].split("CWE-")[1]
                 cwe_tag= "cwe-"
                 for char in cwe_id:
-                    if char.is_integr():
+                    if char.isdigit():
                         cwe_tag += char
                     else:
                         break

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -261,9 +261,25 @@ class Rule:
         Tags to display on SARIF-compliant UIs, such as GitHub security scans.
         """
         if "cwe" in self.metadata:
-            yield "cwe"
+            # Handling unexpected formatting of CWE meta-data
+            try:
+                # Assumed CWE format is CWE-[0-9]+[:]?.*
+                cwe_id = self.metadata["cwe"].split("CWE-")[1]
+                cwe_tag= "cwe-"
+                for char in cwe_id:
+                    if char.is_integr():
+                        cwe_tag += char
+                    else:
+                        break
+                yield cwe_tag
+            except Exception:
+                yield "cwe"
         if "owasp" in self.metadata:
-            yield "owasp"
+            try:
+                # Assumed OWASP format is AX: Description
+                yield "owasp-{}".format(self.metadata["owasp"].split(":")[0])
+            except Exception:
+                yield "owasp"
 
     @property
     def languages(self) -> List[Language]:


### PR DESCRIPTION
The SARIF output for the scans currently only outputs CWE and/or OWASP when those values are present in the rule meta-data. This change will use a shortened version of the CWE (cwe-xxx) and OWASP (owasp-AX) meta values as part of the SARIF output.