### PR TITLE
* core_runner.py: do not call semgrep-core if there are no target

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -562,12 +562,16 @@ class CoreRunner:
                     )
                 )
             ):
+                debug_tqdm_write(f"Running rule {rule._raw.get('id')}...")
                 with tempfile.NamedTemporaryFile(
                     "w", suffix=".yaml"
                 ) as rule_file, tempfile.NamedTemporaryFile("w") as target_file:
                     targets = self.get_files_for_language(
                         language, rule, target_manager
                     )
+                    # opti: no need to call semgrep-core if no target files
+                    if not targets:
+                        continue
                     target_file.write("\n".join(map(lambda p: str(p), targets)))
                     target_file.flush()
                     yaml = YAML()


### PR DESCRIPTION
This fixes I think the last regression of --experimental compared
to the std benchmark. --experimental was slower than std because
for many benchs, we use r2c-ci.yml which contain rules that do
not have any target in the repository (e.g., python rules on a js
repo) and we should not lose time calling semgrep-core for those.

test plan:
./run-benchmarks now shows --experimental always faster (minor small
variations)




PR checklist:
- [ ] changelog is up to date