### PR TITLE
Basic coverage analysis per languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# dune
 _build
 .merlin
+
+# bisect_ppx
+_coverage
+*.coverage
 
 semgrep_core/sgrep.install
 /project.el

--- a/semgrep-core/dune-project
+++ b/semgrep-core/dune-project
@@ -1,2 +1,2 @@
-(lang dune 2.0)
+(lang dune 2.7)
 (name semgrep)

--- a/semgrep-core/matching/dune
+++ b/semgrep-core/matching/dune
@@ -13,4 +13,5 @@
    semgrep_typing
  )
  (preprocess (pps ppx_deriving.show ppx_profiling))
+ (instrumentation (backend bisect_ppx))
 )

--- a/semgrep-core/scripts/run-coverage.py
+++ b/semgrep-core/scripts/run-coverage.py
@@ -27,10 +27,23 @@ def report_summary_for_file_stat(file: str) -> str:
     raise Exception("")
 
 
+metrics_URL = "https://dashboard.semgrep.dev/api/metric"
+
+
+def add_metric(category: str, value: str) -> None:
+    path = f"semgrep.core.{category}.coverage.matching.pct"
+    cmd = f"curl -X POST {metrics_URL}/{path} -d '{value}' 2> /dev/null"
+    out = os.popen(cmd).read()  # nosem
+    patt = re.compile(".*successfully recorded")
+    if patt.match(out) is None:
+        raise Exception(f"Could not push the metric: {out}")
+
+
 # to compile with coverage on
 os.system("dune runtest --instrument-with bisect_ppx --force 2> /dev/null")
 global_stat = report_summary_stat()
 print(f"Aggregated coverage for all languages: {global_stat}%")
