### PR TITLE
Add official Python 3.9 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Official Python 3.9 support
+
 ## [0.42.0](https://github.com/returntocorp/semgrep/releases/tag/v0.42.0) - 2021-03-09
 
 ### Added

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -36,7 +36,7 @@ if WHEEL_CMD in sys.argv:
 
         def get_tag(self):
             _, _, plat = bdist_wheel.get_tag(self)
-            python = "cp36.cp37.cp38.py36.py37.py38"
+            python = "cp36.cp37.cp38.cp39.py36.py37.py38.py39"
             abi = "none"
             plat = "macosx_10_14_x86_64" if "macosx" in plat else "any"
             return python, abi, plat
@@ -127,6 +127,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Security",
         "Topic :: Software Development :: Quality Assurance",
     ],


### PR DESCRIPTION
Fixes #1673.

Now that we're testing against 3.9 (https://github.com/returntocorp/semgrep/pull/2606) we might as well add official support :)