### PR TITLE
Add types for profiling structure

### DIFF
--- a/semgrep-core/src/core/Reporting.ml
+++ b/semgrep-core/src/core/Reporting.ml
@@ -1,0 +1,12 @@
+type profiling = {
+  file: Common.filename;
+  parse_time: float;
+  match_time: float;
+  run_time: float;
+}
+
+type match_result = {
+  matches: Pattern_match.t list;
+  errors: Error_code.error list;
+  profiling: profiling;
+}

--- a/semgrep-core/src/core/Reporting.ml
+++ b/semgrep-core/src/core/Reporting.ml
@@ -1,3 +1,5 @@
+(* Full result information *)
+
 type profiling = {
   file: Common.filename;
   parse_time: float;
@@ -5,8 +7,55 @@ type profiling = {
   run_time: float;
 }
 
-type match_result = {
+(* Partial result information *)
+(* To store match/parse information before total run_time for the *)
+(* rule-file pair is computed *)
+
+type partial_profiling = {
+  file: Common.filename;
+  parse_time: float;
+  match_time: float;
+}
+
+(* To store only time information, as semgrep.check reports *)
+type times = {
+  parse_time: float;
+  match_time: float
+}
+
+(* Substitute in the profiling type we have *)
+
+type 'a match_result = {
   matches: Pattern_match.t list;
   errors: Error_code.error list;
-  profiling: profiling;
+  profiling: 'a;
 }
+
+(* Create empty versions of match results *)
+
+let empty_partial_profiling file =
+  { file; parse_time=0.0; match_time=0.0 }
+
+let empty_semgrep_result = { matches=[]; errors=[]; profiling = { parse_time=0.0; match_time=0.0} }
+
+(* Augment reported information with additional info *)
+
+let add_run_time run_time { matches; errors; profiling = {file; parse_time; match_time} } =
+  { matches; errors; profiling = {file; parse_time; match_time; run_time} }
+
+let add_file file { matches; errors; profiling = {parse_time; match_time} } =
+  { matches; errors; profiling = {file; parse_time; match_time} }
+
+(* Aggregate a list of semgrep results into one returned object *)
+
+let collate_semgrep_results results =
+  let unzip_results l =
+    let rec unzip all_matches all_errors all_parse_time all_match_time = function
+      | {matches; errors; profiling = {parse_time; match_time}} :: l ->
+          unzip (matches :: all_matches) (errors :: all_errors) (parse_time +. all_parse_time) (match_time +. all_match_time) l
+      | [] -> List.rev all_matches, List.rev all_errors, all_parse_time, all_match_time
+    in
+    unzip [] [] 0.0 0.0 l
+  in
+  let matches, errors, parse_time, match_time = unzip_results results in
+  { matches = List.flatten matches; errors = List.flatten errors; profiling = {parse_time; match_time}}

--- a/semgrep-core/src/core/Reporting.mli
+++ b/semgrep-core/src/core/Reporting.mli
@@ -1,3 +1,5 @@
+(* Full result information *)
+
 type profiling = {
   file: Common.filename;
   parse_time: float;
@@ -5,8 +7,36 @@ type profiling = {
   run_time: float;
 }
 
-type match_result = {
+(* Partial result information *)
+(* To store match/parse information before total run_time for the *)
+(* rule-file pair is computed *)
+
+type partial_profiling = {
+  file: Common.filename;
+  parse_time: float;
+  match_time: float;
+}
+
+(* To store only time information, as semgrep.check reports *)
+type times = {
+  parse_time: float;
+  match_time: float
+}
+
+(* Substitute in the profiling type we have *)
+
+type 'a match_result = {
   matches: Pattern_match.t list;
   errors: Error_code.error list;
-  profiling: profiling;
+  profiling: 'a;
 }
+
+val empty_partial_profiling : Common.filename -> partial_profiling
+
+val empty_semgrep_result : times match_result
+
+val add_run_time : float -> partial_profiling match_result -> profiling match_result
+
+val add_file : Common.filename -> times match_result -> partial_profiling match_result
+
+val collate_semgrep_results : times match_result list -> times match_result

--- a/semgrep-core/src/core/Reporting.mli
+++ b/semgrep-core/src/core/Reporting.mli
@@ -1,0 +1,12 @@
+type profiling = {
+  file: Common.filename;
+  parse_time: float;
+  match_time: float;
+  run_time: float;
+}
+
+type match_result = {
+  matches: Pattern_match.t list;
+  errors: Error_code.error list;
+  profiling: profiling;
+}

--- a/semgrep-core/src/engine/Semgrep.mli
+++ b/semgrep-core/src/engine/Semgrep.mli
@@ -8,6 +8,6 @@ val check:
   Config_semgrep.t ->
   Rule.rules ->
   (Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t) ->
-  Rule_match.t list * Error_code.error list * float * float
+  Reporting.times Reporting.match_result
 
 (*e: semgrep/engine/Semgrep.mli *)

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -24,6 +24,7 @@ module R = Mini_rule (* TODO: use MR instead *)
 module E = Error_code
 module J = JSON
 module MV = Metavariable
+module RP = Reporting
 
 open Pattern_match
 
@@ -171,32 +172,32 @@ let match_to_json x =
 
 
 
-let json_time_of_match_times match_times =
+let json_time_of_profiling_data profiling_data =
   [
     "time", J.Object [
       "targets", J.Array (
-        List.map (fun (target, parse_time, match_time, run_time) ->
+        List.map (fun { RP.file = target; times = {parse_time; match_time; run_time } } ->
           J.Object [
             "path", J.String target;
             "parse_time", J.Float parse_time;
             "match_time", J.Float match_time;
             "run_time", J.Float run_time;
           ]
-        ) match_times
+        ) profiling_data
       )
     ]
   ]
 
-let json_fields_of_matches_and_errors files matches errs opt_match_times =
+let json_fields_of_matches_and_errors files matches errs opt_profiling_data =
   let (matches, new_errs) =
     Common.partition_either match_to_json matches in
   let errs = new_errs @ errs in
   let count_errors = (List.length errs) in
   let count_ok = (List.length files) - count_errors in
   let time_field =
-    match opt_match_times with
+    match opt_profiling_data with
     | None -> []
-    | Some x -> json_time_of_match_times x
+    | Some x -> json_time_of_profiling_data x
   in
   [ "matches", J.Array (matches);
     "errors", J.Array (errs |> List.map R2c.error_to_json);

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -176,7 +176,7 @@ let json_time_of_profiling_data profiling_data =
   [
     "time", J.Object [
       "targets", J.Array (
-        List.map (fun { RP.file = target; times = {parse_time; match_time; run_time } } ->
+        List.map (fun { RP.file = target; parse_time; match_time; run_time } ->
           J.Object [
             "path", J.String target;
             "parse_time", J.Float parse_time;

--- a/semgrep-core/src/reporting/JSON_report.mli
+++ b/semgrep-core/src/reporting/JSON_report.mli
@@ -15,7 +15,7 @@ val json_of_exn: exn -> JSON.t
 val json_fields_of_matches_and_errors:
   Common.filename list ->
   Pattern_match.t list -> Error_code.error list ->
-  (string * float * float * float) list option ->
+  Reporting.profiling list option ->
   (string * JSON.t) list
 
 (*s: signature [[JSON_report.match_to_error]] *)

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -265,6 +265,11 @@ def cli() -> None:
         ),
     )
     output.add_argument(
+        "--json-time",
+        action="store_true",
+        help=("The same as --time, included for backwards compatibility"),
+    )
+    output.add_argument(
         "--debugging-json",
         action="store_true",
         help="Output JSON with extra debugging information (experimental).",
@@ -491,6 +496,6 @@ def cli() -> None:
                 timeout_threshold=args.timeout_threshold,
                 skip_unknown_extensions=args.skip_unknown_extensions,
                 severity=args.severity,
-                report_time=args.time,
+                report_time=args.time or args.json_time,
                 optimizations=args.optimizations,
             )

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -15,7 +15,6 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 from typing import Set
-from typing import Tuple
 
 import colorama
 
@@ -36,6 +35,7 @@ from semgrep.error import SemgrepError
 from semgrep.external.junit_xml import TestSuite  # type: ignore[attr-defined]
 from semgrep.external.junit_xml import to_xml_report_string  # type: ignore[attr-defined]
 from semgrep.profile_manager import ProfileManager
+from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.stats import make_loc_stats
@@ -150,7 +150,7 @@ def truncate(file_name: str, col_lim: int) -> str:
 def build_timing_summary(
     rules: List[Rule],
     targets: Set[Path],
-    match_time_matrix: Dict[Tuple[str, str], Tuple[float, float, float]],
+    profiling_data: ProfilingData,
     color_output: bool,
 ) -> Iterator[str]:
     items_to_show = 5
@@ -166,17 +166,16 @@ def build_timing_summary(
         rule_timings[rule.id] = (0.0, 0.0)
         for target in targets:
             path_str = str(target)
-            (parsing_time, matching_time, run_time) = match_time_matrix.get(
-                (rule.id, path_str), (0.0, 0.0, 0.0)
-            )
+            times = profiling_data.get_times(rule.id, path_str)
             rule_timings[rule.id] = tuple(
                 x + y
                 for x, y in zip(
-                    rule_timings[rule.id], (run_time - parsing_time, matching_time)
+                    rule_timings[rule.id],
+                    (times.run_time - times.parse_time, times.match_time),
                 )
             )  # type: ignore
-            file_timings[path_str] = file_timings.get(path_str, 0.0) + run_time
-            total_parsing_time += parsing_time
+            file_timings[path_str] = file_timings.get(path_str, 0.0) + times.run_time
+            total_parsing_time += times.parse_time
     all_total_time = sum(i for i in file_timings.values())
     total_matching_time = sum(i[1] for i in rule_timings.values())
 
@@ -211,7 +210,7 @@ def build_normal_output(
     all_targets: Set[Path],
     show_times: bool,
     filtered_rules: List[Rule],
-    match_time_matrix: Dict[Tuple[str, str], Tuple[float, float, float]],
+    profiling_data: ProfilingData,
 ) -> Iterator[str]:
     RESET_COLOR = colorama.Style.RESET_ALL if color_output else ""
     GREEN_COLOR = colorama.Fore.GREEN if color_output else ""
@@ -275,7 +274,7 @@ def build_normal_output(
             yield f"{BLUE_COLOR}autofix:{RESET_COLOR} s/{fix_regex.get('regex')}/{fix_regex.get('replacement')}/{fix_regex.get('count', 'g')}"
     if show_times:
         yield from build_timing_summary(
-            filtered_rules, all_targets, match_time_matrix, color_output
+            filtered_rules, all_targets, profiling_data, color_output
         )
 
 
@@ -283,19 +282,17 @@ def _build_time_target_json(
     rules: List[Rule],
     target: Path,
     num_bytes: int,
-    match_time_matrix: Dict[Tuple[str, str], Tuple[float, float, float]],
+    profiling_data: ProfilingData,
 ) -> Dict[str, Any]:
     target_json: Dict[str, Any] = {}
     path_str = str(target)
 
     target_json["path"] = path_str
     target_json["num_bytes"] = num_bytes
-    timings = [
-        match_time_matrix.get((rule.id, path_str), (0.0, 0.0, 0.0)) for rule in rules
-    ]
-    target_json["parse_times"] = [timing[0] for timing in timings]
-    target_json["match_times"] = [timing[1] for timing in timings]
-    target_json["run_times"] = [timing[2] for timing in timings]
+    timings = [profiling_data.get_times(rule.id, path_str) for rule in rules]
+    target_json["parse_times"] = [timing.parse_time for timing in timings]
+    target_json["match_times"] = [timing.match_time for timing in timings]
+    target_json["run_times"] = [timing.run_time for timing in timings]
 
     return target_json
 
@@ -303,9 +300,7 @@ def _build_time_target_json(
 def _build_time_json(
     rules: List[Rule],
     targets: Set[Path],
-    match_time_matrix: Dict[
-        Tuple[str, str], Tuple[float, float, float]
-    ],  # (rule, target) -> duration
+    profiling_data: ProfilingData,  # (rule, target) -> times
     total_time: float,
 ) -> Dict[str, Any]:
     """Convert match times to a json-ready format.
@@ -323,7 +318,7 @@ def _build_time_json(
     time_info["total_time"] = total_time
     target_bytes = [Path(str(target)).resolve().stat().st_size for target in targets]
     time_info["targets"] = [
-        _build_time_target_json(rules, target, num_bytes, match_time_matrix)
+        _build_time_target_json(rules, target, num_bytes, profiling_data)
         for target, num_bytes in zip(targets, target_bytes)
     ]
     time_info["total_bytes"] = sum(n for n in target_bytes)
@@ -337,7 +332,7 @@ def build_output_json(
     show_json_stats: bool,
     report_time: bool,
     filtered_rules: List[Rule],
-    match_time_matrix: Dict[Tuple[str, str], Tuple[float, float, float]],
+    profiling_data: ProfilingData,
     profiler: Optional[ProfileManager] = None,
     debug_steps_by_rule: Optional[Dict[Rule, List[Dict[str, Any]]]] = None,
 ) -> str:
@@ -357,7 +352,7 @@ def build_output_json(
     if report_time:
         total_time = profiler.calls["total_time"][0] if profiler else -1.0
         output_json["time"] = _build_time_json(
-            filtered_rules, all_targets, match_time_matrix, total_time
+            filtered_rules, all_targets, profiling_data, total_time
         )
     return json.dumps(output_json)
 
@@ -546,9 +541,9 @@ class OutputHandler:
         self.error_set: Set[SemgrepError] = set()
         self.has_output = False
         self.filtered_rules: List[Rule] = []
-        self.match_time_matrix: Dict[
-            Tuple[str, str], Tuple[float, float, float]
-        ] = {}  # (rule, target) -> duration
+        self.profiling_data: ProfilingData = (
+            ProfilingData()
+        )  # (rule, target) -> duration
 
         self.final_error: Optional[Exception] = None
 
@@ -609,9 +604,7 @@ class OutputHandler:
         all_targets: Set[Path],
         profiler: ProfileManager,
         filtered_rules: List[Rule],
-        match_time_matrix: Dict[
-            Tuple[str, str], Tuple[float, float, float]
-        ],  # (rule, target) -> duration
+        profiling_data: ProfilingData,  # (rule, target) -> duration
     ) -> None:
         self.has_output = True
         self.rules = self.rules.union(rule_matches_by_rule.keys())
@@ -625,7 +618,7 @@ class OutputHandler:
         self.stats_line = stats_line
         self.debug_steps_by_rule.update(debug_steps_by_rule)
         self.filtered_rules = filtered_rules
-        self.match_time_matrix = match_time_matrix
+        self.profiling_data = profiling_data
 
     def handle_unhandled_exception(self, ex: Exception) -> None:
         """
@@ -739,7 +732,7 @@ class OutputHandler:
                 self.settings.json_stats,
                 self.settings.output_time,
                 self.filtered_rules,
-                self.match_time_matrix,
+                self.profiling_data,
                 self.profiler,
                 debug_steps,
             )
@@ -764,7 +757,7 @@ class OutputHandler:
                         self.all_targets,
                         self.settings.output_time,
                         self.filtered_rules,
-                        self.match_time_matrix,
+                        self.profiling_data,
                     )
                 )
             )

--- a/semgrep/semgrep/profiling.py
+++ b/semgrep/semgrep/profiling.py
@@ -1,0 +1,22 @@
+from typing import Dict
+from typing import NamedTuple
+
+Semgrep_run = NamedTuple("Semgrep_run", [("rule", str), ("target", str)])
+
+Times = NamedTuple(
+    "Times", [("parse_time", float), ("match_time", float), ("run_time", float)]
+)
+
+
+class ProfilingData:
+    def __init__(self) -> None:
+        self._match_time_matrix: Dict[Semgrep_run, Times] = {}
+
+    def get_times(self, rule: str, target: str) -> Times:
+        return self._match_time_matrix.get(
+            Semgrep_run(rule=rule, target=target),
+            Times(parse_time=0.0, match_time=0.0, run_time=0.0),
+        )
+
+    def set_times(self, rule: str, target: str, times: Times) -> None:
+        self._match_time_matrix[Semgrep_run(rule=rule, target=target)] = times

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -234,7 +234,7 @@ The two most popular are:
         debug_steps_by_rule,
         semgrep_errors,
         all_targets,
-        match_time_matrix,
+        profiling_data,
     ) = CoreRunner(
         allow_exec=dangerously_allow_arbitrary_code_execution_from_rules,
         jobs=jobs,
@@ -275,7 +275,7 @@ The two most popular are:
         all_targets,
         profiler,
         filtered_rules,
-        match_time_matrix,
+        profiling_data,
     )
 
     if autofix:


### PR DESCRIPTION
On the OCaml and the Python side, refactor to use a type for the result reporting and the profile data, respectively. Also, add --json-time to ensure backwards compatibility

Closes https://github.com/returntocorp/semgrep/issues/3036

PR checklist:
- [x] changelog is up to date

