### PR TITLE
Fix location bug and missing metavariable '$' in spacegrep's json output

### DIFF
--- a/semgrep/semgrep/spacegrep.py
+++ b/semgrep/semgrep/spacegrep.py
@@ -44,7 +44,6 @@ def run_spacegrep(patterns: List[Pattern], targets: List[Path]) -> dict:
 
             output_json = _parse_spacegrep_output(raw_output)
             output_json["matches"] = _patch_id(pattern, output_json.get("matches", []))
-            output_json["matches"] = _patch_lines(output_json.get("matches", []))
 
             matches.extend(output_json["matches"])
             errors.extend(output_json["errors"])
@@ -69,25 +68,5 @@ def _patch_id(pattern: Pattern, matches: List[dict]) -> List[dict]:
     patched = []
     for match in matches:
         match["check_id"] = pattern._id
-        patched.append(match)
-    return patched
-
-
-def _patch_lines(matches: List[dict]) -> List[dict]:
-    patched = []
-    for match in matches:
-        with open(match["path"], "r") as fin:
-            data = fin.readlines()
-        start_l = match.get("start", {}).get("line", 0)
-        start_c = match.get("start", {}).get("col", 0)
-        end_l = match.get("end", {}).get("line", 0)
-        end_c = match.get("end", {}).get("col", 0)
-
-        lines = data[start_l - 2 : end_l - 1]
-        lines[0] = lines[0][start_c - 1 :]
-        lines[-1] = lines[-1][: end_c - 1]
-
-        match["extra"]["lines"] = lines
-
         patched.append(match)
     return patched

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
@@ -5,10 +5,10 @@
       "check_id": "rules.spacegrep.var-in-script-tag",
       "end": {
         "col": 32,
-        "line": 25
+        "line": 24
       },
       "extra": {
-        "lines": "</script>",
+        "lines": "{{ message }}",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -17,17 +17,17 @@
       "path": "targets/spacegrep/html.mustache",
       "start": {
         "col": 19,
-        "line": 25
+        "line": 24
       }
     },
     {
       "check_id": "rules.spacegrep.var-in-script-tag",
       "end": {
         "col": 32,
-        "line": 30
+        "line": 29
       },
       "extra": {
-        "lines": "    console.log(message);",
+        "lines": "{{ message }}",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -36,17 +36,17 @@
       "path": "targets/spacegrep/html.mustache",
       "start": {
         "col": 19,
-        "line": 30
+        "line": 29
       }
     },
     {
       "check_id": "rules.spacegrep.var-in-script-tag",
       "end": {
         "col": 34,
-        "line": 33
+        "line": 32
       },
       "extra": {
-        "lines": "    var flash = document.getElementById(\"flash\");",
+        "lines": "{{ message2 }}",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -55,7 +55,7 @@
       "path": "targets/spacegrep/html.mustache",
       "start": {
         "col": 20,
-        "line": 33
+        "line": 32
       }
     }
   ]

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
@@ -8,7 +8,7 @@
         "line": 25
       },
       "extra": {
-        "lines": "{{ message }};",
+        "lines": "</script>",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -27,7 +27,7 @@
         "line": 30
       },
       "extra": {
-        "lines": "{{ message }};",
+        "lines": "    console.log(message);",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -46,7 +46,7 @@
         "line": 33
       },
       "extra": {
-        "lines": "{{ message2 }};",
+        "lines": "    var flash = document.getElementById(\"flash\");",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
@@ -8,7 +8,7 @@
         "line": 7
       },
       "extra": {
-        "lines": "Content-Type: text/html",
+        "lines": "Connection: Closed",
         "message": "Detected text/html",
         "metadata": {},
         "metavars": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
@@ -5,10 +5,10 @@
       "check_id": "rules.spacegrep.content-type-text-html",
       "end": {
         "col": 24,
-        "line": 7
+        "line": 6
       },
       "extra": {
-        "lines": "Connection: Closed",
+        "lines": "Content-Type: text/html",
         "message": "Detected text/html",
         "metadata": {},
         "metavars": {},
@@ -17,7 +17,7 @@
       "path": "targets/spacegrep/httpresponse.txt",
       "start": {
         "col": 1,
-        "line": 7
+        "line": 6
       }
     }
   ]

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
@@ -5,23 +5,23 @@
       "check_id": "rules.spacegrep.header-2",
       "end": {
         "col": 11,
-        "line": 63
+        "line": 62
       },
       "extra": {
-        "lines": "",
+        "lines": "## Getting",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
-          "TEXT": {
+          "$TEXT": {
             "abstract_content": "Getting",
             "end": {
               "col": 11,
-              "line": 63,
+              "line": 62,
               "offset": 2591
             },
             "start": {
               "col": 4,
-              "line": 63,
+              "line": 62,
               "offset": 2584
             },
             "unique_id": {
@@ -35,30 +35,30 @@
       "path": "targets/spacegrep/markdown.md",
       "start": {
         "col": 1,
-        "line": 63
+        "line": 62
       }
     },
     {
       "check_id": "rules.spacegrep.header-2",
       "end": {
         "col": 12,
-        "line": 98
+        "line": 97
       },
       "extra": {
-        "lines": "",
+        "lines": "## Examples",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
-          "TEXT": {
+          "$TEXT": {
             "abstract_content": "Examples",
             "end": {
               "col": 12,
-              "line": 98,
+              "line": 97,
               "offset": 3702
             },
             "start": {
               "col": 4,
-              "line": 98,
+              "line": 97,
               "offset": 3694
             },
             "unique_id": {
@@ -72,30 +72,30 @@
       "path": "targets/spacegrep/markdown.md",
       "start": {
         "col": 1,
-        "line": 98
+        "line": 97
       }
     },
     {
       "check_id": "rules.spacegrep.header-2",
       "end": {
         "col": 13,
-        "line": 146
+        "line": 145
       },
       "extra": {
-        "lines": "",
+        "lines": "## Resources",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
-          "TEXT": {
+          "$TEXT": {
             "abstract_content": "Resources",
             "end": {
               "col": 13,
-              "line": 146,
+              "line": 145,
               "offset": 8847
             },
             "start": {
               "col": 4,
-              "line": 146,
+              "line": 145,
               "offset": 8838
             },
             "unique_id": {
@@ -109,30 +109,30 @@
       "path": "targets/spacegrep/markdown.md",
       "start": {
         "col": 1,
-        "line": 146
+        "line": 145
       }
     },
     {
       "check_id": "rules.spacegrep.header-2",
       "end": {
         "col": 9,
-        "line": 160
+        "line": 159
       },
       "extra": {
-        "lines": "",
+        "lines": "## Usage",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
-          "TEXT": {
+          "$TEXT": {
             "abstract_content": "Usage",
             "end": {
               "col": 9,
-              "line": 160,
+              "line": 159,
               "offset": 9242
             },
             "start": {
               "col": 4,
-              "line": 160,
+              "line": 159,
               "offset": 9237
             },
             "unique_id": {
@@ -146,30 +146,30 @@
       "path": "targets/spacegrep/markdown.md",
       "start": {
         "col": 1,
-        "line": 160
+        "line": 159
       }
     },
     {
       "check_id": "rules.spacegrep.header-2",
       "end": {
         "col": 16,
-        "line": 189
+        "line": 188
       },
       "extra": {
-        "lines": "",
+        "lines": "## Contributing",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
-          "TEXT": {
+          "$TEXT": {
             "abstract_content": "Contributing",
             "end": {
               "col": 16,
-              "line": 189,
+              "line": 188,
               "offset": 9805
             },
             "start": {
               "col": 4,
-              "line": 189,
+              "line": 188,
               "offset": 9793
             },
             "unique_id": {
@@ -183,30 +183,30 @@
       "path": "targets/spacegrep/markdown.md",
       "start": {
         "col": 1,
-        "line": 189
+        "line": 188
       }
     },
     {
       "check_id": "rules.spacegrep.header-2",
       "end": {
         "col": 14,
-        "line": 204
+        "line": 203
       },
       "extra": {
-        "lines": "",
+        "lines": "## Commercial",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
-          "TEXT": {
+          "$TEXT": {
             "abstract_content": "Commercial",
             "end": {
               "col": 14,
-              "line": 204,
+              "line": 203,
               "offset": 10948
             },
             "start": {
               "col": 4,
-              "line": 204,
+              "line": 203,
               "offset": 10938
             },
             "unique_id": {
@@ -220,7 +220,7 @@
       "path": "targets/spacegrep/markdown.md",
       "start": {
         "col": 1,
-        "line": 204
+        "line": 203
       }
     }
   ]

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
@@ -8,7 +8,7 @@
         "line": 63
       },
       "extra": {
-        "lines": "## Getting",
+        "lines": "",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
@@ -45,7 +45,7 @@
         "line": 98
       },
       "extra": {
-        "lines": "## Examples",
+        "lines": "",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
@@ -82,7 +82,7 @@
         "line": 146
       },
       "extra": {
-        "lines": "## Resources",
+        "lines": "",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
@@ -119,7 +119,7 @@
         "line": 160
       },
       "extra": {
-        "lines": "## Usage",
+        "lines": "",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
@@ -156,7 +156,7 @@
         "line": 189
       },
       "extra": {
-        "lines": "## Contributing",
+        "lines": "",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
@@ -193,7 +193,7 @@
         "line": 204
       },
       "extra": {
-        "lines": "## Commercial",
+        "lines": "",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
@@ -5,10 +5,10 @@
       "check_id": "rules.spacegrep.all-origins-allowed",
       "end": {
         "col": 28,
-        "line": 10
+        "line": 9
       },
       "extra": {
-        "lines": "    expose_headers  = [\"ETag\"]",
+        "lines": "allowed_origins = [\"*\"]",
         "message": "CORS rule on bucket permits any origin",
         "metadata": {},
         "metavars": {},
@@ -17,7 +17,7 @@
       "path": "targets/spacegrep/terraform.tf",
       "start": {
         "col": 5,
-        "line": 10
+        "line": 9
       }
     }
   ]

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
@@ -8,7 +8,7 @@
         "line": 10
       },
       "extra": {
-        "lines": "allowed_origins = [\"*\"]",
+        "lines": "    expose_headers  = [\"ETag\"]",
         "message": "CORS rule on bucket permits any origin",
         "metadata": {},
         "metavars": {},

--- a/spacegrep/src/lib/Semgrep.atd
+++ b/spacegrep/src/lib/Semgrep.atd
@@ -33,14 +33,21 @@ type error = {
 }
 
 type position = {
-  line: int; (* starts at 1 *)
+  line: int; (* starts at 0 *)
   col: int; (* starts at 1 *)
   offset: int; (* byte position from the beginning of the file, starts at 0 *)
 }
 
 type match_extra = {
   ?message: string option; (* rule.message (?) *)
+
+  (*
+     name/value map of the matched metavariables.
+     The leading '$' must be included in the metavariable name.
+  *)
   metavars: (string * metavar_value) list <json repr="object">;
+
+  lines: string list; (* the matching region, split at lines boundaries *)
 }
 
 type error_extra = {

--- a/spacegrep/src/lib/Semgrep.atd
+++ b/spacegrep/src/lib/Semgrep.atd
@@ -33,8 +33,8 @@ type error = {
 }
 
 type position = {
-  line: int; (* starts at 0 *)
-  col: int; (* starts at 1 *)
+  line: int; (* starts from 1 *)
+  col: int; (* starts from 1 *)
   offset: int; (* byte position from the beginning of the file, starts at 0 *)
 }
 

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -8,8 +8,12 @@ open Semgrep_t
 
 let semgrep_pos (x : Lexing.position) : Semgrep_t.position =
   {
-    line = x.pos_lnum - 1;
+    (* both 'line' and 'pos_lnum' start from 1. *)
+    line = x.pos_lnum;
+
+    (* 'col' starts from 1, pos_cnum/pos_bol start from 0. *)
     col = x.pos_cnum - x.pos_bol + 1;
+
     offset = x.pos_cnum;
   }
 

--- a/spacegrep/src/lib/Src_file.ml
+++ b/spacegrep/src/lib/Src_file.ml
@@ -138,6 +138,15 @@ let safe_string_sub s orig_start orig_len =
   let len = max 0 (end_ - start) in
   String.sub s start len
 
+let region_of_pos_range x start_pos end_pos =
+  let open Lexing in
+  safe_string_sub x.contents
+    start_pos.pos_cnum
+    (end_pos.pos_cnum - start_pos.pos_cnum)
+
+let region_of_loc_range x (start_pos, _) (_, end_pos) =
+  region_of_pos_range x start_pos end_pos
+
 let lines_of_pos_range ?highlight ?(line_prefix = "") x start_pos end_pos =
   let s = x.contents in
   let open Lexing in

--- a/spacegrep/src/lib/Src_file.mli
+++ b/spacegrep/src/lib/Src_file.mli
@@ -24,8 +24,16 @@ val source_string : t -> string
 
 val contents : t -> string
 
-(* Extract a specific region specified as (first position, last position). *)
+(*
+   Extract a specific region specified as
+   (start position, end position to be excluded).
+ *)
 val region_of_pos_range : t -> Lexing.position -> Lexing.position -> string
+
+(*
+   Extract a specific region specified by the positions of the first
+   and last tokens to be included in the region.
+*)
 val region_of_loc_range : t -> Loc.t -> Loc.t -> string
 
 (*

--- a/spacegrep/src/lib/Src_file.mli
+++ b/spacegrep/src/lib/Src_file.mli
@@ -24,10 +24,15 @@ val source_string : t -> string
 
 val contents : t -> string
 
+(* Extract a specific region specified as (first position, last position). *)
+val region_of_pos_range : t -> Lexing.position -> Lexing.position -> string
+val region_of_loc_range : t -> Loc.t -> Loc.t -> string
+
 (*
    Extract the lines containing a pair of positions.
+
    This includes the beginning of the first line and the end of the last line
-   even if they're outside the requested range.
+   even if they're outside the requested range, unless trim=true.
 *)
 val lines_of_pos_range :
   ?highlight:(string -> string) ->

--- a/spacegrep/src/lib/Src_file.mli
+++ b/spacegrep/src/lib/Src_file.mli
@@ -40,7 +40,7 @@ val region_of_loc_range : t -> Loc.t -> Loc.t -> string
    Extract the lines containing a pair of positions.
 
    This includes the beginning of the first line and the end of the last line
-   even if they're outside the requested range, unless trim=true.
+   even if they're outside the requested range.
 *)
 val lines_of_pos_range :
   ?highlight:(string -> string) ->


### PR DESCRIPTION
This should fix the following in spacegrep's json output:

* off-by-two error in line numbering
* missing `lines` field
* missing `$` in front of metavariable names

Merges into the branch `spacegrep-integration`.
