### PR TITLE
Treat back pattern-not and pattern-not-inside differently in semgrep-core

### DIFF
--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -89,7 +89,7 @@ let check_formula env lang f =
     match f with
     | Leaf (P _) -> ()
     | Leaf (MetavarCond _) -> ()
-    | Not f -> find_dupe f
+    | Not (f, _) -> find_dupe f
     | Or xs | And xs ->
         let rec aux xs =
           match xs with
@@ -100,7 +100,7 @@ let check_formula env lang f =
               *)
               if xs |> List.exists (equal_formula x)
               then error env (spf "Duplicate pattern %s" (show_formula x));
-              if xs |> List.exists (equal_formula (Not x))
+              if xs |> List.exists (equal_formula (Not (x, None)))
               then error env (spf "Unsatisfiable patterns %s" (show_formula x));
               aux xs
         in

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -118,11 +118,11 @@ let rec (remove_not: Rule.formula -> Rule.formula option) = fun f ->
       if null ys
       then failwith "null Or after remove_not"
       else Some (R.Or ys)
-  | R.Not f ->
+  | R.Not (f, _inside) ->
       (match f with
        | R.Leaf _ -> None
        (* double negation *)
-       | R.Not f -> remove_not f
+       | R.Not (f, _inside2) -> remove_not f
        (* todo? apply De Morgan's law? *)
        | R.Or _xs -> failwith "Not Or"
        | R.And _xs -> failwith "Not And"
@@ -144,7 +144,7 @@ type cnf_step0 = step0 cnf
 let rec (cnf: Rule.formula -> cnf_step0) = fun f ->
   match f with
   | R.Leaf x -> And [Or [L x]]
-  | R.Not _f ->
+  | R.Not (_f, _) ->
       (* should be filtered by remove_not *)
       failwith "call remove_not before cnf"
   (* old:

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -266,7 +266,10 @@ let rec parse_formula_new env (x: J.t) : R.formula =
            R.Or xs
        | ["not", v] ->
            let f = parse_formula_new env v in
-           R.Not f
+           R.Not (f, None)
+       | ["not_inside", v] ->
+           let f = parse_formula_new env v in
+           R.Not (f, Some Inside)
 
        | ["regex", J.String s] ->
            let xpat = R.mk_xpat (R.Regexp (parse_regexp s)) s in

--- a/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/lib_semgrep.jsonnet
@@ -6,6 +6,7 @@
    And: function(x1, x2, x3=null, x4=null) { and: std.prune([x1,x2,x3,x4]) },
    Or: function(x1, x2, x3=null, x4=null) { or: std.prune([x1,x2,x3,x4]) },
    Not: function(x) { not: x },
+   NotInside: function(x) { not_inside: x },
    Regex: function(x) { regex: x },
    Where: function(x) { where: x },
    MetavarRegex: function(x, y) { metavariable_regex: [x, y] },

--- a/semgrep-core/tests/OTHER/rules/negation_ajin.jsonnet
+++ b/semgrep-core/tests/OTHER/rules/negation_ajin.jsonnet
@@ -2,5 +2,5 @@ local s = import 'lib_semgrep.jsonnet';
 
 s.basic_rule('python', 
              s.And('os.environ',
-                   s.Not(s.Or('os.environ.get(...)',
+                   s.NotInside(s.Or('os.environ.get(...)',
                               'os.environ[...]'))))

--- a/semgrep-core/tests/OTHER/rules/negation_ajin.yaml
+++ b/semgrep-core/tests/OTHER/rules/negation_ajin.yaml
@@ -5,7 +5,7 @@ rules:
   match:
     and:
     - os.environ
-    - not:
+    - not_inside:
         or:
         - os.environ.get(...)
         - os.environ[...]

--- a/semgrep-core/tests/OTHER/rules/negation_exact.js
+++ b/semgrep-core/tests/OTHER/rules/negation_exact.js
@@ -1,0 +1,8 @@
+// using a pattern-not-inside instead of a pattern-not in the rule
+// will lead to not finding the match below.
+let func = new Function('var x = "static strings are okay";');
+func();
+
+//ruleid: match (only if use pattern-not)
+func = new Function(xxx);
+func();

--- a/semgrep-core/tests/OTHER/rules/negation_exact.yaml
+++ b/semgrep-core/tests/OTHER/rules/negation_exact.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: new-function-detected
+  patterns:
+  - pattern-not: |
+      $FUNC = new Function('...');
+      ...
+      $FUNC();
+  - pattern: |
+      $FUNC = new Function(...);
+      ...
+      $FUNC();
+  message: xxx
+  languages: [javascript]
+  severity: WARNING


### PR DESCRIPTION
test plan:
```
$ semgrep-core -test_rules ~/github/semgrep-rules/
...
Great: a test file now works: ./javascript/browser/security/new-function-detected.yaml
Great: a test file now works: ./python/django/best-practice/upsell_django_environ.yaml
Great: a test file now works: ./python/django/security/audit/xss/template-translate-as-no-escape.yaml
Great: a test file now works: ./python/django/security/audit/xss/template-translate-no-escape.yaml
Great: a test file now works: ./python/django/security/injection/path-traversal/path-traversal-file-name.yaml
Great: a test file now works: ./python/django/security/injection/path-traversal/path-traversal-join.yaml
Great: a test file now works: ./ruby/lang/security/model-attributes-attr-accessible.yaml
total mismatch: 16
```
was at 28 before