### PR TITLE
Split TyName in TyId and TyIdQualified

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -1757,8 +1757,9 @@ and type_ (env : env) (x : CST.type_) : AST.type_ =
    | `Impl_type tok -> raise Impossible (* "var" *)
    | `Array_type x -> array_type env x
    | `Name x ->
+       (* TODO: TyId or TyIdQualified? *)
        let n = name env x in
-       AST.TyName n
+       AST.TyIdQualified (n, empty_id_info())
    | `Null_type x -> nullable_type env x
    | `Poin_type (v1, v2) ->
        let v1 = type_constraint env v1 in

--- a/semgrep-core/parsing/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_typescript_tree_sitter.ml
@@ -1390,15 +1390,15 @@ and primary_type (env : env) (x : CST.primary_type) : type_ =
    | `Pred_type x ->
        let id = predefined_type env x in
        (* less: could also be a G.TyBuiltin *)
-       G.TyName (G.name_of_id id)
+       G.TyId (id, G.empty_id_info())
    | `Id tok ->
        let id = JS.identifier env tok (* identifier *) in
-       G.TyName (G.name_of_id id)
+       G.TyId (id, G.empty_id_info())
    | `Nested_type_id x ->
        let xs = nested_type_identifier env x in
-       G.TyName (G.name_of_ids xs)
+       G.TyIdQualified (G.name_of_ids xs, G.empty_id_info())
    | `Gene_type x ->
-       G.TyName (generic_type env x)
+       G.TyIdQualified (generic_type env x, G.empty_id_info())
    | `Type_pred (v1, v2, v3) ->
        let v1 = JS.str env v1 (* identifier *) in
        let v2 = JS.token env v2 (* "is" *) in
@@ -1455,7 +1455,7 @@ and primary_type (env : env) (x : CST.primary_type) : type_ =
        let v1 = JS.token env v1 (* "keyof" *) in
        let v2 =
          match v2 with
-         | `Gene_type x -> G.T (G.TyName (generic_type env x))
+         | `Gene_type x -> G.T (G.TyIdQualified (generic_type env x, G.empty_id_info()))
          | `Id tok -> G.Di [JS.identifier env tok] (* identifier *)
          | `Nested_type_id x -> G.Di (nested_type_identifier env x)
        in
@@ -2088,8 +2088,7 @@ and public_field_definition (env : env) ((v1, v2, v3, v4, v5, v6) : CST.public_f
 and anon_choice_choice_type_id_e16f95c (env : env) (x : CST.anon_choice_choice_type_id_e16f95c): parent =
   (match x with
    | `Choice_id x -> (* type to be extended *)
-       let name = anon_choice_type_id_a85f573 env x in
-       Right (G.TyName name)
+       Right (anon_choice_type_id_a85f573 env x)
    | `Exp x -> (* class expression to be extended *)
        Left (expression env x)
   )
@@ -2486,11 +2485,14 @@ and function_declaration (env : env) ((v1, v2, v3, v4, v5, v6) : CST.function_de
   let f = { f_attrs = v1; f_params = v4; f_body = v5; f_rettype = tret } in
   basic_entity v3, FuncDef f
 
-and anon_choice_type_id_a85f573 (env : env) (x : CST.anon_choice_type_id_a85f573) : G.name =
+and anon_choice_type_id_a85f573 (env : env) (x : CST.anon_choice_type_id_a85f573) : G.type_ =
   (match x with
-   | `Id tok -> G.name_of_ids [JS.str env tok] (* identifier *)
-   | `Nested_type_id x -> G.name_of_ids (nested_type_identifier env x)
-   | `Gene_type x -> generic_type env x
+   | `Id tok -> G.TyId (JS.str env tok, G.empty_id_info()) (* identifier *)
+   | `Nested_type_id x ->
+       G.TyIdQualified (G.name_of_ids (nested_type_identifier env x),
+                        G.empty_id_info())
+   | `Gene_type x ->
+       G.TyIdQualified (generic_type env x, G.empty_id_info())
   )
 
 and template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution) =

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -60,7 +60,7 @@ let token default tok =
 
 let print_type = function
   | TyBuiltin (s, _) -> s
-  | TyName (id, _) -> ident id
+  | TyId (id, _) -> ident id
   | x -> todo (T x)
 
 let print_bool env = function

--- a/semgrep-core/typing/Typechecking_generic.ml
+++ b/semgrep-core/typing/Typechecking_generic.ml
@@ -49,11 +49,11 @@ let compatible_type t e =
   | TyBuiltin ((t1, _)), Id (_, {id_type; _}) ->
       (match !id_type with Some (TyBuiltin ((t2, _))) -> t1 = t2
                          | _ -> false)
-  | TyName ((t1, _), _), Id(_, {id_type; _}) ->
-      (match !id_type with Some (TyName (((t2, _), _))) -> t1 = t2
+  | TyId ((t1, _), _), Id(_, {id_type; _}) ->
+      (match !id_type with Some (TyId (((t2, _), _))) -> t1 = t2
                          | _ -> false)
-  | TyArray (_, TyName((t1, _), _)), Id (_, {id_type; _}) ->
-      (match !id_type with Some (TyArray (_, TyName((t2, _), _))) -> t1 = t2
+  | TyArray (_, TyId((t1, _), _)), Id (_, {id_type; _}) ->
+      (match !id_type with Some (TyArray (_, TyId((t2, _), _))) -> t1 = t2
                          | _ -> false)
 
   | _ -> false


### PR DESCRIPTION
This will help for https://github.com/returntocorp/semgrep/issues/2156
by identifying the simpler case where a type is a single id
that can be aslo matched as a class name in other part of the code.

test plan:
make
make test in