### PR TITLE
Add --vim flag for Syntastic

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -263,6 +263,11 @@ def cli() -> None:
         action="store_true",
         help="Output results in Emacs single-line format.",
     )
+    output.add_argument(
+        "--vim",
+        action="store_true",
+        help="Output results in vim single-line format.",
+    )
     output.add_argument("--test", action="store_true", help="Run test suite.")
     parser.add_argument(
         "--test-ignore-todo",
@@ -387,6 +392,8 @@ def cli() -> None:
         output_format = OutputFormat.SARIF
     elif args.emacs:
         output_format = OutputFormat.EMACS
+    elif args.vim:
+        output_format = OutputFormat.VIM
 
     output_settings = OutputSettings(
         output_format=output_format,

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -38,6 +38,7 @@ class OutputFormat(Enum):
     JUNIT_XML = auto()
     SARIF = auto()
     EMACS = auto()
+    VIM = auto()
 
     def is_json(self) -> bool:
         return self == OutputFormat.JSON or self == OutputFormat.JSON_DEBUG

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -262,6 +262,26 @@ def build_emacs_output(rule_matches: List[RuleMatch], rules: FrozenSet[Rule]) ->
     return "\n".join(list(iter_emacs_output(rule_matches, rules)))
 
 
+def build_vim_output(rule_matches: List[RuleMatch], rules: FrozenSet[Rule]) -> str:
+    severity = {
+        "INFO": "I",
+        "WARNING": "W",
+        "ERROR": "E",
+    }
+
+    def _get_parts(rule_match: RuleMatch) -> List[str]:
+        return [
+            str(rule_match.path),
+            str(rule_match.start["line"]),
+            str(rule_match.start["col"]),
+            severity[rule_match.severity],
+            rule_match.id,
+            rule_match.message,
+        ]
+
+    return "\n".join(":".join(_get_parts(rm)) for rm in rule_matches)
+
+
 class OutputSettings(NamedTuple):
     output_format: OutputFormat
     output_destination: Optional[str]
@@ -508,6 +528,8 @@ class OutputHandler:
             return build_sarif_output(self.rule_matches, self.rules)
         elif output_format == OutputFormat.EMACS:
             return build_emacs_output(self.rule_matches, self.rules)
+        elif output_format == OutputFormat.VIM:
+            return build_vim_output(self.rule_matches, self.rules)
         elif output_format == OutputFormat.TEXT:
             return "\n".join(
                 list(


### PR DESCRIPTION
Before moving forward with this, how about we combine this with `--emacs` and use a `--oneline` argument for both? That way we can avoid the CLI flag explosion for all output formats. Looks like `--emacs` came from https://github.com/returntocorp/semgrep/pull/2495. @Ruin0x11 does that seem reasonable to you?