### PR TITLE
Print exit code, stdout, and stderr when semgrep-core fails.

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -27,6 +27,10 @@ dummy:
 	docker pull $(DOCKER_IMG)
 	./run-benchmarks --dummy --docker $(DOCKER_IMG) --upload
 
+.PHONY: dummy-local
+dummy-local:
+	./run-benchmarks --dummy --upload
+
 .PHONY: clean
 clean:
 	rm -rf bench/*/input

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -61,6 +61,7 @@ class SemgrepVariant:
 # disable this or that optimization.
 #
 SEMGREP_VARIANTS = [
+    # default settings
     SemgrepVariant("std", "-bloom_filter"),
     SemgrepVariant("no-cache", "-bloom_filter -no_opt_cache"),
     SemgrepVariant("max-cache", "-bloom_filter -opt_max_cache"),
@@ -95,6 +96,7 @@ def run_semgrep(docker: str, corpus: Corpus, variant: SemgrepVariant) -> float:
         "--timeout",
         "0",
         "--verbose",
+        "--no-git-ignore",  # because files in bench/*/input/ are git-ignored
     ]
     if docker:
         # Absolute paths are required by docker for mounting volumes, otherwise

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -48,7 +48,7 @@ def convert_ranges(ranges: DebugRanges) -> DebugRangesConverted:
 class DebuggingStep:
     filter: str
     pattern_id: Optional[str]
-    ranges: DebugRanges = attr.ib(converter=convert_ranges)
+    ranges: DebugRangesConverted = attr.ib(converter=convert_ranges)
     metavar_ranges: Dict[str, List[PatternMatch]]
 
 

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -86,7 +86,7 @@ class TargetManager:
     ) -> Set[Path]:
         """
         Recursively go through a directory and return list of all files with
-        default file extention of language
+        default file extension of language
         """
 
         def _parse_output(output: str, curr_dir: Path) -> Set[Path]:
@@ -107,7 +107,7 @@ class TargetManager:
                 }
             return files
 
-        def _find_files_with_extention(
+        def _find_files_with_extension(
             curr_dir: Path, extension: FileExtension
         ) -> Set[Path]:
             """
@@ -155,7 +155,7 @@ class TargetManager:
                     )
                 except (subprocess.CalledProcessError, FileNotFoundError):
                     # Not a git directory or git not installed. Fallback to using rglob
-                    ext_files = _find_files_with_extention(curr_dir, ext)
+                    ext_files = _find_files_with_extension(curr_dir, ext)
                     expanded = expanded.union(ext_files)
                 else:
                     tracked = _parse_output(tracked_output, curr_dir)
@@ -166,7 +166,7 @@ class TargetManager:
                     expanded = expanded.difference(deleted)
 
             else:
-                ext_files = _find_files_with_extention(curr_dir, ext)
+                ext_files = _find_files_with_extension(curr_dir, ext)
                 expanded = expanded.union(ext_files)
 
         return expanded


### PR DESCRIPTION
I had a long-running job crashing due to `semgrep-core` exiting with code 2 but without details. Semgrep now prints stdout and stderr in such cases. The following is a sample output produced using a fake `semgrep-core` that always fails:
```
running 1 rules...
semgrep-core exit code: 2
unexpected non-json output while invoking semgrep-core:
--- semgrep-core stdout ---
borken

--- end semgrep-core stdout ---
--- semgrep-core stderr ---

--- end semgrep-core stderr ---
An error occurred while invoking the semgrep engine; please help us fix this by creating an issue at https://github.com/returntocorp/semgrep
semgrep exit status: 2
Traceback (most recent call last):
  File "./run-benchmarks", line 189, in <module>
    main()
  File "./run-benchmarks", line 185, in main
    run_benchmarks(args.docker, args.dummy, args.upload)
  File "./run-benchmarks", line 161, in run_benchmarks
    duration = run_semgrep(docker, corpus, variant)
  File "./run-benchmarks", line 145, in run_semgrep
    res.check_returncode()
  File "/usr/lib/python3.7/subprocess.py", line 444, in check_returncode
    self.stderr)
subprocess.CalledProcessError: Command '['semgrep', '--config', '/home/martin/semgrep/perf/bench/dummy/input/dummy/rules', '/home/martin/semgrep/perf/bench/dummy/input/dummy/targets', '--strict', '--timeout', '0', '--verbose', '--no-git-ignore']' returned non-zero exit status 2.
make: *** [Makefile:32: dummy-local] Error 1
```

This PR also includes small fixes:
* typo extention -> extension
* stuff related to the run-benchmarks program (under development, runs on a daily schedule)
* fix in a type annotation