### PR TITLE
Move logger init after imports

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -20,9 +20,6 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 
-from semgrep.target_manager_extensions import all_supported_languages
-
-logger = logging.getLogger(__name__)
 from ruamel.yaml import YAML
 
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
@@ -33,25 +30,29 @@ from semgrep.error import _UnknownLanguageError
 from semgrep.error import InvalidPatternError
 from semgrep.error import MatchTimeoutError
 from semgrep.error import SemgrepError
-from semgrep.profile_manager import ProfileManager
 from semgrep.error import UnknownLanguageError
 from semgrep.evaluation import enumerate_patterns_in_boolean_expression
 from semgrep.evaluation import evaluate
 from semgrep.pattern import Pattern
 from semgrep.pattern_match import PatternMatch
+from semgrep.profile_manager import ProfileManager
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.semgrep_types import BooleanRuleExpression
+from semgrep.semgrep_types import GENERIC_LANGUAGE
 from semgrep.semgrep_types import Language
-from semgrep.semgrep_types import REGEX_ONLY_LANGUAGE_KEYS, GENERIC_LANGUAGE
 from semgrep.semgrep_types import OPERATORS
+from semgrep.semgrep_types import REGEX_ONLY_LANGUAGE_KEYS
 from semgrep.semgrep_types import TAINT_MODE
 from semgrep.spacegrep import run_spacegrep
 from semgrep.target_manager import TargetManager
+from semgrep.target_manager_extensions import all_supported_languages
 from semgrep.util import debug_tqdm_write
 from semgrep.util import partition
 from semgrep.util import progress_bar
 from semgrep.util import sub_run
+
+logger = logging.getLogger(__name__)
 
 
 def _offset_to_line_no(offset: int, buff: str) -> int:

--- a/semgrep/semgrep/spacegrep.py
+++ b/semgrep/semgrep/spacegrep.py
@@ -10,18 +10,18 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-logger = logging.getLogger(__name__)
-
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.constants import SPACEGREP_PATH
 from semgrep.core_exception import CoreException
 from semgrep.error import InvalidPatternError
-from semgrep.error import SemgrepError
 from semgrep.error import MatchTimeoutError
+from semgrep.error import SemgrepError
 from semgrep.pattern import Pattern
 from semgrep.pattern_match import PatternMatch
 from semgrep.rule_lang import Position
 from semgrep.util import sub_run
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_matching_time(json: Dict[str, Any]) -> float:

--- a/semgrep/semgrep/version.py
+++ b/semgrep/semgrep/version.py
@@ -4,14 +4,13 @@ import time
 from pathlib import Path
 from typing import Optional
 
-logger = logging.getLogger(__name__)
-
-
 from packaging.version import InvalidVersion
 from packaging.version import Version
 
 from semgrep import __VERSION__
 from semgrep.constants import SEMGREP_USER_AGENT
+
+logger = logging.getLogger(__name__)
 
 VERSION_CHECK_URL = str(
     os.environ.get("SEMGREP_VERSION_CHECK_URL", "https://semgrep.dev/api/check-version")


### PR DESCRIPTION
We should initialize the `logger` after all import statements have completed. It looks like there were a few pre-existing pre-commit issues that had to be fixed too.