### PR TITLE
fix: Add workaround for bintray brownout

### DIFF
--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 set -e
+brew update # Needed to sidestep bintray brownout
 brew install opam pkg-config coreutils
 opam init --no-setup --bare;
 opam switch create 4.10.0;


### PR DESCRIPTION
homebrew uses Github package to distribute package instead of bintray but the github action
isnt updated yet. Workaround is to update homebrew before calling install

Relevant links:
https://github.com/Homebrew/discussions/discussions/691
https://github.com/actions/virtual-environments/issues/3165
https://github.com/Homebrew/brew/pull/11070



PR checklist:
- [x] changelog is up to date

