### PR TITLE
[javascript] consider $A; an expression metavariable in addition to stmt metavar

### DIFF
--- a/semgrep-core/tests/js/metavar_stmt_or_expr.js
+++ b/semgrep-core/tests/js/metavar_stmt_or_expr.js
@@ -1,0 +1,4 @@
+//ERROR: match
+b;
+bar(b);
+foo(b);

--- a/semgrep-core/tests/js/metavar_stmt_or_expr.sgrep
+++ b/semgrep-core/tests/js/metavar_stmt_or_expr.sgrep
@@ -1,0 +1,8 @@
+// $A; is actually considered a statement metavariable, even with a following
+// not-fake ;, because there are many languages where we need this ; to
+// parse metavariable statement. But with a recent fix we also
+// consider it an expression metavariable thx to >||>.
+
+$A;
+...
+foo($A);


### PR DESCRIPTION
This should help Emma which recently found this bug.

test plan:
test file included
make test