### PR TITLE
[doc] Remove references to internal executable Main.exe

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -233,13 +233,13 @@ Then to test semgrep on a file, for example tests/GENERIC/test.py run:
 
 ```bash
 $ cd semgrep-core
-$ ./_build/default/CLI/Main.exe -e foo -lang python tests/python
+$ ./bin/semgrep-core -e foo -lang python tests/python
 ```
 
 If you want to test semgrep on a directory with a set of given rules, run:
 
 ```bash
-$ cp ./semgrep-core/_build/default/CLI/Main.exe /usr/local/bin/semgrep_core
+$ cp ./semgrep-core/bin/semgrep-core /usr/local/bin/semgrep_core
 $ cd semgrep
 $ pipenv install --dev
 $ pipenv run semgrep --config <YAML_FILE_OR_DIRECTORY> <code to check>
@@ -273,7 +273,7 @@ a short profile of the code, for example:
 
 ``` bash
 $ cd semgrep-core
-$ ./_build/default/CLI/Main.exe -profile -e foo tests/python
+$ ./bin/semgrep-core -profile -e foo tests/python
 ---------------------
 profiling result
 ---------------------
@@ -287,7 +287,7 @@ You can also instead set the environment variable SEMGREP_CORE_PROFILE to 1 to g
 ```bash
 cd semgrep-core
 export SEMGREP_CORE_PROFILE=1
-./_build/default/CLI/Main.exe -e foo tests/python
+./bin/semgrep-core -e foo tests/python
 ---------------------
 profiling result
 ---------------------

--- a/doc/port-language.md
+++ b/doc/port-language.md
@@ -36,7 +36,7 @@ Now that you have added you new language 'X' to pfff, do the following:
 7. Write a basic test case for your language in `tests/X/hello-world.X`. This can
    just be a hello-world function.
 8. Test that the command
-   `semgrep-core/_build/default/bin/Main.exe -dump_tree_sitter_cst test/X/hello-world` 
+   `semgrep-core/bin/semgrep-core -dump_tree_sitter_cst test/X/hello-world`
    prints out a CST for your language.
 
 


### PR DESCRIPTION
Using `semgrep-core/bin/semgrep-core` instead.