### PR TITLE
Only warn on unrunnable pattern-where-python, unless --strict

### DIFF
--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -228,9 +228,6 @@ def _evaluate_single_expression(
                 f"at least one rule needs to execute arbitrary code; this is dangerous! if you want to continue, enable the flag: {RCE_RULE_FLAG}",
                 code=NEED_ARBITRARY_CODE_EXEC_EXIT_CODE,
             )
-        if not isinstance(expression.operand, str):
-            raise SemgrepError("pattern-where-python must have a string value")
-
         # Look through every range that hasn't been filtered yet
         for pattern_match in list(flatten(pattern_ids_to_pattern_matches.values())):
             # Only need to check where-python clause if the range hasn't already been filtered
@@ -240,7 +237,7 @@ def _evaluate_single_expression(
                     f"WHERE is {expression.operand}, metavars: {pattern_match.metavars}"
                 )
                 if _where_python_statement_matches(
-                    expression.operand, pattern_match.metavars
+                    expression.operand, pattern_match.metavars  # type: ignore
                 ):
                     output_ranges.add(pattern_match.range)
         add_debugging_info(

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -34,7 +34,7 @@ from semgrep.semgrep_types import OPERATOR_PATTERN_NAMES_MAP
 from semgrep.semgrep_types import OPERATORS
 from semgrep.target_manager import TargetManager
 from semgrep.util import partition
-from semgrep.util import recursive_has_key
+from semgrep.util import recursive_has_item
 
 logger = logging.getLogger(__name__)
 
@@ -202,7 +202,7 @@ def main(
     if not dangerously_allow_arbitrary_code_execution_from_rules:
         pattern_where_python_names = OPERATOR_PATTERN_NAMES_MAP[OPERATORS.WHERE_PYTHON]
         pattern_where_python_rules, filtered_rules = partition(
-            lambda r: recursive_has_key(
+            lambda r: recursive_has_item(
                 lambda d: any(name in d for name in pattern_where_python_names), r.raw
             ),
             filtered_rules,

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from typing import Any
 from typing import Callable
+from typing import Dict
 from typing import IO
 from typing import Iterable
 from typing import List
@@ -172,3 +173,17 @@ def compute_semgrep_path() -> str:
 
 def compute_spacegrep_path() -> str:
     return compute_executable_path("spacegrep")
+
+
+def recursive_has_key(pred: Callable, d: Dict) -> bool:
+    if pred(d):
+        return True
+    result = False
+    for v in d.values():
+        if isinstance(v, dict):
+            result = result or recursive_has_key(pred, v)
+        elif isinstance(v, list):
+            result = result or any(
+                recursive_has_key(pred, i) for i in v if isinstance(i, dict)
+            )
+    return result

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -175,16 +175,17 @@ def compute_spacegrep_path() -> str:
     return compute_executable_path("spacegrep")
 
 
-def recursive_has_key(pred: Callable, d: Dict) -> bool:
+def recursive_has_item(pred: Callable, d: Dict) -> bool:
+    """Recursively determine if a dict has an arbitrary item."""
     if pred(d):
         return True
     for v in d.values():
         if isinstance(v, dict):
-            result = recursive_has_key(pred, v)
+            result = recursive_has_item(pred, v)
             if result:
                 return True
         elif isinstance(v, list):
-            result = any(recursive_has_key(pred, i) for i in v if isinstance(i, dict))
+            result = any(recursive_has_item(pred, i) for i in v if isinstance(i, dict))
             if result:
                 return True
     return False

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -178,12 +178,13 @@ def compute_spacegrep_path() -> str:
 def recursive_has_key(pred: Callable, d: Dict) -> bool:
     if pred(d):
         return True
-    result = False
     for v in d.values():
         if isinstance(v, dict):
-            result = result or recursive_has_key(pred, v)
+            result = recursive_has_key(pred, v)
+            if result:
+                return True
         elif isinstance(v, list):
-            result = result or any(
-                recursive_has_key(pred, i) for i in v if isinstance(i, dict)
-            )
-    return result
+            result = any(recursive_has_key(pred, i) for i in v if isinstance(i, dict))
+            if result:
+                return True
+    return False

--- a/semgrep/tests/unit/test_util.py
+++ b/semgrep/tests/unit/test_util.py
@@ -23,5 +23,5 @@ from semgrep import util
         ({"bbb": {"aaa": "value"}, "zzz": {"key1": "value"}}, False),
     ],
 )
-def test_recursive_has_key(test_input, expected):
-    assert util.recursive_has_key(lambda d: "key" in d, test_input) == expected
+def test_recursive_has_item(test_input, expected):
+    assert util.recursive_has_item(lambda d: "key" in d, test_input) == expected

--- a/semgrep/tests/unit/test_util.py
+++ b/semgrep/tests/unit/test_util.py
@@ -1,0 +1,27 @@
+import pytest
+
+from semgrep import util
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ({}, False),
+        ({"key": "value"}, True),
+        ({"key1": "value"}, False),
+        ({"key1": {"key": "value"}}, True),
+        ({"key1": {"key2": "value"}}, False),
+        ({"key1": [{"key": "value"}]}, True),
+        ({"key1": [{"key2": "value"}]}, False),
+        ({"key1": [{"key2": "value"}, {"key": "value"}]}, True),
+        ({"key1": [{"key2": "value"}, {"key3": "value"}]}, False),
+        ({"key1": [{"key2": "value"}, {"key3": {"key": "value"}}]}, True),
+        ({"key1": [{"key2": "value"}, {"key3": {"key4": "value"}}]}, False),
+        ({"zzz": {"aaa": "value", "key": "value"}}, True),
+        ({"zzz": {"aaa": "value", "key1": "value"}}, False),
+        ({"bbb": {"aaa": "value"}, "zzz": {"key": "value"}}, True),
+        ({"bbb": {"aaa": "value"}, "zzz": {"key1": "value"}}, False),
+    ],
+)
+def test_recursive_has_key(test_input, expected):
+    assert util.recursive_has_key(lambda d: "key" in d, test_input) == expected


