### PR TITLE
adding basic kotlin files to enable --dump_tree_sitter_cst

### DIFF
--- a/semgrep-core/parsing/Check_semgrep.ml
+++ b/semgrep-core/parsing/Check_semgrep.ml
@@ -10,7 +10,8 @@ let lang_has_no_dollar_ids = Lang.(function
   | OCaml
   | JSON
   | Csharp
-  -> true
+  | Kotlin
+    -> true
   | Javascript | Ruby | Typescript | PHP
   -> false)
 (*e: constant [[Check_semgrep.lang_has_no_dollar_ids]] *)

--- a/semgrep-core/parsing/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_kotlin_tree_sitter.ml
@@ -1,0 +1,42 @@
+ (* PUT YOUR NAME HERE
+  *
+  * Copyright (c) PUT YOUR COPYRIGHT HERE
+  *
+  * This program is free software; you can redistribute it and/or
+  * modify it under the terms of the GNU General Public License (GPL)
+  * version 2 as published by the Free Software Foundation.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * file license.txt for more details.
+  *)
+ module CST = Tree_sitter_kotlin.CST
+ module H = Parse_tree_sitter_helpers
+
+ (*****************************************************************************)
+ (* Prelude *)
+ (*****************************************************************************)
+ (* Csharp parser using ocaml-tree-sitter-lang/charp and converting
+  * directly to pfff/h_program-lang/AST_generic.ml
+  *
+  *)
+
+ (*****************************************************************************)
+ (* Helpers *)
+ (*****************************************************************************)
+ type env = H.env
+ let _fake = AST_generic.fake
+ let token = H.token
+ let str = H.str
+
+
+ (*****************************************************************************)
+ (* Entry point *)
+ (*****************************************************************************)
+ let parse file =
+   H.wrap_parser
+     (fun () ->
+        Parallel.backtrace_when_exn := false;
+        Parallel.invoke Tree_sitter_csharp.Parse.file file ()
+     )

--- a/semgrep-core/parsing/Test_parsing.ml
+++ b/semgrep-core/parsing/Test_parsing.ml
@@ -46,6 +46,10 @@ let dump_tree_sitter_cst_lang lang file =
       Tree_sitter_csharp.Parse.file file
       |> fail_on_error
       |> Tree_sitter_csharp.CST.dump_tree
+   | Lang.Kotlin ->
+      Tree_sitter_kotlin.Parse.file file
+      |> fail_on_error
+      |> Tree_sitter_kotlin.CST.dump_tree
    | Lang.Javascript ->
       Tree_sitter_javascript.Parse.file file
       |> fail_on_error

--- a/semgrep-core/parsing/dune
+++ b/semgrep-core/parsing/dune
@@ -6,6 +6,7 @@
 
    tree-sitter-lang.ruby
    tree-sitter-lang.java
+   tree-sitter-lang.kotlin
    tree-sitter-lang.go
    tree-sitter-lang.csharp
    tree-sitter-lang.javascript

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -70,7 +70,7 @@ let print_bool env = function
           -> "True"
          | Lang.Java | Lang.Go | Lang.C | Lang.JSON | Lang.Javascript
          | Lang.OCaml | Lang.Ruby | Lang.Typescript
-         | Lang.Csharp | Lang.PHP
+         | Lang.Csharp | Lang.PHP | Lang.Kotlin
           -> "true")
   | false ->
      (match env.lang with
@@ -78,7 +78,7 @@ let print_bool env = function
           -> "False"
          | Lang.Java | Lang.Go | Lang.C | Lang.JSON | Lang.Javascript
          | Lang.OCaml | Lang.Ruby | Lang.Typescript
-         | Lang.Csharp | Lang.PHP
+         | Lang.Csharp | Lang.PHP | Lang.Kotlin
           -> "false")
 
 let arithop env (op, tok) =
@@ -169,6 +169,7 @@ and if_stmt env level (tok, e, s, sopt) =
     | Lang.Python | Lang.Python2 | Lang.Python3 -> (no_paren_cond, "elif", colon_body)
     | Lang.Java | Lang.Go | Lang.C | Lang.Csharp
     | Lang.JSON | Lang.Javascript | Lang.Typescript
+    | Lang.Kotlin
       -> (paren_cond, "else if", bracket_body)
     | Lang.Ruby -> failwith "I don't want to deal with Ruby right now"
     | Lang.OCaml -> failwith "Impossible; if statements should be expressions"
