### PR TITLE
Update csharp

### DIFF
--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1451,14 +1451,15 @@ and statement (env : env) (x : CST.statement) =
        let v4 =
          (match v4 with
           | `Type_choice_id (v1, v2) -> (
-              let v1 = type_ env v1 in
-              match v2 with
-              | `Id x ->
-                  let x = identifier env x in
-                  PatVar (v1, Some (x, empty_id_info ()))
-              | `Tuple_pat x ->
-                  let x = tuple_pattern env x in
-                  PatTyped (x, v1)
+              let v2 = (match v2 with
+                | `Id x ->
+                    let x = identifier env x in
+                    PatId (x, empty_id_info ())
+                | `Tuple_pat x ->tuple_pattern env x) in
+              let v1 = local_variable_type env v1 in
+              (match v1 with
+               | Some t -> PatTyped (v2, t)
+               | None -> v2)
             )
           | `Exp x -> H2.expr_to_pattern (expression env x)
          )

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1079,7 +1079,7 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        let v2 = token env v2 (* "is" *) in
        let v3 = pattern env v3 in
        LetPattern (v3, v1)
-   | `Lambda_exp (v1, v2, v3, v4) ->
+   | `Lambda_exp (v1, vtodo, v2, v3, v4) ->
        let v1 =
          (match v1 with
           | Some tok -> [KeywordAttr (Async, token env tok)] (* "async" *)
@@ -1207,7 +1207,7 @@ and expression (env : env) (x : CST.expression) : AST.expr =
           | None -> todo env ())
        in
        todo env (v1, v2, v3)
-   | `Switch_exp (v1, v2, v3, v4, v5) ->
+   | `Switch_exp (v1, v2, v3, v4, vtodo, v5) ->
        let v1 = expression env v1 in
        let v2 = token env v2 (* "switch" *) in
        let v3 = token env v3 (* "{" *) in
@@ -1326,7 +1326,7 @@ and type_parameter_list (env : env) ((v1, v2, v3, v4) : CST.type_parameter_list)
 
 and type_parameter_constraint (env : env) (x : CST.type_parameter_constraint) =
   (match x with
-   | `Class tok (* "class" *)
+   | `Class_opt_QMARK (tok, _) (* "class" *) (* TODO handle question mark *)
    | `Struct tok (* "struct" *)
    | `Unma tok -> (* "unmanaged" *)
        let t = TyBuiltin (str env tok) in
@@ -1541,13 +1541,13 @@ and statement (env : env) (x : CST.statement) =
        in
        let v3 = token env v3 (* ";" *) in
        Return (v1, v2, v3) |> AST.s
-   | `Switch_stmt (v1, v2, v3, v4, v5) ->
+   | `Switch_stmt (v1, v2, v3) ->
        let v1 = token env v1 (* "switch" *) in
-       let v2 = token env v2 (* "(" *) in
-       let v3 = expression env v3 in
-       let v4 = token env v4 (* ")" *) in
-       let v5 = switch_body env v5 in
-       AST.Switch (v1, Some v3, v5) |> AST.s
+       let v2 = (match v2 with
+       | `LPAR_exp_RPAR v2 -> parenthesized_expression env v2
+       | `Tuple_exp v2 -> tuple_expression env v2) in
+       let v3 = switch_body env v3 in
+       AST.Switch (v1, Some v2, v3) |> AST.s
    | `Throw_stmt (v1, v2, v3) ->
        let v1 = token env v1 (* "throw" *) in
        let v2 =

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -397,7 +397,7 @@ let rec variable_designation (env : env) (x : CST.variable_designation) =
    | `Id tok -> PatId (identifier env tok, empty_id_info ()) (* identifier *)
   )
 
