### PR TITLE
Fix 'make'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN git submodule foreach --recursive git clean -dfX
 
 RUN git submodule update --init --recursive --depth 1
 
-RUN eval "$(opam env)" && ./scripts/install-ocaml-tree-sitter
+RUN eval "$(opam env)" && ./scripts/install-tree-sitter-runtime
 RUN eval "$(opam env)" && opam install --deps-only -y spacegrep/
 RUN eval "$(opam env)" && opam install --deps-only -y semgrep-core/src/pfff/
 RUN eval "$(opam env)" && opam install --deps-only -y semgrep-core/

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,8 @@ install:
 	python3 -m pip install semgrep
 
 .PHONY: build-core
-build-core: build-ocaml-tree-sitter
+build-core:
 	$(MAKE) -C semgrep-core
-
-.PHONY: build-ocaml-tree-sitter
-build-ocaml-tree-sitter:
-	$(MAKE) -C ocaml-tree-sitter
-	$(MAKE) -C ocaml-tree-sitter install
 
 .PHONY: build-spacegrep
 build-spacegrep:

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ rebuild:
 setup:
 	git submodule update --init
 	opam update -y
-	./scripts/install-ocaml-tree-sitter
+	./scripts/install-tree-sitter-runtime
 	opam install -y --deps-only ./semgrep-core/src/pfff
 	opam install -y --deps-only ./semgrep-core
 	opam install -y --deps-only ./spacegrep

--- a/scripts/install-alpine-semgrep-core
+++ b/scripts/install-alpine-semgrep-core
@@ -37,8 +37,8 @@ sudo apk add --no-cache m4 pcre-dev
 echo "Install submodules"
 git submodule update --init --recursive --depth 1
 
-echo "Install ocaml-tree-sitter"
-./scripts/install-ocaml-tree-sitter
+echo "Install tree-sitter runtime and prepare ocaml-tree-sitter source"
+./scripts/install-tree-sitter-runtime
 
 echo "Install spacegrep"
 (

--- a/scripts/install-tree-sitter-runtime
+++ b/scripts/install-tree-sitter-runtime
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 #
-# Install tree-sitter's and ocaml-tree-sitter's runtime libraries.
+# Install tree-sitter's runtime library and inject ocaml-tree-sitter's
+# runtime code to be built with semgrep-core.
 #
 set -eu
 


### PR DESCRIPTION
This removes the step that used to build ocaml-tree-sitter from the main makefile (makefile intended primarily for manual use) since the ocaml-tree-sitter runtime library is now part of the semgrep-core dune build.

PR checklist:
- [x] changelog is up to date

