### PR TITLE
Check benchmark correctness and display results in chart

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -55,8 +55,12 @@ ignore_missing_imports = True
 [mypy-tqdm.*]
 ignore_missing_imports = True
 
-# packaging
-[mypy-packaging.*]
+# matplotlib
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+# pandas
+[mypy-pandas]
 ignore_missing_imports = True
 
 [mypy-semgrep.rule_match]

--- a/mypy.ini
+++ b/mypy.ini
@@ -55,6 +55,10 @@ ignore_missing_imports = True
 [mypy-tqdm.*]
 ignore_missing_imports = True
 
+# packaging
+[mypy-packaging.*]
+ignore_missing_imports = True
+
 # matplotlib
 [mypy-matplotlib.*]
 ignore_missing_imports = True

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -139,6 +139,8 @@ SEMGREP_VARIANTS = [
 ]
 
 
+# This class allows us to put semgrep results in a set and compute set
+# differences while saving the original JSON dictionary
 class SemgrepResult:
     def __init__(self, dict: dict) -> None:
         self.res = dict

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -104,8 +104,8 @@ GITLAB_CORPUSES = [
 
 # For corpuses that cannot be run in CI because they use private repos
 INTERNAL_CORPUSES = [
-    # Run our golang rulepack on a go/html repo
-    Corpus("0c34", "input/golang.yml", "input/govwa"),
+    # Run our javascript and eslint-plugin-security packs on a large JS repo
+    Corpus("lodash", "input/rules", "input/lodash"),
     # Corpus("dogfood", "input/semgrep.yml", "input/"),
 ]
 
@@ -131,13 +131,51 @@ class SemgrepVariant:
 SEMGREP_VARIANTS = [
     # default settings
     SemgrepVariant("std", ""),
-    SemgrepVariant("no-cache", "-no_opt_cache"),
-    SemgrepVariant("max-cache", "-opt_max_cache"),
-    SemgrepVariant("no-bloom", "-no_bloom_filter"),
-    SemgrepVariant("no-gc-tuning", "-no_gc_tuning"),
-    SemgrepVariant("set_filters", "-set_filter"),
+    # SemgrepVariant("no-cache", "-no_opt_cache"),
+    # SemgrepVariant("max-cache", "-opt_max_cache"),
+    # SemgrepVariant("no-bloom", "-no_bloom_filter"),
+    # SemgrepVariant("no-gc-tuning", "-no_gc_tuning"),
+    # SemgrepVariant("set_filters", "-set_filter"),
     SemgrepVariant("experimental", "-fast", "--experimental"),
 ]
+
+
+class SemgrepResult:
+    def __init__(self, dict: dict) -> None:
+        self.res = dict
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SemgrepResult):
+            raise NotImplementedError
+
+        def compare_locs(s_loc: dict, o_loc: dict) -> bool:
+            if s_loc is not None and o_loc is not None:
+                return bool(
+                    s_loc["line"] == o_loc["line"] and s_loc["col"] == o_loc["col"]
+                )
+            else:
+                return False
+
+        def compare_extras(other: SemgrepResult) -> bool:
+            if "extra" in self.res and "extra" in other.res:
+                return True
+                # return json.dumps(self.res["extra"]) == json.dumps(other["extra"])
+            else:
+                return "extra" not in self.res and "extra" not in other.res
+
+        output = (
+            self.res["check_id"] == other.res["check_id"]
+            and self.res["path"] == other.res["path"]
+            and compare_locs(self.res["start"], other.res["start"])
+            and compare_locs(self.res["end"], other.res["end"])
+            and compare_extras(other)
+        )
+        print("Result = ", output)
+        return output
+
+    def __hash__(self) -> int:
+        return hash(json.dumps(self.res))
+
 
 # Add support for: with chdir(DIR): ...
 @contextmanager
@@ -161,11 +199,34 @@ def upload_results(metric_name: str, value: float) -> None:
 
 
 def standardize_findings(findings: dict) -> dict:
