### PR TITLE
Pin lsp to version 1.1.0 since 1.2.0 breaks the semgrep build.

### DIFF
--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -27,7 +27,7 @@ depends: [
   "uutf"
   "re"
   "parmap"
-  "lsp"
+  "lsp" {"1.1.0"}
 ]
 
 build: [make]

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -27,7 +27,7 @@ depends: [
   "uutf"
   "re"
   "parmap"
-  "lsp" {"1.1.0"}
+  "lsp" {= "1.1.0"}
 ]
 
 build: [make]


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/2085