### PR TITLE
Switch to Pcre for the ocaml regexp parsing library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@
 
 FROM returntocorp/ocaml:alpine-2020-10-28 as build-semgrep-core
 
+USER root
 # for ocaml-pcre now used in semgrep-core
 RUN apk add --no-cache pcre-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@
 
 FROM returntocorp/ocaml:alpine-2020-10-28 as build-semgrep-core
 
+# for ocaml-pcre now used in semgrep-core
+RUN apk add --no-cache pcre-dev
+
 USER user
 WORKDIR /home/user
 

--- a/scripts/install-alpine-semgrep-core
+++ b/scripts/install-alpine-semgrep-core
@@ -32,7 +32,7 @@ if [[ "$(basename "$(pwd)")" != semgrep ]]; then
 fi
 
 echo "Install missing packages"
-sudo apk add --no-cache m4
+sudo apk add --no-cache m4 pcre-dev
 
 echo "Install submodules"
 git submodule update --init --recursive

--- a/semgrep-core/Core/Rule.ml
+++ b/semgrep-core/Core/Rule.ml
@@ -42,14 +42,10 @@ type xlang =
   | LGeneric
 [@@deriving show]
 
-(* TODO
-   type regexp = string * Pcre.regexp
-   let pp_regexp fmt (s, _) =
-   Format.fprintf fmt "%s" s
-   let equal_regexp (s1, _) (s2, _) = s1 = s2
-*)
-type regexp = string
-[@@deriving eq, show]
+type regexp = string * Pcre.regexp
+let pp_regexp fmt (s, _) =
+  Format.fprintf fmt "%s" s
+let equal_regexp (s1, _) (s2, _) = s1 = s2
 
 type xpattern = {
   pat: xpattern_kind;

--- a/semgrep-core/Core/dune
+++ b/semgrep-core/Core/dune
@@ -2,7 +2,7 @@
  (name semgrep_core)
  (wrapped false)
  (libraries
-   yaml
+   yaml pcre
    commons
    pfff-config
    pfff-h_program-lang

--- a/semgrep-core/Engine/Convert_rule.ml
+++ b/semgrep-core/Engine/Convert_rule.ml
@@ -34,7 +34,7 @@ let logger = Logging.get_logger [__MODULE__]
 let convert_extra x =
   let s =
     match x with
-    | MetavarRegexp (mvar, re_str) ->
+    | MetavarRegexp (mvar, (re_str, _re)) ->
         (* less: we could use re.match(), to be close to python, but really
          * Eval_generic must do something special here with the metavariable
          * which may not always be a string. The regexp is really done on

--- a/semgrep-core/Engine/Eval_generic.ml
+++ b/semgrep-core/Engine/Eval_generic.ml
@@ -174,8 +174,8 @@ let rec eval env code =
        | String s ->
            (* todo? factorize with Matching_generic.regexp_matcher_of_regexp_.. *)
            (* use of `ANCHORED to simulate Python re.match() (vs re.search) *)
-           let regexp = Re.Pcre.regexp ~flags:[`ANCHORED] re in
-           let res = Re.Pcre.pmatch ~rex:regexp s in
+           let regexp = Pcre.regexp ~flags:[`ANCHORED] re in
+           let res = Pcre.pmatch ~rex:regexp s in
            Bool res
        | _ -> raise (NotHandled code)
       )

--- a/semgrep-core/Engine/dune
+++ b/semgrep-core/Engine/dune
@@ -2,6 +2,7 @@
  (name semgrep_engine)
  (wrapped false)
  (libraries
+   pcre
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
 
    semgrep_core

--- a/semgrep-core/Parsing/Parse_rule.ml
+++ b/semgrep-core/Parsing/Parse_rule.ml
@@ -109,7 +109,7 @@ let parse_metavar_cond s =
   with exn -> raise exn
 
 let parse_regexp  s =
-  s (* TODO , Pcre.regexp s *)
+  s, Pcre.regexp s
 
 let parse_regexps ctx = function
   | J.Array xs -> List.map (fun t -> parse_regexp (parse_string ctx t)) xs

--- a/semgrep-core/Parsing/dune
+++ b/semgrep-core/Parsing/dune
@@ -2,7 +2,7 @@
  (name semgrep_parsing)
  (wrapped false)
  (libraries
-   yaml
+   yaml pcre
 
    commons commons_core
    pfff-config

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -31,6 +31,7 @@ depends: [
   "uucp"
   "uutf"
   "re"
+  "pcre"
   "parmap"
   "lsp" {= "1.1.0"}
 ]

--- a/semgrep-core/tests/OTHER/eval/regexp3.json
+++ b/semgrep-core/tests/OTHER/eval/regexp3.json
@@ -1,0 +1,7 @@
+{
+  "metavars": {
+    "$X": "sodium_crypto_generichash"
+  },
+  "language": "python",
+  "code": "semgrep_re_match($X, '(?!crypt|md5|md5_file|sha1|sha1_file|str_rot13)')"
+}

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -323,7 +323,7 @@ let eval_regression_tests =
       files |> List.iter (fun file ->
         let (env, code) = Eval_generic.parse_json file in
         let res = Eval_generic.eval env code in
-        OUnit.assert_equal ~msg:"it should evaluate to true"
+        OUnit.assert_equal ~msg:(spf "%s should evaluate to true" file)
           (Eval_generic.Bool true) res
       )
   )


### PR DESCRIPTION
The Re OCaml library does not support negative lookup assertion
regexps like (?!foo) which are used in semgrep-rules.

test plan:
test file included
make test