### PR TITLE
Support CaseEllipsis in generic AST to allow ... in switch body and Go parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Next
 
 ### Added
+- experimental support for $...ARGS metavariables to match multiple
+  arguments in JS/TS
+- you can now use '...' inside switch for Go
+- you can now use partial try, catch, or finally pattern statements in JS/TS
+- you can now use partial if pattern statement (e.g., 'if(...)') in Java
+- you can now use {..., $KEY: $VAL, ...} metavariable for dictionnary keys in Ruby
 - An experimental --json-stats flag that adds stats on number and line count of files by 
 supported extension as well as per-rule profiling. This flag is experimental and users
 should not yet rely on the output being stable.
@@ -13,7 +19,10 @@ should not yet rely on the output being stable.
 - To avoid filling the screen with output when your query captures a whole class, separators are printed in between findings and an individual finding can be truncated if it goes over 10 lines. Adjustable with flag `--max-lines-per-finding` (#2082)
 
 ### Fixed
-
+- semgrep should not halt when a rule generate too many matches (complementary of --timeout). See also the new -max_match_per_file command-line flag of semgrep-core.
+- semgrep -debug works again and should output more debugging information from semgrep-core, especially whether some rules are too general and match too many places
+- $X & $Y correctly now matches BitAnd expressions in Ruby
+- allow to reuse the same metavariable for a class identifier in a type context or class definition context
 
 ## [0.33.0](https://github.com/returntocorp/semgrep/releases/tag/v0.33.0) - 2020-12-01
 

--- a/semgrep-core/matching/SubAST_generic.ml
+++ b/semgrep-core/matching/SubAST_generic.ml
@@ -167,7 +167,10 @@ let substmts_of_stmt st =
   | Block (_, xs, _) ->
       xs
   | Switch (_, _, xs) ->
-      xs |> List.map snd
+      xs |> List.map (function
+        | CasesAndBody (_, st) -> [st]
+        | CaseEllipsis _ -> []
+      ) |> List.flatten
   | Try (_, st, xs, opt) ->
       [st] @
       (xs |> List.map Common2.thd3) @

--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -1622,7 +1622,7 @@ and switch_section (env : env) ((v1, v2) : CST.switch_section) : case_and_body =
   in
   let v2 = List.map (statement env) v2 in
   (* TODO: we convert list of statements to a block with fake brackets. Does this make sense? *)
-  (v1, stmt1 v2)
+  CasesAndBody (v1, stmt1 v2)
 
 and attribute_list (env : env) ((v1, v2, v3, v4, v5) : CST.attribute_list) : attribute list =
   let v1 = token env v1 (* "[" *) in

--- a/semgrep-core/parsing/Parse_go_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_go_tree_sitter.ml
@@ -159,7 +159,7 @@ let import_spec (env : env) ((v1, v2) : CST.import_spec) =
   let v2 = string_literal env v2 in
   v1, v2
 
-let rec type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) : case_clause =
+let rec type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
   let v1 = token env v1 (* "case" *) in
   let v2 = type_ env v2 in
   let v3 =
@@ -176,7 +176,7 @@ let rec type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) : case_clau
      | None -> [])
   in
   let xs = v2::v3 in
-  CaseExprs (v1, (xs |> List.map (fun x -> Right x))), stmt1 v5
+  (CaseExprs (v1, (xs |> List.map (fun x -> Right x))), stmt1 v5)
 
 and simple_statement (env : env) (x : CST.simple_statement) : simple =
   (match x with
@@ -508,7 +508,7 @@ and call_expression (env : env) (x : CST.call_expression) =
        Call (v1, v2)
   )
 
-and default_case (env : env) ((v1, v2, v3) : CST.default_case) : case_clause =
+and default_case (env : env) ((v1, v2, v3) : CST.default_case) =
   let v1 = token env v1 (* "default" *) in
   let _v2 = token env v2 (* ":" *) in
   let v3 =
@@ -516,7 +516,7 @@ and default_case (env : env) ((v1, v2, v3) : CST.default_case) : case_clause =
      | Some x -> statement_list env x
      | None -> [])
   in
-  CaseDefault v1, stmt1 v3
+  (CaseDefault v1, stmt1 v3)
 
 and slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
   let v1 = token env v1 (* "[" *) in
@@ -772,8 +772,8 @@ and statement (env : env) (x : CST.statement) : stmt =
        let v5 =
          List.map (fun x ->
            (match x with
-            | `Exp_case x -> expression_case env x
-            | `Defa_case x -> default_case env x
+            | `Exp_case x -> CaseClause (expression_case env x)
+            | `Defa_case x -> CaseClause (default_case env x)
            )
          ) v5
        in
@@ -790,6 +790,7 @@ and statement (env : env) (x : CST.statement) : stmt =
             | `Defa_case x -> default_case env x
            )
          ) v4
+         |> List.map (fun x -> CaseClause x)
        in
        let (a,b) = v2 in
        let _v5 = token env v5 (* "}" *) in
@@ -804,6 +805,7 @@ and statement (env : env) (x : CST.statement) : stmt =
             | `Defa_case x -> default_case env x
            )
          ) v3
+         |> List.map (fun x -> CaseClause x)
        in
        let _v4 = token env v4 (* "}" *) in
        Select (v1, v3)

--- a/semgrep-core/tests/go/dots_switch_cases.go
+++ b/semgrep-core/tests/go/dots_switch_cases.go
@@ -1,0 +1,17 @@
+package Foo
+
+func foo() {
+    os := runtime.GOOS
+
+    //ERROR: match
+	switch os {
+	case "darwin":
+		fmt.Println("OS X.")
+	case "linux":
+		fmt.Println("Linux.")
+	default:
+		// freebsd, openbsd,
+		// plan9, windows...
+		fmt.Printf("%s.\n", os)
+	}
+}

--- a/semgrep-core/tests/go/dots_switch_cases.sgrep
+++ b/semgrep-core/tests/go/dots_switch_cases.sgrep
@@ -1,0 +1,3 @@
+switch $COND {
+  case ...
+}


### PR DESCRIPTION
This fixes https://github.com/returntocorp/semgrep/issues/2215
Right now just the Go parser generate those CaseEllipsis but we
could generalize it to more languages.

test plan:
test files included