### PR TITLE
add an option to only show a max number of lines per finding

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -285,6 +285,15 @@ def cli() -> None:
         ),
     )
 
+    output.add_argument(
+        "--max-lines-per-finding",
+        type=int,
+        default=0,
+        help=(
+            "Maximum number of lines of code that will be shown for each match before trimming."
+        ),
+    )
+
     # logging options
     logging_ = parser.add_argument_group("logging")
 
@@ -355,6 +364,7 @@ def cli() -> None:
         strict=args.strict,
         verbose_errors=args.verbose,
         timeout_threshold=args.timeout_threshold,
+        output_per_finding_max_lines_limit=args.max_lines_per_finding,
     )
 
     if not args.disable_version_check:

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -9,6 +9,7 @@ import semgrep.semgrep_main
 import semgrep.test
 from semgrep import __VERSION__
 from semgrep.constants import DEFAULT_CONFIG_FILE
+from semgrep.constants import DEFAULT_MAX_LINES_PER_FINDING
 from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import MAX_LINES_FLAG_NAME
 from semgrep.constants import OutputFormat
@@ -291,9 +292,9 @@ def cli() -> None:
     output.add_argument(
         MAX_LINES_FLAG_NAME,
         type=int,
-        default=0,
+        default=DEFAULT_MAX_LINES_PER_FINDING,
         help=(
-            "Maximum number of lines of code that will be shown for each match before trimming."
+            "Maximum number of lines of code that will be shown for each match before trimming (set to 0 for unlimited)."
         ),
     )
 

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -10,6 +10,7 @@ import semgrep.test
 from semgrep import __VERSION__
 from semgrep.constants import DEFAULT_CONFIG_FILE
 from semgrep.constants import DEFAULT_TIMEOUT
+from semgrep.constants import MAX_LINES_FLAG_NAME
 from semgrep.constants import OutputFormat
 from semgrep.constants import RCE_RULE_FLAG
 from semgrep.constants import SEMGREP_URL
@@ -162,7 +163,9 @@ def cli() -> None:
         type=int,
         default=DEFAULT_TIMEOUT,
         help=(
-            "Maximum time to spend running a rule on a single file in seconds. If set to 0 will not have time limit. Defaults to {} s.".format(DEFAULT_TIMEOUT)
+            "Maximum time to spend running a rule on a single file in seconds. If set to 0 will not have time limit. Defaults to {} s.".format(
+                DEFAULT_TIMEOUT
+            )
         ),
     )
 
