### PR TITLE
Metavariable interpolation for pattern-inside

### DIFF
--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -375,19 +375,19 @@ def evaluate(
 
     # Addresses https://github.com/returntocorp/semgrep/issues/1699,
     # where metavariables from pattern-inside are not bound to messages.
-    # This should handle most cases. There are some edge cases we don't account for, such
-    # as a '$VAR' used in both pattern-inside and pattern-not-inside clauses. How do
-    # we infer which metavariable was intended for interpolation anyway? As such, this will
-    # fix the immediate issue and # should handle most cases. I'm leaving this comment here
-    # so that anyone who works on this in the future knows there will be some weirdness later. =X
-    all_pattern_match_metavariables: Dict[str, str] = {}
+    # This should handle cases with pattern + pattern-inside. This doesn't handle
+    # pattern-not-inside because it is difficult to determine metavariables for
+    # exclusion ranges. For example: imaagine a pattern-not-inside for 'def $CLASS(): ...'
+    # and a file has multiple classes inside. How do we infer which metavariable was
+    # intended for interpolation? As such, this will fix the immediate issue and should
+    # handle the most common case.
+    # Another corner case is: what should we do with nested metavars? Imagine 'def $FUNC(): ...'
+    # and code with nested functions. Did we want the top-level function? The lowest-level? What
+    # about other nesting cases? ¯\_(ツ)_/¯ Right now it will prefer the largest PatternMatch range.
+    all_pattern_match_metavariables: Dict[str, List[PatternMatch]] = defaultdict(list)
     for pattern_match in pattern_matches:
-        all_pattern_match_metavariables.update(
-            {
-                metavar: pattern_match.get_metavariable_value(metavar)
-                for metavar in pattern_match.metavars
-            }
-        )
+        for metavar_text in pattern_match.metavars.keys():
+            all_pattern_match_metavariables[metavar_text].append(pattern_match)
 
     for pattern_match in pattern_matches:
         if pattern_match.range in valid_ranges_to_output:
@@ -412,15 +412,27 @@ def evaluate(
 def interpolate_message_metavariables(
     rule: Rule,
     pattern_match: PatternMatch,
-    all_pattern_match_metavariables: Dict[str, str],
+    all_pattern_match_metavariables: Dict[str, List[PatternMatch]],
 ) -> str:
     msg_text = rule.message
-    for metavar in all_pattern_match_metavariables:
+    for metavar_text in all_pattern_match_metavariables:
+        replace_text = metavar_text
         try:  # Always prefer the pattern match metavariable first.
-            replace_text = pattern_match.get_metavariable_value(metavar)
+            replace_text = pattern_match.get_metavariable_value(metavar_text)
         except KeyError:  # If one isn't present, retrieve the value from all metavariables.
-            replace_text = all_pattern_match_metavariables.get(metavar, metavar)
-        msg_text = msg_text.replace(metavar, replace_text)
+            pattern_matches_with_metavars_that_enclose_match: List[PatternMatch] = list(
+                filter(
+                    lambda possible_enclosing_match: possible_enclosing_match.range.is_range_enclosing_or_eq(
+                        pattern_match.range
+                    ),
+                    all_pattern_match_metavariables[metavar_text],
+                )
+            )
+            if len(pattern_matches_with_metavars_that_enclose_match):
+                replace_text = pattern_matches_with_metavars_that_enclose_match[
+                    0
+                ].get_metavariable_value(metavar_text)
+        msg_text = msg_text.replace(metavar_text, replace_text)
     return msg_text
 
 

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -377,7 +377,7 @@ def evaluate(
     # where metavariables from pattern-inside are not bound to messages.
     # This should handle cases with pattern + pattern-inside. This doesn't handle
     # pattern-not-inside because it is difficult to determine metavariables for
-    # exclusion ranges. For example: imaagine a pattern-not-inside for 'def $CLASS(): ...'
+    # exclusion ranges. For example: imagine a pattern-not-inside for 'def $CLASS(): ...'
     # and a file has multiple classes inside. How do we infer which metavariable was
     # intended for interpolation? As such, this will fix the immediate issue and should
     # handle the most common case.

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -122,6 +122,9 @@ class Range(NamedTuple):
             and self.vars_match(other_range)
         )
 
+    def is_range_enclosing_or_eq(self, other_range: "Range") -> bool:
+        return self.start <= other_range.start and other_range.end <= self.end
+
     def vars_match(self, rhs: "Range") -> bool:
         """
         Returns true if and only if all metavariables in both this and the other Range refer to the same

--- a/semgrep/tests/e2e/rules/message_interpolation/multi-pattern-inside.yaml
+++ b/semgrep/tests/e2e/rules/message_interpolation/multi-pattern-inside.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: test_rule_id
+  patterns:
+  - pattern-inside: |
+      class $CLASS(...):
+        ...
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern: print($MSG)
+  severity: INFO
+  languages: [python]
+  message: "'print($MSG)' detected in method '$FUNC' in class '$CLASS'"

--- a/semgrep/tests/e2e/rules/message_interpolation/pattern-either.yaml
+++ b/semgrep/tests/e2e/rules/message_interpolation/pattern-either.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: test_rule_id
+  pattern-either:
+  - pattern: |
+      def $FUNC(x):
+        ...
+  - pattern: |
+      def $FUNC(y):
+        ...
+  - pattern: |
+      def $FUNC(z):
+        ...
+  severity: INFO
+  languages: [python]
+  message: method $FUNC detected

--- a/semgrep/tests/e2e/rules/message_interpolation/pattern-inside.yaml
+++ b/semgrep/tests/e2e/rules/message_interpolation/pattern-inside.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test_rule_id
+  patterns:
+  - pattern-inside: |
+      class $CLASS(...):
+        ...
+  - pattern: |
+      def $FUNC(...):
+        ...
+  severity: INFO
+  languages: [python]
+  message: method $FUNC is in $CLASS

--- a/semgrep/tests/e2e/rules/message_interpolation/pattern-not-inside.yaml
+++ b/semgrep/tests/e2e/rules/message_interpolation/pattern-not-inside.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test_rule_id
+  patterns:
+  - pattern-not-inside: |
+      class $CLASS(...):
+        ...
+  - pattern: |
+      def $FUNC(...):
+        ...
+  severity: INFO
+  languages: [python]
+  message: method $FUNC is not inside $CLASS

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside.py/results.json
@@ -1,0 +1,157 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 22,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "        print(\"blah\")",
+        "message": "'print(\"blah\")' detected in method 'B' in class 'A'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "\"blah\"",
+            "end": {
+              "col": 21,
+              "line": 3,
+              "offset": 44
+            },
+            "start": {
+              "col": 15,
+              "line": 3,
+              "offset": 38
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside.py",
+      "start": {
+        "col": 9,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 21,
+        "line": 6
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "        print(\"bla\")",
+        "message": "'print(\"bla\")' detected in method 'C' in class 'A'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "\"bla\"",
+            "end": {
+              "col": 20,
+              "line": 6,
+              "offset": 79
+            },
+            "start": {
+              "col": 15,
+              "line": 6,
+              "offset": 74
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside.py",
+      "start": {
+        "col": 9,
+        "line": 6
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 21,
+        "line": 9
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "        print('ble')",
+        "message": "'print('ble')' detected in method 'D' in class 'A'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "'ble'",
+            "end": {
+              "col": 20,
+              "line": 9,
+              "offset": 114
+            },
+            "start": {
+              "col": 15,
+              "line": 9,
+              "offset": 109
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside.py",
+      "start": {
+        "col": 9,
+        "line": 9
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 24,
+        "line": 16
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "        print(\"qwerty\")",
+        "message": "'print(\"qwerty\")' detected in method 'G' in class 'F'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "\"qwerty\"",
+            "end": {
+              "col": 23,
+              "line": 16,
+              "offset": 191
+            },
+            "start": {
+              "col": 15,
+              "line": 16,
+              "offset": 183
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside.py",
+      "start": {
+        "col": 9,
+        "line": 16
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
@@ -1,0 +1,157 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 26,
+        "line": 4
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "            print(\"blah\")",
+        "message": "'print(\"blah\")' detected in method 'B' in class 'A'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "\"blah\"",
+            "end": {
+              "col": 25,
+              "line": 4,
+              "offset": 65
+            },
+            "start": {
+              "col": 19,
+              "line": 4,
+              "offset": 59
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside_nested.py",
+      "start": {
+        "col": 13,
+        "line": 4
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 21,
+        "line": 7
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "        print('ble')",
+        "message": "'print('ble')' detected in method 'D' in class 'A'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "'ble'",
+            "end": {
+              "col": 20,
+              "line": 7,
+              "offset": 100
+            },
+            "start": {
+              "col": 15,
+              "line": 7,
+              "offset": 95
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside_nested.py",
+      "start": {
+        "col": 9,
+        "line": 7
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 26,
+        "line": 9
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "            print(\"asdf\")",
+        "message": "'print(\"asdf\")' detected in method 'D' in class 'A'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "\"asdf\"",
+            "end": {
+              "col": 25,
+              "line": 9,
+              "offset": 143
+            },
+            "start": {
+              "col": 19,
+              "line": 9,
+              "offset": 137
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside_nested.py",
+      "start": {
+        "col": 13,
+        "line": 9
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 24,
+        "line": 13
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "        print(\"qwerty\")",
+        "message": "'print(\"qwerty\")' detected in method 'G' in class 'F'",
+        "metadata": {},
+        "metavars": {
+          "$MSG": {
+            "abstract_content": "\"qwerty\"",
+            "end": {
+              "col": 23,
+              "line": 13,
+              "offset": 192
+            },
+            "start": {
+              "col": 15,
+              "line": 13,
+              "offset": 184
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/multi_pattern_inside_nested.py",
+      "start": {
+        "col": 9,
+        "line": 13
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-either.yaml-message_interpolationpattern_either_basic.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-either.yaml-message_interpolationpattern_either_basic.py/results.json
@@ -1,0 +1,119 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 13,
+        "line": 2
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "def one(x):\n    print(x)",
+        "message": "method one detected",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "one",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 5,
+              "line": 1,
+              "offset": 4
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_either_basic.py",
+      "start": {
+        "col": 1,
+        "line": 1
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 13,
+        "line": 5
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "def two(y):\n    print(y)",
+        "message": "method two detected",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "two",
+            "end": {
+              "col": 8,
+              "line": 4,
+              "offset": 33
+            },
+            "start": {
+              "col": 5,
+              "line": 4,
+              "offset": 30
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_either_basic.py",
+      "start": {
+        "col": 1,
+        "line": 4
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 13,
+        "line": 8
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "def three(z):\n    print(z)",
+        "message": "method three detected",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "three",
+            "end": {
+              "col": 10,
+              "line": 7,
+              "offset": 61
+            },
+            "start": {
+              "col": 5,
+              "line": 7,
+              "offset": 56
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_either_basic.py",
+      "start": {
+        "col": 1,
+        "line": 7
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_basic.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_basic.py/results.json
@@ -1,0 +1,81 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 21,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    def B():\n        print(\"hey\")",
+        "message": "method B is in A",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "B",
+            "end": {
+              "col": 10,
+              "line": 2,
+              "offset": 20
+            },
+            "start": {
+              "col": 9,
+              "line": 2,
+              "offset": 19
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_inside_basic.py",
+      "start": {
+        "col": 5,
+        "line": 2
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 21,
+        "line": 6
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    def C():\n        print(\"yeh\")",
+        "message": "method C is in A",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "C",
+            "end": {
+              "col": 10,
+              "line": 5,
+              "offset": 55
+            },
+            "start": {
+              "col": 9,
+              "line": 5,
+              "offset": 54
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_inside_basic.py",
+      "start": {
+        "col": 5,
+        "line": 5
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_complex.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_complex.py/results.json
@@ -1,0 +1,119 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 21,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    def B():\n        print(\"hey\")",
+        "message": "method B is in A",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "B",
+            "end": {
+              "col": 10,
+              "line": 2,
+              "offset": 20
+            },
+            "start": {
+              "col": 9,
+              "line": 2,
+              "offset": 19
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_inside_complex.py",
+      "start": {
+        "col": 5,
+        "line": 2
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 21,
+        "line": 6
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    def C():\n        print(\"yeh\")",
+        "message": "method C is in A",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "C",
+            "end": {
+              "col": 10,
+              "line": 5,
+              "offset": 55
+            },
+            "start": {
+              "col": 9,
+              "line": 5,
+              "offset": 54
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_inside_complex.py",
+      "start": {
+        "col": 5,
+        "line": 5
+      }
+    },
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 18,
+        "line": 10
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    def C():\n        print(\"\")",
+        "message": "method C is in B",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "C",
+            "end": {
+              "col": 10,
+              "line": 9,
+              "offset": 101
+            },
+            "start": {
+              "col": 9,
+              "line": 9,
+              "offset": 100
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_inside_complex.py",
+      "start": {
+        "col": 5,
+        "line": 9
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_basic.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_basic.py/results.json
@@ -1,0 +1,43 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 18,
+        "line": 9
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "def D():\n    print(\"asdf\")",
+        "message": "method D is not inside A",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "D",
+            "end": {
+              "col": 6,
+              "line": 8,
+              "offset": 86
+            },
+            "start": {
+              "col": 5,
+              "line": 8,
+              "offset": 85
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_not_inside_basic.py",
+      "start": {
+        "col": 1,
+        "line": 8
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_basic.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_basic.py/results.json
@@ -10,7 +10,7 @@
       "extra": {
         "is_ignored": false,
         "lines": "def D():\n    print(\"asdf\")",
-        "message": "method D is not inside A",
+        "message": "method D is not inside $CLASS",
         "metadata": {},
         "metavars": {
           "$FUNC": {

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_complex.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_complex.py/results.json
@@ -1,0 +1,43 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.message_interpolation.test_rule_id",
+      "end": {
+        "col": 18,
+        "line": 13
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "def D():\n    print(\"asdf\")",
+        "message": "method D is not inside B",
+        "metadata": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "D",
+            "end": {
+              "col": 6,
+              "line": 12,
+              "offset": 129
+            },
+            "start": {
+              "col": 5,
+              "line": 12,
+              "offset": 128
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/message_interpolation/pattern_not_inside_complex.py",
+      "start": {
+        "col": 1,
+        "line": 12
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_complex.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_complex.py/results.json
@@ -10,7 +10,7 @@
       "extra": {
         "is_ignored": false,
         "lines": "def D():\n    print(\"asdf\")",
-        "message": "method D is not inside B",
+        "message": "method D is not inside $CLASS",
         "metadata": {},
         "metavars": {
           "$FUNC": {

--- a/semgrep/tests/e2e/targets/message_interpolation/multi_pattern_inside.py
+++ b/semgrep/tests/e2e/targets/message_interpolation/multi_pattern_inside.py
@@ -1,0 +1,16 @@
+class A():
+    def B():
+        print("blah")
+
+    def C():
+        print("bla")
+
+    def D():
+        print('ble')
+
+def E():
+    print("asdf")
+
+class F():
+    def G():
+        print("qwerty")

--- a/semgrep/tests/e2e/targets/message_interpolation/multi_pattern_inside_nested.py
+++ b/semgrep/tests/e2e/targets/message_interpolation/multi_pattern_inside_nested.py
@@ -1,0 +1,13 @@
+class A():
+    def B():
+        def C():
+            print("blah")
+
+    def D():
+        print('ble')
+        def E():
+            print("asdf")
+
+class F():
+    def G():
+        print("qwerty")

--- a/semgrep/tests/e2e/targets/message_interpolation/pattern_either_basic.py
+++ b/semgrep/tests/e2e/targets/message_interpolation/pattern_either_basic.py
@@ -1,0 +1,8 @@
+def one(x):
+    print(x)
+
+def two(y):
+    print(y)
+
+def three(z):
+    print(z)

--- a/semgrep/tests/e2e/targets/message_interpolation/pattern_inside_basic.py
+++ b/semgrep/tests/e2e/targets/message_interpolation/pattern_inside_basic.py
@@ -1,0 +1,6 @@
+class A():
+    def B():
+        print("hey")
+
+    def C():
+        print("yeh")

--- a/semgrep/tests/e2e/targets/message_interpolation/pattern_inside_complex.py
+++ b/semgrep/tests/e2e/targets/message_interpolation/pattern_inside_complex.py
@@ -1,0 +1,13 @@
+class A():
+    def B():
+        print("hey")
+
+    def C():
+        print("yeh")
+
+class B():
+    def C():
+        print("")
+
+def D():
+    print("asdf")

--- a/semgrep/tests/e2e/targets/message_interpolation/pattern_not_inside_basic.py
+++ b/semgrep/tests/e2e/targets/message_interpolation/pattern_not_inside_basic.py
@@ -1,0 +1,9 @@
+class A():
+    def B():
+        print("hey")
+
+    def C():
+        print("yeh")
+
+def D():
+    print("asdf")

--- a/semgrep/tests/e2e/targets/message_interpolation/pattern_not_inside_complex.py
+++ b/semgrep/tests/e2e/targets/message_interpolation/pattern_not_inside_complex.py
@@ -1,0 +1,13 @@
+class A():
+    def B():
+        print("hey")
+
+    def C():
+        print("yeh")
+
+class B():
+    def C():
+        print("")
+
+def D():
+    print("asdf")

--- a/semgrep/tests/e2e/test_message_interpolation.py
+++ b/semgrep/tests/e2e/test_message_interpolation.py
@@ -8,18 +8,16 @@ import pytest
             "rules/message_interpolation/pattern-inside.yaml",
             "message_interpolation/pattern_inside_basic.py",
         ),
-        # This is an example where we do not correctly report $CLASS.
         (
             "rules/message_interpolation/pattern-inside.yaml",
             "message_interpolation/pattern_inside_complex.py",
         ),
+        # pattern-not-inside is not currently interpolated. These tests make sure
+        # something doesn't break accidentally.
         (
             "rules/message_interpolation/pattern-not-inside.yaml",
             "message_interpolation/pattern_not_inside_basic.py",
         ),
-        # This case below is an example of our simple message replacement not inferring what the user is after successfully.
-        # I, as the author, would actually want to display a message of all classes. However, this is an extreme corner case that
-        # we don't need to cover right now.
         (
             "rules/message_interpolation/pattern-not-inside.yaml",
             "message_interpolation/pattern_not_inside_complex.py",
@@ -27,6 +25,14 @@ import pytest
         (
             "rules/message_interpolation/pattern-either.yaml",
             "message_interpolation/pattern_either_basic.py",
+        ),
+        (
+            "rules/message_interpolation/multi-pattern-inside.yaml",
+            "message_interpolation/multi_pattern_inside.py",
+        ),
+        (
+            "rules/message_interpolation/multi-pattern-inside.yaml",
+            "message_interpolation/multi_pattern_inside_nested.py",
         ),
     ],
 )

--- a/semgrep/tests/e2e/test_message_interpolation.py
+++ b/semgrep/tests/e2e/test_message_interpolation.py
@@ -1,0 +1,37 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "rule,target",
+    [
+        (
+            "rules/message_interpolation/pattern-inside.yaml",
+            "message_interpolation/pattern_inside_basic.py",
+        ),
+        # This is an example where we do not correctly report $CLASS.
+        (
+            "rules/message_interpolation/pattern-inside.yaml",
+            "message_interpolation/pattern_inside_complex.py",
+        ),
+        (
+            "rules/message_interpolation/pattern-not-inside.yaml",
+            "message_interpolation/pattern_not_inside_basic.py",
+        ),
+        # This case below is an example of our simple message replacement not inferring what the user is after successfully.
+        # I, as the author, would actually want to display a message of all classes. However, this is an extreme corner case that
+        # we don't need to cover right now.
+        (
+            "rules/message_interpolation/pattern-not-inside.yaml",
+            "message_interpolation/pattern_not_inside_complex.py",
+        ),
+        (
+            "rules/message_interpolation/pattern-either.yaml",
+            "message_interpolation/pattern_either_basic.py",
+        ),
+    ],
+)
+def test_message_interpolation(run_semgrep_in_tmp, snapshot, rule, target):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(rule, target_name=target),
+        "results.json",
+    )


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/1699.

Only works with pattern + pattern-inside and with pattern-either + pattern.
Uses ranges to determine whether to apply metavariable interpolation. E.g., if a pattern-inside clause contains the pattern, it will interpolate the metavariables from the pattern-inside clause.

Does not work with pattern-not-inside.

This should handle cases with pattern + pattern-inside. This doesn't handle
pattern-not-inside because it is difficult to determine metavariables for
exclusion ranges. For example: imaagine a pattern-not-inside for 'def $CLASS(): ...'
and a file has multiple classes inside. How do we infer which metavariable was
intended for interpolation? As such, this will fix the immediate issue and should
handle the most common case.
Another corner case is: what should we do with nested metavars? Imagine 'def $FUNC(): ...'
and code with nested functions. Did we want the top-level function? The lowest-level? What
about other nesting cases? ¯\_(ツ)_/¯ Right now it will prefer the largest PatternMatch range