### PR TITLE
Handle empty catch declaration in C#

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -733,7 +733,7 @@ and catch_clause (env : env) ((v1, v2, v3, v4) : CST.catch_clause) =
   let v2 =
     (match v2 with
      | Some x -> catch_declaration env x
-     | None -> todo env ())
+     | None -> PatUnderscore (fake "_"))
   in
   let v3 =
     (match v3 with


### PR DESCRIPTION
E.g.
```csharp
catch { ... }
```

As opposed to
```csharp
catch (Exception e) { ... }
```

Pretend there's an underscore, just like Python_to_generic.ml's excepthandler
does.

Related to #1392