### PR TITLE
New JSON interface for -eval metavars, handle float, better json parsing

### DIFF
--- a/semgrep-core/matching/Eval_generic.ml
+++ b/semgrep-core/matching/Eval_generic.ml
@@ -35,9 +35,9 @@ let logger = Logging.get_logger [__MODULE__]
 
 (* This is the (partially parsed) content of a metavariable *)
 type value =
-  | Int of int
   | Bool of bool
-  (* less: Float? *)
+  | Int of int
+  | Float of float
   | String of string (* string without the enclosing '"' *)
   | List of value list
   (* default case where we don't really have good builtin operations.
@@ -57,21 +57,21 @@ exception NotHandled of code
 (*****************************************************************************)
 (* Parsing *)
 (*****************************************************************************)
-let parse_metavar s =
-  match s with
-  | "true" | "True" -> Bool (true)
-  | "false" | "False" -> Bool (false)
-  | _ when s =~ "^[0-9]+$" -> Int (int_of_string s)
-  | _ when s =~ "^\"\\(.*\\)\"$" -> String (Common.matched1 s)
-  | _ -> AST s
+let metavar_of_json s = function
+  | J.Int i -> Int i
+  | J.Bool b -> Bool b
+  | J.String s -> String s
+  | J.Float f -> Float f
+  | _ -> failwith (spf "wrong format for metavar %s" s)
 
 let parse_json file =
   let json = JSON.load_json file in
   match json with
-  | J.Object [
-      "metavars", J.Object xs;
-      "language", J.String lang;
-      "code", J.String code;
+  | J.Object xs ->
+    (match Common.sort_by_key_lowfirst xs with
+    | ["code", J.String code;
+       "language", J.String lang;
+       "metavars", J.Object xs;
       ] ->
       let lang =
         try Hashtbl.find Lang.lang_of_string_map lang
@@ -83,13 +83,13 @@ let parse_json file =
         | G.E e -> e
         | _ -> failwith "only expressions are supported"
       in
-      let metavars = xs |> List.map (fun (s, json) ->
-            match json with
-            | J.String s2 -> s, parse_metavar s2
-            | _ -> failwith "wrong json format for metavar"
-       ) in
+      let metavars =
+        xs |> List.map (fun (s, json) -> s, metavar_of_json s json)
+      in
       Common.hash_of_list metavars, code
 
+    | _ -> failwith "wrong json format"
+    )
   | _ -> failwith "wrong json format"
 
 (*****************************************************************************)
@@ -119,8 +119,12 @@ let rec eval env code =
   | G.L x ->
       (match x with
       | G.Bool (b, _t) -> Bool (b)
-      | G.Int (s, _t) -> Int (int_of_string s)
       | G.String (s, _t) -> String s
+      (* this assumes the string format of the language is handled by
+       * OCaml xx_of_string builtins.
+       *)
+      | G.Int (s, _t) -> Int (int_of_string s)
+      | G.Float (s, _t) -> Float (float_of_string s)
       | _ -> raise (NotHandled code)
       )
   | G.Id ((s, _t), _idinfo) ->
@@ -153,6 +157,12 @@ and eval_op op values code =
   | G.Lt, [Int i1; Int i2] -> Bool (i1 < i2)
   | G.LtE, [Int i1; Int i2] -> Bool (i1 <= i2)
 
+  (* todo: we should perform cast and allow to mix Float and Int *)
+  | G.Gt, [Float i1; Float i2] -> Bool (i1 > i2)
+  | G.GtE, [Float i1; Float i2] -> Bool (i1 >= i2)
+  | G.Lt, [Float i1; Float i2] -> Bool (i1 < i2)
+  | G.LtE, [Float i1; Float i2] -> Bool (i1 <= i2)
+
   | G.And, [Bool b1; Bool b2] -> Bool (b1 && b2)
   | G.Or, [Bool b1; Bool b2] -> Bool (b1 || b2)
   | G.Not, [Bool b1] -> Bool (not b1)
@@ -165,6 +175,18 @@ and eval_op op values code =
   | G.Div, [Int i1; Int i2] -> Int (i1 / i2)
   | G.Mod, [Int i1; Int i2] -> Int (i1 mod i2)
 
+  (* todo: we should perform automatic cast and allow to mix Float and Int *)
+  | G.Plus, [Float i1] -> Float i1
+  | G.Plus, [Float i1; Float i2] -> Float (i1 +. i2)
+  | G.Minus, [Float i1] -> Float (-. i1)
+  | G.Minus, [Float i1; Float i2] -> Float (i1 -. i2)
+  | G.Mult, [Float i1; Float i2] -> Float (i1 *. i2)
+  | G.Div, [Float i1; Float i2] -> Float (i1 /. i2)
+
+  (* abuse generic =. Not that this will prevent
+   * Int 0 to be equal to Float 0.0.
+   * Again need automatic cast.
+   *)
   | G.Eq, [v1; v2] -> Bool (v1 = v2)
   | G.NotEq, [v1; v2] -> Bool (v1 <> v2)
 

--- a/semgrep-core/matching/Eval_generic.mli
+++ b/semgrep-core/matching/Eval_generic.mli
@@ -1,7 +1,8 @@
 
 type value =
-  | Int of int
   | Bool of bool
+  | Int of int
+  | Float of float
   | String of string (* string without the enclosing '"' *)
   | List of value list
   | AST of string (* any AST, e.g., "x+1" *)

--- a/semgrep-core/tests/OTHER/eval/float.json
+++ b/semgrep-core/tests/OTHER/eval/float.json
@@ -1,7 +1,7 @@
 {
   "metavars": {
-    "$X": "2"
+    "$X": 42.0
   },
   "language": "python",
-  "code": "$X in [1,2,3]"
+  "code": "$X > 41.9"
 }

--- a/semgrep-core/tests/OTHER/eval/in_list.json
+++ b/semgrep-core/tests/OTHER/eval/in_list.json
@@ -1,0 +1,7 @@
+{
+  "metavars": {
+    "$X": 2
+  },
+  "language": "python",
+  "code": "$X in [1,2,3]"
+}

--- a/semgrep-core/tests/OTHER/eval/simple_expr.json
+++ b/semgrep-core/tests/OTHER/eval/simple_expr.json
@@ -1,7 +1,7 @@
 {
   "metavars": {
-    "$X": "42",
-    "$Y": "\"foo\"",
+    "$X": 42,
+    "$Y": "foo",
     "$Z": "x+1"
   },
   "language": "python",

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -227,7 +227,7 @@ let lint_regression_tests =
 
 let eval_regression_tests = 
   "eval regression resting" >:: (fun () ->
-      let dir = Filename.concat tests_path "OTHER/EVAL" in
+      let dir = Filename.concat tests_path "OTHER/eval" in
       let files = Common2.glob (spf "%s/*.json" dir) in
       files |> List.iter (fun file ->
         let (env, code) = Eval_generic.parse_json file in


### PR DESCRIPTION
This will help #1724
I am now using JSON value types instead of parsing strings for the metavars
as suggested by Matt.
I also support the different JSON field in any order, and
added basic support for operations on float.

test plan:
test file included