### PR TITLE
Use package_data for package binaries instead of scripts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,8 @@ jobs:
       - name: Install Tox and any other packages
         run: pip install pipenv==2018.11.26 wheel==0.34.2 tox==3.15.0
       - name: Run Tox
+        env:
+          SEMGREP_SKIP_BIN: true
         run: |
           cd semgrep
           tox -e py  # Run tox using the version of Python in `PATH`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   the type of a field
 - Constant propagation for Java final fields (using this.field syntax)
 
+### Changed
+
+- Packaging and `setup.py` functionality (`.whl` and `pip` install unchanged):
+  `SEMGREP_SKIP_BIN`, `SEMGREP_CORE_BIN`, and `SPACEGREP_BIN` now available
+
 ### Fixed
 - correctly match the same metavariable for a field when used at a definition
   site and use site for Java

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=build-semgrep-core \
 RUN ln -sf spacegrep /usr/local/bin/spacecat
 
 COPY semgrep /semgrep
-RUN HOMEBREW_SYSTEM='NOCORE' python -m pip install /semgrep
+RUN SEMGREP_SKIP_BIN=true python -m pip install /semgrep
 RUN semgrep --version
 
 RUN mkdir -p /src

--- a/semgrep/semgrep/bin/__init__.py
+++ b/semgrep/semgrep/bin/__init__.py
@@ -1,0 +1,1 @@
+# Binaries will be installed in this module directory and referenced via 'pkg_resources'

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -88,17 +88,16 @@ if not SEMGREP_SKIP_BIN:
     is_osx = "osx" in distutils.util.get_platform()
     build_dir = os.path.join(REPO_ROOT, "artifacts" if is_osx else "semgrep-files")
 
-    semgrep_core_src = find_executable(
-        SEMGREP_CORE_BIN_ENV, build_dir, SEMGREP_CORE_BIN
-    )
-    semgrep_core_dst = os.path.join(PACKAGE_BIN_DIR, SEMGREP_CORE_BIN)
-    shutil.copyfile(semgrep_core_src, semgrep_core_dst)
-    os.chmod(semgrep_core_dst, os.stat(semgrep_core_dst).st_mode | stat.S_IEXEC)
+    binaries = [
+        (SEMGREP_CORE_BIN_ENV, SEMGREP_CORE_BIN),
+        (SPACEGREP_BIN_ENV, SPACEGREP_BIN),
+    ]
 
-    spacegrep_src = find_executable(SPACEGREP_BIN_ENV, build_dir, SPACEGREP_BIN)
-    spacegrep_dst = os.path.join(PACKAGE_BIN_DIR, SPACEGREP_BIN)
-    shutil.copyfile(spacegrep_src, spacegrep_dst)
-    os.chmod(spacegrep_dst, os.stat(spacegrep_dst).st_mode | stat.S_IEXEC)
+    for binary_env, binary_name in binaries:
+        src = find_executable(binary_env, build_dir, binary_name)
+        dst = os.path.join(PACKAGE_BIN_DIR, binary_name)
+        shutil.copyfile(src, dst)
+        os.chmod(dst, os.stat(dst).st_mode | stat.S_IEXEC)
 
 setuptools.setup(
     name="semgrep",

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -1,34 +1,40 @@
 # type: ignore
-import contextlib
 import distutils.util
 import os
+import shutil
+import stat
 
 import setuptools
-from setuptools import setup
-from setuptools.command.install import install
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+from wheel.bdist_wheel import bdist_wheel
 
 from semgrep import __VERSION__
 
 
-@contextlib.contextmanager
-def chdir(dirname=None):
-    curdir = os.getcwd()
-    try:
-        if dirname is not None:
-            os.chdir(dirname)
-        yield
-    finally:
-        os.chdir(curdir)
+SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SOURCE_DIR)
+BIN_DIR = "bin"
+PACKAGE_BIN_DIR = os.path.join(SOURCE_DIR, "semgrep", BIN_DIR)
+SEMGREP_CORE_BIN = "semgrep-core"
+SEMGREP_CORE_BIN_ENV = "SEMGREP_CORE_BIN"
+SPACEGREP_BIN = "spacegrep"
+SPACEGREP_BIN_ENV = "SPACEGREP_BIN"
+SEMGREP_SKIP_BIN = "SEMGREP_SKIP_BIN" in os.environ
+
+try:
+    with open(os.path.join(REPO_ROOT, "README.md")) as f:
+        long_description = f.read()
+except FileNotFoundError:
+    long_description = "**SETUP: README NOT FOUND**"
 
 
 # TODO: what is the minimum OSX version?
 MIN_OSX_VERSION = "10_14"
 
