### PR TITLE
[JS] support for metavariable in import from $X

### DIFF
--- a/semgrep-core/tests/js/metavar_importfrom.js
+++ b/semgrep-core/tests/js/metavar_importfrom.js
@@ -1,0 +1,6 @@
+//ERROR: match
+import jwt_decode from "jwt_decode";
+
+function foo() {
+    return 1;
+}

--- a/semgrep-core/tests/js/metavar_importfrom.sgrep
+++ b/semgrep-core/tests/js/metavar_importfrom.sgrep
@@ -1,0 +1,1 @@
+import jwt_decode from $X;

--- a/semgrep-core/tests/js/metavar_importfrom2.js
+++ b/semgrep-core/tests/js/metavar_importfrom2.js
@@ -1,0 +1,6 @@
+//ERROR: match
+import jwt_decode from "jwt_decode";
+
+function foo() {
+    return 1;
+}

--- a/semgrep-core/tests/js/metavar_importfrom2.sgrep
+++ b/semgrep-core/tests/js/metavar_importfrom2.sgrep
@@ -1,0 +1,1 @@
+import jwt_decode from "$X";


### PR DESCRIPTION
We actually allowed metavar there already, but the metavar
had to be put inside the string, as in import foo from "$X"
but it seems more intuitive to also allow it as import foo from $X

Fixes part 2 of https://github.com/returntocorp/semgrep/issues/2052

test plan:
test file included