### PR TITLE
Make spacegrep export json for semgrep

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
           name: ocaml-build-artifacts
           path: ocaml-build-artifacts.tgz
       - name: Test spacegrep
-        run: opam exec make -C spacegrep test
+        run: opam exec -- make -C spacegrep test
       - name: Test semgrep-core
         run: |
           eval $(opam env)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
           name: ocaml-build-artifacts
           path: ocaml-build-artifacts.tgz
       - name: Test spacegrep
-        run: make -C spacegrep test
+        run: opam exec make -C spacegrep test
       - name: Test semgrep-core
         run: |
           eval $(opam env)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           name: ocaml-build-artifacts
           path: ocaml-build-artifacts.tgz
+      - name: Test spacegrep
+        run: make -C spacegrep test
       - name: Test semgrep-core
         run: |
           eval $(opam env)

--- a/spacegrep/spacegrep.opam
+++ b/spacegrep/spacegrep.opam
@@ -12,6 +12,7 @@ build: [
 
 depends: [
   "alcotest"
+  "atdgen"
   "ANSITerminal"
   "cmdliner"
   "dune" {>= "2.1"}

--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -174,7 +174,7 @@ let man = [
   `P "Check out bug reports at \
       https://github.com/returntocorp/spacegrep/issues.";
   `S Manpage.s_see_also;
-  `P "spacecat(1)"
+  `P "semgrep, spacecat"
 ]
 
 let parse_command_line () =

--- a/spacegrep/src/lib/Match.mli
+++ b/spacegrep/src/lib/Match.mli
@@ -5,14 +5,56 @@
 val debug : bool ref
 
 (*
+  Unique identifier for a pattern among all the patterns specified
+  on the command line.
+*)
+type pattern_id = int
+
+(*
+   A pair of locations (loc1, loc2)
+     = ((pos1_start, pos1_end), (pos2_start, pos2_end))
+   which is normally a pair of tokens.
+
+   A region can be converted to a location by taking the first and last
+   positions (pos1_start, pos2_end).
+*)
+type region = Loc.t * Loc.t
+
+(*
+  The name of a subpattern and the locations allowing its extraction
+  from the source document.
+*)
+type capture = {
+  name: string;
+  value: string; (* just nice to have, especially since it's a single word *)
+  loc: Loc.t;
+}
+
+(*
+   A match between a pattern and a region of an input file.
+   The captures are where some named subpatterns match.
+*)
+type match_ = {
+  region: region;
+  captures: capture list;
+}
+
+(*
    Match a pattern against a document. Return the list of all
    non-overlapping matches found by scanning the document from left to right.
 *)
-val search : Pattern_AST.t -> Doc_AST.t -> (Loc.t * Loc.t) list
+val search : Pattern_AST.t -> Doc_AST.t -> match_ list
 
 (*
    Print the matched lines to stdout in a human-readable format.
 *)
 val print :
   ?highlight:bool ->
-  Src_file.t -> (Loc.t * Loc.t) list -> unit
+  Src_file.t -> match_ list -> unit
+
+(*
+   Print the results of matching multiple patterns against multiple documents.
+*)
+val print_nested_results :
+  ?highlight:bool ->
+  (Src_file.t * (pattern_id * match_ list) list) list -> unit

--- a/spacegrep/src/lib/Semgrep.atd
+++ b/spacegrep/src/lib/Semgrep.atd
@@ -20,7 +20,7 @@ type match_ = {
   path: string; (* source file *)
   start: position;
   end_ <json name="end">: position;
-  extra: extra;
+  extra: match_extra;
 }
 
 (* See R2c.ml in semgrep-core *)
@@ -38,9 +38,9 @@ type position = {
   offset: int; (* byte position from the beginning of the file, starts at 0 *)
 }
 
-type extra = {
-  message: string; (* rule.message (?) *)
-  metavars: metavar list;
+type match_extra = {
+  ?message: string option; (* rule.message (?) *)
+  metavars: (string * metavar_value) list <json repr="object">;
 }
 
 type error_extra = {
@@ -48,7 +48,7 @@ type error_extra = {
   line: string;
 }
 
-type metavar = {
+type metavar_value = {
   start: position;
   end_ <json name="end">: position;
   abstract_content: string; (* value? *)

--- a/spacegrep/src/lib/Semgrep.atd
+++ b/spacegrep/src/lib/Semgrep.atd
@@ -1,0 +1,71 @@
+(*
+   Type definitions for json communication with semgrep.
+
+   Inferred from JSON_report.ml in semgrep-core.
+*)
+
+type match_results = {
+  matches: match_ list;
+  errors: error list;
+  stats: stats;
+}
+
+type stats = {
+  okfiles: int;
+  errorfiles: int;
+}
+
+type match_ = {
+  ?check_id: string option; (* rule ID *)
+  path: string; (* source file *)
+  start: position;
+  end_ <json name="end">: position;
+  extra: extra;
+}
+
+(* See R2c.ml in semgrep-core *)
+type error = {
+  ?check_id: string option;
+  path: string;
+  start: position;
+  end_ <json name="end">: position;
+  extra: error_extra;
+}
+
+type position = {
+  line: int; (* starts at 1 *)
+  col: int; (* starts at 1 *)
+  offset: int; (* byte position from the beginning of the file, starts at 0 *)
+}
+
+type extra = {
+  message: string; (* rule.message (?) *)
+  metavars: metavar list;
+}
+
+type error_extra = {
+  message: string;
+  line: string;
+}
+
+type metavar = {
+  start: position;
+  end_ <json name="end">: position;
+  abstract_content: string; (* value? *)
+  unique_id: unique_id;
+}
+
+(*
+   This is just the variant for type=AST.
+   In order to accommodate two record types into one variant, use
+   the atdgen feature called a json adapter.
+*)
+type unique_id = {
+  type_ <json name="type">: unique_id_type;
+  md5sum: string;
+}
+
+type unique_id_type = [
+(*  | ID <json name="id"> *) (* variant not supported at the moment *)
+  | AST
+]

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -10,7 +10,7 @@ let semgrep_pos (x : Lexing.position) : Semgrep_t.position =
   {
     line = x.pos_lnum + 1;
     col = x.pos_cnum - x.pos_bol + 1;
-    offset = x.pos_bol;
+    offset = x.pos_cnum;
   }
 
 let unique_id_of_loc (loc : Loc.t) : unique_id =

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -1,0 +1,78 @@
+(*
+   Convert matches to the format expected by the semgrep wrapper,
+   similar to what semgrep-core produces.
+*)
+
+open Match
+open Semgrep_t
+
+let semgrep_pos (x : Lexing.position) : Semgrep_t.position =
+  {
+    line = x.pos_lnum + 1;
+    col = x.pos_cnum - x.pos_bol + 1;
+    offset = x.pos_bol;
+  }
+
+let unique_id_of_loc (loc : Loc.t) : unique_id =
+  let md5sum =
+    Marshal.to_string loc []
+    |> Digest.string
+    |> Digest.to_hex
+  in
+  {
+    type_ = `AST;
+    md5sum;
+  }
+
+let convert_capture x =
+  let pos1, pos2 = x.loc in
+  x.name, {
+    start = semgrep_pos pos1;
+    end_ = semgrep_pos pos2;
+    abstract_content = x.value;
+    unique_id = unique_id_of_loc x.loc;
+  }
+
+(*
+   Convert match results to the format expected by semgrep.
+*)
+let make_semgrep_json doc_matches : Semgrep_t.match_results =
+  let matches =
+    List.map (fun (src, pat_matches) ->
+      let path = Src_file.source_string src in
+      List.map (fun (pat_id, matches) ->
+        let check_id = Some (string_of_int pat_id) in
+        List.map (fun match_ ->
+          let ((pos1, _), (_, pos2)) = match_.region in
+          let metavars = List.map convert_capture match_.captures in
+          let extra = {
+            message = None;
+            metavars;
+          } in
+          ({
+            check_id;
+            path;
+            start = semgrep_pos pos1;
+            end_ = semgrep_pos pos2;
+            extra;
+          } : match_)
+        ) matches
+      ) pat_matches
+      |> List.flatten
+    ) doc_matches
+    |> List.flatten
+  in
+  {
+    matches;
+    errors = [];
+    stats = {
+      okfiles = List.length doc_matches;
+      errorfiles = 0;
+    };
+  }
+
+let print_semgrep_json doc_matches =
+  make_semgrep_json doc_matches
+  |> Semgrep_j.string_of_match_results
+  |> Yojson.Safe.prettify
+  |> print_endline

--- a/spacegrep/src/lib/Semgrep.mli
+++ b/spacegrep/src/lib/Semgrep.mli
@@ -1,0 +1,10 @@
+(*
+   Interface with semgrep wrapper.
+*)
+
+(*
+   Print the matches in the json format that semgrep understands.
+   (See Semgrep.atd)
+*)
+val print_semgrep_json :
+  (Src_file.t * (Match.pattern_id * Match.match_ list) list) list -> unit

--- a/spacegrep/src/lib/dune
+++ b/spacegrep/src/lib/dune
@@ -4,7 +4,18 @@
   (libraries
      ANSITerminal
      unix
+     atdgen-runtime
   )
 )
 
 (ocamllex Lexer)
+
+(rule
+ (targets Semgrep_j.ml Semgrep_j.mli)
+ (deps    Semgrep.atd)
+ (action  (run atdgen -j -j-std %{deps})))
+
+(rule
+ (targets Semgrep_t.ml Semgrep_t.mli)
+ (deps    Semgrep.atd)
+ (action  (run atdgen -t %{deps})))


### PR DESCRIPTION
The command-line option is `--output-format semgrep` (see `spacegrep --help`). There's a good chance that the json format is wrong in some places, since I just guessed it from the ocaml implementation.

Here's some sample output (searching for the pattern `free $X` in the text of the GNU AGPL license):

```
~/semgrep/spacegrep $ ./bin/spacegrep 'free $X' -d LICENSE --output-format semgrep
{
  "matches": [
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 18, "col": 69, "offset": 828 },
      "end": { "line": 19, "col": 9, "offset": 841 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 19, "col": 1, "offset": 833 },
            "end": { "line": 19, "col": 9, "offset": 841 },
            "abstract_content": "software",
            "unique_id": {
              "type": "AST",
              "md5sum": "1a629dbf487ee1ca79cc2d1e486ce02c"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 21, "col": 20, "offset": 881 },
      "end": { "line": 21, "col": 33, "offset": 894 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 21, "col": 25, "offset": 886 },
            "end": { "line": 21, "col": 33, "offset": 894 },
            "abstract_content": "software",
            "unique_id": {
              "type": "AST",
              "md5sum": "bbc57b936bbfa438158dc98783674d59"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 23, "col": 42, "offset": 1041 },
      "end": { "line": 23, "col": 55, "offset": 1054 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 23, "col": 47, "offset": 1046 },
            "end": { "line": 23, "col": 55, "offset": 1054 },
            "abstract_content": "software",
            "unique_id": {
              "type": "AST",
              "md5sum": "5ce1e82ba71603d64920df43efd511ab"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 26, "col": 1, "offset": 1209 },
      "end": { "line": 26, "col": 14, "offset": 1222 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 26, "col": 6, "offset": 1214 },
            "end": { "line": 26, "col": 14, "offset": 1222 },
            "abstract_content": "programs",
            "unique_id": {
              "type": "AST",
              "md5sum": "16a2dfd24543a2ac106890f59cde43b4"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 36, "col": 34, "offset": 1729 },
      "end": { "line": 36, "col": 47, "offset": 1742 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 36, "col": 39, "offset": 1734 },
            "end": { "line": 36, "col": 47, "offset": 1742 },
            "abstract_content": "software",
            "unique_id": {
              "type": "AST",
              "md5sum": "d0df4dcb9761c250dc5958a221841740"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 127, "col": 67, "offset": 6280 },
      "end": { "line": 128, "col": 9, "offset": 6293 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 128, "col": 1, "offset": 6285 },
            "end": { "line": 128, "col": 9, "offset": 6293 },
            "abstract_content": "programs",
            "unique_id": {
              "type": "AST",
              "md5sum": "20cf165194aaee276b15967c27d7c83a"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 490, "col": 10, "offset": 25228 },
      "end": { "line": 490, "col": 17, "offset": 25235 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 490, "col": 15, "offset": 25233 },
            "end": { "line": 490, "col": 17, "offset": 25235 },
            "abstract_content": "of",
            "unique_id": {
              "type": "AST",
              "md5sum": "bb0abe8681c10329a1fa96f8504ea7b7"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 626, "col": 1, "offset": 32588 },
      "end": { "line": 626, "col": 14, "offset": 32601 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 626, "col": 6, "offset": 32593 },
            "end": { "line": 626, "col": 14, "offset": 32601 },
            "abstract_content": "software",
            "unique_id": {
              "type": "AST",
              "md5sum": "ff37ab074556812d3f0d3ef0a375b183"
            }
          }
        }
      }
    },
    {
      "check_id": "0",
      "path": "LICENSE",
      "start": { "line": 636, "col": 21, "offset": 33083 },
      "end": { "line": 636, "col": 34, "offset": 33096 },
      "extra": {
        "metavars": {
          "X": {
            "start": { "line": 636, "col": 26, "offset": 33088 },
            "end": { "line": 636, "col": 34, "offset": 33096 },
            "abstract_content": "software",
            "unique_id": {
              "type": "AST",
              "md5sum": "ccf9c58d24cfa70cbf68103c9f1d1469"
            }
          }
        }
      }
    }
  ],
  "errors": [],
  "stats": { "okfiles": 1, "errorfiles": 0 }
}
```