### PR TITLE
* lang_GENERIC_base/AST_generic.ml: get rid of entity.info now that store the information in indent_or_dynamic

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -64,12 +64,7 @@ let arg_to_expr (a : argument) =
 
 let var_def_stmt (decls : (entity * variable_definition) list) (attrs : attribute list) =
   let stmts = List.map (fun (ent, def) ->
-    let ent = {
-      name = ent.name;
-      attrs = ent.attrs @ attrs;
-      info = ent.info;
-      tparams = ent.tparams;
-    } in
+    let ent = { ent with attrs = ent.attrs @ attrs } in
     DefStmt (ent, VarDef def)
   ) decls in
   stmt1 stmts
@@ -2112,7 +2107,6 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let ent = {
          name = EId (v4, idinfo);
          attrs = v1 @ v2;
-         info = idinfo;
          tparams;
        } in
        AST.DefStmt (ent, AST.ClassDef {
@@ -2162,7 +2156,6 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let ent = {
          name = EId (v3, idinfo);
          attrs = v1 @ v2;
-         info = idinfo;
          tparams = [];
        } in
        let def = AST.FuncDef {
@@ -2194,7 +2187,6 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let ent = {
          name = EId (v5, idinfo);
          attrs = v1 @ v2;
-         info = idinfo;
          tparams;
        } in
        DefStmt (ent, TypeDef { tbody = NewType func })
@@ -2239,7 +2231,6 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let ent = {
          name = EId (v4, idinfo);
          attrs = v1 @ v2;
-         info = idinfo;
          tparams = [];
        } in
        AST.DefStmt (ent, AST.TypeDef {
@@ -2328,7 +2319,6 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let ent = {
          name = EId (v5, idinfo);
          attrs = v1 @ v2;
-         info = idinfo;
          tparams;
        } in
        let def = AST.FuncDef {
@@ -2364,7 +2354,6 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        let ent = {
          name = EId (v5, idinfo);
          attrs = v1 @ v2;
-         info = idinfo;
          tparams = [];
        } in
        let def = AST.FuncDef {

--- a/semgrep-core/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/synthesizing/Pretty_print_generic.ml
@@ -275,10 +275,10 @@ and def_stmt env (entity, def_kind) =
       )
     in
     let (typ, id) =
-      let {id_type; _} = ent.info in
-      match !id_type with
-      | None -> "", ident_or_dynamic ent.name
-      | Some t -> print_type t, ident_or_dynamic ent.name
+      match ent.name with
+      | EId (_, { id_type = {contents = Some t}; _}) ->
+          print_type t, ident_or_dynamic ent.name
+      | _ -> "", ident_or_dynamic ent.name
     in
     match def.vinit with
     | None -> no_val typ id ""


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/2229

test plan:
make
make test