### PR TITLE
Include LICENSE in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Thanks for this remarkable tool!

This just ensures the LICENSE is included in source distributions.

Motivation: looking into packaging this for [conda-forge](https://github.com/conda-forge/staged-recipes/issues/12965), which likes to ensure all license files are included in distributions (even if the license doesn't _demand_ it).

Thanks again!