### PR TITLE
Fix failing homebrew-core release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,7 +277,7 @@ jobs:
 
   homebrew-core-pr:
     name: Update on Homebrew-Core
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:


### PR DESCRIPTION
Looks like linuxbrew and homebrew can sometimes drift and result in
the homebrew bump formula action to fail. Suggested workaround on
https://github.com/dawidd6/action-homebrew-bump-formula/issues/18
is to use macos-latest instead of ubuntu-latest so the action will
not try to use linuxbrew