### PR TITLE
show supported languages on error

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -20,6 +20,8 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 
+from semgrep.target_manager_extensions import all_supported_languages
+
 logger = logging.getLogger(__name__)
 from ruamel.yaml import YAML
 
@@ -479,8 +481,8 @@ class CoreRunner:
             targets = target_manager.get_files(language, rule.includes, rule.excludes)
         except _UnknownLanguageError as ex:
             raise UnknownLanguageError(
-                short_msg="invalid language",
-                long_msg=f"unsupported language {language}",
+                short_msg=f"invalid language: {language}",
+                long_msg=f"unsupported language: {language}. supported langauages are: {', '.join(all_supported_languages())}",
                 spans=[rule.languages_span.with_context(before=1, after=1)],
             ) from ex
         return targets

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -482,7 +482,7 @@ class CoreRunner:
         except _UnknownLanguageError as ex:
             raise UnknownLanguageError(
                 short_msg=f"invalid language: {language}",
-                long_msg=f"unsupported language: {language}. supported langauages are: {', '.join(all_supported_languages())}",
+                long_msg=f"unsupported language: {language}. supported languages are: {', '.join(all_supported_languages())}",
                 spans=[rule.languages_span.with_context(before=1, after=1)],
             ) from ex
         return targets

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import cast
 from typing import Dict
+from typing import Generator
 from typing import List
 from typing import NewType
 from typing import Set
@@ -78,6 +79,13 @@ _LANGS_TO_EXTS_INTERNAL: List[Tuple[Set[Language], List[FileExtension]]] = [
     (langauge_set({"cs", "csharp", "C#"}), CSHARP_EXTENSIONS),
     (REGEX_ONLY_LANGUAGE_KEYS.union({GENERIC_LANGUAGE}), GENERIC_EXTENSIONS),
 ]
+
+
+def all_supported_languages() -> Generator[Language, None, None]:
+    for language_set, _extensions in _LANGS_TO_EXTS_INTERNAL:
+        for lang in language_set:
+            yield lang
+
 
 # create a dictionary for fast lookup and reverse lookup
 _LANGS_TO_EXTS: Dict[Language, List[FileExtension]] = {}

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -81,10 +81,15 @@ _LANGS_TO_EXTS_INTERNAL: List[Tuple[Set[Language], List[FileExtension]]] = [
 ]
 
 
-def all_supported_languages() -> Generator[Language, None, None]:
+def all_supported_languages() -> List[Language]:
+    """
+    We want the list of languages to be deterministic, so sort it
+    """
+    langs = []
     for language_set, _extensions in _LANGS_TO_EXTS_INTERNAL:
         for lang in language_set:
-            yield lang
+            langs.append(lang)
+    return sorted(langs)
 
 
 # create a dictionary for fast lookup and reverse lookup

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -1,10 +1,10 @@
 running 1 rules...
-[31msemgrep error[39m: invalid language
+[31msemgrep error[39m: invalid language: rust
   --> rules/syntax/badlanguage.yaml:7
 [94m6 | [39m    message: "$X is being assigned to one or two"
 [94m7 | [39m    languages: [rust]
 [94m  | [39m               [31m^^^^^^[39m
 [94m8 | [39m    severity: WARNING
 
-[31munsupported language rust[39m
+[31munsupported language: rust. supported languages are: py, python3, python2, python, jsx, javascript, js, typescript, ts, tsx, java, c, go, golang, ocaml, ml, rb, ruby, php, Json, json, JSON, lua, C#, csharp, cs, generic, none, regex[39m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -6,5 +6,5 @@ running 1 rules...
 [94m  | [39m               [31m^^^^^^[39m
 [94m8 | [39m    severity: WARNING
 
-[31munsupported language: rust. supported languages are: py, python3, python2, python, jsx, javascript, js, typescript, ts, tsx, java, c, go, golang, ocaml, ml, rb, ruby, php, Json, json, JSON, lua, C#, csharp, cs, generic, none, regex[39m
+[31munsupported language: rust. supported languages are: C#, JSON, Json, c, cs, csharp, generic, go, golang, java, javascript, js, json, jsx, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, ruby, ts, tsx, typescript[39m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,7 +3,7 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language: rust. supported languages are: python, python3, python2, py, jsx, javascript, js, ts, typescript, tsx, java, c, golang, go, ocaml, ml, rb, ruby, php, Json, json, JSON, lua, cs, C#, csharp, regex, none, generic",
+      "long_msg": "unsupported language: rust. supported languages are: C#, JSON, Json, c, cs, csharp, generic, go, golang, java, javascript, js, json, jsx, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, ruby, ts, tsx, typescript",
       "short_msg": "invalid language: rust",
       "spans": [
         {

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,8 +3,8 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language rust",
-      "short_msg": "invalid language",
+      "long_msg": "unsupported language: rust. supported languages are: python, python3, python2, py, jsx, javascript, js, ts, typescript, tsx, java, c, golang, go, ocaml, ml, rb, ruby, php, Json, json, JSON, lua, cs, C#, csharp, regex, none, generic",
+      "short_msg": "invalid language: rust",
       "spans": [
         {
           "context_end": {


### PR DESCRIPTION
Partially fixes #1977, adds the language that was invalid as well as a list of the supported languages

Doesn't fix the "Semgrep bug generating manual config" message -- that's a bit trickier than I thought unfortunately. @DrewDennison you have any good ideas there?

```
(semgrep) ine@imbp4 ~/D/r/s/semgrep (develop) [8]> pipenv run semgrep -e '$X == $X' --lang=ppp
semgrep error: invalid language: ppp
  --> None:1
1 | Semgrep bug generating manual config An error occurred while invoking the semgrep engine; please help us fix this by creating an issue at https://github.com/returntocorp/semgrep
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

unsupported language ppp. supported languages are: python3, python2, py, python, javascript, jsx, js, typescript, tsx, ts, java, c, go, golang, ocaml, ml, rb, ruby, php, JSON, json, Json, lua, C#, cs, csharp, regex, none, generic

```

```
(semgrep) ine@imbp4 ~/D/r/s/semgrep (develop) [1]> pipenv run semgrep --config=./tests/e2e/rules/eqeq.yaml .
running 4 rules...
  0%|                                                                                                           |0/4
semgrep error: invalid language: pythonp
  --> tests/e2e/rules/eqeq.yaml:8
7 |     message: "possibly useless comparison but in eq function"
8 |     languages: [pythonp]
  |                ^^^^^^^^^
9 |     severity: ERROR

unsupported language: pythonp. supported langauages are: python, python2, py, python3, javascript, js, jsx, ts, tsx, typescript, java, c, golang, go, ml, ocaml, rb, ruby, php, Json, JSON, json, lua, cs, csharp, C#, none, generic, regex
```