### PR TITLE
Enable json output with '-json'

### DIFF
--- a/semgrep-core/cli/Main.ml
+++ b/semgrep-core/cli/Main.ml
@@ -627,7 +627,14 @@ let print_matches_and_errors_json files matches errs =
      "errors", J.Array (errs |> List.map R2c.error_to_json);
      "stats", stats
   ] in
-  let s = J.string_of_json json |> Yojson.Safe.prettify in
+  (*
+     Not pretty-printing the json output (Yojson.Safe.prettify)
+     because it kills performance, adding an extra 50% time on our
+     calculate_ci_perf.py benchmarks.
+     User should use an external tool like jq or ydump (latter comes with
+     yojson) for pretty-printing json.
+  *)
+  let s = J.string_of_json json in
   logger#debug "returned JSON: %s" s;
   pr s
 

--- a/semgrep-core/cli/Main.ml
+++ b/semgrep-core/cli/Main.ml
@@ -998,8 +998,11 @@ let options () =
     " <pattern> expression pattern (need -lang)";
     "-f", Arg.Set_string pattern_file,
     " <file> obtain pattern from file (need -lang)";
-    "-rules_file", Arg.Set_string rules_file,
-    " <file> obtain list of patterns from YAML file";
+    "-rules_file", Arg.String (fun file ->
+      rules_file := file;
+      output_format := Json
+    ),
+    " <file> obtain list of patterns from YAML file. Implies -json";
 
     "-lang", Arg.Set_string lang,
     (spf " <str> choose language (valid choices: %s)" supported_langs);

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -269,6 +269,7 @@ class CoreRunner:
             cmd = [SEMGREP_PATH] + [
                 "-lang",
                 language,
+                "-json",
                 rules_file_flag,
                 pattern_file.name,
                 "-j",


### PR DESCRIPTION
The `-json` option is now honored when the pattern is specified with `-e` or `-f`, that is not with a rules file. However, I didn't get rid of much code like I wanted to. Some legacy code is still used for:

* printing results as text (which is not supported for rules files)
* supporting lang=fuzzy which is not one of the semgrep languages (`Lang.t` etc.)

Anyway, I'm happy that `-json` works so we can see all the details that the text output doesn't show.

I also added pretty-printing for the json output, for user comfort. Normal semgrep usage involves large inputs and a relatively small number of matches, so the cost associated with pretty-printing should not be an issue.

Sample output:
```
~/semgrep/semgrep-core $ semgrep-core -lang java -e 'class $X' tests/java/deep_cond.java -json
{
  "matches": [
    {
      "check_id": "-e/-f",
      "path": "tests/java/deep_cond.java",
      "start": { "line": 1, "col": 1, "offset": 0 },
      "end": { "line": 1, "col": 10, "offset": 9 },
      "extra": {
        "message": "",
        "metavars": {
          "$X": {
            "start": { "line": 1, "col": 7, "offset": 6 },
            "end": { "line": 1, "col": 10, "offset": 9 },
            "abstract_content": "Foo",
            "unique_id": {
              "type": "AST",
              "md5sum": "1f0c9b0d0f3f351a3dd7a4e7ca77c675"
            }
          }
        }
      }
    }
  ],
  "errors": [],
  "stats": { "okfiles": 1, "errorfiles": 0 }
}
```

Fixes https://github.com/returntocorp/semgrep/issues/1469