### PR TITLE
[WIP] Filtering irrelevant rules using regexps by analyzing the whole rule

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -499,7 +499,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout matches =
     )
   in
   new_matches, new_errors
-[@@profiling]
+[@@profiling "Main.filter_too_many_matches"]
 
 (*****************************************************************************)
 (* Parsing *)
@@ -1330,14 +1330,20 @@ let options () =
     (*e: [[Main_semgrep_core.options]] other cases *)
     "-use_parsing_cache", Arg.Set_string use_parsing_cache,
     " <dir> save and use parsed ASTs in a cache at given directory. Caller responsiblity to clear cache";
+
     "-filter_irrelevant_patterns", Arg.Set Flag.filter_irrelevant_patterns,
     " filter patterns not containing any strings in target file";
+    "-no_filter_irrelevant_patterns",Arg.Clear Flag.filter_irrelevant_patterns,
+    " do not filter patterns";
+    "-filter_irrelevant_rules", Arg.Set Flag.filter_irrelevant_rules,
+    " filter rules not containing any strings in target file";
+    "-no_filter_irrelevant_rules", Arg.Clear Flag.filter_irrelevant_rules,
+    " do not filter rules";
+
     "-bloom_filter", Arg.Set Flag.use_bloom_filter,
     " use a bloom filter to only attempt matches when strings in the pattern are in the target";
     "-no_bloom_filter", Arg.Clear Flag.use_bloom_filter,
     " do not use bloom filter";
-    "-no_filter_irrelevant_patterns", Arg.Clear Flag.filter_irrelevant_patterns,
-    " do not filter rules";
     "-tree_sitter_only", Arg.Set Flag.tree_sitter_only,
     " only use tree-sitter-based parsers";
 

--- a/semgrep-core/Core/AST/Lang.ml
+++ b/semgrep-core/Core/AST/Lang.ml
@@ -55,7 +55,7 @@ type t =
   (* config files *)
   | JSON | Yaml
   (*e: type [[Lang.t]] *)
-[@@deriving show]
+[@@deriving show, eq]
 
 (*****************************************************************************)
 (* Helpers *)

--- a/semgrep-core/Core/AST/Lang.mli
+++ b/semgrep-core/Core/AST/Lang.mli
@@ -27,6 +27,7 @@ type t =
   (*e: type [[Lang.t]] *)
 val pp: Format.formatter -> t -> unit
 val show: t -> string
+val equal: t -> t -> bool
 
 (*s: signature [[Lang.lang_of_string_map]] *)
 val lang_of_string_map: (string, t) Hashtbl.t

--- a/semgrep-core/Core/Flag_semgrep.ml
+++ b/semgrep-core/Core/Flag_semgrep.ml
@@ -32,6 +32,10 @@ let max_cache = ref false
 (* look if identifiers in pattern intersect with file using simple regexps *)
 let filter_irrelevant_patterns = ref false
 
+(* similar to filter_irrelevant_patterns, but use the whole rule to extract
+ * the regexp *)
+let filter_irrelevant_rules = ref false
+
 (* check for identifiers before attempting to match a stmt or stmt list *)
 let use_bloom_filter = ref false
 

--- a/semgrep-core/Core/Pattern.ml
+++ b/semgrep-core/Core/Pattern.ml
@@ -61,7 +61,7 @@ let is_special_identifier ?lang str =
   str = AST_generic.special_multivardef_pattern ||
   (* ugly: because ast_js_build introduce some extra "!default" ids *)
   (lang = Some Lang.Javascript && str = Ast_js.default_entity) ||
-  (* parser_js.mly inserts some implicit this *)
+  (* parser_java.mly inserts some implicit this *)
   (lang = Some Lang.Java && str = "this")
 
 (*e: semgrep/core/Pattern.ml *)

--- a/semgrep-core/Core/Regexp_engine.ml
+++ b/semgrep-core/Core/Regexp_engine.ml
@@ -59,21 +59,22 @@
    Re.execp re str
 *)
 
-let regexp_matching_str s =
-  Str.regexp_string s
+module Str_engine = struct
+  type t = Str.regexp
 
-let compile_regexp t = t
-[@@profiling]
+  let matching_string s =
+    Str.regexp_string s
 
