### PR TITLE
Add @@profiling in semgrep-core and improve --experimental

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -158,6 +158,15 @@ SEMGREP_VARIANTS = [
 # For when you just want to test a single change
 STD_VARIANTS = [SemgrepVariant("std", "")]
 
+# Pad's debugging config
+# CORPUSES=[Corpus("lodash", "input/rules", "input/lodash")]
+# CORPUSES=[Corpus("DVWA", "input/rules", "input/DVWA"),]
+# SEMGREP_VARIANTS = [
+#    SemgrepVariant("std", ""),
+#    SemgrepVariant("experimental", "-no_filter_irrelevant_rules", "--experimental"),
+#    SemgrepVariant("experimental_and_fast", "", "--experimental"),
+#    ]
+
 
 # This class allows us to put semgrep results in a set and compute set
 # differences while saving the original JSON dictionary

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1000,11 +1000,13 @@ let extract_info_visitor recursor =
 (*s: function [[Lib_AST.ii_of_any]] *)
 let ii_of_any any =
   extract_info_visitor (fun visitor -> visitor any)
+[@@profiling]
 (*e: function [[Lib_AST.ii_of_any]] *)
 
 let range_of_tokens tokens =
   List.filter Parse_info.is_origintok tokens
   |> Parse_info.min_max_ii_by_pos
+[@@profiling]
 
 let range_of_any any =
   let leftmost_token, rightmost_token =
@@ -1013,3 +1015,4 @@ let range_of_any any =
   in
   (Parse_info.token_location_of_info leftmost_token,
    Parse_info.token_location_of_info rightmost_token)
+[@@profiling]

--- a/semgrep-core/src/core/ast/dune
+++ b/semgrep-core/src/core/ast/dune
@@ -16,6 +16,7 @@
       ppx_deriving.show
       ppx_deriving.eq
       ppx_hash
+      ppx_profiling
    )
  )
 )

--- a/semgrep-core/src/matching/Semgrep_generic.ml
+++ b/semgrep-core/src/matching/Semgrep_generic.ml
@@ -422,7 +422,7 @@ let check2 ~hook config rules equivs (file, lang, ast) =
 
 (* TODO: cant use [@@profile] because it does not handle yet label params *)
 let check ~hook config a b c =
-  Common.profile_code "Semgrep.check"
+  Common.profile_code "Semgrep_generic.check"
     (fun () -> check2 ~hook config a b c)
 
 (*e: semgrep/matching/Semgrep_generic.ml *)


### PR DESCRIPTION
I forgot a debugging flag which was slowing down --experimental, hmm

test plan:
./run-benchmarks shows improvements on --experimental,
just 3 benchs where it is slower than std now




PR checklist:
- [x] changelog is up to date