### PR TITLE
Parse await foreach in C#

### DIFF
--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1455,7 +1455,7 @@ and statement (env : env) (x : CST.statement) =
    | `For_each_stmt (v1, v2, v3, v4, v5, v6, v7, v8) ->
        let v1 =
          (match v1 with
-          | Some tok -> todo env tok (* "await" *)
+          | Some tok -> Some (token env tok) (* "await" *)
           | None -> None)
        in
        let v2 = token env v2 (* "foreach" *) in
@@ -1478,6 +1478,10 @@ and statement (env : env) (x : CST.statement) =
        in
        let v5 = token env v5 (* "in" *) in
        let v6 = expression env v6 in
+       let v6 = (match v1 with
+         | Some tok -> Await (tok, v6) (* "await" *)
+         | None -> v6
+       ) in
        let v7 = token env v7 (* ")" *) in
        let v8 = statement env v8 in
        For (v2, ForEach  (v4, v5, v6), v8) |> AST.s

--- a/semgrep-core/tests/csharp/parsing/async.cs
+++ b/semgrep-core/tests/csharp/parsing/async.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 class HelloWorldAsync
@@ -12,6 +13,14 @@ class HelloWorldAsync
     {
         return "hello world";
     }
+
+    public static async IAsyncEnumerable<char> GetGreetingAsyncEnum()
+    {
+        foreach (var ch in "hello world")
+        {
+            yield return ch;
+        }
+    }
     
     public static async Task Main()
     {
@@ -19,5 +28,10 @@ class HelloWorldAsync
         Console.WriteLine(greeting);
         Console.WriteLine(await GetGreetingAsync());
         var greeting2 = await GetGreetingAsync();
+
+        await foreach (var ch in GetGreetingAsyncEnum())
+        {
+            Console.Write(ch);
+        }
     }
 }


### PR DESCRIPTION
E.g.
```
await foreach (var ch in GetGreetingAsyncEnum())
{
    Console.Write(ch);
}
```

This gets converted roughly into `foreach (var ch in await
GetGreetingAsyncEnum())`, which isn't very accurate but retains the async in a
way that works with the current generic AST.