### PR TITLE
[Lua] support for basic Semgrep patterns!

### DIFF
--- a/semgrep-core/parsing/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_lua_tree_sitter.ml
@@ -746,3 +746,19 @@ let parse file =
            pr2 s;
            raise exn
     )
+
+(* todo: special mode to convert Ellipsis in the right construct! *)
+let parse_pattern str =
+  H.wrap_parser
+    (fun () ->
+       Parallel.backtrace_when_exn := false;
+       Parallel.invoke Tree_sitter_lua.Parse.string str ()
+    )
+    (fun cst ->
+       let file = "<pattern>" in
+       let env = { H.file; conv = Hashtbl.create 0; extra = () } in
+       match map_program env cst with
+       | [{s = G.ExprStmt (e, _);_ }] -> G.E e
+       | [x] -> G.S x
+       | xs -> G.Ss xs
+    )

--- a/semgrep-core/parsing/Parse_lua_tree_sitter.mli
+++ b/semgrep-core/parsing/Parse_lua_tree_sitter.mli
@@ -1,1 +1,3 @@
 val parse: Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t
+
+val parse_pattern: string -> AST_generic.any Tree_sitter_run.Parsing_result.t

--- a/semgrep-core/parsing/Parse_pattern.ml
+++ b/semgrep-core/parsing/Parse_pattern.ml
@@ -22,6 +22,14 @@
 (* Helpers *)
 (*****************************************************************************)
 
+let extract_pattern_from_tree_sitter_result res =
+  match res.Tree_sitter_run.Parsing_result.program, res.errors with
+  | None, _ -> failwith "no pattern found"
+  | Some x, [] -> x
+  (* todo: return error location, use Error module like in Parse_code *)
+  | Some _, _::_ -> failwith "error parsing the pattern"
+
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -30,15 +38,10 @@ let parse_pattern lang str =
     match lang with
     | Lang.Csharp ->
         let res = Parse_csharp_tree_sitter.parse_pattern str in
-        (* todo: double check there is no error?
-         * todo: move in helper conversion of tree-sitter result to pattern
-        *)
-        (match res.program, res.errors with
-         | None, _ -> failwith "no pattern found"
-         | Some x, [] -> x
-         (* todo: return error location, use Error module like in Parse_code *)
-         | Some _, _::_ -> failwith "error parsing the pattern"
-        )
+        extract_pattern_from_tree_sitter_result res
+    | Lang.Lua ->
+        let res = Parse_lua_tree_sitter.parse_pattern str in
+        extract_pattern_from_tree_sitter_result res
     (* use pfff *)
     | _ -> Parse_generic.parse_pattern lang str
   in

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -239,6 +239,12 @@ let lang_regression_tests =
     let lang = Lang.Csharp in
     regression_tests_for_lang files lang
   );
+  "semgrep Lua" >::: (
+    let dir = Filename.concat tests_path "lua" in
+    let files = Common2.glob (spf "%s/*.lua" dir) in
+    let lang = Lang.Lua in
+    regression_tests_for_lang files lang
+  );
  ]
 (*e: constant [[Test.lang_regression_tests]] *)
 

--- a/semgrep-core/tests/lua/concrete_syntax.lua
+++ b/semgrep-core/tests/lua/concrete_syntax.lua
@@ -1,0 +1,14 @@
+function foo()
+ --ERROR:
+    foo(1,2)
+
+ --ERROR:
+ foo(1,
+     2)
+
+ --ERROR:
+ foo (1, -- comment
+      2)
+
+ foo(2,1)
+end

