### PR TITLE
Fix impossible matching on files not containing a newline

### DIFF
--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -41,9 +41,8 @@ let run_all ~debug ~output_format ~highlight patterns docs =
       let matches =
         match doc_type with
         | Gibberish ->
-            if debug then
-              printf "ignore gibberish file: %s\n%!"
-                (Src_file.source_string doc_src);
+            eprintf "ignoring gibberish file: %s\n%!"
+              (Src_file.source_string doc_src);
             []
         | Text ->
             if debug then

--- a/spacegrep/src/lib/File_type.ml
+++ b/spacegrep/src/lib/File_type.ml
@@ -9,8 +9,8 @@ type t =
 let guess src =
   let contents = Src_file.contents src in
   let length = String.length contents in
-  let newlines =
-    let n = ref 0 in
+  let num_lines =
+    let n = ref 1 in
     String.iter (function
       | '\n' -> incr n
       | _ -> ()
@@ -22,7 +22,7 @@ let guess src =
      For random bytes, the average line length is 256.
      For minified source code, there may be not a single newline in the file.
   *)
-  if length = 0 || float newlines /. float length >= 1./.150. then
+  if length = 0 || float num_lines /. float length >= 1./.150. then
     Text
   else
     Gibberish

--- a/spacegrep/src/lib/Match.mli
+++ b/spacegrep/src/lib/Match.mli
@@ -50,6 +50,7 @@ val search : Pattern_AST.t -> Doc_AST.t -> match_ list
 *)
 val print :
   ?highlight:bool ->
+  ?print_optional_separator:(unit -> unit) ->
   Src_file.t -> match_ list -> unit
 
 (*
@@ -57,4 +58,5 @@ val print :
 *)
 val print_nested_results :
   ?highlight:bool ->
+  ?print_optional_separator:(unit -> unit) ->
   (Src_file.t * (pattern_id * match_ list) list) list -> unit


### PR DESCRIPTION
This was an off-by-one error in counting lines, leading to the conclusion that the file was gibberish due to having too much material per line.

Spacegrep will now print something on stderr if a file is skipped.

Also, I added support in spacecat for reading from files instead of stdin, and fixed the spacing between match results just so the output looks better.

Fixes https://github.com/returntocorp/semgrep/issues/1928
