### PR TITLE
[Ruby] create right AST for single quote string

### DIFF
--- a/semgrep-core/parsing/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_ruby_tree_sitter.ml
@@ -43,6 +43,16 @@ let list_to_maybe_tuple = function
  | [x] -> x
  | xs -> Tuple (xs)
 
+let mk_Literal_String (t1, xs, t2) =
+  let string_kind =
+    match PI.str_of_info t1, xs with
+    | "'", [] -> Single ("", PI.combine_infos t1 [t2])
+    | "'", [StrChars (s, t)] ->  Single (s, PI.combine_infos t1 [t; t2])
+    | _ -> Double (t1, xs, t2)
+  in
+  Literal (String string_kind)
+
+
 (*****************************************************************************)
 (* Boilerplate converter *)
 (*****************************************************************************)
@@ -781,8 +791,7 @@ and primary (env : env) (x : CST.primary) : AST.expr =
       let v1 = str env v1 in
       let v2 = token2 env v2 in
       Literal (Rational (v1, v2))
-  | `Str x ->
-        Literal (String (Double (string_ env x)))
+  | `Str x -> mk_Literal_String (string_ env x)
   | `Char tok ->
         Literal (Char (str env tok))
   (* ??? *)
@@ -1687,8 +1696,7 @@ and pair (env : env) (x : CST.pair) =
         | `Id_hash_key tok -> Id (str env tok, ID_Lowercase)
         | `Id tok -> Id (str env tok, ID_Lowercase)
         | `Cst tok -> Id (str env tok, ID_Uppercase)
-        | `Str x ->
-            Literal (String (Double (string_ env x)))
+        | `Str x -> mk_Literal_String (string_ env x)
         )
       in
       let v2 = token2 env v2 in (* : *)

--- a/semgrep-core/tests/ruby/misc_empty_token1.rb
+++ b/semgrep-core/tests/ruby/misc_empty_token1.rb
@@ -1,0 +1,6 @@
+def foo()
+ #ERROR: match
+ a = ''.html_safe
+ #ERROR: match
+ b = "".html_safe
+end

--- a/semgrep-core/tests/ruby/misc_empty_token1.sgrep
+++ b/semgrep-core/tests/ruby/misc_empty_token1.sgrep
@@ -1,0 +1,1 @@
+$STR.html_safe


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/1692

test plan:
You can't see anymore some OE_Expr below, but instead the correct
String("")

$ /home/pad/semgrep/_build/default/cli/Main.exe -dump_ast misc_empty_token1.rb
Pr(
  [DefStmt(
     ({name=EId(("foo", ())); attrs=[]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      FuncDef(
        {fkind=(Method, ()); fparams=[]; frettype=None;
         fbody=Block(
                 [ExprStmt(
                    Assign(
                      Id(("a", ()),
                        {id_resolved=Ref(None); id_type=Ref(None);
                         id_const_literal=Ref(None); }), (),
                      DotAccess(L(String(("", ()))), (),
                        EId(("html_safe", ())))), ());
                  ExprStmt(
                    Assign(
                      Id(("b", ()),
                        {id_resolved=Ref(None); id_type=Ref(None);
                         id_const_literal=Ref(None); }), (),
                      DotAccess(L(String(("", ()))), (),
                        EId(("html_safe", ())))), ())]);
         })))])

Also
$ /home/pad/semgrep/_build/default/cli/Main.exe -lang ruby -f misc_empty_token1.sgrep misc_empty_token1.rb -pvar $STR
misc_empty_token1.rb:3: ''
misc_empty_token1.rb:5: ""