### PR TITLE
Add configNameHash and rulesHash to metrics

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -32,6 +32,7 @@ Environmental data provides contextual data about Semgrep’s runtime environmen
 * The version of Semgrep
 * The user’s OS and shell
 * Anonymized hash of the scanned project’s name
+* Anonymized hash of the rules run
 
 ### Performance
 

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -28,6 +28,8 @@ class _MetricManager:
 
     def __init__(self) -> None:
         self._project_hash: Optional[str] = None
+        self._configs_hash = ""
+        self._rules_hash = ""
         self._return_code: Optional[int] = None
         self._version: Optional[str] = None
         self._num_rules: Optional[int] = None
@@ -42,6 +44,12 @@ class _MetricManager:
 
     def set_project_hash(self, project_hash: Optional[str]) -> None:
         self._project_hash = project_hash
+
+    def set_configs_hash(self, configs_hash: str) -> None:
+        self._configs_hash = configs_hash
+
+    def set_rules_hash(self, rules_hash: str) -> None:
+        self._rules_hash = rules_hash
 
     def set_return_code(self, return_code: int) -> None:
         self._return_code = return_code
@@ -75,6 +83,8 @@ class _MetricManager:
             "environment": {
                 "version": self._version,
                 "projectHash": self._project_hash,
+                "configNamesHash": self._configs_hash,
+                "rulesHash": self._rules_hash,
             },
             "performance": {
                 "runTime": self._run_time,
@@ -112,7 +122,7 @@ class _MetricManager:
 
             try:
                 r = requests.post(
-                    METRICS_ENDPOINT, json=metrics, timeout=10, headers=headers
+                    METRICS_ENDPOINT, json=metrics, timeout=2, headers=headers
                 )
                 r.raise_for_status()
                 logger.debug("Sent non-identifiable metrics")

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 from typing import Any
 from typing import Dict
@@ -5,6 +6,8 @@ from typing import List
 from typing import Optional
 
 from semgrep.constants import SEMGREP_USER_AGENT
+from semgrep.rule import Rule
+
 
 METRICS_ENDPOINT = "https://metrics.semgrep.dev"
 
@@ -15,11 +18,7 @@ class _MetricManager:
     """
     To prevent sending unintended metrics, be sure that any data
     stored on this object is sanitized of anything that we don't
-    want sent.
-
-    All metrics stored should be calculated outside this class (i.e.
-    don't do sanitation in this class and don't populate fields under
-    the hood)
+    want sent (i.e. sanitize before saving not before sending)
 
     Made explicit decision to be verbose in setting metrics instead
     of something more dynamic (and thus less boiler plate code) to
@@ -45,11 +44,20 @@ class _MetricManager:
     def set_project_hash(self, project_hash: Optional[str]) -> None:
         self._project_hash = project_hash
 
-    def set_configs_hash(self, configs_hash: str) -> None:
-        self._configs_hash = configs_hash
+    def set_configs_hash(self, configs: List[str]) -> None:
+        """
+        Assumes configs is list of arguments passed to semgrep using --config
+        """
+        m = hashlib.sha256()
+        for c in configs:
+            m.update(c.encode())
+        self._configs_hash = m.hexdigest()
 
-    def set_rules_hash(self, rules_hash: str) -> None:
-        self._rules_hash = rules_hash
+    def set_rules_hash(self, rules: List[Rule]) -> None:
+        m = hashlib.sha256()
+        for r in rules:
+            m.update(r.full_hash.encode())
+        self._rules_hash = m.hexdigest()
 
     def set_return_code(self, return_code: int) -> None:
         self._return_code = return_code

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -353,6 +355,15 @@ class Rule:
     @property
     def pattern_spans(self) -> Dict[PatternId, Span]:
         return self._pattern_spans
+
+    @property
+    def full_hash(self) -> str:
+        """
+        sha256 hash of the whole rule object instead of just the id
+        """
+        return hashlib.sha256(
+            json.dumps(self._raw, sort_keys=True).encode()
+        ).hexdigest()
 
 
 def operator_for_pattern_name(pattern_name: YamlTree[str]) -> Operator:

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -292,13 +292,9 @@ The two most popular are:
     except Exception as e:
         logger.debug(f"Failed to generate project hash: {e}")
 
-    configs_hash = hashlib.sha256(json.dumps(configs).encode()).hexdigest()
-    rules_hashes = [r.full_hash for r in filtered_rules]
-    rules_hash = hashlib.sha256(json.dumps(rules_hashes).encode()).hexdigest()
-
     metric_manager.set_project_hash(project_hash)
-    metric_manager.set_configs_hash(configs_hash)
-    metric_manager.set_rules_hash(rules_hash)
+    metric_manager.set_configs_hash(configs)
+    metric_manager.set_rules_hash(filtered_rules)
     metric_manager.set_num_rules(len(filtered_rules))
     metric_manager.set_num_targets(len(all_targets))
     metric_manager.set_num_findings(num_findings)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -292,7 +292,13 @@ The two most popular are:
     except Exception as e:
         logger.debug(f"Failed to generate project hash: {e}")
 
+    configs_hash = hashlib.sha256(json.dumps(configs).encode()).hexdigest()
+    rules_hashes = [r.full_hash for r in filtered_rules]
+    rules_hash = hashlib.sha256(json.dumps(rules_hashes).encode()).hexdigest()
+
     metric_manager.set_project_hash(project_hash)
+    metric_manager.set_configs_hash(configs_hash)
+    metric_manager.set_rules_hash(rules_hash)
     metric_manager.set_num_rules(len(filtered_rules))
     metric_manager.set_num_targets(len(all_targets))
     metric_manager.set_num_findings(num_findings)

--- a/semgrep/tests/unit/test_metric_manager.py
+++ b/semgrep/tests/unit/test_metric_manager.py
@@ -1,0 +1,65 @@
+from tempfile import NamedTemporaryFile
+from textwrap import dedent
+
+from semgrep.config_resolver import Config
+from semgrep.metric_manager import metric_manager
+
+
+def test_configs_hash() -> None:
+    metric_manager.set_configs_hash(["p/r2c"])
+    old = metric_manager._configs_hash
+    metric_manager.set_configs_hash(["p/r2c"])
+    assert metric_manager._configs_hash == old
+    metric_manager.set_configs_hash(["not"])
+    assert metric_manager._configs_hash != old
+
+    metric_manager.set_configs_hash(["a", "b"])
+    old = metric_manager._configs_hash
+    metric_manager.set_configs_hash(["a", "b"])
+    assert metric_manager._configs_hash == old
+    metric_manager.set_configs_hash(["b", "a"])
+    assert metric_manager._configs_hash != old
+
+
+def test_rules_hash() -> None:
+    config1 = dedent(
+        """
+    rules:
+    - id: rule1
+      pattern: $X == $X
+      languages: [python]
+      severity: INFO
+      message: bad
+    - id: rule2
+      pattern: $X == $Y
+      languages: [python]
+      severity: INFO
+      message: good
+    - id: rule3
+      pattern: $X < $Y
+      languages: [c]
+      severity: INFO
+      message: doog
+    """
+    )
+    # Load rules
+    with NamedTemporaryFile() as tf1:
+        tf1.write(config1.encode("utf-8"))
+        tf1.flush()
+        config, errors = Config.from_config_list([tf1.name])
+        assert not errors
+        rules = config.get_rules(True)
+        assert len(rules) == 3
+        rule1, rule2, rule3 = rules
+
+    metric_manager.set_rules_hash([rule1])
+    old_hash = metric_manager._rules_hash
+    metric_manager.set_rules_hash([rule1])
+    assert old_hash == metric_manager._rules_hash
+
+    metric_manager.set_rules_hash(rules)
+    old_hash_2 = metric_manager._rules_hash
+    metric_manager.set_rules_hash(rules)
+    assert old_hash_2 == metric_manager._rules_hash
+
+    assert old_hash != old_hash_2


### PR DESCRIPTION
To be able to determine performance regressions it would be useful to have a hash of all the rules run so we can track how changes in versions with the same rules hash perform.

For now the aggregate rules_hash is the sha256 hash of the sha256 hashes of raw rules. So changes to order of rules will give us a different hash and changes to non-pattern fields will also give us a different hash. This limitation seems fine for now

PR checklist:
- [ ] changelog is up to date

Tested manually for now since getting a test for this will be more involved. The e2e tests should capture that this doesnt cause breakages