### PR TITLE
Support "partial" patterns for function signature

### DIFF
--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -2306,6 +2306,11 @@ and m_program a b =
 (* Any *)
 (*****************************************************************************)
 
+and m_partial a b =
+  match a,b with
+  | A.PartialDef a1, B.PartialDef b1 ->
+      m_definition a1 b1
+
 (*s: function [[Generic_vs_generic.m_any]] *)
 and m_any a b =
   match a, b with
@@ -2315,8 +2320,11 @@ and m_any a b =
     m_expr a1 b1
   | A.S(a1), B.S(b1) ->
     m_stmt a1 b1
-  (* boilerplate *)
   (*s: [[Generic_vs_generic.m_any]] boilerplate cases *)
+  | A.Partial(a1), B.Partial(b1) ->
+      m_partial a1 b1
+
+  (* boilerplate *)
   | A.N(a1), B.N(b1) ->
     m_name a1 b1
   | A.Modn(a1), B.Modn(b1) ->
@@ -2361,7 +2369,7 @@ and m_any a b =
   | A.S _, _  | A.T _, _  | A.P _, _  | A.Def _, _  | A.Dir _, _
   | A.Pa _, _  | A.Ar _, _  | A.At _, _  | A.Dk _, _ | A.Pr _, _
   | A.Fld _, _ | A.Ss _, _ | A.Tk _, _ | A.Lbli _, _ | A.Fldi _, _
-  | A.ModDk _, _ | A.TodoK _, _
+  | A.ModDk _, _ | A.TodoK _, _ | A.Partial _, _
    -> fail ()
   (*e: [[Generic_vs_generic.m_any]] boilerplate cases *)
 (*e: function [[Generic_vs_generic.m_any]] *)

--- a/semgrep-core/matching/Generic_vs_generic.mli
+++ b/semgrep-core/matching/Generic_vs_generic.mli
@@ -14,6 +14,7 @@ val m_stmts_deep : less_is_ok:bool->
 
 val m_type_ :   (AST_generic.type_, AST_generic.type_) Matching_generic.matcher
 val m_pattern : (AST_generic.pattern, AST_generic.pattern) Matching_generic.matcher
+val m_partial : (AST_generic.partial, AST_generic.partial) Matching_generic.matcher
 
 (*s: signature [[Generic_vs_generic.m_any]] *)
 (* used only for unit testing *)

--- a/semgrep-core/tests/go/partial_function.go
+++ b/semgrep-core/tests/go/partial_function.go
@@ -1,0 +1,12 @@
+package Foo;
+
+//ERROR: match
+func (o *Type) Method(a *Args,
+         y *Reply) error {
+    longcode()
+    longcode()
+    longcode()
+    longcode()
+    longcode()
+    return 1
+}

--- a/semgrep-core/tests/go/partial_function.sgrep
+++ b/semgrep-core/tests/go/partial_function.sgrep
@@ -1,0 +1,1 @@
+func ($O *Type) Method($A *$ARGTYPE, $R $REPLYTYPE) $RETTYPE


### PR DESCRIPTION
Right now this is just for Go, but it could be extended to
the other languages

test plan:

$ /home/pad/semgrep/_build/default/bin/Main.exe -lang go -f tests/go/partial_function.sgrep tests/go/partial_function.go
tests/go/partial_function.go:4
 func (o *Type) Method(a *Args,
          y *Reply) error {

without displaying also the lines of the body of the function!