### PR TITLE
adding the flag disable-language-overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Next
 
 ### Added
+- disable-language-overrides flag to stop semgrep from automatically running javascript
+  rules on typescript files.
 
 ### Fixed
 - More off by one fixes in autofix

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -89,6 +89,13 @@ def cli() -> None:
         action="store_true",
         help="Only invoke semgrep if configuration files(s) are valid.",
     )
+    config.add_argument(
+        "--disable-language-overrides",
+        action="store_true",
+        help="Semgrep automatically runs subset language rules on superset language files."
+        " For example, semgrep will run javascript rules on typescript files."
+        " To disable this, use the following flag.",
+    )
 
     parser.add_argument(
         "--exclude",
@@ -203,10 +210,9 @@ def cli() -> None:
     output.add_argument(
         "--save-test-output-tar",
         action="store_true",
-        help= (
+        help=(
             "Store json output as a tarball that will be uploaded as a Github artifact."
         ),
-
     )
     output.add_argument(
         "--debugging-json",
@@ -363,7 +369,7 @@ def cli() -> None:
             synthesize_patterns(args.lang, args.synthesize_patterns, target)
         elif args.validate:
             configs, config_errors = semgrep.semgrep_main.get_config(
-                args.pattern, args.lang, args.config
+                args.pattern, args.lang, args.config, args.disable_language_overrides
             )
             valid_str = "invalid" if config_errors else "valid"
             rule_count = len(configs.get_rules(True))
@@ -390,6 +396,7 @@ def cli() -> None:
                 strict=args.strict,
                 autofix=args.autofix,
                 dryrun=args.dryrun,
+                disable_language_overrides=args.disable_language_overrides,
                 disable_nosem=args.disable_nosem,
                 dangerously_allow_arbitrary_code_execution_from_rules=args.dangerously_allow_arbitrary_code_execution_from_rules,
                 no_git_ignore=args.no_git_ignore,

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -56,15 +56,15 @@ class Config:
 
     @classmethod
     def from_pattern_lang(
-        cls, pattern: str, lang: str
+        cls, pattern: str, lang: str, disable_language_overrides: bool
     ) -> Tuple["Config", List[SemgrepError]]:
         config_dict = manual_config(pattern, lang)
-        valid, errors = cls._validate(config_dict)
+        valid, errors = cls._validate(config_dict, disable_language_overrides)
         return cls(valid), errors
 
     @classmethod
     def from_config_list(
-        cls, configs: List[str]
+        cls, configs: List[str], disable_language_overrides: bool
     ) -> Tuple["Config", List[SemgrepError]]:
         """
             Takes in list of files/directories and returns Config object as well as
@@ -87,7 +87,7 @@ class Config:
             except SemgrepError as e:
                 errors.append(e)
 
-        valid, parse_errors = cls._validate(config_dict)
+        valid, parse_errors = cls._validate(config_dict, disable_language_overrides)
         errors.extend(parse_errors)
         return cls(valid), errors
 
@@ -137,7 +137,7 @@ class Config:
 
     @staticmethod
     def _validate(
-        config_dict: Dict[str, YamlTree]
+        config_dict: Dict[str, YamlTree], disable_language_overrides: bool
     ) -> Tuple[Dict[str, List[Rule]], List[SemgrepError]]:
         """
             Take configs and separate into valid and list of errors parsing the invalid ones
@@ -164,7 +164,9 @@ class Config:
             for rule_dict in rules.value:
 
                 try:
-                    rule = validate_single_rule(config_id, rule_dict)
+                    rule = validate_single_rule(
+                        config_id, rule_dict, disable_language_overrides
+                    )
                 except InvalidRuleSchemaError as ex:
                     errors.append(ex)
                 else:
@@ -176,7 +178,7 @@ class Config:
 
 
 def validate_single_rule(
-    config_id: str, rule_yaml: YamlTree[YamlMap]
+    config_id: str, rule_yaml: YamlTree[YamlMap], disable_language_overrides: bool
 ) -> Optional[Rule]:
     """
         Validate that a rule dictionary contains all necessary keys
@@ -185,7 +187,7 @@ def validate_single_rule(
     rule: YamlMap = rule_yaml.value
 
     # Defaults to search mode if mode is not specified
-    return Rule.from_yamltree(rule_yaml)
+    return Rule.from_yamltree(rule_yaml, disable_language_overrides)
 
 
 def manual_config(pattern: str, lang: str) -> Dict[str, YamlTree]:

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_config(
-    pattern: str, lang: str, config_strs: List[str]
+    pattern: str, lang: str, config_strs: List[str], disable_language_overrides: bool
 ) -> Tuple[semgrep.config_resolver.Config, List[SemgrepError]]:
     # let's check for a pattern
     if pattern:
@@ -41,10 +41,14 @@ def get_config(
             raise SemgrepError("language must be specified when a pattern is passed")
 
         # TODO for now we generate a manual config. Might want to just call semgrep -e ... -l ...
-        config, errors = semgrep.config_resolver.Config.from_pattern_lang(pattern, lang)
+        config, errors = semgrep.config_resolver.Config.from_pattern_lang(
+            pattern, lang, disable_language_overrides
+        )
     else:
         # else let's get a config. A config is a dict from config_id -> config. Config Id is not well defined at this point.
-        config, errors = semgrep.config_resolver.Config.from_config_list(config_strs)
+        config, errors = semgrep.config_resolver.Config.from_config_list(
+            config_strs, disable_language_overrides
+        )
 
     # if we can't find a config, use default r2c rules
     if not config:
@@ -163,6 +167,7 @@ def main(
     strict: bool = False,
     autofix: bool = False,
     dryrun: bool = False,
+    disable_language_overrides: bool = False,
     disable_nosem: bool = False,
     dangerously_allow_arbitrary_code_execution_from_rules: bool = False,
     no_git_ignore: bool = False,
@@ -178,7 +183,7 @@ def main(
     if exclude is None:
         exclude = []
 
-    configs_obj, errors = get_config(pattern, lang, configs)
+    configs_obj, errors = get_config(pattern, lang, configs, disable_language_overrides)
     all_rules = configs_obj.get_rules(no_rewrite_rule_ids)
 
     output_handler.handle_semgrep_errors(errors)

--- a/semgrep/tests/unit/test_evaluation.py
+++ b/semgrep/tests/unit/test_evaluation.py
@@ -415,7 +415,7 @@ def test_build_exprs() -> None:
         {**base_rule, **{"pattern-either": [{"pattern": "test(...)"}]}},
     ]
 
-    results = [Rule.from_json(rule).expression for rule in rules]
+    results = [Rule.from_json(rule, False).expression for rule in rules]
     base_expected = [
         BooleanRuleExpression(OPERATORS.AND, PatternId(".0"), None, "test(...)")
     ]

--- a/semgrep/tests/unit/test_yaml_parsing.py
+++ b/semgrep/tests/unit/test_yaml_parsing.py
@@ -37,5 +37,5 @@ rules:
     config = yaml["testfile"].value
     rules = config.get(RULES_KEY)
     for rule_dict in rules.value:
-        validate_single_rule("testfile", rule_dict)
+        validate_single_rule("testfile", rule_dict, False)
     assert True


### PR DESCRIPTION
The --disable-language-overrides flag disables js rules from running on ts files automatically.

**Test Plan:**

To test this, create a repository that has a ts rule and ts code. In the ts rule, make sure the `languages` key only includes language javascript.

Use

`python -m semgrep -f ../semgrep-rules/ts/<rule file> ../semgrep-rules/ts`

to check that the rule will run.

Then use

`python -m semgrep --disable-language-overrides -f ../semgrep-rules/ts/helloworld.yaml ../semgrep-rules/ts`

to check that the rule doesn't run when the disable-language-overrides flag is used.