### PR TITLE
Start integrating spacegrep directly in semgrep-full-rule-in-ocaml (take 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN eval "$(opam env)" && opam install --deps-only -y spacegrep/
 RUN eval "$(opam env)" && opam install --deps-only -y semgrep-core/pfff/
 RUN eval "$(opam env)" && opam install --deps-only -y semgrep-core/
 RUN eval "$(opam env)" && DUNE_PROFILE=static make -C spacegrep/
+RUN eval "$(opam env)" && DUNE_PROFILE=static make -C spacegrep/ install
 RUN eval "$(opam env)" && make -C semgrep-core/ all
 
 # Sanity checks

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ build-ocaml-tree-sitter:
 .PHONY: build-spacegrep
 build-spacegrep:
 	$(MAKE) -C spacegrep
+	$(MAKE) -C spacegrep install
 
 # Update and rebuild everything within the project.
 #

--- a/semgrep-core/CLI/dune
+++ b/semgrep-core/CLI/dune
@@ -28,6 +28,9 @@
     tree-sitter-lang.ruby
     tree-sitter-lang.java
 
+    ; we now also depends on spacegrep with full-rule-in-ocaml
+    spacegrep
+
     ; internal deps
     semgrep_core
     semgrep_metachecking

--- a/semgrep-core/Core/Rule.ml
+++ b/semgrep-core/Core/Rule.ml
@@ -25,7 +25,7 @@ module MV = Metavariable
  * See also Mini_rule.ml where formula and many other features disappears.
  *
  * TODO:
- *  - parse more spacegrep and equivalences
+ *  - parse equivalences
 *)
 
 (*****************************************************************************)
@@ -62,13 +62,10 @@ type xpattern = {
 }
 and xpattern_kind =
   | Sem of Pattern.t
-  | Spacegrep of spacegrep
+  | Spacegrep of Spacegrep.Pattern_AST.t
   | Regexp of regexp
   (* used in the engine for rule->mini_rule and match_result gymnastic *)
 and pattern_id = int
-
-(* TODO: parse it via spacegrep/lib! *)
-and spacegrep = string
 
 [@@deriving show, eq]
 

--- a/semgrep-core/Core/dune
+++ b/semgrep-core/Core/dune
@@ -8,6 +8,8 @@
    pfff-config
    pfff-h_program-lang
    pfff-lang_GENERIC pfff-lang_GENERIC-analyze
+
+   spacegrep
  )
  (preprocess
    (pps

--- a/semgrep-core/Parsing/Parse_rule.ml
+++ b/semgrep-core/Parsing/Parse_rule.ml
@@ -208,8 +208,9 @@ let parse_pattern (id, lang) s =
   | R.LNone ->
       failwith ("you should not use real pattern with language = none")
   | R.LGeneric ->
-      (* todo: call spacegrep to parse s *)
-      R.mk_xpat (Spacegrep s) s
+      let src = Spacegrep.Src_file.of_string s in
+      let ast = Spacegrep.Parse_pattern.of_src src in
+      R.mk_xpat (Spacegrep ast) s
 
 let rec parse_formula_old env (x: string * J.t) : R.formula_old =
   match x with

--- a/semgrep-core/Parsing/dune
+++ b/semgrep-core/Parsing/dune
@@ -13,6 +13,8 @@
    pfff-lang_go pfff-lang_go-analyze
    pfff-lang_js pfff-lang_js-analyze
 
+   spacegrep
+
    semgrep_core semgrep_core_opti
    semgrep_metachecking
    semgrep_parsing_tree_sitter

--- a/spacegrep/src/bin/Space_main.ml
+++ b/spacegrep/src/bin/Space_main.ml
@@ -10,7 +10,6 @@
    on the spacegrep/default help page.
 *)
 
-open Cmdliner
 
 let dispatch () =
   Printexc.record_backtrace true;

--- a/spacegrep/src/bin/Spacecat_main.ml
+++ b/spacegrep/src/bin/Spacecat_main.ml
@@ -2,7 +2,6 @@
    Entrypoint for the 'spacecat' command.
 *)
 
-open Printf
 open Cmdliner
 open Spacegrep
 

--- a/spacegrep/src/lib/Loc.ml
+++ b/spacegrep/src/lib/Loc.ml
@@ -6,6 +6,12 @@ open Printf
 open Lexing
 
 type t = Lexing.position * Lexing.position
