### PR TITLE
[WIP] Use pathspec to match include/exclude files.

### DIFF
--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -106,6 +106,7 @@ setuptools.setup(
         "ruamel.yaml==0.16.10",
         "tqdm>=4.46.1",
         "packaging>=20.4",
+        "pathspec>=0.8.0",
         "jsonschema~=3.2.0",
         # Include 'setuptools' for 'pkg_resources' usage. We shouldn't be
         # overly prescriptive and pin the version for two reasons: 1) because


### PR DESCRIPTION
This is an attempt to address #1834.
If this approach looks promising, I can proceed with updating unit tests, etc.

Something to discuss:
- The pathspec's semantics is similar to the current `match_glob` but not entirely compatible.
   I think the major one is that `b/c/` won't match `a/b/c/d/e.py`.
   It has to be `**/b/c/` to retain the same meaning.
   Do you think this is acceptable?
   (btw, is there a way to match only the prefix of a path in the current `match_glob`)
- Should we reject some special patterns which have special meaning in pathspec (e.g. path starts with `!` or `#`)?
   They are unlikely to be provided, but it is nice to be cautious.