### PR TITLE
Basic support for metavariable_comparison in semgrep-full-rules-in-ocaml

### DIFF
--- a/semgrep-core/Core/Rule.ml
+++ b/semgrep-core/Core/Rule.ml
@@ -187,8 +187,9 @@ type rule = {
 }
 
 and paths = {
-  include_: regexp list;
-  exclude: regexp list;
+  (* not regexp but globs *)
+  include_: string list;
+  exclude: string list;
 }
 [@@deriving show]
 

--- a/semgrep-core/Engine/Convert_rule.ml
+++ b/semgrep-core/Engine/Convert_rule.ml
@@ -35,6 +35,16 @@ let convert_extra x =
   match x with
   | MetavarRegexp (mvar, re) ->
       CondRegexp (mvar, re)
+  | MetavarComparison comp ->
+      (match comp with
+       (* do we care about strip and base? should not Eval_generic handle it?
+        * base I think can be handled automatically, and for strip the user
+        * should instead use a more complex condition that converts
+        * the string into a number (e.g., "1234" in 1234).
+       *)
+       | { metavariable = _; comparison = s; strip = _TODO1; base = _TODO2 } ->
+           CondGeneric (Parse_rule.parse_metavar_cond s)
+      )
   | _ ->
 (*
   logger#debug "convert_extra: %s" s;

--- a/semgrep-core/Engine/Eval_generic.mli
+++ b/semgrep-core/Engine/Eval_generic.mli
@@ -13,8 +13,11 @@ type code = AST_generic.expr
 val parse_json: Common.filename -> env * code
 
 exception NotHandled of code
+exception NotInEnv of Metavariable.mvar
 
-(* raise NotHandled if the code is outside the subset of expressions allowed *)
+(* raise NotHandled if the code is outside the subset of expressions allowed,
+ * and NotInEnv if a metavariable is not binded in the environment.
+*)
 val eval: env -> code -> value
 
 (* entry point for -eval *)

--- a/semgrep-core/tests/OTHER/rules/metavar_cond2.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond2.jsonnet
@@ -1,0 +1,6 @@
+local s = import 'lib_semgrep.jsonnet';
+
+s.basic_rule('python', 
+             s.And('foo($ARG)',
+                   s.Where('$ARG > 10')))
+

--- a/semgrep-core/tests/OTHER/rules/metavar_cond2.py
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond2.py
@@ -1,0 +1,5 @@
+def test():
+    #ERROR:
+    foo(11)
+
+    foo(3)


### PR DESCRIPTION
test plan:
test file included
$ semgrep-core -test_rules tests/OTHER/rules