### PR TITLE
Basic support for pattern-regex in semgrep-full-rule-in-ocaml

### DIFF
--- a/semgrep-core/Core/Rule.ml
+++ b/semgrep-core/Core/Rule.ml
@@ -44,7 +44,7 @@ type xlang =
 
 type regexp = string * Pcre.regexp
 let pp_regexp fmt (s, _) =
-  Format.fprintf fmt "%s" s
+  Format.fprintf fmt "\"%s\"" s
 let equal_regexp (s1, _) (s2, _) = s1 = s2
 
 type xpattern = {

--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -21,6 +21,7 @@ module R = Rule
 module MR = Mini_rule
 module PM = Pattern_match
 module G = AST_generic
+module PI = Parse_info
 
 (*****************************************************************************)
 (* Prelude *)
@@ -109,15 +110,19 @@ type env = {
 (* Helpers *)
 (*****************************************************************************)
 
-let (patterns_in_formula: R.formula -> (R.pattern_id * Pattern.t) list) =
-  fun e ->
+let (xpatterns_in_formula: R.formula -> R.xpattern list) = fun e ->
   let res = ref [] in
-  e |> R.visit_new_formula (fun xpat ->
-    match xpat.pat with
-    | R.Sem p -> Common.push (xpat.R.pid, p) res
-    | _ -> failwith "TODO: Just Sem handled for now"
-  );
+  e |> R.visit_new_formula (fun xpat -> Common.push xpat res);
   !res
+
+let partition_xpatterns xs =
+  xs |> Common.partition_either3 (fun xpat ->
+    let id = xpat.R.pid in
+    match xpat.R.pat with
+    | R.Sem x -> Left3 (id, x)
+    | R.Spacegrep x -> Middle3 (id, x)
+    | R.Regexp x -> Right3 (id, x)
+  )
 
 let (mini_rule_of_pattern: R.t -> (R.pattern_id * Pattern.t) -> MR.t) =
   fun r (id, pattern) ->
@@ -130,11 +135,34 @@ let (mini_rule_of_pattern: R.t -> (R.pattern_id * Pattern.t) -> MR.t) =
     languages =
       (match r.R.languages with
        | R.L (x, xs) -> x::xs
-       | R.LNone | R.LGeneric -> failwith "TODO: LNone | LGeneric"
+       | R.LNone | R.LGeneric -> raise Impossible
       );
     pattern_string = "";
   }
 
+(* todo: change Pattern_match type so we don't need this gymnastic.
+ * A pattern_match should just need the id from the mini_rule
+*)
+let (mini_rule_of_regexp: (R.pattern_id * string) -> MR.t) =
+  fun (id, s) ->
+  { MR.
+    id = string_of_int id;
+    pattern = G.E (G.L (G.Null (PI.fake_info "")));
+    message = ""; severity = MR.Error; languages = [];
+    pattern_string = s;
+  }
+
+(* todo: same, we should not need that *)
+let hmemo = Hashtbl.create 101
+let info_of_token_location file loc =
+  (* first complete the loc with line/col which are needed when printing
+   * matches *)
+  let conv =
+    Common.memoized hmemo file (fun () -> PI.full_charpos_to_pos_large file)
+  in
+  let (line, column) = conv loc.PI.charpos in
+  let loc = { loc with PI. line; column } in
+  { PI.token = PI.OriginTok loc; transfo = PI.NoTransfo }
 
 let (group_matches_per_pattern_id: Pattern_match.t list ->id_to_match_results)=
   fun xs ->
@@ -228,6 +256,52 @@ let filter_ranges xs cond =
   )
 
 (*****************************************************************************)
