### PR TITLE
Add dockerfile into container as /Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-Dockerfile
-dockerfiles
 semgrep/build
 semgrep/dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,9 @@ RUN chmod 777 /src
 RUN mkdir -p /tmp/.cache
 RUN chmod 777 /tmp/.cache
 
+# Let the user know how their container was built
+COPY dockerfiles/semgrep.Dockerfile /Dockerfile
+
 RUN adduser -D -u 1000 semgrep
 USER 1000
 ENV SEMGREP_IN_DOCKER=1

--- a/dockerfiles/semgrep-dev.Dockerfile
+++ b/dockerfiles/semgrep-dev.Dockerfile
@@ -22,5 +22,8 @@ RUN apk add --no-cache \
   bash \
   curl
 
+# Let the user know how their container was built
+COPY dockerfiles/semgrep-dev.Dockerfile /Dockerfile
+
 USER semgrep
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
GitHub Action for building semgrep and semgrep-dev containers seems to be pushing the same image twice when building two different images in the same job.

Having the dockerfile included in the container will help troubleshoot this kind of problems.