+let pp fmt _t =
+  (*if !pp_full_token_info
+    then pp_token_mutable fmt t*)
+  Format.fprintf fmt "()"
+(* we don't care about position information in spacegrep/semgrep *)
+let equal _ _ = true
 
 module Pos = struct
   type t = Lexing.position

--- a/spacegrep/src/lib/Match.ml
+++ b/spacegrep/src/lib/Match.ml
@@ -313,6 +313,7 @@ let rec match_
                     else
                       Fail
 
+(*
 let starts_after last_loc loc =
   let _, last_pos = last_loc in
   let pos, _ = loc in
@@ -326,6 +327,7 @@ let rec get_start_loc (doc : Doc_AST.node list) =
       match get_start_loc doc1 with
       | None -> get_start_loc doc2
       | res -> res
+*)
 
 let rec fold_all acc (doc : Doc_AST.node list) f =
   match doc with
@@ -372,9 +374,11 @@ let convert_named_captures env =
      })
   )
 
+(*
 let to_string src match_ =
   let (start_loc, end_loc) = match_.region in
   Src_file.lines_of_loc_range src start_loc end_loc
+*)
 
 let convert_capture src (start_pos, _) (_, end_pos) =
   let loc = (start_pos, end_pos) in
@@ -505,7 +509,7 @@ let print_nested_results
     ?(print_optional_separator = make_separator_printer ())
     doc_matches =
   List.iter (fun (src, pat_matches) ->
-    List.iter (fun (pat_id, matches) ->
+    List.iter (fun (_pat_id, matches) ->
       print ?highlight ~print_optional_separator src matches
     ) pat_matches
   ) doc_matches

--- a/spacegrep/src/lib/Parse_pattern.ml
+++ b/spacegrep/src/lib/Parse_pattern.ml
@@ -130,7 +130,7 @@ let rec parse_line pending_braces acc (tokens : Lexer.token list)
       (match pending_braces with
        | Curly :: pending_braces ->
            Some (close_acc acc, pending_braces, close_loc, tokens)
-       | (Paren | Bracket) :: pending_braces ->
+       | (Paren | Bracket) :: _pending_braces ->
            None
        | [] ->
            parse_line pending_braces

--- a/spacegrep/src/lib/Pattern_AST.ml
+++ b/spacegrep/src/lib/Pattern_AST.ml
@@ -7,6 +7,7 @@ type atom =
   | Punct of char (* ascii punctuation, including braces *)
   | Byte of char (* everything else, excluding ascii whitespace *)
   | Metavar of string
+[@@deriving show, eq]
 
 type node =
   | Atom of Loc.t * atom
@@ -14,8 +15,10 @@ type node =
   | Dots of Loc.t
   | End (* used to mark the end of the root pattern, so as to distinguish
            it from the end of a sub-pattern. *)
+[@@deriving show, eq]
 
 type t = node list
+[@@deriving show, eq]
 
 (*
    Ignore the special meaning of Dots and Metavars.

--- a/spacegrep/src/lib/Print.ml
+++ b/spacegrep/src/lib/Print.ml
@@ -15,7 +15,7 @@ let string_of_atom atom =
   | Byte c -> sprintf "0x%02x" (Char.code c)
   | Metavar s -> sprintf "$%s" s
 
-let print_atom buf loc indent atom =
+let print_atom buf _loc indent atom =
   match atom with
   | Word s -> bprintf buf "%s%s\n" indent s
   | Punct c -> bprintf buf "%s%c\n" indent c
@@ -26,7 +26,7 @@ let rec print_node buf indent node =
   match node with
   | Atom (loc, atom) -> print_atom buf loc indent atom
   | List nodes -> print_nodes buf (indent ^ "  ") nodes
-  | Dots loc -> bprintf buf "%s...\n" indent
+  | Dots _loc -> bprintf buf "%s...\n" indent
   | End -> ()
 
 and print_nodes buf indent nodes =
@@ -58,7 +58,7 @@ let to_file file nodes =
 module Debug = struct
   let show_loc = false
 
-  let print_loc buf (start, end_) =
+  let print_loc buf (start, _end_) =
     if show_loc then
       bprintf buf "%3i: " start.Lexing.pos_lnum
 

--- a/spacegrep/src/lib/dune
+++ b/spacegrep/src/lib/dune
@@ -6,6 +6,11 @@
      unix
      atdgen-runtime
   )
+  (preprocess
+   (pps
+     ppx_deriving.show
+     ppx_deriving.eq
+   ))
 )
 
 (ocamllex Lexer)


### PR DESCRIPTION
We want semgrep-core to be able to use full rules (not just "mini rules")
so we need to handle the [generic] language and calling spacegrep
directly.

This is the first part towards spacegrep integration in semgrep-core.
We just parse the pattern; we currently do not run the engine.

test plan:
make test