### PR TITLE
[JS/TS] Generate correct AST for foreach (const x of y)

### DIFF
--- a/semgrep-core/tests/js/misc_foreach.js
+++ b/semgrep-core/tests/js/misc_foreach.js
@@ -1,0 +1,4 @@
+//ERROR: match
+for (const x of xs) {
+    return x.fld;
+}

--- a/semgrep-core/tests/js/misc_foreach.sgrep
+++ b/semgrep-core/tests/js/misc_foreach.sgrep
@@ -1,0 +1,3 @@
+for ($X of $Y) {
+  return $X.fld;
+}

--- a/semgrep-core/tests/js/misc_foreach1.js
+++ b/semgrep-core/tests/js/misc_foreach1.js
@@ -1,0 +1,9 @@
+export function findEvent(entityName: string, events: any[]): any {
+  //ERROR: match
+  for (const event of events) {
+    if (event.entity_name === entityName) {
+      return event.color;
+    }
+  }
+  return {};
+}

--- a/semgrep-core/tests/js/misc_foreach1.sgrep
+++ b/semgrep-core/tests/js/misc_foreach1.sgrep
@@ -1,0 +1,6 @@
+for ($ITEM of $COLLECTION) {
+  if ($EXPR) {
+    return $ITEM.$FIELD;
+  }
+}
+return $DEFAULT_EXPR;


### PR DESCRIPTION
We were using the multivardef_pattern special variable to
transform the above definition in
foreach (!MULTIVARDEF = x of y)

but there's no need to use multivardef_pattern when the
pattern is a simple variable

test plan:
test file included
make test