### PR TITLE
Adding stat to Parse_code.parsing_stat

### DIFF
--- a/semgrep-core/cli/Main.ml
+++ b/semgrep-core/cli/Main.ml
@@ -581,7 +581,7 @@ let parse_pattern str =
 let sgrep_ast pattern file any_ast =
   match pattern, any_ast with
   |  _, NoAST -> () (* skipping *)
-  | PatGen (_lang, pattern), Gen ({Parse_code. ast; errors}, lang) ->
+  | PatGen (_lang, pattern), Gen ({Parse_code. ast; errors; _}, lang) ->
       let rule = { R.
                    id = "-e/-f"; pattern_string = "-e/-f";
                    pattern;
@@ -642,7 +642,7 @@ let iter_generic_ast_of_files_and_get_matches_and_exn_to_errors f files =
       try
         run_with_memory_limit !max_memory (fun () ->
           timeout_function file (fun () ->
-            let {Parse_code. ast; errors} = parse_generic lang file in
+            let {Parse_code. ast; errors; _} = parse_generic lang file in
             (* calling the hook *)
             (f file lang ast, errors)
 
@@ -995,7 +995,7 @@ let dump_ast file =
   match Lang.langs_of_filename file with
   | lang::_ ->
       E.try_with_print_exn_and_reraise file (fun () ->
-        let {Parse_code. ast; errors } =
+        let {Parse_code. ast; errors; _ } =
           Parse_code.parse_and_resolve_name_use_pfff_or_treesitter lang file in
         let v = Meta_AST.vof_any (AST_generic.Pr ast) in
         let s = dump_v_to_format v in

--- a/semgrep-core/parsing/Parse_code.mli
+++ b/semgrep-core/parsing/Parse_code.mli
@@ -2,6 +2,7 @@
 type parsing_result = {
   ast: AST_generic.program;
   errors: Error_code.error list;
+  stat: Parse_info.parsing_stat;
 }
 
 (* This uses either the pfff or tree-sitter parsers.

--- a/semgrep-core/parsing/Test_parsing.ml
+++ b/semgrep-core/parsing/Test_parsing.ml
@@ -203,7 +203,7 @@ let diff_pfff_tree_sitter xs =
         let (ast1, _stat1) = Parse_generic.parse_with_lang lang file in
         let ast2 =
           Common.save_excursion Flag_semgrep.tree_sitter_only true (fun () ->
-            let {Parse_code. ast; errors} =
+            let {Parse_code. ast; errors; _} =
               Parse_code.just_parse_with_lang lang file in
             if errors <> [] then failwith (spf "problem parsing %s" file);
             ast

--- a/semgrep-core/synthesizing/Synthesizer.ml
+++ b/semgrep-core/synthesizing/Synthesizer.ml
@@ -5,7 +5,7 @@ module J = JSON
 let synthesize_patterns s file =
   let r = Range.range_of_linecol_spec s file in
   let lang = Lang.langs_of_filename file |> List.hd in
-  let {Parse_code. ast; errors } =
+  let {Parse_code. ast; errors; _ } =
     Parse_code.parse_and_resolve_name_use_pfff_or_treesitter lang file
   in
   if errors <> [] then failwith (spf "problem parsing %s" file);

--- a/semgrep-core/synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/synthesizing/Unit_synthesizer.ml
@@ -186,7 +186,7 @@ let unittest =
       tests |> List.iter (fun (filename, range, sols) ->
         let file = test_path ^ filename in
         let pats = Synthesizer.synthesize_patterns range file in
-        let {Parse_code. ast = code; errors = errs } =
+        let {Parse_code. ast = code; errors = errs; _ } =
           Parse_code.parse_and_resolve_name_use_pfff_or_treesitter lang file
         in
         if errs <> [] then failwith (spf "problem parsing %s" filename);

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -84,7 +84,7 @@ let regression_tests_for_lang files lang =
     in
     let ast = 
         try 
-          let { Parse_code. ast; errors } = 
+          let { Parse_code. ast; errors; _ } = 
             Parse_code.parse_and_resolve_name_use_pfff_or_treesitter lang file 
           in
           if errors <> []


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/2190
We now return parsing stat from pfff parsers and tree-sitter parsers

test plan:
make
make test