### PR TITLE
Use globals instead of labels for optimization flags

### DIFF
--- a/semgrep-core/Core/Flag_semgrep.ml
+++ b/semgrep-core/Core/Flag_semgrep.ml
@@ -26,8 +26,6 @@ let go_deeper_stmt = ref true
 let go_really_deeper_stmt = ref true
 (*e: constant [[Flag_semgrep.go_really_deeper_stmt]] *)
 
-(* Improves performance on some patterns, degrades performance on others. *)
-let max_cache = ref false
 
 (* look if identifiers in pattern intersect with file using simple regexps *)
 let filter_irrelevant_patterns = ref false
@@ -38,6 +36,11 @@ let filter_irrelevant_rules = ref false
 
 (* check for identifiers before attempting to match a stmt or stmt list *)
 let use_bloom_filter = ref false
+
+(* opt = optimization *)
+let with_opt_cache = ref true
+(* Improves performance on some patterns, degrades performance on others. *)
+let max_cache = ref false
 
 (* we usually try first with the pfff parser and then with the tree-sitter
  * parser if pfff fails. Here you can force to only use tree-sitter.

--- a/semgrep-core/Engine/Semgrep.mli
+++ b/semgrep-core/Engine/Semgrep.mli
@@ -4,7 +4,6 @@
    Return matches, errors, match time.
 *)
 val check:
-  (*with_caching:*)bool ->
   (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
   Rule.rules ->
   (Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t) ->

--- a/semgrep-core/Engine/Test_engine.ml
+++ b/semgrep-core/Engine/Test_engine.ml
@@ -98,9 +98,10 @@ let test_rules xs =
     )
     in
     E.g_errors := [];
+    Flag_semgrep.with_opt_cache := false;
     let matches, errors, match_time =
       try
-        Semgrep.check false (fun _ _ _ -> ()) rules
+        Semgrep.check (fun _ _ _ -> ()) rules
           (target, xlang, lazy_ast_and_errors)
       with exn ->
         failwith (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))

--- a/semgrep-core/Matching/Semgrep_generic.ml
+++ b/semgrep-core/Matching/Semgrep_generic.ml
@@ -213,7 +213,7 @@ let must_analyze_statement_bloom_opti_failed pattern_strs (st : AST_generic.stmt
 (*****************************************************************************)
 
 (*s: function [[Semgrep_generic.check2]] *)
-let check2 ~hook ~with_caching rules equivs file lang ast =
+let check2 ~hook rules equivs file lang ast =
   logger#info "checking %s with %d mini rules" file (List.length rules);
 
   let rules =
@@ -258,10 +258,7 @@ let check2 ~hook ~with_caching rules equivs file lang ast =
       let any = Apply_equivalences.apply equivs any in
       (*e: [[Semgrep_generic.check2()]] apply equivalences to rule pattern [[any]] *)
       let cache =
-        if with_caching then
-          Some (Caching.Cache.create ())
-        else
-          None
+        if !Flag.with_opt_cache then Some (Caching.Cache.create ()) else None
       in
       (* Annotate exp, stmt, stmts patterns with the rule strings *)
       let push_with_annotation any pattern rules =
@@ -431,8 +428,8 @@ let check2 ~hook ~with_caching rules equivs file lang ast =
 (*e: function [[Semgrep_generic.check2]] *)
 
 (* TODO: cant use [@@profile] because it does not handle yet label params *)
-let check ~hook ~with_caching a b c d e =
+let check ~hook a b c d e =
   Common.profile_code "Semgrep.check"
-    (fun () -> check2 ~hook ~with_caching a b c d e)
+    (fun () -> check2 ~hook a b c d e)
 
 (*e: semgrep/matching/Semgrep_generic.ml *)

--- a/semgrep-core/Matching/Semgrep_generic.mli
+++ b/semgrep-core/Matching/Semgrep_generic.mli
@@ -2,14 +2,10 @@
 
 (*s: signature [[Semgrep_generic.check]] *)
 val check:
-  hook:(Metavariable.bindings -> Parse_info.t list Lazy.t -> unit)
-  ->
-  with_caching:bool ->
+  hook:(Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
   Mini_rule.rules ->
   Equivalence.equivalences ->
-  Common.filename ->
-  Lang.t ->
-  Target.t ->
+  Common.filename -> Lang.t -> Target.t ->
   Pattern_match.t list
 (*e: signature [[Semgrep_generic.check]] *)
 


### PR DESCRIPTION
They are annoying to thread around. Globals are for non-functional
properties (e.g., optimizations).

test plan:
make test