### PR TITLE
Add a new -max_match_per_file flag to semgrep-core to avoid stalling

### DIFF
--- a/semgrep-core/core/Rule.ml
+++ b/semgrep-core/core/Rule.ml
@@ -44,6 +44,14 @@ type rule = {
   message: string;
   severity: severity;
   languages: Lang.t list; (* at least one element *)
+
+  (* Useful for debugging, to report bad rules. We could rule.id to
+   * report those bad rules, but semgrep-python uses a weird encoding
+   * when flattening the pattern-xxx (-and, -either, -not, etc.)
+   * patterns in the original rule yaml file, which makes it hard
+   * to know what what was the corresponding pattern.
+  *)
+  pattern_string: string;
 }
 (*e: type [[Rule.rule]] *)
 

--- a/semgrep-core/core/Tainting_rule.ml
+++ b/semgrep-core/core/Tainting_rule.ml
@@ -72,7 +72,8 @@ let rule_of_tainting_rule tr =
     severity = tr.severity;
     languages = tr.languages;
     (* arbitrary *)
-    pattern = List.hd (tr.sink)
+    pattern = List.hd (tr.sink);
+    pattern_string = "TODO: no pattern_string";
   }
 (*e: function [[Tainting_rule.rule_of_tainting_rule]] *)
 (*e: semgrep/core/Tainting_rule.ml *)

--- a/semgrep-core/parsing/Parse_rules.ml
+++ b/semgrep-core/parsing/Parse_rules.ml
@@ -95,13 +95,14 @@ let parse file =
                     "id", `String id;
                     "languages", `A langs;
                     "message", `String message;
-                    "pattern", `String pattern;
+                    "pattern", `String pattern_string;
                     "severity", `String sev;
                   ] ->
                       let languages, lang = parse_languages ~id langs in
-                      let pattern = parse_pattern ~id ~lang pattern in
+                      let pattern = parse_pattern ~id ~lang pattern_string in
                       let severity = parse_severity ~id sev in
-                      { R. id; pattern; message; languages; severity }
+                      { R. id; pattern; message; languages; severity;
+                        pattern_string; }
                   | x ->
                       pr2_gen x;
                       raise (InvalidYamlException "wrong rule fields")

--- a/semgrep-core/reporting/JSON_report.ml
+++ b/semgrep-core/reporting/JSON_report.ml
@@ -154,6 +154,7 @@ let match_to_json x =
       "metavars", J.Object (x.env |> List.map (json_metavar x startp));
     ]
   ]
+[@@profiling]
 (*e: function [[JSON_report.match_to_json]] *)
 
 (*****************************************************************************)

--- a/semgrep-core/tainting/Tainting_generic.ml
+++ b/semgrep-core/tainting/Tainting_generic.ml
@@ -56,8 +56,10 @@ let match_pat_instr pat =
       (fun instr ->
          let eorig = instr.IL.iorig in
          (* the rule is just used by match_e_e for profiling stats *)
-         let rule = { Rule.id = "<tainting>"; pattern = AST.E pat; message = "";
-                      severity = Rule.Error; languages = []; } in
+         let rule = { Rule.id = "<tainting>";
+                      pattern = AST.E pat; pattern_string = "<tainting> pat";
+                      message = ""; severity = Rule.Error;
+                      languages = []; } in
 
          let matches_with_env = Semgrep_generic.match_e_e rule pat eorig in
          matches_with_env <> []

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -98,8 +98,10 @@ let regression_tests_for_lang files lang =
     Error_code.g_errors := [];
 
     let rule = { R.
-      id = "unit testing"; pattern; message = ""; severity = R.Error; 
-      languages = [lang] } in
+      id = "unit testing"; pattern; message = ""; 
+      severity = R.Error; languages = [lang];
+      pattern_string = "test: no need for pattern string";
+    } in
     let equiv = 
      (* Python == is not the same than !(==) *)
      if lang <> Lang.Python


### PR DESCRIPTION
This fixes https://github.com/returntocorp/semgrep/issues/2102

This diffs adds also more logging information to track which
files are done processing, how many matches we found, and also
the biggest offending file and rules.

test plan:
install latest semgrep-core in the PATH (make install in semgrep-core/)
then:
(semgrep) pad@yrax:~/work/lang-ts/Signal-Desktop$ time semgrep --debug -f r/typescript
trying to download from https://semgrep.dev/r/typescript
using config from https://semgrep.dev/r/typescript. Visit https://semgrep.dev/registry to see all public rules.
downloading config...
...
[0.481  Info       Main.Dune__exe__Main ] Analyzing ts/textsecure/Helpers.ts
[0.481  Info       Main.Dune__exe__Main ] using cache: /tmp/tmpl79hx_fw/3439090b488f63ce7fa88abebaf9f849.ast_cache
[0.483  Info       Main.Dune__exe__Main ] done with ts/textsecure/Helpers.ts
[0.267  Info       Main.Dune__exe__Main ] found 538304 matches and 8 errors
[0.826  Info       Main.Dune__exe__Main ] too many matches on ts/background.ts, generating Timeout for it
[0.836  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 10130, pattern = $PROP
[0.836  Info       Main.Dune__exe__Main ] too many matches on ts/groups.ts, generating Timeout for it
[0.855  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 9077, pattern = $PROP
[0.855  Info       Main.Dune__exe__Main ] too many matches on ts/models/conversations.ts, generating Timeout for it
[0.872  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 13065, pattern = $PROP
[0.872  Info       Main.Dune__exe__Main ] too many matches on ts/models/messages.ts, generating Timeout for it
[0.888  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 11492, pattern = $PROP
[0.888  Info       Main.Dune__exe__Main ] too many matches on ts/sql/Server.ts, generating Timeout for it
[0.897  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 7378, pattern = $PROP
[0.897  Info       Main.Dune__exe__Main ] too many matches on ts/textsecure/AccountManager.ts, generating Timeout for it
[0.902  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 5134, pattern = $PROP
[0.902  Info       Main.Dune__exe__Main ] too many matches on ts/textsecure/MessageReceiver.ts, generating Timeout for it
[0.909  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 6698, pattern = $PROP
[0.909  Info       Main.Dune__exe__Main ] too many matches on ts/textsecure/SendMessage.ts, generating Timeout for it
[0.919  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 10065, pattern = $PROP
[0.920  Info       Main.Dune__exe__Main ] too many matches on ts/textsecure/WebAPI.ts, generating Timeout for it
[0.977  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 5656, pattern = $PROP
[0.977  Info       Main.Dune__exe__Main ] too many matches on ts/views/conversation_view.ts, generating Timeout for it
[0.990  Info       Main.Dune__exe__Main ] most offending rule: id = 0..1.0.2, matches = 11612, pattern = $PROP
[25.862 Info       Main.Dune__exe__Main ] size of returned JSON string: 155652095
...