### PR TITLE
Parse second `from` clause in query

### DIFF
--- a/semgrep-core/tests/csharp/parsing/linq.cs
+++ b/semgrep-core/tests/csharp/parsing/linq.cs
@@ -6,6 +6,11 @@ class HelloWorldLinq
 {
     public static void Main()
     {
+        FromLetSelect();
+        DoubleFrom();
+    }
+
+    private static void FromLetSelect() {
         var textInfo = new CultureInfo("en-US", false).TextInfo;
 
         var words = new string[] {"hello", "world"};
@@ -17,6 +22,20 @@ class HelloWorldLinq
         foreach (string w in greeting)
         {
             Console.WriteLine(w);
+        }
+    }
+
+    public static void DoubleFrom()
+    {
+        var words1 = new string[] {"hello", "world"};
+
+        var wordList = from w1 in words1
+            from w2 in w1
+            select w1 + w2;
+
+        foreach (var word in wordList)
+        {
+            Console.WriteLine(word);
         }
     }
 }


### PR DESCRIPTION
E.g.
```
        var wordList = from w1 in words1
            from w2 in w1
            select w1 + w2;
```

Map to [SelectMany](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.selectmany?view=net-5.0).