### PR TITLE
Remove existing rule from local semgrep file

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -26,13 +26,6 @@ rules:
        - Unit_*.ml
        - Test_*.ml
 
-  - id: string-missing-comma
-    pattern: |
-      {..., "..." "...", ...}
-    message: You probably forgot a comma
-    languages: [python]
-    severity: ERROR
-
 # not ready yet
 #  - id: no-exit-in-semgrep
 #    pattern: |


### PR DESCRIPTION
We added this pattern to the existing rule in https://github.com/returntocorp/semgrep-rules/pull/1042, and we run this rule locally via the `/p/python` ruleset :+1: 