### PR TITLE
Adding a new config parameter for the matching engine

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -707,10 +707,10 @@ let semgrep_with_rules rules files =
            Common.with_time (fun () ->
              let rules =
                rules |> List.filter (fun r -> List.mem lang r.MR.languages) in
-             Semgrep_generic.check
-               ~hook:(fun _ _ -> ())
+             Semgrep_generic.check ~hook:(fun _ _ -> ())
+               Config_semgrep.default_config
                rules (parse_equivalences ())
-               file lang ast,
+               (file, lang, ast),
              errors
            )
          in
@@ -794,7 +794,8 @@ let semgrep_with_real_rules rules files =
          in
          let xlang = R.L (lang, []) in
          let matches, errors, match_time =
-           Semgrep.check hook rules (file, xlang, lazy_ast_and_errors)
+           Semgrep.check hook Config_semgrep.default_config
+             rules (file, xlang, lazy_ast_and_errors)
          in
          matches, errors, (file, match_time)
       )
@@ -913,8 +914,10 @@ let semgrep_with_one_pattern xs =
                   let xs = Lazy.force matched_tokens in
                   print_match !mvars env Metavariable.ii_of_mval xs
                 )
+                Config_semgrep.default_config
                 [rule] (parse_equivalences ())
-                file lang ast |> ignore
+                (file, lang, ast)
+              |> ignore
             )
           in
 

--- a/semgrep-core/Core/Config_semgrep.ml
+++ b/semgrep-core/Core/Config_semgrep.ml
@@ -1,0 +1,51 @@
+(*s: semgrep/core/Config_semgrep.ml *)
+(*s: pad/r2c copyright *)
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2019-2021 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+*)
+(*e: pad/r2c copyright *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Semgrep engine configuration.
+ *
+ * The goal of this module is to gather in one place all the possible
+ * ways to configure the semgrep matching engine. At some point, we
+ * may let the user enable/disable certain features on a per-rule or even
+ * per-pattern basis. For example, constant propagation may be too powerful
+ * sometimes and prevent people to find certain code.
+ *
+ * Note that each feature in this file will change the matching results;
+ * for non-functinal settings such as optimizations (e.g., using a
+ * cache) use instead Flag_semgrep.ml
+*)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+type t = {
+  constant_propagation: bool;
+  (* TODO: move deep_expr_stmt features in Flag_semgrpe.ml here *)
+}
+
+(*****************************************************************************)
+(* Default config *)
+(*****************************************************************************)
+
+let default_config = {
+  constant_propagation = true;
+}
+
+(*e: semgrep/core/Config_semgrep.ml *)

--- a/semgrep-core/Engine/Semgrep.mli
+++ b/semgrep-core/Engine/Semgrep.mli
@@ -5,6 +5,7 @@
 *)
 val check:
   (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
+  Config_semgrep.t ->
   Rule.rules ->
   (Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t) ->
   Rule_match.t list * Error_code.error list * float

--- a/semgrep-core/Engine/Test_engine.ml
+++ b/semgrep-core/Engine/Test_engine.ml
@@ -99,9 +99,10 @@ let test_rules xs =
     in
     E.g_errors := [];
     Flag_semgrep.with_opt_cache := false;
+    let config = Config_semgrep.default_config in
     let matches, errors, match_time =
       try
-        Semgrep.check (fun _ _ _ -> ()) rules
+        Semgrep.check (fun _ _ _ -> ()) config rules
           (target, xlang, lazy_ast_and_errors)
       with exn ->
         failwith (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))

--- a/semgrep-core/Matching/Apply_equivalences.ml
+++ b/semgrep-core/Matching/Apply_equivalences.ml
@@ -35,7 +35,8 @@ let match_e_e_for_equivalences _ruleid a b =
     Common.save_excursion Flag.go_deeper_expr false (fun () ->
       Common.save_excursion Flag.go_deeper_stmt false (fun () ->
         let cache = None in
-        let env = Matching_generic.empty_environment cache in
+        let config = Config_semgrep.default_config in
+        let env = Matching_generic.empty_environment cache config in
         Generic_vs_generic.m_expr a b env
       )))
 (*e: function [[Apply_equivalences.match_e_e_for_equivalences]] *)

