### PR TITLE
New -test_eval and regexp support in Eval_generic

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -1230,6 +1230,8 @@ let all_actions () = [
   Common.mk_action_2_arg Datalog_experiment.gen_facts;
   "-eval", " <JSON file>",
   Common.mk_action_1_arg Eval_generic.eval_json_file;
+  "-test_eval", " <JSON file>",
+  Common.mk_action_1_arg Eval_generic.test_eval;
 ] @ Test_analyze_generic.actions()
 
 (*e: function [[Main_semgrep_core.all_actions]] *)

--- a/semgrep-core/Core/AST/AST_generic.ml
+++ b/semgrep-core/Core/AST/AST_generic.ml
@@ -214,18 +214,14 @@ let busy_with_equal = ref Not_busy
 let equal_stmt_field_s equal_stmt_kind a b =
   match !busy_with_equal with
   | Not_busy ->
-      (* Call 'Structural.equal_XXX or 'Referential.equal_XXX' to avoid this
-         error. *)
-      assert false
+      failwith "Call AST_generic.with_xxx_equal to avoid this error."
   | Structural_equal -> equal_stmt_kind a b
   | Referential_equal -> true
 
 let equal_stmt_field_s_id a b =
   match !busy_with_equal with
   | Not_busy ->
-      (* Call 'Structural.equal_XXX or 'Referential.equal_XXX' to avoid this
-         error. *)
-      assert false
+      failwith "Call AST_generic.with_xxx_equal to avoid this error."
   | Structural_equal -> true
   | Referential_equal -> Node_ID.equal a b
 

--- a/semgrep-core/Core/Range.ml
+++ b/semgrep-core/Core/Range.ml
@@ -103,5 +103,7 @@ let range_of_tokens xs =
   with PI.NoTokenLocation _ ->
     None
 
-let content_at_range _file _r =
-  raise Todo
+let hmemo = Hashtbl.create 101
+let content_at_range file r =
+  let str = Common.memoized hmemo file (fun () -> Common.read_file file) in
+  String.sub str r.start (r.end_ - r.start + 1)

--- a/semgrep-core/Core/Range.ml
+++ b/semgrep-core/Core/Range.ml
@@ -102,3 +102,6 @@ let range_of_tokens xs =
     Some { start; end_ }
   with PI.NoTokenLocation _ ->
     None
+
+let content_at_range _file _r =
+  raise Todo

--- a/semgrep-core/Core/Range.mli
+++ b/semgrep-core/Core/Range.mli
@@ -1,6 +1,13 @@
 
+(* charpos is 0-indexed. First char of a file is at charpos:0
+ * (unlike in Emacs where point starts at 1).
+*)
 type charpos = int
 
