### PR TITLE
Allow 'nosem' in HTML.

### DIFF
--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -57,7 +57,7 @@ NOSEM_INLINE_RE = re.compile(
     #   Python comments that begin with '# '
     # * nosem and nosemgrep should be interchangeable
     #
-    r" nosem(?:grep)?(?::[\s]?(?P<ids>([^,\s](?:[,\s]+)?)+))?",
+    r" nosem(?:grep)?(?:[:=][\s]?(?P<ids>([^,\s](?:[,\s]+)?)+))?",
     re.IGNORECASE,
 )
 COMMA_SEPARATED_LIST_RE = re.compile(r"[,\s]")

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -105,15 +105,13 @@ def rule_match_nosem(rule_match: RuleMatch, strict: bool) -> bool:
         )
         return True
 
+    # Strip quotes to allow for use of nosem as an HTML attribute inside tags.
+    # HTML comments inside tags are not allowed by the spec.
     pattern_ids = {
-        pattern_id.strip()
+        pattern_id.strip().strip("\"\'")
         for pattern_id in COMMA_SEPARATED_LIST_RE.split(ids_str)
         if pattern_id.strip()
     }
-
-    # Strip comments to allow for use of nosem as an HTML attribute inside tags.
-    # HTML comments inside tags are not allowed by the spec.
-    pattern_ids = set([pid.strip("\"\'") for pid in pattern_ids])
 
     # Filter out ids that are not alphanum+dashes+underscores+periods.
     # This removes trailing symbols from comments, such as HTML comments `-->`

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -2,6 +2,7 @@ import json
 import logging
 from io import StringIO
 from pathlib import Path
+from re import sub
 from typing import Any
 from typing import Dict
 from typing import List
@@ -109,6 +110,9 @@ def rule_match_nosem(rule_match: RuleMatch, strict: bool) -> bool:
         for pattern_id in COMMA_SEPARATED_LIST_RE.split(ids_str)
         if pattern_id.strip()
     }
+    # Filter out ids that are not alphanum+dashes+underscores.
+    # This removes trailing symbols from comments, such as HTML comments' `-->`.
+    pattern_ids = set(filter(lambda x: not sub(r"[\w-]+", "", x), pattern_ids))
 
     result = False
     for pattern_id in pattern_ids:

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -110,9 +110,15 @@ def rule_match_nosem(rule_match: RuleMatch, strict: bool) -> bool:
         for pattern_id in COMMA_SEPARATED_LIST_RE.split(ids_str)
         if pattern_id.strip()
     }
-    # Filter out ids that are not alphanum+dashes+underscores.
-    # This removes trailing symbols from comments, such as HTML comments' `-->`.
-    pattern_ids = set(filter(lambda x: not sub(r"[\w-]+", "", x), pattern_ids))
+
+    # Strip comments to allow for use of nosem as an HTML attribute inside tags.
+    # HTML comments inside tags are not allowed by the spec.
+    pattern_ids = set([pid.strip("\"\'") for pid in pattern_ids])
+
+    # Filter out ids that are not alphanum+dashes+underscores+periods.
+    # This removes trailing symbols from comments, such as HTML comments `-->`
+    # or C-like multiline comments `*/`.
+    pattern_ids = set(filter(lambda x: not sub(r"[\w\-\.]+", "", x), pattern_ids))
 
     result = False
     for pattern_id in pattern_ids:

