### PR TITLE
Add required executionSuccessful attribute to SARIF output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 - Capturing functions when used as both expressions and statements in JS (#1007)
 - Literal for ocaml tree sitter (#2885)
+- SARIF output now contains the required runs.invocations.executionSuccessful property.
 
 ### Changed
 - The `extra` `lines` data is now consistent across scan types

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -307,6 +307,7 @@ def build_sarif_output(
                 "results": [match.to_sarif() for match in rule_matches],
                 "invocations": [
                     {
+                        "executionSuccessful": True,
                         "toolExecutionNotifications": [
                             _sarif_notification_from_error(e)
                             for e in semgrep_structured_errors

--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif
@@ -4,6 +4,7 @@
     {
       "invocations": [
         {
+          "executionSuccessful": true,
           "toolExecutionNotifications": []
         }
       ],


### PR DESCRIPTION
👋  Hello! This is a follow up to: https://github.com/returntocorp/semgrep/pull/2888 🙇 ❤️ 

I realised after fixing the first issue the online Validator actually highlights a few others 🤦 

Of them, only one appears to be a specification violation:

A missing `executionSuccessful` property: https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Ref8832061

You can see this by taking `semgrep/tests/e2e/snapshots/test_check/test_sarif_output/results.sarif` and uploading it to the [online SARIF validator](https://sarifweb.azurewebsites.net/Validation).

Once you fix this a few others appear (A missing `informationUri` property: https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc9244329 and rule "id" not being equal to "name"). As these are optional I wont fix them in this PR - especially as dropping the name attribute may have unintended consequences.

PR checklist:
- [x] changelog is up to date