+
 # from https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it # noqa
-class bdist_wheel(_bdist_wheel):
+class BdistWheel(bdist_wheel):
     def finalize_options(self):
-        _bdist_wheel.finalize_options(self)
+        bdist_wheel.finalize_options(self)
         # Mark us as not a pure python package (we have platform specific rust code)
         self.root_is_pure = False
 
@@ -36,7 +42,7 @@ class bdist_wheel(_bdist_wheel):
         # this set's us up to build generic wheels.
         # note: we're only doing this for windows right now (causes packaging issues
         # with osx)
-        _, _, plat = _bdist_wheel.get_tag(self)
+        _, _, plat = bdist_wheel.get_tag(self)
         # to debug "ERROR: *.whl is not a supported wheel on this platform.":
         # from setuptools.pep425tags import get_supported
         # get_supported()
@@ -57,87 +63,50 @@ class bdist_wheel(_bdist_wheel):
         return python, abi, plat
 
 
-try:
-    with open("../README.md") as f:
-        long_description = f.read()
-except FileNotFoundError:
-    long_description = ""
+def find_executable(env_name, default_dir_name, exec_name):
+    # First, check for an environment override
+    env_value = os.getenv(env_name)
+    if env_value:
+        return env_value
 
-source_dir = os.path.dirname(os.path.abspath(__file__))
-repo_root = os.path.dirname(source_dir)
+    # Second, check for build system artifacts
+    default_name = os.path.join(default_dir_name, exec_name)
+    if os.path.isfile(default_name):
+        return default_name
 
-# Lifted with love (and edits) from https://github.com/benfred/py-spy/blob/master/setup.py
-class PostInstallCommand(install):
-    """Post-installation for installation mode."""
+    # Third, fallback to any system executable
+    which_name = shutil.which(exec_name)
+    if which_name is not None:
+        return which_name
 
