### PR TITLE
Gracefully handle permissions errors

### DIFF
--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -96,8 +96,11 @@ class CoreException:
         elif self._check_id == "LexicalError":
             return LexicalError(self._path, self._rule_id)
         else:
-            with open(self._path, errors="replace") as f:
-                file_hash = SourceTracker.add_source(f.read())
+            try:
+                with open(self._path, errors="replace") as f:
+                    file_hash = SourceTracker.add_source(f.read())
+            except IOError as e:
+                return SemgrepError(f"Could not open '{self._path}': {e}")
             error_span = Span(
                 start=self._start,
                 end=self._end,

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -78,7 +78,7 @@ class TargetManager:
 
     @staticmethod
     def _is_valid(path: Path) -> bool:
-        return path.exists() and not path.is_symlink()
+        return os.access(path, os.R_OK) and path.exists() and not path.is_symlink()
 
     @staticmethod
     def _expand_dir(
@@ -116,7 +116,7 @@ class TargetManager:
             return {
                 p
                 for p in curr_dir.rglob(f"*{extension}")
-                if p.is_file() and TargetManager._is_valid(p)
+                if TargetManager._is_valid(p) and p.is_file()
             }
 
         extensions = lang_to_exts(language)


### PR DESCRIPTION
Fixes #2346.

Manually confirmed the fixes. I added an automated tests too, but unfortunately you can't add a file to `git` that you can't read :exploding_head: 