### PR TITLE
Fix not running multiple configs.

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -85,8 +85,13 @@ class Config:
         for i, config in enumerate(configs):
             try:
                 # Patch config_id to fix https://github.com/returntocorp/semgrep/issues/1912
+                resolved_config = resolve_config(config)
+                if not resolved_config:
+                    logger.debug(f"Could not resolve config for {config}. Skipping.")
+                    continue
+                # Extract key and value
                 resolved_config_key, resolved_config_yaml_tree = next(
-                    iter(resolve_config(config).items())
+                    iter(resolved_config.items())
                 )
                 patched_resolved_config: Dict[str, YamlTree] = {}
                 patched_resolved_config[

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -82,9 +82,18 @@ class Config:
             except SemgrepError as e:
                 errors.append(e)
 
-        for config in configs:
+        for i, config in enumerate(configs):
             try:
-                config_dict.update(resolve_config(config))
+                # Patch config_id to fix https://github.com/returntocorp/semgrep/issues/1912
+                resolved_config_key, resolved_config_yaml_tree = next(
+                    iter(resolve_config(config).items())
+                )
+                patched_resolved_config: Dict[str, YamlTree] = {}
+                patched_resolved_config[
+                    f"{resolved_config_key}_{i}"
+                ] = resolved_config_yaml_tree
+
+                config_dict.update(patched_resolved_config)
             except SemgrepError as e:
                 errors.append(e)
 

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -54,7 +54,7 @@ def _clean_output_json(output_json: str) -> str:
 
 
 def _run_semgrep(
-    config: Optional[Union[str, Path]] = None,
+    config: Optional[Union[str, Path, List[str]]] = None,
     *,
     target_name: str = "basic",
     options: Optional[List[Union[str, Path]]] = None,
@@ -79,7 +79,11 @@ def _run_semgrep(
     options.append("--disable-version-check")
 
     if config is not None:
-        options.extend(["--config", config])
+        if isinstance(config, list):
+            for conf in config:
+                options.extend(["--config", conf])
+        else:
+            options.extend(["--config", config])
 
     if output_format == "json":
         options.append("--json")

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
@@ -1,0 +1,192 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.eqeq-is-bad",
+      "end": {
+        "col": 26,
+        "line": 3
+      },
+      "extra": {
+        "lines": "    return a + b == a + b",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "a+b",
+            "end": {
+              "col": 17,
+              "line": 3,
+              "offset": 60
+            },
+            "start": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 12,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.javascript-basic-eqeq-bad",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "useless comparison",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "eqeq-is-bad",
+      "end": {
+        "col": 26,
+        "line": 3
+      },
+      "extra": {
+        "lines": "    return a + b == a + b",
+        "message": "a + b == a + b is a useless equality check",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "a+b",
+            "end": {
+              "col": 17,
+              "line": 3,
+              "offset": 60
+            },
+            "start": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 12,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "eqeq-is-bad",
+      "end": {
+        "col": 11,
+        "line": 8
+      },
+      "extra": {
+        "lines": "    x == x",
+        "message": "x == x is a useless equality check",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 6,
+              "line": 8,
+              "offset": 169
+            },
+            "start": {
+              "col": 5,
+              "line": 8,
+              "offset": 168
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 5,
+        "line": 8
+      }
+    },
+    {
+      "check_id": "eqeq-is-bad",
+      "end": {
+        "col": 18,
+        "line": 12
+      },
+      "extra": {
+        "lines": "assertTrue(x == x)",
+        "message": "x == x is a useless equality check",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 13,
+              "line": 12,
+              "offset": 261
+            },
+            "start": {
+              "col": 12,
+              "line": 12,
+              "offset": 260
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 12,
+        "line": 12
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
@@ -1,0 +1,118 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.eqeq-is-bad",
+      "end": {
+        "col": 26,
+        "line": 3
+      },
+      "extra": {
+        "lines": "    return a + b == a + b",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "a+b",
+            "end": {
+              "col": 17,
+              "line": 3,
+              "offset": 60
+            },
+            "start": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 12,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.javascript-basic-eqeq-bad",
+      "end": {
+        "col": 19,
+        "line": 3
+      },
+      "extra": {
+        "lines": "console.log(x == x)",
+        "message": "useless comparison",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 25
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 24
+            },
+            "unique_id": {
+              "kind": "Global",
+              "sid": 1,
+              "type": "id",
+              "value": "x"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.js",
+      "start": {
+        "col": 13,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.eqeq-is-bad",
+      "end": {
+        "col": 26,
+        "line": 3
+      },
+      "extra": {
+        "lines": "    return a + b == a + b",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "a+b",
+            "end": {
+              "col": 17,
+              "line": 3,
+              "offset": 60
+            },
+            "start": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid.py",
+      "start": {
+        "col": 12,
+        "line": 3
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -7,6 +7,10 @@ from xmldiff import main
 
 from semgrep import __VERSION__
 
+GITHUB_TEST_GIST_URL = (
+    "https://raw.githubusercontent.com/returntocorp/semgrep-rules/develop/template.yaml"
+)
+
 
 def test_basic_rule__local(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/eqeq.yaml"), "results.json")
@@ -83,10 +87,7 @@ def test_sarif_output(run_semgrep_in_tmp, snapshot):
 
 def test_url_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
-        run_semgrep_in_tmp(
-            "https://raw.githubusercontent.com/returntocorp/semgrep-rules/develop/template.yaml",
-        ),
-        "results.json",
+        run_semgrep_in_tmp(GITHUB_TEST_GIST_URL), "results.json",
     )
 
 
@@ -314,4 +315,17 @@ def test_metavariable_comparison_rule_bad_content(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-comparison-bad-content.yaml"),
         "results.json",
+    )
+
+
+def test_multiple_configs_file(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(["rules/eqeq.yaml", "rules/eqeq-python.yaml"]),
+        "results.json",
+    )
+
+
+def test_multiple_configs_different_origins(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(["rules/eqeq.yaml", GITHUB_TEST_GIST_URL]), "results.json"
     )

--- a/semgrep/tests/unit/test_yaml_parsing.py
+++ b/semgrep/tests/unit/test_yaml_parsing.py
@@ -1,3 +1,7 @@
+from tempfile import NamedTemporaryFile
+from textwrap import dedent
+
+from semgrep.config_resolver import Config
 from semgrep.config_resolver import parse_config_string
 from semgrep.config_resolver import validate_single_rule
 from semgrep.constants import RULES_KEY
@@ -39,3 +43,43 @@ rules:
     for rule_dict in rules.value:
         validate_single_rule("testfile", rule_dict)
     assert True
+
+
+def test_multiple_configs():
+    config1 = dedent(
+        """
+    rules:
+    - id: rule1
+      pattern: $X == $X
+      languages: [python]
+      severity: INFO
+      message: bad
+    """
+    )
+    config2 = dedent(
+        """
+    rules:
+    - id: rule2
+      pattern: $X == $Y
+      languages: [python]
+      severity: INFO
+      message: good
+    - id: rule3
+      pattern: $X < $Y
+      languages: [c]
+      severity: INFO
+      message: doog
+    """
+    )
+
+    with NamedTemporaryFile() as tf1, NamedTemporaryFile() as tf2:
+        tf1.write(config1.encode("utf-8"))
+        tf2.write(config2.encode("utf-8"))
+        tf1.flush()
+        tf2.flush()
+        config_list = [tf1.name, tf2.name]
+        config, errors = Config.from_config_list(config_list)
+        assert not errors
+        rules = config.get_rules(True)
+        assert len(rules) == 3
+        assert {"rule1", "rule2", "rule3"} == set([rule.id for rule in rules])


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/1912.

Patch 'config_id' with an incrementally increasing integer. Added unit test to make sure two configs are resolved.