### PR TITLE
Refactor matching to use Metavars_generic.Id not Metavars_generic.E

### DIFF
--- a/semgrep-core/core/Metavars_generic.ml
+++ b/semgrep-core/core/Metavars_generic.ml
@@ -63,11 +63,19 @@ type mvalue =
 let mvalue_to_any = function
   | E e -> G.E e
   | S s -> G.S s
-  | Id (id, _idinfo) -> G.I id
+  (* bugfix: do not return G.I id. We need the id_info because
+   * it can be used to check if two metavars are equal and have the same
+   * sid (single unique id).
+  *)
+  | Id (id, Some idinfo) -> G.E (G.Id (id, idinfo))
+  | Id (id, None) -> G.E (G.Id (id, G.empty_id_info()))
   | Ss x -> G.Ss x
   | Args x -> G.Args x
   | T x -> G.T x
   | P x -> G.P x
+
+let abstract_position_info_mval x =
+  x |> mvalue_to_any |> Lib_AST.abstract_position_info_any
 
 let str_of_any any =
   if !Flag_semgrep.debug_with_full_position

--- a/semgrep-core/matching/Apply_equivalences.ml
+++ b/semgrep-core/matching/Apply_equivalences.ml
@@ -42,24 +42,29 @@ let match_e_e_for_equivalences _ruleid a b =
 (*****************************************************************************)
 (*s: function [[Apply_equivalences.subst_e]] *)
 let subst_e (bindings: MV.metavars_binding) e =
-  let visitor = M.mk_visitor { M.default_visitor with
-                               M.kexpr = (fun (k, _) x ->
-                                 match x with
-                                 | Id ((str,_tok), _id_info) when MV.is_metavar_name str ->
-                                     (match List.assoc_opt str bindings with
-                                      | Some (E e) ->
-                                          (* less: abstract-line? *)
-                                          e
-                                      | Some _ ->
-                                          failwith (spf "incompatible metavar: %s, was expecting an expr"
-                                                      str)
-                                      | None ->
-                                          failwith (spf "could not find metavariable %s in environment"
-                                                      str)
-                                     )
-                                 | _ -> k x
-                               );
-                             }
+  let visitor =
+    M.mk_visitor
+      { M.default_visitor with
+        M.kexpr = (fun (k, _) x ->
+          match x with
+          | Id ((str,_tok), _id_info) when MV.is_metavar_name str ->
+              (match List.assoc_opt str bindings with
+               | Some (MV.Id (id, Some idinfo)) ->
+                   (* less: abstract-line? *)
+                   Id (id, idinfo)
+               | Some (MV.E e) ->
+                   (* less: abstract-line? *)
+                   e
+               | Some _ ->
+                   failwith (spf "incompatible metavar: %s, was expecting an expr"
+                               str)
+               | None ->
+                   failwith (spf "could not find metavariable %s in environment"
+                               str)
+              )
+          | _ -> k x
+        );
+      }
   in
   visitor.M.vexpr e
 (*e: function [[Apply_equivalences.subst_e]] *)

--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -218,12 +218,12 @@ let rec equal_ast_binded_code (a: MV.mvalue) (b: MV.mvalue) : bool = (
          * the comparison we just need to remove/abstract-away
          * the line number information in each ASTs.
         *)
-        let a_any = MV.mvalue_to_any a in
-        let b_any = MV.mvalue_to_any b in
-        let a = Lib.abstract_position_info_any a_any in
-        let b = Lib.abstract_position_info_any b_any in
+        let a = MV.abstract_position_info_mval a in
+        let b = MV.abstract_position_info_mval b in
         a =*= b
     | MV.Id _, MV.E (A.Id (b_id, b_id_info)) ->
+        (* TODO still needed now that we have the better MV.Id of id_info? *)
+        (* TOFIX: regression if remove this code *)
         (* Allow identifier nodes to match pure identifier expressions *)
 
         (* You should prefer to add metavar as expression (A.E), not id (A.I),

--- a/semgrep-core/tests/java/metavar_class_type.java
+++ b/semgrep-core/tests/java/metavar_class_type.java
@@ -1,0 +1,13 @@
+package com.test.doathing;
+
+//ERROR: match
+public class ApiThing {
+  private String thing;
+  private static ApiThing instance = null;
+
+  public static ApiThing getInstance () {
+    return null;
+  }
+}
+
+

--- a/semgrep-core/tests/java/metavar_class_type.sgrep
+++ b/semgrep-core/tests/java/metavar_class_type.sgrep
@@ -1,0 +1,6 @@
+class $CLASS {
+   ...
+   static $CLASS $METHOD () { ... }
+   ...
+}
+


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/2156

We used to do some hacky things when a metavariable was matching
an identifier such as an id in an expression, or class name, or type.
If the user reuse the same metavariable in different context, we
want the metavariable to match all those contexts if the resulting
is is equal. For example class $X { ... $X foo() { ... } } where
$X is here an entity name (in AST_generic.entity.name), or
a return type (in AST_generic.type_.TyId).

In a expression context, an id has also an id_info with inside
a single unique id assigned during the naming phase. This allows
us to make sure multiple use of the same metavar refer to the same
variable (this is especially useful with deep statement matching where
we can have lots of variables using the same name but in very different scope).

With this diff we add the binded metavariable as an Id with an optional
id_info attached to it, instead of adding it as an (E (Id ...)) which
was then requiring some hacky things.

Test plan:
test file included
make test