### PR TITLE
Run spacegrep matching engine inside semgrep-core

### DIFF
--- a/spacegrep/src/lib/Doc_AST.ml
+++ b/spacegrep/src/lib/Doc_AST.ml
@@ -6,12 +6,15 @@ type atom =
   | Word of string (* ascii words [A-Za-z0-9_]+ *)
   | Punct of char (* ascii punctuation, including braces *)
   | Byte of char (* everything else, excluding ascii whitespace *)
+[@@deriving show { with_path = false }]
 
 type node =
   | Atom of Loc.t * atom
   | List of node list
+[@@deriving show { with_path = false }]
 
 type t = node list
+[@@deriving show]
 
 (*
    For convenience of implementation, a document is parsed as a pattern.

--- a/spacegrep/src/lib/Pattern_AST.ml
+++ b/spacegrep/src/lib/Pattern_AST.ml
@@ -7,7 +7,7 @@ type atom =
   | Punct of char (* ascii punctuation, including braces *)
   | Byte of char (* everything else, excluding ascii whitespace *)
   | Metavar of string
-[@@deriving show, eq]
+[@@deriving show { with_path = false }, eq]
 
 type node =
   | Atom of Loc.t * atom
@@ -15,7 +15,7 @@ type node =
   | Dots of Loc.t
   | End (* used to mark the end of the root pattern, so as to distinguish
            it from the end of a sub-pattern. *)
-[@@deriving show, eq]
+[@@deriving show { with_path = false }, eq]
 
 type t = node list
 [@@deriving show, eq]


### PR DESCRIPTION
test plan:
$ /home/pad/semgrep/_build/default/CLI/Main.exe -test_rules ~/semgrep-rules/go/lang/security/audit/xss/no-interpolation-in-tag.yaml