### PR TITLE
Revert "Skip tree-sitter installation if in homebrew"

### DIFF
--- a/scripts/install-ocaml-tree-sitter
+++ b/scripts/install-ocaml-tree-sitter
@@ -5,13 +5,5 @@
 set -eu
 
 cd ocaml-tree-sitter
-
-# In homebrew, tree-sitter formula is used as dependency
-# instead of installing manually so skip installing tree-sitter-lib
-if [[ -z "${HOMEBREW_SYSTEM+x}" ]]; then
-	./scripts/install-runtime
-else
-	opam install -y .
-fi
-
+./scripts/install-runtime
 ./configure


### PR DESCRIPTION
Reverts returntocorp/semgrep#2969 while https://github.com/returntocorp/semgrep/issues/2989 is unsolved