### PR TITLE
[semgrep-core] Display rule id when a match is found

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -256,12 +256,12 @@ let _matching_tokens = ref []
 (*e: constant [[Main_semgrep_core._matching_tokens]] *)
 
 (*s: function [[Main_semgrep_core.print_match]] *)
-let print_match mvars mvar_binding ii_of_any tokens_matched_code =
+let print_match ?str mvars mvar_binding ii_of_any tokens_matched_code =
   (* there are a few fake tokens in the generic ASTs now (e.g.,
    * for DotAccess generated outside the grammar) *)
   let toks = tokens_matched_code |> List.filter PI.is_origintok in
   (if mvars = []
-   then Matching_report.print_match ~format:!match_format toks
+   then Matching_report.print_match ?str ~format:!match_format toks
    (*s: [[Main_semgrep_core.print_match()]] when non empty [[mvars]] *)
    else begin
      (* similar to the code of Lib_matcher.print_match, maybe could
@@ -879,10 +879,10 @@ let semgrep_with_real_rules ~with_opt_cache ~report_time rules files =
              | R.LNone | R.LGeneric -> true
            )
          in
-         let hook = fun env matched_tokens ->
+         let hook = fun str env matched_tokens ->
            if !output_format = Text then begin
              let xs = Lazy.force matched_tokens in
-             print_match !mvars env Metavariable.ii_of_mval xs
+             print_match ~str !mvars env Metavariable.ii_of_mval xs
            end
          in
          let xlang = R.L (lang, []) in

--- a/semgrep-core/Engine/Semgrep.mli
+++ b/semgrep-core/Engine/Semgrep.mli
@@ -5,7 +5,7 @@
 *)
 val check:
   (*with_caching:*)bool ->
-  (Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) (* hook *) ->
+  (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
   Rule.rules ->
   (Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t) ->
   Rule_match.t list * Error_code.error list * float

--- a/semgrep-core/Engine/Test_engine.ml
+++ b/semgrep-core/Engine/Test_engine.ml
@@ -100,7 +100,7 @@ let test_rules xs =
     E.g_errors := [];
     let matches, errors, match_time =
       try
-        Semgrep.check false (fun _ _ -> ()) rules
+        Semgrep.check false (fun _ _ _ -> ()) rules
           (target, xlang, lazy_ast_and_errors)
       with exn ->
         failwith (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))

--- a/semgrep-core/Reporting/Matching_report.ml
+++ b/semgrep-core/Reporting/Matching_report.ml
@@ -66,7 +66,7 @@ let rec join_with_space_if_needed xs =
 (* Entry point *)
 (*****************************************************************************)
 (*s: function [[Matching_report.print_match]] *)
-let print_match ?(format = Normal) ii =
+let print_match ?(format = Normal) ?(str="") ii =
   try
     let (mini, maxi) = PI.min_max_ii_by_pos ii in
     let (file, line) =
@@ -77,6 +77,7 @@ let print_match ?(format = Normal) ii =
 
     (match format with
      | Normal ->
+         let prefix = if str = "" then prefix else prefix ^ " " ^ str in
          pr prefix;
          (* todo? some context too ? *)
          lines |> List.map (fun i -> arr.(i)) |> List.iter (fun s -> pr (" " ^ s))

--- a/semgrep-core/Reporting/Matching_report.mli
+++ b/semgrep-core/Reporting/Matching_report.mli
@@ -14,7 +14,8 @@ type match_format =
   (*e: type [[Matching_report.match_format]] *)
 
 (*s: signature [[Matching_report.print_match]] *)
-val print_match: ?format:match_format -> Parse_info.t list -> unit
+val print_match:
+  ?format:match_format -> ?str:string -> Parse_info.t list -> unit
 (*e: signature [[Matching_report.print_match]] *)
 
 (*s: signature [[Matching_report.join_with_space_if_needed]] *)


### PR DESCRIPTION
test plan:
```
$ semgrep-core -fast -lang js -config all_nodejsscan.yml
input/big-js/node_modules/jszip/
...
[20.980 Info       Main.Dune__exe__Main ] parsing input/big-js/node_modules/jszip/lib/object.js
input/big-js/node_modules/jszip/lib/object.js:257 with rule regex_dos
                 return file.dir && arg.test(relativePath);
input/big-js/node_modules/jszip/lib/object.js:226 with rule regex_dos
                     return !file.dir && regexp.test(relativePath);
input/big-js/node_modules/jszip/lib/object.js:257 with rule regex_dos
                 return file.dir && arg.test(relativePath);
input/big-js/node_modules/jszip/lib/object.js:226 with rule regex_dos
                     return !file.dir && regexp.test(relativePath);
```