### PR TITLE
Only compute rest of list when necessary in all_elem_and_rest_of_list

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1261,7 +1261,7 @@ and m_list__m_argument (xsa: A.argument list) (xsb: A.argument list) =
           match xs with
           | [] -> fail ()
           | (b, xsb)::xs ->
-              (m_argument a b >>= (fun () -> m_list__m_argument xsa xsb))
+              (m_argument a b >>= (fun () -> m_list__m_argument xsa (lazy_rest_of_list xsb)))
               >||> aux xs
         in
         aux candidates
@@ -2406,7 +2406,7 @@ and m_list__m_field (xsa: A.field list) (xsb: A.field list) =
           match xs with
           | [] -> fail ()
           | (b, xsb)::xs ->
-              (m_field a b >>= (fun () -> m_list__m_field xsa xsb))
+              (m_field a b >>= (fun () -> m_list__m_field xsa (lazy_rest_of_list xsb)))
               >||> aux xs
         in
         aux candidates

--- a/semgrep-core/src/matching/Matching_generic.mli
+++ b/semgrep-core/src/matching/Matching_generic.mli
@@ -90,8 +90,10 @@ val has_ellipsis_stmts : AST_generic.stmt list -> bool
 (*e: signature [[Matching_generic.has_ellipsis_stmts]] *)
 val inits_and_rest_of_list: 'a list -> ('a list * 'a list) list
 (*s: signature [[Matching_generic.all_elem_and_rest_of_list]] *)
-val all_elem_and_rest_of_list : 'a list -> ('a * 'a list) list
+val all_elem_and_rest_of_list : 'a list -> ('a * 'a list Lazy.t) list
 (*e: signature [[Matching_generic.all_elem_and_rest_of_list]] *)
+val lazy_rest_of_list : 'a Lazy.t -> 'a
+
 (*s: signature [[Matching_generic.is_regexp_string]] *)
 (*e: signature [[Matching_generic.is_regexp_string]] *)
 type regexp = Re.re


### PR DESCRIPTION
Speed up cases with many matches on a metavariable by lazily computing the rest of list

Test plan: semgrep-core -profile -config tests/OTHER/perf1/bloom/crlf-injection-rule1.yaml tests/OTHER/perf1/bloom/BadLogClass.java -lang java



PR checklist:
- [ ] changelog is up to date

