### PR TITLE
Fix cycle in named AST for Rust 'fn foo(self)'

### DIFF
--- a/semgrep-core/Analyzing/Constant_propagation.ml
+++ b/semgrep-core/Analyzing/Constant_propagation.ml
@@ -17,6 +17,8 @@ open AST_generic
 module H = AST_generic_helpers
 module V = Visitor_AST
 
+let logger = Logging.get_logger [__MODULE__]
+
 (* TODO: Remove duplication between first and second pass, move towards
    making the first pass as light as possible. *)
 
@@ -256,6 +258,7 @@ and eval_op env op args =
 (*****************************************************************************)
 (* !Note that this assumes Naming_AST.resolve has been called before! *)
 let propagate_basic lang prog =
+  logger#info "Constant_propagation.propagate_basic progran";
   let env = default_env () in
 
   (* step1: first pass const analysis for languages without 'const/final' *)
@@ -349,6 +352,7 @@ let propagate_basic a b = Common.profile_code "Constant_propagation.xxx" (fun ()
   propagate_basic a b)
 
 let propagate_dataflow ast =
+  logger#info "Constant_propagation.propagate_dataflow progran";
   let v = V.mk_visitor
       { V.default_visitor with
         V.kfunction_definition = (fun (_k, _) def ->

--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -1100,12 +1100,15 @@ let dump_pattern (file: Common.filename) =
 (*e: function [[Main_semgrep_core.dump_pattern]] *)
 
 (*s: function [[Main_semgrep_core.dump_ast]] *)
-let dump_ast file =
+let dump_ast ?(naming=false) file =
   match Lang.langs_of_filename file with
   | lang::_ ->
       E.try_with_print_exn_and_reraise file (fun () ->
         let {Parse_target. ast; errors; _ } =
-          Parse_target.parse_and_resolve_name_use_pfff_or_treesitter lang file in
+          if naming
+          then Parse_target.parse_and_resolve_name_use_pfff_or_treesitter lang file
+          else Parse_target.just_parse_with_lang lang file
+        in
         let v = Meta_AST.vof_any (AST_generic.Pr ast) in
         let s = dump_v_to_format v in
         pr s;
@@ -1177,7 +1180,9 @@ let all_actions () = [
   Common.mk_action_1_arg dump_pattern;
   (*x: [[Main_semgrep_core.all_actions]] dumper cases *)
   "-dump_ast", " <file>",
-  Common.mk_action_1_arg dump_ast;
+  Common.mk_action_1_arg (dump_ast ~naming:false);
+  "-dump_named_ast", " <file>",
+  Common.mk_action_1_arg (dump_ast ~naming:true);
   (*x: [[Main_semgrep_core.all_actions]] dumper cases *)
   "-dump_equivalences", " <file>",
   Common.mk_action_1_arg dump_equivalences;

--- a/semgrep-core/Parsing/Parse_target.ml
+++ b/semgrep-core/Parsing/Parse_target.ml
@@ -316,6 +316,8 @@ let parse_and_resolve_name_use_pfff_or_treesitter lang file =
   Constant_propagation.propagate_basic lang ast;
   Constant_propagation.propagate_dataflow ast;
   if !Flag.use_bloom_filter then Bloom_annotation.annotate_program ast;
+
+  logger#info "Parse_target.parse_and_resolve_name_use_pfff_or_treesitter done";
   { ast; errors; stat }
 
 (*****************************************************************************)

--- a/semgrep-core/tests/rust/misc_naming_recursion.rs
+++ b/semgrep-core/tests/rust/misc_naming_recursion.rs
@@ -1,0 +1,8 @@
+// this was causing -dump_named_ast to recurse indefinitely
+// because it was parsed as fn accumulate(self: self) and
+// Naming_AST will add "self", Ty self in the environment, and
+// when we processed the self type, we would look for it in the env
+// and find "self" --> Ty Self and set id_type to itself, creating
+// a cycle in the AST.
+
+fn accumulate(self) {}

--- a/semgrep-core/tests/rust/misc_naming_recursion.sgrep
+++ b/semgrep-core/tests/rust/misc_naming_recursion.sgrep
@@ -1,0 +1,3 @@
+// we just want to make sure we don't loop anymore when processing
+// misc_naming_recursion.rs
+DOES_NOT_MATTER


### PR DESCRIPTION
test plan:
$ semgrep-core -dump_named_ast misc_naming_recursion.rs
does not loop forever anymore.

Test file also included