### PR TITLE
Replacing --experimental with --optimizations [OPTI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Coming up next
 
+### Added
+- A new `--optimizations [STR]` command-line flag to turn on/off optimizations.
+  use 'none' to turn off everything and 'all' to turn on everything.
+  Just using `--optimizations` is equivalent to `--optimizations all`, and
+  not using `--optimizations` is equivalent to `--optimizations none`.
+
+### Fixed
+
+### Changed
+
 ## [0.48.0](https://github.com/returntocorp/semgrep/releases/tag/v0.48.0) - 2021-04-20
 
 ### Added

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -94,6 +94,13 @@ def cli() -> None:
         action="store_true",
         help="Only invoke semgrep if configuration files(s) are valid.",
     )
+    config.add_argument(
+        "--optimizations",
+        nargs="?",
+        const="all",
+        default="none",
+        help="Turn on/off optimizations. Default = 'none'. Use 'all' to turn all optimizations on.",
+    )
 
     parser.add_argument(
         "--exclude",
@@ -325,12 +332,6 @@ def cli() -> None:
         ),
     )
     output.add_argument(
-        "--experimental",
-        action="store_true",
-        help="Pass rules directly to Semgrep core. This will use the logic evaluation available in Semgrep core.",
-    )
-
-    output.add_argument(
         MAX_LINES_FLAG_NAME,
         type=int,
         default=DEFAULT_MAX_LINES_PER_FINDING,
@@ -481,5 +482,5 @@ def cli() -> None:
                 skip_unknown_extensions=args.skip_unknown_extensions,
                 severity=args.severity,
                 report_time=args.json_time,
-                experimental=args.experimental,
+                optimizations=args.optimizations,
             )

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -94,7 +94,7 @@ def cli() -> None:
         action="store_true",
         help="Only invoke semgrep if configuration files(s) are valid.",
     )
-    parser.add_argument(
+    config.add_argument(
         "--optimizations",
         nargs="?",
         const="all",

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -94,7 +94,7 @@ def cli() -> None:
         action="store_true",
         help="Only invoke semgrep if configuration files(s) are valid.",
     )
-    config.add_argument(
+    parser.add_argument(
         "--optimizations",
         nargs="?",
         const="all",

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -550,6 +550,8 @@ class CoreRunner:
         from itertools import chain
         from collections import defaultdict
 
+        logger.debug(f"Passing whole rules directly to semgrep_core")
+
         outputs: Dict[Rule, List[RuleMatch]] = defaultdict(list)
         errors: List[SemgrepError] = []
         # cf. for bar_format: https://tqdm.github.io/docs/tqdm/
@@ -641,7 +643,7 @@ class CoreRunner:
         self,
         target_manager: TargetManager,
         rules: List[Rule],
-        experimental: bool = False,
+        optimizations: str,
     ) -> Tuple[
         Dict[Rule, List[RuleMatch]],
         Dict[Rule, List[Dict[str, Any]]],
@@ -656,6 +658,7 @@ class CoreRunner:
         start = datetime.now()
         profiler = ProfileManager()
 
+        experimental = optimizations == "all"
         runner_fxn = (
             self._run_rules_direct_to_semgrep_core if experimental else self._run_rules
         )

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -183,7 +183,7 @@ def main(
     skip_unknown_extensions: bool = False,
     severity: Optional[List[str]] = None,
     report_time: bool = False,
-    experimental: bool = False,
+    optimizations: str = "none",
 ) -> None:
     if include is None:
         include = []
@@ -264,7 +264,7 @@ The two most popular are:
         timeout_threshold=timeout_threshold,
         report_time=report_time,
     ).invoke_semgrep(
-        target_manager, filtered_rules, experimental
+        target_manager, filtered_rules, optimizations
     )
 
     output_handler.handle_semgrep_errors(semgrep_errors)

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -319,7 +319,7 @@ def generate_file_pairs(
     unsafe: bool,
     json_output: bool,
     save_test_output_tar: bool = True,
-    experimental: bool = False,
+    optimizations: str = "none",
 ) -> None:
     config_filenames = get_config_filenames(config)
     config_test_filenames = get_config_test_filenames(config, config_filenames, target)
@@ -334,7 +334,7 @@ def generate_file_pairs(
         no_rewrite_rule_ids=True,
         strict=strict,
         dangerously_allow_arbitrary_code_execution_from_rules=unsafe,
-        experimental=experimental,
+        optimizations=optimizations,
     )
     with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
         results = pool.starmap(invoke_semgrep_fn, config_with_tests)
@@ -467,5 +467,5 @@ def test_main(args: argparse.Namespace) -> None:
         args.dangerously_allow_arbitrary_code_execution_from_rules,
         args.json,
         args.save_test_output_tar,
-        experimental=args.experimental,
+        args.optimizations,
     )


### PR DESCRIPTION
This will allow us to advertize --experimental to users with a
more stable command-line flag.

test plan:
```
$ semgrep --optimizations --config
ocaml/lang/correctness/useless_if.yaml ocaml/lang/correctness/ --debug
...
Passing whole rules directly to semgrep_core
...

$ semgrep --optimizations none --config
ocaml/lang/correctness/useless_if.yaml ocaml/lang/correctness/ --debug
...

```




PR checklist:
- [x] changelog is up to date