### PR TITLE
rule_schema: Update authoritative URL

### DIFF
--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -1,4 +1,5 @@
-$schema: https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep/semgrep/rule_schema.yaml
+$id: https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep/semgrep/rule_schema.yaml
+$schema: http://json-schema.org/draft-07/schema#
 definitions:
   patterns-content:
     type: array

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -1,4 +1,4 @@
-$schema: http://github.com/returntocorp/semgrep/semgrep/semgrep/rule_schema.yaml
+$schema: https://raw.githubusercontent.com/returntocorp/semgrep/develop/semgrep/semgrep/rule_schema.yaml
 definitions:
   patterns-content:
     type: array


### PR DESCRIPTION
The old URL was http:// and broken. It also was in the wrong field, $schema is meant to show JSONSchema version,  see https://json-schema.org/learn/examples/address.schema.json

Relates to https://github.com/returntocorp/semgrep/issues/2654