### PR TITLE
cleanup Pattern_match.t.rule, just need a rule id

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -495,8 +495,8 @@ let filter_files_with_too_many_matches_and_transform_as_timeout matches =
         let matches = List.assoc file per_files in
         matches
         |> List.map (fun m ->
-          let rule = m.Pattern_match.rule in
-          (rule.Mini_rule.id, rule.Mini_rule.pattern_string), m)
+          let rule_id = m.Pattern_match.rule_id in
+          (rule_id.Pattern_match.id, rule_id.Pattern_match.pattern_string), m)
         |> Common.group_assoc_bykey_eff
         |> List.map (fun (k, xs) -> k, List.length xs)
         |> Common.sort_by_val_highfirst

--- a/semgrep-core/src/core/Mini_rule.ml
+++ b/semgrep-core/src/core/Mini_rule.ml
@@ -18,14 +18,15 @@
 (* Prelude *)
 (*****************************************************************************)
 (* The goal of this module is to make it easy to add lint rules by using
- * sgrep patterns. You just have to store in a special file the patterns
- * and the corresponding warning you want the linter to raise.
+ * semgrep patterns. You just have to store the patterns in a special file
+ * and add the corresponding warnings you want the linter to raise.
  *
  * update: if you need advanced patterns with boolean logic (which used
  * to be partially provided by the hacky OK error keyword), use
- * instead the sgrep python wrapper! It also uses a yaml file but it
+ * instead the semgrep python wrapper! It also uses a yaml file but it
  * has more features, e.g. some pattern-either fields, pattern-inside,
  * where-eval, etc.
+ * update: actually you can now use Rule.ml instead of the python wrapper :)
 *)
 
 (*****************************************************************************)
@@ -33,15 +34,14 @@
 (*****************************************************************************)
 
 (*s: type [[Rule.pattern]] *)
-(* right now only Expr, Stmt, and Stmts are supported *)
-type pattern = Pattern.t
-[@@deriving show]
 (*e: type [[Rule.pattern]] *)
+type mini_rule_id = string
+[@@deriving show, eq]
 
 (*s: type [[Rule.rule]] *)
 type rule = {
-  id: string;
-  pattern: pattern;
+  id: mini_rule_id;
+  pattern: Pattern.t;
   message: string;
   severity: severity;
   languages: Lang.t list; (* at least one element *)
@@ -65,7 +65,7 @@ and rules = rule list
 and severity = Error | Warning | Info
 (*e: type [[Rule.severity]] *)
 
-[@@deriving show]
+[@@deriving eq, show]
 
 (*s: type [[Rule.t]] *)
 (* alias *)

--- a/semgrep-core/src/core/Mini_rule.ml
+++ b/semgrep-core/src/core/Mini_rule.ml
@@ -18,15 +18,14 @@
 (* Prelude *)
 (*****************************************************************************)
 (* The goal of this module is to make it easy to add lint rules by using
- * semgrep patterns. You just have to store the patterns in a special file
- * and add the corresponding warnings you want the linter to raise.
+ * semgrep patterns. You just have to store the patterns in a special
+ * YAML file and add the corresponding warnings you want the linter to raise.
  *
  * update: if you need advanced patterns with boolean logic (which used
  * to be partially provided by the hacky OK error keyword), use
- * instead the semgrep python wrapper! It also uses a yaml file but it
- * has more features, e.g. some pattern-either fields, pattern-inside,
- * where-eval, etc.
- * update: actually you can now use Rule.ml instead of the python wrapper :)
+ * instead Rule.ml (or the semgrep python wrapper). Rule.ml also uses a YAML
+ * file but it has more features, e.g. some pattern-either fields,
+ * pattern-inside, metavariable-comparison, etc.
 *)
 
 (*****************************************************************************)
@@ -35,12 +34,10 @@
 
 (*s: type [[Rule.pattern]] *)
 (*e: type [[Rule.pattern]] *)