@@ -196,7 +197,7 @@ and while_stmt env level (tok, e, s) =
    let while_format =
       (match env.lang with
       | Lang.Python | Lang.Python2 | Lang.Python3 -> python_while
-      | Lang.Java | Lang.C | Lang.Csharp
+      | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
       | Lang.JSON | Lang.Javascript | Lang.Typescript -> c_while
       | Lang.Go -> go_while
       | Lang.Ruby -> ruby_while
@@ -210,7 +211,7 @@ and do_while stmt env level (s, e) =
    let c_do_while = F.sprintf "do %s\nwhile(%s)" in
    let do_while_format =
     (match env.lang with
-    | Lang.Java | Lang.C | Lang.Csharp
+    | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
     | Lang.Javascript | Lang.Typescript -> c_do_while
     | Lang.Python | Lang.Python2 | Lang.Python3
     | Lang.Go | Lang.JSON | Lang.OCaml -> failwith "impossible; no do while"
@@ -223,7 +224,7 @@ and do_while stmt env level (s, e) =
 and for_stmt env level (for_tok, hdr, s) =
    let for_format =
     (match env.lang with
-    | Lang.Java | Lang.C | Lang.Csharp
+    | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
     | Lang.Javascript | Lang.Typescript -> F.sprintf "%s (%s) %s"
     | Lang.Go -> F.sprintf "%s %s %s"
     | Lang.Python | Lang.Python2 | Lang.Python3 -> F.sprintf "%s %s:\n%s"
@@ -257,7 +258,7 @@ and def_stmt env (entity, def_kind) =
   let var_def (ent, def) =
     let (no_val, with_val) =
       (match env.lang with
-       | Lang.Java | Lang.C | Lang.Csharp
+       | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
           -> (fun typ id _e -> F.sprintf "%s %s;" typ id),
              (fun typ id e -> F.sprintf "%s %s = %s;" typ id e)
        | Lang.Javascript | Lang.Typescript
@@ -293,7 +294,7 @@ and return env (tok, eopt) =
   | Some e -> expr env e
   in
   match env.lang with
-  | Lang.Java | Lang.C | Lang.Csharp
+  | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
       -> F.sprintf "%s %s;" (token "return" tok) to_return
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
@@ -310,7 +311,7 @@ and break env (tok, lbl) =
         | LDynamic e -> F.sprintf " %s" (expr env e)
   in
   match env.lang with
-  | Lang.Java | Lang.C | Lang.Csharp
+  | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
     -> F.sprintf "%s%s;" (token "break" tok) lbl_str
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
@@ -327,7 +328,7 @@ and continue env (tok, lbl) =
         | LDynamic e -> F.sprintf " %s" (expr env e)
   in
   match env.lang with
-  | Lang.Java | Lang.C | Lang.Csharp
+  | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
     -> F.sprintf "%s%s;" (token "continue" tok) lbl_str
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
@@ -400,7 +401,7 @@ and literal env = function
       (match env.lang with
       | Lang.Python | Lang.Python2 | Lang.Python3 ->
             "'" ^ s ^ "'"
-      | Lang.Java | Lang.Go | Lang.C | Lang.Csharp
+      | Lang.Java | Lang.Go | Lang.C | Lang.Csharp | Lang.Kotlin
       | Lang.JSON | Lang.Javascript
       | Lang.OCaml | Lang.Ruby | Lang.Typescript ->
             "\"" ^ s ^ "\""

--- a/semgrep-core/tests/kotlin/hello-world.kt
+++ b/semgrep-core/tests/kotlin/hello-world.kt
@@ -1,0 +1,3 @@
+fun main() {
+    println("Hello World!")
+}


### PR DESCRIPTION
Test plan:

Run 

`semgrep-core/_build/default/bin/Main.exe -dump_tree_sitter_cst test/kotlin/hello-world.kt`.

This gives me:
|   |   Decl
|   |   | Func_decl
|   |   |   fun
|   |   |   | Pat_ddcb2a5
|   |   |   | main
|   |   |   | "("
|   |   |   | ")"
|   |   |   |   Blk
|   |   |   |   | "{"
|   |   |   |   |   |   Rep_choice_label_choice_assign
|   |   |   |   |   |   |   Exp
|   |   |   |   |   |   |   | Un_exp
|   |   |   |   |   |   |   |   Call_exp
|   |   |   |   |   |   |   |   |   Prim_exp
|   |   |   |   |   |   |   |   |   | Simple_id
|   |   |   |   |   |   |   |   |   |   Pat_ddcb2a5
|   |   |   |   |   |   |   |   |   |   println
|   |   |   |   |   |   |   |   |   Value_args
|   |   |   |   |   |   |   |   |   | "("
|   |   |   |   |   |   |   |   |   |   |   | Prim_exp
|   |   |   |   |   |   |   |   |   |   |   |   Str_lit
|   |   |   |   |   |   |   |   |   |   |   |   | Line_str_lit
|   |   |   |   |   |   |   |   |   |   |   |   |   "\""
|   |   |   |   |   |   |   |   |   |   |   |   |   |   Line_str_content
|   |   |   |   |   |   |   |   |   |   |   |   |   |   | Line_str_text
|   |   |   |   |   |   |   |   |   |   |   |   |   |   | "Hello World!"
|   |   |   |   |   |   |   |   |   |   |   |   |   "\""
|   |   |   |   |   |   |   |   |   | ")"
|   |   |   |   |   |   ""
|   |   |   |   | "}"
|   | ""