### PR TITLE
Fix: SARIF output, move invocations into runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - YAML language support to --test
 
 ### Fixed
+- SARIF output now nests invocations inside runs.
 
 ### Changed
 - Deep expression matches (`<... foo ...>`) now match within the bodies of anonymous

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -304,14 +304,14 @@ def build_sarif_output(
                     }
                 },
                 "results": [match.to_sarif() for match in rule_matches],
-            }
-        ],
-        "invocations": [
-            {
-                "toolExecutionNotifications": [
-                    _sarif_notification_from_error(e) for e in semgrep_structured_errors
+                "invocations": [
+                    {
+                        "toolExecutionNotifications": [
+                            _sarif_notification_from_error(e) for e in semgrep_structured_errors
+                        ],
+                    }
                 ],
-            }
+            },
         ],
     }
     return json.dumps(output_dict)

--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
@@ -1,12 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-  "invocations": [
-    {
-      "toolExecutionNotifications": []
-    }
-  ],
   "runs": [
     {
+      "invocations": [
+        {
+          "toolExecutionNotifications": []
+        }
+      ],
       "results": [
         {
           "locations": [


### PR DESCRIPTION
Conform with SARIF specification:
  https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540933

See https://github.com/returntocorp/semgrep/issues/2867

PR checklist:
- [x] changelog is up to date

