### PR TITLE
MVP for --watch

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -76,6 +76,13 @@ def cli() -> None:
         type=argparse.FileType("x"),
         help=f"Generate starter configuration file. Defaults to {DEFAULT_CONFIG_FILE}.",
     )
+
+    config.add_argument(
+        "--watch",
+        action="store_true",
+        help="Watch a remote --config and re-run Semgrep when it changes.",
+    )
+
     config.add_argument(
         "-l",
         "--lang",
@@ -482,4 +489,5 @@ def cli() -> None:
                 severity=args.severity,
                 report_time=args.json_time,
                 experimental=args.experimental,
+                watch=args.watch,
             )


### PR DESCRIPTION
As requested by many rule authors, I've implemented an MVP of a --watch mode for semgrep. It will re-run Semgrep if the local or remote config file changes. cc those who had mentioned this, including @smcpeak @devd @julianthome @DrewDennison 

PR checklist:
- [ ] changelog is up to date
- [ ] paginating and clearing the output

