### PR TITLE
Let RuleMatch handle retrieving line information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 ### Changed
+- The `extra` `lines` data is now consistent across scan types
+  (e.g. `semgrep-core`, `spacegrep`, `pattern-regex`)
 
 ## [0.47.0](https://github.com/returntocorp/semgrep/releases/tag/v0.47.0) - 2021-04-15
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -93,7 +93,7 @@ def get_re_matches(
                     "line": _offset_to_line_no(match.end(), contents),
                     "col": _offset_to_col_no(match.end(), contents),
                 },
-                "extra": {"lines": [contents[match.start() : match.end()]]},
+                "extra": {},
             }
         )
         for pattern_id, pattern in patterns_re

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -109,9 +109,6 @@ class RuleMatch:
 
         Assumes file exists.  Note that start/end line is one-indexed
         """
-        if "lines" in self.extra:
-            return self.extra["lines"]
-
         with self.path.open(
             buffering=1, errors="replace"
         ) as fin:  # buffering=1 turns on line-level reads

--- a/semgrep/semgrep/spacegrep.py
+++ b/semgrep/semgrep/spacegrep.py
@@ -2,7 +2,6 @@ import json
 import logging
 import subprocess
 from pathlib import Path
-from textwrap import dedent
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -88,13 +87,6 @@ def run_spacegrep(
                     output_json["matches"] = _patch_id(
                         pattern, output_json.get("matches", [])
                     )
-                    # dedent lines
-                    for match in output_json["matches"]:
-                        match["extra"]["lines"] = dedent(
-                            "\n".join(
-                                filter(None, match.get("extra", {}).get("lines", []))
-                            )
-                        ).split("\n")
 
                     matches.extend(output_json["matches"])
                     errors.extend(output_json["errors"])

--- a/semgrep/tests/e2e/rules/regex-nosemgrep.yaml
+++ b/semgrep/tests/e2e/rules/regex-nosemgrep.yaml
@@ -1,0 +1,9 @@
+rules:
+- id: detected-aws-account-id
+  pattern-regex: |-
+    ("|')?(AWS|aws|Aws)?_?(ACCOUNT|account|Account)_?(ID|id|Id)?("|')?\s*(:|=>|=)\s*("|')?[0-9]{12}("|')?
+  languages: [regex]
+  message: AWS Account ID detected
+  severity: ERROR
+  metadata:
+    source-rule-url: https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "123.123.123.123",
+        "lines": "boto3.client(host=\"123.123.123.123\")",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__issue2465/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__issue2465/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "Foo",
+        "lines": "Foo==1.1.1",
         "message": "Found $TAG",
         "metadata": {},
         "severity": "ERROR"

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__nosemgrep/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__nosemgrep/results.json
@@ -1,0 +1,26 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.detected-aws-account-id",
+      "end": {
+        "col": 28,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "aws_account_id:123456789012",
+        "message": "AWS Account ID detected",
+        "metadata": {
+          "source-rule-url": "https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go"
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/regex-nosemgrep.txt",
+      "start": {
+        "col": 1,
+        "line": 3
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__not2/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__not2/results.json
@@ -123,7 +123,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<pre>{{ body }}</pre>",
+        "lines": "    <pre>{{ body }}</pre>",
         "message": "test regex message",
         "metadata": {},
         "metavars": {

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__pattern_regex_and_pattern_not_regex/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__pattern_regex_and_pattern_not_regex/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<h4>",
+        "lines": "<h4>From: {{ from_email }}</h4>",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"
@@ -28,7 +28,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "</h4>",
+        "lines": "<h4>From: {{ from_email }}</h4>",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"
@@ -47,7 +47,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<h4>",
+        "lines": "<h4>To:",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"
@@ -85,7 +85,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<h4>",
+        "lines": "<h4>Subject: {{subject}}</h4>",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"
@@ -104,7 +104,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "</h4>",
+        "lines": "<h4>Subject: {{subject}}</h4>",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"
@@ -123,7 +123,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<pre>",
+        "lines": "    <pre>{{ body }}</pre>",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"
@@ -142,7 +142,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "</pre>",
+        "lines": "    <pre>{{ body }}</pre>",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "123.123.123.123",
+        "lines": "boto3.client(host=\"123.123.123.123\")",
         "message": "test regex message",
         "metadata": {},
         "severity": "ERROR"

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "{% autoescape off %}",
+        "lines": "    {% autoescape off %}",
         "message": "Detected a segment of a Flask template where autoescaping is explicitly\ndisabled with '{% autoescape off %}'. This allows rendering of raw HTML\nin this segment. Ensure no user data is rendered here, otherwise this\nis a cross-site scripting (XSS) vulnerability.\n",
         "metadata": {
           "cwe": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule_none_alias/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule_none_alias/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "{% autoescape off %}",
+        "lines": "    {% autoescape off %}",
         "message": "Detected a segment of a Flask template where autoescaping is explicitly\ndisabled with '{% autoescape off %}'. This allows rendering of raw HTML\nin this segment. Ensure no user data is rendered here, otherwise this\nis a cross-site scripting (XSS) vulnerability.\n",
         "metadata": {
           "cwe": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "{% autoescape off %}",
+        "lines": "    {% autoescape off %}",
         "message": "Detected a segment of a Flask template where autoescaping is explicitly\ndisabled with '{% autoescape off %}'. This allows rendering of raw HTML\nin this segment. Ensure no user data is rendered here, otherwise this\nis a cross-site scripting (XSS) vulnerability.\n",
         "metadata": {
           "cwe": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule_none_alias/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule_none_alias/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "{% autoescape off %}",
+        "lines": "    {% autoescape off %}",
         "message": "Detected a segment of a Flask template where autoescaping is explicitly\ndisabled with '{% autoescape off %}'. This allows rendering of raw HTML\nin this segment. Ensure no user data is rendered here, otherwise this\nis a cross-site scripting (XSS) vulnerability.\n",
         "metadata": {
           "cwe": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephtml.yaml-spacegrephtml.mustache/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "var message = {{ message }};",
+        "lines": "    var message = {{ message }};",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -29,7 +29,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "var message = {{ message }};",
+        "lines": "    var message = {{ message }};",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},
@@ -49,7 +49,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "var message2 = {{ message2 }};",
+        "lines": "    var message2 = {{ message2 }};",
         "message": "Detected template variable in script tag. This is dangerous because\nHTML escaping does not prevent injection in script contexts.\n",
         "metadata": {},
         "metavars": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepterraform.yaml-spacegrepterraform.tf/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "allowed_origins = [\"*\"]",
+        "lines": "    allowed_origins = [\"*\"]",
         "message": "CORS rule on bucket permits any origin",
         "metadata": {},
         "metavars": {},

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep_nosem/rulesspacegrepnosem-html.yaml-spacegrepnosem.html/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep_nosem/rulesspacegrepnosem-html.yaml-spacegrepnosem.html/results.json
@@ -9,7 +9,7 @@
       },
       "extra": {
         "is_ignored": false,
-        "lines": "<a href = \"{{ link }}\" >{{ link_text }}</a>",
+        "lines": "    <a href = \"{{ link }}\" >{{ link_text }}</a>",
         "message": "Detected a template variable used in an anchor tag with the 'href' attribute. This allows a malicious actor to input the 'javascript:' URI and is subject to cross- site scripting (XSS) attacks. If using Flask, use 'url_for()' to safely generate a URL. If using Django, use the 'url' filter to safely generate a URL. If using Mustache, use a URL encoding library, or prepend a slash '/' to the variable for relative links (`href=\"/{{link}}\"`). You may also consider setting the Content Security Policy (CSP) header.",
         "metadata": {
           "cwe": "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",

--- a/semgrep/tests/e2e/targets/basic/regex-nosemgrep.txt
+++ b/semgrep/tests/e2e/targets/basic/regex-nosemgrep.txt
@@ -1,0 +1,3 @@
+aws_account_id = 123456789012  # nosemgrep
+
+aws_account_id:123456789012

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -214,6 +214,15 @@ def test_regex_rule__invalid_expression(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(excinfo.value.stdout, "error.json")
 
 
+def test_regex_rule__nosemgrep(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/regex-nosemgrep.yaml", target_name="basic/regex-nosemgrep.txt"
+        ),
+        "results.json",
+    )
+
+
 def test_nested_patterns_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/nested-patterns.yaml"), "results.json"


### PR DESCRIPTION
Fixes #2972.

We currently have many ways of retrieving and modifying `lines` information. This caused a subtle bug in #2972 where `nosemgrep` didn't work because it didn't have the additional `lines` context including the comment. We should let `RuleMatch` gather this information for all findings (e.g. `pattern-regex`, `semgrep-core`, `spacegrep`, etc).

