### PR TITLE
Allow unqualified attribute pattern to match imported attribute

### DIFF
--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -1286,10 +1286,14 @@ and m_attribute a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_attribute]] resolving alias case *)
   (* equivalence: name resolving! *)
-  | a,   B.NamedAttr (t1, _b1, { B.id_resolved =
+  | a,   B.NamedAttr (t1, b1, { B.id_resolved =
       {contents = Some ( ( B.ImportedEntity dotted
                          | B.ImportedModule (B.DottedName dotted)
                          ), _sid)}; _}, b2) ->
+    (* We also allow an unqualified pattern like @Attr to match resolved
+     * one like import org.foo.Attr; @Attr *)
+    m_attribute a (B.NamedAttr (t1, b1, B.empty_id_info(), b2))
+    >||>
     m_attribute a (B.NamedAttr (t1, dotted, B.empty_id_info(), b2))
   (*e: [[Generic_vs_generic.m_attribute]] resolving alias case *)
 

--- a/semgrep-core/tests/java/aliasing_and_direct.java
+++ b/semgrep-core/tests/java/aliasing_and_direct.java
@@ -1,0 +1,8 @@
+package Foo;
+
+import org.com.Attr;
+
+//ERROR: match
+@Attr
+class Foo {
+}

--- a/semgrep-core/tests/java/aliasing_and_direct.sgrep
+++ b/semgrep-core/tests/java/aliasing_and_direct.sgrep
@@ -1,0 +1,2 @@
+@Attr
+class $FOO

--- a/semgrep-core/tests/java/misc_import_resolve_unqualified.java
+++ b/semgrep-core/tests/java/misc_import_resolve_unqualified.java
@@ -8,6 +8,10 @@ class Foo {
     return x;
   }
 
+  // We used to not match the code below and force the user to use
+  // a fully qualified attribute like @Foo.Bar.Misc but I think
+  // it's better to also allow direct match
+  //ERROR: match
   @Misc
   @Bar(method="foobar")
   public int foo(int x) { 


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/2029

We used to force people to use fully qualified attribute as in
@org.com.Attr
class X { ...}

to match code like

import org.com.Attr;
@Attr
class X { }

but some users find this confusing.

test plan:
test file included