+(* The range is inclusive, {start = 0; end_ = 4} means [0..4] not [0..4[,
+ * so the first range of the first character of the file will be
+ * {start = 0; end_ = 0} (which also means there are no empty ranges).
+*)
 type t = {
   start: charpos;
   end_: charpos;

--- a/semgrep-core/Core/Range.mli
+++ b/semgrep-core/Core/Range.mli
@@ -1,0 +1,26 @@
+
+type charpos = int
+
+type t = {
+  start: charpos;
+  end_: charpos;
+}
+
+exception NotValidRange of string
+
+(* included or equal *)
+val ($<=$): t -> t -> bool
+(* disjoint *)
+val ($<>$): t -> t -> bool
+
+val range_of_linecol_spec: string -> Common.filename -> t
+
+val range_of_token_locations:
+  Parse_info.token_location -> Parse_info.token_location -> t
+
+val range_of_tokens: Parse_info.t list -> t option
+
+(* Note that the file content is memoized, so multiple calls to
+ * content_at_range will not read_file again and again the same file.
+*)
+val content_at_range: Common.filename -> t -> string

--- a/semgrep-core/Engine/Convert_rule.ml
+++ b/semgrep-core/Engine/Convert_rule.ml
@@ -29,6 +29,21 @@ open Rule
  *
 *)
 
+let convert_extra x =
+  let s =
+    match x with
+    | MetavarRegexp (mvar, re) ->
+        (* less: we could use re.match(), to be close to python, but really
+         * Eval_generic must do something special here with the metavariable
+         * which may not always be a string. The regexp is really done on
+         * the text representation of the metavar content.
+        *)
+        spf "semgrep_re_match(%s, \"%s\")" mvar re
+    | _ -> failwith (spf "convert_extra: TODO: %s" (Rule.show_extra x))
+  in
+  pr2 s;
+  Parse_rule.parse_metavar_cond s
+
 (*****************************************************************************)
 (* Entry points *)
 (*****************************************************************************)
@@ -44,8 +59,9 @@ let (convert_formula_old: formula_old -> formula) = fun e ->
     | Patterns xs ->
         let xs = List.map aux xs in
         And xs
-    | PatExtra _ ->
-        failwith (spf "convert_formula_old: TODO: %s" (Rule.show_formula_old e))
+    | PatExtra x ->
+        let e = convert_extra x in
+        MetavarCond e
   in
   aux e
 

--- a/semgrep-core/Engine/Convert_rule.ml
+++ b/semgrep-core/Engine/Convert_rule.ml
@@ -19,6 +19,8 @@ open Common
 
 open Rule
 
+let logger = Logging.get_logger [__MODULE__]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -41,7 +43,7 @@ let convert_extra x =
         spf "semgrep_re_match(%s, \"%s\")" mvar re
     | _ -> failwith (spf "convert_extra: TODO: %s" (Rule.show_extra x))
   in
-  pr2 s;
+  logger#debug "convert_extra: %s" s;
   Parse_rule.parse_metavar_cond s
 
 (*****************************************************************************)

--- a/semgrep-core/Engine/Eval_generic.ml
+++ b/semgrep-core/Engine/Eval_generic.ml
@@ -101,7 +101,7 @@ let parse_json file =
 (*****************************************************************************)
 (* Converting *)
 (*****************************************************************************)
-let value_to_string = function
+let _value_to_string = function
   | Bool b -> string_of_bool b
   | Int i -> string_of_int i
   | Float f -> string_of_float f
@@ -169,12 +169,15 @@ let rec eval env code =
             (_, [G.Arg e1; G.Arg (G.L (G.String (re, _)))], _)) ->
       (* alt: take the text range of the metavariable in the original file *)
       let v = eval env e1 in
-      let s = value_to_string v in
-
-      (* todo? factorize with Matching_generic.regexp_matcher_of_regexp_.. *)
-      let regexp = Re.Pcre.regexp ~flags:[] re in
-      let res = Re.Pcre.pmatch ~rex:regexp s in
-      Bool res
+      (* old: let s = value_to_string v in *)
+      (match v with
+       | String s ->
+           (* todo? factorize with Matching_generic.regexp_matcher_of_regexp_.. *)
+           let regexp = Re.Pcre.regexp ~flags:[] re in
+           let res = Re.Pcre.pmatch ~rex:regexp s in
+           Bool res
+       | _ -> raise (NotHandled code)
+      )
 
   | _ -> raise (NotHandled code)
 

--- a/semgrep-core/Engine/Eval_generic.ml
+++ b/semgrep-core/Engine/Eval_generic.ml
@@ -173,7 +173,8 @@ let rec eval env code =
       (match v with
        | String s ->
            (* todo? factorize with Matching_generic.regexp_matcher_of_regexp_.. *)
-           let regexp = Re.Pcre.regexp ~flags:[] re in
+           (* use of `ANCHORED to simulate Python re.match() (vs re.search) *)
+           let regexp = Re.Pcre.regexp ~flags:[`ANCHORED] re in
            let res = Re.Pcre.pmatch ~rex:regexp s in
            Bool res
        | _ -> raise (NotHandled code)

--- a/semgrep-core/Engine/Eval_generic.mli
+++ b/semgrep-core/Engine/Eval_generic.mli
@@ -19,3 +19,6 @@ val eval: env -> code -> value
 
 (* entry point for -eval *)
 val eval_json_file: Common.filename -> unit
+
+(* for -test_eval *)
+val test_eval: Common.filename -> unit

--- a/semgrep-core/Engine/Eval_generic.mli
+++ b/semgrep-core/Engine/Eval_generic.mli
@@ -22,3 +22,6 @@ val eval_json_file: Common.filename -> unit
 
 (* for -test_eval *)
 val test_eval: Common.filename -> unit
+
+(* for MetavarCond *)
+val eval_expr_with_bindings: Metavariable.bindings -> code -> bool

--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -100,6 +100,7 @@ type id_to_match_results = (pattern_id, Pattern_match.t) Hashtbl.t
 
 type env = {
   pattern_matches: id_to_match_results;
+  (* unused for now, but could be passed down for Range.content_at_range *)
   file: Common.filename
 }
 

--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -19,6 +19,7 @@ open Common
 
 module R = Rule
 module MR = Mini_rule
+module PM = Pattern_match
 
 (*****************************************************************************)
 (* Prelude *)
@@ -188,6 +189,12 @@ let difference_ranges pos neg =
   in
   surviving_pos
 
+let filter_ranges xs cond =
+  xs |> List.filter (fun r ->
+    let bindings = r.origin.PM.env in
+    Eval_generic.eval_expr_with_bindings bindings cond
+  )
+
 (*****************************************************************************)
 (* Formula evaluation *)
 (*****************************************************************************)
@@ -216,8 +223,8 @@ let rec (evaluate_formula:
            let res = neg |> List.fold_left (fun acc x ->
              difference_ranges acc (evaluate_formula h x)
            ) res in
-           let res = conds |> List.fold_left (fun _acc _cond ->
-             failwith "Todo conds"
+           let res = conds |> List.fold_left (fun acc cond ->
+             filter_ranges acc cond
            ) res in
            res
       )

--- a/semgrep-core/Engine/Test_rule.ml
+++ b/semgrep-core/Engine/Test_rule.ml
@@ -55,6 +55,7 @@ let test_rules xs =
   fullxs |> List.iter (fun file ->
     logger#info "processing rule %s" file;
     let rules = Parse_rule.parse file in
+    (* just a sanity check *)
     rules |> List.iter Check_rule.check;
 
     let lang = lang_of_rules rules in

--- a/semgrep-core/Engine/dune
+++ b/semgrep-core/Engine/dune
@@ -8,5 +8,5 @@
    semgrep_matching
    semgrep_parsing semgrep_reporting ; for Test_rule.ml
  )
- (preprocess (pps ppx_profiling))
+ (preprocess (pps ppx_deriving.show ppx_profiling))
 )

--- a/semgrep-core/Matching/Matching_generic.ml
+++ b/semgrep-core/Matching/Matching_generic.ml
@@ -404,6 +404,7 @@ let regexp_matcher_of_regexp_string s =
       | _ -> failwith (spf "This is not a valid PCRE regexp flag: %s" flags)
     in
     (* old: let re = Str.regexp x in (fun s -> Str.string_match re s 0) *)
+    (* TODO: add `ANCHORED to be consistent with Python re.match (!re.search)*)
     let re = Re.Pcre.regexp ~flags x in
     (fun s2 ->
        Re.Pcre.pmatch ~rex:re s2

--- a/semgrep-core/Metachecking/Check_rule.ml
+++ b/semgrep-core/Metachecking/Check_rule.ml
@@ -116,6 +116,9 @@ let show_formula_old pf =
       x.pstr
   | _ -> R.show_formula_old pf
 
+let equal_formula_old x y =
+  AST_generic.with_structural_equal R.equal_formula_old x y
+
 let check_old_formula env lang f =
   (* check duplicated patterns, essentially:
    *  $K: $PAT
@@ -135,7 +138,7 @@ let check_old_formula env lang f =
               (* todo: for Pat, we could also check if exist PatNot
                * in which case intersection will always be empty
               *)
-              if xs |> List.exists (R.equal_formula_old x)
+              if xs |> List.exists (equal_formula_old x)
               then error env (spf "Duplicate pattern %s" (show_formula_old x));
               aux xs
         in
@@ -163,6 +166,7 @@ let check_old_formula env lang f =
 
 let check r =
   (match r.formula with
+   (* todo: convert old to new so can factorize checks? *)
    | Old f -> check_old_formula r r.languages f;
    | New f -> check_new_formula r r.languages f;
   );

--- a/semgrep-core/Parsing/Parse_rule.ml
+++ b/semgrep-core/Parsing/Parse_rule.ml
@@ -103,7 +103,7 @@ let parse_int ctx = function
 (* Sub parsers extra *)
 (*****************************************************************************)
 
-let parse_where _env s =
+let parse_metavar_cond s =
   try
     let lang = Lang.Python in (* todo? use lang in env? *)
     (match Parse_pattern.parse_pattern lang s with
@@ -264,7 +264,7 @@ let rec parse_formula_new env (x: J.t) : R.formula =
            R.P xpat
 
        | ["where", J.String s] ->
-           R.MetavarCond (parse_where env s)
+           R.MetavarCond (parse_metavar_cond s)
        | _ -> pr2_gen x; error "parse_formula_new"
       )
   | _ -> pr2_gen x; error "parse_formula_new"

--- a/semgrep-core/Parsing/Parse_rule.mli
+++ b/semgrep-core/Parsing/Parse_rule.mli
@@ -2,4 +2,6 @@
 
 val parse: Common.filename -> Rule.rules
 
+(* used also by Convert_rule.ml *)
+val parse_metavar_cond: string -> Rule.metavar_cond
 (*e: semgrep/parsing/Parse_rule.mli *)

--- a/semgrep-core/skip_list.txt
+++ b/semgrep-core/skip_list.txt
@@ -1,9 +1,9 @@
 dir: _build
 
 # when want to focus on semgrep code itself
-#dir: pfff
-#dir: ocaml-tree-sitter-lang
-#dir: parsing/tree_sitter
+dir: pfff
+dir: ocaml-tree-sitter-lang
+dir: Parsing/tree_sitter
 
 dir_element: old
 dir_element: orig_spec

--- a/semgrep-core/tests/OTHER/eval/regexp.json
+++ b/semgrep-core/tests/OTHER/eval/regexp.json
@@ -1,6 +1,6 @@
 {
   "metavars": {
-    "$X": 0
+    "$X": "0"
   },
   "language": "python",
   "code": "semgrep_re_match($X, '0|null|false')"

--- a/semgrep-core/tests/OTHER/eval/regexp.json
+++ b/semgrep-core/tests/OTHER/eval/regexp.json
@@ -1,0 +1,7 @@
+{
+  "metavars": {
+    "$X": 0
+  },
+  "language": "python",
+  "code": "semgrep_re_match($X, '0|null|false')"
+}

--- a/semgrep-core/tests/OTHER/eval/regexp2.json
+++ b/semgrep-core/tests/OTHER/eval/regexp2.json
@@ -1,0 +1,7 @@
+{
+  "metavars": {
+    "$X": "sodium_crypto_generichash"
+  },
+  "language": "python",
+  "code": "semgrep_re_match($X, '.*crypt|md5|md5_file|sha1|sha1_file|str_rot13')"
+}

--- a/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
@@ -6,6 +6,7 @@
    And: function(x1, x2, x3=null, x4=null) { and: std.prune([x1,x2,x3,x4]) },
    Or: function(x1, x2, x3=null, x4=null) { or: std.prune([x1,x2,x3,x4]) },
    Not: function(x) { not: x },
+   Where: function(x) { where: x },
 
    basic_rule: function(lang, match) {
     rules: [

--- a/semgrep-core/tests/OTHER/rules/metavar_cond.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond.jsonnet
@@ -1,0 +1,6 @@
+local s = import 'lib_semgrep.jsonnet';
+
+s.basic_rule('python', 
+             s.And('foo($ARG)',
+                   s.Where('semgrep_re_match($ARG, ".*bar.*")')))
+

--- a/semgrep-core/tests/OTHER/rules/metavar_cond.py
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond.py
@@ -1,0 +1,5 @@
+def test():
+    #ERROR:
+    foo(a_bar_variable)
+
+    foo(a_ba_variable)

--- a/semgrep-core/tests/python/parsing/re.py
+++ b/semgrep-core/tests/python/parsing/re.py
@@ -1,0 +1,1 @@
+re.match(foo, "0|false|null")


### PR DESCRIPTION
This is to support metavariable-regexp in semgrep-ocaml

test plan:
$ /home/pad/semgrep/_build/default/CLI/Main.exe -test_eval regexp.json
true