### PR TITLE
Add command-line option '-i' for case-sensitive matching in spacegrep.

### DIFF
--- a/spacegrep/src/lib/Match.mli
+++ b/spacegrep/src/lib/Match.mli
@@ -42,8 +42,16 @@ type match_ = {
 (*
    Match a pattern against a document. Return the list of all
    non-overlapping matches found by scanning the document from left to right.
+
+   By default, matching ascii words is case-sensitive. Set case_sensitive to
+   false for case-insensitive matching on the ascii letters a-z/A-Z.
+   This doesn't affect backreferences, e.g. the pattern '$A = $A'
+   will match 'A = A' and 'a = a' as always, but not 'A = a', regardless
+   of the case-sensitivity setting.
 *)
-val search : Src_file.t -> Pattern_AST.t -> Doc_AST.t -> match_ list
+val search :
+  ?case_sensitive:bool ->
+  Src_file.t -> Pattern_AST.t -> Doc_AST.t -> match_ list
 
 (*
    Print the matched lines to stdout in a human-readable format.

--- a/spacegrep/src/test/Matcher.ml
+++ b/spacegrep/src/test/Matcher.ml
@@ -61,34 +61,34 @@ let matches_eq expected_doc_strings matches =
   (List.length expected_doc_strings = List.length doc_strings
    && List.for_all2 doc_eq expected_doc_strings doc_strings)
 
-let search pat doc_src doc =
-  let matches = Match.search doc_src pat doc in
+let search ~case_sensitive pat doc_src doc =
+  let matches = Match.search ~case_sensitive doc_src pat doc in
   Match.print doc_src matches;
   matches
 
-let search_str pat_str doc_str =
+let search_str ~case_sensitive pat_str doc_str =
   let pat = Src_file.of_string pat_str |> Parse_pattern.of_src in
   let doc_src = Src_file.of_string doc_str in
   let doc = Parse_doc.of_src doc_src in
-  search pat doc_src doc
+  search ~case_sensitive pat doc_src doc
 
-let check_match_count pat_str doc_str expected_num_matches =
-  let matches = search_str pat_str doc_str in
+let check_match_count ~case_sensitive pat_str doc_str expected_num_matches =
+  let matches = search_str ~case_sensitive pat_str doc_str in
   let num_matches = List.length matches in
   Alcotest.(check int) "number of matches" expected_num_matches num_matches
 
-let check_matches pat_str doc_str expected_matches =
-  let matches = search_str pat_str doc_str in
+let check_matches ~case_sensitive pat_str doc_str expected_matches =
+  let matches = search_str ~case_sensitive pat_str doc_str in
   Alcotest.(check bool) "matches" true (matches_eq expected_matches matches)
 
 type expectation = Count of int | Matches of string list
 
-let check_matching pat_str doc_str expectation =
+let check_matching ~case_sensitive pat_str doc_str expectation =
   match expectation with
   | Count expected_num_matches ->
-      check_match_count pat_str doc_str expected_num_matches
+      check_match_count ~case_sensitive pat_str doc_str expected_num_matches
   | Matches expected_matches ->
-      check_matches pat_str doc_str expected_matches
+      check_matches ~case_sensitive pat_str doc_str expected_matches
 
 let matcher_corpus = [
   (* title, #matches, pattern, document *)
@@ -306,13 +306,29 @@ e
   "...",
   "a b c";
 
+  "case-sensitive", Matches ["foo"],
+  "foo",
+  "Foo or foo";
+]
+
+let matcher_corpus_case_insensitive = [
+  "case-insensitive", Matches ["Foo"; "foo"],
+  "foo",
+  "Foo or foo";
 ]
 
 let matcher_suite =
   List.map (fun (name, expectation, pat_str, doc_str) ->
-    name, `Quick, (fun () -> check_matching pat_str doc_str expectation)
+    name, `Quick, (fun () ->
+      check_matching ~case_sensitive:true pat_str doc_str expectation)
   ) matcher_corpus
+
+let matcher_suite_case_insensitive =
+  List.map (fun (name, expectation, pat_str, doc_str) ->
+    name, `Quick, (fun () ->
+      check_matching ~case_sensitive:false pat_str doc_str expectation)
+  ) matcher_corpus_case_insensitive
 
 let test = "Matcher", [
   "pattern parser", `Quick, test_pattern_parser;
-] @ matcher_suite
+] @ matcher_suite @ matcher_suite_case_insensitive


### PR DESCRIPTION
Implements #2196 

@minusworld don't hesitate to comment if you have suggestions about command-line design, like things you'd expect or find standard or convenient.