### PR TITLE
Parse correctly octal numbers in tree_sitter parsers

### DIFF
--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -48,7 +48,7 @@ let first_xlang_of_rules = fun rs ->
 (* Entry point *)
 (*****************************************************************************)
 
-let test_rules xs =
+let test_rules ?(ounit_context=false) xs =
   let fullxs =
     xs
     |> File_type.files_of_dirs_or_files (function
@@ -142,7 +142,7 @@ let test_rules xs =
     try
       E.compare_actual_to_expected actual_errors expected_error_lines;
       Hashtbl.add newscore file (Common2.Ok)
-    with (OUnitTest.OUnit_failure s) ->
+    with (OUnitTest.OUnit_failure s) when not ounit_context ->
       pr2 s;
       Hashtbl.add newscore file (Common2.Pb s);
       (* coupling: ugly: with Error_code.compare_actual_to_expected *)
@@ -152,6 +152,8 @@ let test_rules xs =
         total_mismatch := !total_mismatch + n
       else failwith (spf "wrong unit failure format: %s" s)
   );
-  Parse_info.print_regression_information ~ext xs newscore;
-  pr2 (spf "total mismatch: %d" !total_mismatch);
+  if not ounit_context then begin
+    Parse_info.print_regression_information ~ext xs newscore;
+    pr2 (spf "total mismatch: %d" !total_mismatch);
+  end;
   ()

--- a/semgrep-core/src/engine/Test_engine.mli
+++ b/semgrep-core/src/engine/Test_engine.mli
@@ -1,2 +1,4 @@
 
-val test_rules: Common.filename list -> unit
+val test_rules:
+  ?ounit_context: bool ->
+  Common.filename list -> unit

--- a/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
@@ -386,7 +386,7 @@ and preproc_call_expression (env : env) ((v1, v2) : CST.preproc_call_expression)
 (* Int or Float ! *)
 and number_literal env tok =
   let (s, t) = str env tok in
