### PR TITLE
[Go] Generate correct AST for init key values in new expression

### DIFF
--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -969,9 +969,7 @@ and anon_choice_elem_c42cd9b (env : env) (x : CST.anon_choice_elem_c42cd9b) =
   (match x with
   | `Elem x -> element env x
   | `Keyed_elem (v1, v2) ->
-
       let v2top = element env v2 in
-
       let v1 =
         (match v1 with
         | `Exp_COLON (v1, v2) ->
@@ -982,11 +980,12 @@ and anon_choice_elem_c42cd9b (env : env) (x : CST.anon_choice_elem_c42cd9b) =
             let v1 = literal_value env v1 in
             let v2 = token env v2 (* ":" *) in
             InitKeyValue (InitBraces v1, v2, v2top)
-        (* ??? *)
-        | `Id_COLON x ->
-              let _ = empty_labeled_statement env x in
-              (* TODO *)
-              InitBraces (AST_generic.fake_bracket [])
+        (* not sure why but Foo:1 is parsed as Keyed_elem(Id_COLON "Foo", 1)
+         * instead of a Keyed_elem(Exp_COLON (Id "Foo"), 1) *)
+        | `Id_COLON (v1, v2) ->
+           let v1 = identifier env v1 (* identifier *) in
+           let v2 = token env v2 (* ":" *) in
+           InitKeyValue (InitExpr (mk_Id v1), v2, v2top)
         )
       in
       v1

--- a/semgrep-core/tests/go/dots_newargs.go
+++ b/semgrep-core/tests/go/dots_newargs.go
@@ -1,0 +1,15 @@
+package Foo
+
+func bad() {
+
+ //ERROR: match
+ req := &http.Request {
+        Method: "POST",
+        URL: reqURL,
+        Header: map[string][]string {
+            "Content-Type": { "application/json; charset=UTF-8" },
+        },
+        Body: reqBody,
+    }
+
+}

--- a/semgrep-core/tests/go/dots_newargs.sgrep
+++ b/semgrep-core/tests/go/dots_newargs.sgrep
@@ -1,0 +1,1 @@
+$REQ = &http.Request { ..., URL: reqURL, ... }

--- a/semgrep-core/tests/go/misc_initkey.go
+++ b/semgrep-core/tests/go/misc_initkey.go
@@ -1,0 +1,9 @@
+
+func (c *UserController) Login(w http.ResponseWriter, r *http.Request, ctx *rack.Context) {
+     w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+     w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+     c.render.Json(w,rsp, http.StatusOK)
+     //ERROR: match
+     c := cors.New(cors.Options{ AllowedOrigins: []string{"*"}, })
+     return
+}

--- a/semgrep-core/tests/go/misc_initkey.sgrep
+++ b/semgrep-core/tests/go/misc_initkey.sgrep
@@ -1,0 +1,1 @@
+$F{ ..., AllowedOrigins: $X, ...}


### PR DESCRIPTION
Parse_go_tree_sitter.ml was incomplete and didn't handle a case that led
to init key values in new expressions (e.g., &foo {fld1: 1, fld2: 2}) to
not be present in the AST.
It was correctly done in the pfff parser, which led to a mismatch
between the AST of the pattern and the AST of the code.

test plan:
test file included
make test