### PR TITLE
Add Emacs format output option

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -257,6 +257,11 @@ def cli() -> None:
     output.add_argument(
         "--sarif", action="store_true", help="Output results in SARIF format."
     )
+    output.add_argument(
+        "--emacs",
+        action="store_true",
+        help="Output results in Emacs single-line format.",
+    )
     output.add_argument("--test", action="store_true", help="Run test suite.")
     parser.add_argument(
         "--test-ignore-todo",
@@ -379,6 +384,8 @@ def cli() -> None:
         output_format = OutputFormat.JUNIT_XML
     elif args.sarif:
         output_format = OutputFormat.SARIF
+    elif args.emacs:
+        output_format = OutputFormat.EMACS
 
     output_settings = OutputSettings(
         output_format=output_format,

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -36,6 +36,7 @@ class OutputFormat(Enum):
     JSON_DEBUG = auto()
     JUNIT_XML = auto()
     SARIF = auto()
+    EMACS = auto()
 
     def is_json(self) -> bool:
         return self == OutputFormat.JSON or self == OutputFormat.JSON_DEBUG


### PR DESCRIPTION
Adds a `--emacs` flag to output matches in a format that can be parsed by Emacs. It makes it useful for navigating between each match, and could make it easier to add proper Emacs support.