### PR TITLE
analyzing: constness: Set function inputs as non-constant

### DIFF
--- a/semgrep-core/Analyzing/AST_to_IL.mli
+++ b/semgrep-core/Analyzing/AST_to_IL.mli
@@ -1,5 +1,8 @@
 (*s: pfff/lang_GENERIC/analyze/AST_to_IL.mli *)
 
+val function_definition: AST_generic.function_definition
+  -> IL.name list * IL.stmt list
+
 (*s: signature [[AST_to_IL.stmt]] *)
 val stmt: AST_generic.stmt -> IL.stmt list
 (*e: signature [[AST_to_IL.stmt]] *)

--- a/semgrep-core/Analyzing/Constant_propagation.ml
+++ b/semgrep-core/Analyzing/Constant_propagation.ml
@@ -352,9 +352,9 @@ let propagate_dataflow ast =
   let v = V.mk_visitor
       { V.default_visitor with
         V.kfunction_definition = (fun (_k, _) def ->
-          let xs = AST_to_IL.stmt def.fbody in
+          let inputs, xs = AST_to_IL.function_definition def in
           let flow = CFG_build.cfg_of_stmts xs in
-          let mapping = Dataflow_constness.fixpoint flow in
+          let mapping = Dataflow_constness.fixpoint inputs flow in
           Dataflow_constness.update_constness flow mapping
         );
       } in

--- a/semgrep-core/Analyzing/Dataflow_constness.mli
+++ b/semgrep-core/Analyzing/Dataflow_constness.mli
@@ -6,7 +6,7 @@ val string_of_constness : AST_generic.constness -> string
 (** Flow-sensitive constant-propagation.
  * !Note that this assumes Naming_AST.resolve has been called before!
 *)
-val fixpoint : IL.cfg -> mapping
+val fixpoint : IL.name list -> IL.cfg -> mapping
 
 (**
  * Updates the [IL.lval.constness] refs according to the mapping.

--- a/semgrep-core/Analyzing/Test_analyze_generic.ml
+++ b/semgrep-core/Analyzing/Test_analyze_generic.ml
@@ -159,10 +159,10 @@ let test_dfg_constness file =
   let v = V.mk_visitor
       { V.default_visitor with
         V.kfunction_definition = (fun (_k, _) def ->
-          let xs = AST_to_IL.stmt def.fbody in
+          let inputs, xs = AST_to_IL.function_definition def in
           let flow = CFG_build.cfg_of_stmts xs in
           pr2 "Constness";
-          let mapping = Dataflow_constness.fixpoint flow in
+          let mapping = Dataflow_constness.fixpoint inputs flow in
           Dataflow_constness.update_constness flow mapping;
           DataflowY.display_mapping flow mapping Dataflow_constness.string_of_constness;
           let s = AST_generic.show_any (S def.fbody) in

--- a/semgrep-core/tests/python/df_input.py
+++ b/semgrep-core/tests/python/df_input.py
@@ -1,0 +1,6 @@
+def update_system(password):
+    if cond():
+        password = "abc"
+    # OK: it's not guaranteed to be "abc"!
+    set_password(password)
+

--- a/semgrep-core/tests/python/df_input.sgrep
+++ b/semgrep-core/tests/python/df_input.sgrep
@@ -1,0 +1,2 @@
+set_password("...")
+


### PR DESCRIPTION
Let's consider the following example:

    def update_system(password):
        if cond():
            password = "abc"
        # OK: it's not guaranteed to be "abc"!
        set_password(password)
    
Here `password` is *not* a constant, because there is a path where its
value comes from an input. But for this to work as expected we must tell
the analysis that function inputs are non-constant!

test plan:
make test