### PR TITLE
Parse extended usage of `using` in C#

### DIFF
--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2660,18 +2660,26 @@ and declaration (env : env) (x : CST.declaration) : stmt =
        Block (open_br, (DefStmt (ent, VarDef vardef) |> AST.s) :: funcs, close_br)|> AST.s
    | `Using_dire (v1, v2, v3, v4) ->
        let v1 = token env v1 (* "using" *) in
-       let v2 =
+       let v3 = name env v3 in
+       let v4 = token env v4 (* ";" *) in
+       let import =
          (match v2 with
           | Some x ->
               (match x with
-               | `Static tok -> todo env tok (* "static" *)
-               | `Name_equals x -> Some (name_equals env x)
+               | `Static tok -> (* "static" *)
+                   (* using static System.Math; *)
+                   (AST.ImportAll (v1, AST.DottedName (ids_of_name v3), v4))
+               | `Name_equals x ->
+                   (* using Foo = System.Text; *)
+                   let alias = (name_equals env x) in
+                   AST.ImportAs (v1, AST.DottedName (ids_of_name v3), Some (alias, empty_id_info ()))
               )
-          | None -> None)
+          | None ->
+              (* using System.IO; *)
+              (AST.ImportAll (v1, AST.DottedName (ids_of_name v3), v4))
+         )
        in
-       let v3 = name env v3 in
-       let v4 = token env v4 (* ";" *) in
-       AST.DirectiveStmt (AST.ImportAll (v1, AST.DottedName (ids_of_name v3), v4)) |> AST.s
+       AST.DirectiveStmt import |> AST.s
   )
 
 (*****************************************************************************)

--- a/semgrep-core/tests/csharp/parsing/using.cs
+++ b/semgrep-core/tests/csharp/parsing/using.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using static System.Math;
+using Foo = System.Text;
 
 class HelloWorldUsing
 {
@@ -7,6 +9,19 @@ class HelloWorldUsing
     {
         UsingBlock();
         UsingDecl();
+        UsingStatic();
+        UsingAlias();
+    }
+
+    private static void UsingAlias()
+    {
+        var builder = new Foo.StringBuilder("hello world");
+        Console.WriteLine(builder.ToString());
+    }
+
+    private static void UsingStatic()
+    {
+        Console.WriteLine(PI);
     }
 
     private static void UsingBlock()


### PR DESCRIPTION
E.g.
```csharp
using static System.Math;
using Foo = System.Text;
```

Both `using SomeNamespace` and `using static SomeType` are mapped to ImportAll.
This is correct for the first one, but not really for `using static`, which
imports the static members of a type.