### PR TITLE
Fix Not_found exn with pattern-regexp in semgrep-full-rule-in-ocaml

### DIFF
--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -285,7 +285,11 @@ let matches_of_xpatterns with_caching orig_rule (file, lang, ast) xpatterns =
     else begin
       let big_str = Common.read_file file in
       regexps |> List.map (fun (id, (s, re)) ->
-        let subs = Pcre.exec_all ~rex:re big_str in
+        let subs =
+          try
+            Pcre.exec_all ~rex:re big_str
+          with Not_found -> [||]
+        in
         subs |> Array.to_list |> List.map (fun sub ->
           let (charpos, _) = Pcre.get_substring_ofs sub 0 in
           let str = Pcre.get_substring sub 0 in

--- a/semgrep-core/tests/OTHER/rules/regexp_nomatch.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/regexp_nomatch.jsonnet
@@ -1,0 +1,7 @@
+local s = import 'lib_semgrep.jsonnet';
+
+s.basic_rule('python', 
+             s.And('foo("...")',
+                   s.Regex(@'ABCDE')))
+
+

--- a/semgrep-core/tests/OTHER/rules/regexp_nomatch.py
+++ b/semgrep-core/tests/OTHER/rules/regexp_nomatch.py
@@ -1,0 +1,9 @@
+def test():
+
+    foo("128.0.0.1")
+
+    foo("this is not an IP")
+
+    foo("neither this")
+
+    # this is an IP but in comment foo("128.0.0.1")


### PR DESCRIPTION
test plan:
$ /home/pad/semgrep/_build/default/CLI/Main.exe -lang python -config regexp_nomatch.jsonnet regexp_nomatch.py
does not raise an exception anymore