### PR TITLE
ci: run brew release after pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,7 @@ jobs:
 
   homebrew-core-pr:
     name: Update on Homebrew-Core
+    needs: [upload-wheels]  # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-latest
     steps:
       - name: Brew update


### PR DESCRIPTION
brew bump-formula-pr checks pypi for the new semgrep version
to see if pypi dependency hashes in the formula need to be updated
because of this the homebrew-core PR can only be created after the
pypi wheel has already been uploaded.

This PR moves the homebrew-pr job to run after the pypi release job



PR checklist:
- [ ] changelog is up to date