--- a/semgrep-core/tests/lua/metavar_arg.lua
+++ b/semgrep-core/tests/lua/metavar_arg.lua
@@ -1,0 +1,18 @@
+function foo()
+    --ERROR:
+    foo(1,2)
+
+    --ERROR:
+    foo(a_very_long_constant_name,
+        2)
+
+    --ERROR:
+    foo (unsafe(), -- indeed
+         2)
+
+    --ERROR:
+    foo(bar(1,3), 2)
+
+    foo(2,1)
+end
+

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -16,6 +16,8 @@ from semgrep.semgrep_types import REGEX_ONLY_LANGUAGE_KEYS
 
 FileExtension = NewType("FileExtension", str)
 
+# coupling: if you add a constant here, modify also ALL_EXTENSIONS below
+# and you probably also need to update _LANGS_TO_EXTS_INTERNAL
 PYTHON_EXTENSIONS = [FileExtension(".py"), FileExtension(".pyi")]
 JAVASCRIPT_EXTENSIONS = [FileExtension(".js"), FileExtension(".jsx")]
 TYPESCRIPT_EXTENSIONS = [FileExtension(".ts"), FileExtension(".tsx")]
@@ -24,6 +26,8 @@ C_EXTENSIONS = [FileExtension(".c")]
 GO_EXTENSIONS = [FileExtension(".go")]
 RUBY_EXTENSIONS = [FileExtension(".rb")]
 PHP_EXTENSIONS = [FileExtension(".php")]
+LUA_EXTENSIONS = [FileExtension(".lua")]
+CSHARP_EXTENSIONS = [FileExtension(".cs")]
 ML_EXTENSIONS = [
     FileExtension(".mli"),
     FileExtension(".ml"),
@@ -70,6 +74,8 @@ _LANGS_TO_EXTS_INTERNAL: List[Tuple[Set[Language], List[FileExtension]]] = [
     (langauge_set({"rb", "ruby"}), RUBY_EXTENSIONS),
     (langauge_set({"php"}), PHP_EXTENSIONS),
     (langauge_set({"json", "JSON", "Json"}), JSON_EXTENSIONS),
+    (langauge_set({"lua"}), LUA_EXTENSIONS),
+    (langauge_set({"cs", "csharp", "C#"}), CSHARP_EXTENSIONS),
     (REGEX_ONLY_LANGUAGE_KEYS.union({GENERIC_LANGUAGE}), GENERIC_EXTENSIONS),
 ]
 


### PR DESCRIPTION
test plan:
test file included!
Also
```
pad@yrax:~/semgrep$ yy -lang lua -dump_pattern tests/POLYGLOT/metavar_arg.sgrep
+ /home/pad/semgrep/_build/default/cli/Main.exe -lang lua -dump_pattern tests/POLYGLOT/metavar_arg.sgrep
[0.103  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.103  Info       Main.Dune__exe__Main ] Executed as: /home/pad/semgrep/_build/default/cli/Main.exe -lang lua -dump_pattern tests/POLYGLOT/metavar_arg.sgrep
[0.103  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.35.0-34-g8f46c332-dirty, pfff: 0.42
E(
  Call(
    Id(("foo", ()),
      {id_resolved=Ref(None); id_type=Ref(None); id_constness=Ref(None); }),
    [Arg(
       Id(("$X", ()),
         {id_resolved=Ref(None); id_type=Ref(None); id_constness=Ref(None); }));
     Arg(L(Float(("2", ()))))]))
pad@yrax:~/semgrep$ yy -log_config_file /tmp/xx -lang lua -f tests/POLYGLOT/metavar_arg.sgrep  tests/lua/metavar_arg.lua
+ /home/pad/semgrep/_build/default/cli/Main.exe -log_config_file /tmp/xx -lang lua -f tests/POLYGLOT/metavar_arg.sgrep tests/lua/metavar_arg.lua
tests/lua/metavar_arg.lua:3
     foo(1,2)
tests/lua/metavar_arg.lua:6
     foo(a_very_long_constant_name,
         2)
tests/lua/metavar_arg.lua:10
     foo (unsafe(), -- indeed
          2)
tests/lua/metavar_arg.lua:14
     foo(bar(1,3), 2)

```