--- a/semgrep-core/Matching/Generic_vs_generic.ml
+++ b/semgrep-core/Matching/Generic_vs_generic.ml
@@ -30,6 +30,7 @@ module B = AST_generic
 module MV = Metavariable
 module AST = AST_generic
 module Flag = Flag_semgrep
+module Config = Config_semgrep
 module H = AST_generic_helpers
 
 (* optimisations *)
@@ -598,11 +599,11 @@ and m_expr a b =
    * const a = "foo"; ... a == "foo" would be catched by $X == $X.
   *)
   | A.L(a1), b1 ->
-      (match Normalize_generic.constant_propagation_and_evaluate_literal b1 with
-       | Some b1 ->
-           m_literal_constness a1 b1
-       | None -> fail ()
-      )
+      if_config (fun x -> x.Config.constant_propagation)
+        (match Normalize_generic.constant_propagation_and_evaluate_literal b1 with
+         | Some b1 -> m_literal_constness a1 b1
+         | None -> fail ()
+        )
   (*e: [[Generic_vs_generic.m_expr()]] propagated constant case *)
 
   (*s: [[Generic_vs_generic.m_expr()]] sequencable container cases *)

--- a/semgrep-core/Matching/Matching_generic.ml
+++ b/semgrep-core/Matching/Matching_generic.ml
@@ -199,6 +199,11 @@ let or_list m a bs =
   in
   aux bs
 
+let if_config f m = fun tin ->
+  if f tin.config
+  then m tin
+  else fail tin
+
 (* Since OCaml 4.08 you can define your own let operators!
  * alt: use ppx_let, but you need to write it as let%bind (uglier)
  * You can use the ppx future_syntax to support older version of OCaml, but

--- a/semgrep-core/Matching/Matching_generic.ml
+++ b/semgrep-core/Matching/Matching_generic.ml
@@ -83,6 +83,8 @@ type tin = {
   mv : Metavariable_capture.t;
   stmts_match_span : Stmts_match_span.t;
   cache : tout Caching.Cache.t option;
+  (* TODO: this does not have to be in tout; maybe split tin in 2? *)
+  config: Config_semgrep.t;
 }
 (*e: type [[Matching_generic.tin]] *)
 (*s: type [[Matching_generic.tout]] *)
@@ -338,12 +340,8 @@ let (envf: (MV.mvar AST.wrap, MV.mvalue) matcher) =
 (*e: function [[Matching_generic.envf]] *)
 
 (*s: function [[Matching_generic.empty_environment]] *)
-let empty_environment opt_cache =
-  {
-    mv = Env.empty;
-    stmts_match_span = Empty;
-    cache = opt_cache;
-  }
+let empty_environment opt_cache config =
+  { mv = Env.empty; stmts_match_span = Empty; cache = opt_cache; config; }
 (*e: function [[Matching_generic.empty_environment]] *)
 
 (*****************************************************************************)

--- a/semgrep-core/Matching/Matching_generic.mli
+++ b/semgrep-core/Matching/Matching_generic.mli
@@ -71,6 +71,9 @@ val envf :
   (Metavariable.mvar AST_generic.wrap, Metavariable.mvalue) matcher
 (*e: signature [[Matching_generic.envf]] *)
 
+val if_config:
+  (Config_semgrep.t -> bool) -> (tin -> tout) -> tin -> tout
+
 (*s: signature [[Matching_generic.check_and_add_metavar_binding]] *)
 val check_and_add_metavar_binding :
   Metavariable.mvar * Metavariable.mvalue ->

--- a/semgrep-core/Matching/Matching_generic.mli
+++ b/semgrep-core/Matching/Matching_generic.mli
@@ -7,6 +7,7 @@ type tin = {
   mv : Metavariable_capture.t;
   stmts_match_span : Stmts_match_span.t;
   cache : tout Caching.Cache.t option;
+  config: Config_semgrep.t;
 }
 (*e: type [[Matching_generic.tin]] *)
 (*s: type [[Matching_generic.tout]] *)
@@ -51,7 +52,8 @@ val or_list: ('a, 'b) matcher -> 'a -> 'b list -> (tin -> tout)
 val (let*) : (tin -> tout) -> (unit -> tin -> tout) -> tin -> tout
 
 (*s: signature [[Matching_generic.empty_environment]] *)
-val empty_environment : tout Caching.Cache.t option -> tin
+val empty_environment :
+  tout Caching.Cache.t option -> Config_semgrep.t -> tin
 (*e: signature [[Matching_generic.empty_environment]] *)
 
 val add_mv_capture :

--- a/semgrep-core/Matching/Semgrep_generic.ml
+++ b/semgrep-core/Matching/Semgrep_generic.ml
@@ -50,7 +50,6 @@ let logger = Logging.get_logger [__MODULE__]
 (*****************************************************************************)
 
 (*s: type [[Semgrep_generic.matcher]] *)
-type ('a, 'b) matcher = 'a -> 'b -> Matching_generic.tout
 (*e: type [[Semgrep_generic.matcher]] *)
 
 (*****************************************************************************)
@@ -77,113 +76,90 @@ let set_last_matched_rule rule f =
 (*****************************************************************************)
 
 (*s: function [[Semgrep_generic.match_e_e]] *)
-let match_e_e2 cache pattern e =
-  let env = MG.empty_environment cache in
-  GG.m_expr pattern e env
-(*e: function [[Semgrep_generic.match_e_e]] *)
-let match_e_e rule cache a b =
+let match_e_e rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_e_e2 cache a b))
+      GG.m_expr a b env))
 [@@profiling]
