### PR TITLE
Test tree-sitter c++ parser

### DIFF
--- a/semgrep-core/cli/Main.ml
+++ b/semgrep-core/cli/Main.ml
@@ -924,6 +924,8 @@ let all_actions () = [
 
   "-test_parse_lang", " <files or dirs>",
   Common.mk_action_n_arg (Test_parsing.test_parse_lang !lang get_final_files);
+  "-test_parse_tree_sitter", " <files or dirs>",
+  Common.mk_action_n_arg (Test_parsing.test_parse_tree_sitter !lang);
   "-dump_tree_sitter_cst", " <file>",
   Common.mk_action_1_arg Test_parsing.dump_tree_sitter_cst;
   "-dump_ast_pfff", " <file>",

--- a/semgrep-core/parsing/Check_semgrep.ml
+++ b/semgrep-core/parsing/Check_semgrep.ml
@@ -6,7 +6,7 @@ let lang_has_no_dollar_ids = Lang.(function
   | Python | Python2 | Python3
   | Java
   | Go
-  | C
+  | C | Cplusplus
   | OCaml
   | JSON
   | Csharp

--- a/semgrep-core/parsing/Test_parsing.mli
+++ b/semgrep-core/parsing/Test_parsing.mli
@@ -2,6 +2,7 @@
 val test_parse_lang: string ->
   (Common.filename list -> Common.filename list) -> Common.filename list ->
   unit
+val test_parse_tree_sitter: string -> Common.filename list -> unit
 
 val dump_tree_sitter_cst: Common.filename -> unit
 val dump_ast_pfff: Common.filename -> unit

--- a/semgrep-core/parsing/dune
+++ b/semgrep-core/parsing/dune
@@ -12,6 +12,8 @@
    tree-sitter-lang.javascript
    tree-sitter-lang.typescript
    tree-sitter-lang.tsx
+   tree-sitter-lang.c
+   tree-sitter-lang.cpp
 
    commons commons_core
    pfff-config

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -68,7 +68,8 @@ let print_bool env = function
      (match env.lang with
          | Lang.Python | Lang.Python2 | Lang.Python3
           -> "True"
-         | Lang.Java | Lang.Go | Lang.C | Lang.JSON | Lang.Javascript
+         | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus
+         | Lang.JSON | Lang.Javascript
          | Lang.OCaml | Lang.Ruby | Lang.Typescript
          | Lang.Csharp | Lang.PHP | Lang.Kotlin
           -> "true")
@@ -76,7 +77,7 @@ let print_bool env = function
      (match env.lang with
          | Lang.Python | Lang.Python2 | Lang.Python3
           -> "False"
-         | Lang.Java | Lang.Go | Lang.C | Lang.JSON | Lang.Javascript
+         | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.JSON | Lang.Javascript
          | Lang.OCaml | Lang.Ruby | Lang.Typescript
          | Lang.Csharp | Lang.PHP | Lang.Kotlin
           -> "false")
@@ -167,7 +168,7 @@ and if_stmt env level (tok, e, s, sopt) =
   let (format_cond, elseif_str, format_block) =
     (match env.lang with
     | Lang.Python | Lang.Python2 | Lang.Python3 -> (no_paren_cond, "elif", colon_body)
-    | Lang.Java | Lang.Go | Lang.C | Lang.Csharp
+    | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.Csharp
     | Lang.JSON | Lang.Javascript | Lang.Typescript
     | Lang.Kotlin
       -> (paren_cond, "else if", bracket_body)
@@ -197,7 +198,7 @@ and while_stmt env level (tok, e, s) =
    let while_format =
       (match env.lang with
       | Lang.Python | Lang.Python2 | Lang.Python3 -> python_while
-      | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
+      | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
       | Lang.JSON | Lang.Javascript | Lang.Typescript -> c_while
       | Lang.Go -> go_while
       | Lang.Ruby -> ruby_while
@@ -211,7 +212,7 @@ and do_while stmt env level (s, e) =
    let c_do_while = F.sprintf "do %s\nwhile(%s)" in
    let do_while_format =
     (match env.lang with
-    | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
+    | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
     | Lang.Javascript | Lang.Typescript -> c_do_while
     | Lang.Python | Lang.Python2 | Lang.Python3
     | Lang.Go | Lang.JSON | Lang.OCaml -> failwith "impossible; no do while"
@@ -224,7 +225,7 @@ and do_while stmt env level (s, e) =
 and for_stmt env level (for_tok, hdr, s) =
    let for_format =
     (match env.lang with
-    | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
+    | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
     | Lang.Javascript | Lang.Typescript -> F.sprintf "%s (%s) %s"
     | Lang.Go -> F.sprintf "%s %s %s"
     | Lang.Python | Lang.Python2 | Lang.Python3 -> F.sprintf "%s %s:\n%s"
@@ -258,7 +259,7 @@ and def_stmt env (entity, def_kind) =
   let var_def (ent, def) =
     let (no_val, with_val) =
       (match env.lang with
-       | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
+       | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
           -> (fun typ id _e -> F.sprintf "%s %s;" typ id),
              (fun typ id e -> F.sprintf "%s %s = %s;" typ id e)
        | Lang.Javascript | Lang.Typescript
@@ -294,7 +295,7 @@ and return env (tok, eopt) =
   | Some e -> expr env e
   in
   match env.lang with
-  | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
+  | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
       -> F.sprintf "%s %s;" (token "return" tok) to_return
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
@@ -311,7 +312,7 @@ and break env (tok, lbl) =
         | LDynamic e -> F.sprintf " %s" (expr env e)
   in
   match env.lang with
-  | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
+  | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
     -> F.sprintf "%s%s;" (token "break" tok) lbl_str
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
@@ -328,7 +329,7 @@ and continue env (tok, lbl) =
         | LDynamic e -> F.sprintf " %s" (expr env e)
   in
   match env.lang with
-  | Lang.Java | Lang.C | Lang.Csharp | Lang.Kotlin
+  | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
     -> F.sprintf "%s%s;" (token "continue" tok) lbl_str
   | Lang.Python | Lang.Python2 | Lang.Python3
   | Lang.Go | Lang.Ruby | Lang.OCaml
@@ -401,7 +402,7 @@ and literal env = function
       (match env.lang with
       | Lang.Python | Lang.Python2 | Lang.Python3 ->
             "'" ^ s ^ "'"
-      | Lang.Java | Lang.Go | Lang.C | Lang.Csharp | Lang.Kotlin
+      | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
       | Lang.JSON | Lang.Javascript
       | Lang.OCaml | Lang.Ruby | Lang.Typescript ->
             "\"" ^ s ^ "\""


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1952

test plan:
pad@yrax:~/work/lang-cpp/Cataclysm-DDA$ yy -lang cpp -test_parse_tree_sitter .
+ /home/pad/semgrep/_build/default/cli/Main.exe -lang cpp -test_parse_tree_sitter .
11 / 852/OVERLOAD/work/lang-cpp/Cataclysm-DDA/src/activity_actor.cpp: exn = Tree_sitter_run.Tree_sitter_error.Error(_)
...

NB total files = 852; NB total lines = 474254; perfect = 662; pbs = 190; timeout = 0; =========> 77%
nb good = 174878,  nb passed = 0 =========> 0.000000%
nb good = 174878,  nb bad = 299376 =========> 36.874333%

For comparison, the C++/C/cpp parser in pfff is doing:
NB total files = 852; NB total lines = 473336; perfect = 110; pbs = 742; timeout = 0; =========> 12%
nb good = 160267,  nb passed = 187 =========> 0.116680%
nb good = 160267,  nb bad = 313069 =========> 33.859035%
pad@yrax:~/work/lang-cpp/Cataclysm-DDA$