### PR TITLE
Turn on bloom filters and add semgrep-core benchmark

### DIFF
--- a/perf/semgrep-core-benchmark
+++ b/perf/semgrep-core-benchmark
@@ -1,13 +1,19 @@
 #! /usr/bin/env python3
 #
 # Run semgrep-core on a series of pairs (rules, repo) with different options
-# and report the time it takes. This is separate from run-benchmarks because
-# semgrep-core needs to pass in the language along with the target files.
+# and report the time it takes.
 #
-# We implement that by adding the main language of the rules being run with
+# This is separate from run-benchmarks because semgrep-core needs to pass in
+# the language along with the target files.
+#
+# We implement that by adding the main language of the rules being run to
 # each corpus. However, this limits the set of languages we can use. We are
 # additionally limited by what semgrep-core is able to parse, as noted by
 # some commented out tests
+#
+# The end goal is for semgrep-core to replace semgrep in analyzing rules
+# and to unify the two files. This file is for local convenience and should
+# not be used in CI
 #
 # Requires semgrep-core (make install in the semgrep-core folder)
 #

--- a/perf/semgrep-core-benchmark
+++ b/perf/semgrep-core-benchmark
@@ -1,0 +1,193 @@
+#! /usr/bin/env python3
+#
+# Run semgrep on a series of pairs (rules, repo) with different options,
+# and report the time it takes. Optionally upload the results to the semgrep
+# dashboard.
+#
+# With the -semgrep-core flag, run semgrep-core with different options and
+# report the time it takes. Requires semgrep-core (make install in the
+# semgrep-core folder)
+#
+import argparse
+import os
+import subprocess
+import time
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+from typing import List
+
+DASHBOARD_URL = "https://dashboard.semgrep.dev"
+
+# Run command and propagate errors
+def cmd(*args: str) -> None:
+    subprocess.run(args, check=True)  # nosem
+
+
+class Corpus:
+    def __init__(self, name: str, rule_dir: str, target_dir: str, language: str):
+        # name for the input corpus (rules and targets)
+        self.name = name
+
+        # folder containing the semgrep rules
+        self.rule_dir = rule_dir
+
+        # folder containing the target source files
+        self.target_dir = target_dir
+
+        # language to run rules with (because semgrep-core requires it)
+        self.language = language
+
+    # Fetch rules and targets is delegated to an ad-hoc script named 'prep'.
+    def prep(self) -> None:
+        cmd("./prep")
+
+
+CORPUSES = [
+    # Run Ajin's nodejsscan rules on some repo containing javascript files.
+    # This takes something like 4 hours or more. Maybe we could run it
+    # on fewer targets.
+    # Corpus("njs", "input/njsscan/njsscan/rules/semantic_grep", "input/juice-shop"),
+    Corpus("big-js", "input/semgrep.yml", "input/big-js", "js"),
+    # Commented out because it can't run with semgrep-core
+    # Corpus(
+    #    "njsbox", "input/njsscan/njsscan/rules/semantic_grep", "input/dropbox-sdk-js", "js"
+    # ),
+    Corpus("zulip", "input/semgrep.yml", "input/zulip", "python"),
+    # The tests below all run r2c rulepacks (in r2c-rules) on public repos
+    # For command Corpus("$X", ..., "input/$Y"), you can find the repo by
+    # going to github.com/$X/$Y
+    #
+    # Run our django rulepack on a large python repo
+    Corpus("apache", "input/django.yml", "input/libcloud", "python"),
+    # Run our flask rulepack on a python repo
+    Corpus("dropbox", "input/flask.yml", "input/pytest-flakefinder", "python"),
+    # Run our golang rulepack on a go/html repo
+    Corpus("0c34", "input/golang.yml", "input/govwa", "go"),
+    # Run our ruby rulepack on a large ruby repo
+    Corpus("rails", "input/ruby.yml", "input/rails", "ruby"),
+    # Also commented out because it can't run with semgrep-core
+    # Run our javascript and eslint-plugin-security packs on a large JS repo
+    # Corpus("lodash", "input/rules", "input/lodash", "js"),
+]
+
+DUMMY_CORPUSES = [Corpus("dummy", "input/dummy/rules", "input/dummy/targets", "js")]
+
+
+class SemgrepVariant:
+    def __init__(self, name: str, semgrep_core_extra: str):
+        # name for the input corpus (rules and targets)
+        self.name = name
+
+        # space-separated extra arguments to pass to the default semgrep
+        # command
+        self.semgrep_core_extra = semgrep_core_extra
+
+
+# Semgrep-core variants are separate for now because semgrep-core with
+# -config is not official. Still uses the class SemgrepVariant
+SEMGREP_CORE_VARIANTS = [
+    SemgrepVariant("std", "-bloom_filter"),
+    SemgrepVariant("no-bloom", "-no_bloom_filter"),
+    SemgrepVariant("fast", "-fast -bloom_filter"),
+    SemgrepVariant("fast-no-bloom", "-fast -no_bloom_filter"),
+]
+
+# Add support for: with chdir(DIR): ...
+@contextmanager
+def chdir(dir: str) -> Iterator[None]:
+    old_dir = os.getcwd()
+    os.chdir(dir)
+    try:
+        yield
+    finally:
+        os.chdir(old_dir)
+
+
+def upload_result(metric_name: str, value: float) -> None:
+    url = f"{DASHBOARD_URL}/api/metric/{metric_name}"
+    print(f"Uploading to {url}")
+    r = urllib.request.urlopen(  # nosem
+        url=url,
+        data=str(value).encode("ascii"),
+    )
+    print(r.read().decode())
+
+
+def run_semgrep_core(corpus: Corpus, variant: SemgrepVariant) -> float:
+    args = []
+    common_args = ["-timeout", "0"]
+    # Using absolute paths because run_semgrep did, and because it is convenient
+    # to be able to run the command in different folders
+    args = [
+        "semgrep-core",
+        "-j",
+        "8",
+        "-lang",
+        corpus.language,
+        "-config",
+        os.path.abspath(corpus.rule_dir),
+        os.path.abspath(corpus.target_dir),
+    ]
+    args.extend(common_args)
+    args.extend(variant.semgrep_core_extra.split(" "))
+
+    print(f"current directory: {os.getcwd()}")
+    print("semgrep-core command: {}".format(" ".join(args)))
+
+    t1 = time.time()
+    res = subprocess.run(args)  # nosem
+    t2 = time.time()
+
+    status = res.returncode
+    print(f"semgrep-core exit status: {status}")
+    if status == 0:
+        print("success")
+    elif status == 3:
+        print("warning: some files couldn't be parsed")
+    else:
+        res.check_returncode()
+
+    return t2 - t1
+
+
+def run_benchmarks(dummy: bool, upload: bool) -> None:
+    results = []
+    corpuses = CORPUSES
+    if dummy:
+        corpuses = DUMMY_CORPUSES
+    for corpus in corpuses:
+        with chdir(corpus.name):
+            corpus.prep()
+            for variant in SEMGREP_CORE_VARIANTS:
+                name = ".".join(["semgrep-core", "bench", corpus.name, variant.name])
+                metric_name = ".".join([name, "duration"])
+                print(f"------ {name} ------")
+                duration = run_semgrep_core(corpus, variant)
+                msg = f"{metric_name} = {duration:.3f} s"
+                print(msg)
+                results.append(msg)
+                if upload:
+                    upload_result(metric_name, duration)
+    for msg in results:
+        print(msg)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dummy",
+        help="run quick, fake benchmarks for development purposes",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--upload", help="upload results to semgrep dashboard", action="store_true"
+    )
+    args = parser.parse_args()
+    with chdir("bench"):
+        run_benchmarks(args.dummy, args.upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/perf/semgrep-core-benchmark
+++ b/perf/semgrep-core-benchmark
@@ -1,12 +1,15 @@
 #! /usr/bin/env python3
 #
-# Run semgrep on a series of pairs (rules, repo) with different options,
-# and report the time it takes. Optionally upload the results to the semgrep
-# dashboard.
+# Run semgrep-core on a series of pairs (rules, repo) with different options
+# and report the time it takes. This is separate from run-benchmarks because
+# semgrep-core needs to pass in the language along with the target files.
 #
-# With the -semgrep-core flag, run semgrep-core with different options and
-# report the time it takes. Requires semgrep-core (make install in the
-# semgrep-core folder)
+# We implement that by adding the main language of the rules being run with
+# each corpus. However, this limits the set of languages we can use. We are
+# additionally limited by what semgrep-core is able to parse, as noted by
+# some commented out tests
+#
+# Requires semgrep-core (make install in the semgrep-core folder)
 #
 import argparse
 import os
@@ -90,8 +93,8 @@ class SemgrepVariant:
 SEMGREP_CORE_VARIANTS = [
     SemgrepVariant("std", "-bloom_filter"),
     SemgrepVariant("no-bloom", "-no_bloom_filter"),
-    SemgrepVariant("fast", "-fast -bloom_filter"),
-    SemgrepVariant("fast-no-bloom", "-fast -no_bloom_filter"),
+    SemgrepVariant("filter-files", "-fast -bloom_filter"),
+    SemgrepVariant("filter-files_no-bloom", "-fast -no_bloom_filter"),
 ]
 
 # Add support for: with chdir(DIR): ...

--- a/semgrep-core/src/core/Flag_semgrep.ml
+++ b/semgrep-core/src/core/Flag_semgrep.ml
@@ -37,7 +37,7 @@ let filter_irrelevant_patterns = ref false
 let filter_irrelevant_rules = ref false
 
 (* check for identifiers before attempting to match a stmt or stmt list *)
-let use_bloom_filter = ref false
+let use_bloom_filter = ref true
 
 (* opt = optimization *)
 let with_opt_cache = ref true

--- a/semgrep-core/src/core/Pattern.ml
+++ b/semgrep-core/src/core/Pattern.ml
@@ -53,7 +53,8 @@ let is_special_string_literal str =
 let is_js lang =
   match lang with
   | Some (Lang.Javascript | Lang.Typescript) -> true
-  | _ -> false
+  | Some _ -> false
+  | None -> true
 
 let is_special_identifier ?lang str =
   Metavariable.is_metavar_name str ||

--- a/semgrep-core/src/optimizing/Analyze_pattern.ml
+++ b/semgrep-core/src/optimizing/Analyze_pattern.ml
@@ -44,7 +44,7 @@ module V = Visitor_AST
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
-let error s =
+let _error s =
   failwith s
 
 (*****************************************************************************)
@@ -83,7 +83,11 @@ let extract_strings_and_mvars ?lang any =
        | TypedMetavar _ ->
            ()
 
-       | DisjExpr _ -> error "DisjExpr, call to ApplyEquivalence too early"
+       (* for bloom_filters: do not recurse here (for ApplyEquivalence,
+        * this would be an error) *)
+       | DisjExpr _ ->
+           ()
+
        | _ -> k x
       );
     );

