### PR TITLE
Skip tree-sitter installation if in homebrew

### DIFF
--- a/scripts/install-ocaml-tree-sitter
+++ b/scripts/install-ocaml-tree-sitter
@@ -5,5 +5,13 @@
 set -eu
 
 cd ocaml-tree-sitter
-./scripts/install-runtime
+
+# In homebrew, tree-sitter formula is used as dependency
+# instead of installing manually so skip installing tree-sitter-lib
+if [[ -z "${HOMEBREW_SYSTEM+x}" ]]; then
+	./scripts/install-runtime
+else
+	opam install -y .
+fi
+
 ./configure


### PR DESCRIPTION
tree-sitter exists as a homebrew formula. Can rely on that instead
of installing tree-sitter from source when building in homebrew



PR checklist:
- [ ] changelog is up to date

