### PR TITLE
Use the metavariables when intersecting ranges (for full-rule-in-ocaml)

### DIFF
--- a/semgrep-core/Core/Range.ml
+++ b/semgrep-core/Core/Range.ml
@@ -19,12 +19,12 @@ module PI = Parse_info
 (*****************************************************************************)
 (* Basic code range (start/end of code portion).
  *
- * For semgrep pattern-from-code synthesizing project we need to
+ * We use this for the pattern-from-code synthesizing project where we need to
  * manipulate code ranges selected by the user.
- * Note that the semgrep python wrapper also needs to manipulate ranges
- * to apply boolean logic operations on them (for pattern-inside, patter-not,
- * etc.), so if one day we decide to port that part to OCaml we will also
- * need the range type of this module.
+ *
+ * We also now use it to manipulate ranges and apply boolean logic operations
+ * on them (for pattern-inside, pattern-not, etc.), now that we also handle
+ * the whole rule in OCaml
 *)
 
 (*****************************************************************************)

--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -231,7 +231,6 @@ let mval_of_spacegrep_string str t =
 (* Logic on ranges *)
 (*****************************************************************************)
 
-(* TODO: also check metavariables! *)
 let intersect_ranges xs ys =
   let surviving_xs =
     xs |> List.filter (fun x ->
@@ -250,6 +249,7 @@ let difference_ranges pos neg =
   let surviving_pos =
     pos |> List.filter (fun x ->
       not (neg |> List.exists (fun y ->
+        (* todo? or also filter if x overlaps with y? *)
         x $<=$ y
       ))
     )
@@ -258,7 +258,7 @@ let difference_ranges pos neg =
 
 let filter_ranges xs cond =
   xs |> List.filter (fun r ->
-    let bindings = r.origin.PM.env in
+    let bindings = r.mvars in
     match cond with
     | R.CondGeneric e ->
         let env = Eval_generic.bindings_to_env bindings in

--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -136,33 +136,6 @@ let partition_xpatterns xs =
     | R.Regexp x -> Right3 (id, x)
   )
 
-let (mini_rule_of_pattern: R.t -> (R.pattern_id * Pattern.t) -> MR.t) =
-  fun r (id, pattern) ->
-  { MR.
-    id = string_of_int id; pattern;
-    (* parts that are not really needed I think in this context, since
-     * we just care about the matching result.
-    *)
-    message = ""; severity = MR.Error;
-    languages =
-      (match r.R.languages with
-       | R.L (x, xs) -> x::xs
-       | R.LNone | R.LGeneric -> raise Impossible
-      );
-    pattern_string = "";
-  }
-
-(* todo: change Pattern_match type so we don't need this gymnastic.
- * A pattern_match should just need the id from the mini_rule
-*)
-let (mini_rule_of_string: (R.pattern_id * string) -> MR.t) =
-  fun (id, s) ->
-  { MR.
-    id = string_of_int id;
-    pattern = G.E (G.L (G.Null (PI.fake_info "")));
-    message = ""; severity = MR.Error; languages = [];
-    pattern_string = s;
-  }
 
 let (group_matches_per_pattern_id: Pattern_match.t list ->id_to_match_results)=
   fun xs ->
@@ -196,6 +169,34 @@ let (split_and:
 (*****************************************************************************)
 (* Adapters *)
 (*****************************************************************************)
+
+let (mini_rule_of_pattern: R.t -> (R.pattern_id * Pattern.t) -> MR.t) =
+  fun r (id, pattern) ->
+  { MR.
+    id = string_of_int id; pattern;
+    (* parts that are not really needed I think in this context, since
+     * we just care about the matching result.
+    *)
+    message = ""; severity = MR.Error;
+    languages =
+      (match r.R.languages with
+       | R.L (x, xs) -> x::xs
+       | R.LNone | R.LGeneric -> raise Impossible
+      );
+    pattern_string = "";
+  }
+
+(* todo: change Pattern_match type so we don't need this gymnastic.
+ * A pattern_match should just need the id from the mini_rule
+*)
+let (mini_rule_of_string: (R.pattern_id * string) -> MR.t) =
+  fun (id, s) ->
+  { MR.
+    id = string_of_int id;
+    pattern = G.E (G.L (G.Null (PI.fake_info "")));
+    message = ""; severity = MR.Error; languages = [];
+    pattern_string = s;
+  }
 
 (* todo: same, we should not need that *)
 let hmemo = Hashtbl.create 101

--- a/semgrep-core/Engine/Semgrep.ml
+++ b/semgrep-core/Engine/Semgrep.ml
@@ -108,6 +108,18 @@ type env = {
 }
 
 (*****************************************************************************)
+(* Range_with_mvars *)
+(*****************************************************************************)
+
+let ($<=$) rv1 rv2 =
+  Range.($<=$) rv1.r rv2.r &&
+  rv1.mvars |> List.for_all (fun (mvar, mval1) ->
+    match List.assoc_opt mvar rv2.mvars with
+    | None -> true
+    | Some mval2 -> Matching_generic.equal_ast_binded_code mval1 mval2
+  )
+
+(*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
@@ -215,19 +227,17 @@ let mval_of_spacegrep_string str t =
 (* Logic on ranges *)
 (*****************************************************************************)
 
-open Range
-
 (* TODO: also check metavariables! *)
 let intersect_ranges xs ys =
   let surviving_xs =
     xs |> List.filter (fun x ->
       ys |> List.exists (fun y ->
-        x.r $<=$ y.r
+        x $<=$ y
       )) in
   let surviving_ys =
     ys |> List.filter (fun y ->
       xs |> List.exists (fun x ->
-        y.r $<=$ x.r
+        y $<=$ x
       ))
   in
   surviving_xs @ surviving_ys
@@ -236,7 +246,7 @@ let difference_ranges pos neg =
   let surviving_pos =
     pos |> List.filter (fun x ->
       not (neg |> List.exists (fun y ->
-        x.r $<=$ y.r
+        x $<=$ y
       ))
     )
   in


### PR DESCRIPTION
test plan:
$ semgrep-core -test_rules ~/semgrep-rules
goes from 144 to 27 mismatches! (and 1 regression).
progress!