### PR TITLE
Fix copy of spacegrep executable during pip install.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Install zip & musl-tools
         run: apt-get update && apt install -y zip musl-tools
       - name: Build the wheels
-        run: PRECOMPILED_LOCATION=$(realpath 'semgrep-files/semgrep-core') ./scripts/build-wheels.sh
+        run: PRECOMPILED_DIR=$(realpath 'semgrep-files') ./scripts/build-wheels.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Install zip & musl-tools
         run: apt-get update && apt install -y zip musl-tools
       - name: Build the wheels
-        run: PRECOMPILED_DIR=$(realpath 'semgrep-files') ./scripts/build-wheels.sh
+        run: ./scripts/build-wheels.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -83,18 +83,14 @@ class PostInstallCommand(install):
         #     https://github.com/pypa/setuptools/issues/210#issuecomment-216657975
         # take the advice from that comment, and move over after install
 
-        if os.environ.get("PRECOMPILED_DIR"):
-            source_dir = os.environ["PRECOMPILED_DIR"]
-            source = os.path.join(source_dir, exec_name)
+        if "osx" in distutils.util.get_platform():
+            with chdir(repo_root):
+                os.system(os.path.join(repo_root, "scripts", "osx-release.sh"))
+                source = os.path.join(repo_root, "artifacts", exec_name)
         else:
-            if "osx" in distutils.util.get_platform():
-                with chdir(repo_root):
-                    os.system(os.path.join(repo_root, "scripts", "osx-release.sh"))
-                    source = os.path.join(repo_root, "artifacts", exec_name)
-            else:
-                with chdir(repo_root):
-                    os.system(os.path.join(repo_root, "scripts", "ubuntu-release.sh"))
-                    source = os.path.join(repo_root, "semgrep-files", exec_name)
+            with chdir(repo_root):
+                os.system(os.path.join(repo_root, "scripts", "ubuntu-release.sh"))
+                source = os.path.join(repo_root, "semgrep-files", exec_name)
 
         ## run this after trying to build (as otherwise this leaves
         ## venv in a bad state: https://github.com/benfred/py-spy/issues/69)

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -83,8 +83,9 @@ class PostInstallCommand(install):
         #     https://github.com/pypa/setuptools/issues/210#issuecomment-216657975
         # take the advice from that comment, and move over after install
 
-        if os.environ.get("PRECOMPILED_LOCATION"):
-            source = os.environ["PRECOMPILED_LOCATION"]
+        if os.environ.get("PRECOMPILED_DIR"):
+            source_dir = os.environ["PRECOMPILED_DIR"]
+            source = os.path.join(source_dir, exec_name)
         else:
             if "osx" in distutils.util.get_platform():
                 with chdir(repo_root):


### PR DESCRIPTION
I removed the environment variable `PRECOMPILED_LOCATION` completely. I tested locally that the `.whl` file created on my ubuntu with `./scripts/built-wheels.sh` contained the correct `semgrep-core` and `spacegrep` files.

Addresses https://github.com/returntocorp/semgrep/issues/1937
Fixes https://github.com/returntocorp/semgrep/issues/1949
