### PR TITLE
Allow ignoring findings with // nosemgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ should not yet rely on the output being stable.
 
 ### Changed
 
+- `// nosemgrep` can now also be used to ignore findings,
+  in addition to `// nosem`
 - Added a default timeout of 30 seconds per file instead of none (#1981).
 
 ## [0.31.1](https://github.com/returntocorp/semgrep/releases/tag/v0.31.1) - 2020-11-11

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -46,17 +46,18 @@ class OutputFormat(Enum):
 NOSEM_INLINE_RE = re.compile(
     # We're looking for items that look like this:
     # ' nosem'
-    # ' nosem: example-pattern-id'
+    # ' nosemgrep: example-pattern-id'
     # ' nosem: pattern-id1,pattern-id2'
-    # ' NOSEM:pattern-id1,pattern-id2'
+    # ' NOSEMGREP:pattern-id1,pattern-id2'
     #
     # * We do not want to capture the ': ' that follows 'nosem'
     # * We do not care about the casing of 'nosem'
     # * We want a comma-separated list of ids
     # * We want multi-language support, so we cannot strictly look for
     #   Python comments that begin with '# '
+    # * nosem and nosemgrep should be interchangeable
     #
-    r" nosem(?::[\s]?(?P<ids>([^,\s](?:[,\s]+)?)+))?",
+    r" nosem(?:grep)?(?::[\s]?(?P<ids>([^,\s](?:[,\s]+)?)+))?",
     re.IGNORECASE,
 )
 COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")

--- a/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule/results.json
@@ -105,7 +105,7 @@
       "check_id": "rules.test-nosem",
       "end": {
         "col": 18,
-        "line": 2
+        "line": 6
       },
       "extra": {
         "is_ignored": false,
@@ -118,7 +118,7 @@
       "path": "targets/basic/nosem.py",
       "start": {
         "col": 1,
-        "line": 2
+        "line": 6
       }
     }
   ]

--- a/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule__with_disable_nosem/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule__with_disable_nosem/results.json
@@ -248,6 +248,86 @@
         "line": 2
       },
       "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func()  # NOSEM: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.py",
+      "start": {
+        "col": 1,
+        "line": 2
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func()  # nosemgrep: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.py",
+      "start": {
+        "col": 1,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 4
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func()  # NOSEMGREP",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.py",
+      "start": {
+        "col": 1,
+        "line": 4
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 5
+      },
+      "extra": {
+        "is_ignored": true,
+        "lines": "test_nosem_func()  # nOseMgREP: rules.test-nosem",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nosem.py",
+      "start": {
+        "col": 1,
+        "line": 5
+      }
+    },
+    {
+      "check_id": "rules.test-nosem",
+      "end": {
+        "col": 18,
+        "line": 6
+      },
+      "extra": {
         "is_ignored": false,
         "lines": "test_nosem_func()",
         "message": "test-nosem-message",
@@ -258,7 +338,7 @@
       "path": "targets/basic/nosem.py",
       "start": {
         "col": 1,
-        "line": 2
+        "line": 6
       }
     }
   ]

--- a/semgrep/tests/e2e/targets/basic/nosem.py
+++ b/semgrep/tests/e2e/targets/basic/nosem.py
@@ -1,2 +1,6 @@
 test_nosem_func()  # nosem: rules.test-nosem
+test_nosem_func()  # NOSEM: rules.test-nosem
+test_nosem_func()  # nosemgrep: rules.test-nosem
+test_nosem_func()  # NOSEMGREP
+test_nosem_func()  # nOseMgREP: rules.test-nosem
 test_nosem_func()


### PR DESCRIPTION
The original keyword, nosem, isn't very easy to Google or understand if
you aren't yet aware of Semgrep.

For backwards compatibility, this commit doesn't remove the 'nosem'
keyword.

This change was tested by adding more lines to the basic/nosem.py test
target and manually reading through the updated snapshots.