### PR TITLE
[Java] import $LIB should binds $LIB to a full import path

### DIFF
--- a/semgrep-core/Core/Metavariable.ml
+++ b/semgrep-core/Core/Metavariable.ml
@@ -53,7 +53,9 @@ type mvar = string
  * use of AST_generic.any for patterns.
 *)
 type mvalue =
+  (* TODO: get rid of Id, N generalize it *)
   | Id of AST_generic.ident * AST_generic.id_info option
+  | N of AST_generic.name
   | E of AST_generic.expr
   | S of AST_generic.stmt
   | Ss of AST_generic.stmt list
@@ -74,6 +76,7 @@ let mvalue_to_any = function
   *)
   | Id (id, Some idinfo) -> G.E (G.N (G.Id (id, idinfo)))
   | Id (id, None) -> G.E (G.N (G.Id (id, G.empty_id_info())))
+  | N x -> G.E (G.N x)
   | Ss x -> G.Ss x
   | Args x -> G.Args x
   | T x -> G.T x

--- a/semgrep-core/Matching/Generic_vs_generic.ml
+++ b/semgrep-core/Matching/Generic_vs_generic.ml
@@ -2577,6 +2577,14 @@ and m_directive a b =
 and m_directive_basic a b =
   match a, b with
   (*s: [[Generic_vs_generic.m_directive_basic]] import cases *)
+  (* metavar: import $LIB should bind $LIB to the full qualified name *)
+  | A.ImportFrom(a0, DottedName [], (str, tok), a3),
+    B.ImportFrom(b0, DottedName xs, x, b3) when MV.is_metavar_name str ->
+      let name = H.name_of_ids (xs @ [x]) in
+      let* () = m_tok a0 b0 in
+      let* () = envf (str, tok) (MV.N name) in
+      (m_option_none_can_match_some m_ident_and_id_info) a3 b3
+
   | A.ImportFrom(a0, a1, a2, a3), B.ImportFrom(b0, b1, b2, b3) ->
       m_tok a0 b0 >>= (fun () ->
         m_module_name_prefix a1 b1 >>= (fun () ->

--- a/semgrep-core/Matching/Generic_vs_generic.ml
+++ b/semgrep-core/Matching/Generic_vs_generic.ml
@@ -235,7 +235,10 @@ let rec m_dotted_name_prefix_ok a b =
   | [(s,t)], [x] when MV.is_metavar_name s ->
       envf (s,t) (MV.Id (x, None))
   | [(s,t)], _::_ when MV.is_metavar_name s ->
-      (* TODO: should we bind it instead to a MV.N IdQualified? *)
+      (* TODO: should we bind it instead to a MV.N IdQualified?
+       * but it is actually just the qualifier part; the last id
+       * is not here (even though make_dottd will not care about that)
+      *)
       envf (s,t) (MV.E (make_dotted b))
   | xa::aas, xb::bbs ->
       let* () = m_ident xa xb in

--- a/semgrep-core/skip_list.txt
+++ b/semgrep-core/skip_list.txt
@@ -3,7 +3,6 @@ dir: _build
 # when want to focus on semgrep code itself
 dir: pfff
 dir: tree-sitter-lang
-dir: Parsing/tree_sitter
 
 dir_element: old
 dir_element: orig_spec

--- a/semgrep-core/tests/java/metavar_name.java
+++ b/semgrep-core/tests/java/metavar_name.java
@@ -1,0 +1,9 @@
+//ERROR: match
+import org.bouncycastle.crypto.provider.BouncyCastleProvider; // would expect this to also match
+
+//TODO have a pattern like import $LIB... new $LIB()
+class Foo {
+  void main() {
+    return new org.bouncycastle.crypto.provider.BouncyCastleProvider();
+  }
+}

--- a/semgrep-core/tests/java/metavar_name.sgrep
+++ b/semgrep-core/tests/java/metavar_name.sgrep
@@ -1,0 +1,1 @@
+import $LIB;


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/2502

test plan:
See how below abstract_content now contains the full path, not just
the last BouncyCastleProvider element.

$ /home/pad/semgrep/_build/default/CLI/Main.exe -lang java -f metavar_name.sgrep metavar_name.java -json
{"matches":[{"check_id":"-e/-f","path":"metavar_name.java","start":{"line":2,"col":1,"offset":15},"end":{"line":2,"col":61,"offset":75},"extra":{"message":"","metavars":{"$LIB":{"start":{"line":2,"col":8,"offset":22},"end":{"line":2,"col":61,"offset":75},"abstract_content":"org bouncycastle crypto provider BouncyCastleProvider","unique_id":{"type":"AST","md5sum":"8e0da5e5f63c8f7baf9ce1b42b240f90"}}}}}],"errors":[],"stats":{"okfiles":1,"errorfiles":0}}