### PR TITLE
Assume no particular extension if language is 'generic'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Gracefully handle empty configuration file.
 - Fix stack overflows in spacegrep on large input files (#1944).
+- Fix extension-based file selection when the language is `generic` (#1968).
 
 ## [0.30.0](https://github.com/returntocorp/semgrep/releases/tag/v0.30.0) - 2020-11-03
 

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -24,20 +24,22 @@ from semgrep.util import sub_check_output
 
 FileExtension = NewType("FileExtension", str)
 
-
-PYTHON_EXTENSIONS = [FileExtension("py"), FileExtension("pyi")]
-JAVASCRIPT_EXTENSIONS = [FileExtension("js"), FileExtension("jsx")]
-TYPESCRIPT_EXTENSIONS = [FileExtension("ts"), FileExtension("tsx")]
-JAVA_EXTENSIONS = [FileExtension("java")]
-C_EXTENSIONS = [FileExtension("c")]
-GO_EXTENSIONS = [FileExtension("go")]
-RUBY_EXTENSIONS = [FileExtension("rb")]
-PHP_EXTENSIONS = [FileExtension("php")]
+PYTHON_EXTENSIONS = [FileExtension(".py"), FileExtension(".pyi")]
+JAVASCRIPT_EXTENSIONS = [FileExtension(".js"), FileExtension(".jsx")]
+TYPESCRIPT_EXTENSIONS = [FileExtension(".ts"), FileExtension(".tsx")]
+JAVA_EXTENSIONS = [FileExtension(".java")]
+C_EXTENSIONS = [FileExtension(".c")]
+GO_EXTENSIONS = [FileExtension(".go")]
+RUBY_EXTENSIONS = [FileExtension(".rb")]
+PHP_EXTENSIONS = [FileExtension(".php")]
 ML_EXTENSIONS = [
-    FileExtension("mli"),
-    FileExtension("ml"),
+    FileExtension(".mli"),
+    FileExtension(".ml"),
 ]
-JSON_EXTENSIONS = [FileExtension("json")]
+JSON_EXTENSIONS = [FileExtension(".json")]
+
+# This is used to determine the set of files with known extensions,
+# i.e. those for which we have a proper parser.
 ALL_EXTENSIONS = (
     PYTHON_EXTENSIONS
     + JAVASCRIPT_EXTENSIONS
@@ -49,6 +51,11 @@ ALL_EXTENSIONS = (
     + ML_EXTENSIONS
     + JSON_EXTENSIONS
 )
+
+# This is used to select the files suitable for spacegrep, which is
+# all of them. It is spacegrep itself that will detect and ignore binary
+# files.
+GENERIC_EXTENSIONS = [FileExtension("")]
 
 def lang_to_exts(language: Language) -> List[FileExtension]:
     """
@@ -78,7 +85,7 @@ def lang_to_exts(language: Language) -> List[FileExtension]:
     elif language in {"json", "JSON", "Json"}:
         return JSON_EXTENSIONS
     elif language in {NONE_LANGUAGE, GENERIC_LANGUAGE}:
-        return [FileExtension("*")]
+        return GENERIC_EXTENSIONS
     else:
         raise _UnknownLanguageError(f"Unsupported Language: {language}")
 
@@ -163,7 +170,7 @@ class TargetManager:
             """
                 Return set of all files in curr_dir with given extension
             """
-            return set(p for p in curr_dir.rglob(f"*.{extension}") if p.is_file())
+            return set(p for p in curr_dir.rglob(f"*{extension}") if p.is_file())
 
         extensions = lang_to_exts(language)
         expanded: Set[Path] = set()
@@ -173,7 +180,7 @@ class TargetManager:
                 try:
                     # Tracked files
                     tracked_output = sub_check_output(
-                        ["git", "ls-files", f"*.{ext}"],
+                        ["git", "ls-files", f"*{ext}"],
                         cwd=curr_dir.resolve(),
                         encoding="utf-8",
                         stderr=subprocess.DEVNULL,
@@ -186,7 +193,7 @@ class TargetManager:
                             "ls-files",
                             "--other",
                             "--exclude-standard",
-                            f"*.{ext}",
+                            f"*{ext}",
                         ],
                         cwd=curr_dir.resolve(),
                         encoding="utf-8",
@@ -194,7 +201,7 @@ class TargetManager:
                     )
 
                     deleted_output = sub_check_output(
-                        ["git", "ls-files", "--deleted", f"*.{ext}"],
+                        ["git", "ls-files", "--deleted", f"*{ext}"],
                         cwd=curr_dir.resolve(),
                         encoding="utf-8",
                         stderr=subprocess.DEVNULL,
@@ -295,7 +302,7 @@ class TargetManager:
         explicit_files_with_lang_extension = set(
             f
             for f in explicit_files
-            if (any(f.match(f"*.{ext}") for ext in lang_to_exts(lang)))
+            if (any(f.match(f"*{ext}") for ext in lang_to_exts(lang)))
         )
         targets = targets.union(explicit_files_with_lang_extension)
 
@@ -303,7 +310,7 @@ class TargetManager:
             explicit_files_with_unknown_extensions = set(
                 f
                 for f in explicit_files
-                if not any(f.match(f"*.{ext}") for ext in ALL_EXTENSIONS)
+                if not any(f.match(f"*{ext}") for ext in ALL_EXTENSIONS)
             )
             targets = targets.union(explicit_files_with_unknown_extensions)
 


### PR DESCRIPTION
An extension is now specified as `.py` instead of just `py`. I'm assuming optimistically that this is internal to `target_manager.py` and won't break anything.

With `-l generic`, all the files are now accepted regardless of their suffix. The user can use `--include=` to filter specific extensions or patterns in the file path.

Fixes https://github.com/returntocorp/semgrep/issues/1968
