### PR TITLE
Parse conditional access in C#

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -898,7 +898,7 @@ and expression (env : env) (x : CST.expression) : AST.expr =
              let x1 = token env x1 (* "." *) in
              let x2 = simple_name env x2 in
              DotAccess (v1, x1, EName x2)
-          | _ -> raise Impossible
+         | _ -> raise Impossible
        ) in
        Conditional (is_null, fake_null, access)
    | `Cond_exp (v1, v2, v3, v4, v5) ->

--- a/semgrep-core/tests/csharp/parsing/condaccess.cs
+++ b/semgrep-core/tests/csharp/parsing/condaccess.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+class HelloWorldCondAccess
+{
+    private static string MaybeNull(int arg)
+    {
+        if (arg > 0)
+        {
+            return "Hello";
+        }
+
+        return null;
+    }
+    public static void Main()
+    {
+        Console.WriteLine(MaybeNull(0)?.Length);
+        Console.WriteLine(MaybeNull(1)?.Length);
+        var greeting = MaybeNull(0);
+        Console.WriteLine(greeting?.Length);
+    }
+}

--- a/semgrep-core/tests/csharp/parsing/condaccess.cs
+++ b/semgrep-core/tests/csharp/parsing/condaccess.cs
@@ -15,7 +15,8 @@ class HelloWorldCondAccess
     {
         Console.WriteLine(MaybeNull(0)?.Length);
         Console.WriteLine(MaybeNull(1)?.Length);
-        var greeting = MaybeNull(0);
+        var greeting = MaybeNull(1);
         Console.WriteLine(greeting?.Length);
+        Console.WriteLine(greeting?[1]);
     }
 }


### PR DESCRIPTION
E.g. `a?.b` and `a?[0]`.
    
AST_generic has no `?.` or `?[...]` equivalents, so we map this to a
Conditional: `null == a ? null : a.b`. The downside of this is that it seems
that `a` is evaluated twice.
    
 Related to #1392
