### PR TITLE
Ej 2601 yaml ellipses

### DIFF
--- a/semgrep-core/Parsing/Parse_target.ml
+++ b/semgrep-core/Parsing/Parse_target.ml
@@ -298,10 +298,7 @@ let just_parse_with_lang lang file =
   | Lang.R ->
       failwith "No R parser yet; improve the one in tree-sitter"
   | Lang.Yaml ->
-      let ch = open_in file in
-      let s = really_input_string ch (in_channel_length ch) in
-      close_in ch;
-      { ast = Yaml_to_generic.program {str = s; file};
+      { ast = Yaml_to_generic.program file;
         errors = [];
         stat = Parse_info.default_stat file}
 

--- a/semgrep-core/Parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/Parsing/other/yaml_to_generic.ml
@@ -37,12 +37,12 @@ let get_res = function
   | Result.Ok v -> v
 
 let tok (index, line, column) str file =
-  {Parse_info.token = Parse_info.OriginTok {str; charpos = index; line; column; file};
+  {Parse_info.token = Parse_info.OriginTok {str; charpos = index; line = line + 1; column; file};
    Parse_info.transfo = NoTransfo}
 
 let mk_tok {E.start_mark = {M.index; M.line; M.column}; _} str file =
   (* their tokens are 0 indexed for line and column, AST_generic's are 1 indexed for line, 0 for column *)
-  tok (index, line + 1, column) str file
+  tok (index, line, column) str file
 
 let mk_bracket ({E.start_mark = {M.index = s_index; M.line = s_line; M.column = s_column}; _},
                 {E.end_mark = {M.index = e_index; M.line = e_line; M.column = e_column}; _}) v file =

--- a/semgrep-core/Parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/Parsing/other/yaml_to_generic.ml
@@ -12,11 +12,6 @@ exception ParseError of string
  * low-level Stream API, which we parse into a generic AST
 *)
 
-type env = {
-  str: string;
-  file: Common.filename
-}
-
 (* Helper functions *)
 
 let p_token = function
@@ -145,6 +140,8 @@ let parse file parser : A.expr =
 
 (* Entry point *)
 
-let program { str; file } = [A.exprstmt (get_res (S.parser str) |> parse file)]
+let program file =
+  let str = Common.read_file file in
+  [A.exprstmt (get_res (S.parser str) |> parse file)]
 
 let any str = A.E (get_res (S.parser str) |> parse "<pattern_file>")

--- a/semgrep-core/Parsing/other/yaml_to_generic.mli
+++ b/semgrep-core/Parsing/other/yaml_to_generic.mli
@@ -1,7 +1,2 @@
-type env = {
-  str: string;
-  file: Common.filename
-}
-
-val program: env -> AST_generic.program
+val program: Common.filename -> AST_generic.program
 val any: string -> AST_generic.any

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -33,6 +33,7 @@ LUA_EXTENSIONS = [FileExtension(".lua")]
 CSHARP_EXTENSIONS = [FileExtension(".cs")]
 RUST_EXTENSIONS = [FileExtension(".rs")]
 KOTLIN_EXTENSIONS = [FileExtension(".kt")]
+YAML_EXTENSIONS = [FileExtension(".yaml")]
 ML_EXTENSIONS = [
     FileExtension(".mli"),
     FileExtension(".ml"),
@@ -53,6 +54,7 @@ ALL_EXTENSIONS = (
     + JSON_EXTENSIONS
     + RUST_EXTENSIONS
     + KOTLIN_EXTENSIONS
+    + YAML_EXTENSIONS
 )
 
 # This is used to select the files suitable for spacegrep, which is
@@ -85,6 +87,7 @@ _LANGS_TO_EXTS_INTERNAL: List[Tuple[Set[Language], List[FileExtension]]] = [
     (langauge_set({"cs", "csharp", "C#"}), CSHARP_EXTENSIONS),
     (langauge_set({"rs", "rust", "Rust"}), RUST_EXTENSIONS),
     (langauge_set({"kt", "kotlin", "Kotlin"}), KOTLIN_EXTENSIONS),
+    (langauge_set({"yaml", "Yaml"}), YAML_EXTENSIONS),
     (REGEX_ONLY_LANGUAGE_KEYS.union({GENERIC_LANGUAGE}), GENERIC_EXTENSIONS),
 ]
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -6,5 +6,5 @@ running 1 rules...
 [94m  | [39m               [31m^^^^^^^^^^[39m
 [94m8 | [39m    severity: WARNING
 
-[31munsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, c, cs, csharp, generic, go, golang, java, javascript, js, json, jsx, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, ts, tsx, typescript[39m
+[31munsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, jsx, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, ts, tsx, typescript, yaml[39m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,7 +3,7 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, c, cs, csharp, generic, go, golang, java, javascript, js, json, jsx, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, ts, tsx, typescript",
+      "long_msg": "unsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, jsx, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, ts, tsx, typescript, yaml",
       "short_msg": "invalid language: intercal",
       "spans": [
         {


### PR DESCRIPTION
Complete basic support for semgrep ellipses and metavariables
    
Adjust the line number of tokens, convert ellipses, add tests

Supports #2601
    
Test plan: makes test