### PR TITLE
Use the semgrep-dev container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,16 +14,15 @@ jobs:
   # A. run semgrep container from existing container: requires mounting
   #    a volume, which is disabled by CircleCI (results in empty folder
   #    once mounted).
-  # B. run everything inside the semgrep container, which is very minimal
-  #    since it doesn't even have bash. At least it has a suitable
-  #    version of python.
+  # B. run everything inside the semgrep-dev container, which comes with
+  #    semgrep and whatever utilities we added.
   #
   # We use B out of necessity.
   #
   # Go through the same steps as the real benchmarks but quickly.
   dummy-benchmarks:
     docker:
-      - image: returntocorp/semgrep:develop
+      - image: returntocorp/semgrep-dev:develop
     steps:
       - checkout
       - run:
@@ -35,7 +34,7 @@ jobs:
   # Real benchmarks
   benchmarks:
     docker:
-      - image: returntocorp/semgrep:develop
+      - image: returntocorp/semgrep-dev:develop
     steps:
       - checkout
       - run:
@@ -68,14 +67,10 @@ workflows:
               only:
                 - develop
 
-  # This is for testing. Requires pushing to a branch named 'dummy-benchmarks'.
+  # This is to check whether we broke the benchmarks before merging a branch.
   dummy-benchmarks-on-commit:
     jobs:
-      - dummy-benchmarks:
-          filters:
-            branches:
-              only:
-                - dummy-benchmarks
+      - dummy-benchmarks
 
   # This is for testing. Requires pushing to a branch named 'force-benchmarks'.
   # It can take hours, use with care.

--- a/dockerfiles/semgrep-dev.Dockerfile
+++ b/dockerfiles/semgrep-dev.Dockerfile
@@ -25,5 +25,8 @@ RUN apk add --no-cache \
 # Let the user know how their container was built
 COPY dockerfiles/semgrep-dev.Dockerfile /Dockerfile
 
+# cd ~
+WORKDIR /home/semgrep
+
 USER semgrep
 ENTRYPOINT ["/bin/bash"]

--- a/perf/README.md
+++ b/perf/README.md
@@ -64,6 +64,10 @@ for CI jobs which run more or less in a consistent environment.
 Troubleshooting CI with the semgrep-dev Docker image
 --
 
+_CI uses CircleCI or GitHub Actions, configured in the standard places
+(`.circleci`, `.github/workflows`). See those files to determine which
+jobs run and when._
+
 We maintain a Docker build that comes with `semgrep`
 pre-installed. It is meant for daily benchmarks and other
 jobs that use the development version of semgrep. The image URL is

--- a/perf/README.md
+++ b/perf/README.md
@@ -60,3 +60,37 @@ $ make
 
 This will *not upload* the results to the dashboard, as it is reserved
 for CI jobs which run more or less in a consistent environment.
+
+Troubleshooting CI with the semgrep-dev Docker image
+--
+
+We maintain a Docker build that comes with `semgrep`
+pre-installed. It is meant for daily benchmarks and other
+jobs that use the development version of semgrep. The image URL is
+[`returntocorp/semgrep-dev:develop`](https://hub.docker.com/r/returntocorp/semgrep-dev/tags).
+It is built and pushed to DockerHub by a CI job that triggers each
+time there's a change on the main branch of the `semgrep` repo.
+
+```
+$ docker pull returntocorp/semgrep-dev:develop     # updates your local copy
+$ docker run -it returntocorp/semgrep-dev:develop  # starts bash in container
+```
+
+If you want to test some of your local code inside the container, you
+would mount your folder using the `-v` option. The usage is
+`-v SRC:DST` where SRC is a path to your original folder and DST is
+the absolute path you want it to have in the container. The home
+folder for this image is set to `/home/semgrep`. For example you'd do
+this:
+
+```
+$ ls
+my_stuff
+$ docker run -v my_stuff:/home/semgrep/my_stuff -it returntocorp/semgrep-dev:develop
+bash-5.1$ whoami
+semgrep
+bash-5.1$ ls ~
+my_stuff
+bash-5.1$ semgrep --version
+0.46.0
+```

--- a/perf/README.md
+++ b/perf/README.md
@@ -78,7 +78,7 @@ $ docker run -it returntocorp/semgrep-dev:develop  # starts bash in container
 
 If you want to test some of your local code inside the container, you
 would mount your folder using the `-v` option. The usage is
-`-v SRC:DST` where SRC is a path to your original folder and DST is
+`-v SRC:DST` where SRC is an absolute path to your original folder and DST is
 the absolute path you want it to have in the container. The home
 folder for this image is set to `/home/semgrep`. For example you'd do
 this:
@@ -86,7 +86,7 @@ this:
 ```
 $ ls
 my_stuff
-$ docker run -v my_stuff:/home/semgrep/my_stuff -it returntocorp/semgrep-dev:develop
+$ docker run -v "$(pwd)"/my_stuff:/home/semgrep/my_stuff -it returntocorp/semgrep-dev:develop
 bash-5.1$ whoami
 semgrep
 bash-5.1$ ls ~


### PR DESCRIPTION
* This adds instructions on how to use the `semgrep-dev` container.
* This also sets the current directory to the home directory instead of `/` in the `semgrep-dev` container.
* I realized that we were not using the `semgrep-dev` extended image for the daily benchmarks. Now we do.
* The dummy benchmarks should now run according to the default schedule, which includes pull requests. Update: they ran and passed on this PR, yay!

PR checklist:
- [x] changelog is up to date

