### PR TITLE
Use metavariable ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   context
 - The `metavariable-comparison` operator
 
+### Fixed
+- Addressed off by one errors in autofix
+- Missing characters in metavariable interpolation
+
 ## [0.27.0](https://github.com/returntocorp/semgrep/releases/tag/v0.27.0) - 2020-10-06
 
 ### Added

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -46,7 +46,7 @@ def get_re_range_matches(
         any_matching_ranges = any(
             pm.range == _range
             and metavariable in pm.metavars
-            and re.match(regex, pm.metavars[metavariable]["abstract_content"])
+            and re.match(regex, pm.get_metavariable_value(metavariable))
             for pm in pattern_matches
         )
         if any_matching_ranges:
@@ -107,7 +107,7 @@ def get_comparison_range_matches(
                 comparison,
                 strip,
                 base,
-                pm.metavars[metavariable]["abstract_content"],
+                pm.get_metavariable_value(metavariable),
             )
             for pm in pattern_matches
         )
@@ -390,8 +390,10 @@ def evaluate(
 
 def interpolate_message_metavariables(rule: Rule, pattern_match: PatternMatch) -> str:
     msg_text = rule.message
-    for metavar, contents in pattern_match.metavars.items():
-        msg_text = msg_text.replace(metavar, contents.get("abstract_content", ""))
+    for metavar in pattern_match.metavars:
+        msg_text = msg_text.replace(
+            metavar, pattern_match.get_metavariable_value(metavar)
+        )
     return msg_text
 
 
@@ -401,8 +403,10 @@ def interpolate_fix_metavariables(
     fix_str = rule.fix
     if fix_str is None:
         return None
-    for metavar, contents in pattern_match.metavars.items():
-        fix_str = fix_str.replace(metavar, contents.get("abstract_content", ""))
+    for metavar in pattern_match.metavars:
+        fix_str = fix_str.replace(
+            metavar, pattern_match.get_metavariable_value(metavar)
+        )
     return fix_str
 
 

--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -8,7 +8,7 @@ from semgrep.semgrep_types import Range
 
 class PatternMatch:
     """
-        Encapsulates a section of code that matches a single pattern
+    Encapsulates a section of code that matches a single pattern
     """
 
     def __init__(self, raw_json: Dict[str, Any]) -> None:
@@ -65,14 +65,14 @@ class PatternMatch:
 
     def get_metavariable_value(self, metavariable: str) -> str:
         """
-            Use metavars start and end to read into the file to find what the
-            metavariable in this pattern match maps to in the file
+        Use metavars start and end to read into the file to find what the
+        metavariable in this pattern match maps to in the file
 
-            Assumes METAVARIABLE is a key in self.metavars
+        Assumes METAVARIABLE is a key in self.metavars
         """
         # Offsets are start inclusive and end exclusive
-        start_offset = self.metavars[metavariable].get("start").get("offset")
-        end_offset = self.metavars[metavariable].get("end").get("offset")
+        start_offset = self.metavars[metavariable]["start"]["offset"]
+        end_offset = self.metavars[metavariable]["end"]["offset"]
         length = end_offset - start_offset
 
         with open(self.path) as file:

--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -63,5 +63,23 @@ class PatternMatch:
             del end["offset"]
         return end
 
+    def get_metavariable_value(self, metavariable: str) -> str:
+        """
+            Use metavars start and end to read into the file to find what the
+            metavariable in this pattern match maps to in the file
+
+            Assumes METAVARIABLE is a key in self.metavars
+        """
+        # Offsets are start inclusive and end exclusive
+        start_offset = self.metavars[metavariable].get("start").get("offset")
+        end_offset = self.metavars[metavariable].get("end").get("offset")
+        length = end_offset - start_offset
+
+        with open(self.path) as file:
+            file.seek(start_offset)
+            value = file.read(length)
+
+        return value
+
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id} range={self.range}>"

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
@@ -67,7 +67,7 @@
         "line": 6
       },
       "extra": {
-        "fix": "inputs.get(x+1)",
+        "fix": "inputs.get(x + 1)",
         "lines": "  if inputs[x + 1] == True:",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_junit_xml_output/results.xml
+++ b/semgrep/tests/e2e/snapshots/test_check/test_junit_xml_output/results.xml
@@ -2,7 +2,7 @@
 <testsuites disabled="0" errors="0" failures="2" tests="2" time="0.0">
 	<testsuite disabled="0" errors="0" failures="2" name="semgrep results" skipped="0" tests="2" time="0">
 		<testcase file="targets/basic/stupid.py" line="3" name="rules.eqeq-is-bad">
-			<failure message="useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?" type="ERROR">['    return a + b == a + b\n']</failure>
+			<failure message="useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?" type="ERROR">['    return a + b == a + b\n']</failure>
 		</testcase>
 		<testcase file="targets/basic/stupid.js" line="3" name="rules.javascript-basic-eqeq-bad">
 			<failure message="useless comparison" type="ERROR">['console.log(x == x)\n']</failure>

--- a/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "console.log(x == x)",
-        "message": "Detected a useless comparison operation `x == x` or `x != x`. This \noperation is always true.\nIf testing for floating point NaN, use `math.isnan`, or\n`cmath.isnan` if the number is complex.\n",
+        "message": "Detected a useless comparison operation `x == x` or `x != x`. This\noperation is always true.\nIf testing for floating point NaN, use `math.isnan`, or\n`cmath.isnan` if the number is complex.\n",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -48,7 +48,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "This is always True: `a+b == a+b` or `a+b != a+b`. If testing for floating point NaN, use `math.isnan(a+b)`,\nor `cmath.isnan(a+b)` if the number is complex.\n",
+        "message": "This is always True: `a + b == a + b` or `a + b != a + b`. If testing for floating point NaN, use `math.isnan(a + b)`,\nor `cmath.isnan(a + b)` if the number is complex.\n",
         "metadata": {},
         "metavars": {
           "$X": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
@@ -21,7 +21,7 @@
             }
           ],
           "message": {
-            "text": "useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?"
+            "text": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?"
           },
           "ruleId": "rules.eqeq-is-bad"
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_terminal_output/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_terminal_output/output.txt
@@ -3,5 +3,5 @@ severity:error rule:rules.javascript-basic-eqeq-bad: useless comparison
 3:console.log(x == x)
 
 targets/basic/stupid.py
-severity:error rule:rules.eqeq-is-bad: useless comparison operation `a+b == a+b` or `a+b != a+b`; possible bug?
+severity:error rule:rules.eqeq-is-bad: useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?
 3:    return a + b == a + b

--- a/semgrep/tests/e2e/snapshots/test_check/test_url_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_url_rule/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "lines": "    return a + b == a + b",
-        "message": "a+b == a+b is a useless equality check",
+        "message": "a + b == a + b is a useless equality check",
         "metadata": {},
         "metavars": {
           "$X": {


### PR DESCRIPTION
Before this commit semgrep was using the abstract_context associated
with each metavariable assuming it was what the metavariable matched with
this is not always the case since the abstract context removes some concrete
syntax.

This PR relies on the more stable line ranges reported with the metavariable
as the value of the metavariable.