### PR TITLE
Add benchmark variant for "no GC tuning"

### DIFF
--- a/perf/bench/big-js/prep
+++ b/perf/bench/big-js/prep
@@ -37,8 +37,5 @@ name="big-js"
 #TODO: the other repo are using https: but this repo is currently private
 # so I use ssh
 url="git@github.com:returntocorp/big-js.git"
-commit="f4986489b41b26ce4d7115a62d49ff080e5767c4"
+commit="08ba212ac7961768fcde386f70eea7a901ddb8f5"
 shallow_clone
-
-cd big-js
-yarn install

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -75,6 +75,7 @@ SEMGREP_VARIANTS = [
     SemgrepVariant("no-cache", "-bloom_filter -no_opt_cache"),
     SemgrepVariant("max-cache", "-bloom_filter -opt_max_cache"),
     SemgrepVariant("no-bloom", "-no_bloom_filter"),
+    SemgrepVariant("no-gc-tuning", "-bloom_filter -no_gc_tuning"),
 ]
 
 # Add support for: with chdir(DIR): ...

--- a/semgrep-core/CLI/Main.ml
+++ b/semgrep-core/CLI/Main.ml
@@ -1264,6 +1264,9 @@ let options () =
       Flag.max_cache := true),
     " cache matches more aggressively; implies -opt_cache (experimental)";
 
+    "-no_gc_tuning", Arg.Clear Flag.gc_tuning,
+    " use OCaml's default garbage collector settings";
+
     (*s: [[Main_semgrep_core.options]] report match mode cases *)
     "-emacs", Arg.Unit (fun () -> match_format := Matching_report.Emacs ),
     " print matches on the same line than the match position";
@@ -1383,7 +1386,6 @@ let options () =
 (*s: function [[Main_semgrep_core.main]] *)
 let main () =
   profile_start := Unix.gettimeofday ();
-  set_gc ();
 
   let usage_msg =
     spf "Usage: %s [options] <pattern> <files_or_dirs> \nOptions:"
@@ -1405,6 +1407,7 @@ let main () =
 
   (* does side effect on many global flags *)
   let args = Common.parse_options (options()) usage_msg (Array.of_list argv) in
+  if !Flag.gc_tuning then set_gc ();
   let args = if !target_file = "" then args else Common.cat !target_file in
 
   if Sys.file_exists !log_config_file

--- a/semgrep-core/Core/Flag_semgrep.ml
+++ b/semgrep-core/Core/Flag_semgrep.ml
@@ -44,7 +44,7 @@ let with_opt_cache = ref true
 (* Improves performance on some patterns, degrades performance on others. *)
 let max_cache = ref false
 
-(* Disabling this lets us measure the effectiveness of our the GC tuning. *)
+(* Disabling this lets us measure the effectiveness of our GC tuning. *)
 let gc_tuning = ref true
 
 (*s: constant [[Flag_semgrep.equivalence_mode]] *)

--- a/semgrep-core/Core/Flag_semgrep.ml
+++ b/semgrep-core/Core/Flag_semgrep.ml
@@ -44,6 +44,9 @@ let with_opt_cache = ref true
 (* Improves performance on some patterns, degrades performance on others. *)
 let max_cache = ref false
 
+(* Disabling this lets us measure the effectiveness of our the GC tuning. *)
+let gc_tuning = ref true
+
 (*s: constant [[Flag_semgrep.equivalence_mode]] *)
 (* special mode to set before using generic_vs_generic to match
  * code equivalences.


### PR DESCRIPTION
Also fixes the `big-js` benchmark.