### PR TITLE
Add v0 opt-in aggregate metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 - Keep track of and report rule parse time in addition to file parse time
+- v0 of opt-in anonymous aggregate metrics
 
 ## [0.50.1](https://github.com/returntocorp/semgrep/releases/tag/v0.50.1) - 2021-05-06
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,138 @@
+# Semgrep Privacy Policy
+
+Semgrep may collect usage data via anonymized metrics to help us improve the product. This document describes:
+
+* the principles that guide our data-collection decisions
+* how to opt-in to Semgrep’s anonymized metrics
+* the breakdown of the data that are and are not collected
+* how we use the data to make Semgrep better
+
+## Principles
+
+These principles inform our decisions around data collection:
+
+1. **Transparency**: Collect and use data in a way that is clearly explained to the user and benefits them
+2. **User control**: Put users in control of their data at all times
+3. **Limited data**: Collect what is needed, de-identify where possible, and delete when no longer necessary
+
+## Opt-in behavior
+
+Semgrep’s opt-in aggregate metrics are only sent when the environment variable `SEMGREP_SEND_METRICS` is set or when the flag `--enable-metrics` is set. If this environment variable is not set or if the flag is not set, the aggregate metrics are not sent anywhere.
+
+## Collected data
+
+Semgrep collects non-identifiable data to improve the underlying tools and user experience. Four types of data are collected:
+
+### Environmental
+
+Environmental data provides contextual data about Semgrep’s runtime environment, as well as information that helps debug any issues users may be facing; e.g.
+
+* How long the command took to run
+* If the command ran in a CI environment
+* The version of Semgrep
+* The user’s OS and shell
+* Anonymized hash of the scanned project’s name
+
+### Performance
+
+Performance data enables understanding of which rules and types of files are slow in the aggregate so r2c can improve the Semgrep program-analysis engine, query optimizer, and debug slow rules; e.g.
+
+* Runtime duration
+* Total number of rules
+* Total number of files
+* Project size in bytes
+* One-way hashes of the rule definitions
+
+### Errors
+
+High-level error and warning classes that Semgrep encounters when run; e.g.
+
+* Semgrep’s return code
+* The number of errors
+* Compile-time error names, e.g., MaxFileSizeExceeded, SystemOutOfMemory, UnknownFileEncoding
+
+### Value
+
+Semgrep reports data that indicate how useful a run is for the end user; e.g.
+
+* Number of raised findings
+* Number of ignored findings
+* One-way hashes of the rule definitions that yield findings
+
+### Data NOT collected
+
+We strive to balance our desire to collect data for improving Semgrep and its underlying tools with our users' need for privacy. The following items don't leave your environment and are not sent or shared with anyone.
+
+* Source code
+* Raw repository names, filenames, file contents, or commit hashes
+* User-identifiable data about Semgrep’s findings in your code, including finding messages
+* Private rules
+
+
+
+## Description of fields
+
+|Category   |Field  |Description    |Use Case   |Example Data   |Type   |
+|---    |---    |---    |---    |---    |---    |
+|Environment    |   |   |   |   |   |
+|   |Timestamp  |Time when the event fired  |Understanding tool usage over time |2021-05-10T21:05:06+00:00  |String |
+|   |Version    |Semgrep version being used |Reproduce and debug issues with specific versions  |0.51.0 |String |
+|   |CI |Notes if Semgrep is running in CI and the name of the provider |Reproduce and debug issues with specific CI providers  |GitLabCI v0.13.12  |String |
+|   |   |   |   |   |   |
+|Performance    |   |   |   |   |   |
+|   |Duration   |How long the command took to run   |Understanding agregate performance improvements and regressions    |14.13  |Number |
+|   |Total Rules    |Count of rules |Understand how duration is affected by #rules  |137    |Number |
+|   |Total Files    |Count of files |Understand how duration is affected by #files  |4378   |Number |
+|   |Total Bytes    |Summation of target file size  |Understand how duration is related to total size of all target files   |40838239   |Number |
+|   |   |   |   |   |   |
+|Errors |   |   |   |   |   |
+|   |Exit Code  |Numeric exit code  |Debug commonly occurring issues and aggregate error counts |1  |Number |
+|   |Number of Errors   |Count of errors    |Understanding avg #errors  |2  |Number |
+|   |Number of Warnings |Count of warnings  |Understanding avg #warnings    |1  |Number |
+|   |Errors |Array of Error Classes (compile-time-constant) |Understand most common errors users encounter  |["UnknownLanguage", "MaxFileSizeExceeded"] |ErrorClass[]   |
+|   |Warnings   |Array of Warning Classes (compile-time-constant)   |Understand most common warnings users encounter    |["TimeoutExceeded"]    |WarningClass[] |
+|   |   |   |   |   |   |
+|Value  |   |   |   |   |   |
+|   |Total Findings |Count of all findings  |Understand if rules are super noisy for the user   |7  |Number |
+|   |Total Nosems   |Count of all `nosem` annotations that tell semgrep to ignore a finding |Understand if rules are super noisy for the user   |3  |Number |
+
+
+
+### Sample metrics
+
+This is a sample blob of anonymized metrics described above:
+
+```
+{
+    "environment": {
+        "timestamp": "2021-05-10T21:05:06+00:00",
+        "version": "0.51.0",
+        "ci": "Gitlab v13.12"
+    },
+    "performance": {
+        "duration": 37.1234233823,
+        "totalRules": 2,
+        "totalFiles": 573,
+        "totalBytes": 33938923
+    },
+    "errors": {
+        "exitCode": 1,
+        "totalErrors": 1,
+        "totalWarnings": 2,
+        "errors": ["UnknownLanguage"],
+        "warnings": ["MaxFileSizeExceeded", "TimeoutExceeded"]
+    },
+    "value": {
+        "totalFindings": 7,
+        "totalNosems": 3
+    }
+}
+```
+
+
+
+## Data sharing
+
+We use some third party companies and services to help administer and provide Semgrep, for example for hosting, customer support, product usage analytics, and database management. These third parties are permitted to handle data only to perform these tasks in a manner consistent with this document and are obligated not to disclose or use it for any other purpose.
+
+We do not share or sell the information provided to us with other organizations without explicit consent, except as described in this document.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -32,6 +32,7 @@ Environmental data provides contextual data about Semgrep’s runtime environmen
 * The version of Semgrep
 * The user’s OS and shell
 * Anonymized hash of the scanned project’s name
