### PR TITLE
This is for Emma

### DIFF
--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -882,6 +882,9 @@ let semgrep_with_one_pattern xs =
         let s = Common.read_file file in
         parse_pattern lang s, s
     (*e: [[Main_semgrep_core.semgrep_with_one_pattern()]] pattern file case *)
+    (* this is for Emma, who often confuses -e with -f :) *)
+    | _, s when s =~ ".*\\.sgrep$" ->
+        failwith "you probably want -f with a .sgrep file, not -e"
     | _, s when s <> ""->
         parse_pattern lang s, s
     | _ -> raise Impossible


### PR DESCRIPTION
test plan:
```
 /home/pad/semgrep/_build/default/CLI/Main.exe -lang java -e tests/POLYGLOT/concrete_syntax.sgrep tests/java/concrete_syntax.java
[0.088  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.088  Info       Main.Dune__exe__Main ] Executed as: /home/pad/semgrep/_build/default/CLI/Main.exe -lang java -e tests/POLYGLOT/concrete_syntax.sgrep tests/java/concrete_syntax.java
[0.088  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.42.0-9-ga43419ba-dirty, pfff: 0.42
Fatal error: exception (Failure "you probably want -f with a .sgrep file, not -e")
Raised at file "stdlib.ml", line 29, characters 22-33
Called from unknown location
```