### PR TITLE
Shorter benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,21 @@ workflows:
               only:
                 - develop
 
-  # This is for testing. Requires pushing to a branch named 'benchmarks'.
+  # This is for testing. Requires pushing to a branch named 'dummy-benchmarks'.
   dummy-benchmarks-on-commit:
     jobs:
       - dummy-benchmarks:
           filters:
             branches:
               only:
-                - benchmarks
+                - dummy-benchmarks
+
+  # This is for testing. Requires pushing to a branch named 'force-benchmarks'.
+  # It can take hours, use with care.
+  benchmarks-on-commit:
+    jobs:
+      - benchmarks:
+          filters:
+            branches:
+              only:
+                - force-benchmarks

--- a/perf/Makefile
+++ b/perf/Makefile
@@ -27,6 +27,10 @@ dummy:
 	docker pull $(DOCKER_IMG)
 	./run-benchmarks --dummy --docker $(DOCKER_IMG) --upload
 
+.PHONY: dummy-local
+dummy-local:
+	./run-benchmarks --dummy --upload
+
 .PHONY: clean
 clean:
 	rm -rf bench/*/input

--- a/perf/bench/njsbox/prep
+++ b/perf/bench/njsbox/prep
@@ -1,0 +1,42 @@
+#! /bin/sh
+#
+# Fetch rules and targets prior for the "njs" benchmark.
+#
+# rule_dir: input/njsscan/njsscan/rules/semantic_grep
+# target_dir: input/juice-shop
+#
+# Uses sh because bash is not installed within the semgrep docker container.
+#
+set -eu
+
+mkdir -p input
+cd input
+
+# Obtain a shallow clone of a git repo for a specific commit
+shallow_clone() {
+  if [ -d "$name" ]; then
+    echo "Reusing repo '$name'"
+  else
+    echo "Obtaining a shallow clone of git repo '$name', commit $commit"
+    mkdir -p "$name"
+    (
+      cd "$name"
+      git init
+      git remote add origin "$url"
+      git fetch --depth 1 origin "$commit"
+      git checkout FETCH_HEAD -b tmp
+    )
+  fi
+}
+
+# Obtain semgrep rules
+name="njsscan"
+url="https://github.com/ajinabraham/njsscan.git"
+commit="edc1d0a8b38bfb5421e21665284f83de3dbe636e"
+shallow_clone
+
+# Obtain targets
+name="dropbox-sdk-js"
+url="https://github.com/dropbox/dropbox-sdk-js.git"
+commit="268887672a0d7be58ffbfaf832731698e31d792d"
+shallow_clone

--- a/perf/bench/zulip/prep
+++ b/perf/bench/zulip/prep
@@ -1,0 +1,41 @@
+#! /bin/sh
+#
+# Fetch rules and targets prior for the "njs" benchmark.
+#
+# rule_dir: input/zulip/???
+# target_dir: input/zulip/???
+#
+# Uses sh because bash is not installed within the semgrep docker container.
+#
+set -eu
+
+mkdir -p input
+
+# This the original ruleset from zulip/tools/ minus the rule that requires
+# '--dangerously-allow-arbitrary-code-execution-from-rules'
+cp semgrep.yml input
+
+cd input
+
+# Obtain a shallow clone of a git repo for a specific commit
+shallow_clone() {
+  if [ -d "$name" ]; then
+    echo "Reusing repo '$name'"
+  else
+    echo "Obtaining a shallow clone of git repo '$name', commit $commit"
+    mkdir -p "$name"
+    (
+      cd "$name"
+      git init
+      git remote add origin "$url"
+      git fetch --depth 1 origin "$commit"
+      git checkout FETCH_HEAD -b tmp
+    )
+  fi
+}
+
+# Obtain semgrep rules and targets
+name="zulip"
+url="https://github.com/zulip/zulip.git"
+commit="829f9272d2c4299a0c0a37a09802248d8136c0a8"
+shallow_clone

--- a/perf/bench/zulip/semgrep.yml
+++ b/perf/bench/zulip/semgrep.yml
@@ -1,0 +1,141 @@
+# See https://semgrep.dev/docs/writing-rules/rule-syntax/ for documentation on YAML rule syntax
+
+rules:
+  ####################### PYTHON RULES #######################
+  - id: deprecated-render-usage
+    pattern: django.shortcuts.render_to_response(...)
+    message: "Use render() (from django.shortcuts) instead of render_to_response()"
+    languages: [python]
+    severity: ERROR
+
+  - id: dont-use-stream-objects-filter
+    pattern: Stream.objects.filter(...)
+    message: "Please use access_stream_by_*() to fetch Stream objects"
+    languages: [python]
+    severity: ERROR
+    paths:
+      include:
+        - zerver/views/
+
+  - id: dont-import-models-in-migrations
+    patterns:
+      - pattern-not: from zerver.lib.redis_utils import get_redis_client
+      - pattern-not: from zerver.models import filter_pattern_validator
+      - pattern-not: from zerver.models import filter_format_validator
+      - pattern-not: from zerver.models import generate_email_token_for_stream
+      - pattern-either:
+          - pattern: from zerver import $X
+          - pattern: from analytics import $X
+          - pattern: from confirmation import $X
+    message: "Don't import models or other code in migrations; see docs/subsystems/schema-migrations.md"
+    languages: [python]
+    severity: ERROR
+    paths:
+      include:
+        - "**/migrations"
+      exclude:
+        - zerver/migrations/0032_verify_all_medium_avatar_images.py
+        - zerver/migrations/0104_fix_unreads.py
+        - zerver/migrations/0206_stream_rendered_description.py
+        - zerver/migrations/0209_user_profile_no_empty_password.py
+        - zerver/migrations/0260_missed_message_addresses_from_redis_to_db.py
+        - pgroonga/migrations/0002_html_escape_subject.py
+
+  # - id: logging-format
+  #   languages: [python]
+  #   patterns:
+  #     - pattern-either:
+  #         - pattern: logging.$Y(... .format(...))
+  #         - pattern: logging.$Y(f"...")
+  #         - pattern: logger.$Y(... .format(...))
+  #         - pattern: logger.$Y(f"...")
+  #     - pattern-where-python: "vars['$Y'] in ['debug', 'info', 'warning', 'error', 'critical', 'exception']"
+  #   severity: ERROR
+  #   message: "Pass format arguments to logging (https://docs.python.org/3/howto/logging.html#optimization)"
+
+  - id: sql-format
+    languages: [python]
+    pattern-either:
+      - pattern: ... .execute("...".format(...))
+      - pattern: ... .execute(f"...")
+      - pattern: psycopg2.sql.SQL(... .format(...))
+      - pattern: psycopg2.sql.SQL(f"...")
+      - pattern: django.db.migrations.RunSQL(..., "..." .format(...), ...)
+      - pattern: django.db.migrations.RunSQL(..., f"...", ...)
+      - pattern: django.db.migrations.RunSQL(..., [..., "..." .format(...), ...], ...)
+      - pattern: django.db.migrations.RunSQL(..., [..., f"...", ...], ...)
+    severity: ERROR
+    message: "Do not write a SQL injection vulnerability please"
+
+  - id: translated-format
+    languages: [python]
+    pattern-either:
+      - pattern: django.utils.translation.ugettext(... .format(...))
+      - pattern: django.utils.translation.ugettext(f"...")
+      - pattern: django.utils.translation.ugettext_lazy(... .format(...))
+      - pattern: django.utils.translation.ugettext_lazy(f"...")
+    severity: ERROR
+    message: "Format strings after translation, not before"
+
+  - id: translated-format-lazy
+    languages: [python]
+    pattern: django.utils.translation.ugettext_lazy(...).format(...)
+    severity: ERROR
+    message: "Immediately formatting a lazily translated string destroys its laziness"
+
+  - id: mutable-default-type
+    languages: [python]
+    pattern-either:
+      - pattern: |
+          def $F(..., $A: typing.List[...] = [...], ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Optional[typing.List[...]] = [...], ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.List[...] = zerver.lib.request.REQ(..., default=[...], ...), ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Optional[typing.List[...]] = zerver.lib.request.REQ(..., default=[...], ...), ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Dict[...] = {}, ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Optional[typing.Dict[...]] = {}, ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Dict[...] = zerver.lib.request.REQ(..., default={}, ...), ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Optional[typing.Dict[...]] = zerver.lib.request.REQ(..., default={}, ...), ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Set[...] = set(), ...) -> ...:
+              ...
+      - pattern: |
+          def $F(..., $A: typing.Optional[typing.Set[...]] = set(), ...) -> ...:
+              ...
+    severity: ERROR
+    message: "Guard mutable default with read-only type (Sequence, Mapping, AbstractSet)"
+
+  - id: percent-formatting
+    languages: [python]
+    pattern-either:
+      - pattern: '"..." % ...'
+      - pattern: django.utils.translation.ugettext(...) % ...
+      - pattern: django.utils.translation.ugettext_lazy(...) % ...
+    severity: ERROR
+    message: "Prefer f-strings or .format for string formatting"
+
+  - id: eval
+    languages: [python]
+    pattern: eval
+    severity: ERROR
+    message: "Do not use eval under any circumstances; consider json.loads instead"
+
+  - id: typing-text
+    languages: [python]
+    pattern: typing.Text
+    severity: ERROR
+    message: "Use str instead of typing.Text"

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -39,8 +39,10 @@ class Corpus:
 
 CORPUSES = [
     # Run Ajin's nodejsscan rules on some repo containing javascript files.
-    Corpus("njs", "input/njsscan/njsscan/rules/semantic_grep", "input/juice-shop"),
-    # add more as needed
+    # This takes something like 4 hours or more. Maybe we could run it
+    # on fewer targets.
+    # Corpus("njs", "input/njsscan/njsscan/rules/semantic_grep", "input/juice-shop"),
+    Corpus("zulip", "input/semgrep.yml", "input/zulip")
 ]
 
 DUMMY_CORPUSES = [Corpus("dummy", "input/dummy/rules", "input/dummy/targets")]

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -61,6 +61,7 @@ class SemgrepVariant:
 # disable this or that optimization.
 #
 SEMGREP_VARIANTS = [
+    # default settings
     SemgrepVariant("std", "-bloom_filter"),
     SemgrepVariant("no-cache", "-bloom_filter -no_opt_cache"),
     SemgrepVariant("max-cache", "-bloom_filter -opt_max_cache"),
@@ -95,6 +96,7 @@ def run_semgrep(docker: str, corpus: Corpus, variant: SemgrepVariant) -> float:
         "--timeout",
         "0",
         "--verbose",
+        "--no-git-ignore",  # because files in bench/*/input/ are git-ignored
     ]
     if docker:
         # Absolute paths are required by docker for mounting volumes, otherwise

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -42,7 +42,10 @@ CORPUSES = [
     # This takes something like 4 hours or more. Maybe we could run it
     # on fewer targets.
     # Corpus("njs", "input/njsscan/njsscan/rules/semantic_grep", "input/juice-shop"),
-    Corpus("zulip", "input/semgrep.yml", "input/zulip")
+    Corpus(
+        "njsbox", "input/njsscan/njsscan/rules/semantic_grep", "input/dropbox-sdk-js"
+    ),
+    Corpus("zulip", "input/semgrep.yml", "input/zulip"),
 ]
 
 DUMMY_CORPUSES = [Corpus("dummy", "input/dummy/rules", "input/dummy/targets")]

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -48,7 +48,7 @@ def convert_ranges(ranges: DebugRanges) -> DebugRangesConverted:
 class DebuggingStep:
     filter: str
     pattern_id: Optional[str]
