### PR TITLE
Split outputting functionality into multiple formatters

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -70,3 +70,7 @@ warn_return_any = False
 [mypy-semgrep.pattern_match]
 disallow_any_decorated = False
 warn_return_any = False
+
+[mypy-semgrep.formatter.*]
+disallow_any_decorated = False
+warn_return_any = False

--- a/semgrep/semgrep/formatter/base.py
+++ b/semgrep/semgrep/formatter/base.py
@@ -1,0 +1,27 @@
+import abc
+from typing import Any
+from typing import Dict
+from typing import FrozenSet
+from typing import List
+
+from semgrep.error import SemgrepError
+from semgrep.rule import Rule
+from semgrep.rule_match import RuleMatch
+
+
+class BaseFormatter(abc.ABC):
+    def __init__(
+        self,
+        rules: FrozenSet[Rule],
+        rule_matches: List[RuleMatch],
+        semgrep_structured_errors: List[SemgrepError],
+        extra: Dict[str, Any],
+    ) -> None:
+        self.rules = rules
+        self.rule_matches = rule_matches
+        self.semgrep_structured_errors = semgrep_structured_errors
+        self.extra = extra
+
+    @abc.abstractmethod
+    def output(self) -> str:
+        raise NotImplementedError

--- a/semgrep/semgrep/formatter/emacs.py
+++ b/semgrep/semgrep/formatter/emacs.py
@@ -1,0 +1,29 @@
+from typing import List
+
+from semgrep.constants import CLI_RULE_ID
+from semgrep.formatter.base import BaseFormatter
+from semgrep.rule_match import RuleMatch
+
+
+class EmacsFormatter(BaseFormatter):
+    @staticmethod
+    def _get_parts(rule_match: RuleMatch) -> List[str]:
+        check_id = (
+            rule_match.id.split(".")[-1] if rule_match.id != CLI_RULE_ID else None
+        )
+        severity = (
+            rule_match.severity.lower() + f"({check_id})"
+            if check_id
+            else rule_match.severity.lower()
+        )
+        return [
+            str(rule_match.path),
+            str(rule_match.start["line"]),
+            str(rule_match.start["col"]),
+            severity,
+            rule_match.lines[0].rstrip(),
+        ]
+
+    def output(self) -> str:
+        rule_matches = sorted(self.rule_matches, key=lambda r: (r.path, r.id))
+        return "\n".join(":".join(self._get_parts(rm)) for rm in rule_matches)

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -1,0 +1,42 @@
+import copy
+import json
+from typing import Any
+from typing import Dict
+
+from semgrep.formatter.base import BaseFormatter
+from semgrep.rule_match import RuleMatch
+
+
+class JsonFormatter(BaseFormatter):
+    @staticmethod
+    def _rule_match_to_json(rule_match: RuleMatch) -> Dict[str, Any]:
+        json_obj = copy.deepcopy(rule_match._pattern_match._raw_json)
+
+        json_obj["check_id"] = rule_match.id
+        json_obj["extra"]["message"] = rule_match.message
+        json_obj["extra"]["metadata"] = rule_match.metadata
+        json_obj["extra"]["severity"] = rule_match.severity
+        json_obj["start"] = rule_match.start
+        json_obj["end"] = rule_match.end
+
+        # 'lines' already contains '\n' at the end of each line
+        json_obj["extra"]["lines"] = "".join(rule_match.lines).rstrip()
+
+        if rule_match.fix:
+            json_obj["extra"]["fix"] = rule_match.fix
+        if rule_match.fix_regex:
+            json_obj["extra"]["fix_regex"] = rule_match.fix_regex
+        if rule_match.is_ignored is not None:
+            json_obj["extra"]["is_ignored"] = rule_match.is_ignored
+
+        return json_obj
+
+    def output(self) -> str:
+        output_dict = {
+            "results": [
+                self._rule_match_to_json(rule_match) for rule_match in self.rule_matches
+            ],
+            "errors": [error.to_dict() for error in self.semgrep_structured_errors],
+            **self.extra,
+        }
+        return json.dumps(output_dict)

