### PR TITLE
[Go] Fix wrong order of imports in AST

### DIFF
--- a/semgrep-core/tests/go/misc_import_order.go
+++ b/semgrep-core/tests/go/misc_import_order.go
@@ -1,0 +1,13 @@
+package main
+
+//ERROR: match
+import (
+    htemplate "html/template"
+    ttemplate "text/template"
+)
+
+func Whatever() {
+    return htemplate.Exec()
+}
+
+func main() {}

--- a/semgrep-core/tests/go/misc_import_order.sgrep
+++ b/semgrep-core/tests/go/misc_import_order.sgrep
@@ -1,0 +1,8 @@
+import (
+    $HTML "html/template"
+    $TEXT "text/template"
+)
+...
+func $ANY(...) {
+  return $HTML.$FUNC(...)
+}


### PR DESCRIPTION
This will help one of the semgrep live example
in https://github.com/returntocorp/semgrep/issues/327

test plan:
test file included

Also

$ /home/pad/semgrep/_build/default/cli/Main.exe -dump_ast misc_import_order.go
Pr(
  [DirectiveStmt(Package((), [("main", ())]));
   DirectiveStmt(
     ImportAs((), FileName(("html/template", ())), Some(("htemplate", ()))));
   DirectiveStmt(
     ImportAs((), FileName(("text/template", ())), Some(("ttemplate", ()))));
   DefStmt(
     ({name=EId(("Whatever", ())); attrs=[]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };

...

show the right order of the DirectiveStmt