### PR TITLE
* semgrep-core/semgrep.opam: switch to easy_logging.git

### DIFF
--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -20,7 +20,6 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
   "dune" {>= "2.7.0" }
   "bisect_ppx" {>= "2.5.0"}
-  "easy_logging_yojson" { dev }
   "ocamlgraph"
   "bloomf"
   "yojson"
@@ -35,8 +34,11 @@ depends: [
   "pcre"
   "parmap"
   "lsp" {= "1.1.0"}
+  "easy_logging" { dev & >= "0.8.0" }
+  "easy_logging_yojson" { dev & >= "0.8.0" }
 ]
 pin-depends: [
+  ["easy_logging.git" "git+https://github.com/aryx/easy_logging.git"]
   ["easy_logging_yojson.git" "git+https://github.com/aryx/easy_logging.git"]
 ]
 

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -16,16 +16,13 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 
 # These are build dependencies.
 # Development-only dependencies are in 'dev/dev.opam'.
-#
+# A big dependency is pfff, but it's now a submodule so it's not listed here
 depends: [
   "dune" {>= "2.7.0" }
   "bisect_ppx" {>= "2.5.0"}
-  "ocamlgraph"
   "bloomf"
   "yojson"
   "yaml"
-  "menhir"
-  "grain_dypgen"
   "ppx_deriving"
   "ppx_hash"
   "uucp"

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -37,7 +37,7 @@ depends: [
   "lsp" {= "1.1.0"}
 ]
 pin-depends: [
-  ["easy_logging_yojson.git" "git@github.com:aryx/easy_logging.git"]
+  ["easy_logging_yojson.git" "git+https://github.com/aryx/easy_logging.git"]
 ]
 
 build: [make]

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
   "dune" {>= "2.7.0" }
   "bisect_ppx" {>= "2.5.0"}
-  "easy_logging_yojson"
+  "easy_logging_yojson" { dev }
   "ocamlgraph"
   "bloomf"
   "yojson"
@@ -35,6 +35,9 @@ depends: [
   "pcre"
   "parmap"
   "lsp" {= "1.1.0"}
+]
+pin-depends: [
+  ["easy_logging_yojson.git" "git@github.com:aryx/easy_logging.git"]
 ]
 
 build: [make]


### PR DESCRIPTION
Path towards using comby in semgrep, which currently has conflicts
with easy_logging because of ppx_deriving < 5 constraint

test plan:
make test, and wait for CI to work