### PR TITLE
Do not consider $_GET and other PHP superglobals as metavariables

### DIFF
--- a/semgrep-core/core/Metavars_generic.ml
+++ b/semgrep-core/core/Metavars_generic.ml
@@ -25,7 +25,7 @@ open Common
 (* Types *)
 (*****************************************************************************)
 
-(* mostly a copy-paste of metavars_fuzzy.ml and metavars_js.ml *)
+(* Mostly a copy-paste of metavars_fuzzy.ml and metavars_js.ml *)
 
 (* less: could want to remember the position in the pattern of the metavar
  * for error reporting on pattern itself? so use a 'string AST_generic.wrap'?
@@ -56,8 +56,11 @@ type metavars_binding = (mvar, AST_generic.any) Common.assoc
  * us to match specifically also identifiers in lower case (e.g., $foo will
  * only match the $foo identifiers in some concrete code; this is not a
  * metavariable).
- *
-*)
+ * We allow _ as a prefix to disable the unused-metavar check (we use
+ * the same convention than OCaml).
+ * However this conflicts with PHP superglobals, hence the special
+ * cases below in is_metavar_name.
+ *)
 let metavar_regexp_string =
   "^\\(\\$[A-Z_][A-Z_0-9]*\\)$"
 (*e: constant [[Metavars_generic.metavar_regexp_string]] *)
@@ -69,6 +72,18 @@ let metavar_regexp_string =
  * AST.ml and extends it with special sgrep constructs.
  *)
 let is_metavar_name s =
-  s =~ metavar_regexp_string
+  match s with
+  (* ugly: we should probably pass the language to is_metavar_name, but
+   * that would require to thread it through lots of functions, so for
+   * now we have this special case for PHP superglobals.
+   * ref: https://www.php.net/manual/en/language.variables.superglobals.php
+   *)
+  | "$_SERVER" | "$_GET" | "$_POST" | "$_FILES"
+  | "$_COOKIES" | "$_REQUEST" | "$_ENV"
+  (* todo: there's also "$GLOBALS" but this may interface with existing rules*)
+  ->
+     false
+  | _ ->
+    s =~ metavar_regexp_string
 (*e: function [[Metavars_generic.is_metavar_name]] *)
 (*e: semgrep/core/Metavars_generic.ml *)

--- a/semgrep-core/tests/php/misc_superglobals.php
+++ b/semgrep-core/tests/php/misc_superglobals.php
@@ -1,0 +1,8 @@
+<?php
+
+echo $settings['something'];
+echo CONSTANT['a'];
+
+//ERROR: match
+echo $_GET['test'];
+

--- a/semgrep-core/tests/php/misc_superglobals.sgrep
+++ b/semgrep-core/tests/php/misc_superglobals.sgrep
@@ -1,0 +1,2 @@
+// those are not metavariables
+$_GET[$KEY]


### PR DESCRIPTION
This is a quick fix. The right solution is to pass the language
to is_metavar_name function (or use an escape mechanism).
This closes https://github.com/returntocorp/semgrep/issues/1790

test plan:
test file included
make test