### PR TITLE
Fix the 'unique_id' field of metavariable captures in json exported by spacegrep

### DIFF
--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -48,6 +48,11 @@ let string_of_resolved = function
  * the callers of sgrep (sgrep-lint) can check if multiple metavariables
  * reference the same entity, or reference exactly the same code.
  * See pfff/.../Naming_AST.ml for more information.
+ *
+ * TODO: provide a typed interface for the json object because it's really
+ *       hard to see how to produce correct output. 'Semgrep.atd' in
+ *       spacegrep already has definitions for about every type except this
+ *       one.
 *)
 let unique_id any =
   match any with

--- a/semgrep/tests/e2e/rules/spacegrep/dockerfile.yaml
+++ b/semgrep/tests/e2e/rules/spacegrep/dockerfile.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: double-root
+  languages:
+    - generic
+  patterns:
+    - pattern-either:
+      - pattern: |
+          USER $ROOT
+    - pattern-inside: |
+        USER $ROOT
+        ...
+        ...
+        USER $ROOT
+  message: |
+    'USER' is specified twice
+  severity: ERROR

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepdockerfile.yaml-spacegreproot.Dockerfile/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepdockerfile.yaml-spacegreproot.Dockerfile/results.json
@@ -1,0 +1,81 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.spacegrep.double-root",
+      "end": {
+        "col": 10,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "USER root",
+        "message": "'USER' is specified twice\n",
+        "metadata": {},
+        "metavars": {
+          "$ROOT": {
+            "abstract_content": "root",
+            "end": {
+              "col": 10,
+              "line": 3,
+              "offset": 43
+            },
+            "start": {
+              "col": 6,
+              "line": 3,
+              "offset": 39
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/spacegrep/root.Dockerfile",
+      "start": {
+        "col": 1,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.spacegrep.double-root",
+      "end": {
+        "col": 10,
+        "line": 7
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "USER root",
+        "message": "'USER' is specified twice\n",
+        "metadata": {},
+        "metavars": {
+          "$ROOT": {
+            "abstract_content": "root",
+            "end": {
+              "col": 10,
+              "line": 7,
+              "offset": 111
+            },
+            "start": {
+              "col": 6,
+              "line": 7,
+              "offset": 107
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/spacegrep/root.Dockerfile",
+      "start": {
+        "col": 1,
+        "line": 7
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/spacegrep/root.Dockerfile
+++ b/semgrep/tests/e2e/targets/spacegrep/root.Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine
+# ruleid: double-root
+USER root
+RUN apk install curl
+CMD ["/hello"]
+# ruleid: double-root
+USER root
+CMD ["ls -ltr"]

--- a/semgrep/tests/e2e/test_spacegrep.py
+++ b/semgrep/tests/e2e/test_spacegrep.py
@@ -11,6 +11,7 @@ import pytest
         ("rules/spacegrep/html.yaml", "spacegrep/html.mustache"),
         ("rules/spacegrep/markdown.yaml", "spacegrep/markdown.md"),
         ("rules/spacegrep/httpresponse.yaml", "spacegrep/httpresponse.txt"),
+        ("rules/spacegrep/dockerfile.yaml", "spacegrep/root.Dockerfile"),
     ],
 )
 def test_spacegrep(run_semgrep_in_tmp, snapshot, rule, target):

--- a/spacegrep/src/lib/Semgrep.atd
+++ b/spacegrep/src/lib/Semgrep.atd
@@ -60,6 +60,26 @@ type metavar_value = {
   start: position;
   end_ <json name="end">: position;
   abstract_content: string; (* value? *)
+
+  (* The unique ID of a metavariable indicates the kind object that was
+     captured for equality purposes. In the simplest case, this is only
+     the name of the metavariable. In semgrep, it can additionally include
+     a disambiguator. For example, consider this target code:
+
+       let foo = 1;
+       {
+         let foo = 2;
+       }
+
+     The pattern '$X' would match the first 'foo' and the second 'foo'.
+     In semgrep, these two 'foo's are identified as different variables,
+     and this is done by setting the metavariable capture's unique ID to
+     something like 'X-1' and 'X-2'. Even though their contents look
+     identical, they're not the same thing.
+
+     Spacegrep doesn't make this analysis, so these two captures will
+     be considered identical, which is not as good.
+  *)
   unique_id: unique_id;
 }
 

--- a/spacegrep/src/lib/Semgrep.atd
+++ b/spacegrep/src/lib/Semgrep.atd
@@ -74,7 +74,7 @@ type metavar_value = {
      The pattern '$X' would match the first 'foo' and the second 'foo'.
      In semgrep, these two 'foo's are identified as different variables,
      and this is done by setting the metavariable capture's unique ID to
-     something like 'X-1' and 'X-2'. Even though their contents look
+     something like foo-1' and 'foo-2'. Even though their contents look
      identical, they're not the same thing.
 
      Spacegrep doesn't make this analysis, so these two captures will

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -17,9 +17,9 @@ let semgrep_pos (x : Lexing.position) : Semgrep_t.position =
     offset = x.pos_cnum;
   }
 
-let unique_id_of_loc (loc : Loc.t) : unique_id =
+let unique_id_of_metavar_capture metavar_name : unique_id =
   let md5sum =
-    Marshal.to_string loc []
+    metavar_name
     |> Digest.string
     |> Digest.to_hex
   in
@@ -35,7 +35,7 @@ let convert_capture (name, x) =
     start = semgrep_pos pos1;
     end_ = semgrep_pos pos2;
     abstract_content = x.value;
-    unique_id = unique_id_of_loc x.loc;
+    unique_id = unique_id_of_metavar_capture name;
   }
 
 let make_target_time (src, match_time) : Semgrep_t.target_time =

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -17,9 +17,9 @@ let semgrep_pos (x : Lexing.position) : Semgrep_t.position =
     offset = x.pos_cnum;
   }
 
-let unique_id_of_metavar_capture metavar_name : unique_id =
+let unique_id_of_capture ~captured_string : unique_id =
   let md5sum =
-    metavar_name
+    captured_string
     |> Digest.string
     |> Digest.to_hex
   in
@@ -35,7 +35,7 @@ let convert_capture (name, x) =
     start = semgrep_pos pos1;
     end_ = semgrep_pos pos2;
     abstract_content = x.value;
-    unique_id = unique_id_of_metavar_capture name;
+    unique_id = unique_id_of_capture ~captured_string:x.value;
   }
 
 let make_target_time (src, match_time) : Semgrep_t.target_time =


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/2778 as indicated there by @aryx