### PR TITLE
ci: check access to secrets before pushing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
           repository: returntocorp/semgrep
           tags: develop
       - name: Push Commit Hash if PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && secrets.DOCKER_USERNAME }}
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
PRs from forks will not try and fail to push to dockerhub