### PR TITLE
Fix pattern-inside: and pattern: conjonction in semgrep-core

### DIFF
--- a/semgrep-core/src/core/Range.ml
+++ b/semgrep-core/src/core/Range.ml
@@ -35,12 +35,14 @@ module PI = Parse_info
  * (unlike in Emacs where point starts at 1).
 *)
 type charpos = int
+[@@deriving show]
 
 (* the range is inclusive, {start = 0; end_ = 4} means [0..4] not [0..4[ *)
 type t = {
   start: charpos;
   end_: charpos;
 }
+[@@deriving show]
 
 (* related: Parse_info.NotTokenLocation *)
 exception NotValidRange of string

--- a/semgrep-core/src/core/Range.mli
+++ b/semgrep-core/src/core/Range.mli
@@ -12,6 +12,7 @@ type t = {
   start: charpos;
   end_: charpos;
 }
+val pp : Format.formatter -> t -> unit
 
 exception NotValidRange of string
 

--- a/semgrep-core/tests/OTHER/rules/and_inside.mustache
+++ b/semgrep-core/tests/OTHER/rules/and_inside.mustache
@@ -1,0 +1,1 @@
+Woop woop. {{/<script>alert("hey");</script>}}

--- a/semgrep-core/tests/OTHER/rules/and_inside.yaml
+++ b/semgrep-core/tests/OTHER/rules/and_inside.yaml
@@ -1,0 +1,10 @@
+# originally generic/html-templates/security/unquoted-attribute-var.yaml
+rules:
+- id: unquoted-attribute-var
+  message: bug
+  languages:
+  - generic
+  severity: WARNING
+  patterns:
+  - pattern-inside: <$TAG ...>
+  - pattern: '{{ ... }}'


### PR DESCRIPTION
This fixes the remaining differences in ./run-benchmarks between
std and experimental!
This also fixes 5 mismatches in semgrep-rules.

test plan:
test file included




PR checklist:
- [ ] changelog is up to date