### PR TITLE
Add unit tests for spacegrep's output, change 'lines' field

### DIFF
--- a/spacegrep/Makefile
+++ b/spacegrep/Makefile
@@ -11,8 +11,8 @@ export DUNE_PROFILE
 #
 .PHONY: build
 build:
+	rm -rf bin
 	dune build --profile $(DUNE_PROFILE)
-	@echo
 	mkdir -p bin
 	ln -sf ../_build/install/default/bin/spacegrep bin/spacegrep
 	ln -sf spacegrep bin/spacecat

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -51,8 +51,7 @@ let make_semgrep_json doc_matches : Semgrep_t.match_results =
           let ((pos1, _), (_, pos2)) = match_.region in
           let metavars = List.map convert_capture match_.named_captures in
           let lines =
-            Src_file.lines_of_pos_range src pos1 pos2
-            |> String.split_on_char '\n'
+            Src_file.list_lines_of_pos_range src pos1 pos2
           in
           let extra = {
             message = None;

--- a/spacegrep/src/lib/Src_file.ml
+++ b/spacegrep/src/lib/Src_file.ml
@@ -114,7 +114,7 @@ let remove_trailing_newline s =
   | s ->
       let len = String.length s in
       if s.[len - 1] = '\n' then
-        String.sub s 0 (len - 1)
+        String.sub s 0 (len - 1) (* nosem *)
       else
         s
 

--- a/spacegrep/src/lib/Src_file.mli
+++ b/spacegrep/src/lib/Src_file.mli
@@ -47,8 +47,13 @@ val region_of_loc_range : t -> Loc.t -> Loc.t -> string
 
    This includes the beginning of the first line and the end of the last line
    even if they're outside the requested range.
+
+   A trailing newline character (LF) is added unless 'force_trailing_newline'
+   is false. Regardless, a trailing newline is always included if there is
+   one in the source file.
 *)
 val lines_of_pos_range :
+  ?force_trailing_newline:bool ->
   ?highlight:(string -> string) ->
   ?line_prefix:string ->
   t -> Lexing.position -> Lexing.position -> string
@@ -57,11 +62,26 @@ val lines_of_pos_range :
    Extract the lines containing a pair of locations.
    A location itself is a range of positions, typically associated with
    an input token.
+
+   See 'lines_of_pos_range' for details.
 *)
 val lines_of_loc_range :
+  ?force_trailing_newline:bool ->
   ?highlight:(string -> string) ->
   ?line_prefix:string ->
   t -> Loc.t -> Loc.t -> string
+
+(* Same as 'lines_of_pos_range' but split the text into a list of lines. *)
+val list_lines_of_pos_range :
+  ?highlight:(string -> string) ->
+  ?line_prefix:string ->
+  t -> Lexing.position -> Lexing.position -> string list
+
+(* Same as 'lines_of_loc_range' but split the text into a list of lines. *)
+val list_lines_of_loc_range :
+  ?highlight:(string -> string) ->
+  ?line_prefix:string ->
+  t -> Loc.t -> Loc.t -> string list
 
 (* not for public use, only exposed to allow unit tests *)
 val insert_highlight : (string -> string) -> string -> int -> int -> string

--- a/spacegrep/src/test/Src_file.ml
+++ b/spacegrep/src/test/Src_file.ml
@@ -7,11 +7,11 @@ open Spacegrep
 let highlight s =
   "[" ^ s ^ "]"
 
-let run_one input start end_ expected_output =
+let test_highlight input start end_ expected_output =
   let output = Src_file.insert_highlight highlight input start end_ in
   Alcotest.(check string) "equal" expected_output output
 
-let corpus = [
+let highlight_corpus = [
   (* name, input, start, end, expected output *)
   "empty", "", 0, 0, "[]";
   "no newline", "a", 0, 1, "[a]";
@@ -21,10 +21,67 @@ let corpus = [
   "empty lines", "012\n\n\n678\n", 0, 8, "[012]\n[]\n[]\n[67]8\n";
 ]
 
+let rec find_word_locations word (ast : Doc_AST.node list) =
+  List.map (find_word_locations_in_node word) ast |> List.flatten
+
+and find_word_locations_in_node word node =
+  match node with
+  | Atom (loc, Word s) when s = word -> [loc]
+  | Atom _ -> []
+  | List l -> find_word_locations word l
+
+let loc_of_word word input =
+  let lexbuf = Lexing.from_string input in
+  let ast = Parse_doc.of_lexbuf lexbuf in
+  match find_word_locations word ast with
+  | [loc] -> loc
+  | _ -> assert false
+
+(*
+   Obtain correct token locations by parsing a document and searching
+   for the words in the AST. This is easy to use but assumes locations
+   set in the AST are correct.
+*)
+let test_lines_of_range
+    input start_word end_word
+    expected_output =
+  let start_loc = loc_of_word start_word input in
+  let end_loc = loc_of_word end_word input in
+  let src = Src_file.of_string input in
+  let lines = Src_file.list_lines_of_loc_range src start_loc end_loc in
+  Alcotest.(check (list string)) "equal" expected_output lines
+
+let lines_of_range_corpus = [
+  (* test name, input, start word, end word, expected output *)
+  "simple", "a\n", "a", "a", ["a"];
+  "no trailing newline", "a", "a", "a", ["a"];
+
+  "partial", "\
+a
+b c d e
+f
+",
+  "c", "d", ["b c d e"];
+
+  "multiline", "\
+a
+b c
+d e
+f
+",
+  "c", "d",
+  ["b c"; "d e"];
+]
+
 let test =
   let suite =
     List.map (fun (name, input, start, end_, expected_output) ->
-      name, `Quick, (fun () -> run_one input start end_ expected_output)
-    ) corpus
+      name, `Quick, (fun () -> test_highlight input start end_ expected_output)
+    ) highlight_corpus
+    @ List.map (fun (name, input, start_word, end_word, expected_output) ->
+      name, `Quick, (fun () ->
+        test_lines_of_range input start_word end_word expected_output
+      )
+    ) lines_of_range_corpus
   in
   "Src_file", suite


### PR DESCRIPTION
This changes the value of the `lines` field of the json object representing a match, which is returned to semgrep. Previously, the lines `"a\nb\n"` would be split into `["a"; "b"; ""]`. Now it's just `["a"; "b"]`.

Let's see how many tests this breaks! 😬