+(*e: function [[Semgrep_generic.match_e_e]] *)
 
 (*s: function [[Semgrep_generic.match_st_st]] *)
-let match_st_st2 cache pattern e =
-  let env = MG.empty_environment cache in
-  GG.m_stmt pattern e env
-(*e: function [[Semgrep_generic.match_st_st]] *)
-let match_st_st rule cache a b =
+let match_st_st rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_st_st2 cache a b))
+      GG.m_stmt a b env))
 [@@profiling]
+(*e: function [[Semgrep_generic.match_st_st]] *)
 
 (*s: function [[Semgrep_generic.match_sts_sts]] *)
-let match_sts_sts2 cache pattern e =
-  let env = MG.empty_environment cache in
-  (* When matching statements, we need not only to report whether
-   * there is match, but also the actual statements that were matched.
-   * Indeed, even if we want the implicit '...' at the end of
-   * a sequence of statements pattern (AST_generic.Ss) to match all
-   * the rest, we don't want to report the whole Ss as a match but just
-   * the actually matched subset.
-   *
-   * TODO? do we need to generate unique key? we don't want
-   * nested calls to m_stmts_deep to pollute our metavar? We need
-   * to pass the key to m_stmts_deep?
-  *)
-  let env =
-    match e with
-    | [] -> env
-    | stmt :: _ -> MG.extend_stmts_match_span stmt env
-  in
-  GG.m_stmts_deep ~less_is_ok:true pattern e env
-(*e: function [[Semgrep_generic.match_sts_sts]] *)
-let match_sts_sts rule cache a b =
+let match_sts_sts rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_sts_sts2 cache a b))
+      (* When matching statements, we need not only to report whether
+       * there is match, but also the actual statements that were matched.
+       * Indeed, even if we want the implicit '...' at the end of
+       * a sequence of statements pattern (AST_generic.Ss) to match all
+       * the rest, we don't want to report the whole Ss as a match but just
+       * the actually matched subset.
+       *
+       * TODO? do we need to generate unique key? we don't want
+       * nested calls to m_stmts_deep to pollute our metavar? We need
+       * to pass the key to m_stmts_deep?
+      *)
+      let env =
+        match b with
+        | [] -> env
+        | stmt :: _ -> MG.extend_stmts_match_span stmt env
+      in
+      GG.m_stmts_deep ~less_is_ok:true a b env
+    ))
 [@@profiling]
+(*e: function [[Semgrep_generic.match_sts_sts]] *)
 
 (*s: function [[Semgrep_generic.match_any_any]] *)
 (* for unit testing *)
