### PR TITLE
Add --force option to spacegrep

### DIFF
--- a/spacegrep/src/bin/Spacecat_main.ml
+++ b/spacegrep/src/bin/Spacecat_main.ml
@@ -57,7 +57,7 @@ let man = [
   `P "Martin Jambon <martin@returntocorp.com>";
   `S Manpage.s_bugs;
   `P "Check out bug reports at \
-      https://github.com/returntocorp/spacegrep/issues.";
+      https://github.com/returntocorp/semgrep/issues.";
   `S Manpage.s_see_also;
   `P "spacegrep(1)"
 ]

--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -229,7 +229,7 @@ let man = [
   `P "Martin Jambon <martin@returntocorp.com>";
   `S Manpage.s_bugs;
   `P "Check out bug reports at \
-      https://github.com/returntocorp/spacegrep/issues.";
+      https://github.com/returntocorp/semgrep/issues.";
   `S Manpage.s_see_also;
   `P "semgrep, spacecat"
 ]


### PR DESCRIPTION
By default, files that look like they can't be processed by spacegrep (minified, non-ascii-compatible encoding, or binary) are skipped. The `--force` option disables this skipping.