+* Anonymized hash of the rules run
 
 ### Performance
 

--- a/semgrep/semgrep/__main__.py
+++ b/semgrep/semgrep/__main__.py
@@ -2,9 +2,11 @@
 import logging.handlers
 import sys
 
+from semgrep import __VERSION__
 from semgrep.cli import cli
 from semgrep.error import OK_EXIT_CODE
 from semgrep.error import SemgrepError
+from semgrep.metric_manager import metric_manager
 
 
 def main() -> int:
@@ -13,14 +15,19 @@ def main() -> int:
     # than warning are handled twice
     logger = logging.getLogger("semgrep")
     logger.propagate = False
+    metric_manager.set_version(__VERSION__)
     try:
         cli()
     # Catch custom exceptions, output the right message and exit.
     # Note: this doesn't catch all Exceptions and lets them bubble up.
     except SemgrepError as e:
+        metric_manager.set_return_code(e.code)
         return e.code
     else:
+        metric_manager.set_return_code(OK_EXIT_CODE)
         return OK_EXIT_CODE
+    finally:
+        metric_manager.send()
 
 
 if __name__ == "__main__":

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -19,11 +19,13 @@ from semgrep.constants import RCE_RULE_FLAG
 from semgrep.constants import SEMGREP_URL
 from semgrep.dump_ast import dump_parsed_ast
 from semgrep.error import SemgrepError
+from semgrep.metric_manager import metric_manager
 from semgrep.output import managed_output
 from semgrep.output import OutputSettings
 from semgrep.synthesize_patterns import synthesize_patterns
 from semgrep.target_manager import optional_stdin_target
 from semgrep.version import is_running_latest