--- a/semgrep-core/src/optimizing/Bloom_annotation.ml
+++ b/semgrep-core/src/optimizing/Bloom_annotation.ml
@@ -86,6 +86,8 @@ let rec statement_strings stmt =
        *)
        | L (String (str, _tok)) ->
            Common.push str res
+       | IdSpecial (_, tok) ->
+           Common.push (Parse_info.str_of_info tok) res
        | _ -> k x
       )
     );


### PR DESCRIPTION
Before deciding to turn on bloom filters, we benchmarked on several repositories, using semgrep/perf/run-benchmark. On some repos, with some rules, bloom filters performed significantly better; however, on others, bloom filters performed up to 20% worse, amounting to a difference to ~4 seconds

To find the source of these slowdowns, we then tested on semgrep-core, where we found that bloom filters did not create a slowdown there. Because of this, we had the confidence to turn bloom filters on.

In the process, I added the benchmark semgrep/perf/semgrep-core-benchmark to test bloom filters, as well as -fast, which is experimental. This benchmark is more limited, since we need to pass in the language, but shows the promise of what we can achieve

semgrep-core.bench.big-js.std.duration = 41.262 s
semgrep-core.bench.big-js.no-bloom.duration = 78.052 s
semgrep-core.bench.big-js.fast.duration = 0.241 s
semgrep-core.bench.big-js.fast-no-bloom.duration = 0.220 s