-    def copy_binary(self, exec_name):
-        if "TOX_ENV_NAME" in os.environ:
-            print("Not attempting to install binary while running under tox")
-            return
-        if "HOMEBREW_SYSTEM" in os.environ:
-            print("Not attempting to install binary while running under homebrew")
-            install.run(self)
-            return
-        # So ths builds the executable, and even installs it
-        # but we can't install to the bin directory:
-        #     https://github.com/pypa/setuptools/issues/210#issuecomment-216657975
-        # take the advice from that comment, and move over after install
-
-        if "osx" in distutils.util.get_platform():
-            with chdir(repo_root):
-                os.system(os.path.join(repo_root, "scripts", "osx-release.sh"))
-                source = os.path.join(repo_root, "artifacts", exec_name)
-        else:
-            with chdir(repo_root):
-                os.system(os.path.join(repo_root, "scripts", "ubuntu-release.sh"))
-                source = os.path.join(repo_root, "semgrep-files", exec_name)
-
-        ## run this after trying to build (as otherwise this leaves
-        ## venv in a bad state: https://github.com/benfred/py-spy/issues/69)
-        install.run(self)
-
-        ## we're going to install the executable (binary) into the scripts directory
-        ## but first make sure the scripts directory exists
-        if not os.path.isdir(self.install_scripts):
-            os.makedirs(self.install_scripts)
-
-        target = os.path.join(self.install_scripts, exec_name)
-        if os.path.isfile(target):
-            os.remove(target)
-
-        self.copy_file(source, target)
-
-    def run(self):
-        self.copy_binary("semgrep-core")
-        self.copy_binary("spacegrep")
-        # FIXME: with an extra 3 MB binary we exceed the 100 MB limit on PyPI
-        # Suggested fixes:
-        # - spacecat and spacegrep are now the same executable. We only need
-        #   the command (= executable file name) to be 'spacecat' to trigger
-        #   the spacecat behavior.
-        #   This can be achieved with a symlink or by copying 'spacegrep'
-        #   to 'spacecat' at installation time. Spacecat is a utility for
-        #   printing an AST, which is nice to have but not called
-        #   by semgrep or semgrep-core.
-        # - Use 'strip' to reduce the size of the semgrep-core executable.
-        #   Its big size is due to large parse tables that support
-        #   the LR(1) parsing algorithm used by menhir and tree-sitter.
-        #   For tree-sitter, those are the 'parser.c' files generated for each
-        #   grammar. We'll have more and more of such files, so the size of
-        #   our static semgrep-core executable is expected to keep growing.
-        #
-        # Original code:
-        #
-        # self.copy_binary("spacecat")
+    raise Exception(
+        f"Could not find '{exec_name}' executable, tried '{env_name}', '{default_dir_name}', and system '{exec_name}'"
+    )
 
 
-setup(
+if not SEMGREP_SKIP_BIN:
+    is_osx = "osx" in distutils.util.get_platform()
+    build_dir = os.path.join(REPO_ROOT, "artifacts" if is_osx else "semgrep-files")
+
+    semgrep_core_src = find_executable(
+        SEMGREP_CORE_BIN_ENV, build_dir, SEMGREP_CORE_BIN
+    )
+    semgrep_core_dst = os.path.join(PACKAGE_BIN_DIR, SEMGREP_CORE_BIN)
+    shutil.copyfile(semgrep_core_src, semgrep_core_dst)
+    os.chmod(semgrep_core_dst, os.stat(semgrep_core_dst).st_mode | stat.S_IEXEC)
+
+    spacegrep_src = find_executable(SPACEGREP_BIN_ENV, build_dir, SPACEGREP_BIN)
+    spacegrep_dst = os.path.join(PACKAGE_BIN_DIR, SPACEGREP_BIN)
+    shutil.copyfile(spacegrep_src, spacegrep_dst)
+    os.chmod(spacegrep_dst, os.stat(spacegrep_dst).st_mode | stat.S_IEXEC)
+
+setuptools.setup(
     name="semgrep",
     version=__VERSION__,
     author="Return To Corporation",
     author_email="support@r2c.dev",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",
-    cmdclass={"install": PostInstallCommand, "bdist_wheel": bdist_wheel},
+    cmdclass={"bdist_wheel": BdistWheel},
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/returntocorp/semgrep",
@@ -146,14 +115,22 @@ setup(
         "colorama>=0.4.3",
         "junit_xml==1.9",
         "requests>=2.22.0",
-        # exact version because of unstable API
+        # Pin exact version of 'ruamel.yaml' because of unstable API.
         "ruamel.yaml==0.16.10",
         "tqdm>=4.46.1",
         "packaging>=20.4",
         "jsonschema~=3.2.0",
+        # Include 'setuptools' for 'pkg_resources' usage. We shouldn't be
+        # overly prescriptive and pin the version for two reasons: 1) because
+        # it may interfere with other 'setuptools' installs on the system,
+        # and 2) our 'pkg_resources' API usage appears to have been available
+        # in 'setuptools' for a very long time, so we don't need a recent
+        # version.
+        "setuptools",
     ],
     entry_points={"console_scripts": ["semgrep=semgrep.__main__:main"]},
     packages=setuptools.find_packages(),
+    package_data={"semgrep": [os.path.join(BIN_DIR, "*")]},
     include_package_data=True,
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/2054.

There will undoubtedly be build failures I'll have to fix, I'm just putting this up to get early eyes on if I'm missing anything obvious, or obvious reasons why this won't work. I won't get into _all_ the details as to why I chose `package_data` for the binaries instead of `scripts` - comments in #2054 cover that.

**TL;DR is [`package_data`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#package-data) is a much cleaner solution for including arbitrary data files (including binaries), and allows us to easily reference the resultant installed file via `pkg_resources`.** We will no longer have to muck around with system binaries/scripts, as [`scripts`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#scripts)/`install_scripts` does, and we can instead directly reference files inside the installed package.

Potential buggy areas:

* There is now more opportunity for a `semgrep` : `semgrep-core` version mismatch. E.g. `semgrep` is somehow missing the `package_data`, falls back on an old `semgrep-core` version, and the version mismatch causes runtime issues. I believe this issue is highly unlikely to occur in practice, and existed before but wasn't explicitly defined. I think a better solution in the long-term is to avoid looking for system-level binaries and only reference `package_data` unless an env variable pointing to `semgrep-core` is explicitly defined. I believe we can live with this deficiency for now, and move toward a cleaner, easier to extend/improve/understand solution right now.

I tested this out with a local `.whl` file install, and a mocked PyPI install via https://github.com/steiza/simplepypi - both worked as expected. I also expect this to solve @blshkv's problem in https://github.com/returntocorp/semgrep/issues/2054.