### PR TITLE
Explicit --timeout 0 should disable timeouts

### DIFF
--- a/semgrep-core/cli/Main.ml
+++ b/semgrep-core/cli/Main.ml
@@ -1189,7 +1189,7 @@ let options () =
     " only use tree-sitter-based parsers";
 
     "-timeout", Arg.Set_float Flag.timeout,
-    " <float> time limit to process one input program (in seconds)";
+    " <float> time limit to process one input program (in seconds); 0 disables timeouts (default is 0)";
     "-max_memory", Arg.Set_int max_memory,
     " <int> maximum memory to use (in MB)";
     "-max_match_per_file", Arg.Set_int max_match_per_file,

--- a/semgrep-core/core/Flag_semgrep.ml
+++ b/semgrep-core/core/Flag_semgrep.ml
@@ -43,6 +43,6 @@ let equivalence_mode = ref false
 
 (* here and not in Main.ml because we need to know if the timeout was
  * set in Parse_code.ml (for the slow pfff-based Javascript parser) *)
-let timeout = ref 0. (* in seconds *)
+let timeout = ref 0. (* in seconds; 0 or less means no timeout *)
 
 (*e: semgrep/core/Flag_semgrep.ml *)

--- a/semgrep-core/parsing/Parse_code.ml
+++ b/semgrep-core/parsing/Parse_code.ml
@@ -210,24 +210,7 @@ let just_parse_with_lang lang file =
       *)
       run file [
         TreeSitter Parse_javascript_tree_sitter.parse;
-        Pfff (throw_tokens (fun file ->
-          let f () =
-            Parse_js.parse file
-          in
-          (* timeout already set in caller, then good to go *)
-          if !Flag.timeout <> 0.
-          then f ()
-          else begin
-            try
-              Common.timeout_function 5 (fun () ->
-                logger#info "running the pfff JS parser with 5s timeout";
-                f ()
-              )
-            with Timeout ->
-              logger#debug "Timeout, transforming in parse error";
-              raise Parsing.Parse_error
-          end
-        ));
+        Pfff (throw_tokens Parse_js.parse)
       ]
         Js_to_generic.program
 


### PR DESCRIPTION
Previously we defaulted to 5 seconds when timeout was 0, but our
documentation states that explicitly setting timeout to 0 should disable
timeouts.

Note that, practically, the OCaml core will _never_ receive an unset
`-timeout` option, as the Python wrapper defaults to 30 seconds.

Fixes #2411.