### PR TITLE
Add 'dev-setup' target for install ocp-indent and merlin.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ lifting program analysis work that makes Semgrep so powerful.
 ### Installing from Source
 
 To compile semgrep, you first need to [install OCaml](https://opam.ocaml.org/doc/Install.html)
-and its package manager OPAM. On macOS, it should simply consist in doing:
+and its package manager OPAM. On macOS, it should consist in doing:
 
 ```bash
 brew install opam
@@ -201,7 +201,7 @@ For a first installation or if you're told external dependencies have
 changed, run
 
 ```
-make setup
+make dev-setup
 ```
 
 For a routine build after pulling in source code changes from git, run

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,13 @@ setup:
 	opam install -y --deps-only ./semgrep-core
 	opam install -y --deps-only ./spacegrep
 
+# Install development dependencies in addition to build dependencies.
+#
+.PHONY: dev-setup
+dev-setup:
+	$(MAKE) setup
+	opam install -y --deps-only ./semgrep-core/dev
+
 # This needs to run initially or when something changed in the external
 # build environment. This typically looks for the location of libraries
 # and header files outside of the project.

--- a/semgrep-core/dev/dev.opam
+++ b/semgrep-core/dev/dev.opam
@@ -1,0 +1,13 @@
+# This is meant to be installed with 'opam install --deps-only ./path/to/dev'
+#
+opam-version: "2.0"
+maintainer: "r2c"
+authors: "r2c"
+homepage: "n/a"
+bug-reports: "n/a"
+synopsis: "OCaml development dependencies"
+
+depends: [
+  "merlin"      # used by the various text editors with ocaml support
+  "ocp-indent"  # required for indenting code, used by the pre-commit hook
+]

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -14,6 +14,9 @@ homepage: "https://semgrep.dev"
 dev-repo: "git+https://github.com/returntocorp/semgrep"
 bug-reports: "https://github.com/returntocorp/semgrep/issues"
 
+# These are build dependencies.
+# Development-only dependencies are in 'dev/dev.opam'.
+#
 depends: [
   "dune" {>= "2.7.0" }
   "bisect_ppx" {dev & >= "2.5.0"}


### PR DESCRIPTION
`make dev-setup` should do the right thing. It relies on an opam file that contains only dev dependencies. The `{dev}` constraints are for something else, so I didn't use that, based on info found at https://khady.info/opam-sandbox.html.