### PR TITLE
Make `--include` additive rather than subtractive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- The `--include` flag is now additive rather than subtractive. The
+  `language` specification already filters based on file extension, a
+  `--include` would further filter this list of files - a double filter. Now,
+  e.g., a `--include "*.txt"` will add text files for analysis.
+
 ## [0.26.0](https://github.com/returntocorp/semgrep/releases/tag/v0.26.0) - 2020-09-30
 
 ### Fixed

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -100,9 +100,8 @@ def cli() -> None:
         "--include",
         action="append",
         default=[],
-        help="Scan only files or directories that match this pattern; --include='*.jsx' will scan"
-        " the following: foo.jsx, src/foo.jsx, foo.jsx/bar.sh. --include='src' will scan src/foo.py"
-        " as well as a/b/src/c/foo.py. Can add multiple times.",
+        help="Add files or directories that match this pattern; --include='*.jsx' will scan"
+        " the following: foo.jsx, src/foo.jsx. Can add multiple times.",
     )
     parser.add_argument(
         "--no-git-ignore",


### PR DESCRIPTION
Fix #1099.

I opened this to get the discussion going. This has been a constant pain for me: there's no way to add additional file extensions for analysis. And since we're already filtering files based on their corresponding language file extensions, a `--include` becomes a double filter, which isn't very useful.

This flag is used in `semgrep-action`: https://github.com/returntocorp/semgrep-action/blob/develop/src/semgrep_agent/semgrep.py#L184. Will this change break that functionality? Why are we using `--include` there and not specifying the files as targets?

I also briefly searched for `--include` use in the cloud app codebase and didn't find anything. Does the "Ignored Paths" functionality use `--include` or `--exclude`? Am I missing anything?