### PR TITLE
Multiple test annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 - YAML language support to --test
+- Ability to list multiple, comma-separated rules on the same line when in --test mode
 - Resolve alias in require/import in Javascript
 ```
 child_process.exec(...)

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -111,22 +111,22 @@ def _annotations(annotation: str) -> Set[str]:
 
 def line_has_todo_rule(line: str) -> bool:
     todo_rule_annotations = _annotations(TODORULEID)
-    return any([annotation in line for annotation in todo_rule_annotations])
+    return any(annotation in line for annotation in todo_rule_annotations)
 
 
 def line_has_rule(line: str) -> bool:
     rule_annotations = _annotations(RULEID)
-    return any([annotation in line for annotation in rule_annotations])
+    return any(annotation in line for annotation in rule_annotations)
 
 
 def line_has_ok(line: str) -> bool:
     rule_annotations = _annotations(OK)
-    return any([annotation in line for annotation in rule_annotations])
+    return any(annotation in line for annotation in rule_annotations)
 
 
 def line_has_todo_ok(line: str) -> bool:
     rule_annotations = _annotations(TODOOK)
-    return any([annotation in line for annotation in rule_annotations])
+    return any(annotation in line for annotation in rule_annotations)
 
 
 def score_output_json(

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -416,7 +416,7 @@ def generate_file_pairs(
 
     for filename, rr in passed_results_first.items():
         print(f"(TODO: {rr['todo']}) {filename}")
-        for check_id, check_results in rr["checks"].items():
+        for check_id, check_results in sorted(rr["checks"].items()):
             print(generate_check_output_line(check_id, check_results))
             if not check_results["passed"]:
                 print(generate_matches_line(check_results))

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -156,20 +156,25 @@ def score_output_json(
             todo_ok_in_line = line_has_todo_ok(line)
             num_todo += int(todo_rule_in_line) + int(todo_ok_in_line)
 
-            if (not ignore_todo and todo_rule_in_line) or rule_in_line:
-                rule_ids = normalize_rule_ids(line)
-                for rule_id in rule_ids:
-                    ruleid_lines[test_file_resolved][rule_id].append(effective_line_num)
-            if (not ignore_todo and todo_rule_in_line) or ok_in_line:
-                rule_ids = normalize_rule_ids(line)
-                for rule_id in rule_ids:
-                    ok_lines[test_file_resolved][rule_id].append(effective_line_num)
-            if ignore_todo and todo_ok_in_line:
-                rule_ids = normalize_rule_ids(line)
-                for rule_id in rule_ids:
-                    todo_ok_lines[test_file_resolved][rule_id].append(
-                        effective_line_num
-                    )
+            try:
+                if (not ignore_todo and todo_rule_in_line) or rule_in_line:
+                    rule_ids = normalize_rule_ids(line)
+                    for rule_id in rule_ids:
+                        ruleid_lines[test_file_resolved][rule_id].append(
+                            effective_line_num
+                        )
+                if (not ignore_todo and todo_rule_in_line) or ok_in_line:
+                    rule_ids = normalize_rule_ids(line)
+                    for rule_id in rule_ids:
+                        ok_lines[test_file_resolved][rule_id].append(effective_line_num)
+                if ignore_todo and todo_ok_in_line:
+                    rule_ids = normalize_rule_ids(line)
+                    for rule_id in rule_ids:
+                        todo_ok_lines[test_file_resolved][rule_id].append(
+                            effective_line_num
+                        )
+            except ValueError:  # comment looked like a test annotation but couldn't parse
+                continue
 
     for result in json_out["results"]:
         reported_lines[str(Path(result["path"]).resolve())][result["check_id"]].append(

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -5,8 +5,6 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from itertools import chain
-from itertools import combinations
 from typing import Any
 from typing import Callable
 from typing import IO
@@ -104,7 +102,9 @@ def partition_set(pred: Callable, iterable: Iterable) -> Tuple[Set, Set]:
 def powerset(iterable: Iterable) -> Iterable[Tuple[Any, ...]]:
     """powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"""
     s = list(iterable)
-    return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+    return itertools.chain.from_iterable(
+        itertools.combinations(s, r) for r in range(len(s) + 1)
+    )
 
 
 def with_color(color: str, text: str, bold: bool = False) -> str:

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from itertools import chain
+from itertools import combinations
 from typing import Any
 from typing import Callable
 from typing import IO
@@ -96,6 +98,13 @@ def partition_set(pred: Callable, iterable: Iterable) -> Tuple[Set, Set]:
     """E.g. partition(is_odd, range(10)) -> 1 3 5 7 9  and  0 2 4 6 8"""
     i1, i2 = itertools.tee(iterable)
     return set(filter(pred, i1)), set(itertools.filterfalse(pred, i2))
+
+
+# cf. https://docs.python.org/3/library/itertools.html#itertools-recipes
+def powerset(iterable: Iterable) -> Iterable[Tuple[Any, ...]]:
+    """powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"""
+    s = list(iterable)
+    return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
 
 
 def with_color(color: str, text: str, bold: bool = False) -> str:

--- a/semgrep/tests/e2e/rules/cli_test/multiple_annotations/multiple-annotations.yaml
+++ b/semgrep/tests/e2e/rules/cli_test/multiple_annotations/multiple-annotations.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: basic-test
+  pattern: $X == $X
+  message: Basic test
+  severity: ERROR
+  languages: [python]
+- id: silly-test
+  pattern: 5 == 5
+  message: Five is right out.
+  severity: ERROR
+  languages: [python]

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_multiline_annotations/results.json
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_multiline_annotations/results.json
@@ -1,0 +1,9 @@
+1 yaml files tested
+check id scoring:
+--------------------------------------------------------------------------------
+(TODO: 0) rules/cli_test/multiple_annotations/multiple-annotations.yaml
+	✔ basic-test                                                   TP: 2 TN: 1 FP: 0 FN: 0
+	✔ silly-test                                                   TP: 1 TN: 1 FP: 0 FN: 0
+--------------------------------------------------------------------------------
+final confusion matrix: TP: 3 TN: 2 FP: 0 FN: 0
+--------------------------------------------------------------------------------

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_multiline_annotations/results.json
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_multiline_annotations/results.json
@@ -2,8 +2,8 @@
 check id scoring:
 --------------------------------------------------------------------------------
 (TODO: 0) rules/cli_test/multiple_annotations/multiple-annotations.yaml
-	✔ basic-test                                                   TP: 2 TN: 1 FP: 0 FN: 0
-	✔ silly-test                                                   TP: 1 TN: 1 FP: 0 FN: 0
+	✔ basic-test                                                   TP: 1 TN: 0 FP: 0 FN: 0
+	✔ silly-test                                                   TP: 1 TN: 0 FP: 0 FN: 0
 --------------------------------------------------------------------------------
-final confusion matrix: TP: 3 TN: 2 FP: 0 FN: 0
+final confusion matrix: TP: 2 TN: 0 FP: 0 FN: 0
 --------------------------------------------------------------------------------

--- a/semgrep/tests/e2e/targets/cli_test/multiple_annotations/multiple-annotations-bad.py
+++ b/semgrep/tests/e2e/targets/cli_test/multiple_annotations/multiple-annotations-bad.py
@@ -1,0 +1,8 @@
+# ruleid: basic-test
+4 == 4
+
+# ruleid: basic-test, silly-test
+5 == 5
+
+# ok: basic-test, silly-test
+1 == 2

--- a/semgrep/tests/e2e/targets/cli_test/multiple_annotations/multiple-annotations.py
+++ b/semgrep/tests/e2e/targets/cli_test/multiple_annotations/multiple-annotations.py
@@ -1,0 +1,8 @@
+# ruleid: basic-test
+4 == 4
+
+# ruleid: basic-test, silly-test
+5 == 5
+
+# ok: basic-test, silly-test
+1 == 2

--- a/semgrep/tests/e2e/targets/cli_test/multiple_annotations/multiple-annotations.py
+++ b/semgrep/tests/e2e/targets/cli_test/multiple_annotations/multiple-annotations.py
@@ -1,8 +1,8 @@
-# ruleid: basic-test
-4 == 4
+#ruleid:
+4 == 3
 
 # ruleid: basic-test, silly-test
 5 == 5
 
-# ok: basic-test, silly-test
+# ok
 1 == 2

--- a/semgrep/tests/e2e/test_cli_test.py
+++ b/semgrep/tests/e2e/test_cli_test.py
@@ -35,3 +35,16 @@ def test_cli_test_suffixes(run_semgrep_in_tmp, snapshot):
         results,
         "results.json",
     )
+
+
+def test_cli_test_multiline_annotations(run_semgrep_in_tmp, snapshot):
+    results = run_semgrep_in_tmp(
+        "rules/cli_test/multiple_annotations/",
+        options=["--test"],
+        target_name="cli_test/multiple_annotations/",
+        output_format="text",
+    )
+    snapshot.assert_match(
+        results,
+        "results.json",
+    )

--- a/semgrep/tests/unit/test_semgrep_test.py
+++ b/semgrep/tests/unit/test_semgrep_test.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from itertools import chain
-from itertools import combinations
 from itertools import product
 from typing import Iterator
 from typing import Set
@@ -17,12 +15,7 @@ from semgrep.test import RULEID
 from semgrep.test import SPACE_OR_NO_SPACE
 from semgrep.test import TODOOK
 from semgrep.test import TODORULEID
-
-# cf. https://docs.python.org/3/library/itertools.html#itertools-recipes
-def powerset(iterable):
-    "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
-    s = list(iterable)
-    return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+from semgrep.util import powerset
 
 
 ANNOTATIONS = (TODOOK, TODORULEID, OK, RULEID)

--- a/semgrep/tests/unit/test_semgrep_test.py
+++ b/semgrep/tests/unit/test_semgrep_test.py
@@ -8,9 +8,15 @@ from typing import Tuple
 
 import pytest
 
+from semgrep.test import COMMENT_SYNTAXES
 from semgrep.test import line_has_ok
 from semgrep.test import line_has_rule
 from semgrep.test import normalize_rule_ids
+from semgrep.test import OK
+from semgrep.test import RULEID
+from semgrep.test import SPACE_OR_NO_SPACE
+from semgrep.test import TODOOK
+from semgrep.test import TODORULEID
 
 # cf. https://docs.python.org/3/library/itertools.html#itertools-recipes
 def powerset(iterable):
@@ -19,9 +25,7 @@ def powerset(iterable):
     return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
 
 
-COMMENT_SYNTAXES = (("#", "\n"), ("//", "\n"), ("<!--", "-->"), ("(*", "*)"))
-ANNOTATIONS = ("ruleid", "ok")
-SPACE_OR_NO_SPACE = ("", " ")
+ANNOTATIONS = (TODOOK, TODORULEID, OK, RULEID)
 RULE_IDS = ("a", "b", "a.b", "a.b.c")
 
 

--- a/semgrep/tests/unit/test_semgrep_test.py
+++ b/semgrep/tests/unit/test_semgrep_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from itertools import chain
+from itertools import combinations
+from itertools import product
+from typing import Iterator
+from typing import Set
+from typing import Tuple
+
+import pytest
+
+from semgrep.test import line_has_ok
+from semgrep.test import line_has_rule
+from semgrep.test import normalize_rule_ids
+
+# cf. https://docs.python.org/3/library/itertools.html#itertools-recipes
+def powerset(iterable):
+    "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
+    s = list(iterable)
+    return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+
+
+COMMENT_SYNTAXES = (("#", "\n"), ("//", "\n"), ("<!--", "-->"), ("(*", "*)"))
+ANNOTATIONS = ("ruleid", "ok")
+SPACE_OR_NO_SPACE = ("", " ")
+RULE_IDS = ("a", "b", "a.b", "a.b.c")
+
+
+def _generate_normalize_rule_ids_test_cases() -> Iterator[Tuple[str, Set[str]]]:
+    for comment_begin, comment_end in COMMENT_SYNTAXES:
+        for annotation in ANNOTATIONS:
+            for space in SPACE_OR_NO_SPACE:
+                for rule_combo in powerset(RULE_IDS):
+                    yield (
+                        f"{comment_begin}{space}{annotation}:{space}{(','+space).join(rule_combo)} {comment_end}",
+                        set(rule_combo),
+                    )
+
+
+@pytest.mark.parametrize(
+    "test_case,expected", list(_generate_normalize_rule_ids_test_cases())
+)
+def test_normalize_rule_ids(test_case, expected):
+    assert normalize_rule_ids(test_case) == expected
+
+
+def _generate_line_has_test_cases(annotation: str) -> Iterator[str]:
+    for comment_begin, comment_end in COMMENT_SYNTAXES:
+        for space in SPACE_OR_NO_SPACE:
+            yield f"{comment_begin}{space}{annotation}:{space}{RULE_IDS[-1]}{comment_end}".strip()
+
+
+@pytest.mark.parametrize(
+    "test_case,expected",
+    list(product(_generate_line_has_test_cases("ruleid"), (True,)))
+    + list(product(_generate_line_has_test_cases("ok"), (False,)))
+    + list(product(_generate_line_has_test_cases("something else"), (False,))),
+)
+def test_line_has_rule(test_case, expected):
+    assert line_has_rule(test_case) == expected
+
+
+@pytest.mark.parametrize(
+    "test_case,expected",
+    list(product(_generate_line_has_test_cases("ruleid"), (False,)))
+    + list(product(_generate_line_has_test_cases("ok"), (True,)))
+    + list(product(_generate_line_has_test_cases("something else"), (False,))),
+)
+def test_line_has_ok(test_case, expected):
+    assert line_has_ok(test_case) == expected


### PR DESCRIPTION
Adds the ability to include multiple rule IDs for test annotations such as `ruleid` and `ok` on the same line. Rule IDs must be comma-separated.

PR checklist:
- [x] changelog is up to date

