### PR TITLE
Add an "is_ignored" field to JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Next
 
-## [0.31.1](https://github.com/returntocorp/semgrep/releases/tag/v0.31.1) - 2020-11-11
+### Added
 
+- JSON output now includes an attribute of findings named `is_ignored`.
+  This is `false` under regular circumstances,
+  but if you run with `--disable-nosem`,
+  it will return `true` for findings
+  that normally would've been excluded by a `// nosem` comment.
+
+## [0.31.1](https://github.com/returntocorp/semgrep/releases/tag/v0.31.1) - 2020-11-11
 ### Fixed
 
 - Regression in 0.31.0 where only a single file was being used when `--config`

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -374,7 +374,7 @@ def evaluate(
         if pattern_match.range in valid_ranges_to_output:
             message = interpolate_message_metavariables(rule, pattern_match)
             fix = interpolate_fix_metavariables(rule, pattern_match)
-            rule_match = RuleMatch(
+            rule_match = RuleMatch.from_pattern_match(
                 rule.id,
                 pattern_match,
                 message=message,

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -337,9 +337,9 @@ def evaluate(
     rule: Rule, pattern_matches: List[PatternMatch], allow_exec: bool
 ) -> Tuple[List[RuleMatch], List[Dict[str, Any]]]:
     """
-        Takes a Rule and list of pattern matches from a single file and
-        handles the boolean expression evaluation of the Rule's patterns
-        Returns a list of RuleMatches.
+    Takes a Rule and list of pattern matches from a single file and
+    handles the boolean expression evaluation of the Rule's patterns
+    Returns a list of RuleMatches.
     """
     output = []
     pattern_ids_to_pattern_matches = group_by_pattern_id(pattern_matches)

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -1,4 +1,5 @@
 import itertools
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -25,10 +26,14 @@ class RuleMatch:
     _fix: Optional[str] = attr.ib(repr=False)
     _fix_regex: Optional[Dict[str, Any]] = attr.ib(repr=False)
 
+    # derived attributes
     _path: Path = attr.ib(repr=str)
     _start: Dict[str, Any] = attr.ib(repr=str)
     _end: Dict[str, Any] = attr.ib(repr=str)
     _extra: Dict[str, Any] = attr.ib(repr=False)
+
+    # optional attributes
+    _is_ignored: Optional[bool] = attr.ib(default=None)
 
     @classmethod
     def from_pattern_match(
@@ -121,7 +126,7 @@ class RuleMatch:
         return self._severity in {"WARNING", "ERROR"}
 
     def to_json(self) -> Dict[str, Any]:
-        json_obj = self._pattern_match._raw_json
+        json_obj = deepcopy(self._pattern_match._raw_json)
         json_obj["check_id"] = self._id
         json_obj["extra"]["message"] = self._message
         json_obj["extra"]["metadata"] = self._metadata
@@ -130,6 +135,8 @@ class RuleMatch:
             json_obj["extra"]["fix"] = self._fix
         if self._fix_regex:
             json_obj["extra"]["fix_regex"] = self._fix_regex
+        if self._is_ignored is not None:
+            json_obj["extra"]["is_ignored"] = self._is_ignored
         json_obj["start"] = self._start
         json_obj["end"] = self._end
         # self.lines already contains \n at the end of each line

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -5,43 +5,61 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+import attr
 from junit_xml import TestCase
 
 from semgrep.pattern_match import PatternMatch
 
 
+@attr.s(frozen=True)
 class RuleMatch:
     """
-        A section of code that matches a single rule (which is potentially many patterns)
+    A section of code that matches a single rule (which is potentially many patterns)
     """
 
-    def __init__(
-        self,
-        id: str,
+    _id: str = attr.ib()
+    _pattern_match: PatternMatch = attr.ib(repr=False)
+    _message: str = attr.ib(repr=False)
+    _metadata: Dict[str, Any] = attr.ib(repr=False)
+    _severity: str = attr.ib(repr=False)
+    _fix: Optional[str] = attr.ib(repr=False)
+    _fix_regex: Optional[Dict[str, Any]] = attr.ib(repr=False)
+
+    _path: Path = attr.ib(repr=str)
+    _start: Dict[str, Any] = attr.ib(repr=str)
+    _end: Dict[str, Any] = attr.ib(repr=str)
+    _extra: Dict[str, Any] = attr.ib(repr=False)
+
+    @classmethod
+    def from_pattern_match(
+        cls,
+        rule_id: str,
         pattern_match: PatternMatch,
-        *,
         message: str,
         metadata: Dict[str, Any],
         severity: str,
         fix: Optional[str],
         fix_regex: Optional[Dict[str, Any]],
-    ) -> None:
-        self._id = id
-        self._message = message
-        self._metadata = metadata
-        self._severity = severity
-        self._fix = fix
-        self._fix_regex = fix_regex
+    ) -> "RuleMatch":
+        path = pattern_match.path
+        start = pattern_match.start
+        end = pattern_match.end
 
-        self._path = pattern_match.path
-        self._start = pattern_match.start
-        self._end = pattern_match.end
-
-        self._extra = (
-            pattern_match.extra
-        )  # note that message is still the old value defined before metavar interpolation
-
-        self._pattern_match = pattern_match
+        # note that message in extra is still the old value defined before metavar interpolation
+        extra = pattern_match.extra
+        return cls(
+            rule_id,
+            pattern_match,
+            message,
+            metadata,
+            severity,
+            fix,
+            fix_regex,
+            path,
+            start,
+            end,
+            extra,
+        )
 
     @property
     def id(self) -> str:
@@ -86,9 +104,9 @@ class RuleMatch:
     @property
     def lines(self) -> List[str]:
         """
-            Return lines in file that this RuleMatch is referring to.
+        Return lines in file that this RuleMatch is referring to.
 
-            Assumes file exists.  Note that start/end line is one-indexed
+        Assumes file exists.  Note that start/end line is one-indexed
         """
         if "lines" in self.extra:
             return self.extra["lines"]
@@ -147,6 +165,3 @@ class RuleMatch:
                 }
             ],
         }
-
-    def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} id={self.id} start={str(self.start)} end={str(self.end)}>"

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
@@ -9,6 +9,7 @@
       },
       "extra": {
         "fix": "inputs.get(x)",
+        "is_ignored": false,
         "lines": "  inputs[x] = 1",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
         "metadata": {},
@@ -68,6 +69,7 @@
       },
       "extra": {
         "fix": "inputs.get(x + 1)",
+        "is_ignored": false,
         "lines": "  if inputs[x + 1] == True:",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py/results.json
@@ -12,6 +12,7 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
+        "is_ignored": false,
         "lines": "csv.writer(csvfile, delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",
         "metadata": {
@@ -41,6 +42,7 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
+        "is_ignored": false,
         "lines": "csv.writer(get_file(), delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",
         "metadata": {

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java/results.json
@@ -12,6 +12,7 @@
           "regex": "DefaultHttpClient\\(",
           "replacement": "SystemDefaultHttpClient("
         },
+        "is_ignored": false,
         "lines": "\t\tHttpClient client = new DefaultHttpClient();",
         "message": "DefaultHttpClient is deprecated. Further, it does not support connections\nusing TLS1.2, which makes using DefaultHttpClient a security hazard.\nUse SystemDefaultHttpClient instead, which supports TLS1.2.\n",
         "metadata": {

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
@@ -12,6 +12,7 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
+        "is_ignored": false,
         "lines": "        new_password = request.data.get(\"password\", \"\")\n        validate_password(new_password, user=user)\n        user.set_password(new_password)\n        user.save()",
         "message": "'new_password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
         "metadata": {
@@ -114,6 +115,7 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
+        "is_ignored": false,
         "lines": "    def create_user(self, email, password=\"\"):\n        \"\"\"\n        Creates and saves a Poster with the given email and password.\n        \"\"\"\n        if not email:\n            raise ValueError('Users must have an email address')\n\n        user = self.model(email=self.normalize_email(email))\n        user.set_password(password)\n        user.save(using=self._db)\n        return user",
         "message": "'password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
         "metadata": {

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py/results.json
@@ -13,6 +13,7 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
+        "is_ignored": false,
         "lines": "    return json.dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",
         "metadata": {},
@@ -37,6 +38,7 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
+        "is_ignored": false,
         "lines": "    return dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py/results.json
@@ -12,6 +12,7 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "is_ignored": false,
         "lines": "r = requests.get(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
         "metadata": {},
@@ -35,6 +36,7 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "is_ignored": false,
         "lines": "r = requests.post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
         "metadata": {},
@@ -58,6 +60,7 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "is_ignored": false,
         "lines": "r = requests.request(\"GET\", url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
         "metadata": {},
@@ -81,6 +84,7 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "is_ignored": false,
         "lines": "r = requests.request(\"GET\", return_url())",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
         "metadata": {},
@@ -104,6 +108,7 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "is_ignored": false,
         "lines": "    r = post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule/results.json
@@ -8,6 +8,7 @@
         "line": 2
       },
       "extra": {
+        "is_ignored": false,
         "lines": "metavariable_comparison_test(100)",
         "message": "Metavariable regex test",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_base/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_base/results.json
@@ -8,6 +8,7 @@
         "line": 1
       },
       "extra": {
+        "is_ignored": false,
         "lines": "metavariable_comparison_test_base(0700)",
         "message": "Metavariable regex test",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_strip/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_strip/results.json
@@ -8,6 +8,7 @@
         "line": 1
       },
       "extra": {
+        "is_ignored": false,
         "lines": "metavariable_comparison_test_strip('100')",
         "message": "Metavariable regex test",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_multi_regex_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_multi_regex_rule/results.json
@@ -8,6 +8,7 @@
         "line": 1
       },
       "extra": {
+        "is_ignored": false,
         "lines": "metavariable_regex_test.method1(arg1)",
         "message": "Metavariable regex test multi regex",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_multi_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_multi_rule/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    metavariable_regex_test.method()",
         "message": "Metavariable regex test multi rule",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_regex_rule/results.json
@@ -8,6 +8,7 @@
         "line": 1
       },
       "extra": {
+        "is_ignored": false,
         "lines": "metavariable_regex_test(\"test\")",
         "message": "Metavariable regex test",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 2
       },
       "extra": {
+        "is_ignored": false,
         "lines": "metavariable_regex_test(\"example\")",
         "message": "Metavariable regex test",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiline/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiline/results.json
@@ -8,6 +8,7 @@
         "line": 8
       },
       "extra": {
+        "is_ignored": false,
         "lines": "        SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK\n        == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK",
         "message": "useless comparison operation `SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK` or `SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK != SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK`; possible bug?",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -84,6 +86,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "a + b == a + b is a useless equality check",
         "metadata": {},
@@ -121,6 +124,7 @@
         "line": 8
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    x == x",
         "message": "x == x is a useless equality check",
         "metadata": {},
@@ -158,6 +162,7 @@
         "line": 12
       },
       "extra": {
+        "is_ignored": false,
         "lines": "assertTrue(x == x)",
         "message": "x == x is a useless equality check",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -84,6 +86,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
@@ -8,6 +8,7 @@
         "line": 2
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    nested_patterns_func('foo', 1)",
         "message": "test",
         "metadata": {},
@@ -27,6 +28,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    nested_patterns_func('bar', 2)",
         "message": "test",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    test_nosem_func();",
         "message": "test-nosem-message",
         "metadata": {},
@@ -27,6 +28,7 @@
         "line": 5
       },
       "extra": {
+        "is_ignored": false,
         "lines": "\ttest_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},
@@ -46,6 +48,7 @@
         "line": 4
       },
       "extra": {
+        "is_ignored": false,
         "lines": "        test_nosem_func();",
         "message": "test-nosem-message",
         "metadata": {},
@@ -65,6 +68,7 @@
         "line": 7
       },
       "extra": {
+        "is_ignored": false,
         "lines": "test_nosem_func(\n    invalid_line // nosem: rules.test-nosem\n)",
         "message": "test-nosem-message",
         "metadata": {},
@@ -84,6 +88,7 @@
         "line": 9
       },
       "extra": {
+        "is_ignored": false,
         "lines": "test_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},
@@ -103,6 +108,7 @@
         "line": 2
       },
       "extra": {
+        "is_ignored": false,
         "lines": "test_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule__with_disable_nosem/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule__with_disable_nosem/results.json
@@ -1,0 +1,265 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 22,
+        "line": 2
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "    test_nosem_func(); // nosem: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.c",
+      "start": {
+        "col": 5,
+        "line": 2
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 22,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    test_nosem_func();",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.c",
+      "start": {
+        "col": 5,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 19,
+        "line": 4
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "\ttest_nosem_func() // nosem: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.go",
+      "start": {
+        "col": 2,
+        "line": 4
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 19,
+        "line": 5
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "\ttest_nosem_func()",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.go",
+      "start": {
+        "col": 2,
+        "line": 5
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 26,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "        test_nosem_func(); // nosem: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.java",
+      "start": {
+        "col": 9,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 26,
+        "line": 4
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "        test_nosem_func();",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.java",
+      "start": {
+        "col": 9,
+        "line": 4
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 1
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func() // nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.js",
+      "start": {
+        "col": 1,
+        "line": 1
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 2
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func() // nosem: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.js",
+      "start": {
+        "col": 1,
+        "line": 2
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func() // NOSEM: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.js",
+      "start": {
+        "col": 1,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 2,
+        "line": 7
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "test_nosem_func(\n    invalid_line // nosem: rules.test-nosem\n)",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.js",
+      "start": {
+        "col": 1,
+        "line": 5
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 9
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "test_nosem_func()",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.js",
+      "start": {
+        "col": 1,
+        "line": 9
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 1
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func()  # nosem: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.py",
+      "start": {
+        "col": 1,
+        "line": 1
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 2
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "test_nosem_func()",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.py",
+      "start": {
+        "col": 1,
+        "line": 2
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
@@ -8,6 +8,7 @@
         "line": 2
       },
       "extra": {
+        "is_ignored": false,
         "lines": "123.123.123.123",
         "message": "test regex message",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
@@ -8,6 +8,7 @@
         "line": 2
       },
       "extra": {
+        "is_ignored": false,
         "lines": "123.123.123.123",
         "message": "test regex message",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule/results.json
@@ -8,6 +8,7 @@
         "line": 9
       },
       "extra": {
+        "is_ignored": false,
         "lines": "{% autoescape off %}",
         "message": "Detected a segment of a Flask template where autoescaping is explicitly\ndisabled with '{% autoescape off %}'. This allows rendering of raw HTML\nin this segment. Ensure no user data is rendered here, otherwise this\nis a cross-site scripting (XSS) vulnerability.\n",
         "metadata": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule/results.json
@@ -8,6 +8,7 @@
         "line": 9
       },
       "extra": {
+        "is_ignored": false,
         "lines": "{% autoescape off %}",
         "message": "Detected a segment of a Flask template where autoescaping is explicitly\ndisabled with '{% autoescape off %}'. This allows rendering of raw HTML\nin this segment. Ensure no user data is rendered here, otherwise this\nis a cross-site scripting (XSS) vulnerability.\n",
         "metadata": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "Detected a useless comparison operation `x == x` or `x != x`. This\noperation is always true.\nIf testing for floating point NaN, use `math.isnan`, or\n`cmath.isnan` if the number is complex.\n",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "This is always True: `a + b == a + b` or `a + b != a + b`. If testing for floating point NaN, use `math.isnan(a + b)`,\nor `cmath.isnan(a + b)` if the number is complex.\n",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_check/test_url_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_url_rule/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return a + b == a + b",
         "message": "a + b == a + b is a useless equality check",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 8
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    x == x",
         "message": "x == x is a useless equality check",
         "metadata": {},
@@ -82,6 +84,7 @@
         "line": 12
       },
       "extra": {
+        "is_ignored": false,
         "lines": "assertTrue(x == x)",
         "message": "x == x is a useless equality check",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
@@ -8,6 +8,7 @@
         "line": 9
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return redirect(request.POST.get(\"next\"))",
         "message": "",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 14
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    return redirect(request.get_host())",
         "message": "",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-include/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-include/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude0/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude0/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude1/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude1/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-exclude/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-exclude/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include0/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include0/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -86,6 +88,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -125,6 +128,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include1/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include1/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -86,6 +88,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -125,6 +128,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include0/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include0/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include1/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include1/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "useless comparison",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
@@ -8,6 +8,7 @@
         "line": 4
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    open(path)",
         "message": "Unsafe open from request data",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 14
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    open(z)",
         "message": "Unsafe open from request data",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
+++ b/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
@@ -8,6 +8,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -47,6 +48,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -86,6 +88,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -125,6 +128,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -164,6 +168,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -203,6 +208,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -242,6 +248,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -281,6 +288,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -320,6 +328,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -359,6 +368,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -398,6 +408,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -437,6 +448,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -476,6 +488,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},
@@ -515,6 +528,7 @@
         "line": 3
       },
       "extra": {
+        "is_ignored": false,
         "lines": "console.log(x == x)",
         "message": "possibly useless comparison but in eq function",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
@@ -8,6 +8,7 @@
         "line": 24
       },
       "extra": {
+        "is_ignored": false,
         "lines": "{{ message }}",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
@@ -27,6 +28,7 @@
         "line": 29
       },
       "extra": {
+        "is_ignored": false,
         "lines": "{{ message }}",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
@@ -46,6 +48,7 @@
         "line": 32
       },
       "extra": {
+        "is_ignored": false,
         "lines": "{{ message2 }}",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
@@ -8,6 +8,7 @@
         "line": 6
       },
       "extra": {
+        "is_ignored": false,
         "lines": "Content-Type: text/html",
         "message": "Detected text/html",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
@@ -8,6 +8,7 @@
         "line": 62
       },
       "extra": {
+        "is_ignored": false,
         "lines": "## Getting",
         "message": "Detected h2 Markdown header",
         "metadata": {},
@@ -45,6 +46,7 @@
         "line": 97
       },
       "extra": {
+        "is_ignored": false,
         "lines": "## Examples",
         "message": "Detected h2 Markdown header",
         "metadata": {},
@@ -82,6 +84,7 @@
         "line": 145
       },
       "extra": {
+        "is_ignored": false,
         "lines": "## Resources",
         "message": "Detected h2 Markdown header",
         "metadata": {},
@@ -119,6 +122,7 @@
         "line": 159
       },
       "extra": {
+        "is_ignored": false,
         "lines": "## Usage",
         "message": "Detected h2 Markdown header",
         "metadata": {},
@@ -156,6 +160,7 @@
         "line": 188
       },
       "extra": {
+        "is_ignored": false,
         "lines": "## Contributing",
         "message": "Detected h2 Markdown header",
         "metadata": {},
@@ -193,6 +198,7 @@
         "line": 203
       },
       "extra": {
+        "is_ignored": false,
         "lines": "## Commercial",
         "message": "Detected h2 Markdown header",
         "metadata": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
@@ -8,6 +8,7 @@
         "line": 9
       },
       "extra": {
+        "is_ignored": false,
         "lines": "allowed_origins = [\"*\"]",
         "message": "CORS rule on bucket permits any origin",
         "metadata": {},

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -24,8 +24,8 @@ def test_basic_rule__relative(run_semgrep_in_tmp, snapshot):
 
 def test_noextension_filtering(run_semgrep_in_tmp, snapshot):
     """
-        Check that semgrep does not filter out files without extensions when
-        said file is explicitly passed
+    Check that semgrep does not filter out files without extensions when
+    said file is explicitly passed
     """
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -157,6 +157,13 @@ def test_nosem_rule__invalid_id(run_semgrep_in_tmp, snapshot):
     assert excinfo.value.returncode == 2
     snapshot.assert_match(excinfo.value.stderr, "error.txt")
     snapshot.assert_match(excinfo.value.stdout, "error.json")
+
+
+def test_nosem_rule__with_disable_nosem(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/nosem.yaml", options=["--disable-nosem"]),
+        "results.json",
+    )
 
 
 def test_metavariable_regex_rule(run_semgrep_in_tmp, snapshot):


### PR DESCRIPTION
This makes it possible for semgrep-agent to tell when a finding has been
ignored with a nosem comment.

Changes were tested with the included test named
`test_nosem_rule__with_disable_nosem`,
as well as reading through the updated snapshots.