### PR TITLE
Change iter_files interface to parse the AST lazily

### DIFF
--- a/semgrep-core/Engine/Semgrep.mli
+++ b/semgrep-core/Engine/Semgrep.mli
@@ -4,7 +4,7 @@ val check:
   (*with_caching:*)bool ->
   (Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) (* hook *) ->
   Rule.rules ->
-  (Common.filename * Rule.xlang * Target.t Lazy.t) ->
-  Rule_match.t list
+  (Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t) ->
+  Rule_match.t list * Error_code.error list
 
 (*e: semgrep/engine/Semgrep.mli *)

--- a/semgrep-core/Engine/Test_rule.ml
+++ b/semgrep-core/Engine/Test_rule.ml
@@ -86,25 +86,28 @@ let test_rules xs =
     let expected_error_lines = E.expected_error_lines_of_files [target] in
 
     (* actual *)
-    let ast = lazy (
+    let lazy_ast_and_errors = lazy (
       match xlang with
       | R.L (lang, _) ->
-          (let {Parse_target. ast; _} =
-             Parse_target.parse_and_resolve_name_use_pfff_or_treesitter
-               lang target
-           in
-           ast)
+          let {Parse_target. ast; errors; _} =
+            Parse_target.parse_and_resolve_name_use_pfff_or_treesitter
+              lang target
+          in
+          ast, errors
       | R.LNone | R.LGeneric -> raise Impossible
     )
     in
     E.g_errors := [];
-    let matches =
+    let matches, errors =
       try
-        Semgrep.check false (fun _ _ -> ()) rules (target, xlang, ast)
+        Semgrep.check false (fun _ _ -> ()) rules
+          (target, xlang, lazy_ast_and_errors)
       with exn ->
         failwith (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))
     in
     matches |> List.iter JSON_report.match_to_error;
+    if not (errors = [])
+    then failwith (spf "parsing error on %s" file);
 
     let actual_errors = !E.g_errors in
     actual_errors |> List.iter (fun e ->


### PR DESCRIPTION
This will enable later to skip parsing entire files if we don't find
certain regexps in it

test plan:
make test