semgrep-core.bench.zulip.std.duration = 5.942 s
semgrep-core.bench.zulip.no-bloom.duration = 6.786 s
semgrep-core.bench.zulip.fast.duration = 5.606 s
semgrep-core.bench.zulip.fast-no-bloom.duration = 5.460 s

semgrep-core.bench.apache.std.duration = 15.396 s
semgrep-core.bench.apache.no-bloom.duration = 20.431 s
semgrep-core.bench.apache.fast.duration = 10.181 s
semgrep-core.bench.apache.fast-no-bloom.duration = 12.053 s

semgrep-core.bench.dropbox.std.duration = 0.292 s
semgrep-core.bench.dropbox.no-bloom.duration = 0.328 s
semgrep-core.bench.dropbox.fast.duration = 0.564 s
semgrep-core.bench.dropbox.fast-no-bloom.duration = 0.524 s

semgrep-core.bench.0c34.std.duration = 0.327 s
semgrep-core.bench.0c34.no-bloom.duration = 0.353 s
semgrep-core.bench.0c34.fast.duration = 0.295 s
semgrep-core.bench.0c34.fast-no-bloom.duration = 0.301 s

semgrep-core.bench.rails.std.duration = 26.885 s
semgrep-core.bench.rails.no-bloom.duration = 27.411 s
semgrep-core.bench.rails.fast.duration = 22.549 s
semgrep-core.bench.rails.fast-no-bloom.duration = 21.306 s