-(* this is not anchored! *)
-let run_regexp re str =
-  (* bugfix:
-   * this does not work!:  Str.string_match re str 0
-   * because you need to add ".*" in front to make it work,
-   * (but then you can not use regexp_string above)
-   * => use Str.search_forward instead.
-  *)
-  try
-    Str.search_forward re str 0 |> ignore; true
-  with Not_found -> false
-[@@profiling]
+  (* this is not anchored! *)
+  let run re str =
+    (* bugfix:
+     * this does not work!:  Str.string_match re str 0
+     * because you need to add ".*" in front to make it work,
+     * (but then you can not use regexp_string above)
+     * => use Str.search_forward instead.
+    *)
+    try
+      Str.search_forward re str 0 |> ignore; true
+    with Not_found -> false
+  [@@profiling]
+end

--- a/semgrep-core/Core/Regexp_engine.mli
+++ b/semgrep-core/Core/Regexp_engine.mli
@@ -1,0 +1,6 @@
+
+module Str_engine : sig
+  type t = Str.regexp
+  val matching_string: string -> t
+  val run: t -> string -> bool
+end

--- a/semgrep-core/Core/Rule.ml
+++ b/semgrep-core/Core/Rule.ml
@@ -34,7 +34,7 @@ module MV = Metavariable
 
 (* less: merge with xpattern_kind? *)
 type xlang =
-  (* for "real" semgrep *)
+  (* for "real" semgrep (the first language is used to parse the pattern) *)
   | L of Lang.t * Lang.t list
   (* for pattern-regex *)
   | LNone
@@ -61,7 +61,7 @@ type xpattern = {
   pid: pattern_id [@equal (fun _ _ -> true)];
 }
 and xpattern_kind =
-  | Sem of Pattern.t
+  | Sem of Pattern.t * Lang.t (* language used for parsing the pattern *)
   | Spacegrep of Spacegrep.Pattern_AST.t
   | Regexp of regexp
   (* used in the engine for rule->mini_rule and match_result gymnastic *)

--- a/semgrep-core/Metachecking/Check_rule.ml
+++ b/semgrep-core/Metachecking/Check_rule.ml
@@ -98,7 +98,7 @@ let check_new_formula env lang f =
   (* call Check_pattern subchecker *)
   f |> visit_new_formula (fun { pat; pstr = _pat_str; pid = _ } ->
     match pat, lang with
-    | Sem semgrep_pat, L (lang, _rest)  ->
+    | Sem (semgrep_pat, _lang), L (lang, _rest)  ->
         Check_pattern.check lang semgrep_pat
     | Spacegrep _spacegrep_pat, LGeneric -> ()
     | Regexp _, _ -> ()
@@ -152,7 +152,7 @@ let check_old_formula env lang f =
   (* call Check_pattern subchecker *)
   f |> visit_old_formula (fun { pat; pstr = _pat_str; pid = _ } ->
     match pat, lang with
-    | Sem semgrep_pat, L (lang, _rest)  ->
+    | Sem (semgrep_pat, _lang), L (lang, _rest)  ->
         Check_pattern.check lang semgrep_pat
     | Spacegrep _spacegrep_pat, LGeneric -> ()
     | Regexp _, _ -> ()

--- a/semgrep-core/Optimizing/Analyze_rule.ml
+++ b/semgrep-core/Optimizing/Analyze_rule.ml
@@ -1,0 +1,61 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2021 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+*)
+
+module Re = Regexp_engine.Str_engine
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Analyzing a semgrep rule for optimization purpose.
+ *
+ * Analyze_pattern.ml tries to extract a regexp from a pattern
+ * in order to skip certain target files. However, it processes only
+ * one pattern at a time and is not aware of the context in which this
+ * pattern is used. For example in
+ *
+ *  id: eval-not-in-foo
+ *  patterns:
+ *    - pattern: eval(...)
+ *    - pattern-not:
+ *        require("foo.js")
+ *        ...
+ *
+ * the current Rules_filter used in Semgrep_generic will just see a flat
+ * list of patterns, and will look separately for 'eval' and 'foo.js'
+ * and filter certain patterns; But really, even if 'foo.js' is mentioned
+ * in a file, we should completly skip the file if 'eval' is not in the file
+ * because after all 'foo.js' is mentioned in a pattern-not context!.
+ *
+ * There are many optimizations opportunities when semgrep-core can see
+ * the whole rule:
+ *  - TODO skip the pattern-not when computing the regexp
+ *  - TODO if a pattern is very general (e.g., $FOO()), but is
+ *    also mentioned in a metavariable-regexp, then we can use this
+ *    regexp to filter the rule/target file.
+ *  - TODO if a pattern is very general (e.g., $PROP), but reference
+ *    metavariables used in other patterns, then you still skip the
+ *    rule/target file
+*)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+(* TODO: hard-coded regexp for now, just to test *)
+let regexp_prefilter_of_formula _f =
+  Some ("regexp: jsonwebtoken", fun big_str ->
+    let re = Re.matching_string "jsonwebtoken" in
+    Re.run re big_str
+  )

