### PR TITLE
Recognize Go `:=' encoded as AssignOp(Eq)

### DIFF
--- a/semgrep-core/Analyzing/AST_to_IL.ml
+++ b/semgrep-core/Analyzing/AST_to_IL.ml
@@ -387,6 +387,12 @@ and expr_aux env eorig =
   | G.Assign (e1, tok, e2) ->
       let exp = expr env e2 in
       assign env e1 tok exp eorig
+  | G.AssignOp (e1, (G.Eq, tok), e2)
+    when Parse_info.str_of_info tok = ":=" ->
+      (* We encode Go's `:=` as `AssignOp(Eq)`,
+       * see "go_to_generic.ml" in Pfff. *)
+      let exp = expr env e2 in
+      assign env e1 tok exp eorig
   | G.AssignOp (e1, op, e2) ->
       let exp = expr env e2 in
       let lval = lval env e1 in

--- a/semgrep-core/Analyzing/Dataflow_constness.ml
+++ b/semgrep-core/Analyzing/Dataflow_constness.ml
@@ -267,6 +267,21 @@ and eval_op env wop args =
 (* Transfer *)
 (*****************************************************************************)
 
+(* FIXME: This takes "Bottom" as the default constness of a variable.
+ *
+ * E.g. in
+ *
+ *     def foo():
+ *         if cond():
+ *              x = "abc"
+ *         return x
+ *
+ * we infer that `foo' returns the string "abc" when `x' may not even be defined!
+ *
+ * It would be more sound to assume "Top" (i.e., `G.NotCst`) as default, or
+ * perhaps we could have a switch to control whether we want a may- or must-
+ * analysis?
+*)
 let union_env =
   Dataflow.varmap_union union
 

--- a/semgrep-core/tests/go/cp_shortassign.go
+++ b/semgrep-core/tests/go/cp_shortassign.go
@@ -1,0 +1,23 @@
+// https://github.com/returntocorp/semgrep/issues/2440
+
+package main
+
+import (
+    "fmt"
+)
+
+func main() {
+    var varDecl0 string = "pass0"
+    var varDecl1 = "pass1"
+    varDecl2 := "pass2"
+
+    //ERROR:
+    fmt.Println(varDecl0)
+
+    //ERROR:
+    fmt.Println(varDecl1)
+
+    //ERROR:
+    fmt.Println(varDecl2)
+}
+

--- a/semgrep-core/tests/go/cp_shortassign.sgrep
+++ b/semgrep-core/tests/go/cp_shortassign.sgrep
@@ -1,0 +1,2 @@
+fmt.Println("...")
+


### PR DESCRIPTION
Closes #2440