### PR TITLE
Refactoring name to cover Id and IdQualified

### DIFF
--- a/semgrep-core/Analyzing/Constant_propagation.ml
+++ b/semgrep-core/Analyzing/Constant_propagation.ml
@@ -129,7 +129,7 @@ let var_stats prog : var_stats =
         match x with
         (* TODO: very incomplete, what if Assign (Tuple?) *)
         | Assign (
-          Id (id, ({ id_resolved = {contents = Some (_kind, sid)}; _ })),
+          N (Id (id, ({ id_resolved = {contents = Some (_kind, sid)}; _ }))),
           _,
           e2) ->
             let var = (H.str_of_ident id, sid) in
@@ -137,7 +137,7 @@ let var_stats prog : var_stats =
             incr stat.lvalue;
             vout (E e2)
 
-        | Id (id, ({ id_resolved = {contents = Some (_kind, sid)}; _ }))->
+        | N (Id (id, ({ id_resolved = {contents = Some (_kind, sid)}; _ })))->
             let var = (H.str_of_ident id, sid) in
             let stat = get_stat_or_create var h in
             incr stat.rvalue;
@@ -202,7 +202,7 @@ let eval_bop_string op s1 s2 =
 
 let rec eval_expr env = function
   | L literal -> Some literal
-  | Id (id, id_info)->
+  | N (Id (id, id_info)) ->
       find_id env id id_info
   (* TODO: do what we do in Normalize_generic.ml.
    * | Call(IdSpecial((Op(Plus | Concat) | ConcatString _), _), args)->
@@ -296,7 +296,7 @@ let propagate_basic lang prog =
       V.kexpr = (fun (k, _) x ->
 
         (match x with
-         | Id (id, id_info)->
+         | N (Id (id, id_info)) ->
              (match find_id env id id_info with
               | Some literal ->
                   id_info.id_constness := Some (Lit literal)
@@ -313,8 +313,8 @@ let propagate_basic lang prog =
 
              (* Assign that is really a hidden VarDef (e.g., in Python) *)
          | Assign (
-           Id (id, ({ id_resolved = {contents = Some (kind, sid)}; _ }
-                    as id_info)),
+           N (Id (id, ({ id_resolved = {contents = Some (kind, sid)}; _ }
+                       as id_info))),
            _,
            rexp) ->
              (match eval_expr env rexp with

--- a/semgrep-core/Analyzing/Naming_AST.ml
+++ b/semgrep-core/Analyzing/Naming_AST.ml
@@ -257,7 +257,7 @@ let get_resolved_type (vinit, vtype) =
       | Some(L (Unit tok)) -> make_type "unit" tok
       | Some(L (Null tok)) -> make_type "null" tok
       | Some(L (Imag (_, tok))) -> make_type "imag" tok
-      | Some(Id (_, {id_type; _})) -> !id_type
+      | Some(N (Id (_, {id_type; _}))) -> !id_type
       | _ -> None
     )
 
@@ -575,7 +575,7 @@ let resolve2 lang prog =
              );
              recurse := false;
 
-         | Id (id, id_info) ->
+         | N (Id (id, id_info)) ->
              (match lookup_scope_opt id env with
               | Some resolved ->
                   (* name resolution *)

--- a/semgrep-core/Analyzing/Unit_typing_generic.ml
+++ b/semgrep-core/Analyzing/Unit_typing_generic.ml
@@ -25,7 +25,7 @@ let unittest =
         let v = V.mk_visitor { V.default_visitor with
                                V.kexpr = (fun (_k, _) exp ->
                                  match exp with
-                                 | A.Id(_, {A.id_type=id_type; _}) -> (
+                                 | A.N (A.Id(_, {A.id_type=id_type; _})) -> (
                                      match !id_type with
                                      | Some(A.TyId(("String", _), _)) -> ()
                                      | _ -> assert_failure("Variable referenced did not have expected type String"))
@@ -49,18 +49,18 @@ let unittest =
                                  match exp with
                                  | A.Call(_, (_,[x;y],_)) ->
                                      ((match x with
-                                        | A.Arg(A.Id(_, {A.id_type=id_type; _})) -> (
+                                        | A.Arg(A.N (A.Id(_, {A.id_type=id_type; _}))) -> (
                                             match !id_type with
                                             | Some(A.TyId(("String", _), _)) -> ()
                                             | _ -> assert_failure("Variable 1 referenced did not have expected type String"))
                                         | _ -> ());
                                       (match y with
-                                       | A.Arg(A.Id(_, {A.id_type=id_type; _})) -> (
+                                       | A.Arg(A.N (A.Id(_, {A.id_type=id_type; _}))) -> (
                                            match !id_type with
                                            | Some(A.TyBuiltin("int", _)) -> ()
                                            | _ -> assert_failure("Variable 2 referenced did not have expected type int"))
                                        | _ -> ()))
-                                 | A.Assign(A.Id(_, {A.id_type=id_type; _}), _, _) -> (
+                                 | A.Assign(A.N (A.Id(_, {A.id_type=id_type; _})), _, _) -> (
                                      match !id_type with
                                      | Some(A.TyId(("String", _), _)) -> ()
                                      | _ -> assert_failure("Variable 1 referenced did not have expected type String"))
@@ -84,13 +84,13 @@ let unittest =
                                  match exp with
                                  | A.Call(_, (_,[x;y],_)) ->
                                      ((match x with
-                                        | A.Arg(A.Id(_, {A.id_type=id_type; _})) -> (
+                                        | A.Arg(A.N (A.Id(_, {A.id_type=id_type; _}))) -> (
                                             match !id_type with
                                             | Some(A.TyBuiltin("int", _)) -> ()
                                             | _ -> assert_failure("Variable 1 referenced did not have expected type String"))
                                         | _ -> ());
                                       (match y with
-                                       | A.Arg(A.Id(_, {A.id_type=id_type; _})) -> (
+                                       | A.Arg(A.N (A.Id(_, {A.id_type=id_type; _}))) -> (
                                            match !id_type with
                                            | Some(A.TyBuiltin("boolean", _)) -> ()
                                            | _ -> assert_failure("Variable 2 referenced did not have expected type int"))
@@ -113,11 +113,11 @@ let unittest =
         let v = V.mk_visitor { V.default_visitor with
                                V.kexpr = (fun (_k, _) exp ->
                                  match exp with
-                                 | A.Id(("age", _), {A.id_type=id_type; _}) -> (
+                                 | A.N (A.Id(("age", _), {A.id_type=id_type; _})) -> (
                                      match !id_type with
                                      | Some(A.TyBuiltin("int", _)) -> ()
                                      | _ -> assert_failure("Variable referenced did not have expected type int"))
-                                 | A.Id(("default_age", _), {A.id_type=id_type; _}) -> (
+                                 | A.N (A.Id(("default_age", _), {A.id_type=id_type; _})) -> (
                                      match !id_type with
                                      | Some(A.TyBuiltin("int", _)) -> ()
                                      | _ -> assert_failure("Variable referenced did not have expected type int"))
@@ -163,7 +163,7 @@ let unittest =
         let v = V.mk_visitor { V.default_visitor with
                                V.kexpr = (fun (_k, _) exp ->
                                  match exp with
-                                 | A.Id(_, {A.id_type=id_type; _}) -> (
+                                 | A.N (A.Id(_, {A.id_type=id_type; _})) -> (
                                      match !id_type with
                                      | Some(A.TyId(("int", _), _)) -> ()
                                      | _ -> assert_failure("Variable referenced did not have expected type int"))
@@ -187,13 +187,13 @@ let unittest =
                                  match exp with
                                  | A.Call(_, (_,[x;y],_)) ->
                                      ((match x with
-                                        | A.Arg(A.Id(("a", _), {A.id_type=id_type; _})) -> (
+                                        | A.Arg(A.N (A.Id(("a", _), {A.id_type=id_type; _}))) -> (
                                             match !id_type with
                                             | Some(A.TyId(("int", _), _)) -> ()
                                             | _ -> assert_failure("Variable referenced did not have expected type int"))
                                         | _ -> assert_failure("Expected function call to be with int a as first argument"));
                                       (match y with
-                                       | A.Arg(A.Id(("c", _), {A.id_type=id_type; _})) -> (
+                                       | A.Arg(A.N (A.Id(("c", _), {A.id_type=id_type; _}))) -> (
                                            match !id_type with
                                            | Some(A.TyId(("bool", _), _)) -> ()
                                            | _ -> assert_failure("Variable referenced did not have expected type bool"))
@@ -216,15 +216,15 @@ let unittest =
         let v = V.mk_visitor { V.default_visitor with
                                V.kexpr = (fun (_k, _) exp ->
                                  match exp with
-                                 | A.Id(("a", _), {A.id_type=id_type; _}) -> (
+                                 | A.N (A.Id(("a", _), {A.id_type=id_type; _})) -> (
                                      match !id_type with
                                      | Some(A.TyId(("char", _), _)) -> ()
                                      | _ -> assert_failure("Variable referenced did not have expected type char"))
-                                 | A.Id(("b", _), {A.id_type=id_type; _}) -> (
+                                 | A.N (A.Id(("b", _), {A.id_type=id_type; _})) -> (
                                      match !id_type with
                                      | Some(A.TyId(("int", _), _)) -> ()
                                      | _ -> assert_failure("Variable referenced did not have expected type int"))
-                                 | A.Id(("c", _), {A.id_type=id_type; _}) -> (
+                                 | A.N (A.Id(("c", _), {A.id_type=id_type; _})) -> (
                                      match !id_type with
                                      | Some(A.TyId(("char", _), _)) -> ()
                                      | _ -> assert_failure("Variable referenced did not have expected type char"))

--- a/semgrep-core/Analyzing/lrvalue.ml
+++ b/semgrep-core/Analyzing/lrvalue.ml
@@ -83,12 +83,12 @@ let rec visit_expr hook lhs expr =
   match expr with
   (* the leaf *)
 
-  | Id (name, idinfo) ->
+  | N (Id (name, idinfo)) ->
       (* calling the hook! *)
       hook lhs name idinfo
 
   (* TODO? *)
-  | IdQualified _ -> ()
+  | N (IdQualified _) -> ()
 
   (* the assignements *)
 

--- a/semgrep-core/Core/AST/AST_generic.ml
+++ b/semgrep-core/Core/AST/AST_generic.ml
@@ -391,7 +391,7 @@ and resolved_name_kind =
 
 (*s: type [[AST_generic.name]] *)
 (* TODO: make a name with Id | IdQualified *)
-type name = ident * name_info
+type name_ = ident * name_info
 (*e: type [[AST_generic.name]] *)
 (*s: type [[AST_generic.name_info]] *)
 and name_info = {
@@ -422,7 +422,7 @@ and ident_or_dynamic =
    * Note that we could also use EDynamic (IdQualified) but better to
    * add special case here.
   *)
-  | EName of name
+  | EName of (ident * name_info)
   (* for PHP/JS fields (even though JS use ArrayAccess for that), or Ruby *)
   | EDynamic of expr
 
@@ -509,7 +509,7 @@ and expr =
    * or module, but you may need advanced semantic information and global
    * analysis to disambiguate.
   *)
-  | IdQualified of name * id_info
+  | IdQualified of (ident * name_info) * id_info
   (*x: [[AST_generic.expr]] other identifier cases *)
   | IdSpecial of special wrap
   (*e: [[AST_generic.expr]] other identifier cases *)
@@ -1157,7 +1157,7 @@ and type_ =
    *  self/parent/static (e.g., in PHP)
   *)
   | TyId of ident * id_info
-  | TyIdQualified of name * id_info
+  | TyIdQualified of (ident * name_info) * id_info
   (* covers tuples, list, etc.
    * TODO: merge with TyIdQualified? name_info has name_typeargs
   *)
@@ -1755,7 +1755,7 @@ and any =
   | Dir of directive
   | Pr of program
   (*s: [[AST_generic.any]] other cases *)
-  | N of name
+  | N of (ident * name_info)
   | Modn of module_name
   | ModDk of module_definition_kind
   | En of entity

--- a/semgrep-core/Core/AST/AST_generic.ml
+++ b/semgrep-core/Core/AST/AST_generic.ml
@@ -297,6 +297,10 @@ type 'a bracket = tok * 'a * tok
 type sc = tok
 [@@deriving show, eq, hash] (* with tarzan *)
 
+(* an AST element not yet handled; works with the Xx_Todo and Todo in any *)
+type todo_kind = string wrap
+[@@deriving show, eq, hash]  (* with tarzan *)
+
 (*****************************************************************************)
 (* Names *)
 (*****************************************************************************)
@@ -381,10 +385,6 @@ and resolved_name_kind =
   | EnumConstant
   (*e: type [[AST_generic.resolved_name_kind]] *)
 [@@deriving show { with_path = false }, eq, hash]  (* with tarzan *)
-
-(* an AST element not yet handled; works with the Xx_Todo and Todo in any *)
-type todo_kind = string wrap
-[@@deriving show, eq, hash]  (* with tarzan *)
 
 (* Start of big mutually recursive types because of the use of 'any'
  * in OtherXxx *)
@@ -477,7 +477,7 @@ and expr =
    * (ab)used also for polymorphic variants where qualifier is QTop with
    * the '`' token.
   *)
-  | Constructor of name * expr list
+  | Constructor of dotted_ident * expr list
   (* see also Call(IdSpecial (New,_), [ArgType _;...] for other values *)
   (*e: [[AST_generic.expr]] other composite cases *)
 
@@ -1082,9 +1082,9 @@ and pattern =
   | PatLiteral of literal
   (* Or-Type, used also to match OCaml exceptions *)
   (* Used with Rust path expressions, with an empty pattern list *)
-  | PatConstructor of name * pattern list
+  | PatConstructor of dotted_ident * pattern list
   (* And-Type*)
-  | PatRecord of (name * pattern) list bracket
+  | PatRecord of (dotted_ident * pattern) list bracket
 
   (* newvar:! *)
   | PatId of ident * id_info (* Usually Local/Param, Global in toplevel let *)
@@ -1161,7 +1161,7 @@ and type_ =
   (* covers tuples, list, etc.
    * TODO: merge with TyIdQualified? name_info has name_typeargs
   *)
-  | TyNameApply of name * type_arguments
+  | TyNameApply of dotted_ident * type_arguments
 
   | TyVar of ident (* type variable in polymorphic types (not a typedef) *)
   | TyAny of tok (* anonymous type, '_' in OCaml *)
@@ -1626,7 +1626,7 @@ and module_definition = {
 
 (*s: type [[AST_generic.module_definition_kind]] *)
 and module_definition_kind =
-  | ModuleAlias of name
+  | ModuleAlias of dotted_ident
   (* newscope: *)
   | ModuleStruct of dotted_ident option * item list
 

--- a/semgrep-core/Core/AST/AST_generic_helpers.ml
+++ b/semgrep-core/Core/AST/AST_generic_helpers.ml
@@ -45,11 +45,11 @@ let gensym () =
 (* before Naming_AST.resolve can do its job *)
 (*e: function [[AST_generic.gensym]] *)
 
-(* todo: should also mae sure nameinfo.name_typeargs is empty? *)
-let id_of_name (id, nameinfo) =
+(* todo: should also make sure nameinfo.name_typeargs is empty? *)
+let id_of_name_ (id, nameinfo) =
   match nameinfo.name_qualifier with
-  | None | Some (QDots []) -> Id (id, empty_id_info ())
-  | _ -> IdQualified ((id, nameinfo), empty_id_info())
+  | None | Some (QDots []) -> N (Id (id, empty_id_info ()))
+  | _ -> N (IdQualified ((id, nameinfo), empty_id_info()))
 
 let name_of_id id =
   (id, empty_name_info)
@@ -80,7 +80,7 @@ let tyid_of_name (id, nameinfo) =
 let rec expr_to_pattern e =
   (* TODO: diconstruct e and generate the right pattern (PatLiteral, ...) *)
   match e with
-  | Id (id, info) -> PatId (id, info)
+  | N (Id (id, info)) -> PatId (id, info)
   | Tuple (t1, xs, t2) -> PatTuple (t1, xs  |> List.map expr_to_pattern, t2)
   | L l -> PatLiteral l
   | Container(List, (t1, xs, t2)) ->
@@ -96,7 +96,7 @@ exception NotAnExpr
 (* sgrep: this is to treat pattern metavars as expr metavars *)
 let rec pattern_to_expr p =
   match p with
-  | PatId (id, info) -> Id (id, info)
+  | PatId (id, info) -> N (Id (id, info))
   | PatTuple (t1, xs, t2) -> Tuple (t1, xs |> List.map pattern_to_expr, t2)
   | PatLiteral l -> L l
   | PatList (t1, xs, t2) ->
@@ -154,10 +154,10 @@ let is_boolean_operator = function
 let ident_or_dynamic_to_expr name idinfo_opt =
   match name, idinfo_opt with
   (* assert idinfo = _idinfo below? *)
-  | EId (id, idinfo), None -> Id (id, idinfo)
-  | EId (id, _idinfo), Some idinfo -> Id (id, idinfo)
-  | EName n, None -> IdQualified (n, empty_id_info())
-  | EName n, Some idinfo -> IdQualified (n, idinfo)
+  | EId (id, idinfo), None -> N (Id (id, idinfo))
+  | EId (id, _idinfo), Some idinfo -> N (Id (id, idinfo))
+  | EName n, None -> N (IdQualified (n, empty_id_info()))
+  | EName n, Some idinfo -> N (IdQualified (n, idinfo))
   | EDynamic e, _ -> e
 
 

--- a/semgrep-core/Core/AST/Map_AST.ml
+++ b/semgrep-core/Core/AST/Map_AST.ml
@@ -107,7 +107,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | TypeName -> TypeName
 
 
-  and map_name (v1, v2) =
+  and map_name_ (v1, v2) =
     let v1 = map_ident v1 and v2 = map_name_info v2 in (v1, v2)
   and
     map_name_info {
@@ -161,8 +161,15 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | XmlExpr v1 -> let v1 = map_expr v1 in XmlExpr v1
     | XmlXml v1 -> let v1 = map_xml v1 in XmlXml v1
 
+  and map_name = function
+    | Id (v1, v2) ->
+        let v1 = map_ident v1 and v2 = map_id_info v2 in Id (v1, v2)
+    | IdQualified (v1, v2) ->
+        let v1 = map_name_ v1 and v2 = map_id_info v2 in IdQualified (v1, v2)
+
   and map_expr x =
     let k x = match x with
+      | N v1 -> let v1 = map_name v1 in N v1
       | DotAccessEllipsis (v1, v2) -> let v1 = map_expr v1 in
           let v2 = map_tok v2 in
           DotAccessEllipsis (v1, v2)
@@ -187,10 +194,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | AnonClass v1 ->
           let v1 = map_class_definition v1 in AnonClass v1
       | Xml v1 -> let v1 = map_xml v1 in Xml v1
-      | Id (v1, v2) ->
-          let v1 = map_ident v1 and v2 = map_id_info v2 in Id (v1, v2)
-      | IdQualified (v1, v2) ->
-          let v1 = map_name v1 and v2 = map_id_info v2 in IdQualified (v1, v2)
       | IdSpecial v1 -> let v1 = map_wrap map_special v1 in IdSpecial v1
       | Call (v1, v2) ->
           let v1 = map_expr v1 and v2 = map_arguments v2 in Call (v1, v2)
@@ -262,7 +265,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v1 = map_ident v1 in
         let v2 = map_id_info v2 in
         EId (v1, v2)
-    | EName v1 -> let v1 = map_name v1 in EName v1
+    | EName v1 -> let v1 = map_name_ v1 in EName v1
     | EDynamic v1 -> let v1 = map_expr v1 in EDynamic v1
 
   and map_literal =
@@ -370,7 +373,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v2 = map_id_info v2 in
         TyId (v1, v2)
     | TyIdQualified (v1, v2) ->
-        let v1 = map_name v1 in
+        let v1 = map_name_ v1 in
         let v2 = map_id_info v2 in
         TyIdQualified (v1, v2)
     | TyVar v1 -> let v1 = map_ident v1 in TyVar v1
@@ -930,7 +933,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | TodoK v1 -> let v1 = map_ident v1 in TodoK v1
     | Tk v1 -> let v1 = map_tok v1 in Tk v1
     | I v1 -> let v1 = map_ident v1 in I v1
-    | N v1 -> let v1 = map_name v1 in N v1
     | Modn v1 -> let v1 = map_module_name v1 in Modn v1
     | ModDk v1 -> let v1 = map_module_definition_kind v1 in ModDk v1
     | En v1 -> let v1 = map_entity v1 in En v1

--- a/semgrep-core/Core/AST/Map_AST.ml
+++ b/semgrep-core/Core/AST/Map_AST.ml
@@ -179,7 +179,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let v1 = map_bracket (map_of_list map_field) v1 in
           Record v1
       | Constructor (v1, v2) ->
-          let v1 = map_name v1
+          let v1 = map_dotted_ident v1
           and v2 = map_of_list map_expr v2
           in Constructor (v1, v2)
       | Lambda v1 ->
@@ -362,7 +362,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         and v2 = map_type_ v2
         in TyFun (v1, v2)
     | TyNameApply (v1, v2) ->
-        let v1 = map_name v1
+        let v1 = map_dotted_ident v1
         and v2 = map_type_arguments v2
         in TyNameApply (v1, v2)
     | TyId (v1, v2) ->
@@ -598,7 +598,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v1 =
           map_bracket (map_of_list
                          (fun (v1, v2) ->
-                            let v1 = map_name v1 and v2 = map_pattern v2 in (v1, v2)))
+                            let v1 = map_dotted_ident v1 and v2 = map_pattern v2 in (v1, v2)))
             v1
         in PatRecord v1
     | PatId (v1, v2) ->
@@ -614,7 +614,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | PatLiteral v1 -> let v1 = map_literal v1 in PatLiteral v1
     | PatType v1 -> let v1 = map_type_ v1 in PatType v1
     | PatConstructor (v1, v2) ->
-        let v1 = map_name v1
+        let v1 = map_dotted_ident v1
         and v2 = map_of_list map_pattern v2
         in PatConstructor (v1, v2)
     | PatTuple v1 -> let v1 = map_bracket (map_of_list map_pattern) v1 in PatTuple v1
@@ -686,7 +686,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     { mbody = v_mbody; }
   and map_module_definition_kind =
     function
-    | ModuleAlias v1 -> let v1 = map_name v1 in ModuleAlias v1
+    | ModuleAlias v1 -> let v1 = map_dotted_ident v1 in ModuleAlias v1
     | ModuleStruct (v1, v2) ->
         let v1 = map_of_option map_dotted_ident v1
         and v2 = map_of_list map_item v2

--- a/semgrep-core/Core/AST/Meta_AST.ml
+++ b/semgrep-core/Core/AST/Meta_AST.ml
@@ -154,7 +154,7 @@ and vof_expr =
       let v1 = vof_bracket (OCaml.vof_list vof_field) v1 in
       OCaml.VSum ("Record", [ v1 ])
   | Constructor (v1, v2) ->
-      let v1 = vof_name v1
+      let v1 = vof_dotted_ident v1
       and v2 = OCaml.vof_list vof_expr v2
       in OCaml.VSum ("Constructor", [ v1; v2 ])
   | Lambda v1 ->
@@ -478,7 +478,7 @@ and vof_type_ =
       and v2 = vof_type_ v2
       in OCaml.VSum ("TyFun", [ v1; v2 ])
   | TyNameApply (v1, v2) ->
-      let v1 = vof_name v1
+      let v1 = vof_dotted_ident v1
       and v2 = vof_type_arguments v2
       in OCaml.VSum ("TyNameApply", [ v1; v2 ])
   | TyId (v1, v2) ->
@@ -817,13 +817,13 @@ and vof_pattern =
       let v1 =
         vof_bracket (OCaml.vof_list
                        (fun (v1, v2) ->
-                          let v1 = vof_name v1
+                          let v1 = vof_dotted_ident v1
                           and v2 = vof_pattern v2
                           in OCaml.VTuple [ v1; v2 ]))
           v1
       in OCaml.VSum ("PatRecord", [ v1 ])
   | PatConstructor (v1, v2) ->
-      let v1 = vof_name v1
+      let v1 = vof_dotted_ident v1
       and v2 = OCaml.vof_list vof_pattern v2
       in OCaml.VSum ("PatConstructor", [ v1; v2 ])
   | PatWhen (v1, v2) ->
@@ -927,7 +927,7 @@ and vof_module_definition { mbody = v_mbody } =
 and vof_module_definition_kind =
   function
   | ModuleAlias v1 ->
-      let v1 = vof_name v1 in OCaml.VSum ("ModuleAlias", [ v1 ])
+      let v1 = vof_dotted_ident v1 in OCaml.VSum ("ModuleAlias", [ v1 ])
   | ModuleStruct (v1, v2) ->
       let v1 = OCaml.vof_option vof_dotted_name v1
       and v2 = OCaml.vof_list vof_item v2

--- a/semgrep-core/Core/AST/Meta_AST.ml
+++ b/semgrep-core/Core/AST/Meta_AST.ml
@@ -61,7 +61,7 @@ let rec vof_qualifier = function
       let v2 = vof_tok v2 in
       OCaml.VSum ("QExpr", [v1; v2])
 
-and vof_name (v1, v2) =
+and vof_name_ (v1, v2) =
   let v1 = vof_ident v1 and v2 = vof_name_info v2 in OCaml.VTuple [ v1; v2 ]
 
 and
@@ -134,6 +134,15 @@ and vof_xml_body =
   | XmlExpr v1 -> let v1 = vof_expr v1 in OCaml.VSum ("XmlExpr", [ v1 ])
   | XmlXml v1 -> let v1 = vof_xml v1 in OCaml.VSum ("XmlXml", [ v1 ])
 
+and vof_name = function
+  | Id (v1, v2) ->
+      let v1 = vof_ident v1
+      and v2 = vof_id_info v2
+      in OCaml.VSum ("Id", [ v1; v2 ])
+  | IdQualified (v1, v2) ->
+      let v1 = vof_name_ v1
+      and v2 = vof_id_info v2
+      in OCaml.VSum ("IdQualified", [ v1; v2 ])
 
 and vof_expr =
   function
@@ -163,14 +172,7 @@ and vof_expr =
   | AnonClass v1 ->
       let v1 = vof_class_definition v1
       in OCaml.VSum ("AnonClass", [ v1 ])
-  | Id (v1, v2) ->
-      let v1 = vof_ident v1
-      and v2 = vof_id_info v2
-      in OCaml.VSum ("Id", [ v1; v2 ])
-  | IdQualified (v1, v2) ->
-      let v1 = vof_name v1
-      and v2 = vof_id_info v2
-      in OCaml.VSum ("IdQualified", [ v1; v2 ])
+  | N v1 -> let v1 = vof_name v1 in OCaml.VSum ("N", [v1])
   | IdSpecial v1 ->
       let v1 = vof_wrap vof_special v1 in OCaml.VSum ("IdSpecial", [ v1 ])
   | Call (v1, v2) ->
@@ -253,7 +255,7 @@ and vof_ident_or_dynamic = function
       let v1 = vof_ident v1 in
       let v2 = vof_id_info v2 in
       OCaml.VSum ("EId", [v1; v2])
-  | EName v1 -> let v1 = vof_name v1 in OCaml.VSum ("EName", [v1])
+  | EName v1 -> let v1 = vof_name_ v1 in OCaml.VSum ("EName", [v1])
   | EDynamic v1 -> let v1 = vof_expr v1 in OCaml.VSum ("EDynamic", [v1])
 
 and vof_literal =
@@ -486,7 +488,7 @@ and vof_type_ =
       let v2 = vof_id_info v2 in
       OCaml.VSum ("TyId", [ v1; v2 ])
   | TyIdQualified (v1, v2) ->
-      let v1 = vof_name v1 in
+      let v1 = vof_name_ v1 in
       let v2 = vof_id_info v2 in
       OCaml.VSum ("TyIdQualified", [ v1; v2 ])
   | TyVar v1 -> let v1 = vof_ident v1 in OCaml.VSum ("TyVar", [ v1 ])
@@ -1221,7 +1223,6 @@ and vof_any =
   | Partial v1 -> let v1 = vof_partial v1 in OCaml.VSum ("Partial", [ v1 ])
   | TodoK v1 -> let v1 = vof_ident v1 in OCaml.VSum ("TodoK", [ v1 ])
   | Tk v1 -> let v1 = vof_tok v1 in OCaml.VSum ("Tk", [ v1 ])
-  | N v1 -> let v1 = vof_name v1 in OCaml.VSum ("N", [ v1 ])
   | Modn v1 -> let v1 = vof_module_name v1 in OCaml.VSum ("Modn", [ v1 ])
   | ModDk v1 -> let v1 = vof_module_definition_kind v1 in OCaml.VSum ("ModDk", [ v1 ])
   | En v1 -> let v1 = vof_entity v1 in OCaml.VSum ("En", [ v1 ])

--- a/semgrep-core/Core/AST/Visitor_AST.ml
+++ b/semgrep-core/Core/AST/Visitor_AST.ml
@@ -230,7 +230,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | Tuple v1 -> let v1 = v_bracket (v_list v_expr) v1 in ()
       | Record v1 -> let v1 = v_bracket (v_list v_field) v1 in ()
       | Constructor (v1, v2) ->
-          let v1 = v_name v1 and v2 = v_list v_expr v2 in ()
+          let v1 = v_dotted_ident v1 and v2 = v_list v_expr v2 in ()
       | Lambda v1 -> let v1 = v_function_definition v1 in ()
       | AnonClass v1 -> let v1 = v_class_definition v1 in ()
       | Xml v1 -> let v1 = v_xml v1 in ()
@@ -373,7 +373,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | TyFun (v1, v2) -> let v1 = v_list v_parameter v1 and
         v2 = v_type_ v2 in ()
       | TyNameApply (v1, v2) ->
-          let v1 = v_name v1 and v2 = v_type_arguments v2 in ()
+          let v1 = v_dotted_ident v1 and v2 = v_type_arguments v2 in ()
       | TyId (v1, v2) ->
           let v1 = v_ident v1 in v_id_info v2
       | TyIdQualified (v1, v2) ->
@@ -594,7 +594,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | PatRecord v1 ->
           let v1 =
             v_bracket (v_list
-                         (fun (v1, v2) -> let v1 = v_name v1 and v2 = v_pattern v2 in ()))
+                         (fun (v1, v2) -> let v1 = v_dotted_ident v1 and v2 = v_pattern v2 in ()))
               v1
           in ()
       | PatId (v1, v2) -> let v1 = v_ident v1 and v2 = v_id_info v2 in ()
@@ -608,7 +608,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | PatLiteral v1 -> let v1 = v_literal v1 in ()
       | PatType v1 -> let v1 = v_type_ v1 in ()
       | PatConstructor (v1, v2) ->
-          let v1 = v_name v1 and v2 = v_list v_pattern v2 in ()
+          let v1 = v_dotted_ident v1 and v2 = v_list v_pattern v2 in ()
       | PatTuple (_, v1, _) -> let v1 = v_list v_pattern v1 in ()
       | PatList v1 -> let v1 = v_bracket (v_list v_pattern) v1 in ()
       | PatKeyVal (v1, v2) -> let v1 = v_pattern v1 and v2 = v_pattern v2 in ()
@@ -857,7 +857,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     let arg = v_module_definition_kind v_mbody in ()
   and v_module_definition_kind =
     function
-    | ModuleAlias v1 -> let v1 = v_name v1 in ()
+    | ModuleAlias v1 -> let v1 = v_dotted_ident v1 in ()
     | ModuleStruct (v1, v2) ->
         let v1 = v_option v_dotted_ident v1 and v2 = v_stmts v2 in ()
     | OtherModule (v1, v2) ->

--- a/semgrep-core/Core/AST/Visitor_AST.ml
+++ b/semgrep-core/Core/AST/Visitor_AST.ml
@@ -40,7 +40,7 @@ type visitor_in = {
 
   kparam: (parameter  -> unit) * visitor_out -> parameter  -> unit;
   kident: (ident -> unit)  * visitor_out -> ident  -> unit;
-  kname: (name -> unit)  * visitor_out -> name  -> unit;
+  kname: (name_ -> unit)  * visitor_out -> name_  -> unit;
   kentity: (entity -> unit)  * visitor_out -> entity  -> unit;
 
   kfunction_definition: (function_definition -> unit) * visitor_out ->

--- a/semgrep-core/Core/AST/Visitor_AST.ml
+++ b/semgrep-core/Core/AST/Visitor_AST.ml
@@ -162,7 +162,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | TypeName -> ()
 
 
-  and v_name x =
+  and v_name_ x =
     let k x =
       let (v1, v2) = x in
       let v1 = v_ident v1
@@ -215,6 +215,9 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
          * against nested XmlXml elements *)
         v_expr (Xml v1)
 
+  and v_name = function
+    | Id (v1, v2) -> let v1 = v_ident v1 and v2 = v_id_info v2 in ()
+    | IdQualified (v1, v2) -> let v1 = v_name_ v1 and v2 = v_id_info v2 in ()
 
   and v_expr x =
     let k x =
@@ -234,8 +237,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | Lambda v1 -> let v1 = v_function_definition v1 in ()
       | AnonClass v1 -> let v1 = v_class_definition v1 in ()
       | Xml v1 -> let v1 = v_xml v1 in ()
-      | Id (v1, v2) -> let v1 = v_ident v1 and v2 = v_id_info v2 in ()
-      | IdQualified (v1, v2) -> let v1 = v_name v1 and v2 = v_id_info v2 in ()
+      | N v1 -> v_name v1
       | IdSpecial v1 -> let v1 = v_wrap v_special v1 in ()
       | Call (v1, v2) -> let v1 = v_expr v1 and v2 = v_arguments v2 in ()
       | Assign (v1, v2, v3) ->
@@ -287,7 +289,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
 
   and v_ident_or_dynamic = function
     | EId (id, idinfo) -> v_ident id; v_id_info idinfo
-    | EName n -> v_name n
+    | EName n -> v_name_ n
     | EDynamic e -> v_expr e
 
   and v_literal =
@@ -377,7 +379,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | TyId (v1, v2) ->
           let v1 = v_ident v1 in v_id_info v2
       | TyIdQualified (v1, v2) ->
-          let v1 = v_name v1 in v_id_info v2
+          let v1 = v_name_ v1 in v_id_info v2
       | TyVar v1 -> let v1 = v_ident v1 in ()
       | TyAny v1 -> let v1 = v_tok v1 in ()
       | TyArray (v1, v2) ->
@@ -909,7 +911,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | Args v1 -> v_list v_argument v1
     | Partial v1 -> v_partial ~recurse:true v1
     | TodoK v1 -> v_ident v1
-    | N v1 -> let v1 = v_name v1 in ()
     | Modn v1 -> let v1 = v_module_name v1 in ()
     | ModDk v1 -> let v1 = v_module_definition_kind v1 in ()
     | En v1 -> let v1 = v_entity v1 in ()

--- a/semgrep-core/Core/AST/Visitor_AST.mli
+++ b/semgrep-core/Core/AST/Visitor_AST.mli
@@ -19,7 +19,7 @@ type visitor_in = {
 
   kparam: (parameter  -> unit) * visitor_out -> parameter  -> unit;
   kident: (ident -> unit)  * visitor_out -> ident  -> unit;
-  kname: (name -> unit)  * visitor_out -> name  -> unit;
+  kname: (name_ -> unit)  * visitor_out -> name_  -> unit;
   kentity: (entity -> unit)  * visitor_out -> entity  -> unit;
 
   kfunction_definition: (function_definition -> unit) * visitor_out ->

--- a/semgrep-core/Core/Metavariable.ml
+++ b/semgrep-core/Core/Metavariable.ml
@@ -73,8 +73,8 @@ let mvalue_to_any = function
    * it can be used to check if two metavars are equal and have the same
    * sid (single unique id).
   *)
-  | Id (id, Some idinfo) -> G.E (G.Id (id, idinfo))
-  | Id (id, None) -> G.E (G.Id (id, G.empty_id_info()))
+  | Id (id, Some idinfo) -> G.E (G.N (G.Id (id, idinfo)))
+  | Id (id, None) -> G.E (G.N (G.Id (id, G.empty_id_info())))
   | Ss x -> G.Ss x
   | Args x -> G.Args x
   | T x -> G.T x

--- a/semgrep-core/Engine/Eval_generic.ml
+++ b/semgrep-core/Engine/Eval_generic.ml
@@ -148,7 +148,7 @@ let rec eval env code =
       )
 
   (* less: sanity check that s is a metavar_name? *)
-  | G.Id ((s, _t), _idinfo) ->
+  | G.N (G.Id ((s, _t), _idinfo)) ->
       (try Hashtbl.find env s
        with Not_found ->
          logger#debug "could not find a value for %s in env" s;
@@ -173,7 +173,7 @@ let rec eval env code =
        | _ -> Bool (false)
       )
   (* Emulate Python re.match just enough *)
-  | G.Call (G.DotAccess(G.Id (("re", _), _), _, EId ((("match"),_),_)),
+  | G.Call (G.DotAccess(G.N (G.Id (("re", _), _)), _, EId ((("match"),_),_)),
             (_, [G.Arg e1; G.Arg (G.L (G.String (re, _)))], _)) ->
       (* alt: take the text range of the metavariable in the original file,
        * and enforce e1 can only be an Id metavariable.

--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -246,8 +246,8 @@ let filter_ranges xs cond =
            * but too many possible escaping problems, so easier to build
            * an expression manually.
           *)
-          G.Call (G.DotAccess(G.Id (("re", fk), fki), fk, EId ((("match"),fk),fki)),
-                  (fk, [G.Arg (G.Id ((mvar, fk), fki));
+          G.Call (G.DotAccess(G.N (G.Id (("re", fk), fki)), fk, EId ((("match"),fk),fki)),
+                  (fk, [G.Arg (G.N (G.Id ((mvar, fk), fki)));
                         G.Arg (G.L (G.String (re_str, fk)))], fk))
 
         in

--- a/semgrep-core/Matching/Apply_equivalences.ml
+++ b/semgrep-core/Matching/Apply_equivalences.ml
@@ -49,11 +49,11 @@ let subst_e (env : MV.Env.t) e =
       { M.default_visitor with
         M.kexpr = (fun (k, _) x ->
           match x with
-          | Id ((str,_tok), _id_info) when MV.is_metavar_name str ->
+          | N (Id ((str,_tok), _id_info)) when MV.is_metavar_name str ->
               (match List.assoc_opt str bindings with
                | Some (MV.Id (id, Some idinfo)) ->
                    (* less: abstract-line? *)
-                   Id (id, idinfo)
+                   N (Id (id, idinfo))
                | Some (MV.E e) ->
                    (* less: abstract-line? *)
                    e

--- a/semgrep-core/Matching/Generic_vs_generic.ml
+++ b/semgrep-core/Matching/Generic_vs_generic.ml
@@ -211,7 +211,7 @@ let make_dotted xs =
   match xs with
   | [] -> raise Impossible
   | x::xs ->
-      let base = B.Id (x, B.empty_id_info()) in
+      let base = B.N (B.Id (x, B.empty_id_info())) in
       List.fold_left (fun acc e ->
         let tok = Parse_info.fake_info "." in
         B.DotAccess (acc, tok, B.EId (e, B.empty_id_info()))) base xs
@@ -331,7 +331,7 @@ let _m_resolved_name (a1, a2) (b1, b2) =
 
 (* start of recursive need *)
 (*s: function [[Generic_vs_generic.m_name]] *)
-let rec m_name a b =
+let rec m_name_ a b =
   match a,b with
   | (a1, a2), (b1, b2) ->
       m_ident a1 b1 >>= (fun () ->
@@ -474,22 +474,22 @@ and m_expr a b =
   (*e: [[Generic_vs_generic.m_expr()]] disjunction case *)
   (*s: [[Generic_vs_generic.m_expr()]] resolving alias case *)
   (* equivalence: name resolving! *)
-  | a,   B.Id (idb, { B.id_resolved =
-                        {contents = Some ( ( B.ImportedEntity dotted
-                                           | B.ImportedModule (B.DottedName dotted)
-                                           ), _sid)}; _}) ->
+  | a,   B.N (B.Id (idb, { B.id_resolved =
+                             {contents = Some ( ( B.ImportedEntity dotted
+                                                | B.ImportedModule (B.DottedName dotted)
+                                                ), _sid)}; _})) ->
       (* We used to force to fully qualify entities in the pattern
        * (e.g., with org.foo(...)) but this is confusing for users.
        * We now allow an unqualified pattern like 'foo' to match resolved
        * entities like import org.foo; foo(), just like for attributes.
       *)
-      m_expr a (B.Id (idb, B.empty_id_info()))
+      m_expr a (B.N (B.Id (idb, B.empty_id_info())))
       >||>
       (* try this time a match with the resolved entity *)
       m_expr a (make_dotted dotted)
   (* Put this before the next case to prevent overly eager dealiasing *)
-  | A.IdQualified(a1, a2), B.IdQualified(b1, b2) ->
-      m_name a1 b1 >>= (fun () ->
+  | A.N (A.IdQualified(a1, a2)), B.N (B.IdQualified(b1, b2)) ->
+      m_name_ a1 b1 >>= (fun () ->
         m_id_info a2 b2
       )
   (* Matches pattern
@@ -498,7 +498,7 @@ and m_expr a b =
    *   import a.b.C
    *   C.x
   *)
-  | A.IdQualified ((alabel, { A.name_qualifier = Some(A.QDots names); _ }), _id_info), b ->
+  | A.N (A.IdQualified ((alabel, { A.name_qualifier = Some(A.QDots names); _ }), _id_info)), b ->
       let full = names @ [alabel] in
       m_expr (make_dotted full) b
   (*e: [[Generic_vs_generic.m_expr()]] resolving alias case *)
@@ -510,7 +510,7 @@ and m_expr a b =
    * bugfix: note that we must forbid that only in a Call context; we want
    * $THIS to match IdSpecial (This) for example.
   *)
-  | A.Call (A.Id ((str,_tok), _id_info), _argsa),
+  | A.Call (A.N (A.Id ((str,_tok), _id_info)), _argsa),
     B.Call (B.IdSpecial _, _argsb)
     when MV.is_metavar_name str ->
       fail ()
@@ -518,13 +518,13 @@ and m_expr a b =
   (* Matching a generic Id metavariable to an IdSpecial will fail as it is missing the token
    * info; instead the Id should match Call(IdSpecial _, _)
   *)
-  | A.Id ((str, _), _), B.IdSpecial (B.ConcatString _, _) when MV.is_metavar_name str ->
+  | A.N (A.Id ((str, _), _)), B.IdSpecial (B.ConcatString _, _) when MV.is_metavar_name str ->
       fail ()
   (*e: [[Generic_vs_generic.m_expr()]] forbidden metavariable case *)
-  | A.Id ((str,tok), _id_info), B.Id (idb, id_infob)
+  | A.N (A.Id ((str,tok), _id_info)), B.N (B.Id (idb, id_infob))
     when MV.is_metavar_name str ->
       envf (str, tok) (MV.Id (idb, Some id_infob))
-  | A.Id ((str,tok), _id_info), e2
+  | A.N (A.Id ((str,tok), _id_info)), e2
     when MV.is_metavar_name str ->
       envf (str, tok) (MV.E (e2))
   (*e: [[Generic_vs_generic.m_expr()]] metavariable case *)
@@ -611,7 +611,7 @@ and m_expr a b =
         ))
 
   (* boilerplate *)
-  | A.Id(a1, a2), B.Id(b1, b2) ->
+  | A.N (A.Id(a1, a2)), B.N (B.Id(b1, b2)) ->
       m_ident a1 b1 >>= (fun () ->
         m_id_info a2 b2 )
 
@@ -758,7 +758,7 @@ and m_expr a b =
       )
   | A.Container _, _  | A.Tuple _, _  | A.Record _, _
   | A.Constructor _, _  | A.Lambda _, _  | A.AnonClass _, _
-  | A.Id _, _  | A.IdQualified _, _ | A.IdSpecial _, _
+  | A.N _, _ | A.IdSpecial _, _
   | A.Call _, _  | A.Xml _, _
   | A.Assign _, _  | A.AssignOp _, _  | A.LetPattern _, _  | A.DotAccess _, _
   | A.ArrayAccess _, _  | A.Conditional _, _  | A.MatchPattern _, _
@@ -790,7 +790,7 @@ and m_ident_or_dynamic a b =
   (* boilerplate *)
   (*s: [[Generic_vs_generic.m_field_ident()]] boilerplate cases *)
   | A.EName a, B.EName b ->
-      m_name a b
+      m_name_ a b
   | A.EDynamic a, B.EDynamic b ->
       m_expr a b
   | A.EId _, _
@@ -1060,11 +1060,11 @@ and m_bodies a b =
 and m_compatible_type typed_mvar t e =
   match t, e with
   (* for Python literal checking *)
-  | A.OtherType (A.OT_Expr, [A.E (A.Id (("int", _tok), _idinfo))]),
+  | A.OtherType (A.OT_Expr, [A.E (A.N (A.Id (("int", _tok), _idinfo)))]),
     B.L (B.Int _) -> envf typed_mvar (MV.E e)
-  | A.OtherType (A.OT_Expr, [A.E (A.Id (("float", _tok), _idinfo))]),
+  | A.OtherType (A.OT_Expr, [A.E (A.N (A.Id (("float", _tok), _idinfo)))]),
     B.L (B.Float _) -> envf typed_mvar (MV.E e)
-  | A.OtherType (A.OT_Expr, [A.E (A.Id (("str", _tok), _idinfo))]),
+  | A.OtherType (A.OT_Expr, [A.E (A.N (A.Id (("str", _tok), _idinfo)))]),
     B.L (B.String _) -> envf typed_mvar (MV.E e)
   (* for java literals *)
   | A.TyBuiltin (("int", _)),  B.L (B.Int _) -> envf typed_mvar (MV.E e)
@@ -1083,8 +1083,8 @@ and m_compatible_type typed_mvar t e =
       m_type_ t (A.TyPointer (t1, TyBuiltin(("char", tok)))) >>=
       (fun () -> envf typed_mvar (MV.E e))
   (* for matching ids *)
-  | ta, ( B.Id (idb, {B.id_type=tb; _})
-        | B.IdQualified ((idb, _), {B.id_type=tb;_})
+  | ta, ( B.N (B.Id (idb, {B.id_type=tb; _}))
+        | B.N (B.IdQualified ((idb, _), {B.id_type=tb;_}))
         | B.DotAccess (IdSpecial (This, _), _, EId (idb, {B.id_type=tb; _}))
         ) ->
       m_type_option_with_hook idb (Some ta) !tb >>=
@@ -1162,7 +1162,7 @@ and m_list__m_argument (xsa: A.argument list) (xsb: A.argument list) =
   | [A.Arg (A.Ellipsis _i)], [] ->
       return ()
 
-  | A.Arg (A.Id ((s, tok), _idinfo))::xsa, xb::xsb
+  | A.Arg (A.N (A.Id ((s, tok), _idinfo)))::xsa, xb::xsb
     when MV.is_metavar_ellipsis s ->
       (* can match 1 or more arguments (or 0 is ok too?) *)
       let candidates = inits_and_rest_of_list (xb::xsb) in
@@ -1336,7 +1336,7 @@ and m_type_ a b =
   | A.TyAny(a1), B.TyAny(b1) ->
       m_tok a1 b1
   | A.TyIdQualified(a1, a2), B.TyIdQualified(b1, b2) ->
-      let* () = m_name a1 b1 in
+      let* () = m_name_ a1 b1 in
       m_id_info a2 b2
   | A.TyNameApply(a1, a2), B.TyNameApply(b1, b2) ->
       m_dotted_name a1 b1 >>= (fun () ->
@@ -1670,7 +1670,7 @@ and m_stmt a b =
   (*e: [[Generic_vs_generic.m_stmt()]] disjunction case *)
   (*s: [[Generic_vs_generic.m_stmt()]] metavariable case *)
   (* metavar: *)
-  | A.ExprStmt(A.Id ((str,tok), _id_info), _), _b
+  | A.ExprStmt(A.N (A.Id ((str,tok), _id_info)), _), _b
     when MV.is_metavar_name str ->
       envf (str, tok) (MV.S b)
   (*e: [[Generic_vs_generic.m_stmt()]] metavariable case *)
@@ -2656,8 +2656,6 @@ and m_any a b =
       m_list m_argument a1 b1
 
   (* boilerplate *)
-  | A.N(a1), B.N(b1) ->
-      m_name a1 b1
   | A.Modn(a1), B.Modn(b1) ->
       m_module_name a1 b1
   | A.ModDk(a1), B.ModDk(b1) ->
@@ -2696,7 +2694,7 @@ and m_any a b =
       m_label_ident a1 b1
   | A.IoD(a1), B.IoD(b1) ->
       m_ident_or_dynamic a1 b1
-  | A.I _, _  | A.N _, _  | A.Modn _, _ | A.Di _, _  | A.En _, _  | A.E _, _
+  | A.I _, _  | A.Modn _, _ | A.Di _, _  | A.En _, _  | A.E _, _
   | A.S _, _  | A.T _, _  | A.P _, _  | A.Def _, _  | A.Dir _, _
   | A.Pa _, _  | A.Ar _, _  | A.At _, _  | A.Dk _, _ | A.Pr _, _
   | A.Fld _, _ | A.Ss _, _ | A.Tk _, _ | A.Lbli _, _ | A.IoD _, _

--- a/semgrep-core/Matching/Generic_vs_generic.ml
+++ b/semgrep-core/Matching/Generic_vs_generic.ml
@@ -677,7 +677,7 @@ and m_expr a b =
   | A.Record(a1), B.Record(b1) ->
       (m_bracket (m_fields)) a1 b1
   | A.Constructor(a1, a2), B.Constructor(b1, b2) ->
-      m_name a1 b1 >>= (fun () ->
+      m_dotted_name a1 b1 >>= (fun () ->
         (m_list m_expr) a2 b2
       )
   | A.Lambda(a1), B.Lambda(b1) ->
@@ -1339,7 +1339,7 @@ and m_type_ a b =
       let* () = m_name a1 b1 in
       m_id_info a2 b2
   | A.TyNameApply(a1, a2), B.TyNameApply(b1, b2) ->
-      m_name a1 b1 >>= (fun () ->
+      m_dotted_name a1 b1 >>= (fun () ->
         m_type_arguments a2 b2
       )
   | A.TyVar(a1), B.TyVar(b1) ->
@@ -1963,7 +1963,7 @@ and m_pattern a b =
   | A.PatType(a1), B.PatType(b1) ->
       m_type_ a1 b1
   | A.PatConstructor(a1, a2), B.PatConstructor(b1, b2) ->
-      m_name a1 b1 >>= (fun () ->
+      m_dotted_name a1 b1 >>= (fun () ->
         (m_list m_pattern) a2 b2
       )
   | A.PatTuple(a1), B.PatTuple(b1) ->
@@ -2014,7 +2014,7 @@ and m_pattern a b =
 and m_field_pattern a b =
   match a, b with
   | (a1, a2), (b1, b2) ->
-      m_name a1 b1 >>= (fun () ->
+      m_dotted_name a1 b1 >>= (fun () ->
         m_pattern a2 b2
       )
 (*e: function [[Generic_vs_generic.m_field_pattern]] *)
@@ -2484,7 +2484,7 @@ and m_module_definition a b =
 and m_module_definition_kind a b =
   match a, b with
   | A.ModuleAlias(a1), B.ModuleAlias(b1) ->
-      m_name a1 b1
+      m_dotted_name a1 b1
   | A.ModuleStruct(a1, a2), B.ModuleStruct(b1, b2) ->
       (m_option m_dotted_name) a1 b1 >>= (fun () ->
         (m_list m_item) a2 b2

--- a/semgrep-core/Matching/Matching_generic.ml
+++ b/semgrep-core/Matching/Matching_generic.ml
@@ -265,7 +265,7 @@ let rec equal_ast_binded_code (a: MV.mvalue) (b: MV.mvalue) : bool = (
          * - id_constness (see the special @equal for id_constness)
         *)
         MV.Structural.equal_mvalue a b
-    | MV.Id _, MV.E (A.Id (b_id, b_id_info)) ->
+    | MV.Id _, MV.E (A.N (A.Id (b_id, b_id_info))) ->
         (* TODO still needed now that we have the better MV.Id of id_info? *)
         (* TOFIX: regression if remove this code *)
         (* Allow identifier nodes to match pure identifier expressions *)

--- a/semgrep-core/Matching/Normalize_generic.ml
+++ b/semgrep-core/Matching/Normalize_generic.ml
@@ -81,7 +81,7 @@ let normalize_import_opt is_pattern i =
 let rec eval x :constness option =
   match x with
   | L x -> Some (Lit x)
-  | Id (_, { id_constness = {contents = Some x}; _})
+  | N (Id (_, { id_constness = {contents = Some x}; _}))
   | DotAccess (IdSpecial (This, _), _, EId (_, {id_constness = {contents = Some x}; _})) ->
       Some x
 

--- a/semgrep-core/Matching/SubAST_generic.ml
+++ b/semgrep-core/Matching/SubAST_generic.ml
@@ -35,7 +35,7 @@ module V = Visitor_AST
 let subexprs_of_expr e =
   match e with
   | L _
-  | Id _ | IdQualified _  | IdSpecial _
+  | N _  | IdSpecial _
   | Ellipsis _ | TypedMetavar _
     -> []
 

--- a/semgrep-core/Parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/Python_to_generic.ml
@@ -190,7 +190,7 @@ let rec expr (x: expr) =
       and _v2TODO = expr_context v2
       and v3 = vref resolved_name v3
       in
-      G.Id (v1 ,{ (G.empty_id_info ()) with G.id_resolved = v3 })
+      G.N (G.Id (v1 ,{ (G.empty_id_info ()) with G.id_resolved = v3 }))
 
   | Tuple (CompList v1, v2) ->
       let v1 = bracket (list expr) v1
@@ -511,7 +511,7 @@ and list_stmt1 xs =
    * in which case we remove the G.Block around it.
    * hacky ...
   *)
-  | [{G.s=G.ExprStmt (G.Id ((s, _), _), _);_} as x]
+  | [{G.s=G.ExprStmt (G.N (G.Id ((s, _), _)), _);_} as x]
     when AST_generic_.is_metavar_name s
     -> x
   | xs -> G.Block (fb xs) |> G.s

--- a/semgrep-core/Parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/c_to_generic.ml
@@ -168,11 +168,11 @@ and expr =
       G.Call (G.IdSpecial (G.ConcatString (G.SequenceConcat), fake " "),
               fb (xs |> List.map (fun x -> G.Arg (G.L (G.String x)))))
   | Defined (t, id) ->
-      let e = G.Id (id, G.empty_id_info()) in
+      let e = G.N (G.Id (id, G.empty_id_info())) in
       G.Call (G.IdSpecial (G.Defined, t), fb [G.Arg e])
 
   | Id v1 -> let v1 = name v1 in
-      G.Id (v1, G.empty_id_info())
+      G.N (G.Id (v1, G.empty_id_info()))
   | Ellipses v1 -> let v1 = info v1 in G.Ellipsis v1
   | DeepEllipsis v1 -> let v1 = bracket (expr) v1 in G.DeepEllipsis v1
   | Call (v1, v2) -> let v1 = expr v1 and v2 = bracket (list argument) v2 in

--- a/semgrep-core/Parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/c_to_generic.ml
@@ -129,9 +129,11 @@ let rec type_ =
       let v1 = name v1 in
       G.TyId (v1, G.empty_id_info())
   | TMacroApply (v1, (_lp, v2, _rp)) ->
-      let v1 = name v1 in
+      let v1 = dotted_ident_of_id v1 in
       let v2 = type_ v2 in
-      G.TyNameApply((v1, G.empty_name_info), [G.TypeArg v2])
+      G.TyNameApply(v1, [G.TypeArg v2])
+
+and dotted_ident_of_id id = [id]
 
 and function_type (v1, v2) =
   let v1 = type_ v1 and

--- a/semgrep-core/Parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/go_to_generic.ml
@@ -180,7 +180,7 @@ let top_func () =
     | EmbeddedField (v1, v2) ->
         let _v1TODO = option tok v1 and v2 = qualified_ident v2 in
         let name = name_of_qualified_ident v2 in
-        G.FieldSpread (fake "...", G.IdQualified (name, G.empty_id_info()))
+        G.FieldSpread (fake "...", G.N (G.IdQualified (name, G.empty_id_info())))
     | FieldEllipsis t ->
         G.fieldEllipsis t
 
@@ -197,7 +197,7 @@ let top_func () =
                                                G.empty_fbody))))
     | EmbeddedInterface v1 -> let v1 = qualified_ident v1 in
         let name = name_of_qualified_ident v1 in
-        G.FieldSpread (fake "...", G.IdQualified (name, G.empty_id_info()))
+        G.FieldSpread (fake "...", G.N (G.IdQualified (name, G.empty_id_info())))
     | FieldEllipsis2 t ->
         G.fieldEllipsis t
 
@@ -210,11 +210,11 @@ let top_func () =
     | BasicLit v1 -> let v1 = literal v1 in
         G.L v1
     | Id (v1) -> let v1 = ident v1 in
-        G.Id (v1,
-              (* we share the resolved_name ref! so any naming done on the
-               * generic AST will have a (wanted) side effect on the Go AST *)
-              (*{ (G.empty_id_info()) with G.id_resolved = vref; }) *)
-              G.empty_id_info())
+        G.N (G.Id (v1,
+                   (* we share the resolved_name ref! so any naming done on the
+                    * generic AST will have a (wanted) side effect on the Go AST *)
+                   (*{ (G.empty_id_info()) with G.id_resolved = vref; }) *)
+                   G.empty_id_info()))
     | Selector (v1, v2, v3) ->
         let v1 = expr v1 and v2 = tok v2 and v3 = ident v3 in
         G.DotAccess (v1, v2, G.EId (v3, G.empty_id_info()))

--- a/semgrep-core/Parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/go_to_generic.ml
@@ -50,7 +50,7 @@ let name_of_qualified_ident = function
 let fake s = Parse_info.fake_info s
 let fake_id s = (s, fake s)
 let fb = G.fake_bracket
-let mk_name s tok = (s, tok), G.empty_name_info
+let mk_dotted_ident s tok = [(s, tok)]
 
 let ii_of_any = Lib_parsing_go.ii_of_any
 
@@ -131,9 +131,9 @@ let top_func () =
         in
         G.TyFun (params, ret)
     | TMap ((t, (_, v1, _), v2)) -> let v1 = type_ v1 and v2 = type_ v2 in
-        G.TyNameApply (mk_name "map" t, [G.TypeArg v1; G.TypeArg v2])
+        G.TyNameApply (mk_dotted_ident "map" t, [G.TypeArg v1; G.TypeArg v2])
     | TChan (t, v1, v2) -> let v1 = chan_dir v1 and v2 = type_ v2 in
-        G.TyNameApply (mk_name "chan" t, [G.TypeArg v1; G.TypeArg v2])
+        G.TyNameApply (mk_dotted_ident "chan" t, [G.TypeArg v1; G.TypeArg v2])
 
     | TStruct (t, v1) -> let v1 = bracket (list struct_field) v1 in
         G.TyRecordAnon (t, v1)

--- a/semgrep-core/Parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/java_to_generic.ml
@@ -209,7 +209,7 @@ and expr e =
       G.DotAccessEllipsis (v1, v2)
   | Ellipsis v1 -> let v1 = tok v1 in G.Ellipsis v1
   | DeepEllipsis v1 -> let v1 = bracket expr v1 in G.DeepEllipsis v1
-  | Name v1 -> name v1
+  | Name v1 -> G.N (name v1)
   | NameOrClassType _v1 ->
       let ii = Lib_parsing_java.ii_of_any (AExpr e) in
       error (List.hd ii)

--- a/semgrep-core/Parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/js_to_generic.ml
@@ -192,7 +192,7 @@ and expr (x: expr) =
   | L x -> G.L (literal x)
   | Id v1 ->
       let v1 = name v1 in
-      G.Id (v1, G.empty_id_info())
+      G.N (G.Id (v1, G.empty_id_info()))
 
   | IdSpecial v1 ->
       let x = special v1 in

--- a/semgrep-core/Parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/php_to_generic.ml
@@ -244,15 +244,15 @@ and expr =
       G.L (G.Float v1)
   | String v1 -> let v1 = wrap string v1 in
       G.L (G.String v1)
-  | Id [v1] -> G.Id (v1, G.empty_id_info())
+  | Id [v1] -> G.N (G.Id (v1, G.empty_id_info()))
   | Id v1 -> let v1 = name_of_qualified_ident v1 in
-      G.IdQualified (v1, G.empty_id_info ())
+      G.N (G.IdQualified (v1, G.empty_id_info ()))
   | IdSpecial v1 ->
       let v1 = wrap special v1 in
       G.IdSpecial v1
   (* unify Id and Var, finally *)
   | Var v1 -> let v1 = var v1 in
-      G.Id (v1, G.empty_id_info())
+      G.N (G.Id (v1, G.empty_id_info()))
   | Array_get ((v1, (t1, Some v2, t2))) ->
       let v1 = expr v1 and v2 = expr v2 in
       G.ArrayAccess (v1, (t1, v2, t2))

--- a/semgrep-core/Parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/ruby_to_generic.ml
@@ -71,10 +71,10 @@ let rec expr = function
       (match kind with
        | ID_Self -> G.IdSpecial (G.Self, (snd id))
        | ID_Super -> G.IdSpecial (G.Super, (snd id))
-       | _ -> G.Id (ident id, G.empty_id_info())
+       | _ -> G.N (G.Id (ident id, G.empty_id_info()))
       )
   | ScopedId x -> let name = scope_resolution x in
-      G.IdQualified (name, G.empty_id_info())
+      G.N (G.IdQualified (name, G.empty_id_info()))
   | Hash (_bool, xs) -> G.Container (G.Dict, bracket (list expr) xs)
   | Array xs -> G.Container (G.Array, bracket (list expr) xs)
   | Tuple xs -> G.Tuple (G.fake_bracket (list expr xs))
@@ -640,7 +640,7 @@ and list_stmt1 xs =
    * in which case we remove the G.Block around it.
    * hacky ...
   *)
-  | [{G.s=G.ExprStmt (G.Id ((s, _), _), _);_} as x]
+  | [{G.s=G.ExprStmt (G.N (G.Id ((s, _), _)), _);_} as x]
     when AST_generic_.is_metavar_name s
     -> x
   | xs -> G.Block (fb xs) |> G.s

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -114,7 +114,7 @@ let create_join_result_lambda lambda_params ident =
   let p1 = param_from_lambda_params lambda_params in
   let p2 = ParamClassic (param_of_id ident) in
   let fparams = [p1; p2] in
-  let ids = lambda_params @ [ident] |> List.map (fun id -> Id (id, empty_id_info ())) in
+  let ids = lambda_params @ [ident] |> List.map (fun id -> N (Id (id, empty_id_info ()))) in
   let expr = Tuple (fake_bracket ids) in
   Lambda {
     fkind = (Arrow, fake "=>");
@@ -150,7 +150,7 @@ let rec linq_remainder_to_expr (query : linq_query_part list) (base_expr : expr)
            (* base_expr.Select(lambda_params -> (lambda_params..., expr))
             * and add ident to lambda_params
            *)
-           let ids = List.map (fun id -> Id (id, empty_id_info ())) lambda_params in
+           let ids = List.map (fun id -> N (Id (id, empty_id_info ()))) lambda_params in
            let expr = Tuple (fake_bracket (ids @ [expr])) in
            let func = create_lambda lambda_params expr in
            let base_expr = call_lambda base_expr "Select" tok [func] in
@@ -1109,10 +1109,10 @@ and expression (env : env) (x : CST.expression) : AST.expr =
               let id = (match _x with
                 | TyBuiltin sw -> sw
                 | _ -> raise Impossible) in
-              Id (id, empty_id_info ()) (* TODO should this be IdQualified? *)
+              N (Id (id, empty_id_info ())) (* TODO should this be IdQualified? *)
           | `Name x ->
               let n = name env x in
-              H2.id_of_name n
+              H2.id_of_name_ n
          )
        in
        let v2 =
@@ -1247,10 +1247,10 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        let v4 = token env v4 (* ")" *) in
        Call (IdSpecial (Typeof, v1), (v2, [ArgType v3], v4))
    | `Simple_name x ->
-       H2.id_of_name (simple_name env x)
+       H2.id_of_name_ (simple_name env x)
    | `Rese_id x ->
        let x = reserved_identifier env x in
-       AST.Id (x, empty_id_info ())
+       AST.N (AST.Id (x, empty_id_info ()))
    | `Lit x ->
        let x = literal env x in
        AST.L x

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -35,7 +35,7 @@ let _fake = AST_generic.fake
 let token = H.token
 let str = H.str
 
-let ids_of_name (name : name) : dotted_ident =
+let ids_of_name (name : name_) : dotted_ident =
   let (ident, name_info) = name in
   (match name_info.name_qualifier with
    | Some(q) -> (match q with
@@ -1256,7 +1256,7 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        AST.L x
   )
 
-and simple_name (env : env) (x : CST.simple_name) : AST.name =
+and simple_name (env : env) (x : CST.simple_name) : (AST.ident * AST.name_info) =
   (match x with
    | `Gene_name (v1, v2) ->
        let v1 = identifier env v1 (* identifier *) in

--- a/semgrep-core/Parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -512,7 +512,7 @@ and binary_expression (env : env) (x : CST.binary_expression) =
    | `Infix_exp (v1, v2, v3) ->
        let v1 = expression env v1 in
        let v2 = simple_identifier env v2 in
-       let v2_id = Id (v2, empty_id_info()) in
+       let v2_id = N (Id (v2, empty_id_info())) in
        let v3 = expression env v3 in
        Call (v2_id, fb[Arg v1; Arg v3])
    | `Elvis_exp (v1, v2, v3) ->
@@ -1233,7 +1233,7 @@ and jump_expression (env : env) (x : CST.jump_expression) =
       (match id with
        | None -> Return (return_tok, v2, sc)
        | Some simple_id ->
-           let id = Id(simple_id, empty_id_info()) in
+           let id = N (Id(simple_id, empty_id_info())) in
            (match v2 with
             | None ->
                 let list = [TodoK ("todo return@", return_tok);E id] in
@@ -1362,10 +1362,10 @@ and navigation_suffix (env : env) ((v1, v2) : CST.navigation_suffix) =
   let v2 =
     (match v2 with
      | `Simple_id x -> let id = simple_identifier env x in
-         Id(id, empty_id_info())
+         G.N (Id(id, empty_id_info()))
      | `Paren_exp x -> parenthesized_expression env x
      | `Class tok -> let id = str env tok in (* "class" *)
-         Id (id, empty_id_info())
+         G.N (Id (id, empty_id_info()))
     )
   in
   v2
@@ -1446,7 +1446,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
    | `Paren_exp x -> parenthesized_expression env x
    | `Simple_id x ->
        let id = simple_identifier env x in
-       Id(id, empty_id_info())
+       G.N (Id(id, empty_id_info()))
    | `Lit_cst x -> L (literal_constant env x)
    | `Str_lit x -> L (String (string_literal env x))
    | `Call_ref (v1, v2, v3) ->
@@ -1454,10 +1454,10 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
          (match v1 with
           | Some x ->
               let id = simple_identifier env x in
-              Id(id, empty_id_info())
+              G.N (Id(id, empty_id_info()))
           | None ->
               let fake_id = ("None", fake "None") in
-              Id(fake_id, empty_id_info()))
+              G.N (Id(fake_id, empty_id_info())))
        in
        let v2 = token env v2 (* "::" *) in
        let v3 =

--- a/semgrep-core/Parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -1619,7 +1619,7 @@ and simple_user_type (env : env) ((v1, v2) : CST.simple_user_type) =
     (match v2 with
      | Some x ->
          let args = type_arguments env x in
-         let name = (v1, empty_name_info) in
+         let name = [v1] in
          TyNameApply (name, args)
      | None -> TyId (v1, empty_id_info()))
   in

--- a/semgrep-core/Parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -404,7 +404,7 @@ and map_expression (env : env) (x : CST.expression): G.expr =
    | `True tok -> G.L (G.Bool (true, token env tok)) (* "true" *)
    | `False tok -> G.L (G.Bool (false, token env tok)) (* "false" *)
    | `Id tok ->
-       ident env tok (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
+       G.N (ident env tok) (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
   )
 
 and map_field (env : env) (x : CST.field): G.expr =
@@ -422,7 +422,7 @@ and map_field (env : env) (x : CST.field): G.expr =
         in
         let v2 = token env v2 (* "=" *) in
         let v3 = map_expression env v3 in
-        (G.Id (v1, G.empty_id_info ()), v2, v3)
+        (G.N (G.Id (v1, G.empty_id_info ())), v2, v3)
     | `Exp x -> let expr = map_expression env x in
         let ident = G.IdSpecial (G.NextArrayIndex, G.fake "next_array_index") in
         (ident, G.fake "=", expr)
@@ -463,7 +463,7 @@ and map_function_call_expr (env : env) (x : CST.function_call_statement): G.expr
        let fn_name = identifier env v3 in (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
        let name = (fn_name, {G.name_qualifier = Some (G.QExpr (prefix, colon)); G.name_typeargs = None}) in
        let args = map_arguments env v4 in
-       G.Call (G.IdQualified (name, G.empty_id_info ()), args)
+       G.Call (G.N (G.IdQualified (name, G.empty_id_info ())), args)
   )
 
 
@@ -521,8 +521,8 @@ and map_loop_expression (env : env) ((v1, v2, v3, v4, v5, v6) : CST.loop_express
 
 and map_global_variable (env : env) (x: CST.global_variable) : G.expr =
   match x with
-  | `X__G t -> G.Id (("_G", token env t), G.empty_id_info())
-  | `X__VERSION t -> G.Id (("_VERSION", token env t), G.empty_id_info())
+  | `X__G t -> G.N (G.Id (("_G", token env t), G.empty_id_info()))
+  | `X__VERSION t -> G.N (G.Id (("_VERSION", token env t), G.empty_id_info()))
 
 and map_prefix (env : env) (x : CST.prefix): G.expr =
   (match x with
@@ -686,7 +686,7 @@ and map_table (env : env) ((v1, v2, v3) : CST.table): G.expr =
 and map_variable_declarator_expr (env : env) (x : CST.variable_declarator): G.expr =
   match x with
   | `Id tok ->
-      ident env tok (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
+      G.N (ident env tok) (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
   | `Prefix_LBRACK_exp_RBRACK (v1, v2, v3, v4) ->
       let v1 = map_prefix env v1 in
       let v2 = token env v2 (* "[" *) in
@@ -703,12 +703,12 @@ and map_variable_declarator_expr (env : env) (x : CST.variable_declarator): G.ex
       in
       let qual = G.QExpr (v1, v2) in
       let name = (v3, { G.name_qualifier = Some qual; G.name_typeargs = None }) in
-      G.IdQualified (name, G.empty_id_info ())
+      G.N (G.IdQualified (name, G.empty_id_info ()))
 
 and map_variable_declarator (env : env) (x : CST.variable_declarator): G.expr =
   match x with
   | `Id tok ->
-      G.Id (identifier env tok, G.empty_id_info ()) (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
+      G.N (G.Id (identifier env tok, G.empty_id_info ())) (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
   | `Prefix_LBRACK_exp_RBRACK (v1, v2, v3, v4) ->
       let v1 = map_prefix env v1 in
       let v2 = token env v2 (* "[" *) in
@@ -722,7 +722,7 @@ and map_variable_declarator (env : env) (x : CST.variable_declarator): G.expr =
       let ident =
         identifier env v3 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
       in
-      G.DotAccess (G.Id (ident, G.empty_id_info()), dot, G.EDynamic prefix)
+      G.DotAccess (G.N (G.Id (ident, G.empty_id_info())), dot, G.EDynamic prefix)
 
 let map_program (env : env) ((v1, v2) : CST.program): G.program =
   map_statements_and_return env (v1, v2)

--- a/semgrep-core/Parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -162,7 +162,7 @@ let map_local_variable_declarator (env : env) ((v1, v2) : CST.local_variable_dec
   in
   List.map (fun x -> G.basic_entity x [G.KeywordAttr (G.Static, local)]) (ident_first::ident_rest)
 
-let map_function_name_field (env : env) ((v1, v2) : CST.function_name_field) (colon_and_ident): G.name =
+let map_function_name_field (env : env) ((v1, v2) : CST.function_name_field) (colon_and_ident): (G.ident * G.name_info) =
   let v1 =
     identifier env v1 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
   in
@@ -188,7 +188,7 @@ let map_function_name_field (env : env) ((v1, v2) : CST.function_name_field) (co
   )
 
 
-let map_function_name (env : env) ((v1, v2) : CST.function_name): G.name =
+let map_function_name (env : env) ((v1, v2) : CST.function_name): (G.ident * G.name_info) =
   match v1 with
   | `Id tok ->
       let ident = identifier env tok in (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)

--- a/semgrep-core/Reporting/JSON_report.ml
+++ b/semgrep-core/Reporting/JSON_report.ml
@@ -50,7 +50,7 @@ let string_of_resolved = function
 *)
 let unique_id any =
   match any with
-  | E (Id (id, { id_resolved = {contents = Some (resolved, sid)}; _})) ->
+  | E (N (Id (id, { id_resolved = {contents = Some (resolved, sid)}; _}))) ->
       J.Object [
         "type", J.String "id";
         "value", J.String (AST_generic_helpers.str_of_ident id);

--- a/semgrep-core/Synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/Synthesizing/Pattern_from_Code.ml
@@ -58,8 +58,8 @@ let body_ellipsis t1 t2 = Block(t1, [fk_stmt], t2) |> G.s
 let _bk f (lp,x,rp) = (lp, f x, rp)
 
 let default_id str =
-  Id((str, fk),
-     {id_resolved = ref None; id_type = ref None; id_constness = ref None})
+  G.N (Id((str, fk),
+          {id_resolved = ref None; id_type = ref None; id_constness = ref None}))
 
 let default_tyvar str typ =
   TypedMetavar((str, fk), fk, typ)
@@ -88,7 +88,7 @@ let get_id ?(with_type=false) env e =
       let (new_id, new_has_type) =
         if with_type then
           (match e with
-           | Id (_, {id_type; _}) ->
+           | N (Id (_, {id_type; _})) ->
                (match !id_type with
                 | None -> (notype_id, has_type)
                 | Some t -> (default_tyvar (count_to_id env.count) t), true)
@@ -190,7 +190,7 @@ let generalize_call env = function
 (* Id *)
 let generalize_id env e =
   match e with
-  | Id _ ->
+  | G.N (Id _) ->
       let (_, id) = get_id env e in
       let (env', id_t) = get_id ~with_type:true env e in
       if env'.has_type then ["metavar", E id; "typed metavar", E id_t]
@@ -221,7 +221,7 @@ and generalize_assign env e =
 and generalize_exp e env =
   match e with
   | Call _ -> generalize_call env e
-  | Id _ -> generalize_id env e
+  | N (Id _) -> generalize_id env e
   | L _ -> let (_, id) = get_id env e in ["metavar", E id]
   | DotAccess _ -> let (_, id) = get_id env e in ["metavar", E id]
   | Assign _ -> generalize_assign env e

--- a/semgrep-core/Synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/Synthesizing/Pretty_print_generic.ml
@@ -360,8 +360,8 @@ and continue env (tok, lbl) _sc =
 
 and expr env =
   function
-  | Id ((s,_), idinfo) -> id env (s, idinfo)
-  | IdQualified(name, idinfo) -> id_qualified env (name, idinfo)
+  | N (Id ((s,_), idinfo)) -> id env (s, idinfo)
+  | N (IdQualified(name, idinfo)) -> id_qualified env (name, idinfo)
   | IdSpecial (sp, tok) -> special env (sp, tok)
   | Call (e1, e2) -> call env (e1, e2)
   | L x -> literal env x

--- a/semgrep-core/Typing/Typechecking_generic.ml
+++ b/semgrep-core/Typing/Typechecking_generic.ml
@@ -40,19 +40,19 @@ open AST_generic
 *)
 let compatible_type t e =
   match t, e with
-  | OtherType (OT_Expr, [E (Id (("int", _tok), _idinfo))]),
+  | OtherType (OT_Expr, [E (N (Id (("int", _tok), _idinfo)))]),
     L (Int _) -> true
-  | OtherType (OT_Expr, [E (Id (("float", _tok), _idinfo))]),
+  | OtherType (OT_Expr, [E (N (Id (("float", _tok), _idinfo)))]),
     L (Float _) -> true
-  | OtherType (OT_Expr, [E (Id (("str", _tok), _idinfo))]),
+  | OtherType (OT_Expr, [E (N (Id (("str", _tok), _idinfo)))]),
     L (String _) -> true
-  | TyBuiltin ((t1, _)), Id (_, {id_type; _}) ->
+  | TyBuiltin ((t1, _)), N (Id (_, {id_type; _})) ->
       (match !id_type with Some (TyBuiltin ((t2, _))) -> t1 = t2
                          | _ -> false)
-  | TyId ((t1, _), _), Id(_, {id_type; _}) ->
+  | TyId ((t1, _), _), N (Id(_, {id_type; _})) ->
       (match !id_type with Some (TyId (((t2, _), _))) -> t1 = t2
                          | _ -> false)
-  | TyArray (_, TyId((t1, _), _)), Id (_, {id_type; _}) ->
+  | TyArray (_, TyId((t1, _), _)), N (Id (_, {id_type; _})) ->
       (match !id_type with Some (TyArray (_, TyId((t2, _), _))) -> t1 = t2
                          | _ -> false)
 


### PR DESCRIPTION
The goal is to factorize Id/IdQualified and TyId/TyIdQualified
which in turn will let us name this thing, and store it in a metavariable,
and let us do import $X match import java.util.ArrayList and get
$X binded to a name (instead of just the Id ArrayList).

This will help https://github.com/returntocorp/semgrep/issues/2502

this commit is just the start, and replace all use of name to
dotted_ident to make it easier to change really the name we care about
(in Idqualified and TyIdQualified).

test plan:
make
make test