### PR TITLE
Add "rust" to list of supported languages

### DIFF
--- a/semgrep-core/Core/AST/Lang.ml
+++ b/semgrep-core/Core/AST/Lang.ml
@@ -90,6 +90,7 @@ let list_of_lang = [
   "kt", Kotlin;
   "lua", Lua;
   "rs", Rust;
+  "rust", Rust;
   "r", R;
   "yaml", Yaml;
 ]


### PR DESCRIPTION
In addition to "rs", it should also be possible to use "rust".