### PR TITLE
Move Ruby from beta to GA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 
 - Support for '...' in chains of method calls in JS, e.g. `$O.foo() ... .bar()`
+- Official Ruby GA support
 
 ## [0.34.0](https://github.com/returntocorp/semgrep/releases/tag/v0.34.0) - 2020-12-09
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Semgrep is used in production everywhere from one-person startups to multi-billi
 
 <h4 align="center">General availability</h4>
 <p align="center">
-Go · Java · JavaScript · JSON · Python</br>
+Go · Java · JavaScript · JSON · Python · Ruby</br>
 </p>
 <h4 align="center">Beta</h4>
 <p align="center">
-Ruby · TypeScript · JSX · TSX</br></br>
+TypeScript · JSX · TSX</br></br>
 Visit <a href="https://semgrep.dev/docs/status/">Supported languages</a> for the complete list.
 </p>
 


### PR DESCRIPTION
I wanted to get this in before the `0.35.0` release :tada: 