### PR TITLE
Remove the ... optimisation which introduces some regressions

### DIFF
--- a/semgrep-core/Core/Mini_rule.ml
+++ b/semgrep-core/Core/Mini_rule.ml
@@ -70,5 +70,6 @@ and severity = Error | Warning | Info
 (*s: type [[Rule.t]] *)
 (* alias *)
 type t = rule
+[@@deriving show]
 (*e: type [[Rule.t]] *)
 (*e: semgrep/core/Mini_rule.ml *)

--- a/semgrep-core/Core/Pattern_match.ml
+++ b/semgrep-core/Core/Pattern_match.ml
@@ -20,13 +20,25 @@
 (* Types *)
 (*****************************************************************************)
 
+(* We use 'eq' below to possibly remove redundant equivalent matches
+ * (Generic_vs_generic sometimes return multiple times the same match,
+ * sometimes because of some bugs we didn't fix, sometimes it's normal
+ * because of the way '...' operate. TODO: an example
+ * Note that you should not ignore the rule when comparing 2 matches!
+ * One (mini) rule can be part of a pattern-not: in which case
+ * even if it returns the same match than a similar rule in a pattern:,
+ * we should not merge them!
+*)
+
 (*s: type [[Match_result.t]] *)
 type t = {
-  rule: Mini_rule.t;
+  rule: Mini_rule.t [@equal fun a b -> a.Mini_rule.id = b.Mini_rule.id];
   file: Common.filename;
   location: Parse_info.token_location * Parse_info.token_location;
-  tokens: Parse_info.t list Lazy.t; (* do we need to be lazy? *)
+  (* do we need to be lazy? *)
+  tokens: Parse_info.t list Lazy.t [@equal fun _a _b -> true];
   env: Metavariable.bindings;
 }
+[@@deriving show, eq]
 (*e: type [[Match_result.t]] *)
 (*e: semgrep/core/Pattern_match.ml *)

--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -29,6 +29,7 @@ e2etest:
 	python3 tests/e2e/test_target_file.py
 install:
 	dune install
+	cp ./_build/default/CLI/Main.exe ../semgrep/semgrep/bin/semgrep-core
 dump:
 	./_build/default/tests/test.bc -dump_ast tests/lint/stupid.py
 

--- a/semgrep-core/Matching/Generic_vs_generic.ml
+++ b/semgrep-core/Matching/Generic_vs_generic.ml
@@ -1757,23 +1757,29 @@ and m_stmt a b =
    * TODO: we should not need this; '...' should not enumerate all
    * possible subset of stmt list and take forever.
   *)
-  | A.Block(_, [{s=A.ExprStmt(A.Ellipsis _i, _);_}], _),
-    B.Block(_b1) -> return ()
-  (* opti: another specialization; again we should not need it *)
-  | A.Block(_, [
-    {s=A.ExprStmt(A.Ellipsis _, _);_};
-    a;
-    {s=A.ExprStmt(A.Ellipsis _, _);_};
-  ]
-           , _),
-    B.Block(_, bs, _) ->
-      let bs =
-        match SubAST_generic.flatten_substmts_of_stmts bs with
-        (* already flat  *)
-        | None -> bs
-        | Some (xs, _) -> xs
-      in
-      or_list m_stmt a bs
+  (* TODO this is commented because it introduces some regressions in
+   * the semgrep python wrapper.
+   * See tests/OTHER/rules/regression_uniq_or_ellipsis.go and also
+   * the related TODO in Semgrep_generic.check
+
+     | A.Block(_, [{s=A.ExprStmt(A.Ellipsis _i, _);_}], _),
+      B.Block(_b1) -> return ()
+     (* opti: another specialization; again we should not need it *)
+     | A.Block(_, [
+      {s=A.ExprStmt(A.Ellipsis _, _);_};
+      a;
+      {s=A.ExprStmt(A.Ellipsis _, _);_};
+     ]
+             , _),
+      B.Block(_, bs, _) ->
+        let bs =
+          match SubAST_generic.flatten_substmts_of_stmts bs with
+          (* already flat  *)
+          | None -> bs
+          | Some (xs, _) -> xs
+        in
+        or_list m_stmt a bs
+  *)
   (* the general case *)
   (* TODO: ... will allow a subset of stmts? good? *)
   | A.Block(a1), B.Block(b1) ->

