### PR TITLE
run-benchmarks: abstract away differences in md5sum unique_id

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -177,9 +177,14 @@ class SemgrepResult:
             # TODO: full-rule does not correctly update message with metavars
             if "message" in dict2["extra"]:
                 dict2["extra"]["message"] = ""
-            # TODO: spacegrep.py calls dedent
+            # TODO: spacegrep.py calls dedent() on lines (not sure why)
             if "lines" in dict2["extra"]:
                 dict2["extra"]["lines"] = ""
+            # TODO: spacegrep/../Semgrep.ml uses a different unique_id hashing
+            if "metavars" in dict2["extra"]:
+                for _, v in dict2["extra"]["metavars"].items():
+                    if "unique_id" in v:
+                        v["unique_id"] = ""
 
             self.str = json.dumps(dict2, sort_keys=True)
         else:


### PR DESCRIPTION
We use a different md5sum when spacegrep is run inside semgrep-core.
It does not really matter though, so let's abstract away those md5sum

test plan:
$ ./run-benchmarks --filter-corpus netflix --filter-variant '^(std|experimental)$'

does not show anymore differences




PR checklist:
- [x] changelog is up to date