### PR TITLE
Add a TyInterfaceAnon type to the generic AST

### DIFF
--- a/semgrep-core/Core/AST/AST_generic.ml
+++ b/semgrep-core/Core/AST/AST_generic.ml
@@ -1163,6 +1163,7 @@ and type_ =
    * via a TyName. Here we have flexible record types (a.k.a. rows in OCaml).
   *)
   | TyRecordAnon of tok (* 'struct/shape', fake in other *)* field list bracket
+  | TyInterfaceAnon of tok (* 'struct/shape', fake in other *)* field list bracket
 
   (* sgrep-ext: *)
   | TyEllipsis of tok

--- a/semgrep-core/Core/AST/Map_AST.ml
+++ b/semgrep-core/Core/AST/Map_AST.ml
@@ -342,6 +342,10 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v0 = map_tok v0 in
         let v1 = map_bracket (map_of_list map_field) v1
         in TyRecordAnon (v0, v1)
+    | TyInterfaceAnon (v0, v1) ->
+        let v0 = map_tok v0 in
+        let v1 = map_bracket (map_of_list map_field) v1
+        in TyInterfaceAnon (v0, v1)
     | TyOr (v1, v2, v3) ->
         let v1 = map_type_ v1 in
         let v2 = map_tok v2 in

--- a/semgrep-core/Core/AST/Meta_AST.ml
+++ b/semgrep-core/Core/AST/Meta_AST.ml
@@ -456,6 +456,10 @@ and vof_type_ =
       let v0 = vof_tok v0 in
       let v1 = vof_bracket (OCaml.vof_list vof_field) v1
       in OCaml.VSum ("TyAnd", [ v0; v1 ])
+  | TyInterfaceAnon (v0, v1) ->
+      let v0 = vof_tok v0 in
+      let v1 = vof_bracket (OCaml.vof_list vof_field) v1
+      in OCaml.VSum ("TyAnd", [ v0; v1 ])
   | TyOr (v1, v2, v3) ->
       let v1 = vof_type_ v1 in
       let v2 = vof_tok v2 in

--- a/semgrep-core/Core/AST/Visitor_AST.ml
+++ b/semgrep-core/Core/AST/Visitor_AST.ml
@@ -363,6 +363,10 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           v_tok v0;
           let v1 = v_bracket (v_list v_field) v1
           in ()
+      | TyInterfaceAnon (v0, v1) ->
+          v_tok v0;
+          let v1 = v_bracket (v_list v_field) v1
+          in ()
       | TyOr (v1, v2, v3) -> v_type_ v1; v_tok v2; v_type_ v3
       | TyAnd (v1, v2, v3) -> v_type_ v1; v_tok v2; v_type_ v3
       | TyBuiltin v1 -> let v1 = v_wrap v_string v1 in ()

--- a/semgrep-core/Matching/Generic_vs_generic.ml
+++ b/semgrep-core/Matching/Generic_vs_generic.ml
@@ -1325,6 +1325,9 @@ and m_type_ a b =
   | A.TyRecordAnon(a0, a1), B.TyRecordAnon(b0, b1) ->
       let* () = m_tok a0 b0 in
       m_bracket m_fields a1 b1
