### PR TITLE
spacegrep optimizations

### DIFF
--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -363,5 +363,12 @@ let parse_command_line name =
    Entry point for calling the command 'spacegrep' directly.
 *)
 let main () =
+  (*
+     Make the GC work less aggressively than the default.
+     This wastes memory but makes everything up to twice as fast.
+     TODO: clean benchmarks
+  *)
+  Gc.set { (Gc.get()) with Gc.space_overhead = 500 };
+
   let config = parse_command_line "spacegrep" in
   run config

--- a/spacegrep/src/bin/Spacegrep_main.ml
+++ b/spacegrep/src/bin/Spacegrep_main.ml
@@ -42,6 +42,10 @@ let detect_highlight when_use_color oc =
 let run_all
     ~case_sensitive ~debug ~force ~output_format ~highlight ~warn
     patterns docs =
+  let num_files = ref 0 in
+  let num_analyzed = ref 0 in
+  let num_matching_files = ref 0 in
+  let num_matches = ref 0 in
   let matches =
     List.filter_map (fun (get_doc_src : ?max_len:int -> unit -> Src_file.t) ->
       (*
@@ -52,43 +56,61 @@ let run_all
       let peek_length = 4096 in
       let partial_doc_src = get_doc_src ~max_len:peek_length () in
       let doc_type = File_type.classify partial_doc_src in
-      let doc_src =
-        if Src_file.length partial_doc_src < peek_length then
-          (* it's actually complete, no need to re-input the file *)
-          partial_doc_src
-        else
-          get_doc_src ()
-      in
-      let matches =
-        match doc_type, force with
-        | (Minified | Binary), false ->
-            if warn then
-              eprintf "ignoring gibberish file: %s\n%!"
-                (Src_file.source_string doc_src);
-            []
-        | _ ->
-            if debug then
-              printf "read document: %s\n%!"
-                (Src_file.source_string doc_src);
-            let doc = Parse_doc.of_src doc_src in
+      incr num_files;
+      match doc_type, force with
+      | (Minified | Binary), false ->
+          if warn then
+            eprintf "ignoring gibberish file: %s\n%!"
+              (Src_file.source_string partial_doc_src);
+          None
+      | _ ->
+          incr num_analyzed;
+          let doc_src =
+            if Src_file.length partial_doc_src < peek_length then
+              (* it's actually complete, no need to re-input the file *)
+              partial_doc_src
+            else
+              get_doc_src ()
+          in
+          if debug then
+            printf "parse document: %s\n%!"
+              (Src_file.source_string doc_src);
+          let doc = Parse_doc.of_src doc_src in
+          let matches_in_file =
             List.mapi (fun pat_id (pat_src, pat) ->
               if debug then
                 printf "match document from %s against pattern from %s\n%!"
                   (Src_file.source_string doc_src)
                   (Src_file.source_string pat_src);
-              (pat_id, Match.search ~case_sensitive doc_src pat doc)
+              let matches_for_pat =
+                Match.search ~case_sensitive doc_src pat doc
+              in
+              match matches_for_pat with
+              | [] -> None
+              | matches_for_pat ->
+                  num_matches := !num_matches + List.length matches_for_pat;
+                  Some (pat_id, matches_for_pat)
             ) patterns
-      in
-      match matches with
-      | [] -> None
-      | _ -> Some (doc_src, matches)
+            |> List.filter_map (fun x -> x)
+          in
+          match matches_in_file with
+          | [] -> None
+          | _ ->
+              incr num_matching_files;
+              Some (doc_src, matches_in_file)
     ) docs
   in
-  match output_format with
-  | Text ->
-      Match.print_nested_results ~highlight matches
-  | Semgrep ->
-      Semgrep.print_semgrep_json matches
+  (match output_format with
+   | Text ->
+       Match.print_nested_results ~highlight matches
+   | Semgrep ->
+       Semgrep.print_semgrep_json matches
+  );
+  if debug then (
+    printf "\nanalyzed %i files out of %i\n"
+      !num_analyzed !num_files;
+    printf "found %i matches in %i files\n" !num_matches !num_matching_files
+  )
 
 let apply_timeout config =
   match config.timeout with

--- a/spacegrep/src/lib/Src_file.mli
+++ b/spacegrep/src/lib/Src_file.mli
@@ -11,10 +11,15 @@ type source =
   | String
   | Channel
 
+(*
+   Read data from various sources.
+   Specifying max_len allows for reading at most the first max_len bytes
+   of data.
+*)
 val of_string : ?source:source -> string -> t
-val of_channel : ?source:source -> in_channel -> t
+val of_channel : ?source:source -> ?max_len:int -> in_channel -> t
 val of_stdin : ?source:source -> unit -> t
-val of_file : ?source:source -> string -> t
+val of_file : ?source:source -> ?max_len:int -> string -> t
 
 val to_lexbuf : t -> Lexing.lexbuf
 
@@ -23,6 +28,7 @@ val show_source : source -> string
 val source_string : t -> string
 
 val contents : t -> string
+val length : t -> int
 
 (*
    Extract a specific region specified as


### PR DESCRIPTION
* Only peek into the first 4096 (first FS block or so) to determine whether to skip an input file.
* Don't keep all file contents in memory until the end. This saves a lot of memory when matches are only in some files. Still a problem when all the files match.

I tested this just with `spacegrep hello .` on the whole semgrep repo after a build. ~~Getting 1 min 10 now for what used to take 1 min 35.~~

None of this is in the critical path of semgrep usage, since it only applies when scanning whole directories without filtering based on file extensions. It's just for making spacegrep more pleasant when used directly from the command line and in demos.
