### PR TITLE
Deduplicate rules prior to run (Closes: #2298)

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -133,16 +134,9 @@ class Config:
             # re-write the configs to have the hierarchical rule ids
             configs = self._rename_rule_ids(configs)
 
-        rules = []
-        seen = set()
-        for rule in [rule for rules in configs.values() for rule in rules]:
-            if rule.id in seen:
-                next
-            else:
-                rules.append(rule)
-                seen.add(rule.id)
-
-        return rules
+        return list(
+            OrderedDict.fromkeys([rule for rules in configs.values() for rule in rules])
+        )
 
     @staticmethod
     def _safe_relative_to(a: Path, b: Path) -> Path:

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -133,7 +133,16 @@ class Config:
             # re-write the configs to have the hierarchical rule ids
             configs = self._rename_rule_ids(configs)
 
-        return [rule for rules in configs.values() for rule in rules]
+        rules = []
+        seen = set()
+        for rule in [rule for rules in configs.values() for rule in rules]:
+            if rule.id in seen:
+                next
+            else:
+                rules.append(rule)
+                seen.add(rule.id)
+
+        return rules
 
     @staticmethod
     def _safe_relative_to(a: Path, b: Path) -> Path:

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -68,6 +68,15 @@ class Rule:
         if any([lang in REGEX_ONLY_LANGUAGE_KEYS for lang in self._languages]):
             self._validate_none_language_rule()
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return False
+
+        return self._raw == other._raw
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
     def _validate_none_language_rule(self) -> None:
         """
         For regex-only rules, only patterns, pattern-either, and pattern-regex is valid.

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
@@ -78,44 +78,6 @@
         "col": 13,
         "line": 3
       }
-    },
-    {
-      "check_id": "rules.eqeq-is-bad",
-      "end": {
-        "col": 26,
-        "line": 3
-      },
-      "extra": {
-        "is_ignored": false,
-        "lines": "    return a + b == a + b",
-        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "a+b",
-            "end": {
-              "col": 17,
-              "line": 3,
-              "offset": 60
-            },
-            "start": {
-              "col": 12,
-              "line": 3,
-              "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/basic/stupid.py",
-      "start": {
-        "col": 12,
-        "line": 3
-      }
     }
   ]
 }


### PR DESCRIPTION
Because the rule objects contain context from the ruleset they came
from, we can't directly compare them. Instead, we have to do a little
dance and indirectly deduplicate them by their id.

Signed-off-by: Harlan Lieberman-Berg <harlan@rebelliondefense.com>