### PR TITLE
Use consistent python executable in tests

### DIFF
--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import List
 from typing import Optional
@@ -93,7 +94,7 @@ def _run_semgrep(
         options.append("--sarif")
 
     output = subprocess.check_output(
-        ["python3", "-m", "semgrep", *options, Path("targets") / target_name],
+        [sys.executable, "-m", "semgrep", *options, Path("targets") / target_name],
         encoding="utf-8",
         stderr=subprocess.STDOUT if stderr else subprocess.PIPE,
     )

--- a/semgrep/tests/e2e/test_api.py
+++ b/semgrep/tests/e2e/test_api.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 
 from semgrep.semgrep_main import invoke_semgrep
@@ -20,7 +21,7 @@ def test_api(capsys, run_semgrep_in_tmp):
     # Check that logging code isnt handled by default root handler and printed to stderr
     x = subprocess.run(
         [
-            "python3",
+            sys.executable,
             "-c",
             "from semgrep.semgrep_main import invoke_semgrep; from pathlib import Path; invoke_semgrep(Path('rules/eqeq.yaml'),[Path('targets/bad/invalid_python.py'), Path('targets/basic/stupid.py')],)",
         ],

--- a/semgrep/tests/e2e/test_generate_config.py
+++ b/semgrep/tests/e2e/test_generate_config.py
@@ -1,6 +1,7 @@
 import subprocess
+import sys
 
 
 def test_generate_config(run_semgrep_in_tmp):
-    subprocess.check_output(["python3", "-m", "semgrep", "--generate-config"])
+    subprocess.check_output([sys.executable, "-m", "semgrep", "--generate-config"])
     run_semgrep_in_tmp(".semgrep.yml")

--- a/semgrep/tests/e2e/test_semgrep_rules_repo.py
+++ b/semgrep/tests/e2e/test_semgrep_rules_repo.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 import pytest
 
@@ -20,11 +21,11 @@ def test_semgrep_rules_repo(run_semgrep_in_tmp):
         ["git", "clone", "--depth=1", "https://github.com/returntocorp/semgrep-rules"]
     )
 
-    _fail_subprocess_on_error(["python3", "-m", "semgrep", "--generate-config"])
+    _fail_subprocess_on_error([sys.executable, "-m", "semgrep", "--generate-config"])
 
     _fail_subprocess_on_error(
         [
-            "python3",
+            sys.executable,
             "-m",
             "semgrep",
             "--dangerously-allow-arbitrary-code-execution-from-rules",
@@ -36,5 +37,5 @@ def test_semgrep_rules_repo(run_semgrep_in_tmp):
     )
 
     _fail_subprocess_on_error(
-        ["python3", "-m", "semgrep", "--validate", "--config", "semgrep-rules"]
+        [sys.executable, "-m", "semgrep", "--validate", "--config", "semgrep-rules"]
     )

--- a/semgrep/tests/qa/test_public_repos.py
+++ b/semgrep/tests/qa/test_public_repos.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -33,7 +34,7 @@ SENTINEL_PATTERN = f"$SENTINEL = {SENTINEL_VALUE}"
 def _assert_sentinel_results(repo_url, repo_path, sentinel_path, language):
     semgrep_run = subprocess.run(
         [
-            "python3",
+            sys.executable,
             "-m",
             "semgrep",
             "--pattern",
@@ -103,7 +104,7 @@ def test_semgrep_on_repo(monkeypatch, clone_github_repo, tmp_path, public_repo_u
 
     sub_output = subprocess.check_output(
         [
-            "python3",
+            sys.executable,
             "-m",
             "semgrep",
             "--config=rules/regex-sentinel.yaml",


### PR DESCRIPTION
Tests were running semgrep using "python3" when this might not
be the executable that is running tests. This leads to problems when
dependencies were installed with (for example) "python3.7".

Instead use sys.executable to run the same executable that is running
the tests to run semgrep.