### PR TITLE
Continues work on #2352

### DIFF
--- a/semgrep-core/Analyzing/Bloom_annotation.ml
+++ b/semgrep-core/Analyzing/Bloom_annotation.ml
@@ -102,7 +102,6 @@ let rec statement_strings stmt =
        *)
        | L (String (str, _tok)) ->
            push str res
-       | TypedMetavar _ -> ()
        | _ -> k x
       )
     );
@@ -154,6 +153,7 @@ let list_of_pattern_strings any =
            if not (special_literal str) then
              push str res
        | TypedMetavar _ -> ()
+       | DisjExpr _ -> ()
        | _ -> k x
       )
     );

--- a/semgrep-core/Core/Flag_semgrep.ml
+++ b/semgrep-core/Core/Flag_semgrep.ml
@@ -33,7 +33,7 @@ let max_cache = ref false
 let filter_irrelevant_rules = ref false
 
 (* check for identifiers before attempting to match a stmt or stmt list *)
-let use_bloom_filter = ref false
+let use_bloom_filter = ref true
 
 (* we usually try first with the pfff parser and then with the tree-sitter
  * parser if pfff fails. Here you can force to only use tree-sitter.

--- a/semgrep-core/Core/Flag_semgrep.ml
+++ b/semgrep-core/Core/Flag_semgrep.ml
@@ -33,7 +33,7 @@ let max_cache = ref false
 let filter_irrelevant_rules = ref false
 
 (* check for identifiers before attempting to match a stmt or stmt list *)
-let use_bloom_filter = ref true
+let use_bloom_filter = ref false
 
 (* we usually try first with the pfff parser and then with the tree-sitter
  * parser if pfff fails. Here you can force to only use tree-sitter.


### PR DESCRIPTION
Fix equivalences bug

When there is a DisjExpr, don't put strings from either side into the filter

Test plan same as #2500