### PR TITLE
Parse default operator in C#

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -885,12 +885,12 @@ and expression (env : env) (x : CST.expression) : AST.expr =
          (match v2 with
           | Some (v1, v2, v3) ->
               let v1 = token env v1 (* "(" *) in
-              let v2 = type_constraint env v2 in
+              let v2 = ArgType (type_constraint env v2) in
               let v3 = token env v3 (* ")" *) in
-              todo env (v1, v2, v3)
-          | None -> todo env ())
+              v1, [v2], v3
+          | None -> fake_bracket [])
        in
-       todo env (v1, v2)
+       Call (IdSpecial (New, v1), v2)
    | `Elem_access_exp (v1, v2) ->
        let v1 = expression env v1 in
        let v2 = element_binding_expression env v2 in

--- a/semgrep-core/tests/csharp/parsing/defaultoperator.cs
+++ b/semgrep-core/tests/csharp/parsing/defaultoperator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+class HelloWorldDefault
+{
+    public static void Main()
+    {
+        var hello = default(string) + "hello";
+        var world = World("world");
+        var excl = Exclamation(default);
+        Console.WriteLine(hello + world + excl);
+    }
+
+    private static string World<T>(T param)
+    {
+        var t = default(T);
+        return t + param.ToString();
+    }
+
+    private static string Exclamation(string param)
+    {
+        return param + "!";
+    }
+}


### PR DESCRIPTION
E.g.
```
Console.WriteLine(default(int));
```

We convert it to a call to `new()`, which is not totally the same but comes
pretty close.

Relates to #1392