### PR DESCRIPTION
Fixes #2427.

```
$ cat code.py 
1 == 1
```

```
$ cat safe.yml 
rules:
- id: eqeq-is-bad1
  pattern: 1 == 1
  message: 1 == 1 is a useless equality check
  languages: [python]
  severity: ERROR
```

```
$ cat dangerous.yml 
rules:
- id: eqeq-is-bad2
  patterns:
  - pattern: $X == $X
  - pattern-where-python: bool(vars['$X'])
  message: X == X is a useless equality check
  languages: [python]
  severity: ERROR
- id: eqeq-is-bad3
  pattern: 3 == 3
  message: 3 == 3 is a useless equality check
  languages: [python]
  severity: ERROR
```

```
$ python -m semgrep --config /tmp/dangerous-test/ /tmp/dangerous-test/code.py 
skipping rule 'tmp.dangerous-test.eqeq-is-bad2' due to pattern-where-python usage, pass '--dangerously-allow-arbitrary-code-execution-from-rules' to enable
running 2 rules...
/tmp/dangerous-test/code.py
severity:error rule:tmp.dangerous-test.eqeq-is-bad1: 1 == 1 is a useless equality check
1:1 == 1
ran 2 rules on 1 files: 1 findings
```

```
$ python -m semgrep --config /tmp/dangerous-test/ /tmp/dangerous-test/code.py --strict
skipping rule 'tmp.dangerous-test.eqeq-is-bad2' due to pattern-where-python usage, pass '--dangerously-allow-arbitrary-code-execution-from-rules' to enable
failing due to unrunnable pattern-where-python and --strict
```

```
$ python -m semgrep --config /tmp/dangerous-test/ /tmp/dangerous-test/code.py --dangerously-allow-arbitrary-code-execution-from-rules
running 3 rules...
/tmp/dangerous-test/code.py
severity:error rule:tmp.dangerous-test.eqeq-is-bad1: 1 == 1 is a useless equality check
1:1 == 1
--------------------------------------------------------------------------------
severity:error rule:tmp.dangerous-test.eqeq-is-bad2: X == X is a useless equality check
1:1 == 1
ran 3 rules on 1 files: 2 findings
```

