### PR TITLE
[JS] use $...ARGS instead of $ARGS...

### DIFF
--- a/semgrep-core/core/Metavars_generic.ml
+++ b/semgrep-core/core/Metavars_generic.ml
@@ -139,7 +139,7 @@ let is_metavar_name s =
 (*e: function [[Metavars_generic.is_metavar_name]] *)
 
 let metavar_ellipsis_regexp_string =
-  "^\\(\\$[A-Z_][A-Z_0-9]*\\)\\.\\.\\.$"
+  "^\\(\\$\\.\\.\\.[A-Z_][A-Z_0-9]*\\)$"
 let is_metavar_ellipsis s =
   s =~ metavar_ellipsis_regexp_string
 

--- a/semgrep-core/tests/js/metavar_ellipsis_args.sgrep
+++ b/semgrep-core/tests/js/metavar_ellipsis_args.sgrep
@@ -1,1 +1,1 @@
-foo($ARGS..., 3, $ARGS...)
+foo($...ARGS, 3, $...ARGS)


### PR DESCRIPTION
This create less ambiguity when parsing old patterns like <...$VAR...>

alt: look for $XXX...> and do an yyback 4 and reutrn a metavar

different take on https://github.com/returntocorp/semgrep/issues/2150

test plan:
make
make test