### PR TITLE
[Java] Typed metavariable can now match this.foo when we know the type of foo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 
 - Support for '...' in chains of method calls in JS, e.g. `$O.foo() ... .bar()`
+- typed metavariables can now match field access when we can propagate
+  the type of a field
 - Official Ruby GA support
 
 ### Fixed

--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -1023,7 +1023,7 @@ and m_bodies a b =
 
 and m_compatible_type typed_mvar t e =
   match t, e with
-  (* for python literal checking *)
+  (* for Python literal checking *)
   | A.OtherType (A.OT_Expr, [A.E (A.Id (("int", _tok), _idinfo))]),
     B.L (B.Int _) -> envf typed_mvar (MV.E e)
   | A.OtherType (A.OT_Expr, [A.E (A.Id (("float", _tok), _idinfo))]),
@@ -1038,9 +1038,13 @@ and m_compatible_type typed_mvar t e =
   | A.TyId (("int", _), _), B.L (B.Int _) -> envf typed_mvar (MV.E e)
   | A.TyId (("float", _), _), B.L (B.Float _) -> envf typed_mvar (MV.E e)
   | A.TyId (("str", _), _), B.L (B.String _) -> envf typed_mvar (MV.E e)
+
   (* for matching ids *)
   | ta, ( B.Id (idb, {B.id_type=tb; _})
         | B.IdQualified ((idb, _), {B.id_type=tb;_})
+        (* todo: Java does not generate a special This! use Id *)
+        | B.DotAccess ((IdSpecial (This, _) | Id(("this", _), _)),
+                       _, EId (idb, {B.id_type=tb; _}))
         ) ->
       m_type_option_with_hook idb (Some ta) !tb
   | _ -> fail ()

--- a/semgrep-core/tests/java/metavar_typed_field.java
+++ b/semgrep-core/tests/java/metavar_typed_field.java
@@ -1,0 +1,12 @@
+public class Person {
+    FooType default_age;
+
+    void check(FooType age) {
+        age = default_age;
+        //ERROR:
+        check(age);
+        //ERROR:
+        check(this.default_age);
+    }
+}
+

--- a/semgrep-core/tests/java/metavar_typed_field.sgrep
+++ b/semgrep-core/tests/java/metavar_typed_field.sgrep
@@ -1,0 +1,1 @@
+check((FooType $X))


### PR DESCRIPTION
This is thx to the new id_info in ident_or_dynamic used inside
DotAccess and the update of Naming_AST.ml to resolve type for field
access.

Test plan:
test file included