### PR TITLE
Parse `new()` type constraint in C#

### DIFF
--- a/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/parsing/Parse_csharp_tree_sitter.ml
@@ -17,6 +17,7 @@ module AST = AST_generic
 module H = Parse_tree_sitter_helpers
 open AST_generic
 module H2 = AST_generic_helpers
+module PI = Parse_info
 
 (*****************************************************************************)
 (* Prelude *)
@@ -1294,7 +1295,8 @@ and type_parameter_constraint (env : env) (x : CST.type_parameter_constraint) =
        let v1 = token env v1 (* "new" *) in
        let v2 = token env v2 (* "(" *) in
        let v3 = token env v3 (* ")" *) in
-       todo env (v1, v2, v3)
+       let tok = PI.combine_infos v1 [v2; v3] in
+       HasConstructor tok
    | `Type_cons x -> Extends (type_constraint env x)
   )
 

--- a/semgrep-core/tests/csharp/parsing/typeconstraints.cs
+++ b/semgrep-core/tests/csharp/parsing/typeconstraints.cs
@@ -1,0 +1,25 @@
+using System;
+
+class HelloWorldTypeConstraints : IRunnable
+{
+    public static void Main()
+    {
+        var hello = CreateT<HelloWorldTypeConstraints>();
+        hello.Run();
+    }
+
+    private static T CreateT<T>() where T : class, IRunnable, new()
+    {
+        return new T();
+    }
+
+    public void Run()
+    {
+        Console.WriteLine("hello world");
+    }
+}
+
+interface IRunnable
+{
+    public void Run();
+}


### PR DESCRIPTION
`where T : new()` indicates that the generic type T has a parameterless
constructor. Map this to `HasConstructor`, which [was added to pfff for this
purpose](https://github.com/returntocorp/pfff/pull/384).

We combine the `new`, `(` and `)` tokens using `combine_infos`. Is this correct
usage of `combine_infos`?