+add_metric("all", global_stat)
 
 # Substrings to pass to text.exe to run a test subset; see ../tests/Test.ml
 languages = [
@@ -51,6 +64,7 @@ for lang in languages:
     os.system(f"cd {path};./test.exe {lang} > /dev/null")  # nosem
     lang_stat = report_summary_stat()
     print(f"Coverage stat for {lang}: {lang_stat}%")
+    add_metric(lang.lower(), lang_stat)
 
 subsystems = [
     ("eval", "matching/Eval_generic.ml"),

--- a/semgrep-core/scripts/run-coverage.py
+++ b/semgrep-core/scripts/run-coverage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+import os
+import re
+
+path = "_build/default/tests"
+
+print("Coverage statistics for files under semgrep-core/matching/")
+
+
+def report_summary_stat() -> int:
+    stat = os.popen("bisect-ppx-report summary").read()
+    patt = re.compile("Coverage:\s+\d+/\d+\s+\((\d+\.\d*)%\)")
+    # mobj = patt.match("Coverage: 4/4 (4.4%)")
+    mobj = patt.match(stat)
+    if mobj is not None:
+        return int(mobj.group(1))
+    raise Exception("")
+
+
+def report_summary_for_file_stat(file: str) -> int:
+    stat = os.popen("bisect-ppx-report summary --per-file").readlines()
+    patt = re.compile(f"\s*(\d+.\d*)\s+%\s+\d+/\d+\s+{file}")
+    for line in stat:
+        mobj = patt.match(line)
+        if mobj is not None:
+            return int(mobj.group(1))
+    raise Exception("")
+
+
+# to compile with coverage on
+os.system("dune runtest --instrument-with bisect_ppx --force 2> /dev/null")
+global_stat = report_summary_stat()
+print(f"Aggregated coverage for all languages: {global_stat}%")
+
+# Substrings to pass to text.exe to run a test subset; see ../tests/Test.ml
+languages = [
+    "Python",
+    "Javascript",
+    "Typescript",
+    "JSON",
+    "Java",
+    "C",
+    "Go",
+    "OCaml",
+    "Ruby",
+    "PHP",
+]
+# cleanup and run the analysis for each separate languages
+for lang in languages:
+    os.system(f"rm -f {path}/*.coverage")  # nosem
+    os.system(f"cd {path};./test.exe {lang} > /dev/null")  # nosem
+    lang_stat = report_summary_stat()
+    print(f"Coverage stat for {lang}: {lang_stat}%")
+
+subsystems = [
+    ("eval", "matching/Eval_generic.ml"),
+]
+
+
+for (test, file) in subsystems:
+    print(test, file)
+
+    os.system(f"rm -f {path}/*.coverage")  # nosem
+    os.system(f"cd {path};./test.exe {test} > /dev/null")  # nosem
+    stat = report_summary_for_file_stat(file)
+    print(f"Coverage stat for {test} in file {file}: {stat}%")

--- a/semgrep-core/scripts/run-coverage.py
+++ b/semgrep-core/scripts/run-coverage.py
@@ -58,8 +58,6 @@ subsystems = [
 
 
 for (test, file) in subsystems:
-    print(test, file)
-
     os.system(f"rm -f {path}/*.coverage")  # nosem
     os.system(f"cd {path};./test.exe {test} > /dev/null")  # nosem
     stat = report_summary_for_file_stat(file)

--- a/semgrep-core/scripts/run-coverage.py
+++ b/semgrep-core/scripts/run-coverage.py
@@ -7,23 +7,23 @@ path = "_build/default/tests"
 print("Coverage statistics for files under semgrep-core/matching/")
 
 
-def report_summary_stat() -> int:
+def report_summary_stat() -> str:
     stat = os.popen("bisect-ppx-report summary").read()
     patt = re.compile("Coverage:\s+\d+/\d+\s+\((\d+\.\d*)%\)")
     # mobj = patt.match("Coverage: 4/4 (4.4%)")
     mobj = patt.match(stat)
     if mobj is not None:
-        return int(mobj.group(1))
+        return mobj.group(1)
     raise Exception("")
 
 
-def report_summary_for_file_stat(file: str) -> int:
+def report_summary_for_file_stat(file: str) -> str:
     stat = os.popen("bisect-ppx-report summary --per-file").readlines()
     patt = re.compile(f"\s*(\d+.\d*)\s+%\s+\d+/\d+\s+{file}")
     for line in stat:
         mobj = patt.match(line)
         if mobj is not None:
-            return int(mobj.group(1))
+            return mobj.group(1)
     raise Exception("")
 
 

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -15,13 +15,14 @@ dev-repo: "git+https://github.com/returntocorp/semgrep"
 bug-reports: "https://github.com/returntocorp/semgrep/issues"
 
 depends: [
-  "dune"
+  "dune" {>= "2.7.0" }
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "easy_logging_yojson"
   "ocamlgraph"
   "yojson"
   "yaml"
-  "easy_logging_yojson"
-  "grain_dypgen"
   "menhir"
+  "grain_dypgen"
   "uucp"
   "uutf"
   "re"
@@ -30,3 +31,7 @@ depends: [
 ]
 
 build: [make]
+
+pin-depends: [
+  ["bisect_ppx.git" "git+https://github.com/aantron/bisect_ppx.git"]
+]


### PR DESCRIPTION
This uses the bisect_ppx OCaml package to turn-on instrumentation
for coverage analysis.
Right now, we enable this coverage just for the semgrep-core/matching/
directory (the matching engine behing semgrep).
We run all the semgrep-core tests in tests/Test.ml, which itself
use the many tests under sengrep-core/tests/.

Test plan:
$ ./scripts/run-coverage.py
Coverage statistics for files under semgrep-core/matching/
Aggregated coverage for all languages: 59.21%
Coverage stat for Python: 41.10%
Coverage stat for Javascript: 38.90%
Coverage stat for Typescript: 38.74%
Coverage stat for JSON: 9.11%
Coverage stat for Java: 44.97%
Coverage stat for C: 22.51%
Coverage stat for Go: 34.92%
Coverage stat for OCaml: 13.04%
Coverage stat for Ruby: 18.06%
Coverage stat for PHP: 13.72%
Coverage stat for eval in file matching/Eval_generic.ml: 45.83%