### PR TITLE
Fix build of semgrep-dev docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,14 +18,18 @@ jobs:
         run: docker build -t returntocorp/semgrep .
       - name: Check the semgrep Docker image
         run: ./scripts/validate-docker-build.sh returntocorp/semgrep
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Push develop image if on develop branch
         if: ${{ github.event_name == 'push'}}
         uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: returntocorp/semgrep
-          tags: develop
+          tags: returntocorp/semgrep:develop
       - name: Push commit hash if PR
         # Don't run when PR is from a fork
         # For security, we do not autopush to docker when from PRs
@@ -35,10 +39,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }} && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: returntocorp/semgrep
-          tags: ${{ github.event.pull_request.head.sha }}
+          tags: returntocorp/semgrep:${{ github.event.pull_request.head.sha }}
       - name: update dev.semgrep.dev
         run: curl --fail -X POST https://dev.semgrep.dev/api/admin/update-docker
       - name: update staging.semgrep.dev
@@ -54,7 +55,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: dockerfiles/semgrep-dev.Dockerfile
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: returntocorp/semgrep-dev
-          tags: develop
+          tags: returntocorp/semgrep-dev:develop

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
         if: ${{ github.event_name == 'push'}}
         uses: docker/build-push-action@v2
         with:
+          context: .
           tags: returntocorp/semgrep:develop
       - name: Push commit hash if PR
         # Don't run when PR is from a fork
@@ -39,6 +40,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }} && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/build-push-action@v2
         with:
+          context: .
           tags: returntocorp/semgrep:${{ github.event.pull_request.head.sha }}
       - name: update dev.semgrep.dev
         run: curl --fail -X POST https://dev.semgrep.dev/api/admin/update-docker
@@ -51,8 +53,9 @@ jobs:
       # adding some utilities. This image is meant for internal uses
       # such as benchmarks.
       - name: Build and push semgrep-dev image if on develop branch
-#        if: ${{ github.event_name == 'push'}}
+        if: ${{ github.event_name == 'push'}}
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: dockerfiles/semgrep-dev.Dockerfile
           tags: returntocorp/semgrep-dev:develop

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          push: true
           tags: returntocorp/semgrep:develop
       - name: Push commit hash if PR
         # Don't run when PR is from a fork
@@ -41,6 +42,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          push: true
           tags: returntocorp/semgrep:${{ github.event.pull_request.head.sha }}
       - name: update dev.semgrep.dev
         run: curl --fail -X POST https://dev.semgrep.dev/api/admin/update-docker
@@ -58,4 +60,5 @@ jobs:
         with:
           context: .
           file: dockerfiles/semgrep-dev.Dockerfile
+          push: true
           tags: returntocorp/semgrep-dev:develop

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build the semgrep Docker image
+      - name: Build the semgrep Docker image with default Dockerfile
         run: docker build -t returntocorp/semgrep .
       - name: Check the semgrep Docker image
         run: ./scripts/validate-docker-build.sh returntocorp/semgrep
       - name: Push develop image if on develop branch
         if: ${{ github.event_name == 'push'}}
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -33,7 +33,7 @@ jobs:
         # nicer to not have a "failing" CI job in the PR so don't even
         # try if we can detect is coming from a fork
         if: ${{ github.event_name == 'pull_request' }} && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -49,15 +49,11 @@ jobs:
       # Extend the semgrep image, changing the entry point to bash and
       # adding some utilities. This image is meant for internal uses
       # such as benchmarks.
-      - name: Build the extended semgrep-dev Docker image
-        run: |
-          docker build \
-            -f dockerfiles/semgrep-dev.Dockerfile \
-            -t returntocorp/semgrep-dev .
-      - name: Push develop image if on develop branch
-        if: ${{ github.event_name == 'push'}}
-        uses: docker/build-push-action@v1
+      - name: Build and push semgrep-dev image if on develop branch
+#        if: ${{ github.event_name == 'push'}}
+        uses: docker/build-push-action@v2
         with:
+          file: dockerfiles/semgrep-dev.Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: returntocorp/semgrep-dev


### PR DESCRIPTION
This upgrades the GitHub action used to (re)build the image and push to DockerHub, using https://github.com/docker/build-push-action/blob/master/UPGRADE.md as a reference.

The main problem was that the semgrep-dev build was using the default Dockerfile. I understand how it works now.