--- a/semgrep/semgrep/spacegrep.py
+++ b/semgrep/semgrep/spacegrep.py
@@ -3,6 +3,7 @@ import logging
 import re
 import subprocess
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -70,6 +71,9 @@ def run_spacegrep(
                     output_json["matches"] = _patch_id(
                         pattern, output_json.get("matches", [])
                     )
+                    # dedent lines
+                    for match in output_json["matches"]:
+                        match["extra"]["lines"] = dedent('\n'.join(filter(None, match.get("extra", {}).get("lines", [])))).split('\n')
 
                     matches.extend(output_json["matches"])
                     errors.extend(output_json["errors"])

--- a/semgrep/tests/e2e/rules/nosem-unicode.yaml
+++ b/semgrep/tests/e2e/rules/nosem-unicode.yaml
@@ -1,0 +1,6 @@
+rules:
+- id: 寿司
+  message: test-nosem-message
+  severity: WARNING
+  languages: [c, go, java, javascript, python]
+  pattern: test_nosem_func(...)

--- a/semgrep/tests/e2e/rules/spacegrep/nosem-html.yaml
+++ b/semgrep/tests/e2e/rules/spacegrep/nosem-html.yaml
@@ -1,0 +1,41 @@
+rules:
+- id: var-in-href
+  message: >-
+    Detected a template variable used in an anchor tag with
+    the 'href' attribute. This allows a malicious actor to
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks.
+    If using Flask, use 'url_for()' to safely generate a URL.
+    If using Django, use the 'url' filter to safely generate a URL.
+    If using Mustache, use a URL encoding library, or prepend a slash '/' to the
+    variable for relative links (`href="/{{link}}"`).
+    You may also consider setting the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
+    - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#url
+    - https://github.com/pugjs/pug/issues/2952
+    - https://content-security-policy.com/
+  languages:
+  - generic
+  paths:
+    include:
+    - '*.html'
+    - '*.mustache'
+    - '*.hbs'
+  severity: WARNING
+  patterns:
+  - pattern-inside: <a ...>
+  - pattern-either:
+    - pattern: href = {{ ... }}
+    - pattern: href = "{{ ... }}"
+    - pattern: href = '{{ ... }}'
+  # OK for Flask
+  - pattern-not-inside: href = {{ url_for(...) ... }}
+  - pattern-not-inside: href = "{{ url_for(...) ... }}"
+  - pattern-not-inside: href = '{{ url_for(...) ... }}'
+  # OK for all templates
+  - pattern-not-inside: href = "/{{ ... }}"
+  - pattern-not-inside: href = '/{{ ... }}'

--- a/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule_unicode/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nosem_rule_unicode/results.json
@@ -1,0 +1,25 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.\u5bff\u53f8",
+      "end": {
+        "col": 18,
+        "line": 6
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "test_nosem_func()",
+        "message": "test-nosem-message",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/advanced_nosem/nosem-unicode.py",
+      "start": {
+        "col": 1,
+        "line": 6
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__not2/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__not2/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<h4>",
+        "lines": "<h4>From: {{ from_email }}</h4>",
         "message": "test regex message",
         "metadata": {},
         "metavars": {
@@ -47,7 +47,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<h4>",
+        "lines": "<h4>To:",
         "message": "test regex message",
         "metadata": {},
         "metavars": {
@@ -85,7 +85,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<h4>",
+        "lines": "<h4>Subject: {{subject}}</h4>",
         "message": "test regex message",
         "metadata": {},
         "metavars": {
@@ -123,7 +123,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<pre>",
+        "lines": "<pre>{{ body }}</pre>",
         "message": "test regex message",
         "metadata": {},
         "metavars": {

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "{{ message }}",
+        "lines": "var message = {{ message }};",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -29,7 +29,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "{{ message }}",
+        "lines": "var message = {{ message }};",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -49,7 +49,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "{{ message2 }}",
+        "lines": "var message2 = {{ message2 }};",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "## Getting",
+        "lines": "## Getting Started",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {
@@ -199,7 +199,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "## Commercial",
+        "lines": "## Commercial Support",
         "message": "Detected h2 Markdown header",
         "metadata": {},
         "metavars": {

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep_nosem/rulesspacegrepnosem-html.yaml-spacegrepnosem.html/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep_nosem/rulesspacegrepnosem-html.yaml-spacegrepnosem.html/results.json
@@ -1,0 +1,34 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "var-in-href",
+      "end": {
+        "col": 27,
+        "line": 15
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "<a href = \"{{ link }}\" >{{ link_text }}</a>",
+        "message": "Detected a template variable used in an anchor tag with the 'href' attribute. This allows a malicious actor to input the 'javascript:' URI and is subject to cross- site scripting (XSS) attacks. If using Flask, use 'url_for()' to safely generate a URL. If using Django, use the 'url' filter to safely generate a URL. If using Mustache, use a URL encoding library, or prepend a slash '/' to the variable for relative links (`href=\"/{{link}}\"`). You may also consider setting the Content Security Policy (CSP) header.",
+        "metadata": {
+          "cwe": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+          "owasp": "A7: Cross-site Scripting (XSS)",
+          "references": [
+            "https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI",
+            "https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#url",
+            "https://github.com/pugjs/pug/issues/2952",
+            "https://content-security-policy.com/"
+          ]
+        },
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/spacegrep/nosem.html",
+      "start": {
+        "col": 8,
+        "line": 15
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/advanced_nosem/nosem-unicode.py
+++ b/semgrep/tests/e2e/targets/advanced_nosem/nosem-unicode.py
@@ -1,0 +1,6 @@
+test_nosem_func()  # nosem: rules.寿司
+test_nosem_func()  # NOSEM: rules.寿司
+test_nosem_func()  # nosemgrep: rules.寿司
+test_nosem_func()  # NOSEMGREP
+test_nosem_func()  # nOseMgREP: rules.寿司
+test_nosem_func()

--- a/semgrep/tests/e2e/targets/spacegrep/nosem.html
+++ b/semgrep/tests/e2e/targets/spacegrep/nosem.html
@@ -10,11 +10,11 @@
 </div>
 <div class="email-text" style="display: none;">
     <pre>{{ body }}</pre>
-    <!-- nosem: tests.e2e.rules.spacegrep.var-in-href --> <a href='{{ link }}'>{{ link_text }}</a>
-    <a href = '{{ link }}' >{{ link_text }}</a> <!-- nosemgrep: tests.e2e.rules.spacegrep.var-in-href -->
+    <a href='{{ link }}'>{{ link_text }}</a> <!-- nosem: var-in-href -->
+    <a href = '{{ link }}' >{{ link_text }}</a> <!-- nosemgrep: var-in-href -->
     <a href = "{{ link }}" >{{ link_text }}</a>
     <a
-        href = "{{ link }}" nosem="tests.e2e.rules.spacegrep.var-in-href"
+        href = "{{ link }}" nosem="var-in-href"
     >
         {{ link_text }}
     </a>

--- a/semgrep/tests/e2e/targets/spacegrep/nosem.html
+++ b/semgrep/tests/e2e/targets/spacegrep/nosem.html
@@ -1,0 +1,25 @@
+<h4>From: {{ from_email }}</h4>
+<h4>To:
+    {% for recipient in recipients %}
+    {{ recipient }}&nbsp;
+    {% endfor %}
+</h4>
+<h4>Subject: {{subject}}</h4>
+<div class="email" style="display: block;">
+    {{ message }}
+</div>
+<div class="email-text" style="display: none;">
+    <pre>{{ body }}</pre>
+    <!-- nosem: tests.e2e.rules.spacegrep.var-in-href --> <a href='{{ link }}'>{{ link_text }}</a>
+    <a href = '{{ link }}' >{{ link_text }}</a> <!-- nosemgrep: tests.e2e.rules.spacegrep.var-in-href -->
+    <a href = "{{ link }}" >{{ link_text }}</a>
+    <a
+        href = "{{ link }}" nosem="tests.e2e.rules.spacegrep.var-in-href"
+    >
+        {{ link_text }}
+    </a>
+    <a href="{{ url_for('index') }}">{{ link_text }}</a>
+    <a href="https://example.com/">{{ link_text }}</a>
+    <a href="https://example.com/{{ link_path }}">{{ link_text }}</a>
+</div>
+<hr>

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -183,6 +183,10 @@ def test_nosem_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/nosem.yaml"), "results.json")
 
 
+def test_nosem_rule_unicode(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(run_semgrep_in_tmp("rules/nosem-unicode.yaml", target_name="advanced_nosem/nosem-unicode.py"), "results.json")
+
+
 def test_nosem_rule__invalid_id(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/nosem.yaml", target_name="nosem_invalid_id")

--- a/semgrep/tests/e2e/test_spacegrep.py
+++ b/semgrep/tests/e2e/test_spacegrep.py
@@ -27,6 +27,6 @@ def test_spacegrep(run_semgrep_in_tmp, snapshot, rule, target):
 )
 def test_spacegrep_nosem(run_semgrep_in_tmp, snapshot, rule, target):
     snapshot.assert_match(
-        run_semgrep_in_tmp(rule, target_name=target),
+        run_semgrep_in_tmp(rule, target_name=target, options=["--no-rewrite-rule-ids"]),
         "results.json",
     )

--- a/semgrep/tests/e2e/test_spacegrep.py
+++ b/semgrep/tests/e2e/test_spacegrep.py
@@ -14,7 +14,18 @@ import pytest
     ],
 )
 def test_spacegrep(run_semgrep_in_tmp, snapshot, rule, target):
-    # Yes, this is fugly. I apologize. T_T
+    snapshot.assert_match(
+        run_semgrep_in_tmp(rule, target_name=target),
+        "results.json",
+    )
+
+@pytest.mark.parametrize(
+    "rule,target",
+    [
+        ("rules/spacegrep/nosem-html.yaml", "spacegrep/nosem.html"),
+    ],
+)
+def test_spacegrep_nosem(run_semgrep_in_tmp, snapshot, rule, target):
     snapshot.assert_match(
         run_semgrep_in_tmp(rule, target_name=target),
         "results.json",

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -51,7 +51,7 @@ let make_semgrep_json doc_matches : Semgrep_t.match_results =
           let ((pos1, _), (_, pos2)) = match_.region in
           let metavars = List.map convert_capture match_.named_captures in
           let lines =
-            Src_file.region_of_pos_range src pos1 pos2
+            Src_file.lines_of_pos_range src pos1 pos2
             |> String.split_on_char '\n'
           in
           let extra = {


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/2566.

Changes spacegrep slightly to return the whole line for a match.

Filters out IDs from nosem strings that are not alphumeric, underscores, or dashes. This keeps the current nosem regex intact while allowing trailing characters such as required by HTML comments: `-->`.