### PR TITLE
Support metavariable_regexp with PCRE and prepare for metavariable_comparison

### DIFF
--- a/semgrep-core/Core/Rule.ml
+++ b/semgrep-core/Core/Rule.ml
@@ -97,7 +97,16 @@ type formula =
   *)
   | Not of formula
 
-and metavar_cond = AST_generic.expr (* see Eval_generic.ml *)
+and metavar_cond =
+  | CondGeneric of AST_generic.expr (* see Eval_generic.ml *)
+  (* todo: at some point we should remove CondRegexp and have just
+   * CondGeneric, but for now there are some
+   * differences between using the matched text region of a metavariable
+   * (which we use for MetavarRegexp) and using its actual value
+   * (which we use for MetavarComparison), which translate to different
+   * calls in Eval_generic.ml
+  *)
+  | CondRegexp of MV.mvar * regexp
 
 [@@deriving show, eq]
 

--- a/semgrep-core/Engine/Convert_rule.ml
+++ b/semgrep-core/Engine/Convert_rule.ml
@@ -19,7 +19,7 @@ open Common
 
 open Rule
 
-let logger = Logging.get_logger [__MODULE__]
+let _logger = Logging.get_logger [__MODULE__]
 
 (*****************************************************************************)
 (* Prelude *)
@@ -32,19 +32,15 @@ let logger = Logging.get_logger [__MODULE__]
 *)
 
 let convert_extra x =
-  let s =
-    match x with
-    | MetavarRegexp (mvar, (re_str, _re)) ->
-        (* less: we could use re.match(), to be close to python, but really
-         * Eval_generic must do something special here with the metavariable
-         * which may not always be a string. The regexp is really done on
-         * the text representation of the metavar content.
-        *)
-        spf "semgrep_re_match(%s, \"%s\")" mvar re_str
-    | _ -> failwith (spf "convert_extra: TODO: %s" (Rule.show_extra x))
-  in
+  match x with
+  | MetavarRegexp (mvar, re) ->
+      CondRegexp (mvar, re)
+  | _ ->
+(*
   logger#debug "convert_extra: %s" s;
   Parse_rule.parse_metavar_cond s
+*)
+      failwith (spf "convert_extra: TODO: %s" (Rule.show_extra x))
 
 (*****************************************************************************)
 (* Entry points *)

--- a/semgrep-core/Engine/Eval_generic.mli
+++ b/semgrep-core/Engine/Eval_generic.mli
@@ -24,4 +24,6 @@ val eval_json_file: Common.filename -> unit
 val test_eval: Common.filename -> unit
 
 (* for MetavarCond *)
-val eval_expr_with_bindings: Metavariable.bindings -> code -> bool
+val bindings_to_env: Metavariable.bindings -> env
+val bindings_to_env_with_just_strings: Metavariable.bindings -> env
+val eval_bool: env -> code -> bool

--- a/semgrep-core/Parsing/Parse_rule.ml
+++ b/semgrep-core/Parsing/Parse_rule.ml
@@ -267,7 +267,11 @@ let rec parse_formula_new env (x: J.t) : R.formula =
            R.P xpat
 
        | ["where", J.String s] ->
-           R.MetavarCond (parse_metavar_cond s)
+           R.MetavarCond (R.CondGeneric (parse_metavar_cond s))
+
+       | ["metavariable_regex", J.Array [J.String mvar; J.String re]] ->
+           R.MetavarCond (R.CondRegexp (mvar, parse_regexp re))
+
        | _ -> pr2_gen x; error "parse_formula_new"
       )
   | _ -> pr2_gen x; error "parse_formula_new"

--- a/semgrep-core/Parsing/Parse_rule.mli
+++ b/semgrep-core/Parsing/Parse_rule.mli
@@ -3,5 +3,5 @@
 val parse: Common.filename -> Rule.rules
 
 (* used also by Convert_rule.ml *)
-val parse_metavar_cond: string -> Rule.metavar_cond
+val parse_metavar_cond: string -> AST_generic.expr
 (*e: semgrep/parsing/Parse_rule.mli *)

--- a/semgrep-core/tests/OTHER/eval/regexp.json
+++ b/semgrep-core/tests/OTHER/eval/regexp.json
@@ -3,5 +3,5 @@
     "$X": "0"
   },
   "language": "python",
-  "code": "semgrep_re_match($X, '0|null|false')"
+  "code": "re.match($X, '0|null|false')"
 }

--- a/semgrep-core/tests/OTHER/eval/regexp2.json
+++ b/semgrep-core/tests/OTHER/eval/regexp2.json
@@ -3,5 +3,5 @@
     "$X": "sodium_crypto_generichash"
   },
   "language": "python",
-  "code": "semgrep_re_match($X, '.*crypt|md5|md5_file|sha1|sha1_file|str_rot13')"
+  "code": "re.match($X, '.*crypt|md5|md5_file|sha1|sha1_file|str_rot13')"
 }

--- a/semgrep-core/tests/OTHER/eval/regexp3.json
+++ b/semgrep-core/tests/OTHER/eval/regexp3.json
@@ -3,5 +3,5 @@
     "$X": "sodium_crypto_generichash"
   },
   "language": "python",
-  "code": "semgrep_re_match($X, '(?!crypt|md5|md5_file|sha1|sha1_file|str_rot13)')"
+  "code": "re.match($X, '(?!crypt|md5|md5_file|sha1|sha1_file|str_rot13)')"
 }

--- a/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
@@ -7,6 +7,7 @@
    Or: function(x1, x2, x3=null, x4=null) { or: std.prune([x1,x2,x3,x4]) },
    Not: function(x) { not: x },
    Where: function(x) { where: x },
+   MetavarRegex: function(x, y) { metavariable_regex: [x, y] },
 
    basic_rule: function(lang, match) {
     rules: [

--- a/semgrep-core/tests/OTHER/rules/metavar_cond.py
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond.py
@@ -1,5 +1,5 @@
 def test():
     #ERROR:
-    foo(a_bar_variable)
+    foo("a_bar_variable")
 
-    foo(a_ba_variable)
+    foo("a_ba_variable")

--- a/semgrep-core/tests/OTHER/rules/metavar_regex.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/metavar_regex.jsonnet
@@ -2,5 +2,6 @@ local s = import 'lib_semgrep.jsonnet';
 
 s.basic_rule('python', 
              s.And('foo($ARG)',
-                   s.Where('re.match($ARG, ".*bar.*")')))
+                   s.MetavarRegex('$ARG', ".*bar.*")))
+
 

--- a/semgrep-core/tests/OTHER/rules/metavar_regex.py
+++ b/semgrep-core/tests/OTHER/rules/metavar_regex.py
@@ -1,0 +1,5 @@
+def test():
+    #ERROR:
+    foo(a_bar_variable)
+
+    foo(a_ba_variable)


### PR DESCRIPTION
test plan:
test file included
$ semgrep-core -test_rules tests/OTHER/rules/