### PR TITLE
Do not follow symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - In generic mode, shorter matches are now always preferred over
   longer ones. This avoids matches like `def bar def foo` when the
-  pattern is `def ... foo`, instead matching just `def foo`.
+  pattern is `def ... foo`, instead matching just `def foo`
 - In generic mode, leading dots must now match at the beginning of a
-  block, allowing patterns like `... foo` to match what comes before `foo`.
+  block, allowing patterns like `... foo` to match what comes before `foo`
+- Disabled link following for parity with other LINUX tools (e.g. ripgrep)
 
 ## [0.32.0](https://github.com/returntocorp/semgrep/releases/tag/v0.32.0) - 2020-11-18
 

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -143,6 +143,10 @@ class TargetManager:
         )
 
     @staticmethod
+    def _is_valid(path: Path) -> bool:
+        return path.exists() and not path.is_symlink()
+
+    @staticmethod
     def _expand_dir(
         curr_dir: Path, language: Language, respect_git_ignore: bool
     ) -> Set[Path]:
@@ -171,7 +175,11 @@ class TargetManager:
             """
             Return set of all files in curr_dir with given extension
             """
-            return set(p for p in curr_dir.rglob(f"*{extension}") if p.is_file())
+            return {
+                p
+                for p in curr_dir.rglob(f"*{extension}")
+                if p.is_file() and TargetManager._is_valid(p)
+            }
 
         extensions = lang_to_exts(language)
         expanded: Set[Path] = set()
@@ -234,7 +242,7 @@ class TargetManager:
         """
         expanded = set()
         for target in targets:
-            if not target.exists():
+            if not TargetManager._is_valid(target):
                 continue
 
             if target.is_dir():

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -164,9 +164,13 @@ class TargetManager:
             """
             files: Set[Path] = set()
             if output:
-                files = set(
-                    Path(curr_dir) / elem for elem in output.strip().split("\n")
-                )
+                files = {
+                    p
+                    for p in (
+                        Path(curr_dir) / elem for elem in output.strip().split("\n")
+                    )
+                    if TargetManager._is_valid(p)
+                }
             return files
 
         def _find_files_with_extention(

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -366,6 +366,26 @@ def test_expand_targets_not_git(tmp_path, monkeypatch):
     )
 
 
+def test_skip_symlink(tmp_path, monkeypatch):
+    foo = tmp_path / "foo"
+    foo.mkdir()
+    (foo / "a.py").touch()
+    (foo / "link.py").symlink_to(foo / "a.py")
+
+    monkeypatch.chdir(tmp_path)
+
+    python_language = Language("python")
+
+    assert cmp_path_sets(
+        TargetManager.expand_targets([foo], python_language, False),
+        {foo / "a.py"},
+    )
+
+    assert cmp_path_sets(
+        TargetManager.expand_targets([foo / "link.py"], python_language, False), set()
+    )
+
+
 def test_explicit_path(tmp_path, monkeypatch):
     foo = tmp_path / "foo"
     foo.mkdir()


### PR DESCRIPTION
Symlinks break semgrep, as they often point outside of the path actually
mounted into the core library, or are otherwise unresolveable by the
core.

In the tradition of comparable UNIX tools (such as ripgrep), we disable
link following.

In the future, we may want to add a switch to allow link following, but
let's wait until this is actually needed to avoid flag bloat in the
immediate.

Fixes #2005.