### PR TITLE
analyzing: Infer global constant declarations in JS/TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Coming up next
+
 ### Added
+- JS/TS: Infer global constants even if the `const` qualifier is missing (#2978)
+
 ### Fixed
 ### Changed
 

--- a/semgrep-core/tests/js/infer_const.js
+++ b/semgrep-core/tests/js/infer_const.js
@@ -1,0 +1,13 @@
+// https://github.com/returntocorp/semgrep/issues/554
+
+var string1 = 'test1'
+//ERROR:
+console.log(`Insert a string here: ${string1}`);
+//ERROR:
+console.log(`Insert a string here:` + string1);
+
+let string2 = 'test2'
+//ERROR:
+console.log(`Insert a string here: ${string2}`);
+//ERROR:
+console.log(`Insert a string here:` + string2);

--- a/semgrep-core/tests/js/infer_const.sgrep
+++ b/semgrep-core/tests/js/infer_const.sgrep
@@ -1,0 +1,1 @@
+console.log("...")

--- a/semgrep-core/tests/js/infer_const_1.js
+++ b/semgrep-core/tests/js/infer_const_1.js
@@ -1,0 +1,25 @@
+// https://github.com/returntocorp/semgrep/issues/554
+
+//ERROR:
+var foo = 'sensitive_var=test1';
+
+//ERROR:
+var foo = 'otherdata=foo&sensitive_var=test-2&moredata=bar';
+
+var LITERAL = 'test-3'
+//ERROR:
+var foo = `otherdata=foo&sensitive_var=${LITERAL}&moredata=bar`;
+//ERROR:
+var foo = 'otherdata=foo&sensitive_var=' + LITERAL + '&moredata=bar';
+
+const LITERAL = 'test-4'
+//ERROR:
+var foo = `otherdata=foo&sensitive_var=${LITERAL}&moredata=bar`;
+//ERROR:
+var foo = 'otherdata=foo&sensitive_var=' + LITERAL + '&moredata=bar';
+
+let LITERAL = 'test-4'
+//ERROR:
+var foo = `&otherdata=foo&sensitive_var=${LITERAL}&moredata=bar`;
+//ERROR:
+var foo = 'otherdata=foo&sensitive_var=' + LITERAL + '&moredata=bar';

--- a/semgrep-core/tests/js/infer_const_1.sgrep
+++ b/semgrep-core/tests/js/infer_const_1.sgrep
@@ -1,0 +1,1 @@
+"=~/.*sensitive_var=[A-Za-z0-9_-]+.*/"

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
@@ -56,12 +56,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -18,12 +18,12 @@
             "end": {
               "col": 14,
               "line": 3,
-              "offset": 25
+              "offset": 62
             },
             "start": {
               "col": 13,
               "line": 3,
-              "offset": 24
+              "offset": 61
             },
             "unique_id": {
               "kind": "Global",

--- a/semgrep/tests/e2e/targets/basic/stupid.js
+++ b/semgrep/tests/e2e/targets/basic/stupid.js
@@ -1,3 +1,3 @@
-var x = 1;
+var x = window.prompt() // arbitrary user input
 
 console.log(x == x)


### PR DESCRIPTION
Even if the `const' qualifier is missing; it's enough if the variable is
resolved, it's set to a literal, and it's only assigned once.

Closes: #554



PR checklist:
- [ x] changelog is up to date

