### PR TITLE
Use spacegrep captured variable in full-rule-in-ocaml

### DIFF
--- a/semgrep-core/Engine/Test_rule.ml
+++ b/semgrep-core/Engine/Test_rule.ml
@@ -99,7 +99,11 @@ let test_rules xs =
     in
     E.g_errors := [];
     let matches =
-      Semgrep.check false (fun _ _ -> ()) rules (target, xlang, ast) in
+      try
+        Semgrep.check false (fun _ _ -> ()) rules (target, xlang, ast)
+      with exn ->
+        failwith (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))
+    in
     matches |> List.iter JSON_report.match_to_error;
 
     let actual_errors = !E.g_errors in


### PR DESCRIPTION
test plan:
semgrep-core -test_rules ~/semgrep-rules goes from 155 mismatch
to 144! progress