--- a/semgrep/semgrep/formatter/junit_xml.py
+++ b/semgrep/semgrep/formatter/junit_xml.py
@@ -1,0 +1,32 @@
+from typing import cast
+
+from semgrep.external.junit_xml import TestCase  # type: ignore[attr-defined]
+from semgrep.external.junit_xml import TestSuite  # type: ignore[attr-defined]
+from semgrep.external.junit_xml import to_xml_report_string  # type: ignore[attr-defined]
+from semgrep.formatter.base import BaseFormatter
+from semgrep.rule_match import RuleMatch
+
+
+class JunitXmlFormatter(BaseFormatter):
+    @staticmethod
+    def _rule_match_to_test_case(rule_match: RuleMatch) -> TestCase:  # type: ignore
+        test_case = TestCase(
+            rule_match.id,
+            file=str(rule_match.path),
+            line=rule_match.start["line"],
+            classname=str(rule_match.path),
+        )
+        test_case.add_failure_info(
+            message=rule_match.message,
+            output=rule_match.lines,
+            failure_type=rule_match.severity,
+        )
+        return test_case
+
+    def output(self) -> str:
+        test_cases = [
+            self._rule_match_to_test_case(rule_match)
+            for rule_match in self.rule_matches
+        ]
+        ts = TestSuite("semgrep results", test_cases)
+        return cast(str, to_xml_report_string([ts]))

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -1,0 +1,137 @@
+import json
+from typing import Any
+from typing import Dict
+from typing import List
+
+from semgrep import __VERSION__
+from semgrep.error import Level
+from semgrep.error import SemgrepError
+from semgrep.formatter.base import BaseFormatter
+from semgrep.rule import Rule
+from semgrep.rule_match import RuleMatch
+
+
+class SarifFormatter(BaseFormatter):
+    @staticmethod
+    def _rule_match_to_sarif(rule_match: RuleMatch) -> Dict[str, Any]:
+        return {
+            "ruleId": rule_match.id,
+            "message": {"text": rule_match.message},
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {
+                            "uri": str(rule_match.path),
+                            "uriBaseId": "%SRCROOT%",
+                        },
+                        "region": {
+                            "startLine": rule_match.start["line"],
+                            "startColumn": rule_match.start["col"],
+                            "endLine": rule_match.end["line"],
+                            "endColumn": rule_match.end["col"],
+                        },
+                    }
+                }
+            ],
+        }
+
+    @staticmethod
+    def _rule_to_sarif(rule: Rule) -> Dict[str, Any]:
+        severity = SarifFormatter._rule_to_sarif_severity(rule)
+        tags = SarifFormatter._rule_to_sarif_tags(rule)
+        return {
+            "id": rule.id,
+            "name": rule.id,
+            "shortDescription": {"text": rule.message},
+            "fullDescription": {"text": rule.message},
+            "defaultConfiguration": {"level": severity},
+            "properties": {"precision": "very-high", "tags": tags},
+        }
+
+    @staticmethod
+    def _rule_to_sarif_severity(rule: Rule) -> str:
+        """
+        SARIF v2.1.0-compliant severity string.
+
+        See https://github.com/oasis-tcs/sarif-spec/blob/a6473580/Schemata/sarif-schema-2.1.0.json#L1566
+        """
+        mapping = {"INFO": "note", "ERROR": "error", "WARNING": "warning"}
+        return mapping[rule.severity]
+
+    @staticmethod
+    def _rule_to_sarif_tags(rule: Rule) -> List[str]:
+        """
+        Tags to display on SARIF-compliant UIs, such as GitHub security scans.
+        """
+        result = []
+        if "cwe" in rule.metadata:
+            result.append(rule.metadata["cwe"])
+        if "owasp" in rule.metadata:
+            owasp = rule.metadata["owasp"]
+            result.append(f"OWASP-{owasp}")
+        return result
+
+    @staticmethod
+    def _semgrep_error_to_sarif_notification(error: SemgrepError) -> Dict[str, Any]:
+        error_dict = error.to_dict()
+        descriptor = error_dict["type"]
+
+        error_to_sarif_level = {
+            Level.ERROR.name.lower(): "error",
+            Level.WARN.name.lower(): "warning",
+        }
+        level = error_to_sarif_level[error_dict["level"]]
+
+        message = error_dict.get("message")
+        if message is None:
+            message = error_dict.get("long_msg")
+        if message is None:
+            message = error_dict.get("short_msg", "")
+
+        return {
+            "descriptor": {"id": descriptor},
+            "message": {"text": message},
+            "level": level,
+        }
+
+    def output(self) -> str:
+        """
+        Format matches in SARIF v2.1.0 formatted JSON.
+
+        - Written based on:
+            https://help.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-sarif-support-for-code-scanning
+        - Which links to this schema:
+            https://github.com/oasis-tcs/sarif-spec/blob/master/Schemata/sarif-schema-2.1.0.json
+        - Full specification is at:
+            https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html
+        """
+
+        output_dict = {
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "semgrep",
+                            "semanticVersion": __VERSION__,
+                            "rules": [self._rule_to_sarif(rule) for rule in self.rules],
+                        }
+                    },
+                    "results": [
+                        self._rule_match_to_sarif(rule_match)
+                        for rule_match in self.rule_matches
+                    ],
+                    "invocations": [
+                        {
+                            "executionSuccessful": True,
+                            "toolExecutionNotifications": [
+                                self._semgrep_error_to_sarif_notification(error)
+                                for error in self.semgrep_structured_errors
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+        return json.dumps(output_dict)

--- a/semgrep/semgrep/formatter/vim.py
+++ b/semgrep/semgrep/formatter/vim.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from semgrep.formatter.base import BaseFormatter
+from semgrep.rule_match import RuleMatch
+
+
+class VimFormatter(BaseFormatter):
+    @staticmethod
+    def _get_parts(rule_match: RuleMatch) -> List[str]:
+        severity = {
+            "INFO": "I",
+            "WARNING": "W",
+            "ERROR": "E",
+        }
+        return [
+            str(rule_match.path),
+            str(rule_match.start["line"]),
+            str(rule_match.start["col"]),
+            severity[rule_match.severity],
+            rule_match.id,
+            rule_match.message,
+        ]
+
+    def output(self) -> str:
+        return "\n".join(":".join(self._get_parts(rm)) for rm in self.rule_matches)

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -1,11 +1,9 @@
 import contextlib
-import json
 import logging
 import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
-from typing import cast
 from typing import Dict
 from typing import FrozenSet
 from typing import Generator
@@ -15,10 +13,10 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 from typing import Set
+from typing import Type
 
 import colorama
 
-from semgrep import __VERSION__
 from semgrep import config_resolver
 from semgrep.constants import BREAK_LINE
 from semgrep.constants import BREAK_LINE_CHAR
@@ -32,8 +30,12 @@ from semgrep.error import FINDINGS_EXIT_CODE
 from semgrep.error import Level
 from semgrep.error import MatchTimeoutError
 from semgrep.error import SemgrepError
-from semgrep.external.junit_xml import TestSuite  # type: ignore[attr-defined]
-from semgrep.external.junit_xml import to_xml_report_string  # type: ignore[attr-defined]
+from semgrep.formatter.base import BaseFormatter
+from semgrep.formatter.emacs import EmacsFormatter
+from semgrep.formatter.json import JsonFormatter
+from semgrep.formatter.junit_xml import JunitXmlFormatter
+from semgrep.formatter.sarif import SarifFormatter
+from semgrep.formatter.vim import VimFormatter
 from semgrep.profile_manager import ProfileManager
 from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
@@ -262,7 +264,7 @@ def build_normal_output(
         elif rule_match.fix_regex:
             fix_regex = rule_match.fix_regex
             yield f"{BLUE_COLOR}autofix:{RESET_COLOR} s/{fix_regex.get('regex')}/{fix_regex.get('replacement')}/{fix_regex.get('count', 'g')}"
-        
+
         is_same_file = (
             next_rule_match.path == rule_match.path if next_rule_match else False
         )
@@ -324,161 +326,6 @@ def _build_time_json(
     ]
     time_info["total_bytes"] = sum(n for n in target_bytes)
     return time_info
-
-
-def build_output_json(
-    rule_matches: List[RuleMatch],
-    semgrep_structured_errors: List[SemgrepError],
-    all_targets: Set[Path],
-    show_json_stats: bool,
-    report_time: bool,
-    filtered_rules: List[Rule],
-    profiling_data: ProfilingData,
-    profiler: Optional[ProfileManager] = None,
-    debug_steps_by_rule: Optional[Dict[Rule, List[Dict[str, Any]]]] = None,
-) -> str:
-    output_json: Dict[str, Any] = {}
-    output_json["results"] = [rm.to_json() for rm in rule_matches]
-    if debug_steps_by_rule:
-        output_json["debug"] = [
-            {r.id: steps for r, steps in debug_steps_by_rule.items()}
-        ]
-    output_json["errors"] = [e.to_dict() for e in semgrep_structured_errors]
-    if show_json_stats:
-        output_json["stats"] = {
-            "targets": make_target_stats(all_targets),
-            "loc": make_loc_stats(all_targets),
-            "profiler": profiler.dump_stats() if profiler else None,
-        }
-    if report_time:
-        total_time = profiler.calls["total_time"][0] if profiler else -1.0
-        output_json["time"] = _build_time_json(
-            filtered_rules, all_targets, profiling_data, total_time
-        )
-    return json.dumps(output_json)
-
-
-def build_junit_xml_output(
-    rule_matches: List[RuleMatch], rules: FrozenSet[Rule]
-) -> str:
-    """
-    Format matches in JUnit XML format.
-    """
-    test_cases = [match.to_junit_xml() for match in rule_matches]
-    ts = TestSuite("semgrep results", test_cases)
-    return cast(str, to_xml_report_string([ts]))
-
-
-def _sarif_tool_info() -> Dict[str, Any]:
-    return {"name": "semgrep", "semanticVersion": __VERSION__}
-
-
-def _sarif_notification_from_error(error: SemgrepError) -> Dict[str, Any]:
-    error_dict = error.to_dict()
-    descriptor = error_dict["type"]
-
-    error_to_sarif_level = {
-        Level.ERROR.name.lower(): "error",
-        Level.WARN.name.lower(): "warning",
-    }
-    level = error_to_sarif_level[error_dict["level"]]
-
-    message = error_dict.get("message")
-    if message is None:
-        message = error_dict.get("long_msg")
-    if message is None:
-        message = error_dict.get("short_msg", "")
-
-    return {
-        "descriptor": {"id": descriptor},
-        "message": {"text": message},
-        "level": level,
-    }
-
-
-def build_sarif_output(
-    rule_matches: List[RuleMatch],
-    rules: FrozenSet[Rule],
-    semgrep_structured_errors: List[SemgrepError],
-) -> str:
-    """
-    Format matches in SARIF v2.1.0 formatted JSON.
-
-    - written based on https://help.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-sarif-support-for-code-scanning
-    - which links to this schema https://github.com/oasis-tcs/sarif-spec/blob/master/Schemata/sarif-schema-2.1.0.json
-    - full spec is at https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html
-    """
-
-    output_dict = {
-        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-        "version": "2.1.0",
-        "runs": [
-            {
-                "tool": {
-                    "driver": {
-                        **_sarif_tool_info(),
-                        "rules": [rule.to_sarif() for rule in rules],
-                    }
-                },
-                "results": [match.to_sarif() for match in rule_matches],
-                "invocations": [
-                    {
-                        "executionSuccessful": True,
-                        "toolExecutionNotifications": [
-                            _sarif_notification_from_error(e)
-                            for e in semgrep_structured_errors
-                        ],
-                    }
-                ],
-            },
-        ],
-    }
-    return json.dumps(output_dict)
-
-
-def iter_emacs_output(
-    rule_matches: List[RuleMatch], rules: FrozenSet[Rule]
-) -> Iterator[str]:
-    last_file = None
-    last_message = None
-    sorted_rule_matches = sorted(rule_matches, key=lambda r: (r.path, r.id))
-    for _, rule_match in enumerate(sorted_rule_matches):
-        current_file = rule_match.path
-        check_id = rule_match.id
-        message = rule_match.message
-        severity = rule_match.severity.lower()
-        start_line = rule_match.start.get("line")
-        start_col = rule_match.start.get("col")
-        line = rule_match.lines[0].rstrip()
-        info = ""
-        if check_id and check_id != CLI_RULE_ID:
-            check_id = check_id.split(".")[-1]
-            info = f"({check_id})"
-        yield f"{current_file}:{start_line}:{start_col}:{severity}{info}:{line}"
-
-
-def build_emacs_output(rule_matches: List[RuleMatch], rules: FrozenSet[Rule]) -> str:
-    return "\n".join(list(iter_emacs_output(rule_matches, rules)))
-
-
-def build_vim_output(rule_matches: List[RuleMatch], rules: FrozenSet[Rule]) -> str:
-    severity = {
-        "INFO": "I",
-        "WARNING": "W",
-        "ERROR": "E",
-    }
-
-    def _get_parts(rule_match: RuleMatch) -> List[str]:
-        return [
-            str(rule_match.path),
-            str(rule_match.start["line"]),
-            str(rule_match.start["col"]),
-            severity[rule_match.severity],
-            rule_match.id,
-            rule_match.message,
-        ]
-
-    return "\n".join(":".join(_get_parts(rm)) for rm in rule_matches)
 
 
 # WARNING: this class is unofficially part of our external API. It can be passed
@@ -726,29 +573,38 @@ class OutputHandler:
         per_line_max_chars_limit: Optional[int],
     ) -> str:
         output_format = self.settings.output_format
-        if output_format == OutputFormat.JSON:
-            debug_steps = self.debug_steps_by_rule if self.settings.debug else None
-            return build_output_json(
-                self.rule_matches,
-                self.semgrep_structured_errors,
-                self.all_targets,
-                self.settings.json_stats,
-                self.settings.output_time,
-                self.filtered_rules,
-                self.profiling_data,
-                self.profiler,
-                debug_steps,
+
+        extra: Dict[str, Any] = {}
+        if self.settings.debug:
+            extra["debug"] = [
+                {rule.id: steps for rule, steps in self.debug_steps_by_rule.items()}
+            ]
+        if self.settings.json_stats:
+            extra["stats"] = {
+                "targets": make_target_stats(self.all_targets),
+                "loc": make_loc_stats(self.all_targets),
+                "profiler": self.profiler.dump_stats() if self.profiler else None,
+            }
+        if self.settings.output_time:
+            total_time = self.profiler.calls["total_time"][0] if self.profiler else -1.0
+            extra["time"] = _build_time_json(
+                self.filtered_rules, self.all_targets, self.profiling_data, total_time
             )
-        elif output_format == OutputFormat.JUNIT_XML:
-            return build_junit_xml_output(self.rule_matches, self.rules)
-        elif output_format == OutputFormat.SARIF:
-            return build_sarif_output(
-                self.rule_matches, self.rules, self.semgrep_structured_errors
+
+        structured_formatters: Dict[OutputFormat, Type[BaseFormatter]] = {
+            OutputFormat.EMACS: EmacsFormatter,
+            OutputFormat.JSON: JsonFormatter,
+            OutputFormat.JUNIT_XML: JunitXmlFormatter,
+            OutputFormat.SARIF: SarifFormatter,
+            OutputFormat.VIM: VimFormatter,
+        }
+        formatter_type = structured_formatters.get(output_format)
+
+        if formatter_type is not None:
+            formatter = formatter_type(
+                self.rules, self.rule_matches, self.semgrep_structured_errors, extra
             )
-        elif output_format == OutputFormat.EMACS:
-            return build_emacs_output(self.rule_matches, self.rules)
-        elif output_format == OutputFormat.VIM:
-            return build_vim_output(self.rule_matches, self.rules)
+            return formatter.output()
         elif output_format == OutputFormat.TEXT:
             return "\n".join(
                 list(

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -265,26 +265,6 @@ class Rule:
         return self._mode
 
     @property
-    def sarif_severity(self) -> str:
-        """
-        SARIF v2.1.0-compliant severity string.
-
-        See https://github.com/oasis-tcs/sarif-spec/blob/a6473580/Schemata/sarif-schema-2.1.0.json#L1566
-        """
-        mapping = {"INFO": "note", "ERROR": "error", "WARNING": "warning"}
-        return mapping[self.severity]
-
-    @property
-    def sarif_tags(self) -> Iterator[str]:
-        """
-        Tags to display on SARIF-compliant UIs, such as GitHub security scans.
-        """
-        if "cwe" in self.metadata:
-            yield self.metadata["cwe"]
-        if "owasp" in self.metadata:
-            yield f"OWASP-{self.metadata['owasp']}"
-
-    @property
     def languages(self) -> List[Language]:
         return self._languages
 
@@ -324,19 +304,6 @@ class Rule:
     @classmethod
     def from_yamltree(cls, rule_yaml: YamlTree[YamlMap]) -> "Rule":
         return cls(rule_yaml)
-
-    def to_json(self) -> Dict[str, Any]:
-        return self._raw
-
-    def to_sarif(self) -> Dict[str, Any]:
-        return {
-            "id": self.id,
-            "name": self.id,
-            "shortDescription": {"text": self.message},
-            "fullDescription": {"text": self.message},
-            "defaultConfiguration": {"level": self.sarif_severity},
-            "properties": {"precision": "very-high", "tags": list(self.sarif_tags)},
-        }
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id}>"


### PR DESCRIPTION
This PR creates a more cohesive concept of an output "formatter" and splits up the code so it's easier to digest. Formatters are now self-contained and won't require changes across multiple modules. This also opens the door for a pluggable interface in the future. I.e. "bring your own" formatters instead of us needing to maintain many types. (This is what `flake8` does: https://flake8.pycqa.org/en/latest/plugin-development/formatters.html)