### PR TITLE
Consistently use `#! /usr/bin/env bash' as shebang

### DIFF
--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -e
 pip install setuptools wheel
 cd semgrep && python setup.py sdist bdist_wheel

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -e
 brew install opam pkg-config coreutils
 opam init --no-setup --bare;

--- a/scripts/ubuntu-generic.sh
+++ b/scripts/ubuntu-generic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -e
 version="${VERSION:?Set a version to install}"
 tarball=semgrep-v$version-ubuntu-16.04.tgz

--- a/scripts/ubuntu-release.sh
+++ b/scripts/ubuntu-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # Make a semgrep release for Linux x86_64.
 #

--- a/scripts/validate-docker-release.sh
+++ b/scripts/validate-docker-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#! /usr/bin/env bash -e
 version="${GITHUB_REF/refs\/tags\//}"
 version="${version:-$VERSION}"
 version="${version:?Version must be set}"

--- a/scripts/validate-osx-release.sh
+++ b/scripts/validate-osx-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -e
 
 echo "Loading version from file: $(cat version)"

--- a/semgrep-core/cli/flags.sh
+++ b/semgrep-core/cli/flags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # Use static linking if platform allows.
 #

--- a/semgrep-core/tests/report_test_metrics.sh
+++ b/semgrep-core/tests/report_test_metrics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 set -e
 HOST="https://dashboard.semgrep.dev"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/semgrep/tests/run-perf-tests.sh
+++ b/semgrep/tests/run-perf-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -e
 # set -x


### PR DESCRIPTION
This increase portability of semgrep on platforms not having bash as
/bin/bash.

This is not just a possible theoretical problem but actually helps helping build
semgrep on NetBSD!

(And, FTR, I was finally able to build semgrep and can use it on NetBSD with mostly just this patch and a couple of notes that I should tidy up and share (but probably only relevant for NetBSD and pkgsrc users! :))