### PR TITLE
Move package information to dunder attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,5 +109,5 @@ gitclean:
 
 .PHONY: bump
 bump:
-	$(SED) 's/__version__ = ".*"/__VERSION__ = "$(SEMGREP_VERSION)"/g' semgrep/semgrep/__init__.py
+	$(SED) 's/__version__ = ".*"/__version__ = "$(SEMGREP_VERSION)"/g' semgrep/semgrep/__init__.py
 	$(SED) 's/^    install_requires=\["semgrep==.*"\],$$/    install_requires=["semgrep==$(SEMGREP_VERSION)"],/g' setup.py

--- a/Makefile
+++ b/Makefile
@@ -109,5 +109,5 @@ gitclean:
 
 .PHONY: bump
 bump:
-	$(SED) 's/__VERSION__ = ".*"/__VERSION__ = "$(SEMGREP_VERSION)"/g' semgrep/semgrep/__init__.py
+	$(SED) 's/__version__ = ".*"/__VERSION__ = "$(SEMGREP_VERSION)"/g' semgrep/semgrep/__init__.py
 	$(SED) 's/^    install_requires=\["semgrep==.*"\],$$/    install_requires=["semgrep==$(SEMGREP_VERSION)"],/g' setup.py

--- a/semgrep/semgrep/__init__.py
+++ b/semgrep/semgrep/__init__.py
@@ -5,6 +5,6 @@ __description__ = (
     "Find bug variants with patterns that look like source code."
 )
 __license__ = "LGPL-2.1-only"
-__name__ = "semgrep"
+__title__ = "semgrep"
 __url__ = "https://github.com/returntocorp/semgrep"
 __version__ = "0.34.0"

--- a/semgrep/semgrep/__init__.py
+++ b/semgrep/semgrep/__init__.py
@@ -1,1 +1,10 @@
-__VERSION__ = "0.34.0"
+__name__ = "semgrep"
+__version__ = "0.34.0"
+__author__ = "Return To Corporation"
+__author_email__ = "support@r2c.dev"
+__description__ = (
+    "Lightweight static analysis for many languages. "
+    "Find bug variants with patterns that look like source code."
+)
+__url__ = "https://github.com/returntocorp/semgrep"
+__license__ = "LGPL-2.1-only"

--- a/semgrep/semgrep/__init__.py
+++ b/semgrep/semgrep/__init__.py
@@ -1,10 +1,10 @@
-__name__ = "semgrep"
-__version__ = "0.34.0"
 __author__ = "Return To Corporation"
 __author_email__ = "support@r2c.dev"
 __description__ = (
     "Lightweight static analysis for many languages. "
     "Find bug variants with patterns that look like source code."
 )
-__url__ = "https://github.com/returntocorp/semgrep"
 __license__ = "LGPL-2.1-only"
+__name__ = "semgrep"
+__url__ = "https://github.com/returntocorp/semgrep"
+__version__ = "0.34.0"

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -7,7 +7,7 @@ import os
 import semgrep.config_resolver
 import semgrep.semgrep_main
 import semgrep.test
-from semgrep import __VERSION__
+from semgrep import __version__
 from semgrep.constants import DEFAULT_CONFIG_FILE
 from semgrep.constants import DEFAULT_MAX_LINES_PER_FINDING
 from semgrep.constants import DEFAULT_TIMEOUT
@@ -350,7 +350,7 @@ def cli() -> None:
     ### Parse and validate
     args = parser.parse_args()
     if args.version:
-        print(__VERSION__)
+        print(__version__)
         return
 
     if args.pattern and not args.lang:

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -3,7 +3,7 @@ import re
 from enum import auto
 from enum import Enum
 
-from semgrep import __VERSION__
+from semgrep import __version__
 from semgrep.util import compute_semgrep_path
 from semgrep.util import compute_spacegrep_path
 
@@ -21,7 +21,7 @@ DEFAULT_TIMEOUT = 30  # seconds
 
 YML_EXTENSIONS = {".yml", ".yaml"}
 
-SEMGREP_USER_AGENT = f"Semgrep/{__VERSION__}"
+SEMGREP_USER_AGENT = f"Semgrep/{__version__}"
 SEMGREP_USER_AGENT_APPEND = os.environ.get("SEMGREP_USER_AGENT_APPEND")
 if SEMGREP_USER_AGENT_APPEND is not None:
     SEMGREP_USER_AGENT = f"{SEMGREP_USER_AGENT} {SEMGREP_USER_AGENT_APPEND}"

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -19,7 +19,7 @@ from typing import Set
 import colorama
 from junit_xml import TestSuite
 
