### PR TITLE
spacegrep - detect binary files more aggressively + tests

### DIFF
--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -38,10 +38,10 @@ let run_all ~debug ~force ~output_format ~highlight patterns docs =
   let matches =
     List.map (fun get_doc_src ->
       let doc_src = get_doc_src () in
-      let doc_type = File_type.guess doc_src in
+      let doc_type = File_type.classify doc_src in
       let matches =
         match doc_type, force with
-        | Gibberish, false ->
+        | (Minified | Binary), false ->
             eprintf "ignoring gibberish file: %s\n%!"
               (Src_file.source_string doc_src);
             []

--- a/spacegrep/src/lib/File_type.ml
+++ b/spacegrep/src/lib/File_type.ml
@@ -7,6 +7,11 @@ type t =
   | Minified (* looks like source code from which whitespace was removed *)
   | Binary (* doesn't look like source code *)
 
+let to_string = function
+  | Text -> "text"
+  | Minified -> "minified"
+  | Binary -> "binary"
+
 let classify src =
   let contents = Src_file.contents src in
   let length = String.length contents in

--- a/spacegrep/src/lib/File_type.ml
+++ b/spacegrep/src/lib/File_type.ml
@@ -3,26 +3,63 @@
 *)
 
 type t =
-  | Text
-  | Gibberish
+  | Text (* looks like source code *)
+  | Minified (* looks like source code from which whitespace was removed *)
+  | Binary (* doesn't look like source code *)
 
-let guess src =
+let classify src =
   let contents = Src_file.contents src in
   let length = String.length contents in
-  let num_lines =
-    let n = ref 1 in
+  let num_lines, ascii_printable, ascii_not_printable =
+    let newlines = ref 0 in
+    let ascii_printable = ref 0 in
+    let ascii_not_printable = ref 0 in
     String.iter (function
-      | '\n' -> incr n
-      | _ -> ()
+      (* LF *)
+      | '\n' ->
+          incr newlines;
+          incr ascii_printable
+
+      (* ascii and printable, other than LF *)
+      | '\t'
+      | '\r'
+      | ' '..'~' ->
+          incr ascii_printable
+
+      (* non-ascii *)
+      | '\x80'..'\xff' -> ()
+
+      (* ascii and not printable *)
+      | '\x00'..'\x08'
+      | '\x0b'..'\x0c'
+      | '\x0e'..'\x1f'
+      | '\x7f' ->
+          incr ascii_not_printable
+
     ) contents;
-    !n
+    let num_lines = !newlines + 1 in
+    num_lines, !ascii_printable, !ascii_not_printable
   in
+
   (* If the average line is longer than 150, it's considered not
      human-readable.
      For random bytes, the average line length is 256.
      For minified source code, there may be not a single newline in the file.
   *)
-  if length = 0 || float num_lines /. float length >= 1./.150. then
+  let has_enough_lines =
+    length = 0
+    || float num_lines /. float length >= 1./.150. in
+
+  (* We don't care how many non-ascii bytes there are. *)
+  let is_binary =
+    length > 0
+    && float ascii_not_printable
+       /. float (ascii_printable + ascii_not_printable) >= 0.01
+  in
+
+  if is_binary then
+    Binary
+  else if has_enough_lines then
     Text
   else
-    Gibberish
+    Minified

--- a/spacegrep/src/test/File_type.ml
+++ b/spacegrep/src/test/File_type.ml
@@ -1,0 +1,38 @@
+(*
+   Test the detection of non-text files to be ignored by spacegrep.
+*)
+
+open Spacegrep
+
+let corpus = [
+  "hello", File_type.Text, "hello, world.\n";
+  "no newline", File_type.Text, "hello, world.";
+  "just newlines", File_type.Text, "\n\n\n\n\n\n\n\n\n\n\n";
+
+  "some control characters", File_type.Binary,
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\x05zzzzzzzzzzzzzzzzzzzzzz";
+
+  "some non-ascii", File_type.Text, "a\x80";
+  "just non-ascii", File_type.Text, "\x80\x90\xff";
+
+  "one long line", File_type.Minified,
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+]
+
+let run_one expected_class data =
+  let src = Src_file.of_string data in
+  let class_ = File_type.classify src in
+  Alcotest.(check string) "equal"
+    (File_type.to_string expected_class)
+    (File_type.to_string class_)
+
+let test =
+  let suite =
+    List.map (fun (name, expected_class, data) ->
+      name, `Quick, (fun () -> run_one expected_class data)
+    ) corpus
+  in
+  "File_type", suite

--- a/spacegrep/src/test/test.ml
+++ b/spacegrep/src/test/test.ml
@@ -3,6 +3,7 @@
 *)
 
 let test_suites : unit Alcotest.test list = [
+  File_type.test;
   Parser.test;
   Matcher.test;
   Src_file.test;


### PR DESCRIPTION
This allows a `spacegrep` scan to exclude all binary files by looking at the frequency of ascii control characters, which is an improvement over what we had before (which is just based on the frequency of `\n` and doesn't always work to exclude binary files). This is useful when using the spacegrep command recursively e.g.
```
spacegrep 'eval(...)' -d .
```
