### PR TITLE
analyzing: tainting: Allow arbitrary expressions to be sources

### DIFF
--- a/semgrep-core/src/analyzing/Dataflow_tainting.mli
+++ b/semgrep-core/src/analyzing/Dataflow_tainting.mli
@@ -9,6 +9,7 @@ type mapping = unit Dataflow.mapping
 (* this can use semgrep patterns under the hood *)
 type config = {
   is_source: IL.instr -> bool;
+  is_source_exp: IL.exp -> bool;
   is_sink: IL.instr -> bool;
   is_sanitizer: IL.instr -> bool;
 

--- a/semgrep-core/src/testing/Test_analyze_generic.ml
+++ b/semgrep-core/src/testing/Test_analyze_generic.ml
@@ -141,6 +141,7 @@ let test_dfg_tainting file =
          pr2 "Tainting";
          let config = { Dataflow_tainting.
                         is_source = (fun _ -> false);
+                        is_source_exp = (fun _ -> false);
                         is_sink = (fun _ -> false);
                         is_sanitizer = (fun _ -> false);
                         found_tainted_sink = (fun _ _ -> ());

--- a/semgrep-core/tests/dune
+++ b/semgrep-core/tests/dune
@@ -26,6 +26,7 @@
     semgrep_core
     semgrep_parsing
     semgrep_matching
+    semgrep_tainting
     semgrep_synthesizing
     semgrep_reporting
     semgrep_engine

--- a/semgrep-core/tests/tainting_rules/python/tainting.py
+++ b/semgrep-core/tests/tainting_rules/python/tainting.py
@@ -1,0 +1,9 @@
+def foo():
+  a = source1()
+  if True:
+     b = a
+     b = sanitize1()
+  else:
+     b = a
+  #ERROR:
+  sink1(b)

--- a/semgrep-core/tests/tainting_rules/python/tainting.rules
+++ b/semgrep-core/tests/tainting_rules/python/tainting.rules
@@ -1,0 +1,14 @@
+rules:
+  - id: tainting
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - sink1(...)
+    pattern-sources:
+      - source1(...)
+    pattern-sanitizers:
+      - sanitize1(...)
+    severity: ERROR
+

--- a/semgrep-core/tests/tainting_rules/python/tainting2.py
+++ b/semgrep-core/tests/tainting_rules/python/tainting2.py
@@ -1,0 +1,24 @@
+# No security problem
+def foo():
+  a = source1()
+  b = sanitize(a)
+  #OK:
+  sink1(b)
+  #OK:
+  sink(b)
+
+# Should alarm- sanitize does not occur
+def bar():
+  a = source1()
+  sanitize()
+  #ERROR:
+  eval(a)
+  #ERROR:
+  sink(a)
+
+# No security problem
+def baz():
+  a = source1()
+  b = sanitize()
+  #OK:
+  eval(b)

--- a/semgrep-core/tests/tainting_rules/python/tainting2.rules
+++ b/semgrep-core/tests/tainting_rules/python/tainting2.rules
@@ -1,0 +1,16 @@
+rules:
+  - id: tainting
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - sink(...)
+      - sink1(...)
+      - eval(...)
+    pattern-sources:
+      - source1(...)
+    pattern-sanitizers:
+      - sanitize(...)
+    severity: ERROR
+

--- a/semgrep-core/tests/tainting_rules/ts/2787.rules
+++ b/semgrep-core/tests/tainting_rules/ts/2787.rules
@@ -1,0 +1,16 @@
+rules:
+  - id: typescript.nestjs.security.test-taint-mode
+    languages:
+      - typescript
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - React.createElement(...)
+    pattern-sources:
+      - location.href
+      - location.hash
+      - location.search
+      - location.pathname
+      - document.referrer
+    severity: ERROR
+

--- a/semgrep-core/tests/tainting_rules/ts/2787.ts
+++ b/semgrep-core/tests/tainting_rules/ts/2787.ts
@@ -1,0 +1,24 @@
+// https://github.com/returntocorp/semgrep/issues/2787
+import React, { Component } from "react";
+class BadPractice extends Component {
+  render() {
+    // Testing DOM XSS source --> sink taint tracking in `mode: taint`
+
+    const a = location.href;
+    //ERROR:
+    React.createElement("a", { href: a });
+
+    //ERROR:
+    React.createElement("a", { href: location.hash });
+
+    const c = location.href + "bbb";
+    //ERROR:
+    React.createElement("a", { href: c });
+
+    //ERROR:
+    React.createElement("a", { href: "aa" + location.href });
+
+  }
+}
+export default BadPractice;
+


### PR DESCRIPTION
This fixes 3 out of the 5 non-working examples in #2787. 