### PR TITLE
Report single number capturing semgrep performance

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -29,6 +29,7 @@ import semgrep_core_benchmark  # type: ignore
 DASHBOARD_URL = "https://dashboard.semgrep.dev"
 STATS_URL = "https://stats.semgrep.dev"
 BPS_ENDPOINT = "semgrep.perf.bps"
+LPS_ENDPOINT = "semgrep.perf.lps"
 
 STD = "std"
 
@@ -257,10 +258,23 @@ def upload_result(
         assert "rules" in timings
         assert "total_time" in timings
         assert "total_bytes" in timings
-        bps = timings["total_bytes"] / (timings["total_time"] * len(timings["rules"]))
+        num_rules = len(timings["rules"])
+        bps = timings["total_bytes"] / (timings["total_time"] * num_rules)
 
         bps_url = f"{DASHBOARD_URL}/api/metric/{BPS_ENDPOINT}"
         upload(bps_url, str(bps))
+
+        # Similarly, compute lps
+        assert "targets" in timings
+        num_lines = 0
+        for target in timings["targets"]:
+            assert "path" in target
+            with open(target["path"]) as f:
+                num_lines += sum(1 for _ in f)
+        lps = num_lines / (timings["total_time"] * num_rules)
+
+        lps_url = f"{DASHBOARD_URL}/api/metric/{LPS_ENDPOINT}"
+        upload(lps_url, str(lps))
 
         # Upload timing data as a json
         print(f"Uploading timing data to {STATS_URL}")

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -30,6 +30,8 @@ DASHBOARD_URL = "https://dashboard.semgrep.dev"
 STATS_URL = "https://stats.semgrep.dev"
 BPS_ENDPOINT = "semgrep.perf.bps"
 
+STD = "std"
+
 # Run command and propagate errors
 def cmd(*args: str) -> None:
     subprocess.run(args, check=True)  # nosem
@@ -159,7 +161,7 @@ class SemgrepVariant:
 #
 SEMGREP_VARIANTS = [
     # default settings
-    SemgrepVariant("std", ""),
+    SemgrepVariant(STD, ""),
     # removing optimisations
     SemgrepVariant("no-cache", "-no_opt_cache"),
     SemgrepVariant("max-cache", "-opt_max_cache"),
@@ -174,7 +176,7 @@ SEMGREP_VARIANTS = [
 ]
 
 # For when you just want to test a single change
-STD_VARIANTS = [SemgrepVariant("std", "")]
+STD_VARIANTS = [SemgrepVariant(STD, "")]
 
 
 # This class allows us to put semgrep results in a set and compute set
@@ -243,25 +245,30 @@ def upload(url: str, value: str) -> None:
     print(r.read().decode())
 
 
-def upload_result(metric_name: str, value: float, timings: dict) -> None:
+def upload_result(
+    variant_name: str, metric_name: str, value: float, timings: dict
+) -> None:
     # Upload overall runtime of the benchmark
     metric_url = f"{DASHBOARD_URL}/api/metric/{metric_name}"
     upload(metric_url, str(value))
 
-    # Compute bps from semgrep timing data
-    assert "rules" in timings
-    assert "total_time" in timings
-    assert "total_bytes" in timings
-    bps = timings["total_bytes"] / (timings["total_time"] * len(timings["rules"]))
+    if variant_name == STD:
+        # Compute bps from semgrep timing data
+        assert "rules" in timings
+        assert "total_time" in timings
+        assert "total_bytes" in timings
+        bps = timings["total_bytes"] / (timings["total_time"] * len(timings["rules"]))
 
-    bps_url = f"{DASHBOARD_URL}/api/metric/{BPS_ENDPOINT}"
-    upload(bps_url, str(bps))
+        bps_url = f"{DASHBOARD_URL}/api/metric/{BPS_ENDPOINT}"
+        upload(bps_url, str(bps))
 
-    # Upload timing data as a json
-    print(f"Uploading timing data to {STATS_URL}")
-    headers = {"content-type": "application/json"}
-    r = requests.post(STATS_URL, data=json.dumps(timings), headers=headers, timeout=30)
-    print(r.content)
+        # Upload timing data as a json
+        print(f"Uploading timing data to {STATS_URL}")
+        headers = {"content-type": "application/json"}
+        r = requests.post(
+            STATS_URL, data=json.dumps(timings), headers=headers, timeout=30
+        )
+        print(r.content)
 
 
 def standardize_findings(findings: dict) -> Tuple[dict, dict]:
@@ -426,14 +433,14 @@ def run_benchmarks(
                 findings, timings = standardize_findings(json.loads(findings_bytes))
 
                 if upload:
-                    upload_result(metric_name, duration, timings)
+                    upload_result(variant.name, metric_name, duration, timings)
 
                 # Check correctness
                 num_results = len(findings["results"])
                 num_errors = len(findings["errors"])
                 print(f"Result: {num_results} findings, {num_errors} parse errors")
 
-                if variant.name == "std":
+                if variant.name == STD:
                     std_findings = findings
                 elif findings["results"] ^ std_findings["results"] != set():
                     fd_len, sd_len = output_differences(

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -270,7 +270,10 @@ def upload_result(
         for target in timings["targets"]:
             assert "path" in target
             with open(target["path"]) as f:
-                num_lines += sum(1 for _ in f)
+                try:
+                    num_lines += sum(1 for _ in f)
+                except UnicodeDecodeError:
+                    pass
         lps = num_lines / (timings["total_time"] * num_rules)
 
         lps_url = f"{DASHBOARD_URL}/api/metric/{LPS_ENDPOINT}"

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -23,9 +23,12 @@ from contextlib import contextmanager
 from typing import Iterator
 from typing import Tuple
 
+import requests
 import semgrep_core_benchmark  # type: ignore
 
 DASHBOARD_URL = "https://dashboard.semgrep.dev"
+STATS_URL = "https://stats.semgrep.dev"
+BPS_ENDPOINT = "semgrep.perf.bps"
 
 # Run command and propagate errors
 def cmd(*args: str) -> None:
@@ -231,27 +234,52 @@ def chdir(dir: str) -> Iterator[None]:
         os.chdir(old_dir)
 
 
-def upload_result(metric_name: str, value: float) -> None:
-    url = f"{DASHBOARD_URL}/api/metric/{metric_name}"
+def upload(url: str, value: str) -> None:
     print(f"Uploading to {url}")
     r = urllib.request.urlopen(  # nosem
         url=url,
-        data=str(value).encode("ascii"),
+        data=value.encode("ascii"),
     )
     print(r.read().decode())
 
 
-def standardize_findings(findings: dict) -> dict:
+def upload_result(metric_name: str, value: float, timings: dict) -> None:
+    # Upload overall runtime of the benchmark
+    metric_url = f"{DASHBOARD_URL}/api/metric/{metric_name}"
+    upload(metric_url, str(value))
+
+    # Compute bps from semgrep timing data
+    assert "rules" in timings
+    assert "total_time" in timings
+    assert "total_bytes" in timings
+    bps = timings["total_bytes"] / (timings["total_time"] * len(timings["rules"]))
+
+    bps_url = f"{DASHBOARD_URL}/api/metric/{BPS_ENDPOINT}"
+    upload(bps_url, str(bps))
+
+    # Upload timing data as a json
+    print(f"Uploading timing data to {STATS_URL}")
+    headers = {"content-type": "application/json"}
+    r = requests.post(STATS_URL, data=json.dumps(timings), headers=headers, timeout=30)
+    print(r.content)
+
+
+def standardize_findings(findings: dict) -> Tuple[dict, dict]:
     if "errors" not in findings:
         msg = json.dumps(findings, indent=4) + "\n\nDid not find expected key 'errors'"
         raise Exception(msg)
     if "results" not in findings:
         msg = json.dumps(findings, indent=4) + "\n\nDid not find expected key 'results'"
         raise Exception(msg)
-    return {
+    if "time" not in findings:
+        msg = json.dumps(findings, indent=4) + "\n\nDid not find expected key 'time'"
+        raise Exception(msg)
+    results = {
         "errors": findings["errors"],
         "results": {SemgrepResult(i) for i in findings["results"]},
     }
+    timings = findings["time"]
+    return results, timings
 
 
 def output_differences(
@@ -279,6 +307,7 @@ def run_semgrep(
     common_args = [
         "--strict",
         "--json",
+        "--json-time",
         "--timeout",
         "0",
         "--verbose",
@@ -394,12 +423,12 @@ def run_benchmarks(
                 durations += f"{duration:.3f}\n"
                 results[variant.name].append(duration)
 
+                findings, timings = standardize_findings(json.loads(findings_bytes))
+
                 if upload:
-                    upload_result(metric_name, duration)
+                    upload_result(metric_name, duration, timings)
 
                 # Check correctness
-                findings = standardize_findings(json.loads(findings_bytes))
-
                 num_results = len(findings["results"])
                 num_errors = len(findings["errors"])
                 print(f"Result: {num_results} findings, {num_errors} parse errors")

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -642,6 +642,7 @@ class CoreRunner:
     def invoke_semgrep(
         self,
         target_manager: TargetManager,
+        profiler: ProfileManager,
         rules: List[Rule],
         optimizations: str,
     ) -> Tuple[
@@ -649,14 +650,12 @@ class CoreRunner:
         Dict[Rule, List[Dict[str, Any]]],
         List[SemgrepError],
         Set[Path],
-        ProfileManager,
         Dict[Tuple[str, str], float],
     ]:
         """
         Takes in rules and targets and retuns object with findings
         """
         start = datetime.now()
-        profiler = ProfileManager()
 
         experimental = optimizations == "all"
         runner_fxn = (
@@ -687,7 +686,6 @@ class CoreRunner:
             debug_steps_by_rule,
             errors,
             all_targets,
-            profiler,
             match_time_matrix,
         )
 

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -231,7 +231,7 @@ def _build_time_json(
     the target file will become negligible once we run many rules on the
     same AST.
     """
-    time_info = {}
+    time_info: Dict[str, Any] = {}
     # this list of all rules names is given here so they don't have to be
     # repeated for each target in the 'targets' field, saving space.
     time_info["rules"] = [{"id": rule.id} for rule in rules]

--- a/semgrep/semgrep/profile_manager.py
+++ b/semgrep/semgrep/profile_manager.py
@@ -18,5 +18,10 @@ class ProfileManager:
         self.calls[key].append(time.time() - start_time)
         return result
 
+    # This method is an even more rudimentary tool for profiling
+    # function calls
+    def save(self, key: str, start_time: float) -> Any:
+        self.calls[key].append(time.time() - start_time)
+
     def dump_stats(self) -> Dict[str, List[float]]:
         return dict(sorted(self.calls.items(), key=lambda x: x[1]))

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from io import StringIO
 from pathlib import Path
 from re import sub
@@ -22,6 +23,7 @@ from semgrep.error import MISSING_CONFIG_EXIT_CODE
 from semgrep.error import SemgrepError
 from semgrep.output import OutputHandler
 from semgrep.output import OutputSettings
+from semgrep.profile_manager import ProfileManager
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.target_manager import TargetManager
@@ -249,13 +251,15 @@ The two most popular are:
         skip_unknown_extensions=skip_unknown_extensions,
     )
 
+    profiler = ProfileManager()
+
+    start_time = time.time()
     # actually invoke semgrep
     (
         rule_matches_by_rule,
         debug_steps_by_rule,
         semgrep_errors,
         all_targets,
-        profiler,
         match_time_matrix,
     ) = CoreRunner(
         allow_exec=dangerously_allow_arbitrary_code_execution_from_rules,
@@ -265,8 +269,9 @@ The two most popular are:
         timeout_threshold=timeout_threshold,
         report_time=report_time,
     ).invoke_semgrep(
-        target_manager, filtered_rules, optimizations
+        target_manager, profiler, filtered_rules, optimizations
     )
+    profiler.save("total_time", start_time)
 
     output_handler.handle_semgrep_errors(semgrep_errors)
 

--- a/semgrep/semgrep/spacegrep.py
+++ b/semgrep/semgrep/spacegrep.py
@@ -22,7 +22,11 @@ def _extract_matching_time(json: Dict[str, Any]) -> float:
 
     It is expected to have run a single pattern on a single target.
     """
-    if "time" in json:
+    if (
+        "time" in json
+        and "targets" in json["time"]
+        and len(json["time"]["targets"]) > 0
+    ):
         res = json["time"]["targets"][0]["match_time"]
         if isinstance(res, float) or isinstance(res, int):
             return res


### PR DESCRIPTION
On each run, compute bytes per second using total_bytes/(total_time * num_rules) and post that. Also post the entire json-time object

Test plan: perf/run-benchmarks --dummy --upload --filter-variant std
Full test: ../perf/run-benchmarks --upload --filter-variant std



PR checklist:
- [x] changelog is up to date

