### PR TITLE
Improve --generate-config capabilities

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -51,13 +51,6 @@ def cli() -> None:
     config = parser.add_argument_group("config")
     config_ex = config.add_mutually_exclusive_group()
     config_ex.add_argument(
-        "-g",
-        "--generate-config",
-        action="store_true",
-        help=f"Generate starter configuration file, {DEFAULT_CONFIG_FILE}",
-    )
-
-    config_ex.add_argument(
         "-f",  # for backwards compatibility
         "-c",
         "--config",
@@ -69,11 +62,19 @@ def cli() -> None:
             "name. See https://semgrep.dev/docs/writing-rules/rule-syntax for information on configuration file format."
         ),
     )
-
     config_ex.add_argument(
         "-e",
         "--pattern",
         help="Code search pattern. See https://semgrep.dev/docs/writing-rules/pattern-syntax for information on pattern features.",
+    )
+    config.add_argument(
+        "-g",
+        "--generate-config",
+        action="store",
+        nargs="?",
+        const=DEFAULT_CONFIG_FILE,
+        type=argparse.FileType("x"),
+        help=f"Generate starter configuration file. Defaults to {DEFAULT_CONFIG_FILE}.",
     )
     config.add_argument(
         "-l",
@@ -433,7 +434,9 @@ def cli() -> None:
                     output_handler.handle_semgrep_error(error)
                 raise SemgrepError("Please fix the above errors and try again.")
         elif args.generate_config:
-            semgrep.config_resolver.generate_config()
+            semgrep.config_resolver.generate_config(
+                args.generate_config, args.lang, args.pattern
+            )
         else:
             semgrep.semgrep_main.main(
                 output_handler=output_handler,

--- a/semgrep/tests/e2e/test_generate_config.py
+++ b/semgrep/tests/e2e/test_generate_config.py
@@ -5,3 +5,9 @@ import sys
 def test_generate_config(run_semgrep_in_tmp):
     subprocess.check_output([sys.executable, "-m", "semgrep", "--generate-config"])
     run_semgrep_in_tmp(".semgrep.yml")
+
+
+def test_generate_config_with_filename(run_semgrep_in_tmp):
+    filename = "test.yml"
+    subprocess.check_output([sys.executable, "-m", "semgrep", "--generate-config", filename])
+    run_semgrep_in_tmp(filename)


### PR DESCRIPTION
This came out of a conversation with the folks over at Gitlab.

Let's say you're hacking on a particular pattern:

```
$ semgrep --lang python --pattern '$X == $X' ...
```

Wouldn't it be nice if you could quickly turn this into a configuration file and continue hacking from there?

```
$ semgrep --lang python --pattern 'hashlib.md5(...)' -g
Template config successfully written to .semgrep.yml
$ cat .semgrep.yml 
rules:
- id: eqeq-is-bad
  pattern: hashlib.md5(...)
  message: $X == $X is a useless equality check
  languages:
  - python
  severity: ERROR
```

Okay, the `message` is off, but you can take it from there. Wouldn't it be nice if you could write to an arbitrary file?

```
$ semgrep --lang python --pattern 'hashlib.md5(...)' -g arbitrary.yml
Template config successfully written to arbitrary.yml
$ cat arbitrary.yml 
rules:
- id: eqeq-is-bad
  pattern: hashlib.md5(...)
  message: $X == $X is a useless equality check
  languages:
  - python
  severity: ERROR
```

This takes the existing `--generate-config` flag and makes it respect `--lang`, `--pattern`, and take an optional filename :+1: 