### PR TITLE
Fixing triple token repeat for EncodedString in semgrep message

### DIFF
--- a/semgrep-core/bin/Main.ml
+++ b/semgrep-core/bin/Main.ml
@@ -250,6 +250,7 @@ let print_match mvars mvar_binding ii_of_any tokens_matched_code =
           match Common2.assoc_opt x mvar_binding with
           | Some any ->
               ii_of_any any
+              |> List.filter PI.is_origintok
               |> List.map PI.str_of_info
               |> Matching_report.join_with_space_if_needed
           | None ->

--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -775,7 +775,7 @@ and m_special a b =
   | A.Op(a1), B.Op(b1) ->
     m_arithmetic_operator a1 b1
   | A.EncodedString(a1), B.EncodedString(b1) ->
-    m_wrap m_string a1 b1
+    m_string a1 b1
   | A.IncrDecr(a1, a2), B.IncrDecr(b1, b2) ->
     m_eq a1 b1 >>= (fun () ->
     m_eq a2 b2

--- a/semgrep-core/tests/python/misc_encoded_string.py
+++ b/semgrep-core/tests/python/misc_encoded_string.py
@@ -1,0 +1,5 @@
+a = [ 
+  #ERROR: match
+  url(r'^whitesource_list', views.whitesource_list)
+]
+

--- a/semgrep-core/tests/python/misc_encoded_string.sgrep
+++ b/semgrep-core/tests/python/misc_encoded_string.sgrep
@@ -1,0 +1,1 @@
+url($PATH, $FUNC)


### PR DESCRIPTION
This fixes https://github.com/returntocorp/semgrep/issues/1749

test plan:
$ /home/pad/semgrep/_build/default/bin/Main.exe -lang python -f tests/python/misc_encoded_string.sgrep tests/python/misc_encoded_string.py -pvar $PATH

tests/python/misc_encoded_string.py:2: r'^whitesource_list'

instead of 3 times the same thing.