### PR TITLE
Add profiling for method causing slowness in python rule

### DIFF
--- a/semgrep-core/src/optimizing/Stmts_match_span.ml
+++ b/semgrep-core/src/optimizing/Stmts_match_span.ml
@@ -79,6 +79,7 @@ let location x =
       let min_loc, _ = Visitor_AST.range_of_any (AST_generic.Ss left_stmts) in
       let _, max_loc = Visitor_AST.range_of_any (AST_generic.Ss right_stmts) in
       Some (min_loc, max_loc)
+[@@profiling]
 
 let merge_and_deduplicate get_key a b =
   let tbl = Hashtbl.create 100 in
@@ -121,3 +122,4 @@ let list_original_tokens x =
       merge_and_deduplicate
         Parse_info.token_location_of_info
         left_tokens right_tokens
+[@@profiling]

--- a/semgrep-core/tests/OTHER/perf1/benchmarking/netflix-slow-javascript.yml
+++ b/semgrep-core/tests/OTHER/perf1/benchmarking/netflix-slow-javascript.yml
@@ -1,0 +1,32 @@
+- id: typescript.react.security.audit.react-css-injection.react-css-injection
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        import $STYLE from "...";
+        ...
+    - pattern-inside: |
+        $STYLE = $METHOD(...);
+        ...
+    - pattern-inside: |
+        function $FUNC(...,{$STYLE},...) {
+          ...
+        }
+    - pattern-inside: |
+        function $FUNC(...,$STYLE,...) {
+          ...
+        }
+  - pattern-inside: |
+      <$EL style={$STYLE} />
+  - pattern-not-inside: |
+      <$EL style={{$X:...}} />
+  - pattern: $STYLE
+  message: |
+    User controlled data in a `style` attribute is an anti-pattern than can lead to XSS vulnerabilities
+  metadata:
+    cwe: 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp: 'A7: Cross-site Scripting (XSS)'
+  languages:
+  - typescript
+  - javascript
+  severity: WARNING

--- a/semgrep-core/tests/OTHER/perf1/benchmarking/netflix-slow-python.yml
+++ b/semgrep-core/tests/OTHER/perf1/benchmarking/netflix-slow-python.yml
@@ -1,0 +1,64 @@
+rules:
+- id: python.django.security.injection.path-traversal.path-traversal-file-name.path-traversal-file-name
+  message: |
+    Data from request is passed to a file name `$FILE`.
+    This is a path traversal vulnerability: https://owasp.org/www-community/attacks/Path_Traversal
+    To mitigate, consider using os.path.abspath or os.path.realpath or Path library.
+  metadata:
+    cwe: 'CWE-22: Improper Limitation of a Pathname to a Restricted Directory (''Path
+      Traversal'')'
+    owasp: 'A1: Injection'
+    references:
+    - https://owasp.org/www-community/attacks/Path_Traversal
+  patterns:
+  - pattern-inside: |
+      def $F(...):
+        ...
+  - pattern-not: |
+      ...
+      os.path.realpath(...)
+      ...
+  - pattern-not: |
+      ...
+      os.path.abspath(...)
+      ...
+  - pattern-either:
+    - pattern: |
+        $V = request.$W.get($X)
+        ...
+        $FILE % ($V)
+    - pattern: |
+        $V = request.$W[$X]
+        ...
+        $FILE % ($V)
+    - pattern: |
+        $V = request.$W($X)
+        ...
+        $FILE % ($V)
+    - pattern: |
+        $V = request.$W
+        ...
+        $FILE % ($V)
+        # match format use cases
+    - pattern: |
+        $V = request.$W.get($X)
+        ...
+        $FILE.format(..., $V, ...)
+    - pattern: |
+        $V = request.$W[$X]
+        ...
+        $FILE.format(..., $V, ...)
+    - pattern: |
+        $V = request.$W($X)
+        ...
+        $FILE.format(..., $V, ...)
+    - pattern: |
+        $V = request.$W
+        ...
+        $FILE.format(..., $V, ...)
+  - metavariable-regex:
+      metavariable: $FILE
+      regex: .*\.(log|zip|txt|csv|xml|html).*
+  languages:
+  - python
+  severity: WARNING


### PR DESCRIPTION
Added the rule and profiling on Stmts_match_span.location

This rule is slow because we need to get the location of many matches spanning the entire tree.

We can solve it in two ways. One, we can predetermine the range of each statement (easy to add), as well as each statement list, so that work is not being repeated. Two, now that we analyze the whole rule, we should not run pattern-not on the entire rule, but only the considered matches.

Test plan:

semgrep-core -profile -bloom_filter -config tests/OTHER/perf1/benchmarking/netflix-slow-python.yml ../perf/bench/netflix/input/lemur -lang python



PR checklist:
- [x] changelog is up to date

