### PR TITLE
Update LSP to 1.3.0 so we can compile semgrep with ocaml 4.12.0

### DIFF
--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -41,7 +41,7 @@ depends: [
   "pcre"
   "parmap"
   "ppxlib" {= "0.15.0" }
-  "lsp" {= "1.1.0"}
+  "lsp" {= "1.3.0"}
   "comby-kernel" {= "1.4.1"}
 ]
 

--- a/semgrep-core/src/typing/LSP_client.ml
+++ b/semgrep-core/src/typing/LSP_client.ml
@@ -111,7 +111,7 @@ end
 
 let send_request req io =
   incr counter;
-  let id = Stdune.Right !counter in
+  let id = `Int !counter in
   let json_rpc = Client_request2.to_jsonrpc_request req ~id in
   let json = Jsonrpc.Message.yojson_of_request json_rpc in
   let either = Jsonrpc.Message.either_of_yojson json in


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/3026

test plan:
make test




PR checklist:
- [x] changelog is up to date