### PR TITLE
Generate pattern which will match targets

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -1213,7 +1213,7 @@ let all_actions () = [
   Common.mk_action_2_arg Test_synthesizing.expr_at_range;
   "-synthesize_patterns", " <l:c-l:c> <file>",
   Common.mk_action_2_arg Test_synthesizing.synthesize_patterns;
-  "-generate_patterns", " <file>",
+  "-generate_patterns", " <l:c-l:c>+ <file>",
   Common.mk_action_n_arg Test_synthesizing.generate_pattern_choices;
 
   "-stat_matches", " <marshalled file>",

--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -1213,6 +1213,8 @@ let all_actions () = [
   Common.mk_action_2_arg Test_synthesizing.expr_at_range;
   "-synthesize_patterns", " <l:c-l:c> <file>",
   Common.mk_action_2_arg Test_synthesizing.synthesize_patterns;
+  "-generate_patterns", " <file>",
+  Common.mk_action_n_arg Test_synthesizing.generate_pattern_choices;
 
   "-stat_matches", " <marshalled file>",
   Common.mk_action_1_arg stat_matches;

--- a/semgrep-core/Synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/Synthesizing/Pattern_from_Code.ml
@@ -48,10 +48,10 @@ let lookup env e =
   in
   look mapping
 
-
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+
 let fk = Parse_info.fake_info "fake"
 let fk_stmt = ExprStmt (Ellipsis fk, fk) |> G.s
 let body_ellipsis t1 t2 = Block(t1, [fk_stmt], t2) |> G.s

--- a/semgrep-core/Synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/Synthesizing/Pattern_from_Targets.ml
@@ -354,7 +354,7 @@ let rec generate_patterns_help (target_patterns : pattern_instrs list) =
   (* Keep only the patterns in each Sn that appear in every other OR *)
   (* the patterns that were included last time, don't have children, and have another replacement to try *)
   let included_patterns = get_included_patterns pattern_children in
-  let cont = List.fold_left (fun prev patterns -> prev && (not (List.length patterns = 0))) true included_patterns in
+  let cont = List.fold_left (fun prev patterns -> prev && (not (patterns = []))) true included_patterns in
   (* Call recursively on these patterns *)
   if cont then generate_patterns_help included_patterns else target_patterns
 

--- a/semgrep-core/Synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/Synthesizing/Pattern_from_Targets.ml
@@ -307,7 +307,7 @@ and get_one_step_replacements (env, pattern, holes) =
        * For example, if f turns foo(...), a -> foo(a), and g turns (...), a -> (a, ...), we want a function *
        * that turns foo(...), a -> foo(a, ...) *)
       let incorporate_holes holes =
-        List.map (fun (removed_target, g) -> (removed_target, fun (h : any -> any) (any : any) : any -> f (g h) any)) holes
+        List.map (fun (removed_target, g) -> (removed_target, fun h any -> f (g h) any)) holes
       in
       (env, pattern, holes'),
       List.map
@@ -344,8 +344,9 @@ let rec generate_patterns_help (target_patterns : pattern_instrs list) =
   (*    ex: ($X, bar(foo(2), x), f) ------> [$X(...), [bar, fun x -> x(...); [foo(2), x], fun xs -> bar(xs)]] *)
   (*        (pattern, any, any -> any) list *)
   (* Flatten the list. Each node n will have a corresponding set of patterns Sn *)
-  pr2 "target patterns";
-  show_pattern_sets target_patterns;
+  if false then (* Set this for debug info *)
+    (pr2 "target patterns";
+     show_pattern_sets target_patterns);
   let pattern_children =
     List.map (fun patterns -> List.map (fun pattern -> get_one_step_replacements pattern) patterns)
       target_patterns

--- a/semgrep-core/Synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/Synthesizing/Pattern_from_Targets.ml
@@ -1,0 +1,115 @@
+(* Emma Jin
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License (GPL)
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * file license.txt for more details.
+*)
+open AST_generic
+open Common
+module Set = Set_
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* The main target intersection algorithm.
+ * Helper functions are very similar to Pattern_from_Code --- refactor?
+ *
+ * related work:
+ *  - coccinelle spinfer?
+*)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type stage = DONE | ANY of any
+
+(*****************************************************************************)
+(* Print *)
+(*****************************************************************************)
+
+let show_stage = function
+  | DONE -> "done"
+  | ANY any -> AST_generic.show_any any
+
+let rec show_patterns patterns =
+  match patterns with
+  | [] -> pr2 ""
+  | (pattern, target, _)::pats ->
+      pr2 ("( " ^ (show_any pattern) ^ ", " ^ (show_stage target) ^ " )");
+      show_patterns pats
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let fk = Parse_info.fake_info "fake"
+let fk_stmt = ExprStmt (Ellipsis fk, fk) |> s
+let _body_ellipsis t1 t2 = Block(t1, [fk_stmt], t2) |> s
+let _bk f (lp,x,rp) = (lp, f x, rp)
+
+let default_id str =
+  N (Id((str, fk),
+        {id_resolved = ref None; id_type = ref None; id_constness = ref None}))
+
+(*****************************************************************************)
+(* Algorithm *)
+(*****************************************************************************)
+
+let pattern_from_any s =
+  let metavar_pattern _e = E (default_id "X") in
+  match s with
+  | ANY (E e) -> [metavar_pattern e, DONE, fun x -> x]
+  | _ -> []
+
+let get_one_step_replacements (_, target, f) =
+  (* Case on any and use it to get the list of possible replacements (pattern, removed_target, g) list *)
+  let target_replacements = pattern_from_any target in
+  (* Return the (f pattern, removed_target, f circ g) list *)
+  List.map (fun (pattern, removed_target, g) -> (f pattern, removed_target, fun x -> f (g x))) target_replacements
+
+let get_intersecting_patterns pattern_lists =
+  let intersect_all sets =
+    match sets with
+    | [] -> Set.empty
+    | [x] -> x
+    | x::xs -> List.fold_left (fun acc s -> Set.inter acc s) x xs
+  in
+  let sets = List.map (fun patterns ->
+    List.fold_left (fun s (pattern, _, _) -> Set.add pattern s) Set.empty patterns)
+    pattern_lists
+  in
+  let intersection = intersect_all sets in
+  List.map (fun patterns -> List.filter (fun (pattern, _, _) -> Set.mem pattern intersection) patterns) pattern_lists,
+  Set.is_empty intersection
+
+let rec generate_patterns_help target_patterns =
+  (* For each pattern in each set of target_patterns, generate the list of one step replacements *)
+  (*    ex: ($X, bar(foo(2), x), f) ------> [bar(...), [foo(2), x], fun xs -> bar(xs)] *)
+  (*        (pattern, any, any -> any) list *)
+  (* Flatten the list. Each node n will have a corresponding set of patterns Sn *)
+  let new_target_patterns =
+    List.map (fun patterns -> List.flatten (List.map get_one_step_replacements patterns)) target_patterns
+  in
+  (* Keep only the patterns in each Sn that appear in every other *)
+  let intersecting_patterns, cont = get_intersecting_patterns new_target_patterns in
+  (* Call recursively on these patterns *)
+  if cont then generate_patterns_help intersecting_patterns else intersecting_patterns
+
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let generate_patterns s =
+  (* Start each target node any as [$X, any, fun x -> x ] *)
+  let patterns = List.map (fun any -> [E (Ellipsis fk), ANY any, fun x -> x]) s in
+  let patterns = List.flatten (generate_patterns_help patterns) in
+  List.map (fun (pattern, _, _) -> pattern) patterns

--- a/semgrep-core/Synthesizing/Pattern_from_Targets.mli
+++ b/semgrep-core/Synthesizing/Pattern_from_Targets.mli
@@ -1,0 +1,40 @@
+
+(*
+ * The pattern_from_code feature allows users to highlight code and
+ * autogenerate patterns that match
+ *
+ * There are three parts to pattern-from-code: taking a range and turning it
+ * into an AST, taking an AST and modifying parts to make it a pattern,
+ * and taking a pattern’s AST and outputting it.
+ *
+ * A highlighted section is turned into a range of the form row:col-row:col,
+ * which is fed as input into semgrep-core. If you’ve cloned semgrep,
+ * you can actually run it locally in semgrep/semgrep-core.
+ * An example run looks like:
+ * semgrep-core  -synthesize_patterns 8:5-8:21 tests/SYNTHESIZING/password.go
+ * The range is turned into a character position, and then the AST is visited
+ * to find the first expression in the range.
+ *
+ * Once we have an expression, we feed it into Pattern_from_code.from_expr,
+ * which makes modifications to the AST so that it’s more general.
+ * This is broken down based on what kind of expression is given.
+ * Function calls and variables are kept self contained, as the smallest
+ * “blocks” of expressions, but other expressions, like assignments,
+ * will recursively generalize their subexpressions. The guiding philosophy
+ * behind these decisions is that a pattern is only useful if it suggests
+ * a possibility for a user.
+ *
+ * Finally, we output the pattern by giving it to Pretty_print_generic.pattern_to_string,
+ * a language-aware AST-to-string converter.
+ *)
+
+(* ex:
+ *  ["exact match", <metrics.send('my-report-id')>;
+ *   "one argument", <metrics.send($X)>;
+ *   "zero or more arguments", <metrics.send(...)>;
+ *  ]
+*)
+
+(* limited to expressions for now *)
+val generate_patterns:
+  AST_generic.any list -> Pattern.t list

--- a/semgrep-core/Synthesizing/Pattern_from_Targets.mli
+++ b/semgrep-core/Synthesizing/Pattern_from_Targets.mli
@@ -58,13 +58,6 @@
  * its individual state, such as how many metavariables have already been used.
  *)
 
-(* ex:
- *  ["exact match", <metrics.send('my-report-id')>;
- *   "one argument", <metrics.send($X)>;
- *   "zero or more arguments", <metrics.send(...)>;
- *  ]
-*)
-
 (* limited to expressions for now *)
 val generate_patterns:
   AST_generic.any list -> Lang.t -> Pattern.t list

--- a/semgrep-core/Synthesizing/Pattern_from_Targets.mli
+++ b/semgrep-core/Synthesizing/Pattern_from_Targets.mli
@@ -1,31 +1,61 @@
 
 (*
- * The pattern_from_code feature allows users to highlight code and
- * autogenerate patterns that match
+ * The pattern_from_targets feature allows users to highlight separate code
+ * snipppets and autogenerate patterns that match all snippets
  *
- * There are three parts to pattern-from-code: taking a range and turning it
- * into an AST, taking an AST and modifying parts to make it a pattern,
- * and taking a pattern’s AST and outputting it.
+ * Consider if you have foo(3) and bar(3, m). We would like to
+ * generate the pattern $X(3, ...), which is the "most specific" pattern
+ * that matches both
  *
- * A highlighted section is turned into a range of the form row:col-row:col,
- * which is fed as input into semgrep-core. If you’ve cloned semgrep,
- * you can actually run it locally in semgrep/semgrep-core.
- * An example run looks like:
- * semgrep-core  -synthesize_patterns 8:5-8:21 tests/SYNTHESIZING/password.go
- * The range is turned into a character position, and then the AST is visited
- * to find the first expression in the range.
+ * To do so, we follow a breadth first tree comparison. At each level, we
+ * will produce all patterns that could match the tree if only that much
+ * was revealed. In the above example, we would first generate
  *
- * Once we have an expression, we feed it into Pattern_from_code.from_expr,
- * which makes modifications to the AST so that it’s more general.
- * This is broken down based on what kind of expression is given.
- * Function calls and variables are kept self contained, as the smallest
- * “blocks” of expressions, but other expressions, like assignments,
- * will recursively generalize their subexpressions. The guiding philosophy
- * behind these decisions is that a pattern is only useful if it suggests
- * a possibility for a user.
+ * ... and ...
  *
- * Finally, we output the pattern by giving it to Pretty_print_generic.pattern_to_string,
- * a language-aware AST-to-string converter.
+ * We then intersect the two sets and proceed with the patterns that appear
+ * in both. Since ... is in both, we continue with that on each side
+ *
+ * The next pattern that matches both is
+ *
+ * $X(...) and $X(...)
+ *
+ * Once again, this appears in both. Now, we want to try exploring both
+ * $X and ... further. First, we try $X
+ *
+ * foo(...) and bar(...)
+ *
+ * The intersection is now empty, so we try substituting into the ... instead
+ *
+ * $X(..., $Y, ...) and $X(..., $Y, ...), $X(..., $Y, ...)
+ *
+ * The latter pattern appears repeated, but actually the $X represents two
+ * different potential arguments: 3 and m. This will be apparent in the next
+ * generation
+ *
+ * $X(..., 3, ...) and $X(..., 3, ...), $X(..., m, ...)
+ *
+ * This will then proceed to explore the $X(..., 3, ....), and so on, always
+ * going from a more general pattern to a more specific pattern
+ *
+ * When the intersection is empty and there are no more possible routes to try
+ * (at least one target is out of replacement functions), return the last set
+ * of patterns that was in the intersection of all the targets
+ *
+ * To implement this algorithm, for each target, we generate a list of
+ * possible patterns. These patterns need to not only save the current
+ * pattern (e.g. $X(...)) but also how to fill each hole. Filling a hole
+ * requires instructions for where the hole is, but also what to use to
+ * generate replacement patterns.
+ *
+ * These instructions need to be as general as possible, since they essentially
+ * only indicate the position of the hole. Therefore, the function takes
+ * instructions for how to convert the hole (e.g. fun x -> x just replaces it)
+ * and then the actual pattern to convert. This allows us to recurse without
+ * worrying in the child about the parent's pattern
+ *
+ * The type also includes an environment, since each pattern must keep track of
+ * its individual state, such as how many metavariables have already been used.
  *)
 
 (* ex:

--- a/semgrep-core/Synthesizing/Pattern_from_Targets.mli
+++ b/semgrep-core/Synthesizing/Pattern_from_Targets.mli
@@ -37,4 +37,4 @@
 
 (* limited to expressions for now *)
 val generate_patterns:
-  AST_generic.any list -> Pattern.t list
+  AST_generic.any list -> Lang.t -> Pattern.t list

--- a/semgrep-core/Synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/Synthesizing/Pretty_print_generic.ml
@@ -522,6 +522,7 @@ let pattern_to_string lang any =
   match any with
   | E e -> expr_to_string lang mvars e
   | S s -> stmt_to_string lang mvars s
+  | Args args -> arguments { lang; mvars } args
   | _ ->
       pr2 (AST_generic.show_any any);
       failwith "todo: only expression pattern can be pretty printed right now"

--- a/semgrep-core/Synthesizing/Synthesizer.ml
+++ b/semgrep-core/Synthesizing/Synthesizer.ml
@@ -35,4 +35,4 @@ let generate_pattern_choices s =
   let lang = Lang.langs_of_filename file |> List.hd in
   let targets = List.map (range_to_ast file lang) ranges in
   (List.map (Pretty_print_generic.pattern_to_string lang) targets) @
-  List.map (Pretty_print_generic.pattern_to_string lang) (Pattern_from_Targets.generate_patterns targets)
+  List.map (Pretty_print_generic.pattern_to_string lang) (Pattern_from_Targets.generate_patterns targets lang)

--- a/semgrep-core/Synthesizing/Synthesizer.ml
+++ b/semgrep-core/Synthesizing/Synthesizer.ml
@@ -34,5 +34,5 @@ let generate_pattern_choices s =
   let ranges, file = read_input s in
   let lang = Lang.langs_of_filename file |> List.hd in
   let targets = List.map (range_to_ast file lang) ranges in
-  (List.map (Pretty_print_generic.pattern_to_string lang) targets) @
+  (List.map (fun target -> "target: " ^ (Pretty_print_generic.pattern_to_string lang target)) targets) @
   List.map (Pretty_print_generic.pattern_to_string lang) (Pattern_from_Targets.generate_patterns targets lang)

--- a/semgrep-core/Synthesizing/Synthesizer.mli
+++ b/semgrep-core/Synthesizing/Synthesizer.mli
@@ -1,2 +1,4 @@
 (* range as "start row:start col-end row:end col" -> filename -> (label * pattern) list *)
 val synthesize_patterns: string -> string -> (string * string) list
+
+val generate_pattern_choices: string list -> string list

--- a/semgrep-core/Synthesizing/Synthesizer.mli
+++ b/semgrep-core/Synthesizing/Synthesizer.mli
@@ -1,4 +1,7 @@
 (* range as "start row:start col-end row:end col" -> filename -> (label * pattern) list *)
+(* Sythesize possible patterns from a given target range *)
 val synthesize_patterns: string -> string -> (string * string) list
 
+(* "start row:start col-end row:end col"+ file ((range list)@[file]) -> pattern list *)
+(* Generates a pattern from several target ranges that matches each target *)
 val generate_pattern_choices: string list -> string list

--- a/semgrep-core/Synthesizing/Test_synthesizing.ml
+++ b/semgrep-core/Synthesizing/Test_synthesizing.ml
@@ -37,3 +37,8 @@ let synthesize_patterns s file =
   let s = J.string_of_json json_opts in
   pr s
 [@@action]
+
+let generate_pattern_choices s =
+  let options = Synthesizer.generate_pattern_choices s in
+  List.iter (fun s -> pr s) options
+[@@action]

--- a/semgrep-core/Synthesizing/Test_synthesizing.mli
+++ b/semgrep-core/Synthesizing/Test_synthesizing.mli
@@ -2,3 +2,5 @@
 val expr_at_range: string -> Common.filename -> unit
 
 val synthesize_patterns: string -> Common.filename -> unit
+
+val generate_pattern_choices: string list -> unit


### PR DESCRIPTION
Given two or more targets, generate a pattern by creating potential patterns in layers. 

For example, if our targets are 
` foo(m, n)` and `foo(bar(2), 3)`, we will try the patterns: 

`...`, `$X(...)`, `foo(...)`, `foo($X, ...)`, `foo(m, ...)` vs `foo($X(...), ....)`, `foo($X, $Y)`, and `foo($X, n)` vs `foo($X, 3)`. Since the last one is terminal, we will return `foo($X, $Y)` as our generated pattern.