### PR TITLE
Get the latest semgrep docker image when running benchmarks from 'make'

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -4,10 +4,12 @@
 #
 .PHONY: run
 run:
+	docker pull returntocorp/semgrep:develop
 	./run-benchmarks --docker returntocorp/semgrep:develop
 
 .PHONY: dummy
 dummy:
+	docker pull returntocorp/semgrep:develop
 	./run-benchmarks --dummy --docker returntocorp/semgrep:develop --upload
 
 .PHONY: clean

--- a/perf/Makefile
+++ b/perf/Makefile
@@ -2,16 +2,32 @@
 # Run semgrep benchmarks.
 # See './run-benchmarks --help' for options.
 #
+
+DOCKER_IMG = returntocorp/semgrep:develop
+
+# Run whichever version of semgrep is available locally.
 .PHONY: run
 run:
-	docker pull returntocorp/semgrep:develop
-	./run-benchmarks --docker returntocorp/semgrep:develop
+	@set -e; \
+	if ! semgrep --version > /dev/null; then \
+	  echo "Missing 'semgrep' executable. Consider using 'make docker'."; \
+	  exit 1; \
+	fi
+	./run-benchmarks
 
+# Use the latest semgrep build published on DockerHub.
+.PHONY: docker
+docker:
+	docker pull $(DOCKER_IMG)
+	./run-benchmarks --docker $(DOCKER_IMG)
+
+# This is for testing the setup.
 .PHONY: dummy
 dummy:
-	docker pull returntocorp/semgrep:develop
-	./run-benchmarks --dummy --docker returntocorp/semgrep:develop --upload
+	docker pull $(DOCKER_IMG)
+	./run-benchmarks --dummy --docker $(DOCKER_IMG) --upload
 
 .PHONY: clean
 clean:
-	git clean -dfX
+	rm -rf bench/*/input
+	rm -rf bench/*/output

--- a/perf/README.md
+++ b/perf/README.md
@@ -21,16 +21,21 @@ The workspace looks like this:
 ```
 .
 ├── bench
-│   ├── njs
-│   │   ├── extra-cache
-│   │   ├── no-bloom
-│   │   ├── no-cache
-│   │   └── std
-│   └── zulip
-│       ├── extra-cache
-│       ├── no-bloom
-│       ├── no-cache
-│       └── std
+│   ├── dummy
+│   │   ├── input
+│   │   │   └── dummy
+│   │   │       ├── rules
+│   │   │       │   └── exec.yaml
+│   │   │       └── targets
+│   │   │           ├── hello.js
+│   │   │           └── malformed.js
+│   │   └── prep
+│   └── njs
+│       ├── input
+│       │   ├── juice-shop/ (lots of files)
+│       │   └── njsscan/ (lots of files)
+│       └── prep
+├── Makefile
 ├── README.md
 └── run-benchmarks
 ```
@@ -46,7 +51,9 @@ offered by the host as is the default for `semgrep`.
 Manual operation
 --
 
-Use the Makefile to run the benchmarks:
+Read and use the Makefile or call `./run-benchmarks` directly.
+The bare `make` command will use the local `semgrep` command and
+overall is safe to use.
 ```
 $ make
 ```

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -126,7 +126,7 @@ def run_semgrep(docker: str, corpus: Corpus, variant: SemgrepVariant) -> float:
     print(f"current directory: {os.getcwd()}")
     print("semgrep command: {}".format(" ".join(args)))
     os.environ["SEMGREP_CORE_EXTRA"] = variant.semgrep_core_extra
-    print(f"extra arguments for semgrep-core: {variant.semgrep_core_extra}")
+    print(f"extra arguments for semgrep-core: '{variant.semgrep_core_extra}'")
 
     t1 = time.time()
     res = subprocess.run(args)  # nosem


### PR DESCRIPTION
This leaves control over which docker image to use when calling `run-benchmarks` directly (I'm assuming that's better).