-from semgrep import __VERSION__
+from semgrep import __version__
 from semgrep import config_resolver
 from semgrep.constants import BREAK_LINE_CHAR
 from semgrep.constants import BREAK_LINE_WIDTH
@@ -206,7 +206,7 @@ def build_junit_xml_output(
 
 
 def _sarif_tool_info() -> Dict[str, Any]:
-    return {"name": "semgrep", "semanticVersion": __VERSION__}
+    return {"name": "semgrep", "semanticVersion": __version__}
 
 
 def build_sarif_output(rule_matches: List[RuleMatch], rules: FrozenSet[Rule]) -> str:

--- a/semgrep/semgrep/version.py
+++ b/semgrep/semgrep/version.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
-from semgrep import __VERSION__
+from semgrep import __version__
 from semgrep.constants import SEMGREP_USER_AGENT
 
 VERSION_CHECK_URL = str(
@@ -108,7 +108,7 @@ def is_running_latest(version_cache_path: Path = VERSION_CACHE_PATH) -> bool:
 
     try:
         latest_version = Version(latest_version_str)
-        current_version = Version(__VERSION__)
+        current_version = Version(__version__)
     except InvalidVersion as e:
         logger.debug(f"Invalid version string: {e}")
         return False

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -8,7 +8,13 @@ from setuptools import setup
 from setuptools.command.install import install
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
-import semgrep
+from semgrep import __author__
+from semgrep import __author_email__
+from semgrep import __description__
+from semgrep import __license__
+from semgrep import __name__
+from semgrep import __url__
+from semgrep import __version__
 
 
 @contextlib.contextmanager
@@ -21,14 +27,6 @@ def chdir(dirname=None):
     finally:
         os.chdir(curdir)
 
-
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-try:
-    with open(os.path.join(REPO_ROOT, "README.md")) as f:
-        long_description = f.read()
-except FileNotFoundError:
-    long_description = "**SETUP: COULD NOT FIND README**"
 
 # TODO: what is the minimum OSX version?
 MIN_OSX_VERSION = "10_14"
@@ -65,6 +63,15 @@ class bdist_wheel(_bdist_wheel):
         return python, abi, plat
 
 
+try:
+    with open("../README.md") as f:
+        long_description = f.read()
+except FileNotFoundError:
+    long_description = ""
+
+source_dir = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.dirname(source_dir)
+
 # Lifted with love (and edits) from https://github.com/benfred/py-spy/blob/master/setup.py
 class PostInstallCommand(install):
     """Post-installation for installation mode."""
@@ -83,13 +90,13 @@ class PostInstallCommand(install):
         # take the advice from that comment, and move over after install
 
         if "osx" in distutils.util.get_platform():
-            with chdir(REPO_ROOT):
-                os.system(os.path.join(REPO_ROOT, "scripts", "osx-release.sh"))
-                source = os.path.join(REPO_ROOT, "artifacts", exec_name)
+            with chdir(repo_root):
+                os.system(os.path.join(repo_root, "scripts", "osx-release.sh"))
+                source = os.path.join(repo_root, "artifacts", exec_name)
         else:
-            with chdir(REPO_ROOT):
-                os.system(os.path.join(REPO_ROOT, "scripts", "ubuntu-release.sh"))
-                source = os.path.join(REPO_ROOT, "semgrep-files", exec_name)
+            with chdir(repo_root):
+                os.system(os.path.join(repo_root, "scripts", "ubuntu-release.sh"))
+                source = os.path.join(repo_root, "semgrep-files", exec_name)
 
         ## run this after trying to build (as otherwise this leaves
         ## venv in a bad state: https://github.com/benfred/py-spy/issues/69)
@@ -131,16 +138,16 @@ class PostInstallCommand(install):
 
 
 setup(
-    name=semgrep.__name__,
-    version=semgrep.__version__,
-    author=semgrep.__author__,
-    author_email=semgrep.__author_email__,
-    description=semgrep.__description__,
+    name=__name__,
+    version=__version__,
+    author=__author__,
+    author_email=__author_email__,
+    description=__description__,
     cmdclass={"install": PostInstallCommand, "bdist_wheel": bdist_wheel},
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url=semgrep.__url__,
-    license=semgrep.__license__,
+    url=__url__,
+    license=__license__,
     install_requires=[
         "attrs>=19.3.0",
         "colorama>=0.4.3",

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 from setuptools.command.install import install
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
-from semgrep import __VERSION__
+import semgrep
 
 
 @contextlib.contextmanager
@@ -21,6 +21,14 @@ def chdir(dirname=None):
     finally:
         os.chdir(curdir)
 
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    with open(os.path.join(REPO_ROOT, "README.md")) as f:
+        long_description = f.read()
+except FileNotFoundError:
+    long_description = "**SETUP: COULD NOT FIND README**"
 
 # TODO: what is the minimum OSX version?
 MIN_OSX_VERSION = "10_14"
@@ -57,15 +65,6 @@ class bdist_wheel(_bdist_wheel):
         return python, abi, plat
 
 
-try:
-    with open("../README.md") as f:
-        long_description = f.read()
-except FileNotFoundError:
-    long_description = ""
-
-source_dir = os.path.dirname(os.path.abspath(__file__))
-repo_root = os.path.dirname(source_dir)
-
 # Lifted with love (and edits) from https://github.com/benfred/py-spy/blob/master/setup.py
 class PostInstallCommand(install):
     """Post-installation for installation mode."""
@@ -84,13 +83,13 @@ class PostInstallCommand(install):
         # take the advice from that comment, and move over after install
 
         if "osx" in distutils.util.get_platform():
-            with chdir(repo_root):
-                os.system(os.path.join(repo_root, "scripts", "osx-release.sh"))
-                source = os.path.join(repo_root, "artifacts", exec_name)
+            with chdir(REPO_ROOT):
+                os.system(os.path.join(REPO_ROOT, "scripts", "osx-release.sh"))
+                source = os.path.join(REPO_ROOT, "artifacts", exec_name)
         else:
-            with chdir(repo_root):
-                os.system(os.path.join(repo_root, "scripts", "ubuntu-release.sh"))
-                source = os.path.join(repo_root, "semgrep-files", exec_name)
+            with chdir(REPO_ROOT):
+                os.system(os.path.join(REPO_ROOT, "scripts", "ubuntu-release.sh"))
+                source = os.path.join(REPO_ROOT, "semgrep-files", exec_name)
 
         ## run this after trying to build (as otherwise this leaves
         ## venv in a bad state: https://github.com/benfred/py-spy/issues/69)
@@ -132,15 +131,16 @@ class PostInstallCommand(install):
 
 
 setup(
-    name="semgrep",
-    version=__VERSION__,
-    author="Return To Corporation",
-    author_email="support@r2c.dev",
-    description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",
+    name=semgrep.__name__,
+    version=semgrep.__version__,
+    author=semgrep.__author__,
+    author_email=semgrep.__author_email__,
+    description=semgrep.__description__,
     cmdclass={"install": PostInstallCommand, "bdist_wheel": bdist_wheel},
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/returntocorp/semgrep",
+    url=semgrep.__url__,
+    license=semgrep.__license__,
     install_requires=[
         "attrs>=19.3.0",
         "colorama>=0.4.3",

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -12,7 +12,7 @@ from semgrep import __author__
 from semgrep import __author_email__
 from semgrep import __description__
 from semgrep import __license__
-from semgrep import __name__
+from semgrep import __title__
 from semgrep import __url__
 from semgrep import __version__
 
@@ -138,7 +138,7 @@ class PostInstallCommand(install):
 
 
 setup(
-    name=__name__,
+    name=__title__,
     version=__version__,
     author=__author__,
     author_email=__author_email__,

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError
 import pytest
 from xmldiff import main
 
-from semgrep import __VERSION__
+from semgrep import __version__
 
 GITHUB_TEST_GIST_URL = (
     "https://raw.githubusercontent.com/returntocorp/semgrep-rules/develop/template.yaml"
@@ -81,7 +81,7 @@ def test_sarif_output(run_semgrep_in_tmp, snapshot):
 
     # Semgrep version is included in sarif output. Verify this independently so
     # snapshot does not need to be updated on version bump
-    assert sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] == __VERSION__
+    assert sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] == __version__
     sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] = "placeholder"
 
     snapshot.assert_match(


### PR DESCRIPTION
Also, general packaging cleanup in anticipation of making some improvements for https://github.com/returntocorp/semgrep/issues/2054.

Using dunder (double underscore) module attributes is a common way for specifying this information: https://github.com/psf/requests/blob/master/requests/__version__.py. The primary advantage here is that other tools/packages and programmatically query this information from the `semgrep` module.