### PR TITLE
Adding id_info to EId field constructor

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -2108,10 +2108,11 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let (open_bra, stmts, close_bra) = declaration_list env v8 in
        let fields = List.map (fun x -> AST.FieldStmt x) stmts in
        let tparams = type_parameters_with_constraints v5 v7 in
+       let idinfo = empty_id_info() in
        let ent = {
-         name = EId v4;
+         name = EId (v4, idinfo);
          attrs = v1 @ v2;
-         info = empty_id_info ();
+         info = idinfo;
          tparams;
        } in
        AST.DefStmt (ent, AST.ClassDef {
@@ -2157,10 +2158,11 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let v5 = type_constraint env v5 in
        let v6 = parameter_list env v6 in
        let v7 = function_body env v7 in
+       let idinfo = empty_id_info () in
        let ent = {
-         name = EId v3;
+         name = EId (v3, idinfo);
          attrs = v1 @ v2;
-         info = empty_id_info ();
+         info = idinfo;
          tparams = [];
        } in
        let def = AST.FuncDef {
@@ -2188,10 +2190,11 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let v9 = token env v9 (* ";" *) in
        let tparams = type_parameters_with_constraints v6 v8 in
        let func = TyFun (v7, v4) in
+       let idinfo = empty_id_info () in
        let ent = {
-         name = EId v5;
+         name = EId (v5, idinfo);
          attrs = v1 @ v2;
-         info = empty_id_info ();
+         info = idinfo;
          tparams;
        } in
        DefStmt (ent, TypeDef { tbody = NewType func })
@@ -2232,10 +2235,11 @@ and declaration (env : env) (x : CST.declaration) : stmt =
           | Some tok -> Some (token env tok) (* ";" *)
           | None -> None)
        in
+       let idinfo = empty_id_info () in
        let ent = {
-         name = EId v4;
+         name = EId (v4, idinfo);
          attrs = v1 @ v2;
-         info = empty_id_info ();
+         info = idinfo;
          tparams = [];
        } in
        AST.DefStmt (ent, AST.TypeDef {
@@ -2320,10 +2324,11 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        in
        let v9 = function_body env v9 in
        let tparams = type_parameters_with_constraints v6 v8 in
+       let idinfo = empty_id_info () in
        let ent = {
-         name = EId v5;
+         name = EId (v5, idinfo);
          attrs = v1 @ v2;
-         info = empty_id_info ();
+         info = idinfo;
          tparams;
        } in
        let def = AST.FuncDef {
@@ -2355,10 +2360,11 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let v6 = parameter_list env v6 in
        let v7 = function_body env v7 in
        (* TODO make clear that this is an operator overload, by using IdSpecial as the name, or adding a keyword attribute *)
+       let idinfo = empty_id_info () in
        let ent = {
-         name = EId v5;
+         name = EId (v5, idinfo);
          attrs = v1 @ v2;
-         info = empty_id_info ();
+         info = idinfo;
          tparams = [];
        } in
        let def = AST.FuncDef {

--- a/semgrep-core/parsing/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_kotlin_tree_sitter.ml
@@ -1429,7 +1429,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           | `Class tok -> str env tok (* "class" *)
          )
        in
-       let ident_v3 = EId v3 in
+       let ident_v3 = EId (v3, empty_id_info()) in
        DotAccess (v1, v2, ident_v3)
    | `Func_lit x -> function_literal env x
    | `Obj_lit (v1, v2, v3) ->

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -47,7 +47,7 @@ let todo any =
 let ident (s, _) = s
 
 let ident_or_dynamic = function
-  | EId x -> ident x
+  | EId (x, _idinfo) -> ident x
   | EName _ | EDynamic _ -> raise Todo
 
 let opt f = function
@@ -453,7 +453,7 @@ and dot_access env (e, _tok, fi) =
 
 and field_ident env fi =
   match fi with
-  | EId id -> ident id
+  | EId (id, _idinfo) -> ident id
   | EName (id, _) -> ident id
   | EDynamic e -> expr env e
 


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/2229

Right now we rely on the AST_generic.id_info type to store
extra information about identifier such as its type, or whether
its value is a constant literal. This allows us to perform
some semantic matching in semgrep. Until now we were
doing that only for Id expression, so basic identifiers (locals, params,
globals) but not for fields. By adding
id_info in the ident_or_dynamic type, which is used in Dot, we can
store more semantic information about field, for example
what is the type of a private field, or whether its value is also a constant.

test plan:
make
make test