### PR TITLE
Use org fork of homebrew-core when creating version bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,12 @@ jobs:
     name: Update on Homebrew-Core
     runs-on: macos-latest
     steps:
+      - name: Brew update
+        run: brew update
+      - name: Install pipgrip
+        run: brew install pipgrip
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           token: ${{ secrets.HOMEBREW_PR_TOKEN }}
           formula: semgrep
+          org: returntocorp


### PR DESCRIPTION
Before this commit, we were using a private fork to make a PR
to homebrew-core to bump the version of semgrep. After brew 3.1.3
it is possible to add a --fork-org flag to specify using an org
fork for bump-version-pr. This PR makes use of this new flag in the
bump-version-pr github action.