-  match int_of_string_opt s with
+  match H.int_of_string_c_octal_opt s with
   | Some i -> Int (Some i, t)
   | None ->
       (match float_of_string_opt s with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -334,6 +334,9 @@ let attribute_target_specifier (env : env) ((v1, v2) : CST.attribute_target_spec
   let v2 = token env v2 (* ":" *) in
   todo env (v1, v2)
 
+(* note that there's no octal literal in C# so no need for
+ * H.int_of_string_c_octal_opt
+*)
 let integer_literal (env : env) (tok : CST.integer_literal) =
   let (s, t) = str env tok in (* integer_literal *)
   AST.Int (int_of_string_opt s, t)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -82,7 +82,7 @@ let float_literal (env : env) (tok : CST.float_literal) =
 
 let int_literal (env : env) (tok : CST.int_literal) =
   let (s, t) = str env tok (* int_literal *) in
-  int_of_string_opt s, t
+  H.int_of_string_c_octal_opt s, t
 
 let rune_literal (env : env) (tok : CST.rune_literal) =
   str env tok (* rune_literal *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -116,7 +116,7 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
 
 let int_literal env tok =
   let (s, t) = str env tok in
-  int_of_string_opt s, t
+  H.int_of_string_c_octal_opt s, t
 
 let string_literal env tok =
   let (s, t) = str env tok in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_javascript_tree_sitter.ml
@@ -121,7 +121,7 @@ and anon_choice_type_id (env : env) (x : CST.anon_choice_id_b8f8ced) : ident lis
 
 let number (env : env) (tok : CST.number) =
   let (s, t) = str env tok (* number *) in
-  (match int_of_string_opt s with
+  (match H.int_of_string_c_octal_opt s with
    | Some i -> Some (float_of_int i)
    | None ->
        float_of_string_opt s

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -195,6 +195,9 @@ let additive_operator (env : env) (x : CST.additive_operator) =
    | `DASH tok -> Minus, token env tok (* "-" *)
   )
 
+(* note that there's no octal literal in Kotlin so no need for
+ * H.int_of_string_c_octal_opt
+*)
 let integer_literal (env : env) (tok : CST.integer_literal) =
   let (s, t) = str env tok (* integer_literal *) in
   (int_of_string_opt s, t)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
@@ -11,6 +11,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
 *)
+open Common
+
 module PI = Parse_info
 
 (*****************************************************************************)
@@ -92,6 +94,13 @@ let combine_tokens env xs =
   | x::_xsTODO ->
       let t = token env x in
       t
+
+let int_of_string_c_octal_opt s =
+  if s =~ "^0\\([0-7]+\\)$"
+  then
+    let s = Common.matched1 s in
+    int_of_string_opt ("0o" ^ s)
+  else int_of_string_opt s
 
 let wrap_parser tree_sitter_parser ast_mapper =
   (* Note that because we currently use Parallel.invoke to

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
@@ -14,6 +14,10 @@ val str: 'a env -> Tree_sitter_run.Token.t -> string * Parse_info.t
 
 val combine_tokens: 'a env -> Tree_sitter_run.Token.t list -> Parse_info.t
 
+(* like int_of_string_opt, but also converts C octals like 0400 in
+ * the right value. *)
+val int_of_string_c_octal_opt: string -> int option
+
 (*
    Call a tree-sitter parser and then map the CST into an AST
    with the user-provided function. Takes care of error handling.

--- a/semgrep-core/tests/OTHER/rules/Makefile
+++ b/semgrep-core/tests/OTHER/rules/Makefile
@@ -1,0 +1,25 @@
+
+# We convert the .jsonnet in .yaml here, even though semgrep-core
+# knows how to do that by itself, to avoid to add a jsonnet dependency
+# in CI.
+JSONNET_TESTS=\
+  metavar_cond.jsonnet \
+  metavar_cond2.jsonnet \
+  metavar_cond_octal.jsonnet \
+  metavar_regex.jsonnet \
+  negation_ajin.jsonnet \
+  regexp.jsonnet \
+  regexp_nomatch.jsonnet \
+
+all: $(JSONNET_TESTS:.jsonnet=.yaml)
+
+%.json: %.jsonnet
+	jsonnet $^ > $@
+
+# this requires json-yaml of https://github.com/sjmulder/json-yaml
+# (available in arch-linux at https://aur.archlinux.org/packages/json-yaml/)
+%.yaml: %.json
+	json-yaml $^ > $@
+
+
+

--- a/semgrep-core/tests/OTHER/rules/inception.yaml
+++ b/semgrep-core/tests/OTHER/rules/inception.yaml
@@ -1,4 +1,5 @@
 rules:
+#ERROR:
 - id: double-id
   message: |
     you use multiple times the same id

--- a/semgrep-core/tests/OTHER/rules/metavar_cond.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: rule_template_id
+  languages:
+  - python
+  match:
+    and:
+    - foo($ARG)
+    - where: re.match($ARG, ".*bar.*")
+  message: rule_template_message
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/metavar_cond2.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond2.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: rule_template_id
+  languages:
+  - python
+  match:
+    and:
+    - foo($ARG)
+    - where: $ARG > 10
+  message: rule_template_message
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/metavar_cond_octal.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond_octal.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: rule_template_id
+  languages:
+  - go
+  match:
+    and:
+    - os.Mkdir($NAME, $PERM)
+    - where: $PERM > 0o600
+  message: rule_template_message
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/metavar_regex.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_regex.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: rule_template_id
+  languages:
+  - python
+  match:
+    and:
+    - foo($ARG)
+    - metavariable_regex:
+      - $ARG
+      - .*bar.*
+  message: rule_template_message
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/negation_ajin.yaml
+++ b/semgrep-core/tests/OTHER/rules/negation_ajin.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: rule_template_id
+  languages:
+  - python
+  match:
+    and:
+    - os.environ
+    - not:
+        or:
+        - os.environ.get(...)
+        - os.environ[...]
+  message: rule_template_message
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/regexp.yaml
+++ b/semgrep-core/tests/OTHER/rules/regexp.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: rule_template_id
+  languages:
+  - python
+  match:
+    and:
+    - foo("...")
+    - regex: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
+  message: rule_template_message
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/regexp_nomatch.yaml
+++ b/semgrep-core/tests/OTHER/rules/regexp_nomatch.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: rule_template_id
+  languages:
+  - python
+  match:
+    and:
+    - foo("...")
+    - regex: ABCDE
+  message: rule_template_message
+  severity: ERROR

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -137,7 +137,7 @@ let regression_tests_for_lang ~with_caching files lang =
 (*e: function [[Test.regression_tests_for_lang]] *)
 
 (*****************************************************************************)
-(* More tests *)
+(* Tests *)
 (*****************************************************************************)
 
 (* This differs from pfff/tests/<lang>/parsing because here we also use
@@ -295,6 +295,12 @@ let lang_regression_tests ~with_caching =
  ]
 (*e: constant [[Test.lang_regression_tests]] *)
 
+let full_rule_regression_tests =
+  "full rule" >:: (fun () ->
+      let path = Filename.concat tests_path "OTHER/rules" in
+      Test_engine.test_rules ~ounit_context:true [path]
+  )
+
 (*s: constant [[Test.lint_regression_tests]] *)
 (* mostly a copy paste of pfff/linter/unit_linter.ml *)
 let lint_regression_tests ~with_caching =
@@ -384,6 +390,7 @@ let test regexp =
       lint_regression_tests ~with_caching:false;
       lint_regression_tests ~with_caching:true;
       eval_regression_tests;
+      full_rule_regression_tests;
     ]
   in
   let suite =


### PR DESCRIPTION
This will fix some regressions in tests/OTHER/rules.
Also plug Test_engine regressions tests in 'make test'

test plan:
make test