### PR TITLE
Can specify config without full url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Next
 
 ### Added
+- Allow user to specify registry path without having to add semgrep.dev url
+  i.e.: instead of `--config https://semgrep.dev/p/r2c-ci` users can use `--config p/r2c-ci`
+- Allow user to specify snippet id withouth having to add semgrep.dev url
+  i.e.: instead of `--config https://semgrep.dev/s/username:snippetname`
+  users can use `--config username:snippetname`
 
 ### Fixed
 - More off by one fixes in autofix

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -16,6 +16,7 @@ from semgrep.constants import DEFAULT_SEMGREP_CONFIG_NAME
 from semgrep.constants import ID_KEY
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.constants import RULES_KEY
+from semgrep.constants import SEMGREP_URL
 from semgrep.constants import SEMGREP_USER_AGENT
 from semgrep.constants import YML_EXTENSIONS
 from semgrep.error import InvalidRuleSchemaError
@@ -407,15 +408,14 @@ def registry_id_to_url(registry_id: str) -> str:
     """
         Convert from registry_id to semgrep.dev url
     """
-    return f"https://semgrep.dev/{registry_id}"
+    return f"{SEMGREP_URL}{registry_id}"
 
 
 def saved_snippet_to_url(snippet_id: str) -> str:
     """
         Convert from username:snippetname to semgrep.dev url
     """
-    username, snippetname = snippet_id.split(":")
-    return f"https://semgrep.dev/s/{username}/{snippetname}"
+    return registry_id_to_url(f"s/{snippet_id}")
 
 
 def resolve_config(config_str: str) -> Dict[str, YamlTree]:

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -400,7 +400,7 @@ def is_saved_snippet(config_str: str) -> bool:
     """
         config_str is saved snippet which has format username:snippetname
     """
-    return len(config_str.split(":")) is 2
+    return len(config_str.split(":")) == 2
 
 
 def registry_id_to_url(registry_id: str) -> str:

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -389,6 +389,35 @@ def download_config(config_url: str) -> Dict[str, YamlTree]:
     return None
 
 
+def is_registry_id(config_str: str) -> bool:
+    """
+        Starts with r/, p/, s/ for registry, pack, and snippet respectively
+    """
+    return config_str[:2] in {"r/", "p/", "s/"}
+
+
+def is_saved_snippet(config_str: str) -> bool:
+    """
+        config_str is saved snippet which has format username:snippetname
+    """
+    return len(config_str.split(":")) is 2
+
+
+def registry_id_to_url(registry_id: str) -> str:
+    """
+        Convert from registry_id to semgrep.dev url
+    """
+    return f"https://semgrep.dev/{registry_id}"
+
+
+def saved_snippet_to_url(snippet_id: str) -> str:
+    """
+        Convert from username:snippetname to semgrep.dev url
+    """
+    username, snippetname = snippet_id.split(":")
+    return f"https://semgrep.dev/s/{username}/{snippetname}"
+
+
 def resolve_config(config_str: str) -> Dict[str, YamlTree]:
     """ resolves if config arg is a registry entry, a url, or a file, folder, or loads from defaults if None"""
     start_t = time.time()
@@ -396,6 +425,10 @@ def resolve_config(config_str: str) -> Dict[str, YamlTree]:
         config = download_config(RULES_REGISTRY[config_str])
     elif is_url(config_str):
         config = download_config(config_str)
+    elif is_registry_id(config_str):
+        config = download_config(registry_id_to_url(config_str))
+    elif is_saved_snippet(config_str):
+        config = download_config(saved_snippet_to_url(config_str))
     else:
         config = load_config_from_local_path(config_str)
     if config:


### PR DESCRIPTION
- Allow user to specify registry path without having to add semgrep.dev url
  i.e.: instead of `--config https://semgrep.dev/p/r2c-ci` users can use `--config p/r2c-ci`
- Allow user to specify snippet id withouth having to add semgrep.dev url
  i.e.: instead of `--config https://semgrep.dev/s/username:snippetname`
  users can use `--config username:snippetname`