-let match_any_any cache pattern e =
-  let env = MG.empty_environment cache in
+let match_any_any pattern e env =
   GG.m_any pattern e env
 (*e: function [[Semgrep_generic.match_any_any]] *)
 
-let match_t_t2 cache pattern e =
-  let env = MG.empty_environment cache in
-  GG.m_type_ pattern e env
-let match_t_t rule cache a b =
+let match_t_t rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_t_t2 cache a b))
+      GG.m_type_ a b env))
 [@@profiling]
 
-let match_p_p2 cache pattern e =
-  let env = MG.empty_environment cache in
-  GG.m_pattern pattern e env
-let match_p_p rule cache a b =
+let match_p_p rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_p_p2 cache a b))
+      GG.m_pattern a b env))
 [@@profiling]
 
-let match_partial_partial2 cache pattern e =
-  let env = MG.empty_environment cache in
-  GG.m_partial pattern e env
-let match_partial_partial rule cache a b =
+let match_partial_partial rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_partial_partial2 cache a b))
+      GG.m_partial a b env))
 [@@profiling]
 
-let match_at_at2 cache pattern e =
-  let env = MG.empty_environment cache in
-  GG.m_attribute pattern e env
-let match_at_at rule cache a b =
+let match_at_at rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_at_at2 cache a b))
+      GG.m_attribute a b env))
 [@@profiling]
 
