### PR TITLE
Print benchmark results at the end

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -158,6 +158,7 @@ def run_semgrep(docker: str, corpus: Corpus, variant: SemgrepVariant) -> float:
 
 def run_benchmarks(docker: str, dummy: bool, upload: bool) -> None:
     corpuses = CORPUSES
+    results = []
     if dummy:
         corpuses = DUMMY_CORPUSES
     for corpus in corpuses:
@@ -168,9 +169,13 @@ def run_benchmarks(docker: str, dummy: bool, upload: bool) -> None:
                 metric_name = ".".join([name, "duration"])
                 print(f"------ {name} ------")
                 duration = run_semgrep(docker, corpus, variant)
-                print(f"{metric_name} = {duration:.3f} s")
+                msg = f"{metric_name} = {duration:.3f} s"
+                print(msg)
+                results.append(msg)
                 if upload:
                     upload_result(metric_name, duration)
+    for msg in results:
+        print(msg)
 
 
 def main() -> None:


### PR DESCRIPTION
... so we don't have to sift through the error and warning messages to find the benchmark results. Looks like this:
```
semgrep.bench.big-js.std.duration = 49.044 s
semgrep.bench.big-js.no-cache.duration = 48.977 s
semgrep.bench.big-js.max-cache.duration = 44.766 s
semgrep.bench.big-js.no-bloom.duration = 90.448 s
semgrep.bench.big-js.no-gc-tuning.duration = 51.564 s
semgrep.bench.njsbox.std.duration = 43.827 s
semgrep.bench.njsbox.no-cache.duration = 42.582 s
semgrep.bench.njsbox.max-cache.duration = 43.153 s
semgrep.bench.njsbox.no-bloom.duration = 62.298 s
semgrep.bench.njsbox.no-gc-tuning.duration = 45.698 s
semgrep.bench.zulip.std.duration = 6.735 s
semgrep.bench.zulip.no-cache.duration = 6.916 s
semgrep.bench.zulip.max-cache.duration = 7.359 s
semgrep.bench.zulip.no-bloom.duration = 7.242 s
semgrep.bench.zulip.no-gc-tuning.duration = 7.847 s