### PR TITLE
Generating a TooManyMatches error instead of Timeout

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -476,7 +476,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout matches =
   let new_errors =
     offending_files |> Common.hashset_to_list |> List.map (fun file ->
       (* logging useful info for rule writers *)
-      logger#info "too many matches on %s, generating Timeout for it" file;
+      logger#info "too many matches on %s, generating exn for it" file;
       let biggest_offending_rule =
         let matches = List.assoc file per_files in
         matches
@@ -494,7 +494,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout matches =
 
       (* todo: we should maybe use a new error: TooManyMatches of int * string*)
       let loc = Parse_info.first_loc_of_file file in
-      Error_code.mk_error_loc loc (Error_code.Timeout None)
+      Error_code.mk_error_loc loc (Error_code.TooManyMatches pat)
     )
   in
   new_matches, new_errors

--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -7,6 +7,7 @@ from semgrep.error import MatchTimeoutError
 from semgrep.error import OutOfMemoryError
 from semgrep.error import SemgrepError
 from semgrep.error import SourceParseError
+from semgrep.error import TooManyMatchesError
 from semgrep.rule_lang import Position
 from semgrep.rule_lang import SourceTracker
 from semgrep.rule_lang import Span
@@ -93,6 +94,8 @@ class CoreException:
             return MatchTimeoutError(self._path, self._rule_id)
         elif self._check_id == "OutOfMemory":
             return OutOfMemoryError(self._path, self._rule_id)
+        elif self._check_id == "TooManyMatches":
+            return TooManyMatchesError(self._path, self._rule_id)
         elif self._check_id == "LexicalError":
             return LexicalError(self._path, self._rule_id)
         else:

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -27,6 +27,7 @@ INVALID_LANGUAGE_EXIT_CODE = 8
 MATCH_TIMEOUT_EXIT_CODE = 9
 MATCH_MAX_MEMORY_EXIT_CODE = 10
 LEXICAL_ERROR_EXIT_CODE = 11
+TOO_MANY_MATCHES_EXIT_CODE = 12
 
 
 class Level(Enum):
@@ -284,6 +285,25 @@ class MatchTimeoutError(SemgrepError):
 
     def __str__(self) -> str:
         msg = f"Warning: Semgrep exceeded timeout when running {self.rule_id} on {self.path}. See `--timeout` for more info."
+        return with_color(Fore.RED, msg)
+
+    def to_dict_base(self) -> Dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "rule_id": self.rule_id,
+        }
+
+
+@attr.s(frozen=True, eq=True)
+class TooManyMatchesError(SemgrepError):
+    path: Path = attr.ib()
+    rule_id: str = attr.ib()
+
+    code = TOO_MANY_MATCHES_EXIT_CODE
+    level = Level.WARN
+
+    def __str__(self) -> str:
+        msg = f"Warning: Semgrep exceeded number of matches when running {self.rule_id} on {self.path}."
         return with_color(Fore.RED, msg)
 
     def to_dict_base(self) -> Dict[str, Any]:


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/2411

test plan:
$ home/pad/semgrep/_build/default/CLI/Main.exe -timeout 0 -lang js -e $E perf/input/l10000.js -json
[0.091  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.091  Info       Main.Dune__exe__Main ] Executed as: /home/pad/semgrep/_build/default/CLI/Main.exe -timeout 0 -lang js -e $E perf/input/l10000.js -json
[0.091  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.39.1-21-g0812812b-dirty, pfff: 0.42
[0.092  Info       Main.Dune__exe__Main ] processing 1 files
[0.093  Info       Main.Dune__exe__Main ] Analyzing perf/input/l10000.js
[0.093  Info       Main.Parse_target    ] trying to parse with TreeSitter parser perf/input/l10000.js
[0.875  Info       Main.Dune__exe__Main ] done with perf/input/l10000.js
[0.878  Info       Main.Dune__exe__Main ] found 38175 matches and 0 errors
[0.899  Info       Main.Dune__exe__Main ] too many matches on perf/input/l10000.js, generating exn for it
[0.922  Info       Main.Dune__exe__Main ] most offending rule: id = -e/-f, matches = 38175, pattern = $E
[0.934  Info       Main.Dune__exe__Main ] size of returned JSON string: 230
{"matches":[],"errors":[{"check_id":"TooManyMatches","path":"perf/input/l10000.js","start":{"line":1,"col":1},"end":{"line":1,"col":1},"extra":{"message":"too many matches: $E","line":"/**"}}],"stats":{"okfiles":0,"errorfiles":1}}

$ semgrep -e '$E' -l js perf/input/l10000.js --verbose
Warning: Semgrep exceeded number of matches when running - on perf/input/l10000.js.
ran 1 rules on 1 files: 0 findings
1 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed