### PR TITLE
[Java] use latest pfff where the AST for names and Dot change

### DIFF
--- a/semgrep-core/Parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/Parsing/pfff/java_to_generic.ml
@@ -175,6 +175,9 @@ and annotation_pair =
 
 (* id_or_name_of_qualified_ident *)
 and name v =
+  let v = ident v in
+  G.Id (v, G.empty_id_info())
+(*
   let res = list1
       (fun (v1, v2) ->
          let _v1TODO = list type_argument v1
@@ -191,6 +194,7 @@ and name v =
                        } in
        G.IdQualified ((name, name_info), G.empty_id_info())
   )
+*)
 
 
 and literal = function
@@ -209,7 +213,7 @@ and expr e =
       G.DotAccessEllipsis (v1, v2)
   | Ellipsis v1 -> let v1 = tok v1 in G.Ellipsis v1
   | DeepEllipsis v1 -> let v1 = bracket expr v1 in G.DeepEllipsis v1
-  | Name v1 -> G.N (name v1)
+  | NameId v1 -> G.N (name v1)
   | NameOrClassType _v1 ->
       let ii = Lib_parsing_java.ii_of_any (AExpr e) in
       error (List.hd ii)

--- a/semgrep-core/Parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/Parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -472,7 +472,8 @@ and basic_type_extra env = function
       TClass x
 
 and name_of_id env tok =
-  Name ([[], str env tok])
+  (*Name ([[], str env tok]) *)
+  NameId (str env tok)
 
 (* TODO: use a special at some point *)
 and super env tok =
@@ -510,7 +511,7 @@ and primary (env : env) (x : CST.primary) =
          (match v1 with
           | `Choice_id x ->
               let id = id_extra env x in
-              Name [[], id]
+              NameId id
           | `Choice_prim_DOT_opt_super_DOT_opt_type_args_choice_id (v1, v2, v3, v4, v5) ->
               let v1 =
                 (match v1 with

--- a/semgrep-core/tests/java/parsing/field.java
+++ b/semgrep-core/tests/java/parsing/field.java
@@ -1,0 +1,7 @@
+package X;
+
+class A {
+    void main() {
+	return foo.x.y.z;
+    }
+}


### PR DESCRIPTION
This gets pfff and tree-sitter java parser closer to each other.

test plan:
$ semgrep-core -diff_pfff_tree_sitter field.java
does not show any difference