### PR TITLE
Parse event fields in C#

### DIFF
--- a/semgrep-core/tests/csharp/parsing/events.cs
+++ b/semgrep-core/tests/csharp/parsing/events.cs
@@ -1,0 +1,22 @@
+using System;
+
+class HelloWorldEvents
+{
+    private event EventHandler<string> StringEvent;
+
+    public static void Main()
+    {
+        var instance = new HelloWorldEvents();
+        instance.Run();
+    }
+    
+    public void Run() {
+        StringEvent += PrintString;
+        StringEvent.Invoke(this, "Hello world");
+    }
+
+    private void PrintString(object sender, string e)
+    {
+        Console.WriteLine(e);
+    }
+}


### PR DESCRIPTION
Add a function to create variable definition statements, that also adds
attributes to the entity. Add an `event` NamedAttr to event fields. Maybe this
should actually be a keyword attr?

Related to #1392