### PR TITLE
Add: ignore .git directories when resolving targets to scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - JS/TS: Infer global constants even if the `const` qualifier is missing (#2978)
 
 ### Fixed
+
 ### Changed
+- .git/ directories are ignored when scanning
 
 ## [0.49.0](https://github.com/returntocorp/semgrep/releases/tag/v0.49.0) - 2021-04-28
 

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -230,9 +230,6 @@ class TargetManager:
 
         files, directories = partition_set(lambda p: not p.is_dir(), targets)
 
-        # Filter out .git directories
-        directories = set(d for d in directories if d.resolve().name != ".git")
-
         # Error on non-existent files
         explicit_files, nonexistent_files = partition_set(lambda p: p.is_file(), files)
         if nonexistent_files:
@@ -242,7 +239,7 @@ class TargetManager:
 
         targets = self.expand_targets(directories, lang, self.respect_git_ignore)
         targets = self.filter_includes(targets, self.includes)
-        targets = self.filter_excludes(targets, self.excludes)
+        targets = self.filter_excludes(targets, self.excludes + [".git"])
 
         # Remove explicit_files with known extensions.
         explicit_files_with_lang_extension = set(

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -220,6 +220,8 @@ class TargetManager:
         match any pattern in EXCLUDES. Any file in TARGET bypasses excludes and includes.
         If a file in TARGET has a known extension that is not for langugage LANG then
         it is also filtered out
+
+        Note also filters out any directory and decendants of `.git`
         """
         if lang in self._filtered_targets:
             return self._filtered_targets[lang]
@@ -227,6 +229,9 @@ class TargetManager:
         targets = self.resolve_targets(self.targets)
 
         files, directories = partition_set(lambda p: not p.is_dir(), targets)
+
+        # Filter out .git directories
+        directories = set(d for d in directories if d.resolve().name != ".git")
 
         # Error on non-existent files
         explicit_files, nonexistent_files = partition_set(lambda p: p.is_file(), files)

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -386,6 +386,33 @@ def test_skip_symlink(tmp_path, monkeypatch):
     )
 
 
+def test_ignore_git_dir(tmp_path, monkeypatch):
+    """
+    Ignores all files in .git directory when scanning generic
+    """
+    foo = tmp_path / ".git"
+    foo.mkdir()
+    (foo / "bar").touch()
+
+    monkeypatch.chdir(tmp_path)
+    language = Language("generic")
+    output_settings = OutputSettings(
+        output_format=OutputFormat.TEXT,
+        output_destination=None,
+        error_on_findings=False,
+        verbose_errors=False,
+        strict=False,
+        json_stats=False,
+        json_time=False,
+        output_per_finding_max_lines_limit=None,
+        output_per_line_max_chars_limit=None,
+    )
+    defaulthandler = OutputHandler(output_settings)
+    assert [] == TargetManager([], [], [foo], True, defaulthandler, False).get_files(
+        language, [], []
+    )
+
+
 def test_explicit_path(tmp_path, monkeypatch):
     foo = tmp_path / "foo"
     foo.mkdir()


### PR DESCRIPTION
.git directory contains a lot of objects that semgrep does not need
to scan. Because generic language can potentially scan any file with
any extension it does end up scanning the large object files in the .git
directory. This is normally not a problem since we only scan files that
are tracked by git but if `--no-git-ignore` flag is set it will end up scaning
the .git directory. With this PR, generic langauage should see a speed \
up when running on a directory with .git folders with `--no-git-ignore`



PR checklist:
- [x] changelog is up to date

