### PR TITLE
type outline for kotlin

### DIFF
--- a/semgrep-core/parsing/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_kotlin_tree_sitter.ml
@@ -467,7 +467,7 @@ and anon_choice_param_b77c1d8 (env : env) (x : CST.anon_choice_param_b77c1d8) =
    | `Param x -> parameter env x
    | `Type x ->
        let v1 =  type_ env x in
-       ParamPattern (PatType v1)
+       ParamClassic (param_of_type v1)
   )
 
 and assignment (env : env) (x : CST.assignment) =
@@ -1347,22 +1347,14 @@ and nullable_type (env : env) ((v1, v2) : CST.nullable_type) =
   let v2 = List.map (token env) (* "?" *) v2 in
   (match v2 with
    | hd::tl -> TyQuestion (v1, hd)
-   | _ ->
-       let q = Parse_info.fake_info "?" in
-       TyQuestion (v1, q)
+   | [] -> raise Impossible (* see repeat1($._quest) in grammar.js *)
   )
 
 and parameter (env : env) ((v1, v2, v3) : CST.parameter) : parameter =
   let v1 = simple_identifier env v1 in
   let v2 = token env v2 (* ":" *) in
   let v3 = type_ env v3 in
-  let param = {
-    pname = Some v1;
-    ptype = Some v3;
-    pdefault = None;
-    pattrs = [];
-    pinfo = empty_id_info();
-  } in
+  let param = { (param_of_id v1) with ptype = Some v3 } in
   ParamClassic param
 
 and parameter_modifiers (env : env) (x : CST.parameter_modifiers) =

--- a/semgrep-core/tests/kotlin/types.kt
+++ b/semgrep-core/tests/kotlin/types.kt
@@ -1,0 +1,3 @@
+fun foo(x: String?, y: Int, z: Short) {
+    return x
+}


### PR DESCRIPTION
Basic type support for kotlin. 

**Test Plan:**
Run `semgrep-core -dump_ast tests/kotlin/types.kt`. This gives me the AST:
```
Pr(
  [DefStmt(
     ({
       name=EId(("foo", ()),
              {id_resolved=Ref(None); id_type=Ref(None);
               id_const_literal=Ref(None); });
       attrs=[]; tparams=[]; },
      FuncDef(
        {fkind=(Function, ()); fparams=[]; frettype=None;
         fbody=Block(
                 [ExprStmt(
                    Call(
                      Id(("x", ()),
                        {id_resolved=Ref(None); id_type=Ref(None);
                         id_const_literal=Ref(None); }),
                      [Arg(OtherExpr(OE_StmtExpr, [S(Return((), None, ()))]));
                       Arg(IdSpecial((This, ())))]), ())]);
         })))])

``` 

__Todo:__
* add type modifier information to type_ function (after annotations and everything else are done)

_Unsure about:_
* TyTuple return for user_type -- is this ok?
* function_type is not using v1 currently. Will need to think about how to add this in.
