### PR TITLE
Perform set operations on pattern ranges received from semgrep-core

### DIFF
--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -220,9 +220,9 @@ def _evaluate_single_expression(
     if not expression.pattern_id:
         raise SemgrepError(f"expected expression '{expression}' to have pattern_id")
 
-    ranges_for_pattern = [
+    ranges_for_pattern = {
         x.range for x in pattern_ids_to_pattern_matches.get(expression.pattern_id, [])
-    ]
+    }
 
     if expression.operator == OPERATORS.AND:
         # remove all ranges that don't equal the ranges for this pattern

--- a/semgrep/tests/unit/test_evaluation.py
+++ b/semgrep/tests/unit/test_evaluation.py
@@ -540,3 +540,21 @@ def test_evaluate_python_bad_return_type() -> None:
 
     with pytest.raises(SemgrepError):
         evaluate_expression(expression, results, allow_exec=True)
+
+
+def test_single_pattern_match_filtering() -> None:
+    results = {
+        PatternId("pattern1"): [PatternMatchMock(30, 100, {"$X": "x1", "$Y": "y1"})],
+        PatternId("pattern2"): [PatternMatchMock(30, 100, {"$X": "x1", "$Y": "y2"})],
+        PatternId("pattern3"): [PatternMatchMock(30, 100, {"$X": "x1"})],
+    }
+    expression = [
+        BooleanRuleExpression(
+            OPERATORS.AND_EITHER,
+            None,
+            [RuleExpr(OPERATORS.AND, "pattern1"), RuleExpr(OPERATORS.AND, "pattern2")],
+        ),
+        RuleExpr(OPERATORS.AND_NOT, "pattern3"),
+    ]
+    result = evaluate_expression(expression, results)
+    assert result == set(), f"{result}"


### PR DESCRIPTION
Fixes #2646.

This was a particularly tricky bug that occurred due to an assumption mismatch between semgrep-py and semgrep-core. This PR (https://github.com/returntocorp/semgrep/pull/2618) de-duplicated matches sent by semgrep-core for a particular pattern. This change surfaced an odd implementation detail in Python's `set` operations, which, combined with our somewhat odd metavariable matching implementation caused this bug.

The way we define equality on our `Range` implementation, particularly the `vars_match` function lead to some weird behavior. This minimal Python script highlights the issue:

```python
class Foo:
    def __init__(self, a, b, c=None):
        self.a = a
        self.b = b
        self.c = c

    def __repr__(self):
        return "<Foo a={} b={} c={}>".format(self.a, self.b, self.c)

    def __hash__(self):
        return hash((self.a, self.b))

    def __eq__(self, rhs):
        if self.c and rhs.c:
            return self.a == rhs.a and self.b == rhs.b and self.c == rhs.c

        return self.a == rhs.a and self.b == rhs.b


s1 = {Foo(1, 2, 3), Foo(1, 2, 4)}
s2 = {Foo(1, 2)}
l1 = [Foo(1, 2)]
l2 = [Foo(1, 2), Foo(1, 2)]

print("s1 = {}".format(s1))
print("s2 = {}".format(s2))
print("l1 = {}".format(l1))
print("l2 = {}".format(l2))

print("s1 - s2 = {}".format(s1.difference(s2)))
print("s1 - l1 = {}".format(s1.difference(l1)))
print("s1 - l2 = {}".format(s1.difference(l2)))
```

```
$ python set_test.py 
s1 = {<Foo a=1 b=2 c=3>, <Foo a=1 b=2 c=4>}
s2 = {<Foo a=1 b=2 c=None>}
l1 = [<Foo a=1 b=2 c=None>]
l2 = [<Foo a=1 b=2 c=None>, <Foo a=1 b=2 c=None>]
s1 - s2 = set()
s1 - l1 = {<Foo a=1 b=2 c=4>}
s1 - l2 = set()
```

The oddity here is that I would've expected `s1 - l1` and `s1 - l2` to yield the same result. This means that after https://github.com/returntocorp/semgrep/pull/2618, and matches are being de-duplicated, we were not getting the same result. That is, I would've expected the `difference` call to implicitly convert its argument to a `set` and effectively result in `s1 - s2`. We can force this, as seen in the fix, by explicitly using a `set`.

Another option here would have been to redefine the `vars_match` function on `Range`. It seems odd that our metavariable matching logic uses a subset operation rather than a true equality. E.g. `{"$X": "x1"}` equals both `{"$X": "x1", "$Y": "y1"}` and `{"$X": "x1", "$Y": "y2"}`, but those two are not equivalent. This may be a "better" fix, but is much more likely to break things for existing users relying on this implicit behavior. cc @nbrahms who may be able to fill us in on the original intent here.