### PR TITLE
Parse construction initializer

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -1905,12 +1905,12 @@ let constructor_initializer (env : env) ((v1, v2, v3) : CST.constructor_initiali
   let v1 = token env v1 (* ":" *) in
   let v2 =
     (match v2 with
-    | `Base tok -> token env tok (* "base" *)
-    | `This tok -> token env tok (* "this" *)
+    | `Base tok -> IdSpecial (Super, token env tok) (* "base" *)
+    | `This tok -> IdSpecial (This, token env tok) (* "this" *)
     )
   in
   let v3 = argument_list env v3 in
-  todo env (v1, v2, v3)
+  ExprStmt (Call (v2, v3), sc)
 
 let enum_member_declaration (env : env) ((v1, v2, v3) : CST.enum_member_declaration) =
   let v1 = List.concat_map (attribute_list env) v1 in
@@ -2091,11 +2091,14 @@ and declaration (env : env) (x : CST.declaration) : stmt =
         | None -> None)
       in
       let v6 = function_body env v6 in
+      let fbody = (match v5 with
+        | Some init -> Block (fake_bracket [init; v6])
+        | None -> v6) in
       let def = AST.FuncDef {
         fkind = (AST.Method, tok);
         fparams = v4;
         frettype = None;
-        fbody = v6;
+        fbody;
       } in
       let ent = basic_entity v3 (v1 @ v2) in (* TODO add Ctor attribute *)
       AST.DefStmt (ent, def)


### PR DESCRIPTION
E.g.

```csharp
   public SampleCollection() : this(3)
   {
   }
```

We transform this into `Call(This, 3)`, and prepend that to the function body.
Perhaps we should actually use the method name in here somewhere, or call
`.ctor`.