+
 
 logger = logging.getLogger(__name__)
 try:
@@ -360,6 +362,21 @@ def cli() -> None:
         "--version", action="store_true", help="Show the version and exit."
     )
 
+    metric_group = parser.add_argument_group("config")
+    metric_ex = metric_group.add_mutually_exclusive_group()
+    metric_ex.add_argument(
+        "--enable-metrics",
+        action="store_true",
+        help="Opt-in to metrics. Defaults to what SEMGREP_SEND_METRICS envvar is set to",
+        default=os.environ.get("SEMGREP_SEND_METRICS"),
+    )
+    metric_ex.add_argument(
+        "--disable-metrics",
+        action="store_false",
+        help="Opt-out of metrics.",
+        dest="enable_metrics",
+    )
+
     parser.add_argument(
         "--force-color",
         action="store_true",
@@ -394,9 +411,15 @@ def cli() -> None:
 
     ### Parse and validate
     args = parser.parse_args()
+
     if args.version:
         print(__VERSION__)
         return
+
+    if args.enable_metrics:
+        metric_manager.enable()
+    else:
+        metric_manager.disable()
 
     if args.pattern and not args.lang:
         parser.error("-e/--pattern and -l/--lang must both be specified")

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -5,8 +5,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-import requests
-
 from semgrep.constants import SEMGREP_USER_AGENT
 
 METRICS_ENDPOINT = "https://stats.semgrep.dev"
@@ -78,6 +76,8 @@ class _MetricManager:
         Send metrics to the metrics server. Is a noop if SEMGREP_SEND_METRICS
         env var is not set
         """
+        import requests
+
         if os.environ.get("SEMGREP_SEND_METRICS"):
             metrics = self.as_dict()
             headers = {"User-Agent": SEMGREP_USER_AGENT}

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -1,0 +1,95 @@
+import logging
+import os
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import requests
+
+from semgrep.constants import SEMGREP_USER_AGENT
+
+METRICS_ENDPOINT = "https://stats.semgrep.dev"
+
+logger = logging.getLogger(__name__)
+
+
+class _MetricManager:
+    """
+
+    Made explicit decision to be verbose in setting metrics instead
+    of something more dynamic (and thus less boiler plate code) to
+    be very explicit in what metrics are being collected
+    """
+
+    def __init__(self) -> None:
+        self._return_code: Optional[int] = None
+        self._version: Optional[str] = None
+        self._num_rules: Optional[int] = None
+        self._num_targets: Optional[int] = None
+        self._num_findings: Optional[int] = None
+        self._num_ignored: Optional[int] = None
+        self._run_time: Optional[float] = None
+        self._total_bytes_scanned: Optional[int] = None
+        self._errors: List[str] = []
+
+    def set_return_code(self, return_code: int) -> None:
+        self._return_code = return_code
+
+    def set_version(self, version: str) -> None:
+        self._version = version
+
+    def set_num_rules(self, num_rules: int) -> None:
+        self._num_rules = num_rules
+
+    def set_num_targets(self, num_targets: int) -> None:
+        self._num_targets = num_targets
+
+    def set_num_findings(self, num_findings: int) -> None:
+        self._num_findings = num_findings
+
+    def set_num_ignored(self, num_ignored: int) -> None:
+        self._num_ignored = num_ignored
+
+    def set_run_time(self, run_time: float) -> None:
+        self._run_time = run_time
+
+    def set_total_bytes_scanned(self, total_bytes_scanned: int) -> None:
+        self._total_bytes_scanned = total_bytes_scanned
+
+    def set_errors(self, error_types: List[str]) -> None:
+        self._errors = error_types
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "return_code": self._return_code,
+            "version": self._version,
+            "num_rules": self._num_rules,
+            "num_targets": self._num_targets,
+            "num_findings": self._num_findings,
+            "num_ignored": self._num_ignored,
+            "run_time": self._run_time,
+            "total_bytes_scanned": self._total_bytes_scanned,
+            "errors": self._errors,
+        }
+
+    def send(self) -> None:
+        """
+        Send metrics to the metrics server. Is a noop if SEMGREP_SEND_METRICS
+        env var is not set
+        """
+        if os.environ.get("SEMGREP_SEND_METRICS"):
+            metrics = self.as_dict()
+            headers = {"User-Agent": SEMGREP_USER_AGENT}
+
+            try:
+                r = requests.post(
+                    METRICS_ENDPOINT, json=metrics, timeout=10, headers=headers
+                )
+                r.raise_for_status()
+                logger.info("Sent anonymized metrics.")
+            except Exception as e:
+                logger.info("Failed to send anonymized metrics.")
+
+
+metric_manager = _MetricManager()

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -40,7 +40,7 @@ class _MetricManager:
 
         self._send_metrics = False
 
-    def set_project_hash(self, project_hash: str) -> None:
+    def set_project_hash(self, project_hash: Optional[str]) -> None:
         self._project_hash = project_hash
 
     def set_return_code(self, return_code: int) -> None:
@@ -115,9 +115,9 @@ class _MetricManager:
                     METRICS_ENDPOINT, json=metrics, timeout=10, headers=headers
                 )
                 r.raise_for_status()
-                logger.debug("Sent anonymized metrics.")
+                logger.debug("Sent non-identifiable metrics")
             except Exception as e:
-                logger.debug("Failed to send anonymized metrics.")
+                logger.debug(f"Failed to send non-identifiable metrics: {e}")
 
 
 metric_manager = _MetricManager()

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -353,6 +355,15 @@ class Rule:
     @property
     def pattern_spans(self) -> Dict[PatternId, Span]:
         return self._pattern_spans
+
+    @property
+    def full_hash(self) -> str:
+        """
+        sha256 hash of the whole rule object instead of just the id
+        """
+        return hashlib.sha256(
+            json.dumps(self._raw, sort_keys=True).encode()
+        ).hexdigest()
 
 
 def operator_for_pattern_name(pattern_name: YamlTree[str]) -> Operator:

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -277,7 +277,6 @@ The two most popular are:
     num_findings = sum(len(v) for v in rule_matches_by_rule.values())
     stats_line = f"ran {len(filtered_rules)} rules on {len(all_targets)} files: {num_findings} findings"
 
-    # TODO gate behind gitlab
     metric_manager.set_num_rules(len(filtered_rules))
     metric_manager.set_num_targets(len(all_targets))
     metric_manager.set_num_findings(num_findings)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -291,7 +291,6 @@ The two most popular are:
         project_hash = hashlib.sha256(project_url.encode()).hexdigest()
     except Exception as e:
         logger.debug(f"Failed to generate project hash: {e}")
-        raise e
 
     metric_manager.set_project_hash(project_hash)
     metric_manager.set_num_rules(len(filtered_rules))

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -293,6 +293,8 @@ The two most popular are:
         logger.debug(f"Failed to generate project hash: {e}")
 
     metric_manager.set_project_hash(project_hash)
+    metric_manager.set_configs_hash(configs)
+    metric_manager.set_rules_hash(filtered_rules)
     metric_manager.set_num_rules(len(filtered_rules))
     metric_manager.set_num_targets(len(all_targets))
     metric_manager.set_num_findings(num_findings)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -262,17 +262,21 @@ The two most popular are:
         for rule, rule_matches in rule_matches_by_rule.items()
     }
 
+    num_findings_nosem = 0
     if not disable_nosem:
-        rule_matches_by_rule = {}
-        num_findings_nosem = 0
+        filtered_rule_matches_by_rule = {}
         for rule, rule_matches in rule_matches_by_rule.items():
             filtered_rule_matches = []
             for rule_match in rule_matches:
+                print(rule_match._is_ignored)
                 if rule_match._is_ignored:
+                    print("totally ignored you lol")
                     num_findings_nosem += 1
                 else:
+                    print("ok?")
                     filtered_rule_matches.append(rule_match)
-            rule_matches_by_rule[rule] = filtered_rule_matches
+            filtered_rule_matches_by_rule[rule] = filtered_rule_matches
+        rule_matches_by_rule = filtered_rule_matches_by_rule
 
     num_findings = sum(len(v) for v in rule_matches_by_rule.values())
     stats_line = f"ran {len(filtered_rules)} rules on {len(all_targets)} files: {num_findings} findings"

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -268,12 +268,9 @@ The two most popular are:
         for rule, rule_matches in rule_matches_by_rule.items():
             filtered_rule_matches = []
             for rule_match in rule_matches:
-                print(rule_match._is_ignored)
                 if rule_match._is_ignored:
-                    print("totally ignored you lol")
                     num_findings_nosem += 1
                 else:
-                    print("ok?")
                     filtered_rule_matches.append(rule_match)
             filtered_rule_matches_by_rule[rule] = filtered_rule_matches
         rule_matches_by_rule = filtered_rule_matches_by_rule

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Union
 
@@ -65,6 +66,7 @@ def _run_semgrep(
     output_format: OutputFormat = OutputFormat.JSON,
     stderr: bool = False,
     strict: bool = True,
+    env: Optional[Mapping[str, str]] = None,
 ) -> str:
     """Run the semgrep CLI.
 
@@ -100,6 +102,7 @@ def _run_semgrep(
         [sys.executable, "-m", "semgrep", *options, Path("targets") / target_name],
         encoding="utf-8",
         stderr=subprocess.STDOUT if stderr else subprocess.PIPE,
+        env=env,
     )
 
     if output_format.is_json() and not stderr:

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -1,0 +1,72 @@
+def test_envvar(run_semgrep_in_tmp):
+    """
+    Test metrics sending respects SEMGREP_SEND_METRICS envvar
+    """
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", "SEMGREP_SEND_METRICS": "1"},
+    )
+    assert "Sent non-identifiable metrics" in output
+
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", "SEMGREP_SEND_METRICS": "true"},
+    )
+    assert "Sent non-identifiable metrics" in output
+
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", "SEMGREP_SEND_METRICS": ""},
+    )
+    assert "Sent non-identifiable metrics" not in output
+
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing"},
+    )
+    assert "Sent non-identifiable metrics" not in output
+
+
+def test_flags(run_semgrep_in_tmp):
+    """
+    Test metrics sending respects flags. Flags take precedence over envvar
+    """
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug", "--enable-metrics"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing"},
+    )
+    assert "Sent non-identifiable metrics" in output
+
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug", "--enable-metrics"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", "SEMGREP_SEND_METRICS": ""},
+    )
+    assert "Sent non-identifiable metrics" in output
+
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug", "--disable-metrics"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing"},
+    )
+    assert "Sent non-identifiable metrics" not in output
+
+    output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        stderr=True,
+        options=["--debug", "--disable-metrics"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", "SEMGREP_SEND_METRICS": "1"},
+    )
+    assert "Sent non-identifiable metrics" not in output