@@ -286,7 +289,7 @@ def cli() -> None:
     )
 
     output.add_argument(
-        "--max-lines-per-finding",
+        MAX_LINES_FLAG_NAME,
         type=int,
         default=0,
         help=(

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -61,6 +61,6 @@ NOSEM_INLINE_RE = re.compile(
 )
 COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")
 
-
+MAX_LINES_FLAG_NAME = "--max-lines-per-finding"
 BREAK_LINE_WIDTH = 80
 BREAK_LINE_CHAR = "-"

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -60,3 +60,7 @@ NOSEM_INLINE_RE = re.compile(
     re.IGNORECASE,
 )
 COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")
+
+
+BREAK_LINE_WIDTH = 80
+BREAK_LINE_CHAR = "-"

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -62,5 +62,6 @@ NOSEM_INLINE_RE = re.compile(
 COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")
 
 MAX_LINES_FLAG_NAME = "--max-lines-per-finding"
+DEFAULT_MAX_LINES_PER_FINDING = 10
 BREAK_LINE_WIDTH = 80
 BREAK_LINE_CHAR = "-"

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -88,7 +88,7 @@ def finding_to_line(
 
             yield f"{line_number}:{line}" if line_number else f"{line}"
         if trimmed > 0:
-            yield f"...not showing an additional {trimmed} lines for brevity..."
+            yield f"...hiding {trimmed} lines..."
 
 
 def build_normal_output(

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -21,6 +21,8 @@ from junit_xml import TestSuite
 
 from semgrep import __VERSION__
 from semgrep import config_resolver
+from semgrep.constants import BREAK_LINE_CHAR
+from semgrep.constants import BREAK_LINE_WIDTH
 from semgrep.constants import OutputFormat
 from semgrep.error import FINDINGS_EXIT_CODE
 from semgrep.error import Level
@@ -89,21 +91,11 @@ def finding_to_line(
 
             yield f"{line_number}:{line}" if line_number else f"{line}"
         trimmed_str = f" [hid {trimmed} additional lines] "
-        if len(lines) > 1 and not is_last:
-            ellipsis_output = "-" * 80
+        if per_finding_max_lines_limit != 1:
             if trimmed > 0:
-                start_index = (len(ellipsis_output) // 2) - (len(trimmed_str) // 2)
-                end_index = start_index + len(trimmed_str)
-                output = (
-                    ellipsis_output[:start_index]
-                    + trimmed_str
-                    + ellipsis_output[:end_index]
-                )
-                yield output
+                yield trimmed_str.center(BREAK_LINE_WIDTH, BREAK_LINE_CHAR)
             else:
-                yield ellipsis_output
-        elif trimmed > 0:
-            yield trimmed_str
+                yield BREAK_LINE_CHAR * BREAK_LINE_WIDTH
 
 
 def build_normal_output(

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -138,6 +138,7 @@ def invoke_semgrep(config: Path, targets: List[Path], **kwargs: Any) -> Any:
             error_on_findings=False,
             verbose_errors=False,
             strict=False,
+            output_per_finding_max_lines_limit=None,
         ),
         stdout=io_capture,
     )

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -388,6 +388,7 @@ def test_explicit_path(tmp_path, monkeypatch):
         error_on_findings=False,
         verbose_errors=False,
         strict=False,
+        output_per_finding_max_lines_limit=None,
     )
     defaulthandler = OutputHandler(output_settings)
 


### PR DESCRIPTION
Not a perfect response to https://github.com/returntocorp/semgrep/issues/1482 but close.

A question for reviewers: should we truncate at 10 or 20 lines by default? We'll show the flag users can use to adjust it next to the truncation message.

Output example:

### the new default:
```
tests/unit/test_version.py
9:    with mock.patch("semgrep.version._fetch_latest_version") as fetched_mock:

tests/unit/test_yaml_parsing.py
40:    yaml = parse_config_string("testfile", yaml_contents, "file.py")
--------------------------------------------------------------------------------
44:        validate_single_rule("testfile", rule_dict)
--------------------------------------------------------------------------------
49:    config1 = dedent(
50:        """
51:    rules:
52:    - id: rule1
53:      pattern: $X == $X
54:      languages: [python]
55:      severity: INFO
56:      message: bad
57:    """
58:    )
--------------------------------------------------------------------------------
59:    config2 = dedent(
60:        """
61:    rules:
62:    - id: rule2
63:      pattern: $X == $Y
64:      languages: [python]
65:      severity: INFO
66:      message: good
67:    - id: rule3
68:      pattern: $X < $Y
69:      languages: [c]
70:      severity: INFO
71:      message: doog
72:    """
73:    )
--------------------------------------------------------------------------------
76:        tf1.write(config1.encode("utf-8"))
--------------------------------------------------------------------------------
77:        tf2.write(config2.encode("utf-8"))
ran 1 rules on 72 files: 318 findings
```


### max 4 lines
```
pipenv run semgrep --max-lines-per-finding=4 -e '$X.$Y("...", ...)' -l py
...
tests/unit/test_version.py
9:    with mock.patch("semgrep.version._fetch_latest_version") as fetched_mock:

tests/unit/test_yaml_parsing.py
40:    yaml = parse_config_string("testfile", yaml_contents, "file.py")
--------------------------------------------------------------------------------
44:        validate_single_rule("testfile", rule_dict)
--------------------------------------------------------------------------------
49:    config1 = dedent(
50:        """
51:    rules:
52:    - id: rule1
-------- [hid 6 additional lines, adjust with --max-lines-per-finding] ---------
59:    config2 = dedent(
60:        """
61:    rules:
62:    - id: rule2
-------- [hid 11 additional lines, adjust with --max-lines-per-finding] --------
76:        tf1.write(config1.encode("utf-8"))
--------------------------------------------------------------------------------
77:        tf2.write(config2.encode("utf-8"))
ran 1 rules on 72 files: 318 findings
```

### with max-lines = 1

```
pipenv run semgrep --max-lines-per-finding=1 -e '$X.$Y("...", ...)' -l py
...
tests/unit/test_version.py
9:    with mock.patch("semgrep.version._fetch_latest_version") as fetched_mock:

tests/unit/test_yaml_parsing.py
40:    yaml = parse_config_string("testfile", yaml_contents, "file.py")
44:        validate_single_rule("testfile", rule_dict)
49:    config1 = dedent(
59:    config2 = dedent(
76:        tf1.write(config1.encode("utf-8"))
77:        tf2.write(config2.encode("utf-8"))
ran 1 rules on 72 files: 318 findings
```