### PR TITLE
Correctly bind a metavariable in an import to the fully qualified name

### DIFF
--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -439,7 +439,9 @@ let rec m_list_prefix f a b =
       f xa xb >>= (fun () ->
       m_list_prefix f aas bbs
       )
+  (* less-is-ok: prefix is ok *)
   | [], _ -> return ()
+
   | _::_, _ ->
       fail ()
 (*e: function [[Matching_generic.m_list_prefix]] *)

--- a/semgrep-core/tests/python/import_metavar_fullpath.py
+++ b/semgrep-core/tests/python/import_metavar_fullpath.py
@@ -1,0 +1,16 @@
+# what actually matters in this test is the value binded to $X
+# in the .sgrep. It should be the full path!
+# use semgrep-core ... -pvar '$X' to print the value.
+
+#ERROR: match
+import a
+#ERROR: match
+import auth
+#ERROR: match
+import arbitrary_auth
+#ERROR: match
+import a.auth
+#ERROR: match
+import b.auth
+#ERROR: match
+import a.b.auth

--- a/semgrep-core/tests/python/import_metavar_fullpath.sgrep
+++ b/semgrep-core/tests/python/import_metavar_fullpath.sgrep
@@ -1,0 +1,1 @@
+import $X


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/1771

This should also help
https://github.com/returntocorp/semgrep/issues/975

Test plan:

$ semgrep -f /tmp/test2.yml tests/python/import_metavar_fullpath.py
running 1 rules...
tests/python/import_metavar_fullpath.py
severity:error rule:tmp.import-auth: spooky import

12:import a.auth
14:import b.auth
16:import a.b.auth
ran 1 rules on 1 files: 3 findings