--- a/semgrep/tests/unit/test_metric_manager.py
+++ b/semgrep/tests/unit/test_metric_manager.py
@@ -1,0 +1,91 @@
+from tempfile import NamedTemporaryFile
+from textwrap import dedent
+
+import pytest
+
+from semgrep.config_resolver import Config
+from semgrep.metric_manager import metric_manager
+
+
+def test_configs_hash() -> None:
+    metric_manager.set_configs_hash(["p/r2c"])
+    old = metric_manager._configs_hash
+    metric_manager.set_configs_hash(["p/r2c"])
+    assert metric_manager._configs_hash == old
+    metric_manager.set_configs_hash(["not"])
+    assert metric_manager._configs_hash != old
+
+    metric_manager.set_configs_hash(["a", "b"])
+    old = metric_manager._configs_hash
+    metric_manager.set_configs_hash(["a", "b"])
+    assert metric_manager._configs_hash == old
+    metric_manager.set_configs_hash(["b", "a"])
+    assert metric_manager._configs_hash != old
+
+
+def test_rules_hash() -> None:
+    config1 = dedent(
+        """
+    rules:
+    - id: rule1
+      pattern: $X == $X
+      languages: [python]
+      severity: INFO
+      message: bad
+    - id: rule2
+      pattern: $X == $Y
+      languages: [python]
+      severity: INFO
+      message: good
+    - id: rule3
+      pattern: $X < $Y
+      languages: [c]
+      severity: INFO
+      message: doog
+    """
+    )
+    # Load rules
+    with NamedTemporaryFile() as tf1:
+        tf1.write(config1.encode("utf-8"))
+        tf1.flush()
+        config, errors = Config.from_config_list([tf1.name])
+        assert not errors
+        rules = config.get_rules(True)
+        assert len(rules) == 3
+        rule1, rule2, rule3 = rules
+
+    metric_manager.set_rules_hash([rule1])
+    old_hash = metric_manager._rules_hash
+    metric_manager.set_rules_hash([rule1])
+    assert old_hash == metric_manager._rules_hash
+
+    metric_manager.set_rules_hash(rules)
+    old_hash_2 = metric_manager._rules_hash
+    metric_manager.set_rules_hash(rules)
+    assert old_hash_2 == metric_manager._rules_hash
+
+    assert old_hash != old_hash_2
+
+
+def test_send() -> None:
+    """
+    Check that no network does not cause failures
+    """
+    import socket
+    import requests
+
+    class block_network(socket.socket):
+        def __init__(self, *args, **kwargs):
+            raise Exception("Network call blocked")
+
+    socket.socket = block_network  # type: ignore
+
+    # test that network is blocked
+    with pytest.rasies(Exception):
+        r = requests.get(
+            "https://semgrep.dev",
+            timeout=2,
+        )
+
+    metric_manager.enable()
+    metric_manager.send()

