### PR TITLE
Add parentheses to the go ast for TypeAssertions

### DIFF
--- a/semgrep-core/Parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/go_to_generic.ml
@@ -247,9 +247,9 @@ let top_func () =
         and v3 = option expr v3
         in
         G.SliceAccess (e, v1, v2, v3)
-    | TypeAssert (v1, v2) -> let v1 = expr v1 and v2 = type_ v2 in
+    | TypeAssert (v1, (lp, v2, rp)) -> let v1 = expr v1 and v2 = type_ v2 in
         G.Call (G.IdSpecial (G.Instanceof, fake "instanceof"),
-                fb[G.Arg v1; G.ArgType v2])
+                (lp, [G.Arg v1; G.ArgType v2], rp))
     | Ellipsis v1 -> let v1 = tok v1 in
         G.Ellipsis v1
     | DeepEllipsis v1 -> let v1 = bracket expr v1 in

--- a/semgrep-core/Parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -597,10 +597,10 @@ and expression (env : env) (x : CST.expression) : expr =
    | `Type_asse_exp (v1, v2, v3, v4, v5) ->
        let v1 = expression env v1 in
        let _v2 = token env v2 (* "." *) in
-       let _v3 = token env v3 (* "(" *) in
+       let v3 = token env v3 (* "(" *) in
        let v4 = type_ env v4 in
-       let _v5 = token env v5 (* ")" *) in
-       TypeAssert (v1, v4)
+       let v5 = token env v5 (* ")" *) in
+       TypeAssert (v1, (v3, v4, v5))
    | `Type_conv_exp (v1, v2, v3, v4, v5) ->
        let v1 = type_ env v1 in
        let _v2 = token env v2 (* "(" *) in


### PR DESCRIPTION
Closes #2316

Incorporates changes from https://github.com/returntocorp/pfff/pull/391 to add parentheses to TypeAssert.

Test plan: see pfff commit