### PR TITLE
Turn on caching optimization by default.

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -183,7 +183,7 @@ let ncores = ref 1
 (* ------------------------------------------------------------------------- *)
 
 (* opt = optimization *)
-let with_opt_cache = ref false (* TODO: change after merging to main branch *)
+let with_opt_cache = ref true
 
 (* ------------------------------------------------------------------------- *)
 (* flags used by the semgrep-python wrapper *)


### PR DESCRIPTION
This enables the caching optimization by default. It was off so we can start performance graphs without caching and then see a jump when we start caching.

Note that `semgrep-core` has command-line options for deciding what level of caching to use. The default will now be `-opt_cache` which performs moderate caching, the other behaviors being selected `-no_opt_cache` and `-opt_max_cache`.