-type mini_rule_id = string
-[@@deriving show, eq]
 
 (*s: type [[Rule.rule]] *)
 type rule = {
-  id: mini_rule_id;
+  id: string;
   pattern: Pattern.t;
   message: string;
   severity: severity;

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -17,28 +17,73 @@
 (*e: pad/r2c copyright *)
 
 (*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Type to represent a pattern match.
+ *
+ * old: used to be called Match_result.t
+*)
+
+(*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
 
-(* We use 'eq' below to possibly remove redundant equivalent matches
- * (Generic_vs_generic sometimes return multiple times the same match,
+(* We use 'eq' below to possibly remove redundant equivalent matches. Indeed,
+ * Generic_vs_generic sometimes return multiple times the same match,
  * sometimes because of some bugs we didn't fix, sometimes it's normal
- * because of the way '...' operate. TODO: an example
- * Note that you should not ignore the rule when comparing 2 matches!
- * One (mini) rule can be part of a pattern-not: in which case
- * even if it returns the same match than a similar rule in a pattern:,
- * we should not merge them!
+ * because of the way '...' operate. TODO: add an example of such situation.
+ *
+ * Note that you should not ignore the rule id when comparing 2 matches!
+ * One match can come from a pattern-not: in which case
+ * even if it returns the same match than a similar match coming
+ * from a pattern:, we should not merge them!
 *)
 
 (*s: type [[Match_result.t]] *)
 type t = {
-  rule: Mini_rule.t [@equal fun a b -> a.Mini_rule.id = b.Mini_rule.id];
-  file: Common.filename;
-  location: Parse_info.token_location * Parse_info.token_location;
-  (* do we need to be lazy? *)
+  (* rule (or mini rule) responsible for the pattern match found *)
+  rule_id: rule_id [@equal fun a b -> a.id = b.id];
+
+  (* location information *)
+  file: Common.filename; (* less: redundant with location? *)
+  (* note that the two token_location can be equal *)
+  range_loc: Parse_info.token_location * Parse_info.token_location;
+  (* less: do we need to be lazy? *)
   tokens: Parse_info.t list Lazy.t [@equal fun _a _b -> true];
+
+  (* metavars for the pattern match *)
   env: Metavariable.bindings;
 }
+
+(* This is currently a record, but really only the rule id should matter.
+ *
+ * We could derive information in the other fields from the id, but that
+ * would require to pass around the list of rules to get back the
+ * information. Instead by embedding the information in the pattern match,
+ * some functions are simpler.
+ * alt: reuse Mini_rule.t
+*)
+and rule_id = {
+  (* this id is usually a string like 'check-double-equal', but
+   * when we use a full rule, it temporarily stores a Rule.pattern_id *)
+  id: Mini_rule.mini_rule_id;
+
+  (* other parts of Mini_rule.t used in JSON_report.ml *)
+  message: string;
+  (* used for debugging (could be removed) *)
+  pattern_string: string;
+}
+
 [@@deriving show, eq]
 (*e: type [[Match_result.t]] *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let (rule_id_of_mini_rule: Mini_rule.t -> rule_id) = fun mr ->
+  { id = mr.Mini_rule.id;
+    message = mr.Mini_rule.message;
+    pattern_string = mr.Mini_rule.pattern_string;
+  }
 (*e: semgrep/core/Pattern_match.ml *)

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -60,30 +60,26 @@ type t = {
  * We could derive information in the other fields from the id, but that
  * would require to pass around the list of rules to get back the
  * information. Instead by embedding the information in the pattern match,
- * some functions are simpler.
+ * some functions are simpler (we use the same trick with Parse_info.t
+ * where for example we embed the filename in it, not just a position).
  * alt: reuse Mini_rule.t
 *)
 and rule_id = {
-  (* this id is usually a string like 'check-double-equal', but
-   * when we use a full rule, it temporarily stores a Rule.pattern_id *)
-  id: Mini_rule.mini_rule_id;
+  (* This id is usually a string like 'check-double-equal'.
+   * It can be the id of a rule or mini rule.
+   *
+   * Note that when we process a full rule, this id can temporarily
+   * contain a Rule.pattern_id.
+  *)
+  id: string;
 
-  (* other parts of Mini_rule.t used in JSON_report.ml *)
+  (* other parts of a rule (or mini_rule) used in JSON_report.ml *)
   message: string;
-  (* used for debugging (could be removed) *)
+  (* used for debugging (could be removed at some point) *)
   pattern_string: string;
 }
 
 [@@deriving show, eq]
 (*e: type [[Match_result.t]] *)
 
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-let (rule_id_of_mini_rule: Mini_rule.t -> rule_id) = fun mr ->
-  { id = mr.Mini_rule.id;
-    message = mr.Mini_rule.message;
-    pattern_string = mr.Mini_rule.pattern_string;
-  }
 (*e: semgrep/core/Pattern_match.ml *)

--- a/semgrep-core/src/core/Tainting_rule.ml
+++ b/semgrep-core/src/core/Tainting_rule.ml
@@ -63,16 +63,12 @@ type t = rule
 
 
 (*s: function [[Tainting_rule.rule_of_tainting_rule]] *)
-(* for Match_result.t.rule compatibility *)
+(* for Pattern_match.t.rule compatibility *)
 
-let rule_of_tainting_rule tr =
-  { R.
+let rule_id_of_tainting_rule tr =
+  { Pattern_match.
     id = tr.id;
     message = tr.message;
-    severity = tr.severity;
-    languages = tr.languages;
-    (* arbitrary *)
-    pattern = List.hd (tr.sink);
     pattern_string = "TODO: no pattern_string";
   }
 (*e: function [[Tainting_rule.rule_of_tainting_rule]] *)

--- a/semgrep-core/src/matching/Semgrep_generic.ml
+++ b/semgrep-core/src/matching/Semgrep_generic.ml
@@ -20,7 +20,7 @@ module V = Visitor_AST
 module AST = AST_generic
 module Err = Error_code
 module PI = Parse_info
-module R = Mini_rule
+module R = Mini_rule (* TODO: rename to MR *)
 module Eq = Equivalence
 module PM = Pattern_match
 module GG = Generic_vs_generic
@@ -164,9 +164,11 @@ let match_rules_and_recurse config (file,hook,matches) rules matcher k any x =
     then (* Found a match *)
       matches_with_env |> List.iter (fun (env : MG.tin) ->
         let env = env.mv.full_env in
-        let location = V.range_of_any (any x) in
+        let range_loc = V.range_of_any (any x) in
         let tokens = lazy (V.ii_of_any (any x)) in
-        Common.push { PM. rule; file; env; location; tokens } matches;
+        let rule_id = PM.rule_id_of_mini_rule rule in
+        Common.push { PM. rule_id; file; env; range_loc; tokens }
+          matches;
         hook env tokens
       )
   );
@@ -273,9 +275,11 @@ let check2 ~hook config rules equivs (file, lang, ast) =
             then (* Found a match *)
               matches_with_env |> List.iter (fun (env : MG.tin) ->
                 let env = env.mv.full_env in
-                let location = V.range_of_any (E x) in
+                let range_loc = V.range_of_any (E x) in
                 let tokens = lazy (V.ii_of_any (E x)) in
-                Common.push { PM. rule; file; env; location; tokens } matches;
+                let rule_id = PM.rule_id_of_mini_rule rule in
+                Common.push {PM. rule_id; file; env; range_loc; tokens}
+                  matches;
                 hook env tokens
               )
           );
@@ -300,10 +304,11 @@ let check2 ~hook config rules equivs (file, lang, ast) =
               then (* Found a match *)
                 matches_with_env |> List.iter (fun (env : MG.tin) ->
                   let env = env.mv.full_env in
-                  let location = V.range_of_any (S x) in
+                  let range_loc = V.range_of_any (S x) in
                   let tokens = lazy (V.ii_of_any (S x)) in
-                  Common.push
-                    { PM. rule; file; env; location; tokens } matches;
+                  let rule_id = PM.rule_id_of_mini_rule rule in
+                  Common.push {PM. rule_id; file; env; range_loc; tokens }
+                    matches;
                   hook env tokens
                 )
             );
@@ -353,12 +358,13 @@ let check2 ~hook config rules equivs (file, lang, ast) =
                 let span = env.stmts_match_span in
                 match Stmts_match_span.location span with
                 | None -> () (* empty sequence or bug *)
-                | Some location ->
+                | Some range_loc ->
                     let env = env.mv.full_env in
                     let tokens =
                       lazy (Stmts_match_span.list_original_tokens span) in
-                    Common.push
-                      { PM. rule; file; env; location; tokens } matches;
+                    let rule_id = PM.rule_id_of_mini_rule rule in
+                    Common.push {PM. rule_id; file; env; range_loc; tokens}
+                      matches;
                     hook env tokens
               )
           );

--- a/semgrep-core/src/matching/Semgrep_generic.ml
+++ b/semgrep-core/src/matching/Semgrep_generic.ml
@@ -156,6 +156,12 @@ let match_fld_fld rule a b env =
 (* Helpers *)
 (*****************************************************************************)
 
+let (rule_id_of_mini_rule: Mini_rule.t -> Pattern_match.rule_id) = fun mr ->
+  { PM.id = mr.Mini_rule.id;
+    message = mr.Mini_rule.message;
+    pattern_string = mr.Mini_rule.pattern_string;
+  }
+
 let match_rules_and_recurse config (file,hook,matches) rules matcher k any x =
   rules |> List.iter (fun (pattern, rule, cache) ->
     let env = MG.empty_environment cache config in
@@ -166,7 +172,7 @@ let match_rules_and_recurse config (file,hook,matches) rules matcher k any x =
         let env = env.mv.full_env in
         let range_loc = V.range_of_any (any x) in
         let tokens = lazy (V.ii_of_any (any x)) in
-        let rule_id = PM.rule_id_of_mini_rule rule in
+        let rule_id = rule_id_of_mini_rule rule in
         Common.push { PM. rule_id; file; env; range_loc; tokens }
           matches;
         hook env tokens
@@ -277,7 +283,7 @@ let check2 ~hook config rules equivs (file, lang, ast) =
                 let env = env.mv.full_env in
                 let range_loc = V.range_of_any (E x) in
                 let tokens = lazy (V.ii_of_any (E x)) in
-                let rule_id = PM.rule_id_of_mini_rule rule in
+                let rule_id = rule_id_of_mini_rule rule in
                 Common.push {PM. rule_id; file; env; range_loc; tokens}
                   matches;
                 hook env tokens
@@ -306,7 +312,7 @@ let check2 ~hook config rules equivs (file, lang, ast) =
                   let env = env.mv.full_env in
                   let range_loc = V.range_of_any (S x) in
                   let tokens = lazy (V.ii_of_any (S x)) in
-                  let rule_id = PM.rule_id_of_mini_rule rule in
+                  let rule_id = rule_id_of_mini_rule rule in
                   Common.push {PM. rule_id; file; env; range_loc; tokens }
                     matches;
                   hook env tokens
@@ -362,7 +368,7 @@ let check2 ~hook config rules equivs (file, lang, ast) =
                     let env = env.mv.full_env in
                     let tokens =
                       lazy (Stmts_match_span.list_original_tokens span) in
-                    let rule_id = PM.rule_id_of_mini_rule rule in
+                    let rule_id = rule_id_of_mini_rule rule in
                     Common.push {PM. rule_id; file; env; range_loc; tokens}
                       matches;
                     hook env tokens

--- a/semgrep-core/src/parsing/Parse_mini_rule.mli
+++ b/semgrep-core/src/parsing/Parse_mini_rule.mli
@@ -29,7 +29,7 @@ val parse_languages: id:string -> Yaml.value list -> Lang.t list * Lang.t
 val parse_severity: id:string -> string -> Mini_rule.severity
 (*e: signature [[Parse_rules.parse_severity]] *)
 (*s: signature [[Parse_rules.parse_pattern]] *)
-val parse_pattern: id:string -> lang:Lang.t -> string -> Mini_rule.pattern
+val parse_pattern: id:string -> lang:Lang.t -> string -> Pattern.t
 (*e: signature [[Parse_rules.parse_pattern]] *)
 
 (*e: semgrep/parsing/Parse_mini_rule.mli *)

--- a/semgrep-core/src/tainting/Tainting_generic.ml
+++ b/semgrep-core/src/tainting/Tainting_generic.ml
@@ -20,6 +20,7 @@ module V = Visitor_AST
 module R = Tainting_rule
 module R2 = Mini_rule
 module Flag = Flag_semgrep
+module PM = Pattern_match
 
 (*****************************************************************************)
 (* Prelude *)
@@ -100,17 +101,12 @@ let check rules file ast =
       rules |> List.iter (fun rule ->
         let found_tainted_sink = (fun instr _env ->
           let code = AST.E instr.IL.iorig in
-          let location = V.range_of_any code in
+          let range_loc = V.range_of_any code in
           let tokens = lazy (V.ii_of_any code) in
-          Common.push {
-            Pattern_match.
-            rule = Tainting_rule.rule_of_tainting_rule rule;
-            file;
-            location;
-            tokens;
-            (* todo: use env from sink matching func?  *)
-            env = [];
-          } matches;
+          let rule_id = Tainting_rule.rule_id_of_tainting_rule rule in
+          (* todo: use env from sink matching func?  *)
+          Common.push { PM. rule_id; file; range_loc; tokens; env = []; }
+            matches;
         ) in
         let config = config_of_rule found_tainted_sink rule in
         let mapping = Dataflow_tainting.fixpoint config flow in


### PR DESCRIPTION
Now, semgrep-core -config also returns the right check_id and message
for a match.

test plan:
```
$ /home/pad/semgrep/_build/default/src/cli/Main.exe -lang ocaml -config
 ocaml/lang/correctness/useless_if.yaml
 ocaml/lang/correctness/useless_if.ml -json | jq
{
  "matches": [
    {
      "check_id": "ocamllint-useless-if",
      "path": "ocaml/lang/correctness/useless_if.ml",
      "start": {
        "line": 3,
        "col": 6,
        "offset": 56
      },
      "end": {
        "line": 5,
        "col": 11,
        "offset": 81
      },
      "extra": {
        "message": "Useless if. Both branches are equal.",
	...
```