### PR TITLE
Pass type in arguments in new call

### DIFF
--- a/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1235,7 +1235,9 @@ and expression (env : env) (x : CST.expression) : AST.expr =
           | None -> None)
        in
        (* TODO handle v4 *)
-       Call (IdSpecial (New, v1), v3)
+       let lp, args, rp = v3 in
+       let args = (lp, ArgType v2 :: args, rp) in
+       Call (IdSpecial (New, v1), args)
    | `Paren_exp (x) -> parenthesized_expression env x
    | `Post_un_exp x -> postfix_unary_expression env x
    | `Prefix_un_exp x -> prefix_unary_expression env x


### PR DESCRIPTION
Convert `new System.Index(6)` to `New (System.Index, 6)`. Previously we only
passed the arguments and threw the type away, but now we pass the type (`v2`)
as first parameter.