### PR TITLE
* semgrep-core/src/parsing/Test_parsing.mli: comments

### DIFF
--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -116,11 +116,6 @@ let dump_tree_sitter_cst file =
   | _::_::_ -> failwith (spf "too many languages detected for %s" file)
 
 let test_parse_tree_sitter lang xs =
-  let lang =
-    match Lang.lang_of_string_opt lang with
-    | Some l -> l
-    | None -> failwith "no language or unsupported language; use correct -lang"
-  in
   let xs = List.map Common.fullpath xs in
   let fullxs = Lang.files_of_dirs_or_files lang xs
                |> Skip_code.filter_files_if_skip_list ~root:xs
@@ -182,9 +177,9 @@ let test_parse_tree_sitter lang xs =
 (* Pfff and tree-sitter parsing *)
 (*****************************************************************************)
 
-let parsing_common ?(verbose=true) lang get_final_files xs =
+let parsing_common ?(verbose=true) lang xs =
   let xs = List.map Common.fullpath xs in
-  let fullxs = get_final_files xs
+  let fullxs = Lang.files_of_dirs_or_files lang xs
                |> Skip_code.filter_files_if_skip_list ~root:xs
   in
 
@@ -208,8 +203,8 @@ let parsing_common ?(verbose=true) lang get_final_files xs =
   !stat_list
 
 
-let parsing_stats lang json get_final_files files =
-  let stat_list = parsing_common lang get_final_files files in
+let parsing_stats lang json files_or_dirs =
+  let stat_list = parsing_common lang files_or_dirs in
   if json
   then
     let (total, bad) = Parse_info.aggregate_stats stat_list in
@@ -224,8 +219,8 @@ let parsing_stats lang json get_final_files files =
   else
     Parse_info.print_parsing_stat_list stat_list
 
-let parsing_regressions  lang get_final_files files =
-  let _stat_list = parsing_common lang get_final_files files in
+let parsing_regressions  lang files_or_dirs =
+  let _stat_list = parsing_common lang files_or_dirs in
   raise Todo
 
 

--- a/semgrep-core/src/parsing/Test_parsing.mli
+++ b/semgrep-core/src/parsing/Test_parsing.mli
@@ -1,16 +1,47 @@
 
-val parsing_stats: Lang.t -> bool (* json *) ->
-  (Common.filename list -> Common.filename list) -> Common.filename list ->
-  unit
+(* [parsing_stats l json_output paths] recursively explores [paths] to
+ * find files in given language [l]. Then it parses those files using
+ * [Parse_target.parse_program] (which internally uses either a
+ * treesitter or pfff parser) and output parsing statistics on stdout.
+ * The output can be in JSON format if [json_output] is true.
+ *
+ * This function is called by the -parsing_stat command-line action.
+ * Here is an example of use:
+ *   $ semgrep-core -lang ocaml -parsing_stats tests/ocaml/ -json
+ *   {"total":111,"bad":0,"percent_correct":100.0}
+*)
+val parsing_stats:
+  Lang.t -> bool (* json *) -> Common.path list -> unit
 
-val parsing_regressions: Lang.t ->
-  (Common.filename list -> Common.filename list) -> Common.filename list ->
-  unit
+(* TODO: parsing regressions as in pfff (unfinished) *)
+val parsing_regressions:
+  Lang.t -> Common.path list -> unit
 
-val test_parse_tree_sitter: string -> Common.filename list -> unit
+(* Similar to [parsing_stats], but uses only tree-sitter parsers,
+ * and stop the parsing at the tree-sitter CST level (it does not
+ * try to convert this CST in the generic AST).
+*)
+val test_parse_tree_sitter: Lang.t -> Common.filename list -> unit
 
-val dump_tree_sitter_cst: Common.filename -> unit
-val dump_ast_pfff: Common.filename -> unit
+(* Dump the tree-sitter CST of the given file (it automatically detects
+ * the language and parser to use based on the filename extension). *)
+val dump_tree_sitter_cst : Common.filename -> unit
+
+(* Dump the generic AST of the given file (it automatically detects
+ * the language to use based on the filename extension) but only use
+ * a pfff parser.
+*)
+val dump_ast_pfff        : Common.filename -> unit
+
+(* For each file, parse the file using a pfff parser and
+ * parse the file using a tree-sitter parser and output the differences
+ * in the generic ASTs produced (internally using the Unix diff program
+ * on the dumped ASTs).
+*)
 val diff_pfff_tree_sitter: Common.filename list -> unit
 
-val test_parse_rules: Common.filename list -> unit
+(* [test_parse_rules paths] recursively explores [paths] to
+ * find YAML files containing rules and check if they
+ * parse correctly using Parse_rule.parse.
+*)
+val test_parse_rules: Common.path list -> unit

--- a/semgrep-core/tests/OTHER/rules/spacegrep_metavarbug.dockerfile
+++ b/semgrep-core/tests/OTHER/rules/spacegrep_metavarbug.dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+USER root
+RUN apk install curl
+CMD ["/hello"]
+# semgrep with spacegrep used to return a match here, but it should
+# not really; it was just by chance, because it was returning different
+# unique id for $ROOT even though they had the same content
+# see https://github.com/returntocorp/semgrep/issues/2778
+USER root
+CMD ["ls -ltr"]

--- a/semgrep-core/tests/OTHER/rules/spacegrep_metavarbug.yaml
+++ b/semgrep-core/tests/OTHER/rules/spacegrep_metavarbug.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: last-user-is-root
+    patterns:
+      - pattern: USER $ROOT
+      - pattern-not-inside: |
+          USER $ROOT
+          ...
+          ...
+          USER $OTHER
+      - metavariable-regex:
+          metavariable: "$ROOT"
+          regex: "root"
+    message: xxx
+    severity: ERROR
+    languages: [generic]


### PR DESCRIPTION
This PR also cleanups Main.ml and reduce the use of the global !lang

test plan:
$ semgrep-core -lang ocaml -parsing_stats tests/ocaml/ -json
{"total":111,"bad":0,"percent_correct":100.0}