### PR TITLE
* semgrep-core/tests/OTHER/rules/negation_ajin.jsonnet: New test file

### DIFF
--- a/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
@@ -1,0 +1,22 @@
+{
+   //old: And: function(arr) { and: arr },
+   //trick to emulate variable number of arguments in jsonnet
+   //src:  https://groups.google.com/g/jsonnet/c/45DS8Q7zmsM?pli=1
+   // 
+   And: function(x1, x2, x3=null, x4=null) { and: std.prune([x1,x2,x3,x4]) },
+   Or: function(x1, x2, x3=null, x4=null) { or: std.prune([x1,x2,x3,x4]) },
+   Not: function(x) { not: x },
+
+   basic_rule: function(lang, match) {
+    rules: [
+    {
+      id: 'rule_template_id',
+      match: match,
+      message: 'rule_template_message',
+      languages: [lang],
+      severity: 'ERROR',
+    },
+    ],
+  }
+
+}

--- a/semgrep-core/tests/OTHER/rules/negation_ajin.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/negation_ajin.jsonnet
@@ -1,0 +1,6 @@
+local s = import 'lib_semgrep.jsonnet';
+
+s.basic_rule('python', 
+             s.And('os.environ',
+                   s.Not(s.Or('os.environ.get(...)',
+                              'os.environ[...]'))))

--- a/semgrep-core/tests/OTHER/rules/negation_ajin.py
+++ b/semgrep-core/tests/OTHER/rules/negation_ajin.py
@@ -1,0 +1,8 @@
+import os
+#ERROR: 
+x = os.environ
+
+verify = (os.environ.get('REQUESTS_CA_BUNDLE') or os.environ.get('CURL_CA_BUNDLE'))
+os.environ[env_name] = 1
+k = None
+get_proxy = os.environ.get(k) or os.environ.get(k.upper())

--- a/semgrep-core/tests/OTHER/rules/negation_ajin_orig_jsonnet
+++ b/semgrep-core/tests/OTHER/rules/negation_ajin_orig_jsonnet
@@ -1,0 +1,22 @@
+{
+  rules: [
+    {
+      id: 'neg',
+      match: {
+        and: [
+          'os.environ',
+          { not: 
+              { or: [
+                 'os.environ.get(...)',
+                 'os.environ[...]',
+                ]
+              },
+          }
+        ],
+      },
+      message: 'neg',
+      languages: ['python'],
+      severity: 'ERROR',
+    },
+  ],
+}

--- a/semgrep-core/tests/OTHER/rules/skip_list.txt
+++ b/semgrep-core/tests/OTHER/rules/skip_list.txt
@@ -1,0 +1,1 @@
+file: lib_semgrep.jsonnet


### PR DESCRIPTION
related to https://github.com/returntocorp/semgrep/issues/2457

test plan:
```
$ /home/pad/semgrep/_build/default/CLI/Main.exe -lang python -config negation_ajin.jsonnet negation_ajin.py
negation_ajin.py:3
 x = os.environ

$ /home/pad/semgrep/_build/default/CLI/Main.exe -test_rules .