+(* Evaluating xpatterns *)
+(*****************************************************************************)
+
+let matches_of_xpatterns with_caching orig_rule (file, lang, ast) xpatterns =
+  let (patterns, _spacegrepsTODO, regexps) =
+    partition_xpatterns xpatterns in
+
+  (* semgrep *)
+  let mini_rules =
+    patterns |> List.map (mini_rule_of_pattern orig_rule) in
+  let equivalences =
+    (* TODO *)
+    [] in
+  let semgrep_matches =
+    Semgrep_generic.check
+      ~with_caching
+      ~hook:(fun _ _ -> ())
+      mini_rules equivalences file lang ast
+  in
+
+  (* spacegrep *)
+
+  (* regexps *)
+  let regexp_matches =
+    if regexps = []
+    then []
+    else begin
+      let big_str = Common.read_file file in
+      regexps |> List.map (fun (id, (s, re)) ->
+        let subs = Pcre.exec_all ~rex:re big_str in
+        subs |> Array.to_list |> List.map (fun sub ->
+          let (charpos, _) = Pcre.get_substring_ofs sub 0 in
+          let str = Pcre.get_substring sub 0 in
+          let loc = {PI. str; charpos; file; line = -1; column = -1 } in
+          let mini_rule = mini_rule_of_regexp (id, s) in
+          {PM. rule = mini_rule; file; location = loc, loc;
+           tokens = lazy [info_of_token_location file loc]; env = [] }
+        )
+      ) |> List.flatten
+    end
+  in
+
+  (* final result *)
+  semgrep_matches @ regexp_matches
+
+(*****************************************************************************)
 (* Formula evaluation *)
 (*****************************************************************************)
 (* TODO: use Set instead of list? *)
@@ -279,20 +353,10 @@ let check with_caching hook rules (file, lang, ast) =
       | R.Old oldf -> Convert_rule.convert_formula_old oldf
     in
 
-    let (patterns: (R.pattern_id * Pattern.t) list) =
-      patterns_in_formula formula
-    in
-    let mini_rules =
-      patterns |> List.map (mini_rule_of_pattern r) in
-    let equivalences =
-      (* TODO *)
-      [] in
+    let xpatterns =
+      xpatterns_in_formula formula in
     let matches =
-      Semgrep_generic.check
-        ~with_caching
-        ~hook:(fun _ _ -> ())
-        mini_rules equivalences file lang ast
-    in
+      matches_of_xpatterns with_caching r (file, lang, ast) xpatterns in
     (* match results per minirule id which is the same than pattern_id in
      * the formula *)
     let pattern_matches_per_id =

--- a/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
@@ -2,10 +2,11 @@
    //old: And: function(arr) { and: arr },
    //trick to emulate variable number of arguments in jsonnet
    //src:  https://groups.google.com/g/jsonnet/c/45DS8Q7zmsM?pli=1
-   // 
+   //coupling: see Parse_rule.ml for the format 
    And: function(x1, x2, x3=null, x4=null) { and: std.prune([x1,x2,x3,x4]) },
    Or: function(x1, x2, x3=null, x4=null) { or: std.prune([x1,x2,x3,x4]) },
    Not: function(x) { not: x },
+   Regex: function(x) { regex: x },
    Where: function(x) { where: x },
    MetavarRegex: function(x, y) { metavariable_regex: [x, y] },
 

--- a/semgrep-core/tests/OTHER/rules/regexp.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/regexp.jsonnet
@@ -1,0 +1,7 @@
+local s = import 'lib_semgrep.jsonnet';
+
+s.basic_rule('python', 
+             s.And('foo("...")',
+                   s.Regex(@'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')))
+
+

--- a/semgrep-core/tests/OTHER/rules/regexp.py
+++ b/semgrep-core/tests/OTHER/rules/regexp.py
@@ -1,0 +1,9 @@
+def test():
+    #ERROR:
+    foo("128.0.0.1")
+
+    foo("this is not an IP")
+
+    foo("neither this")
+
+    # this is an IP but in comment foo("128.0.0.1")


### PR DESCRIPTION
test plan:
$ /home/pad/semgrep/_build/default/CLI/Main.exe -lang python -config regexp.jsonnet regexp.py
regexp.py:3
     foo("128.0.0.1")