We also checked the memory usage of bloom filters on one of our test cases. This was done by using top on one terminal, and showed roughly 30M additional memory used (on a large python repo)

time sc -j 8 -config ../perf/bench/apache/input/django.yml ../perf/bench/apache/input/libcloud -lang python
 PID COMMAND %CPU TIME #TH #WQ #PORTS MEM PURG CMPRS PGRP PPID STATE BOOSTS
 21832 Main.exe   100.9   00:14.73 1/1  0  8   131M- 0B   0B   21815 21815 running *0[1]
21829 Main.exe   100.6   00:14.73 1/1  0  8   113M  0B   0B   21815 21815 running *0[1]
21826 Main.exe   100.6   00:14.73 1/1  0  8   118M  0B   0B   21815 21815 running *0[1]
21827 Main.exe   100.3   00:14.73 1/1  0  8   110M+ 0B   0B   21815 21815 running *0[1]
21831 Main.exe   100.1   00:14.73 1/1  0  8   113M+ 0B   0B   21815 21815 running *0[1]
21828 Main.exe   99.8   00:14.73 1/1  0  8   116M  0B   0B   21815 21815 running *0[1]
21830 Main.exe   99.8   00:14.72 1/1  0  8   114M  0B   0B   21815 21815 running *0[1]
21825 Main.exe   99.5   00:14.72 1/1  0  8   109M+ 0B   0B   21815 21815 running *0[1]
 time sc -j 8 -bloom_filter -config ../perf/bench/apache/input/django.yml ../perf/bench/apache/input/libcloud -lang python
 ID COMMAND %CPU TIME #TH #WQ #PORTS MEM PURG CMPRS PGRP PPID STATE BOOSTS
21867 Main.exe   100.0   00:09.84 1/1  0  8   123M+ 0B   0B   21855 21855 running *0[1]
21869 Main.exe   100.0   00:09.85 1/1  0  8   145M+ 0B   0B   21855 21855 running *0[1]
21872 Main.exe   99.9   00:09.85 1/1  0  8   146M+ 0B   0B   21855 21855 running *0[1]
21873 Main.exe   99.8   00:09.83 1/1  0  8   147M+ 0B   0B   21855 21855 running *0[1]
21868 Main.exe   99.7   00:09.84 1/1  0  8   132M+ 0B   0B   21855 21855 running *0[1]
21870 Main.exe   99.7   00:09.84 1/1  0  8   119M+ 0B   0B   21855 21855 running *0[1]
21866 Main.exe   99.7   00:09.85 1/1  0  8   111M  0B   0B   21855 21855 running *0[1]
21871 Main.exe   99.5   00:09.83 1/1  0  8   162M+ 0B   0B   21855 21855 running *0[1]