-    ranges: DebugRanges = attr.ib(converter=convert_ranges)
+    ranges: DebugRangesConverted = attr.ib(converter=convert_ranges)
     metavar_ranges: Dict[str, List[PatternMatch]]
 
 

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -86,7 +86,7 @@ class TargetManager:
     ) -> Set[Path]:
         """
         Recursively go through a directory and return list of all files with
-        default file extention of language
+        default file extension of language
         """
 
         def _parse_output(output: str, curr_dir: Path) -> Set[Path]:
@@ -107,7 +107,7 @@ class TargetManager:
                 }
             return files
 
-        def _find_files_with_extention(
+        def _find_files_with_extension(
             curr_dir: Path, extension: FileExtension
         ) -> Set[Path]:
             """
@@ -155,7 +155,7 @@ class TargetManager:
                     )
                 except (subprocess.CalledProcessError, FileNotFoundError):
                     # Not a git directory or git not installed. Fallback to using rglob
-                    ext_files = _find_files_with_extention(curr_dir, ext)
+                    ext_files = _find_files_with_extension(curr_dir, ext)
                     expanded = expanded.union(ext_files)
                 else:
                     tracked = _parse_output(tracked_output, curr_dir)
@@ -166,7 +166,7 @@ class TargetManager:
                     expanded = expanded.difference(deleted)
 
             else:
-                ext_files = _find_files_with_extention(curr_dir, ext)
+                ext_files = _find_files_with_extension(curr_dir, ext)
                 expanded = expanded.union(ext_files)
 
         return expanded


### PR DESCRIPTION
This replaces the previous benchmark ("njs") that was taking too long (4+ hours). The new benchmarks take only a few minutes. They are:
* "njsbox": uses nodejsscan's 111 rules and runs them on a small repo
* "zulip": uses 10 rules from zulip (excluding the one that evals python code) and runs them on the zulip repo

This PR is on top a previous one https://github.com/returntocorp/semgrep/pull/2661 (it was just easier that way).
