### PR TITLE
Fix regressions on semgrep-rules when using -fast

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -64,6 +64,8 @@ index:
 
 visual:
 	codemap -screen_size 3 -filter pfff -efuns_client efuns_client -emacs_client /dev/null .
+visual2:
+	codemap -screen_size 3 -filter pfff -efuns_client efuns_client -emacs_client /dev/null src
 
 .PHONY: check index visual
 

--- a/semgrep-core/src/optimizing/Analyze_pattern.ml
+++ b/semgrep-core/src/optimizing/Analyze_pattern.ml
@@ -34,12 +34,11 @@ module V = Visitor_AST
  *  - Mini_rules_filter and Semgrep_generic, to skip certain mini-rules
  *    (but not entire files)
  *  - the bloom filter pattern extractor of Nathan and Emma
- *  - TODO: the Semgrep.ml engine to skip entire files!
+ *  - the Semgrep.ml engine to skip entire files!
  *
  * TODO:
  *  - extract identifiers, and basic strings
  *  - TODO extract filenames in import
- *  - TODO extract metavariables for Analyze_rule.ml
 *)
 
 (*****************************************************************************)


### PR DESCRIPTION
test plan:
semgrep-core -fast -test_rules ~/github/semgrep-rules/ now return
back the 28 mismatch (instead of 131 before this PR)