-    findings["results"] = sorted(
-        findings["results"],
-        key=lambda i: (i["path"], i["start"]["line"], i["start"]["col"]),
-    )
-    return findings
+    if "errors" not in findings:
+        msg = json.dumps(findings, indent=4) + "\n\nDid not find expected key 'errors'"
+        raise Exception(msg)
+    if "results" not in findings:
+        msg = json.dumps(findings, indent=4) + "\n\nDid not find expected key 'results'"
+        raise Exception(msg)
+    return {
+        "errors": findings["errors"],
+        "results": {SemgrepResult(i) for i in findings["results"]},
+    }
+
+
+def output_differences(
+    findings: set, std_findings: set, variant: str
+) -> Tuple[int, int]:
+    def output_diff(diff: set) -> None:
+        for d in diff:
+            print(json.dumps(d, indent=4))
+
+    f_diff = findings.difference(std_findings)
+    s_diff = std_findings.difference(findings)
+    fd_len = len(f_diff)
+    sd_len = len(s_diff)
+    print("In", variant, "but not std", fd_len, "findings :")
+    output_diff(f_diff)
+    print("In std but not", variant, sd_len, "findings :")
+    output_diff(s_diff)
+    return fd_len, sd_len
 
 
 def run_semgrep(
@@ -258,26 +319,36 @@ def run_benchmarks(
                 metric_name = ".".join([name, "duration"])
                 print(f"------ {name} ------")
                 duration, findings_bytes = run_semgrep(docker, corpus, variant)
+
+                # Report results
                 msg = f"{metric_name} = {duration:.3f} s"
                 print(msg)
                 results_msgs.append(msg)
                 results[variant.name].append(duration)
 
-                # Process results
                 if upload:
                     upload_results(metric_name, duration)
 
+                # Check correctness
                 findings = standardize_findings(json.loads(findings_bytes))
+
+                num_results = len(findings["results"])
+                num_errors = len(findings["errors"])
+                print(f"Result: {num_results} findings, {num_errors} parse errors")
+
+                print("Checking symmetric difference")
                 if variant.name == "std":
                     std_findings = findings
-                elif json.dumps(findings["results"]) != json.dumps(
-                    std_findings["results"]
-                ):
-                    results_msgs[-1] += " ERROR: result not same as std"
-                elif json.dumps(findings["errors"]) != json.dumps(
-                    std_findings["errors"]
-                ):
-                    results_msgs[-1] += " WARNING: errors not same as std"
+                elif findings["results"] ^ std_findings["results"] != set():
+                    print("found difference")
+                    fd_len, sd_len = output_differences(
+                        findings["results"], std_findings["results"], variant.name
+                    )
+                    results_msgs[
+                        -1
+                    ] += f" ERROR: {fd_len} extra findings, {sd_len} missing findings"
+                elif len(findings["errors"]) > len(std_findings["errors"]):
+                    results_msgs[-1] += " WARNING: more errors than std"
 
     # Show summary data
     for msg in results_msgs:

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -180,7 +180,7 @@ def chdir(dir: str) -> Iterator[None]:
         os.chdir(old_dir)
 
 
-def upload_results(metric_name: str, value: float) -> None:
+def upload_result(metric_name: str, value: float) -> None:
     url = f"{DASHBOARD_URL}/api/metric/{metric_name}"
     print(f"Uploading to {url}")
     r = urllib.request.urlopen(  # nosem
@@ -319,7 +319,7 @@ def run_benchmarks(
                 results[variant.name].append(duration)
 
                 if upload:
-                    upload_results(metric_name, duration)
+                    upload_result(metric_name, duration)
 
                 # Check correctness
                 findings = standardize_findings(json.loads(findings_bytes))

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -12,6 +12,7 @@
 # the results to the dashboard, and use a dummy set instead
 #
 import argparse
+import copy
 import json
 import os
 import subprocess
@@ -104,8 +105,8 @@ GITLAB_CORPUSES = [
 
 # For corpuses that cannot be run in CI because they use private repos
 INTERNAL_CORPUSES = [
-    # Run our javascript and eslint-plugin-security packs on a large JS repo
-    Corpus("lodash", "input/rules", "input/lodash"),
+    # Run our r2c-ci and r2c-security audit packs on a JS/other repo
+    Corpus("draios", "input/rules", "input/sysdig-inspect"),
     # Corpus("dogfood", "input/semgrep.yml", "input/"),
 ]
 
@@ -144,37 +145,28 @@ class SemgrepResult:
     def __init__(self, dict: dict) -> None:
         self.res = dict
 
+        # TODO: remove this if, and just always make the str the dump
+        if "extra" in dict and "message" in dict["extra"]:
+            dict2 = copy.deepcopy(dict)
+            dict2["extra"]["message"] = ""
+            self.str = json.dumps(dict2)
+        else:
+            self.str = json.dumps(dict)
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SemgrepResult):
             raise NotImplementedError
 
-        def compare_locs(s_loc: dict, o_loc: dict) -> bool:
-            if s_loc is not None and o_loc is not None:
-                return bool(
-                    s_loc["line"] == o_loc["line"] and s_loc["col"] == o_loc["col"]
-                )
-            else:
-                return False
+        return self.str == other.str
 
-        def compare_extras(other: SemgrepResult) -> bool:
-            if "extra" in self.res and "extra" in other.res:
-                return True
-                # return json.dumps(self.res["extra"]) == json.dumps(other["extra"])
-            else:
-                return "extra" not in self.res and "extra" not in other.res
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SemgrepResult):
+            raise NotImplementedError
 
-        output = (
-            self.res["check_id"] == other.res["check_id"]
-            and self.res["path"] == other.res["path"]
-            and compare_locs(self.res["start"], other.res["start"])
-            and compare_locs(self.res["end"], other.res["end"])
-            and compare_extras(other)
-        )
-        print("Result = ", output)
-        return output
+        return self.str > other.str
 
     def __hash__(self) -> int:
-        return hash(json.dumps(self.res))
+        return hash(self.str)
 
 
 # Add support for: with chdir(DIR): ...
@@ -215,8 +207,8 @@ def output_differences(
     findings: set, std_findings: set, variant: str
 ) -> Tuple[int, int]:
     def output_diff(diff: set) -> None:
-        for d in diff:
-            print(json.dumps(d, indent=4))
+        for d in sorted(diff):
+            print(json.dumps(d.res, indent=4))
 
     f_diff = findings.difference(std_findings)
     s_diff = std_findings.difference(findings)
@@ -336,11 +328,9 @@ def run_benchmarks(
                 num_errors = len(findings["errors"])
                 print(f"Result: {num_results} findings, {num_errors} parse errors")
 
-                print("Checking symmetric difference")
                 if variant.name == "std":
                     std_findings = findings
                 elif findings["results"] ^ std_findings["results"] != set():
-                    print("found difference")
                     fd_len, sd_len = output_differences(
                         findings["results"], std_findings["results"], variant.name
                     )

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -86,11 +86,11 @@ DUMMY_CORPUSES = [Corpus("dummy", "input/dummy/rules", "input/dummy/targets")]
 # Projects GitLab is using to benchmark us on perf
 GITLAB_CORPUSES = [
     # (Gitlab large) Run our javascript and r2c-secuirty audit packs on a js/ruby repo
-    # Corpus("gitlab", "input/rules", "input/gitlab"),
+    Corpus("gitlab", "input/rules", "input/gitlab"),
     # (Gitlab large) Run our security-audit pack on a c repo
-    # Corpus("smacker", "input/r2c-security-audit.yml", "input/gotree"),
+    Corpus("smacker", "input/r2c-security-audit.yml", "input/gotree"),
     # (Gitlab large) Run our java pack on a java repo
-    # Corpus("spring-projects", "input/java.yml", "input/spring"),
+    Corpus("spring-projects", "input/java.yml", "input/spring"),
     # (Gitlab medium) Run our python and flask packs on a python repo
     Corpus("django", "input/rules", "input/django"),
     # (Gitlab medium) Run our r2c-ci and r2c-security audit packs on a java repo
@@ -105,9 +105,7 @@ GITLAB_CORPUSES = [
 
 # For corpuses that cannot be run in CI because they use private repos
 INTERNAL_CORPUSES = [
-    # Run our r2c-ci and r2c-security audit packs on a JS/other repo
-    Corpus("draios", "input/rules", "input/sysdig-inspect"),
-    # Corpus("dogfood", "input/semgrep.yml", "input/"),
+    Corpus("dogfood", "input/semgrep.yml", "input/"),
 ]
 
 
@@ -132,11 +130,11 @@ class SemgrepVariant:
 SEMGREP_VARIANTS = [
     # default settings
     SemgrepVariant("std", ""),
-    # SemgrepVariant("no-cache", "-no_opt_cache"),
-    # SemgrepVariant("max-cache", "-opt_max_cache"),
-    # SemgrepVariant("no-bloom", "-no_bloom_filter"),
-    # SemgrepVariant("no-gc-tuning", "-no_gc_tuning"),
-    # SemgrepVariant("set_filters", "-set_filter"),
+    SemgrepVariant("no-cache", "-no_opt_cache"),
+    SemgrepVariant("max-cache", "-opt_max_cache"),
+    SemgrepVariant("no-bloom", "-no_bloom_filter"),
+    SemgrepVariant("no-gc-tuning", "-no_gc_tuning"),
+    SemgrepVariant("set_filters", "-set_filter"),
     SemgrepVariant("experimental", "-fast", "--experimental"),
 ]
 

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -12,13 +12,17 @@
 # the results to the dashboard, and use a dummy set instead
 #
 import argparse
+import json
 import os
 import subprocess
 import time
 import urllib.request
 from contextlib import contextmanager
 from typing import Iterator
+from typing import Tuple
 
+import matplotlib.pyplot as plt
+import pandas as pd
 import semgrep_core_benchmark  # type: ignore
 
 DASHBOARD_URL = "https://dashboard.semgrep.dev"
@@ -81,11 +85,11 @@ DUMMY_CORPUSES = [Corpus("dummy", "input/dummy/rules", "input/dummy/targets")]
 # Projects GitLab is using to benchmark us on perf
 GITLAB_CORPUSES = [
     # (Gitlab large) Run our javascript and r2c-secuirty audit packs on a js/ruby repo
-    Corpus("gitlab", "input/rules", "input/gitlab"),
+    # Corpus("gitlab", "input/rules", "input/gitlab"),
     # (Gitlab large) Run our security-audit pack on a c repo
-    Corpus("smacker", "input/r2c-security-audit.yml", "input/gotree"),
+    # Corpus("smacker", "input/r2c-security-audit.yml", "input/gotree"),
     # (Gitlab large) Run our java pack on a java repo
-    Corpus("spring-projects", "input/java.yml", "input/spring"),
+    # Corpus("spring-projects", "input/java.yml", "input/spring"),
     # (Gitlab medium) Run our python and flask packs on a python repo
     Corpus("django", "input/rules", "input/django"),
     # (Gitlab medium) Run our r2c-ci and r2c-security audit packs on a java repo
@@ -100,7 +104,9 @@ GITLAB_CORPUSES = [
 
 # For corpuses that cannot be run in CI because they use private repos
 INTERNAL_CORPUSES = [
-    Corpus("dogfood", "input/semgrep.yml", "input/"),
+    # Run our golang rulepack on a go/html repo
+    Corpus("0c34", "input/golang.yml", "input/govwa"),
+    # Corpus("dogfood", "input/semgrep.yml", "input/"),
 ]
 
 
@@ -144,7 +150,7 @@ def chdir(dir: str) -> Iterator[None]:
         os.chdir(old_dir)
 
 
-def upload_result(metric_name: str, value: float) -> None:
+def upload_results(metric_name: str, value: float) -> None:
     url = f"{DASHBOARD_URL}/api/metric/{metric_name}"
     print(f"Uploading to {url}")
     r = urllib.request.urlopen(  # nosem
@@ -154,10 +160,21 @@ def upload_result(metric_name: str, value: float) -> None:
     print(r.read().decode())
 
 
-def run_semgrep(docker: str, corpus: Corpus, variant: SemgrepVariant) -> float:
+def standardize_findings(findings: dict) -> dict:
+    findings["results"] = sorted(
+        findings["results"],
+        key=lambda i: (i["path"], i["start"]["line"], i["start"]["col"]),
+    )
+    return findings
+
+
+def run_semgrep(
+    docker: str, corpus: Corpus, variant: SemgrepVariant
+) -> Tuple[float, bytes]:
     args = []
     common_args = [
         "--strict",
+        "--json",
         "--timeout",
         "0",
         "--verbose",
@@ -198,7 +215,7 @@ def run_semgrep(docker: str, corpus: Corpus, variant: SemgrepVariant) -> float:
     print(f"extra arguments for semgrep-core: '{variant.semgrep_core_extra}'")
 
     t1 = time.time()
-    res = subprocess.run(args)  # nosem
+    res = subprocess.run(args, capture_output=True)  # nosem
     t2 = time.time()
 
     status = res.returncode
@@ -210,13 +227,20 @@ def run_semgrep(docker: str, corpus: Corpus, variant: SemgrepVariant) -> float:
     else:
         res.check_returncode()
 
-    return t2 - t1
+    return t2 - t1, res.stdout
 
 
 def run_benchmarks(
-    docker: str, dummy: bool, gitlab: bool, internal: bool, upload: bool
+    docker: str,
+    dummy: bool,
+    gitlab: bool,
+    internal: bool,
+    plot_benchmarks: bool,
+    upload: bool,
 ) -> None:
-    results = []
+    results_msgs = []
+    results: dict = {variant.name: [] for variant in SEMGREP_VARIANTS}
+
     corpuses = CORPUSES
     if dummy:
         corpuses = DUMMY_CORPUSES
@@ -227,18 +251,42 @@ def run_benchmarks(
     for corpus in corpuses:
         with chdir(corpus.name):
             corpus.prep()
+            std_findings = {}
             for variant in SEMGREP_VARIANTS:
+                # Run variant
                 name = ".".join(["semgrep", "bench", corpus.name, variant.name])
                 metric_name = ".".join([name, "duration"])
                 print(f"------ {name} ------")
-                duration = run_semgrep(docker, corpus, variant)
+                duration, findings_bytes = run_semgrep(docker, corpus, variant)
                 msg = f"{metric_name} = {duration:.3f} s"
                 print(msg)
-                results.append(msg)
+                results_msgs.append(msg)
+                results[variant.name].append(duration)
+
+                # Process results
                 if upload:
-                    upload_result(metric_name, duration)
-    for msg in results:
+                    upload_results(metric_name, duration)
+
+                findings = standardize_findings(json.loads(findings_bytes))
+                if variant.name == "std":
+                    std_findings = findings
+                elif json.dumps(findings["results"]) != json.dumps(
+                    std_findings["results"]
+                ):
+                    results_msgs[-1] += " ERROR: result not same as std"
+                elif json.dumps(findings["errors"]) != json.dumps(
+                    std_findings["errors"]
+                ):
+                    results_msgs[-1] += " WARNING: errors not same as std"
+
+    # Show summary data
+    for msg in results_msgs:
         print(msg)
+    if plot_benchmarks:
+        indexes = [corpus.name for corpus in corpuses]
+        plotdata = pd.DataFrame(results, index=indexes)
+        plotdata.plot(kind="bar")
+        plt.show()
 
 
 def main() -> None:
@@ -268,6 +316,11 @@ def main() -> None:
         "--upload", help="upload results to semgrep dashboard", action="store_true"
     )
     parser.add_argument(
+        "--plot_benchmarks",
+        help="display a graph of the benchmark results",
+        action="store_true",
+    )
+    parser.add_argument(
         "--semgrep_core", help="run semgrep-core benchmarks", action="store_true"
     )
     args = parser.parse_args()
@@ -276,7 +329,12 @@ def main() -> None:
             semgrep_core_benchmark.run_benchmarks(args.dummy, args.upload)
         else:
             run_benchmarks(
-                args.docker, args.dummy, args.gitlab, args.internal, args.upload
+                args.docker,
+                args.dummy,
+                args.gitlab,
+                args.internal,
+                args.plot_benchmarks,
+                args.upload,
             )
 
 


### PR DESCRIPTION
Closes #2852

Add flag --plot_benchmarks to automatically graph the benchmarks

Check errors and results against the std benchmark. For each benchmark, it will output an error if the results do not match, and a warning if it counts more errors in the benchmark than the std. Currently, errors do not compare the message, because the experimental variants aren't propagating metavariables properly. We achieve this by using the class SemgrepResult, which compares results using an object that elides the message first. This should be restored after the experimental variant is fixed.

Some of the experimental results are still different---it seems that the column numbers are sometimes off by one.

Test plan:
./run_benchmarks
./run_benchmarks --plot_benchmarks



PR checklist:
- [x] changelog is up to date