+  | A.TyInterfaceAnon(a0, a1), B.TyInterfaceAnon(b0, b1) ->
+      let* () = m_tok a0 b0 in
+      m_bracket m_fields a1 b1
   | A.TyOr (a1, a2, a3), B.TyOr (b1, b2, b3) ->
       m_type_ a1 b1 >>= (fun () ->
         m_tok a2 b2 >>= (fun () ->
@@ -1343,7 +1346,7 @@ and m_type_ a b =
   | A.TyBuiltin _, _  | A.TyFun _, _  | A.TyNameApply _, _  | A.TyVar _, _
   | A.TyArray _, _  | A.TyPointer _, _ | A.TyTuple _, _  | A.TyQuestion _, _
   | A.TyId _, _ | A.TyIdQualified _, _ | A.TyAny _, _
-  | A.TyOr _, _ | A.TyAnd _, _ | A.TyRecordAnon _, _
+  | A.TyOr _, _ | A.TyAnd _, _ | A.TyRecordAnon _, _ | A.TyInterfaceAnon _, _
   | A.TyRef _, _
   | A.OtherType _, _
     -> fail ()

--- a/semgrep-core/Parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/go_to_generic.ml
@@ -144,14 +144,7 @@ let top_func () =
 
     | TStruct (t, v1) -> let v1 = bracket (list struct_field) v1 in
         G.TyRecordAnon (t, v1)
-    | TInterface (t, v1) -> let v1 = bracket (list interface_field) v1 in
-        let s = gensym () in
-        let ent = G.basic_entity (s, t) [] in
-        let def = G.ClassDef { G.ckind = (G.Interface, t);
-                               cextends = []; cimplements = []; cmixins = [];
-                               cbody = v1; } in
-        Common.push (ent, def) anon_types;
-        G.TyId ((s,t), G.empty_id_info())
+    | TInterface (t, v1) -> TyInterfaceAnon (t, v1)
 
   and chan_dir = function
     | TSend -> G.TyId (fake_id "send", G.empty_id_info())

--- a/semgrep-core/Parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/go_to_generic.ml
@@ -106,13 +106,6 @@ let qualified_ident v =
   | _ -> raise Impossible
 
 let top_func () =
-  let anon_types = ref [] in
-  (* let cnt = ref 0 in
-     let gensym () =
-     incr cnt;
-     spf "_anon%d" !cnt
-     in *)
-
   let rec type_ =
     function
     | TName v1 -> let v1 = qualified_ident v1 in
@@ -593,11 +586,8 @@ let top_func () =
         G.ImportAll (itok, module_name, v1)
 
   and program xs =
-    anon_types := [];
-    let xs = list top_decl xs in
-    let arg_types = !anon_types |> List.map (fun x -> G.DefStmt x |> G.s) in
-    (* TODO? put after program and imports? *)
-    arg_types @ xs
+    list top_decl xs
+  (* TODO? put after program and imports? *)
 
   and item_aux = function
     | ITop x -> [top_decl x]
@@ -616,7 +606,6 @@ let top_func () =
         )
 
   and any x =
-    anon_types := [];
     let res =
       match x with
       | Partial v1 -> let v1 = partial v1 in G.Partial v1
@@ -632,8 +621,6 @@ let top_func () =
       | Item v1 -> let v1 = item v1 in G.S v1
       | Items v1 -> let v1 = list item_aux v1 in G.Ss (List.flatten v1)
     in
-    if !anon_types <> []
-    then failwith "TODO: anon_types not empty";
     res
 
   in

--- a/semgrep-core/Parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/go_to_generic.ml
@@ -107,11 +107,11 @@ let qualified_ident v =
 
 let top_func () =
   let anon_types = ref [] in
-  let cnt = ref 0 in
-  let gensym () =
-    incr cnt;
-    spf "_anon%d" !cnt
-  in
+  (* let cnt = ref 0 in
+     let gensym () =
+     incr cnt;
+     spf "_anon%d" !cnt
+     in *)
 
   let rec type_ =
     function
@@ -144,7 +144,8 @@ let top_func () =
 
     | TStruct (t, v1) -> let v1 = bracket (list struct_field) v1 in
         G.TyRecordAnon (t, v1)
-    | TInterface (t, v1) -> TyInterfaceAnon (t, v1)
+    | TInterface (t, v1) -> let v1 = bracket (list interface_field) v1 in
+        G.TyInterfaceAnon (t, v1)
 
   and chan_dir = function
     | TSend -> G.TyId (fake_id "send", G.empty_id_info())

--- a/semgrep-core/tests/go/interface_type_assertion.go
+++ b/semgrep-core/tests/go/interface_type_assertion.go
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+    var value interface{}
+    _ = v.([]interface{})
+}
+

--- a/semgrep-core/tests/go/interface_type_assertion.go
+++ b/semgrep-core/tests/go/interface_type_assertion.go
@@ -2,6 +2,7 @@ package main
 
 func main() {
     var value interface{}
+    // ERROR: 
     _ = v.([]interface{})
 }
 

--- a/semgrep-core/tests/go/interface_type_assertion.sgrep
+++ b/semgrep-core/tests/go/interface_type_assertion.sgrep
@@ -1,0 +1,1 @@
+$VALUE.([]interface{})


### PR DESCRIPTION
Closes #2376
    
Explicitly handle interface types in go patterns by directly translating interface types into a generic AST interface type value.
    
Test plan: make test with new tests