### PR TITLE
Use ocaml ruleset in policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     working_directory: /src
     steps:
       - checkout
-      - run: semgrep --config semgrep.yml --config https://semgrep.dev/p/ocaml --error --strict --verbose --exclude tests --exclude TODO --exclude _build .
+      - run: semgrep --config semgrep.yml --error --strict --verbose --exclude tests --exclude TODO --exclude _build .
 
   # For the benchmarks below, we had two alternatives:
   # A. run semgrep container from existing container: requires mounting


### PR DESCRIPTION
Here are the existing findings:

```
$ python -m semgrep --config https://semgrep.dev/p/ocaml .
using config from https://semgrep.dev/p/ocaml. Visit https://semgrep.dev/registry to see all public rules.
downloading config...
running 21 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|21/21
semgrep-core/tests/ocaml/dots_nested_stmts.ml
severity:error rule:ocaml.lang.correctness.useless_if.ocamllint-useless-if: Useless if. Both branches are equal.
2:let foo = if x = 1 then 2 else 2

semgrep-core/tests/ocaml/equivalence_eq.ml
severity:error rule:ocaml.lang.correctness.useless_eq.useless-equal: This is always true. If testing for floating point NaN, use `Float.is_nan` instead.
5:  if a+b = a+b then 1 else 2

semgrep-core/tests/ocaml/foo.ml
severity:error rule:ocaml.lang.compatibility.deprecated.deprecated-pervasives: Pervasives is deprecated and will not be available after 4.10. Use Stdlib.
3:  Pervasives.compare a b

semgrep-core/tests/ocaml/metavar_equality_expr.ml
severity:error rule:ocaml.lang.correctness.useless_eq.useless-equal: This is always true. If testing for floating point NaN, use `Float.is_nan` instead.
5:  if a+b = a+b then 1 else 2

semgrep-core/tests/ocaml/metavar_equality_stmt.ml
severity:error rule:ocaml.lang.correctness.useless_if.ocamllint-useless-if: Useless if. Both branches are equal.
3:  if x > 2 then
4:    foo
5:  else
6:    foo

semgrep-core/tests/ocaml/regexp.ml
severity:warning rule:ocaml.lang.portability.slash_tmp.not-portable-tmp-string: You should probably use Filename.get_temp_dirname().
2:let x = "/tmp/foo"
ran 21 rules on 262 files: 6 findings
```

These should all already be correctly ignored by our `.semgrepignore` configuration :+1: 