### PR TITLE
Enforce "shortest match" rule in spacegrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Changed
 
+- In generic mode, shorter matches are now always preferred over
+  longer ones. This avoids matches like `def bar def foo` when the
+  pattern is `def ... foo`, instead matching just `def foo`.
+- In generic mode, leading dots must now match at the beginning of a
+  block, allowing patterns like `... foo` to match what comes before `foo`.
+
 ## [0.32.0](https://github.com/returntocorp/semgrep/releases/tag/v0.32.0) - 2020-11-18
 
 ### Added

--- a/spacegrep/src/lib/Loc.ml
+++ b/spacegrep/src/lib/Loc.ml
@@ -37,6 +37,9 @@ module Pos = struct
       pos.pos_lnum pos.pos_bol pos.pos_cnum
 end
 
+let eq a b =
+  a = b
+
 let length (a, b) =
   let start = a.pos_bol + a.pos_cnum in
   let end_ = b.pos_bol + a.pos_cnum in

--- a/spacegrep/src/lib/Match.ml
+++ b/spacegrep/src/lib/Match.ml
@@ -310,8 +310,6 @@ let rec fold_all acc (doc : Doc_AST.node list) f =
       let acc = f acc loc doc in
       fold_all acc doc_tail f
   | List doc1 :: doc2 ->
-      (* FIXME: should also call 'f acc loc doc' like the Atom case above
-                but we can't because we don't have a location for the List. *)
       let acc = fold_all acc doc1 f in
       fold_all acc doc2 f
 
@@ -331,7 +329,6 @@ let fold_block_starts acc (doc : Doc_AST.node list) f =
         in
         fold ~is_block_start:false acc doc_tail
     | List doc1 :: doc2 ->
-        (* FIXME: see remark in 'fold_all'. *)
         let acc = fold ~is_block_start:true acc doc1 in
         fold ~is_block_start:false acc doc2
   in

--- a/spacegrep/src/test/Matcher.ml
+++ b/spacegrep/src/test/Matcher.ml
@@ -277,10 +277,23 @@ b
   "$A ... $B",
   "1 2 3";
 
-  (* TODO: should match the whole document *)
-  "try to match everything", Matches ["c"],
+  "match everything", Matches ["a b c"],
   "...",
   "a b c";
+
+  "leading dots", Matches ["a b"],
+  "... b",
+  "a b c";
+
+  "match block start", Matches ["a"; "b"],
+  "... $X",
+  "\
+a
+  b
+  c
+d
+e
+";
 ]
 
 let matcher_suite =

--- a/spacegrep/src/test/Matcher.ml
+++ b/spacegrep/src/test/Matcher.ml
@@ -295,21 +295,9 @@ e
   "...",
   "a b c";
 
-  "nested matches", Matches [
-    "\
-a
-  a b
-b
-";
-    "a b";
-  ],
-  "...",
-  "\
-a
-  a b
-b
-";
-
+  "nested matches", Matches ["a b b a"; "b b"],
+  "$A ... $A",
+  "a b b a";
 ]
 
 let matcher_suite =

--- a/spacegrep/src/test/Matcher.ml
+++ b/spacegrep/src/test/Matcher.ml
@@ -265,9 +265,20 @@ b
   "$X $Y $X $Y",
   "a b a b";
 
+  "nested matches", Matches ["a b b a"; "b b"],
+  "$A ... $A",
+  "a b b a";
+
   "prefer shorter match", Matches ["function foo"],
   "function ... foo",
   "function x function foo";
+
+  "prefer shorter match 2", Matches [
+    "a 2 b 2";
+    "a 1 b 1";
+  ],
+  "a $N ... b $N",
+  "a 1  a 2 b 2  a 1 b 1";
 
   "overlapping matches", Matches [ "1 2"; "2 3" ],
   "$A $B",
@@ -295,9 +306,6 @@ e
   "...",
   "a b c";
 
-  "nested matches", Matches ["a b b a"; "b b"],
-  "$A ... $A",
-  "a b b a";
 ]
 
 let matcher_suite =

--- a/spacegrep/src/test/Matcher.ml
+++ b/spacegrep/src/test/Matcher.ml
@@ -277,10 +277,6 @@ b
   "$A ... $B",
   "1 2 3";
 
-  "match everything", Matches ["a b c"],
-  "...",
-  "a b c";
-
   "leading dots", Matches ["a b"],
   "... b",
   "a b c";
@@ -294,6 +290,26 @@ a
 d
 e
 ";
+
+  "match everything", Matches ["a b c"],
+  "...",
+  "a b c";
+
+  "nested matches", Matches [
+    "\
+a
+  a b
+b
+";
+    "a b";
+  ],
+  "...",
+  "\
+a
+  a b
+b
+";
+
 ]
 
 let matcher_suite =

--- a/spacegrep/src/test/Matcher.ml
+++ b/spacegrep/src/test/Matcher.ml
@@ -264,6 +264,23 @@ b
   "multiple metavariables", Count 1,
   "$X $Y $X $Y",
   "a b a b";
+
+  "prefer shorter match", Matches ["function foo"],
+  "function ... foo",
+  "function x function foo";
+
+  "overlapping matches", Matches [ "1 2"; "2 3" ],
+  "$A $B",
+  "1 2 3";
+
+  "shortest overlapping matches", Matches [ "1 2"; "2 3" ],
+  "$A ... $B",
+  "1 2 3";
+
+  (* TODO: should match the whole document *)
+  "try to match everything", Matches ["c"],
+  "...",
+  "a b c";
 ]
 
 let matcher_suite =


### PR DESCRIPTION
Until now, the pattern `function ... foo` would match the whole `function bar function foo` instead of just `function foo`. This is now fixed by starting the search from all possible locations, allowing overlapping matches, but eliminating the longer of two matches that end at the same location.

I also fixed the behavior of patterns with leading dots such as `... foo`. Now, they may only match at the beginning of a block. Consequently, `...` now correctly matches the whole document.
