### PR TITLE
Add profiling for method causing slowness in Nathan's CRLF-injection rule

### DIFF
--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -378,6 +378,7 @@ let _ = Common2.example
 let all_elem_and_rest_of_list xs =
   let xs = Common.index_list xs |> List.map (fun (x, i) -> (i, x)) in
   xs |> List.map (fun (i, x) -> x, List.remove_assq i xs |> List.map snd)
+[@@profiling]
 (*e: function [[Matching_generic.all_elem_and_rest_of_list]] *)
 
 (*s: toplevel [[Matching_generic._1]] *)

--- a/semgrep-core/tests/OTHER/perf1/bloom/crlf-injection-rule1.yaml
+++ b/semgrep-core/tests/OTHER/perf1/bloom/crlf-injection-rule1.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: 0..1
+  pattern: |
+    class $CLASS {
+      ...
+      Logger $LOG = ...;
+      ...
+      $X $METHOD(...) {
+        HttpServletRequest $REQ = ...;
+        ...
+        String $VAL = $REQ.getParameter(...);
+        ...
+        $LOG.$LEVEL(<... $VAL ...>);
+        ...
+      }
+      ...
+    }
+  severity: WARNING
+  languages:
+  - java
+  message: <internalonly>


### PR DESCRIPTION
Added the rule and profiling on all_elem_and_rest_of_list

This rule is slow because there are a lot of potential matches (7400), and all_elem_and_rest_of_list operates on that list of potential matches in n^2 fashion. all_elem_and_rest_of_list turns a list ['a';'b';'c'] into [('a', ['b';'c']); ('b', ['a';'c']); ('c', ['a';'b'])].

We can optimize this function by having a special datastructure instead that doesn't create each sublist, but has a special iterate function instead

Test plan:

semgrep-core -profile -config tests/OTHER/perf1/bloom/crlf-injection-rule1.yaml tests/OTHER/perf1/bloom/BadLogClass.java -lang java



PR checklist:
- [x] changelog is up to date

