### PR TITLE
Just add some .mli in spacegrep

### DIFF
--- a/spacegrep/src/lib/Parse_doc.mli
+++ b/spacegrep/src/lib/Parse_doc.mli
@@ -1,0 +1,4 @@
+
+val of_lexbuf: Lexing.lexbuf -> Doc_AST.t
+
+val of_src: Src_file.t -> Doc_AST.t

--- a/spacegrep/src/lib/Parse_pattern.mli
+++ b/spacegrep/src/lib/Parse_pattern.mli
@@ -1,0 +1,4 @@
+
+val of_lexbuf: ?is_doc:bool -> Lexing.lexbuf -> Pattern_AST.t
+
+val of_src: ?is_doc:bool -> Src_file.t -> Pattern_AST.t


### PR DESCRIPTION
As I was trying to integrate spacegrep in my new
full-rules-in-ocaml engine (see semgrep-core/Engine/Semgrep.ml),
I was missing a few .mli files.

test plan:
make