### PR TITLE
Flip constants -> util dependency

### DIFF
--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -4,8 +4,6 @@ from enum import auto
 from enum import Enum
 
 from semgrep import __VERSION__
-from semgrep.util import compute_semgrep_path
-from semgrep.util import compute_spacegrep_path
 
 RCE_RULE_FLAG = "--dangerously-allow-arbitrary-code-execution-from-rules"
 RULES_KEY = "rules"
@@ -25,8 +23,9 @@ SEMGREP_USER_AGENT_APPEND = os.environ.get("SEMGREP_USER_AGENT_APPEND")
 if SEMGREP_USER_AGENT_APPEND is not None:
     SEMGREP_USER_AGENT = f"{SEMGREP_USER_AGENT} {SEMGREP_USER_AGENT_APPEND}"
 
-SEMGREP_PATH = compute_semgrep_path()
-SPACEGREP_PATH = compute_spacegrep_path()
+YML_EXTENSIONS = {".yml", ".yaml"}
+YML_SUFFIXES = [[ext] for ext in YML_EXTENSIONS]
+YML_TEST_SUFFIXES = [[".test", ext] for ext in YML_EXTENSIONS]
 
 
 class OutputFormat(Enum):

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -23,7 +23,6 @@ from typing import Tuple
 from ruamel.yaml import YAML
 
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
-from semgrep.constants import SEMGREP_PATH
 from semgrep.core_exception import CoreException
 from semgrep.equivalences import Equivalence
 from semgrep.error import _UnknownLanguageError
@@ -50,6 +49,7 @@ from semgrep.target_manager_extensions import all_supported_languages
 from semgrep.util import debug_tqdm_write
 from semgrep.util import partition
 from semgrep.util import progress_bar
+from semgrep.util import SEMGREP_PATH
 from semgrep.util import sub_run
 
 logger = logging.getLogger(__name__)

--- a/semgrep/semgrep/dump_ast.py
+++ b/semgrep/semgrep/dump_ast.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 import semgrep.config_resolver
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
-from semgrep.constants import SEMGREP_PATH
 from semgrep.error import SemgrepError
+from semgrep.util import SEMGREP_PATH
 from semgrep.util import sub_check_output
 
 

--- a/semgrep/semgrep/metavariable_comparison.py
+++ b/semgrep/semgrep/metavariable_comparison.py
@@ -4,8 +4,8 @@ import tempfile
 from typing import Union
 
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
-from semgrep.constants import SEMGREP_PATH
 from semgrep.error import SemgrepError
+from semgrep.util import SEMGREP_PATH
 from semgrep.util import sub_check_output
 
 

--- a/semgrep/semgrep/spacegrep.py
+++ b/semgrep/semgrep/spacegrep.py
@@ -7,11 +7,11 @@ from typing import cast
 from typing import Dict
 from typing import List
 
-from semgrep.constants import SPACEGREP_PATH
 from semgrep.core_exception import CoreException
 from semgrep.error import SemgrepError
 from semgrep.pattern import Pattern
 from semgrep.rule_lang import Position
+from semgrep.util import SPACEGREP_PATH
 from semgrep.util import sub_run
 
 logger = logging.getLogger(__name__)

--- a/semgrep/semgrep/synthesize_patterns.py
+++ b/semgrep/semgrep/synthesize_patterns.py
@@ -3,8 +3,8 @@ from typing import List
 
 import semgrep.config_resolver
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
-from semgrep.constants import SEMGREP_PATH
 from semgrep.error import SemgrepError
+from semgrep.util import SEMGREP_PATH
 from semgrep.util import sub_check_output
 
 

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -19,11 +19,10 @@ import pkg_resources
 from colorama import Fore
 from tqdm import tqdm
 
-T = TypeVar("T")
+from semgrep.constants import YML_SUFFIXES
+from semgrep.constants import YML_TEST_SUFFIXES
 
-YML_EXTENSIONS = {".yml", ".yaml"}
-YML_SUFFIXES = [[ext] for ext in YML_EXTENSIONS]
-YML_TEST_SUFFIXES = [[".test", ext] for ext in YML_EXTENSIONS]
+T = TypeVar("T")
 
 global DEBUG
 global QUIET
@@ -188,6 +187,10 @@ def compute_semgrep_path() -> str:
 
 def compute_spacegrep_path() -> str:
     return compute_executable_path("spacegrep")
+
+
+SEMGREP_PATH = compute_semgrep_path()
+SPACEGREP_PATH = compute_spacegrep_path()
 
 
 def liststartswith(l: List[T], head: List[T]) -> bool:


### PR DESCRIPTION
Everything in `constants` should be, well, constant, or at least self-contained. These path variables are dependent on the environment, so they're not constant. This also allows `constants` to be imported by virtually everything without circular dependency concerns (i.e. `constants` shouldn't import any other `semgrep` modules, except `__VERSION__`).