-let anon_choice_id_43fe74f (env : env) (x : CST.anon_choice_id_43fe74f) =
+let anon_choice_id_c036834 (env : env) (x : CST.anon_choice_id_c036834) =
   (match x with
    | `Id tok -> identifier env tok (* identifier *)
    | `Disc tok -> todo env tok (* "_" *)
@@ -410,7 +410,7 @@ let join_into_clause (env : env) ((v1, v2) : CST.join_into_clause) =
 
 let identifier_or_global (env : env) (x : CST.identifier_or_global) =
   (match x with
-   | `Global tok -> identifier env tok (* "global" *)
+   | `Global tok -> str env tok (* "global" *)
    | `Id tok -> identifier env tok (* identifier *)
   )
 
@@ -422,11 +422,11 @@ let identifier_or_global_qualifier (env : env) (x : CST.identifier_or_global) =
 
 let tuple_pattern (env : env) ((v1, v2, v3, v4) : CST.tuple_pattern) =
   let v1 = token env v1 (* "(" *) in
-  let v2 = anon_choice_id_43fe74f env v2 in
+  let v2 = anon_choice_id_c036834 env v2 in
   let v3 =
     List.map (fun (v1, v2) ->
       let v1 = token env v1 (* "," *) in
-      let v2 = anon_choice_id_43fe74f env v2 in
+      let v2 = anon_choice_id_c036834 env v2 in
       v2
     ) v3
   in
@@ -482,7 +482,7 @@ let literal (env : env) (x : CST.literal) : literal =
 let rec return_type (env : env) (x : CST.return_type) : type_ =
   (match x with
    | `Type x -> type_constraint env x
-   | `Void_kw tok -> TyBuiltin (identifier env tok) (* "void" *)
+   | `Void_kw tok -> TyBuiltin (str env tok) (* "void" *)
   )
 
 and variable_declaration (env : env) ((v1, v2, v3) : CST.variable_declaration) : (entity * variable_definition) list =
@@ -1333,7 +1333,7 @@ and type_parameter_constraint (env : env) (x : CST.type_parameter_constraint) =
    | `Class tok (* "class" *)
    | `Struct tok (* "struct" *)
    | `Unma tok -> (* "unmanaged" *)
-       let t = TyBuiltin (identifier env tok) in
+       let t = TyBuiltin (str env tok) in
        Extends t
    | `Cons_cons (v1, v2, v3) ->
        let v1 = token env v1 (* "new" *) in
@@ -1514,7 +1514,7 @@ and statement (env : env) (x : CST.statement) =
        let v4 = variable_declaration env v4 in
        let v5 = token env v5 (* ";" *) in
        var_def_stmt v4 v3
-   | `Local_func_stmt (v1, v2, v3, v4, v5, v6, v7) ->
+   | `Local_func_stmt (vtodo, v1, v2, v3, v4, v5, v6, v7) ->
        let v1 = List.map (modifier env) v1 in
        let v2 = return_type env v2 in
        let v3 = identifier env v3 (* identifier *) in
@@ -2079,10 +2079,10 @@ let accessor_declaration (env : env) ((v1, v2, v3, v4) : CST.accessor_declaratio
   let v2 = List.map (modifier env) v2 in
   let v3 =
     (match v3 with
-     | `Get tok -> identifier env tok, KeywordAttr (Getter, token env tok) (* "get" *)
-     | `Set tok -> identifier env tok, KeywordAttr (Setter, token env tok) (* "set" *)
-     | `Add tok -> identifier env tok, unhandled_keywordattr_to_namedattr env tok (* "add" *)
-     | `Remove tok -> identifier env tok, unhandled_keywordattr_to_namedattr env tok (* "remove" *)
+     | `Get tok -> str env tok, KeywordAttr (Getter, token env tok) (* "get" *)
+     | `Set tok -> str env tok, KeywordAttr (Setter, token env tok) (* "set" *)
+     | `Add tok -> str env tok, unhandled_keywordattr_to_namedattr env tok (* "add" *)
+     | `Remove tok -> str env tok, unhandled_keywordattr_to_namedattr env tok (* "remove" *)
      | `Id tok -> todo env tok (* identifier *)
     )
   in

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1135,10 +1135,6 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        let v3 = simple_name env v3 in
        let name = AST.IdQualified (v3, AST.empty_id_info()) in
        AST.DotAccess (v1, v2, AST.EN name)
-   | `Member_bind_exp (v1, v2) ->
-       let v1 = token env v1 (* "." *) in
-       let v2 = simple_name env v2 in
-       todo env (v1, v2)
    | `Obj_crea_exp (v1, v2, v3, v4) ->
        let v1 = token env v1 (* "new" *) in
        let v2 = type_constraint env v2 in

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1117,12 +1117,9 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        let v1 =
          (match v1 with
           | `Exp x -> expression env x
-          | `Type x ->
+          | `Pred_type x ->
               (* e.g. `int` in `int.maxValue` *)
-              let _x = type_constraint env x in
-              let id = (match _x with
-                | TyBuiltin sw -> sw
-                | _ -> raise Impossible) in
+              let id = str env x in
               N (Id (id, empty_id_info ())) (* TODO should this be IdQualified? *)
           | `Name x ->
               let n = name env x in

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -311,11 +311,6 @@ let overloadable_operator (env : env) (x : CST.overloadable_operator) =
    | `LTEQ tok -> str env tok (* "<=" *)
   )
 
-let reserved_identifier (env : env) (x : CST.reserved_identifier) =
-  (match x with
-   | `From tok -> str env tok (* "from" *)
-  )
-
 let unhandled_keywordattr_to_namedattr (env : env) tok =
   NamedAttr (token env tok, Id (str env tok, empty_id_info ()), fake_bracket [])
 
@@ -1265,9 +1260,6 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        Call (IdSpecial (Typeof, v1), (v2, [ArgType v3], v4))
    | `Simple_name x ->
        id_of_name_ (simple_name env x)
-   | `Rese_id x ->
-       let x = reserved_identifier env x in
-       AST.N (AST.Id (x, empty_id_info ()))
    | `Lit x ->
        let x = literal env x in
        AST.L x

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1287,7 +1287,10 @@ and anon_choice_param_ce11a32 (env : env) (x : CST.anon_choice_param_ce11a32) =
    | `Param_array (v1, v2, v3, v4) ->
        let v1 = List.concat_map (attribute_list env) v1 in
        let v2 = token env v2 (* "params" *) in
-       let v3 = array_type env v3 in
+       let v3 = (match v3 with
+         | `Array_type v3 -> array_type env v3
+         | `Null_type v3 -> nullable_type env v3
+       ) in
        let v4 = identifier env v4 (* identifier *) in
        ParamRest (v2, {
          pname = Some v4;

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -630,16 +630,6 @@ and binary_expression (env : env) (x : CST.binary_expression) =
        let v2 = token env v2 (* "??" *) in
        let v3 = expression env v3 in
        Call (IdSpecial (Op Nullish, v2), fake_bracket [Arg v1; Arg v3])
-   | `Exp_choice_is_type (v1, v2, v3) ->
-       let v1 = expression env v1 in
-       let v3 = type_constraint env v3 in
-       match v2 with
-       | `Is tok ->
-           let v2 = token env tok (* "is" *) in
-           Call (IdSpecial (Instanceof, v2), fake_bracket [Arg v1; ArgType v3])
-       | `As tok ->
-           let v2 = token env tok (* "as" *) in
-           Cast (v3, v1) (* TODO `as` is really a conditional cast *)
   )
 
 and block (env : env) ((v1, v2, v3) : CST.block) : stmt =
@@ -989,6 +979,11 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        in
        let args = ArgType v2 :: List.map (fun x -> Arg x) v3 in
        Call (IdSpecial (New, v1), fake_bracket args)
+   | `As_exp (v1, v2, v3) ->
+       let v1 = expression env v1 in
+       let v2 = token env v2 (* "as" *) in
+       let v3 = type_ env v3 in
+       Cast (v3, v1) (* TODO `as` is really a conditional cast *)
    | `Assign_exp (v1, v2, v3) ->
        let v1 = expression env v1 in
        let v2 = assignment_operator env v2 in
@@ -1074,6 +1069,11 @@ and expression (env : env) (x : CST.expression) : AST.expr =
        let v1 = expression env v1 in
        let v2 = argument_list env v2 in
        AST.Call (v1, v2)
+   | `Is_exp (v1, v2, v3) ->
+       let v1 = expression env v1 in
+       let v2 = token env v2 (* "is" *) in
+       let v3 = type_ env v3 in
+       Call (IdSpecial (Instanceof, v2), fake_bracket [Arg v1; ArgType v3])
    | `Is_pat_exp (v1, v2, v3) ->
        let v1 = expression env v1 in
        let v2 = token env v2 (* "is" *) in

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -355,7 +355,10 @@ let real_literal (env : env) (tok : CST.real_literal) =
 (* TODO should real be returned as float? *)
 
 let identifier (env : env) (tok : CST.identifier) : ident =
-  str env tok
+  match tok with
+  | `Choice_id_tok (`Id_tok tok) -> str env tok
+  | `Choice_id_tok (`Cont_keywos kw) -> todo env kw
+  | `Tok_pat_8cc7dbf tok -> str env tok
 
 (* TODO: not sure why preprocessor_call was not generated. Because
  * was in extras?

--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -355,10 +355,39 @@ let real_literal (env : env) (tok : CST.real_literal) =
   AST.Float (str env tok) (* real_literal *)
 (* TODO should real be returned as float? *)
 
+let contextual_keywords env x =
+  (match x with
+   | `Asce x (* "ascending" *)
+   | `By x (* "by" *)
+   | `Desc x (* "descending" *)
+   | `Equals x (* "equals" *)
+   | `From x (* "from" *)
+   | `Group x (* "group" *)
+   | `Into x (* "into" *)
+   | `Join x (* "join" *)
+   | `Let x (* "let" *)
+   | `On x (* "on" *)
+   | `Orde x (* "orderby" *)
+   | `Select x (* "select" *)
+   | `Where x (* "where" *)
+   | `Add x (* "add" *)
+   | `Get x (* "get" *)
+   | `Remove x (* "remove" *)
+   | `Set x (* "set" *)
+   | `Global x (* "global" *)
+   | `Alias x (* "alias" *)
+   | `Dyna x (* "dynamic" *)
+   | `Nameof x (* "nameof" *)
+   | `Notn x (* "notnull" *)
+   | `Unma x (* "unmanaged" *)
+   | `When x (* "when" *)
+   | `Yield x (* "yield" *) -> str env x
+  )
+
 let identifier (env : env) (tok : CST.identifier) : ident =
   match tok with
   | `Choice_id_tok (`Id_tok tok) -> str env tok
-  | `Choice_id_tok (`Cont_keywos kw) -> todo env kw
+  | `Choice_id_tok (`Cont_keywos kw) -> contextual_keywords env kw
   | `Tok_pat_8cc7dbf tok -> str env tok
 
 (* TODO: not sure why preprocessor_call was not generated. Because


### PR DESCRIPTION
Replaces and closes #2567.

Update the C# parser to the latest upstream tree-sitter parser.