### PR TITLE
Gracefully handle LexicalError's from semgrep-core

### DIFF
--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 from typing import Dict
 
+from semgrep.error import LexicalError
 from semgrep.error import MatchTimeoutError
 from semgrep.error import OutOfMemoryError
 from semgrep.error import SemgrepError
@@ -77,14 +78,15 @@ class CoreException:
         )
 
     def into_semgrep_error(self) -> SemgrepError:
-        with open(self._path, errors="replace") as f:
-            file_hash = SourceTracker.add_source(f.read())
-
         if self._check_id == "Timeout":
             return MatchTimeoutError(self._path, self._rule_id)
         elif self._check_id == "OutOfMemory":
             return OutOfMemoryError(self._path, self._rule_id)
+        elif self._check_id == "LexicalError":
+            return LexicalError(self._path, self._rule_id)
         else:
+            with open(self._path, errors="replace") as f:
+                file_hash = SourceTracker.add_source(f.read())
             error_span = Span(
                 start=self._start,
                 end=self._end,

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -26,6 +26,7 @@ MISSING_CONFIG_EXIT_CODE = 7
 INVALID_LANGUAGE_EXIT_CODE = 8
 MATCH_TIMEOUT_EXIT_CODE = 9
 MATCH_MAX_MEMORY_EXIT_CODE = 10
+LEXICAL_ERROR_EXIT_CODE = 11
 
 
 class Level(Enum):
@@ -302,6 +303,25 @@ class OutOfMemoryError(SemgrepError):
 
     def __str__(self) -> str:
         msg = f"Warning: Semgrep exceeded memory when running {self.rule_id} on {self.path}. See `--max-memory` for more info."
+        return with_color(Fore.RED, msg)
+
+    def to_dict_base(self) -> Dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "rule_id": self.rule_id,
+        }
+
+
+@attr.s(frozen=True, eq=True)
+class LexicalError(SemgrepError):
+    path: Path = attr.ib()
+    rule_id: str = attr.ib()
+
+    code = LEXICAL_ERROR_EXIT_CODE
+    level = Level.WARN
+
+    def __str__(self) -> str:
+        msg = f"Warning: Semgrep encountered a lexical error when running {self.rule_id} on {self.path}. Please ensure this is valid code."
         return with_color(Fore.RED, msg)
 
     def to_dict_base(self) -> Dict[str, Any]:


### PR DESCRIPTION
E.g.

```
$ python3 -m semgrep --pattern '$X == $X' --lang c /tmp/test.c --verbose
Warning: Semgrep encountered a lexical error when running - on /tmp/test.c. Please ensure this is valid code.
ran 1 rules on 1 files: 0 findings
1 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed
```

```
$ python3 -m semgrep --pattern '$X == $X' --lang c /tmp/test.c --json
{"results": [], "errors": [{"type": "LexicalError", "code": 11, "path": "/tmp/test.c", "rule_id": "-"}]}
ran 1 rules on 1 files: 0 findings
1 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed
```