### PR TITLE
Dedup matchings in semgrep-core, and abstract away metavars

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -180,11 +180,15 @@ class SemgrepResult:
             # TODO: spacegrep.py calls dedent() on lines (not sure why)
             if "lines" in dict2["extra"]:
                 dict2["extra"]["lines"] = ""
-            # TODO: spacegrep/../Semgrep.ml uses a different unique_id hashing
             if "metavars" in dict2["extra"]:
+                # TODO: spacegrep/../Semgrep.ml uses a different unique_id
                 for _, v in dict2["extra"]["metavars"].items():
                     if "unique_id" in v:
                         v["unique_id"] = ""
+                # TODO: core_runner.py dedup_output() depends on the order
+                # of the elements in the list to remove similar findings
+                # but with different metavars
+                dict2["extra"]["metavars"] = ""
 
             self.str = json.dumps(dict2, sort_keys=True)
         else:

--- a/semgrep-core/src/matching/Semgrep_generic.ml
+++ b/semgrep-core/src/matching/Semgrep_generic.ml
@@ -413,10 +413,14 @@ let check2 ~hook config rules equivs (file, lang, ast) =
 
     !matches |> List.rev
     (* TODO: optimize uniq_by? Too slow? Use a hash?
-     * Note that this uniq_by was introducing regressions in semgrep!
+     * Note that this may not be enough for Semgrep.ml. Indeed, we can have
+     * different mini-rules matching the same code with the same metavar,
+     * but in Semgrep.ml they get agglomerated under the same rule id, in
+     * which case we want to dedup them.
+     * old: this uniq_by was introducing regressions in semgrep!
      * See tests/OTHER/rules/regression_uniq_or_ellipsis.go but it's fixed now.
-     * |> Common.uniq_by (AST_utils.with_structural_equal Pattern_match.equal)
     *)
+    |> Common.uniq_by (AST_utils.with_structural_equal Pattern_match.equal)
   end
 (*e: function [[Semgrep_generic.check2]] *)
 


### PR DESCRIPTION
Even after dedupping findings in semgrep-core for --experimental,
there was still differences in findings in run-benchmarks
for flask-app, etc, because the metavariables were different.
Indeed, dedup_output() dedup findings with different metavariables
(I think this is wrong, but it's another problem).

test plan:
./run-benchmarks --filter-corpus flask
does not show any more differences between std and experimental




PR checklist:
- [x] changelog is up to date