### PR TITLE
Use semgrep-core benchmarks as a submodule of run-benchmarks

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -4,6 +4,13 @@
 # and report the time it takes. Optionally upload the results to the semgrep
 # dashboard.
 #
+# With the --semgrep_core option, instead run semgrep-core on a series of
+# pairs (rules, repo) with options chosen to test semgrep-core performance.
+# Note that semgrep-core can currently be run for one language only, so
+# these benchmarks only include corpuses that are primarily one language.
+# This allows them to be compared to the semgrep runtimes. Can also upload
+# the results to the dashboard, and use a dummy set instead
+#
 import argparse
 import os
 import subprocess
@@ -13,8 +20,6 @@ from contextlib import contextmanager
 from typing import Iterator
 
 import semgrep_core_benchmark
-
-# With the --semgrep-core option, run semgrep-core on a series of pairs
 
 DASHBOARD_URL = "https://dashboard.semgrep.dev"
 

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -10,9 +10,11 @@ import subprocess
 import time
 import urllib.request
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Iterator
-from typing import List
+
+import semgrep_core_benchmark
+
+# With the --semgrep-core option, run semgrep-core on a series of pairs
 
 DASHBOARD_URL = "https://dashboard.semgrep.dev"
 
@@ -93,11 +95,11 @@ class SemgrepVariant:
 #
 SEMGREP_VARIANTS = [
     # default settings
-    SemgrepVariant("std", "-bloom_filter"),
-    SemgrepVariant("no-cache", "-bloom_filter -no_opt_cache"),
-    SemgrepVariant("max-cache", "-bloom_filter -opt_max_cache"),
+    SemgrepVariant("std", ""),
+    SemgrepVariant("no-cache", "-no_opt_cache"),
+    SemgrepVariant("max-cache", "-opt_max_cache"),
     SemgrepVariant("no-bloom", "-no_bloom_filter"),
-    SemgrepVariant("no-gc-tuning", "-bloom_filter -no_gc_tuning"),
+    SemgrepVariant("no-gc-tuning", "-no_gc_tuning"),
 ]
 
 # Add support for: with chdir(DIR): ...
@@ -223,9 +225,15 @@ def main() -> None:
     parser.add_argument(
         "--upload", help="upload results to semgrep dashboard", action="store_true"
     )
+    parser.add_argument(
+        "--semgrep_core", help="run semgrep-core benchmarks", action="store_true"
+    )
     args = parser.parse_args()
     with chdir("bench"):
-        run_benchmarks(args.docker, args.dummy, args.internal, args.upload)
+        if args.semgrep_core:
+            semgrep_core_benchmark.run_benchmarks(args.dummy, args.upload)
+        else:
+            run_benchmarks(args.docker, args.dummy, args.internal, args.upload)
 
 
 if __name__ == "__main__":

--- a/perf/semgrep_core_benchmark.py
+++ b/perf/semgrep_core_benchmark.py
@@ -1,19 +1,27 @@
 #! /usr/bin/env python3
 #
+# Main function is in run-benchmarks. Can be called via
+#               ./run-benchmarks --semgrep_core
+#
 # Run semgrep-core on a series of pairs (rules, repo) with different options
 # and report the time it takes.
 #
-# This is separate from run-benchmarks because semgrep-core needs to pass in
-# the language along with the target files.
-#
+# semgrep-core needs the user to pass in the language to analyze in.
 # We implement that by adding the main language of the rules being run to
-# each corpus. However, this limits the set of languages we can use. We are
-# additionally limited by what semgrep-core is able to parse, as noted by
-# some commented out tests
+# each corpus. However, this limits the set of corpuses we can use.
+#
+# Right now, the corpus is labelled with a language because we chose to only
+# use corpuses that are primarily one language, which makes their runtime
+# comparable to the runs using semgrep. We could also have chosen to
+# label the rules, or change the pair to (rules, repo, lang), but ultimately
+# we would like semgrep-core to be able to infer the language
+#
+# We are additionally limited by what semgrep-core is able to parse, as
+# noted by some commented out tests
 #
 # The end goal is for semgrep-core to replace semgrep in analyzing rules
-# and to unify the two files. This file is for local convenience and should
-# not be used in CI
+# and to unify the two files. The --semgrep_core option is currently meant
+# for local convenience, not use in CI
 #
 # Requires semgrep-core (make install in the semgrep-core folder)
 #


### PR DESCRIPTION
Removed -bloom_filter, changed -fast to -filter_irrelevant_rules, removed main in semgrep_core_benchmarks and instead called it in run-benchmarks (this necessitated changing the naming convention to underscores)