### PR TITLE
Remove semgrep-exe

### DIFF
--- a/semgrep/semgrep-exe
+++ b/semgrep/semgrep-exe
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# semgrep single executable must be run from the folder with all the shared objects
-
-THIS_DIR="$(dirname "$(realpath "$0")")";
-"${THIS_DIR}"/__main__ "$@"


### PR DESCRIPTION
This file was last referenced in https://github.com/returntocorp/semgrep/pull/1615. Since `semgrep/build.sh` is gone we no longer need this.