### PR TITLE
Fix matching of trailing dots

### DIFF
--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -55,7 +55,7 @@ let run_all ~debug ~force ~output_format ~highlight patterns docs =
                 printf "match document from %s against pattern from %s\n%!"
                   (Src_file.source_string doc_src)
                   (Src_file.source_string pat_src);
-              (pat_id, Match.search pat doc)
+              (pat_id, Match.search doc_src pat doc)
             ) patterns
       in
       (doc_src, matches)

--- a/spacegrep/src/lib/Doc_AST.ml
+++ b/spacegrep/src/lib/Doc_AST.ml
@@ -59,3 +59,7 @@ and to_pat_atom (atom : atom) : Pattern_AST.atom =
   | Word s -> Word s
   | Punct c -> Punct c
   | Byte c -> Byte c
+
+(* Equality function that disregards location. Meant for unit tests. *)
+let eq a b =
+  Pattern_AST.eq (to_pattern a) (to_pattern b)

--- a/spacegrep/src/lib/Match.ml
+++ b/spacegrep/src/lib/Match.ml
@@ -98,7 +98,7 @@ let rec extend_last_loc ~max_line_num last_loc (doc : Doc_AST.node list) =
       if loc_lnum loc <= max_line_num then
         extend_last_loc ~max_line_num loc doc
       else
-        None
+        Some last_loc
 
 let doc_matches_dots ~dots last_loc doc =
   match dots, doc with
@@ -328,7 +328,7 @@ let to_string src match_ =
 
 let convert_capture src (start_pos, _) (_, end_pos) =
   let loc = (start_pos, end_pos) in
-  let value = Src_file.lines_of_pos_range src start_pos end_pos in
+  let value = Src_file.region_of_pos_range src start_pos end_pos in
   { value; loc }
 
 (*

--- a/spacegrep/src/lib/Match.mli
+++ b/spacegrep/src/lib/Match.mli
@@ -25,8 +25,7 @@ type region = Loc.t * Loc.t
   from the source document.
 *)
 type capture = {
-  name: string;
-  value: string; (* just nice to have, especially since it's a single word *)
+  value: string; (* source text, substring of the original document. *)
   loc: Loc.t;
 }
 
@@ -36,14 +35,15 @@ type capture = {
 *)
 type match_ = {
   region: region;
-  captures: capture list;
+  capture: capture;
+  named_captures: (string * capture) list;
 }
 
 (*
    Match a pattern against a document. Return the list of all
    non-overlapping matches found by scanning the document from left to right.
 *)
-val search : Pattern_AST.t -> Doc_AST.t -> match_ list
+val search : Src_file.t -> Pattern_AST.t -> Doc_AST.t -> match_ list
 
 (*
    Print the matched lines to stdout in a human-readable format.

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -28,8 +28,7 @@ let unique_id_of_loc (loc : Loc.t) : unique_id =
     md5sum;
   }
 
-let convert_capture x =
-  let name = x.name in
+let convert_capture (name, x) =
   assert (name <> "" && name.[0] <> '$');
   let pos1, pos2 = x.loc in
   ("$" ^ name), {
@@ -50,7 +49,7 @@ let make_semgrep_json doc_matches : Semgrep_t.match_results =
         let check_id = Some (string_of_int pat_id) in
         List.map (fun match_ ->
           let ((pos1, _), (_, pos2)) = match_.region in
-          let metavars = List.map convert_capture match_.captures in
+          let metavars = List.map convert_capture match_.named_captures in
           let lines =
             Src_file.region_of_pos_range src pos1 pos2
             |> String.split_on_char '\n'

--- a/spacegrep/src/test/Matcher.ml
+++ b/spacegrep/src/test/Matcher.ml
@@ -97,6 +97,7 @@ let matcher_corpus = [
   "simple fail", Count 0, "a", "ab cd";
   "sequence", Count 1, "a b", "a b c";
   "stutter", Count 1, "a b", "a a b";
+  "search", Matches ["a"; "a"; "a"], "a", "42 a\n, b, a, c a";
   "cover parenthesized block", Count 1, "a (b c) d", "a (b c) d";
 
   "cover indented block", Count 1, "a b c d e",
@@ -131,11 +132,11 @@ c
 
   "multiple matches", Count 3, "a", "a a a";
   "just dots", Count 1, "...", "a b";
-  "dots", Count 1, "a...b", "a x y b";
+  "dots", Matches ["a x y b"], "a...b", "a x y b";
   "unnecessary dots", Count 1, "a...b", "a b";
   "overnumerous dots", Count 1, "a ... ... c", "a b c";
   "double dots", Count 1, "a...b...c", "a x b x x c";
-  "trailing dots", Count 1, "a ...", "a b";
+  "trailing dots", Matches ["a b"], "a ...", "a b";
 
   "dots in subblock mismatch", Count 0,
   "\
@@ -203,6 +204,12 @@ d
   "double dots overflow", Count 0, "0 ... ... 21",
   "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n\
    10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21";
+
+  "trailing dots", Matches ["0 1 2 3 4 5"], "0 ...",
+  "0\n1\n2\n3\n4\n5\n";
+
+  "trailing dots limit", Matches ["0 1 2 3 4 5 6 7 8 9 10"], "0 ...",
+  "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12";
 
   "code match", Count 1,
   "function foo(x, y) { x = 42; ... y = x + 3; ... }",


### PR DESCRIPTION
Writing a test for this required the ability, in unit tests, to compare expected matches with the actual matches. So I added this functionality. Previously we were just counting how matches were returned without looking what they captured.

So, the failing test was the following:
```
$ seq 0 20
0
1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
$ seq 0 20 | spacegrep '5...'
5
```

The spacegrep result `5` above is incorrect. The dots should match up to 10 lines after the last item captured before the dots. The result should be:
```
$ seq 0 20 | spacegrep '5...'
5
6
7
8
9
10
11
12
13
14
15
```

It now works correctly.

The value of this fix is primarily for pedagogical purposes, because it shows that the dots match at most 10 lines. Trailing dots are otherwise not expected to be a useful feature.
