### PR TITLE
[TS] Generate Cast for 'as' type asserting/casting operations

### DIFF
--- a/semgrep-core/tests/ts/misc_as_cast.sgrep
+++ b/semgrep-core/tests/ts/misc_as_cast.sgrep
@@ -1,0 +1,1 @@
+$VAR = $EXPR as $TYPE;

--- a/semgrep-core/tests/ts/misc_as_cast.ts
+++ b/semgrep-core/tests/ts/misc_as_cast.ts
@@ -1,0 +1,4 @@
+//ERROR: match
+x = 42 as number;
+//ERROR: match
+x = <number> 0;


### PR DESCRIPTION
Related to https://github.com/returntocorp/semgrep/issues/2192

test plan:
test file included

```
+ /home/pad/semgrep/_build/default/cli/Main.exe -dump_ast misc_as_cast.ts
Pr(
  [ExprStmt(
     Assign(
       Id(("x", ()),
         {id_resolved=Ref(None); id_type=Ref(None);
          id_const_literal=Ref(None); }), (),
       Cast(
         TyId(("number", ()),
           {id_resolved=Ref(None); id_type=Ref(None);
            id_const_literal=Ref(None); }), L(Float(("42", ()))))), ());
   ExprStmt(
     Assign(
       Id(("x", ()),
         {id_resolved=Ref(None); id_type=Ref(None);
          id_const_literal=Ref(None); }), (),
       Cast(
         TyId(("number", ()),
           {id_resolved=Ref(None); id_type=Ref(None);
            id_const_literal=Ref(None); }), L(Float(("0", ()))))), ())])
```