### PR TITLE
Add section about extending language support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ Contents:
   * [Development Environment](#development-environment)
   * [Profiling Code](#profiling-code)
   * [Testing](#testing-1)
-* [Adding Language Support](#adding-language-support)
+* [Adding Support for a Language](#adding-support-for-a-language)
   * [Legacy Parsers](#legacy-parsers)
-  * [Tree-sitter Parsers](#tree-sitter-parsers)
+  * [Tree-Sitter Parsers](#tree-sitter-parsers)
 
 ## Development Workflow
 
@@ -326,7 +326,7 @@ Semgrep.match_sts_sts                    :      0.559 sec     185064 count
 `make test` in the `semgrep-core` directory will run tests that check code is correctly parsed
 and patterns perform as expected. To add a test in an appropriate language subdirectory, `semgrep-core/tests/LANGUAGE`, create a target file (expected file extension given language) and a .sgrep file with a pattern. The testing suite will check that all places with a comment with `ERROR` were matches found by the .sgrep file. See existing tests for more clarity.
 
-## Adding Language Support
+## Adding Support for a Language
 
 The programming languages supported by semgrep fall into two
 categories:
@@ -368,7 +368,7 @@ These parsers are implemented in
 [pfff](https://github.com/returntocorp/pfff), which is an OCaml
 project plugged into semgrep-core as a submodule.
 
-### Tree-sitter Parsers
+### Tree-Sitter Parsers
 
 Tree-sitter parsers exist as individual public projects, which are
 shared with other users of tree-sitter. Our

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,16 +328,15 @@ and patterns perform as expected. To add a test in an appropriate language subdi
 
 ## Adding Support for a Language
 
-The programming languages supported by semgrep fall into two
-categories:
-* legacy parsers: implemented directly in OCaml via a parser generator
-* tree-sitter parsers: community parsers implemented as
+The parsers used by semgrep fall into these categories:
+* legacy parsers (pfff): implemented directly in OCaml via a parser generator
+* tree-sitter parsers: third-party parsers implemented as
   [tree-sitter](https://tree-sitter.github.io/) grammars
-* generic parser: fallback for unsupported languages,
-  uses its own matching engine
+* generic parser (spacegrep): fallback for unsupported languages,
+  comes with its own matching engine
 
-For each language we need a parser for a target file and a parser for a
-semgrep pattern. For a given language, ideally both would use the same
+For each language, we need a parser for target files and a parser for
+semgrep patterns. For a given language, ideally both would use the same
 parser. For historical reasons, some languages use a legacy
 parser for patterns and a tree-sitter parser for target code.
 Here's the breakdown by language as of February 2021:
@@ -366,12 +365,12 @@ New languages should use tree-sitter.
 
 These parsers are implemented in
 [pfff](https://github.com/returntocorp/pfff), which is an OCaml
-project plugged into semgrep-core as a submodule.
+project that we plug into semgrep-core as a git submodule.
 
 ### Tree-Sitter Parsers
 
-Tree-sitter parsers exist as individual public projects, which are
-shared with other users of tree-sitter. Our
+Tree-sitter parsers exist as individual public projects. They are
+shared with other users of tree-sitter outside of semgrep. Our
 [ocaml-tree-sitter](https://github.com/returntocorp/ocaml-tree-sitter)
 project adds the necessary extensions for supporting semgrep patterns
 (ellipsis `...` and such). It also contains the machinery for turning
@@ -382,7 +381,8 @@ For example, for the Kotlin language we have:
 * output: [semgrep-kotlin](https://github.com/returntocorp/semgrep-kotlin)
 
 Assuming the tree-sitter grammar works well enough, most of the work
-consists of mapping the CST to an abstract syntax tree (AST).
+consists in mapping the CST to the generic abstract syntax tree (AST)
+shared by all languages in semgrep.
 
 These guides go over the integration work in more details:
 


### PR DESCRIPTION
This adds a section about extending language support to `CONTRIBUTING.md`.

Reviewers: take a look at the list of languages and let me know if you see some that are misclassified.

(I also need to update ocaml-tree-sitter)
