### PR TITLE
* Restore test_spacegrep test on markdown

### DIFF
--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
@@ -208,12 +208,12 @@
             "end": {
               "col": 14,
               "line": 203,
-              "offset": 10948
+              "offset": 10946
             },
             "start": {
               "col": 4,
               "line": 203,
-              "offset": 10938
+              "offset": 10936
             },
             "unique_id": {
               "md5sum": "<masked in tests>",

--- a/semgrep/tests/e2e/test_spacegrep.py
+++ b/semgrep/tests/e2e/test_spacegrep.py
@@ -9,8 +9,7 @@ import pytest
     [
         ("rules/spacegrep/terraform.yaml", "spacegrep/terraform.tf"),
         ("rules/spacegrep/html.yaml", "spacegrep/html.mustache"),
-        # TODO: works locally but not in CI; difference in offset
-        # ("rules/spacegrep/markdown.yaml", "spacegrep/markdown.md"),
+        ("rules/spacegrep/markdown.yaml", "spacegrep/markdown.md"),
         ("rules/spacegrep/httpresponse.yaml", "spacegrep/httpresponse.txt"),
     ],
 )


### PR DESCRIPTION
I have no idea what I'm doing. This test used to fail in CI on
unrelated PR, so I comment it; it was actually working locally.
And now I put it back and it also fails locally, so I could update
the snapshot.
No idea why it failed in CI and worked locally, and now why it also
does not work locally.

Test plan:
pytest tests/e2e/test_spacegrep.py