### PR TITLE
Remove gitbook

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,7 +1,0 @@
-root: ./docs/
-
-structure:
-    readme: README.md
-    summary: SUMMARY.md
-
-redirects:


### PR DESCRIPTION
No longer needed with https://semgrep.dev/docs/.