### PR TITLE
Typed metavariables in go match literal strings

### DIFF
--- a/semgrep-core/matching/Generic_vs_generic.ml
+++ b/semgrep-core/matching/Generic_vs_generic.ml
@@ -1046,7 +1046,7 @@ and m_compatible_type typed_mvar t e =
   (* for go literals *)
   | A.TyId (("int", _), _), B.L (B.Int _) -> envf typed_mvar (MV.E e)
   | A.TyId (("float", _), _), B.L (B.Float _) -> envf typed_mvar (MV.E e)
-  | A.TyId (("str", _), _), B.L (B.String _) -> envf typed_mvar (MV.E e)
+  | A.TyId (("string", _), _), B.L (B.String _) -> envf typed_mvar (MV.E e)
 
   (* for matching ids *)
   | ta, ( B.Id (idb, {B.id_type=tb; _})

--- a/semgrep-core/tests/go/metavar_typed_args.go
+++ b/semgrep-core/tests/go/metavar_typed_args.go
@@ -3,7 +3,7 @@ package Foo
 func bar() {
     var x = 1
     var b = 2.2
-    var c str
+    var c string
     var y, z int = 2, 4
     var d bool = true
 

--- a/semgrep-core/tests/go/metavar_typed_args.sgrep
+++ b/semgrep-core/tests/go/metavar_typed_args.sgrep
@@ -1,1 +1,1 @@
-foo(($X : int), ($Y : float), ($Z : str), ($A : bool), ...)
+foo(($X : int), ($Y : float), ($Z : string), ($A : bool), ...)

--- a/semgrep-core/tests/go/metavar_typed_literal.go
+++ b/semgrep-core/tests/go/metavar_typed_literal.go
@@ -1,0 +1,12 @@
+var somekey string
+// ERROR:
+somekey := "585kf5999713"
+
+// ERROR:
+var s string = "fjsdklspa0ck"
+// ERROR:
+testval = s
+
+//shouldn't be matched
+key = testvaluebig
+key = aaa

--- a/semgrep-core/tests/go/metavar_typed_literal.sgrep
+++ b/semgrep-core/tests/go/metavar_typed_literal.sgrep
@@ -1,0 +1,1 @@
+$KEY = ($VAL : string)


### PR DESCRIPTION
Closes #2401

Fixed typo in Generic_vs_generic that expects strings to be encoded as "str" rather than "string"

Added a test specifically for literals and modified metavar_typed_args appropriately.

Test plan: make test with new tests