-let match_fld_fld2 cache pattern e =
-  let env = MG.empty_environment cache in
-  GG.m_field pattern e env
-let match_fld_fld rule cache a b =
+let match_fld_fld rule a b env =
   Common.profile_code ("rule:" ^ rule.R.id) (fun () ->
     set_last_matched_rule rule (fun () ->
-      match_fld_fld2 cache a b))
+      GG.m_field a b env))
 [@@profiling]
 
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
-let match_rules_and_recurse (file, hook, matches) rules matcher k any x =
+let match_rules_and_recurse config (file,hook,matches) rules matcher k any x =
   rules |> List.iter (fun (pattern, rule, cache) ->
-    let matches_with_env = matcher rule cache pattern x in
+    let env = MG.empty_environment cache config in
+    let matches_with_env = matcher rule pattern x env in
     if matches_with_env <> []
     then (* Found a match *)
       matches_with_env |> List.iter (fun (env : MG.tin) ->
@@ -213,7 +189,7 @@ let must_analyze_statement_bloom_opti_failed pattern_strs (st : AST_generic.stmt
 (*****************************************************************************)
 
 (*s: function [[Semgrep_generic.check2]] *)
-let check2 ~hook _config rules equivs (file, lang, ast) =
+let check2 ~hook config rules equivs (file, lang, ast) =
   logger#info "checking %s with %d mini rules" file (List.length rules);
 
   let rules =
@@ -291,7 +267,8 @@ let check2 ~hook _config rules equivs (file, lang, ast) =
            * against an expression recursively
           *)
           !expr_rules |> List.iter (fun (pattern, _bf, rule, cache) ->
-            let matches_with_env = match_e_e rule cache pattern x in
+            let env = MG.empty_environment cache config in
+            let matches_with_env = match_e_e rule pattern x env in
             if matches_with_env <> []
             then (* Found a match *)
               matches_with_env |> List.iter (fun (env : MG.tin) ->
@@ -316,8 +293,9 @@ let check2 ~hook _config rules equivs (file, lang, ast) =
            * but inlined to handle specially Bloom filter in stmts for now.
           *)
           let visit_stmt () =
-            !stmt_rules |> List.iter (fun (pattern, _pattern_strs, rule, cache) ->
-              let matches_with_env = match_st_st rule cache pattern x in
+            !stmt_rules |> List.iter (fun (pattern,_pattern_strs,rule,cache) ->
+              let env = MG.empty_environment cache config in
+              let matches_with_env = match_st_st rule pattern x env in
               if matches_with_env <> []
               then (* Found a match *)
                 matches_with_env |> List.iter (fun (env : MG.tin) ->
@@ -366,8 +344,9 @@ let check2 ~hook _config rules equivs (file, lang, ast) =
            * do things a little bit different with the matched_statements also
            * in matches_with_env here.
           *)
-          !stmts_rules |> List.iter (fun (pattern, _pattern_strs, rule, cache) ->
-            let matches_with_env = match_sts_sts rule cache pattern x in
+          !stmts_rules |> List.iter (fun (pattern,_pattern_strs,rule,cache) ->
+            let env = MG.empty_environment cache config in
+            let matches_with_env = match_sts_sts rule pattern x env in
             if matches_with_env <> []
             then (* Found a match *)
               matches_with_env |> List.iter (fun (env : MG.tin) ->
@@ -388,24 +367,24 @@ let check2 ~hook _config rules equivs (file, lang, ast) =
         (*e: [[Semgrep_generic.check2()]] visitor fields *)
 
         V.ktype_ = (fun (k, _) x ->
-          match_rules_and_recurse (file, hook, matches)
+          match_rules_and_recurse config (file, hook, matches)
             !type_rules match_t_t k (fun x -> T x) x
         );
         V.kpattern = (fun (k, _) x ->
-          match_rules_and_recurse (file, hook, matches)
+          match_rules_and_recurse config (file, hook, matches)
             !pattern_rules match_p_p k (fun x -> P x) x
         );
         V.kattr = (fun (k, _) x ->
-          match_rules_and_recurse (file, hook, matches)
+          match_rules_and_recurse config (file, hook, matches)
             !attribute_rules match_at_at k (fun x -> At x) x
         );
         V.kfield = (fun (k, _) x ->
-          match_rules_and_recurse (file, hook, matches)
+          match_rules_and_recurse config (file, hook, matches)
             !fld_rules match_fld_fld k (fun x -> Fld x) x
         );
 
         V.kpartial = (fun (k, _) x ->
-          match_rules_and_recurse (file, hook, matches)
+          match_rules_and_recurse config (file, hook, matches)
             !partial_rules match_partial_partial k (fun x -> Partial x) x
         );
       }

--- a/semgrep-core/Matching/Semgrep_generic.ml
+++ b/semgrep-core/Matching/Semgrep_generic.ml
@@ -213,7 +213,7 @@ let must_analyze_statement_bloom_opti_failed pattern_strs (st : AST_generic.stmt
 (*****************************************************************************)
 
 (*s: function [[Semgrep_generic.check2]] *)
-let check2 ~hook rules equivs file lang ast =
+let check2 ~hook _config rules equivs (file, lang, ast) =
   logger#info "checking %s with %d mini rules" file (List.length rules);
 
   let rules =
@@ -428,8 +428,8 @@ let check2 ~hook rules equivs file lang ast =
 (*e: function [[Semgrep_generic.check2]] *)
 
 (* TODO: cant use [@@profile] because it does not handle yet label params *)
-let check ~hook a b c d e =
+let check ~hook config a b c =
   Common.profile_code "Semgrep.check"
-    (fun () -> check2 ~hook a b c d e)
+    (fun () -> check2 ~hook config a b c)
 
 (*e: semgrep/matching/Semgrep_generic.ml *)

--- a/semgrep-core/Matching/Semgrep_generic.mli
+++ b/semgrep-core/Matching/Semgrep_generic.mli
@@ -12,7 +12,6 @@ val check:
 val last_matched_rule: Mini_rule.t option ref
 
 (*s: type [[Semgrep_generic.matcher]] *)
-type ('a, 'b) matcher = 'a -> 'b -> Matching_generic.tout
 (*e: type [[Semgrep_generic.matcher]] *)
 
 (* used by tainting *)
@@ -20,15 +19,13 @@ type ('a, 'b) matcher = 'a -> 'b -> Matching_generic.tout
 (*s: signature [[Semgrep_generic.match_e_e]] *)
 val match_e_e:
   Mini_rule.t ->
-  Matching_generic.tout Caching.Cache.t option ->
-  (AST_generic.expr, AST_generic.expr) matcher
+  (AST_generic.expr, AST_generic.expr) Matching_generic.matcher
 (*e: signature [[Semgrep_generic.match_e_e]] *)
 
 (*s: signature [[Semgrep_generic.match_any_any]] *)
 (* for unit testing *)
 val match_any_any:
-  Matching_generic.tout Caching.Cache.t option ->
-  (AST_generic.any, AST_generic.any) matcher
+  (AST_generic.any, AST_generic.any) Matching_generic.matcher
 (*e: signature [[Semgrep_generic.match_any_any]] *)
 
 (*e: semgrep/matching/Semgrep_generic.mli *)

--- a/semgrep-core/Matching/Semgrep_generic.mli
+++ b/semgrep-core/Matching/Semgrep_generic.mli
@@ -3,9 +3,9 @@
 (*s: signature [[Semgrep_generic.check]] *)
 val check:
   hook:(Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
-  Mini_rule.rules ->
-  Equivalence.equivalences ->
-  Common.filename -> Lang.t -> Target.t ->
+  Config_semgrep.t ->
+  Mini_rule.rules -> Equivalence.equivalences ->
+  (Common.filename * Lang.t * Target.t) ->
   Pattern_match.t list
 (*e: signature [[Semgrep_generic.check]] *)
 

--- a/semgrep-core/Matching/Unit_matcher.ml
+++ b/semgrep-core/Matching/Unit_matcher.ml
@@ -149,8 +149,10 @@ let unittest ~any_gen_of_string =
         let pattern = any_gen_of_string spattern in
         let code    = any_gen_of_string scode in
         let cache = None in
+        let config = Config_semgrep.default_config in
+        let env = Matching_generic.empty_environment cache config in
         let matches_with_env =
-          Semgrep_generic.match_any_any cache pattern code in
+          Semgrep_generic.match_any_any pattern code env in
         if should_match
         then
           assert_bool (spf "pattern:|%s| should match |%s" spattern scode)

--- a/semgrep-core/Synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/Synthesizing/Unit_synthesizer.ml
@@ -212,9 +212,10 @@ let unittest =
                   | (_, x) -> x
                 in
                 let matches_with_env =
-                  let cache = None in
-                  Semgrep_generic.match_any_any
-                    cache pattern code in
+                  let env =
+                    Matching_generic.empty_environment None
+                      Config_semgrep.default_config in
+                  Semgrep_generic.match_any_any pattern code env in
                 (* Debugging note: uses pattern_to_string for convenience,
                  * but really should match the code in the given file at
                  * the given range *)

--- a/semgrep-core/Tainting/Tainting_generic.ml
+++ b/semgrep-core/Tainting/Tainting_generic.ml
@@ -62,9 +62,11 @@ let match_pat_instr pat =
                       message = ""; severity = R2.Error;
                       languages = []; } in
 
-         let cache = None in (* would it make sense to use caching? *)
+         let env = Matching_generic.empty_environment None
+             Config_semgrep.default_config
+         in
          let matches_with_env =
-           Semgrep_generic.match_e_e rule cache pat eorig in
+           Semgrep_generic.match_e_e rule pat eorig env in
          matches_with_env <> []
       )
 (*e: function [[Tainting_generic.match_pat_instr]] *)

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -124,7 +124,9 @@ let regression_tests_for_lang ~with_caching files lang =
          let (minii, _maxii) = Parse_info.min_max_ii_by_pos toks in
          Error_code.error minii (Error_code.SemgrepMatchFound ("",""))
        )
-       [rule] equiv file lang ast |> ignore;
+       Config_semgrep.default_config
+       [rule] equiv (file, lang, ast) 
+     |> ignore;
   
      let actual = !Error_code.g_errors in
      let expected = Error_code.expected_error_lines_of_files [file] in
@@ -318,7 +320,10 @@ let lint_regression_tests ~with_caching =
     let { Parse_target. ast; _} = 
         Parse_target.just_parse_with_lang lang file in
     Common.save_excursion Flag_semgrep.with_opt_cache with_caching (fun() ->
-      Semgrep_generic.check ~hook:(fun _ _ -> ()) rules equivs file lang ast
+      Semgrep_generic.check ~hook:(fun _ _ -> ())
+         Config_semgrep.default_config
+         rules equivs 
+         (file, lang, ast)
       |> List.iter JSON_report.match_to_error;
     )
   ));


### PR DESCRIPTION
This is the first step towards enabling/disabling individual
features on a per-rule or per-pattern basis, e.g., disabling
constant propagation for some rules.

test plan:
make test