--- a/semgrep/tests/unit/test_metric_manager.py
+++ b/semgrep/tests/unit/test_metric_manager.py
@@ -81,7 +81,7 @@ def test_send() -> None:
     socket.socket = block_network  # type: ignore
 
     # test that network is blocked
-    with pytest.rasies(Exception):
+    with pytest.raises(Exception):
         r = requests.get(
             "https://semgrep.dev",
             timeout=2,


### PR DESCRIPTION
This PR adds the ability to capture opt-in, anonymized metrics behind the environment variable `SEMGREP_SEND_METRICS` or the CLI flag `--enable-metrics`.

The motivation for this change is to prioritize engineering work improving Semgrep’s performance and language support. We’ve added a dizzying number of languages to over the past year (~13), and also became committers to the tree-sitter project, which powers parsing. This has significantly increased support load and development cost across parsers, generic AST, the matcher, and community rules. If someone contributes a slow rule, it’s difficult to trace the stack to understand which part is making it slow. We have aggressive performance goals for Semgrep (think: in-editor speed) so capturing these metrics helps us understand real-world performance and be data-driven in prioritization.

Our decisions around metrics are informed by these principles:

1. Transparency: Collect and use data in a way that is clearly explained to the user and benefits them
2. User control: Put users in control of their data at all times
3. Limited data: Collect what is needed, de-identify where possible, and delete when no longer necessary

The specific metrics collected, descriptions of fields, example values, and additional context are included in the PRIVACY.md file.

Note for GitLab SAST users: by default the security scanner semgrep-sast will turn on these metrics via an environment variable.

We’re opening a comment period to collect feedback about the metrics coming in v0.51.0. For future releases, we’re also considering adding more advanced profiling and metrics, and making the metrics opt-out instead of opt-in. We’d appreciate community input on that as well.

We’d deeply appreciate any input on this topic.

In sum, for now this PR only the following gathers anonymized aggregate metrics:

* semgrep version
* number of files scanned
* number of rules run
* number of findings ignored with nosem
* types of errors returned by semgrep-core
* return code
* total number of bytes scanned
* number of findings
* total run time

PR checklist:

*  changelog is up to date

