### PR TITLE
Use deriving eq to automatically generate equal_xxx functions for generic AST

### DIFF
--- a/semgrep-core/core/Metavars_generic.ml
+++ b/semgrep-core/core/Metavars_generic.ml
@@ -26,8 +26,6 @@ module G = AST_generic
 (* Types *)
 (*****************************************************************************)
 
-(* Mostly a copy-paste of metavars_fuzzy.ml and metavars_js.ml *)
-
 (* less: could want to remember the position in the pattern of the metavar
  * for error reporting on pattern itself? so use a 'string AST_generic.wrap'?
 *)
@@ -35,7 +33,7 @@ module G = AST_generic
 type mvar = string
 (*e: type [[Metavars_generic.mvar]] *)
 
-(* mvalue used to be just an alias to AST_generic.any, but it's more
+(* 'mvalue' below used to be just an alias to AST_generic.any, but it is more
  * precise to have a type just for the metavariable values; we do not
  * need all the AST_generic.any cases (however this forces us to
  * define a few boilerplate functions like mvalue_to_any below).
@@ -56,6 +54,7 @@ type mvalue =
   | T of AST_generic.type_
   | P of AST_generic.pattern
   | Args of AST_generic.argument list
+[@@deriving show, eq]
 
 (* we sometimes need to convert to an any to be able to use
  * Lib_AST.ii_of_any, or Lib_AST.abstract_position_info_any
@@ -74,7 +73,8 @@ let mvalue_to_any = function
   | T x -> G.T x
   | P x -> G.P x
 
-let abstract_position_info_mval x =
+(* update: you should use equal_mvalue (from deriving eq) now *)
+let _abstract_position_info_mval x =
   x |> mvalue_to_any |> Lib_AST.abstract_position_info_any
 
 let str_of_any any =

--- a/semgrep-core/core/dune
+++ b/semgrep-core/core/dune
@@ -8,5 +8,5 @@
    pfff-h_program-lang
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
  )
- (preprocess (pps ppx_profiling))
+ (preprocess (pps ppx_profiling ppx_deriving.show ppx_deriving.eq))
 )

--- a/semgrep-core/matching/Matching_generic.ml
+++ b/semgrep-core/matching/Matching_generic.ml
@@ -214,13 +214,20 @@ let rec equal_ast_binded_code (a: MV.mvalue) (b: MV.mvalue) : bool = (
          * sgrep command line argument), we can not just use the
          * generic '=' OCaml operator as 'a' and 'b' may represent
          * the same code but they will contain leaves in their AST
-         * with different position information. So before doing
+         * with different position information.
+
+         * old: So before doing
          * the comparison we just need to remove/abstract-away
          * the line number information in each ASTs.
+         * let a = MV.abstract_position_info_mval a in
+         * let b = MV.abstract_position_info_mval b in
+         * a =*= b
         *)
-        let a = MV.abstract_position_info_mval a in
-        let b = MV.abstract_position_info_mval b in
-        a =*= b
+        (* This will perform equality but not care about:
+         * - position information (see adhoc AST_generic.equal_tok)
+         * - id_constness (see the special @equal for id_constness)
+        *)
+        MV.equal_mvalue a b
     | MV.Id _, MV.E (A.Id (b_id, b_id_info)) ->
         (* TODO still needed now that we have the better MV.Id of id_info? *)
         (* TOFIX: regression if remove this code *)


### PR DESCRIPTION
The use of Lib_AST.abstract_info_xxx is a bit ugly and potentially also
slower than using deriving eq with some well placed adhoc equal functions
(e.g., equal_tok to abstract away information position).
This also abstract away the constness that we need when we will plug
Iago's dataflow-based constness analysis.

test plan:
make test