### PR TITLE
Combine spacegrep and spacecat into one executable file

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -73,10 +73,8 @@ jobs:
           ls -l artifacts
           chmod +x ./artifacts/semgrep-core
           chmod +x ./artifacts/spacegrep
-          chmod +x ./artifacts/spacecat
           ./artifacts/semgrep-core -help
           ./artifacts/spacegrep --help
-          ./artifacts/spacecat --help
 
   release-ubuntu:
     name: Check builds for ubuntu

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ RUN eval "$(opam env)" && DUNE_PROFILE=static make -C spacegrep/
 RUN eval "$(opam env)" && make -C semgrep-core/ all
 
 # Sanity checks
-RUN test -x ./spacegrep/_build/install/default/bin/spacecat
 RUN test -x ./spacegrep/_build/install/default/bin/spacegrep
 RUN ./semgrep-core/_build/install/default/bin/semgrep-core -version
 
@@ -54,11 +53,9 @@ COPY --from=build-semgrep-core \
 RUN semgrep-core -version
 
 COPY --from=build-semgrep-core \
-     /semgrep/spacegrep/_build/install/default/bin/spacecat \
-     /usr/local/bin/spacecat
-COPY --from=build-semgrep-core \
      /semgrep/spacegrep/_build/install/default/bin/spacegrep \
      /usr/local/bin/spacegrep
+RUN ln -sf spacegrep /usr/local/bin/spacecat
 
 COPY semgrep /semgrep
 RUN HOMEBREW_SYSTEM='NOCORE' python -m pip install /semgrep

--- a/scripts/install-alpine-semgrep-core
+++ b/scripts/install-alpine-semgrep-core
@@ -66,7 +66,6 @@ echo "Copy executables to artifacts archive"
 rm -rf ocaml-build-artifacts
 bin=ocaml-build-artifacts/bin
 mkdir -p "$bin"
-cp ./spacegrep/_build/install/default/bin/spacecat "$bin"
 cp ./spacegrep/_build/install/default/bin/spacegrep "$bin"
 cp ./semgrep-core/_build/install/default/bin/semgrep-core "$bin"
 tar czf ocaml-build-artifacts.tgz ocaml-build-artifacts

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -21,5 +21,4 @@ make build-core
 mkdir -p artifacts
 cp ./semgrep-core/_build/install/default/bin/semgrep-core artifacts
 cp ./spacegrep/_build/install/default/bin/spacegrep artifacts
-cp ./spacegrep/_build/install/default/bin/spacecat artifacts
 zip -r artifacts.zip artifacts

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -113,7 +113,24 @@ class PostInstallCommand(install):
     def run(self):
         self.copy_binary("semgrep-core")
         self.copy_binary("spacegrep")
-        # FIXME: with this binary we exceed the 100 MB limit on PyPI
+        # FIXME: with an extra 3 MB binary we exceed the 100 MB limit on PyPI
+        # Suggested fixes:
+        # - spacecat and spacegrep are now the same executable. We only need
+        #   the command (= executable file name) to be 'spacecat' to trigger
+        #   the spacecat behavior.
+        #   This can be achieved with a symlink or by copying 'spacegrep'
+        #   to 'spacecat' at installation time. Spacecat is a utility for
+        #   printing an AST, which is nice to have but not called
+        #   by semgrep or semgrep-core.
+        # - Use 'strip' to reduce the size of the semgrep-core executable.
+        #   Its big size is due to large parse tables that support
+        #   the LR(1) parsing algorithm used by menhir and tree-sitter.
+        #   For tree-sitter, those are the 'parser.c' files generated for each
+        #   grammar. We'll have more and more of such files, so the size of
+        #   our static semgrep-core executable is expected to keep growing.
+        #
+        # Original code:
+        #
         # self.copy_binary("spacecat")
 
 

--- a/spacegrep/Makefile
+++ b/spacegrep/Makefile
@@ -4,10 +4,18 @@ ifndef DUNE_PROFILE
 endif
 export DUNE_PROFILE
 