--- a/semgrep-core/Optimizing/Analyze_rule.ml
+++ b/semgrep-core/Optimizing/Analyze_rule.ml
@@ -23,7 +23,7 @@ module Re = Regexp_engine.Str_engine
  * Analyze_pattern.ml tries to extract a regexp from a pattern
  * in order to skip certain target files. However, it processes only
  * one pattern at a time and is not aware of the context in which this
- * pattern is used. For example in
+ * pattern is used. For example in:
  *
  *  id: eval-not-in-foo
  *  patterns:
@@ -32,21 +32,20 @@ module Re = Regexp_engine.Str_engine
  *        require("foo.js")
  *        ...
  *
- * the current Rules_filter used in Semgrep_generic will just see a flat
+ * the current Mii_rules_filter used in Semgrep_generic will just see a flat
  * list of patterns, and will look separately for 'eval' and 'foo.js'
  * and filter certain patterns; But really, even if 'foo.js' is mentioned
  * in a file, we should completly skip the file if 'eval' is not in the file
- * because after all 'foo.js' is mentioned in a pattern-not context!.
+ * because after all 'foo.js' is mentioned in a pattern-not context!
  *
- * There are many optimizations opportunities when semgrep-core can see
+ * There are many optimization opportunities when semgrep-core can see
  * the whole rule:
  *  - TODO skip the pattern-not when computing the regexp
  *  - TODO if a pattern is very general (e.g., $FOO()), but is
  *    also mentioned in a metavariable-regexp, then we can use this
  *    regexp to filter the rule/target file.
  *  - TODO if a pattern is very general (e.g., $PROP), but reference
- *    metavariables used in other patterns, then you still skip the
- *    rule/target file
+ *    metavariables used in other patterns, then you can skip this pattern
 *)
 
 (*****************************************************************************)

--- a/semgrep-core/Optimizing/Analyze_rule.mli
+++ b/semgrep-core/Optimizing/Analyze_rule.mli
@@ -1,0 +1,3 @@
+
+val regexp_prefilter_of_formula:
+  Rule.formula -> (string (* for debugging *) * (string -> bool)) option

--- a/semgrep-core/Optimizing/Mini_rules_filter.ml
+++ b/semgrep-core/Optimizing/Mini_rules_filter.ml
@@ -15,6 +15,8 @@
 module Flag = Flag_semgrep
 module R = Mini_rule
 
+module Re = Regexp_engine.Str_engine
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -51,9 +53,9 @@ let filter_mini_rules_relevant_to_file_using_regexp rules lang file =
        * extract a complex regexp instead handling itself disjunction.
       *)
       xs |> List.for_all (fun x ->
-        let t = Regexp_engine.regexp_matching_str x in
-        let re = Regexp_engine.compile_regexp t in
-        Regexp_engine.run_regexp re str
+        let re = Re.matching_string x in
+        (* let re = Regexp_engine.compile_regexp t in *)
+        Re.run re str
       )
 
     in

--- a/semgrep-core/Parsing/Parse_rule.ml
+++ b/semgrep-core/Parsing/Parse_rule.ml
@@ -204,7 +204,7 @@ type _env = (string * R.xlang)
 let parse_pattern (id, lang) s =
   match lang with
   | R.L (lang, _) ->
-      R.mk_xpat (Sem (H.parse_pattern ~id ~lang s)) s
+      R.mk_xpat (Sem (H.parse_pattern ~id ~lang s, lang)) s
   | R.LNone ->
       failwith ("you should not use real pattern with language = none")
   | R.LGeneric ->


### PR DESCRIPTION
This is similar to the filtering of irrelevant patterns I was doing
in Mini_rules.filter.ml, but analyzing the whole rule, not individual
patterns to skip entire rules. By also making the generic AST parsing
lazy, we can even sometimes skip parsing a file.

Right now the regexp is hardcoded for the rule used to match
big-js, but subsequents commits will fix that.

test plan:
$ time yy -profile -debug -lang js -config bench/big-js/semgrep_slow.yml
bench/big-js/
=> 5m27
$ time yy -profile -filter_irrelevant_rules -debug -lang js -config bench/big-js/semgrep_slow.yml bench/big-js/
=> 0.6s