### PR TITLE
Parse empty yaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - JS/TS: Infer global constants even if the `const` qualifier is missing (#2978)
 
 ### Fixed
+- Empty yaml files do not crash
+
 ### Changed
 
 ## [0.49.0](https://github.com/returntocorp/semgrep/releases/tag/v0.49.0) - 2021-04-28


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/2981

Test plan: 
```
touch empty.yaml
sc -f tests/generic/metavar_stmt.sgrep empty.yaml -lang yaml
```

Should return nothing and not crash

PR checklist:
- [x] changelog is up to date