+# Build a single executable. Its behavior depends on the command name:
+#
+# - spacegrep (default)
+# - spacecat
+#
 .PHONY: build
 build:
 	dune build --profile $(DUNE_PROFILE)
-	test -e bin || ln -s _build/install/default/bin .
+	@echo
+	mkdir -p bin
+	ln -sf ../_build/install/default/bin/spacegrep bin/spacegrep
+	ln -sf spacegrep bin/spacecat
 
 .PHONY: install
 install:

--- a/spacegrep/src/bin/Space_main.ml
+++ b/spacegrep/src/bin/Space_main.ml
@@ -1,0 +1,21 @@
+(*
+   Select spacegrep or spacecat behavior depending on the command name.
+   This allows us to build a single executable, which is more compact
+   than two.
+
+   Cmdliner would let us create a single 'space' executable that would be
+   called as 'space grep', 'space cat', 'space-grep', 'spacegrep', etc.
+   but it may be confusing for users. Instead, we default to spacegrep
+   behavior if the command name is unrecognized and we don't show spacecat
+   on the spacegrep/default help page.
+*)
+
+open Cmdliner
+
+let dispatch () =
+  Printexc.record_backtrace true;
+  match Filename.basename Sys.argv.(0) with
+  | "spacecat" | "space-cat" -> Spacecat_main.main ()
+  | _ -> Spacegrep_main.main ()
+
+let () = dispatch ()

--- a/spacegrep/src/bin/Spacecat_main.ml
+++ b/spacegrep/src/bin/Spacecat_main.ml
@@ -51,14 +51,14 @@ let man = [
   `P "spacegrep(1)"
 ]
 
-let parse_command_line () =
-  let info =
-    Term.info
-      ~doc
-      ~man
-      "spacecat"
-  in
-  match Term.eval (cmdline_term, info) with
+let info name =
+  Term.info
+    ~doc
+    ~man
+    name
+
+let parse_command_line name =
+  match Term.eval (cmdline_term, info name) with
   | `Error _ -> exit 1
   | `Version | `Help -> exit 0
   | `Ok config -> config
@@ -81,8 +81,5 @@ let run config =
   print pat
 
 let main () =
-  Printexc.record_backtrace true;
-  let config = parse_command_line () in
+  let config = parse_command_line "spacecat" in
   run config
-
-let () = main ()

--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -221,21 +221,21 @@ let man = [
   `P "semgrep, spacecat"
 ]
 
-let parse_command_line () =
-  let info =
-    Term.info
-      ~doc
-      ~man
-      "spacegrep"
-  in
-  match Term.eval (cmdline_term, info) with
+let info name =
+  Term.info
+    ~doc
+    ~man
+    name
+
+let parse_command_line name =
+  match Term.eval (cmdline_term, info name) with
   | `Error _ -> exit 1
   | `Version | `Help -> exit 0
   | `Ok config -> config
 
+(*
+   Entry point for calling the command 'spacegrep' directly.
+*)
 let main () =
-  Printexc.record_backtrace true;
-  let config = parse_command_line () in
+  let config = parse_command_line "spacegrep" in
   run config
-
-let () = main ()

--- a/spacegrep/src/bin/dune
+++ b/spacegrep/src/bin/dune
@@ -1,6 +1,6 @@
 (executables
-  (public_names spacegrep spacecat)
-  (names Spacegrep_main Spacecat_main)
+  (public_names spacegrep)
+  (names Space_main)
   (libraries
     spacegrep
     cmdliner


### PR DESCRIPTION
This reduces the size of `spacegrep` and `spacecat` by having both behaviors in the same executable. argv[0] determines which behavior is invoked. Each executable used to be 3 MB and 4 MB; it's now 4.5 MB.

This doesn't install a `spacecat` command. I left a comment in `setup.py` which explains what needs to be done (something like `ln -s spacegrep spacecat`).