--- a/semgrep-core/Matching/Semgrep_generic.ml
+++ b/semgrep-core/Matching/Semgrep_generic.ml
@@ -422,6 +422,16 @@ let check2 ~hook ~with_caching rules equivs file lang ast =
     visitor prog;
 
     !matches |> List.rev
+    (* TODO: this uniq_by introduces some regressions in the semgrep wrapper!
+     * See tests/OTHER/rules/regression_uniq_or_ellipsis.go
+     * You have the regression also if you do the optimisation
+     * in Generic_vs_generic.m_stmt doing
+     *  | A.Block(_, [{s=A.ExprStmt(A.Ellipsis _i, _);_}], _),
+     *     B.Block(_b1) -> return ()
+     * which really has for effect to reduce the number of equivalent matches.
+     * WEIRD!
+       |> Common.uniq_by (AST_utils.with_structural_equal Pattern_match.equal)
+    *)
   end
 (*e: function [[Semgrep_generic.check2]] *)
 

--- a/semgrep-core/tests/OTHER/rules/regression_uniq_or_ellipsis.go
+++ b/semgrep-core/tests/OTHER/rules/regression_uniq_or_ellipsis.go
@@ -1,0 +1,61 @@
+//lint:file-ignore Ignore all the checks
+// Package testdata is a test function for the wrong-err-check rule
+package testdata
+
+import "fmt"
+
+func handle() {
+    err := fmt.Errorf("error")
+
+    // ruleid:wrong-err-check
+    if someErr := something(); err != nil {
+        fmt.Println(someErr)
+        return
+    }
+
+    // ok:wrong-err-check
+    if err := something(); err != nil {
+        return
+    }
+
+    // ok:wrong-err-check
+    if _, err := something2(); err != nil {
+        return
+    }
+
+    // ok:wrong-err-check
+    if err, _ := something3(); err != nil {
+        return
+    }
+
+    // ok:wrong-err-check
+    if err := nest().Error; err != nil {
+        return
+    }
+
+    // ok:wrong-err-check
+    err = something()
+    if err != nil {
+        return
+    }
+}
+
+func something() error {
+    return fmt.Errorf("error")
+}
+
+func something2() (string, error) {
+    return "", nil
+}
+
+func something3() (error, bool) {
+    return nil, false
+}
+
+type Nest struct {
+    Error error
+}
+
+func nest() Nest {
+    return Nest{Error: fmt.Errorf("error")}
+}

--- a/semgrep-core/tests/OTHER/rules/regression_uniq_or_ellipsis.yaml
+++ b/semgrep-core/tests/OTHER/rules/regression_uniq_or_ellipsis.yaml
@@ -1,0 +1,40 @@
+rules:
+- id: wrong-err-check
+  message: |
+    Did you mean to check $ERR_A instead of $ERR_B?
+  severity: ERROR
+  languages: [go]
+  patterns: 
+    - pattern-either:
+        - pattern: |
+            if ...,$ERR_A = <...$F(...)...>; $ERR_B != nil {
+              ...
+            }
+        - pattern: |
+            if $ERR_A = <...$F(...)...>; $ERR_B != nil {
+              ...
+            }
+    - pattern-not: |
+        if ...,$ERR_B = <...$F(...)...>; $ERR_B != nil {
+          ...
+        }
+    # The patterns below rule out false positives where the error is the
+    # first return argument of the function.
+    - pattern-not: |
+        if $ERR_B, ... = <...$F(...)...>; $ERR_B != nil {
+          ...
+        }
+    - pattern-not: |
+        if $ERR_B = <...$F(...)...>; $ERR_B != nil {
+          ...
+        }
+    # We use meta variable regexes to surface checks which are likely to
+    # be dealing with error types. We use these because Semgrep doesn't
+    # currently support matching on Go function types. For now this is
+    # an effective heuristic.
+    - metavariable-regex:
+          metavariable: "$ERR_A"
+          regex: "err|(.*Err$)" 
+    - metavariable-regex:
+          metavariable: "$ERR_B"
+          regex: "err|(.*Err$)" 


### PR DESCRIPTION
This helps https://github.com/returntocorp/semgrep/issues/2646
but this is not the right fix.
The only difference is that we return multiple times the same thing
in semgrep-core, which should not matter, but it seems to matter
for the semgrep wrapper.
Note that semgrep-core -config is not affected by the PR.

test plan:
$ semgrep --debug --verbose --config
tests/OTHER/rules/regression_uniq_or_ellipsis.yaml tests/OTHER/rules/

returns only 1 match (like in 0.40)