### PR TITLE
handle invalid unicode files

### DIFF
--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -75,7 +75,7 @@ class PatternMatch:
         end_offset = self.metavars[metavariable]["end"]["offset"]
         length = end_offset - start_offset
 
-        with open(self.path) as file:
+        with open(self.path, errors='replace') as file:
             file.seek(start_offset)
             value = file.read(length)
 

--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -74,7 +74,8 @@ class PatternMatch:
         start_offset = self.metavars[metavariable]["start"]["offset"]
         end_offset = self.metavars[metavariable]["end"]["offset"]
         length = end_offset - start_offset
-
+           
+        # open path and ignore non-utf8 bytes. https://stackoverflow.com/a/56441652
         with open(self.path, errors='replace') as file:
             file.seek(start_offset)
             value = file.read(length)


### PR DESCRIPTION
related to https://github.com/returntocorp/semgrep/issues/2128

```
  File "/Users/dennison/.pyenv/versions/3.7.7/bin/semgrep", line 10, in <module>
    sys.exit(main())
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/__main__.py", line 17, in main
    cli()
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/cli.py", line 431, in cli
    severity=args.severity,
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/semgrep_main.py", line 242, in main
    ).invoke_semgrep(target_manager, filtered_rules)
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/core_runner.py", line 537, in invoke_semgrep
    rules, target_manager
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/core_runner.py", line 505, in _run_rules
    rule, target_manager, semgrep_core_ast_cache_dir, max_timeout_files
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/core_runner.py", line 430, in _run_rule
    rule, pattern_matches, self._allow_exec
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/evaluation.py", line 378, in evaluate
    message = interpolate_message_metavariables(rule, pattern_match)
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/evaluation.py", line 398, in interpolate_message_metavariables
    metavar, pattern_match.get_metavariable_value(metavar)
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/site-packages/semgrep/pattern_match.py", line 80, in get_metavariable_value
    value = file.read(length)
  File "/Users/dennison/.pyenv/versions/3.7.7/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd6 in position 7723: invalid continuation byte
```