### PR TITLE
Parse conversion operator overload in C#

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -2141,15 +2141,27 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let v2 = List.map (modifier env) v2 in
        let v3 =
          (match v3 with
-          | `Impl tok -> token env tok (* "implicit" *)
-          | `Expl tok -> token env tok (* "explicit" *)
+          | `Impl tok -> ("op_Implicit", token env tok) (* "implicit" *)
+          | `Expl tok -> ("op_Explicit", token env tok) (* "explicit" *)
          )
        in
        let v4 = token env v4 (* "operator" *) in
        let v5 = type_constraint env v5 in
        let v6 = parameter_list env v6 in
        let v7 = function_body env v7 in
-       todo env (v1, v2, v3, v4, v5, v6, v7)
+       let ent = {
+         name = EId v3;
+         attrs = v1 @ v2;
+         info = empty_id_info ();
+         tparams = [];
+       } in
+       let def = AST.FuncDef {
+         fkind = (AST.Method, v4);
+         fparams = v6;
+         frettype = Some v5;
+         fbody = v7;
+       } in
+       AST.DefStmt (ent, def)
    | `Dele_decl (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
        let v1 = List.concat_map (attribute_list env) v1 in
        let v2 = List.map (modifier env) v2 in

--- a/semgrep-core/tests/csharp/parsing/operatoroverload.cs
+++ b/semgrep-core/tests/csharp/parsing/operatoroverload.cs
@@ -1,0 +1,37 @@
+using System;
+
+class HelloWorldTernary
+{
+    public static void Main()
+    {
+        var hello = new SpaceString("hello");
+        var world = new SpaceString("world");
+        Console.WriteLine(hello + world);
+        Console.WriteLine((int)hello);
+    }
+}
+
+internal class SpaceString
+{
+    private string content;
+
+    public SpaceString(string content)
+    {
+        this.content = content;
+    }
+
+    public static SpaceString operator +(SpaceString a, SpaceString b)
+    {
+        return new SpaceString(a.content + " " + b.content);
+    }
+
+    public static implicit operator string(SpaceString s)
+    {
+        return s.content;
+    }
+    
+    public static explicit operator int(SpaceString s)
+    {
+        return s.content.Length;
+    }
+}


### PR DESCRIPTION
E.g.
```csharp
public static implicit operator string(SpaceString s) { ... }
```

Name the methods `op_Explicit` and `op_Implicit`, just like C# does.

Also, add an example C# file that demonstrates this behaviour. This file is not
yet parsed in a test setup.