### PR TITLE
Remove '--debugging-json' and '--json-time' in favor of their equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `OutputSettings.json_time` has moved to `OutputSettings.output_time`,
   this and many other `OutputSettings` arguments have been made optional
 
+### Removed
+- `--debugging-json` flag in favor of `--json` + `--debug`
+- `--json-time` flag in favor of `--json` + `--time`
+
 ## [0.49.0](https://github.com/returntocorp/semgrep/releases/tag/v0.49.0) - 2021-04-28
 
 ### Added

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -251,28 +251,12 @@ def cli() -> None:
         ),
     )
     output.add_argument(
-        "--json-stats",
-        action="store_true",
-        help=argparse.SUPPRESS,  # this flag is experimental and users should not yet rely on the output being stable
-        # help="Include statistical information about performance in JSON output (experimental).",
-    )
-    output.add_argument(
         "--time",
         action="store_true",
         help=(
             "Include a timing summary with the results"
             "If output format is json, provides times for each pair (rule, target)."
         ),
-    )
-    output.add_argument(
-        "--json-time",
-        action="store_true",
-        help=("The same as --time, included for backwards compatibility"),
-    )
-    output.add_argument(
-        "--debugging-json",
-        action="store_true",
-        help="Output JSON with extra debugging information (experimental).",
     )
     output.add_argument(
         "--junit-xml", action="store_true", help="Output results in JUnit XML format."
@@ -387,6 +371,27 @@ def cli() -> None:
         help="Disable checking for latest version.",
     )
 
+    # These flags are deprecated or experimental - users should not
+    # rely on their existence, or their output being stable
+    output.add_argument(
+        "--json-stats",
+        action="store_true",
+        help=argparse.SUPPRESS,
+        # help="Include statistical information about performance in JSON output (experimental).",
+    )
+    output.add_argument(
+        "--json-time",
+        action="store_true",
+        help=argparse.SUPPRESS,
+        # help="Deprecated alias for --json + --time",
+    )
+    output.add_argument(
+        "--debugging-json",
+        action="store_true",
+        help=argparse.SUPPRESS,
+        # help="Deprecated alias for --json + --debug",
+    )
+
     ### Parse and validate
     args = parser.parse_args()
     if args.version:
@@ -399,8 +404,11 @@ def cli() -> None:
     if args.dump_ast and not args.lang:
         parser.error("--dump-ast and -l/--lang must both be specified")
 
+    output_time = args.time or args.json_time
+    debug = args.debug or args.debugging_json
+
     # set the flags
-    semgrep.util.set_flags(args.debug, args.quiet, args.force_color)
+    semgrep.util.set_flags(debug, args.quiet, args.force_color)
 
     # change cwd if using docker
     try:
@@ -410,10 +418,8 @@ def cli() -> None:
         raise e
 
     output_format = OutputFormat.TEXT
-    if args.json:
+    if args.json or args.json_time or args.debugging_json:
         output_format = OutputFormat.JSON
-    elif args.debugging_json:
-        output_format = OutputFormat.JSON_DEBUG
     elif args.junit_xml:
         output_format = OutputFormat.JUNIT_XML
     elif args.sarif:
@@ -428,10 +434,11 @@ def cli() -> None:
         output_destination=args.output,
         error_on_findings=args.error,
         strict=args.strict,
+        debug=debug,
         verbose_errors=args.verbose,
         timeout_threshold=args.timeout_threshold,
         json_stats=args.json_stats,
-        output_time=args.time,
+        output_time=output_time,
         output_per_finding_max_lines_limit=args.max_lines_per_finding,
         output_per_line_max_chars_limit=args.max_chars_per_line,
     )
@@ -496,6 +503,6 @@ def cli() -> None:
                 timeout_threshold=args.timeout_threshold,
                 skip_unknown_extensions=args.skip_unknown_extensions,
                 severity=args.severity,
-                report_time=args.time or args.json_time,
+                report_time=output_time,
                 optimizations=args.optimizations,
             )

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -31,14 +31,13 @@ YML_TEST_SUFFIXES = [[".test", ext] for ext in YML_EXTENSIONS]
 class OutputFormat(Enum):
     TEXT = auto()
     JSON = auto()
-    JSON_DEBUG = auto()
     JUNIT_XML = auto()
     SARIF = auto()
     EMACS = auto()
     VIM = auto()
 
     def is_json(self) -> bool:
-        return self in [OutputFormat.JSON, OutputFormat.JSON_DEBUG, OutputFormat.SARIF]
+        return self in [OutputFormat.JSON, OutputFormat.SARIF]
 
 
 # Inline 'noqa' implementation modified from flake8:

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -491,6 +491,7 @@ class OutputSettings(NamedTuple):
     error_on_findings: bool = False
     verbose_errors: bool = False
     strict: bool = False
+    debug: bool = False
     json_stats: bool = False
     output_time: bool = False
     timeout_threshold: int = 0
@@ -724,10 +725,8 @@ class OutputHandler:
         per_line_max_chars_limit: Optional[int],
     ) -> str:
         output_format = self.settings.output_format
-        debug_steps = None
-        if output_format == OutputFormat.JSON_DEBUG:
-            debug_steps = self.debug_steps_by_rule
-        if output_format in [OutputFormat.JSON, OutputFormat.JSON_DEBUG]:
+        if output_format == OutputFormat.JSON:
+            debug_steps = self.debug_steps_by_rule if self.settings.debug else None
             return build_output_json(
                 self.rule_matches,
                 self.semgrep_structured_errors,

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -90,8 +90,6 @@ def _run_semgrep(
 
     if output_format == "json":
         options.append("--json")
-    elif output_format == "debugging-json":
-        options.append("--debugging-json")
     elif output_format == "junit-xml":
         options.append("--junit-xml")
     elif output_format == "sarif":
@@ -103,7 +101,7 @@ def _run_semgrep(
         stderr=subprocess.STDOUT if stderr else subprocess.PIPE,
     )
 
-    if output_format in {"json", "debugging-json", "sarif"} and not stderr:
+    if output_format in {"json", "sarif"} and not stderr:
         output = _clean_output_json(output)
 
     return output

--- a/semgrep/tests/e2e/test_debugging_json.py
+++ b/semgrep/tests/e2e/test_debugging_json.py
@@ -3,7 +3,8 @@ def test_debugging_json(run_semgrep_in_tmp, snapshot):
         run_semgrep_in_tmp(
             "rules/eqeq.yaml",
             target_name="basic/stupid.py",
-            output_format="debugging-json",
+            options=["--debug"],
+            output_format="json",
         ),
         "results.json",
     )


### PR DESCRIPTION
Manually ran like `semgrep --debugging-json --json-time ...` to confirm that those flags will still work for semgrep.dev. I'll also manually confirm that the playground works with `version=develop` :+1: 

PR checklist:
- [x] changelog is up to date

