### PR TITLE
Use a canonical string for each language

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -42,7 +42,6 @@ from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.semgrep_types import BooleanRuleExpression
 from semgrep.semgrep_types import Language
-from semgrep.semgrep_types import Language_util
 from semgrep.semgrep_types import OPERATORS
 from semgrep.semgrep_types import TAINT_MODE
 from semgrep.spacegrep import run_spacegrep
@@ -436,8 +435,9 @@ class CoreRunner:
                     self.handle_regex_patterns(outputs, patterns_regex, targets)
 
                 # regex-only rules only support OPERATORS.REGEX.
+                # generic-only rules should go through spacegrep
                 # Skip passing this rule to semgrep-core.
-                if language in Language_util.language_strs(Language.REGEX):
+                if language in [Language.REGEX, Language.GENERIC]:
                     continue
 
                 # semgrep-core doesn't know about the following operators -
@@ -456,7 +456,7 @@ class CoreRunner:
 
                 patterns_json = [p.to_json() for p in patterns]
 
-                if language in Language_util.language_strs(Language.GENERIC):
+                if language == Language.GENERIC:
                     output_json = profiler.track(
                         rule.id,
                         run_spacegrep,

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -44,11 +44,10 @@ from semgrep.semgrep_types import BooleanRuleExpression
 from semgrep.semgrep_types import Language
 from semgrep.semgrep_types import OPERATORS
 from semgrep.semgrep_types import TAINT_MODE
+from semgrep.semgrep_types import User_language
 from semgrep.spacegrep import run_spacegrep
 from semgrep.target_manager import TargetManager
 from semgrep.target_manager_extensions import all_supported_languages
-from semgrep.target_manager_extensions import GENERIC_LANGUAGES
-from semgrep.target_manager_extensions import REGEX_LANGUAGES
 from semgrep.util import debug_tqdm_write
 from semgrep.util import partition
 from semgrep.util import progress_bar
@@ -234,7 +233,7 @@ class CoreRunner:
 
             cmd = [SEMGREP_PATH] + [
                 "-lang",
-                language,
+                language.value,
                 "-json",
                 rules_file_flag,
                 pattern_file.name,
@@ -438,6 +437,7 @@ class CoreRunner:
 
                 # regex-only rules only support OPERATORS.REGEX.
                 # Skip passing this rule to semgrep-core.
+                REGEX_LANGUAGES = User_language.language_mappings[Language.REGEX]
                 if language in REGEX_LANGUAGES:
                     continue
 
@@ -457,6 +457,7 @@ class CoreRunner:
 
                 patterns_json = [p.to_json() for p in patterns]
 
+                GENERIC_LANGUAGES = User_language.language_mappings[Language.GENERIC]
                 if language in GENERIC_LANGUAGES:
                     output_json = profiler.track(
                         rule.id,
@@ -481,7 +482,7 @@ class CoreRunner:
                     )
 
             errors.extend(
-                CoreException.from_json(e, language, rule.id).into_semgrep_error()
+                CoreException.from_json(e, language.value, rule.id).into_semgrep_error()
                 for e in output_json["errors"]
             )
             outputs.extend(PatternMatch(m) for m in output_json["matches"])
@@ -656,7 +657,7 @@ class CoreRunner:
 
                     cmd = [SEMGREP_PATH] + [
                         "-lang",
-                        language,
+                        language.value,
                         "-fast",
                         "-json",
                         "-config",
@@ -704,7 +705,9 @@ class CoreRunner:
                 findings = dedup_output(findings)
                 outputs[rule].extend(findings)
                 errors.extend(
-                    CoreException.from_json(e, language, rule.id).into_semgrep_error()
+                    CoreException.from_json(
+                        e, language.value, rule.id
+                    ).into_semgrep_error()
                     for e in output_json["errors"]
                 )
         # end for rule, language ...

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -435,9 +435,8 @@ class CoreRunner:
                     self.handle_regex_patterns(outputs, patterns_regex, targets)
 
                 # regex-only rules only support OPERATORS.REGEX.
-                # generic-only rules should go through spacegrep
                 # Skip passing this rule to semgrep-core.
-                if language in [Language.REGEX, Language.GENERIC]:
+                if language == Language.REGEX:
                     continue
 
                 # semgrep-core doesn't know about the following operators -

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -42,9 +42,9 @@ from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.semgrep_types import BooleanRuleExpression
 from semgrep.semgrep_types import Language
+from semgrep.semgrep_types import Language_util
 from semgrep.semgrep_types import OPERATORS
 from semgrep.semgrep_types import TAINT_MODE
-from semgrep.semgrep_types import User_language
 from semgrep.spacegrep import run_spacegrep
 from semgrep.target_manager import TargetManager
 from semgrep.target_manager_extensions import all_supported_languages
@@ -437,8 +437,7 @@ class CoreRunner:
 
                 # regex-only rules only support OPERATORS.REGEX.
                 # Skip passing this rule to semgrep-core.
-                REGEX_LANGUAGES = User_language.language_mappings[Language.REGEX]
-                if language in REGEX_LANGUAGES:
+                if language in Language_util.language_strs(Language.REGEX):
                     continue
 
                 # semgrep-core doesn't know about the following operators -
@@ -457,8 +456,7 @@ class CoreRunner:
 
                 patterns_json = [p.to_json() for p in patterns]
 
-                GENERIC_LANGUAGES = User_language.language_mappings[Language.GENERIC]
-                if language in GENERIC_LANGUAGES:
+                if language in Language_util.language_strs(Language.GENERIC):
                     output_json = profiler.track(
                         rule.id,
                         run_spacegrep,

--- a/semgrep/semgrep/equivalences.py
+++ b/semgrep/semgrep/equivalences.py
@@ -1,6 +1,6 @@
 from typing import Any
 from typing import Dict
-from typing import Set
+from typing import List
 
 from semgrep.semgrep_types import Language
 
@@ -20,7 +20,7 @@ class Equivalence:
     '''
     """
 
-    def __init__(self, equiv_id: str, pattern: str, languages: Set[Language]):
+    def __init__(self, equiv_id: str, pattern: str, languages: List[Language]):
         self._id = equiv_id
         self._pattern = pattern
         self._languages = languages
@@ -33,5 +33,5 @@ class Equivalence:
         return {
             "id": self._id,
             "pattern": self._pattern,
-            "languages": list(self._languages),
+            "languages": list(lang.value for lang in self._languages),
         }

--- a/semgrep/semgrep/equivalences.py
+++ b/semgrep/semgrep/equivalences.py
@@ -1,6 +1,6 @@
 from typing import Any
 from typing import Dict
-from typing import List
+from typing import Set
 
 from semgrep.semgrep_types import Language
 
@@ -20,7 +20,7 @@ class Equivalence:
     '''
     """
 
-    def __init__(self, equiv_id: str, pattern: str, languages: List[Language]):
+    def __init__(self, equiv_id: str, pattern: str, languages: Set[Language]):
         self._id = equiv_id
         self._pattern = pattern
         self._languages = languages
@@ -30,4 +30,8 @@ class Equivalence:
         return self._pattern
 
     def to_json(self) -> Dict[str, Any]:
-        return {"id": self._id, "pattern": self._pattern, "languages": self._languages}
+        return {
+            "id": self._id,
+            "pattern": self._pattern,
+            "languages": list(self._languages),
+        }

--- a/semgrep/semgrep/pattern.py
+++ b/semgrep/semgrep/pattern.py
@@ -45,7 +45,7 @@ class Pattern:
             "id": self._id,
             "pattern": self._pattern,
             "severity": self._severity,
-            "languages": [self._language],
+            "languages": [self._language.value],
             "message": "<internalonly>",
         }
 

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -60,7 +60,7 @@ class Rule:
             path_dict = paths_tree.unroll_dict()
         self._includes = path_dict.get("include", [])
         self._excludes = path_dict.get("exclude", [])
-        self._languages = {Language(l) for l in self._raw["languages"]}
+        self._languages = {User_language(l).lang for l in self._raw["languages"]}
 
         # add typescript to languages if the rule supports javascript.
         JAVASCRIPT_LANGUAGES = User_language.language_mappings[Language.JAVASCRIPT]

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -6,7 +6,6 @@ from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
-from typing import Set
 from typing import Tuple
 
 from semgrep.equivalences import Equivalence
@@ -60,11 +59,13 @@ class Rule:
             path_dict = paths_tree.unroll_dict()
         self._includes = path_dict.get("include", [])
         self._excludes = path_dict.get("exclude", [])
-        self._languages = {Language_util.resolve(l) for l in self._raw["languages"]}
+        rule_languages = {Language_util.resolve(l) for l in self._raw["languages"]}
 
         # add typescript to languages if the rule supports javascript.
-        if any(language == Language.JAVASCRIPT for language in self._languages):
-            self._languages.add(Language.TYPESCRIPT)
+        if any(language == Language.JAVASCRIPT for language in rule_languages):
+            rule_languages.add(Language.TYPESCRIPT)
+
+        self._languages = sorted(rule_languages, key=lambda lang: lang.value)  # type: ignore
 
         # check taint/search mode
         self._expression, self._mode = self._build_search_patterns_for_mode(self._yaml)
@@ -286,7 +287,7 @@ class Rule:
             yield f"OWASP-{self.metadata['owasp']}"
 
     @property
-    def languages(self) -> Set[Language]:
+    def languages(self) -> List[Language]:
         return self._languages
 
     @property

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -20,6 +20,7 @@ from semgrep.semgrep_types import ALLOWED_GLOB_TYPES
 from semgrep.semgrep_types import BooleanRuleExpression
 from semgrep.semgrep_types import DEFAULT_MODE
 from semgrep.semgrep_types import Language
+from semgrep.semgrep_types import Language_util
 from semgrep.semgrep_types import Mode
 from semgrep.semgrep_types import Operator
 from semgrep.semgrep_types import OPERATOR_PATTERN_NAMES_MAP
@@ -29,7 +30,6 @@ from semgrep.semgrep_types import pattern_names_for_operator
 from semgrep.semgrep_types import PATTERN_NAMES_OPERATOR_MAP
 from semgrep.semgrep_types import PatternId
 from semgrep.semgrep_types import TAINT_MODE
-from semgrep.semgrep_types import User_language
 from semgrep.semgrep_types import YAML_TAINT_MUST_HAVE_KEYS
 
 
@@ -60,17 +60,17 @@ class Rule:
             path_dict = paths_tree.unroll_dict()
         self._includes = path_dict.get("include", [])
         self._excludes = path_dict.get("exclude", [])
-        self._languages = {User_language(l).lang for l in self._raw["languages"]}
+        self._languages = {Language_util.resolve(l) for l in self._raw["languages"]}
 
         # add typescript to languages if the rule supports javascript.
-        JAVASCRIPT_LANGUAGES = User_language.language_mappings[Language.JAVASCRIPT]
+        JAVASCRIPT_LANGUAGES = Language_util.language_strs(Language.JAVASCRIPT)
         if any(language in self._languages for language in JAVASCRIPT_LANGUAGES):
             self._languages.add(Language.TYPESCRIPT)
 
         # check taint/search mode
         self._expression, self._mode = self._build_search_patterns_for_mode(self._yaml)
 
-        REGEX_LANGUAGES = User_language.language_mappings[Language.REGEX]
+        REGEX_LANGUAGES = Language_util.language_strs(Language.REGEX)
         if any(language in REGEX_LANGUAGES for language in self._languages):
             self._validate_none_language_rule()
 

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -63,15 +63,13 @@ class Rule:
         self._languages = {Language_util.resolve(l) for l in self._raw["languages"]}
 
         # add typescript to languages if the rule supports javascript.
-        JAVASCRIPT_LANGUAGES = Language_util.language_strs(Language.JAVASCRIPT)
-        if any(language in self._languages for language in JAVASCRIPT_LANGUAGES):
+        if any(language == Language.JAVASCRIPT for language in self._languages):
             self._languages.add(Language.TYPESCRIPT)
 
         # check taint/search mode
         self._expression, self._mode = self._build_search_patterns_for_mode(self._yaml)
 
-        REGEX_LANGUAGES = Language_util.language_strs(Language.REGEX)
-        if any(language in REGEX_LANGUAGES for language in self._languages):
+        if any(language == Language.REGEX for language in self._languages):
             self._validate_none_language_rule()
 
     def __eq__(self, other: object) -> bool:

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -59,7 +59,10 @@ class Rule:
             path_dict = paths_tree.unroll_dict()
         self._includes = path_dict.get("include", [])
         self._excludes = path_dict.get("exclude", [])
-        rule_languages = {Language_util.resolve(l) for l in self._raw["languages"]}
+        rule_languages = {
+            Language_util.resolve(l, self.languages_span)
+            for l in self._raw["languages"]
+        }
 
         # add typescript to languages if the rule supports javascript.
         if any(language == Language.JAVASCRIPT for language in rule_languages):

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -2,6 +2,7 @@ import functools
 from enum import Enum
 from typing import Any
 from typing import Dict
+from typing import KeysView
 from typing import List
 from typing import Mapping
 from typing import NamedTuple
@@ -48,8 +49,9 @@ class Language(Enum):
     GENERIC: str = "generic"
 
 
-class User_language:
-    language_mappings: Dict[Language, List[str]] = {
+class Language_util:
+
+    language_to_strs: Dict[Language, List[str]] = {
         Language.PYTHON: [Language.PYTHON.value, "py"],
         Language.PYTHON2: [Language.PYTHON2.value],
         Language.PYTHON3: [Language.PYTHON3.value],
@@ -71,16 +73,25 @@ class User_language:
         Language.GENERIC: [Language.GENERIC.value],
     }
 
-    canonical_languages = {}
-    for canon_language in language_mappings.keys():
-        for language in language_mappings[canon_language]:
-            canonical_languages[language] = canon_language
+    str_to_language = {}
+    for language in language_to_strs.keys():
+        for lang_str in language_to_strs[language]:
+            str_to_language[lang_str] = language
 
-    def __init__(self, lang: str):
-        if lang in self.canonical_languages:
-            self.lang = self.canonical_languages[lang]
+    @classmethod
+    def resolve(cls, lang_str: str) -> Language:
+        if lang_str in cls.str_to_language:
+            return cls.str_to_language[lang_str]
         else:
-            self.lang = Language.GENERIC
+            return Language.GENERIC
+
+    @classmethod
+    def language_strs(cls, lang: Language) -> List[str]:
+        return cls.language_to_strs[lang]
+
+    @classmethod
+    def all_language_strs(cls) -> KeysView[str]:
+        return cls.str_to_language.keys()
 
 
 class OPERATORS:

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -77,6 +77,14 @@ class Language_util:
         for lang_str in language_to_strs[language]:
             str_to_language[lang_str] = language
 
+    """ Convert an inputted string representing a language to a Language
+
+    Keyword arguments;
+    lang_str -- string representing a language (e.g. "C#")
+    span     -- span of language string in the original file (for error reporting),
+                None if resolve was called within semgrep
+    """
+
     @classmethod
     def resolve(cls, lang_str: str, span: Optional[Span] = None) -> Language:
         if lang_str in cls.str_to_language:
@@ -87,11 +95,12 @@ class Language_util:
                 long_msg=f"unsupported language: {lang_str}. supported languages are: {', '.join(cls.all_language_strs())}",
                 spans=[span.with_context(before=1, after=1)]
                 if span
-                else [],  # rule.languages_span.with_context(before=1, after=1)],
+                else [],  # not called from a config file
             )
 
     @classmethod
     def all_language_strs(cls) -> List[str]:
+        # sort to standardize because this is used in outputting methods
         return sorted(cls.str_to_language.keys())
 
 

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -12,6 +12,7 @@ from typing import Union
 
 import attr
 
+from semgrep.error import UnknownLanguageError
 from semgrep.rule_lang import YamlMap
 
 Mode = NewType("Mode", str)
@@ -40,7 +41,7 @@ class Language(Enum):
     LUA: str = "lua"
     CSHARP: str = "csharp"
     RUST: str = "rust"
-    KOTLIN: str = "kotlin"
+    KOTLIN: str = "kt"
     YAML: str = "yaml"
     ML: str = "ml"
     JSON: str = "json"
@@ -49,7 +50,6 @@ class Language(Enum):
 
 
 class Language_util:
-
     language_to_strs: Dict[Language, List[str]] = {
         Language.PYTHON: [Language.PYTHON.value, "py"],
         Language.PYTHON2: [Language.PYTHON2.value],
@@ -64,7 +64,7 @@ class Language_util:
         Language.LUA: [Language.LUA.value],
         Language.CSHARP: [Language.CSHARP.value, "cs", "C#"],
         Language.RUST: [Language.RUST.value, "Rust", "rs"],
-        Language.KOTLIN: [Language.KOTLIN.value, "Kotlin", "kt"],
+        Language.KOTLIN: [Language.KOTLIN.value, "Kotlin", "kotlin"],
         Language.YAML: [Language.YAML.value, "YAML"],
         Language.ML: [Language.ML.value, "ocaml"],
         Language.JSON: [Language.JSON.value, "JSON", "Json"],
@@ -82,11 +82,11 @@ class Language_util:
         if lang_str in cls.str_to_language:
             return cls.str_to_language[lang_str]
         else:
-            return Language.GENERIC
-
-    @classmethod
-    def language_strs(cls, lang: Language) -> List[str]:
-        return cls.language_to_strs[lang]
+            raise UnknownLanguageError(
+                short_msg=f"invalid language: {str}",
+                long_msg=f"unsupported language: {str}. supported languages are: {', '.join(cls.all_language_strs())}",
+                spans=[],  # rule.languages_span.with_context(before=1, after=1)],
+            )
 
     @classmethod
     def all_language_strs(cls) -> KeysView[str]:

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -1,4 +1,5 @@
 import functools
+from enum import Enum
 from typing import Any
 from typing import Dict
 from typing import List
@@ -12,8 +13,7 @@ import attr
 
 from semgrep.rule_lang import YamlMap
 
-
-Language = NewType("Language", str)
+# Language = NewType("Language", str)
 Mode = NewType("Mode", str)
 PatternId = NewType("PatternId", str)
 Operator = NewType("Operator", str)
@@ -24,6 +24,63 @@ SEARCH_MODE = DEFAULT_MODE = Mode("search")
 SUPPORTED_MODES = {TAINT_MODE, SEARCH_MODE}
 
 YAML_TAINT_MUST_HAVE_KEYS = {"pattern-sinks", "pattern-sources"}
+
+
+class Language(Enum):
+    PYTHON: str = "python"
+    PYTHON2: str = "python2"
+    PYTHON3: str = "python3"
+    JAVASCRIPT: str = "javascript"
+    TYPESCRIPT: str = "typescript"
+    JAVA: str = "java"
+    C: str = "c"
+    GO: str = "go"
+    RUBY: str = "ruby"
+    PHP: str = "php"
+    LUA: str = "lua"
+    CSHARP: str = "csharp"
+    RUST: str = "rust"
+    KOTLIN: str = "kotlin"
+    YAML: str = "yaml"
+    ML: str = "ml"
+    JSON: str = "json"
+    REGEX: str = "regex"
+    GENERIC: str = "generic"
+
+
+class User_language:
+    language_mappings: Dict[Language, List[str]] = {
+        Language.PYTHON: [Language.PYTHON.value, "py"],
+        Language.PYTHON2: [Language.PYTHON2.value],
+        Language.PYTHON3: [Language.PYTHON3.value],
+        Language.JAVASCRIPT: [Language.JAVASCRIPT.value, "js"],
+        Language.TYPESCRIPT: [Language.TYPESCRIPT.value, "ts"],
+        Language.JAVA: [Language.JAVA.value],
+        Language.C: [Language.C.value],
+        Language.GO: [Language.GO.value, "golang"],
+        Language.RUBY: [Language.RUBY.value, "rb"],
+        Language.PHP: [Language.PHP.value],
+        Language.LUA: [Language.LUA.value],
+        Language.CSHARP: [Language.CSHARP.value, "cs", "C#"],
+        Language.RUST: [Language.RUST.value, "Rust", "rs"],
+        Language.KOTLIN: [Language.KOTLIN.value, "Kotlin", "kt"],
+        Language.YAML: [Language.YAML.value, "YAML"],
+        Language.ML: [Language.ML.value, "ocaml"],
+        Language.JSON: [Language.JSON.value, "JSON", "Json"],
+        Language.REGEX: [Language.REGEX.value, "none"],
+        Language.GENERIC: [Language.GENERIC.value],
+    }
+
+    canonical_languages = {}
+    for canon_language in language_mappings.keys():
+        for language in language_mappings[canon_language]:
+            canonical_languages[language] = canon_language
+
+    def __init__(self, lang: str):
+        if lang in self.canonical_languages:
+            self.lang = self.canonical_languages[lang]
+        else:
+            self.lang = Language.GENERIC
 
 
 class OPERATORS:

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -2,7 +2,6 @@ import functools
 from enum import Enum
 from typing import Any
 from typing import Dict
-from typing import KeysView
 from typing import List
 from typing import Mapping
 from typing import NamedTuple
@@ -13,6 +12,7 @@ from typing import Union
 import attr
 
 from semgrep.error import UnknownLanguageError
+from semgrep.rule_lang import Span
 from semgrep.rule_lang import YamlMap
 
 Mode = NewType("Mode", str)
@@ -65,7 +65,7 @@ class Language_util:
         Language.CSHARP: [Language.CSHARP.value, "cs", "C#"],
         Language.RUST: [Language.RUST.value, "Rust", "rs"],
         Language.KOTLIN: [Language.KOTLIN.value, "Kotlin", "kotlin"],
-        Language.YAML: [Language.YAML.value, "YAML"],
+        Language.YAML: [Language.YAML.value, "Yaml"],
         Language.ML: [Language.ML.value, "ocaml"],
         Language.JSON: [Language.JSON.value, "JSON", "Json"],
         Language.REGEX: [Language.REGEX.value, "none"],
@@ -78,19 +78,21 @@ class Language_util:
             str_to_language[lang_str] = language
 
     @classmethod
-    def resolve(cls, lang_str: str) -> Language:
+    def resolve(cls, lang_str: str, span: Optional[Span] = None) -> Language:
         if lang_str in cls.str_to_language:
             return cls.str_to_language[lang_str]
         else:
             raise UnknownLanguageError(
-                short_msg=f"invalid language: {str}",
-                long_msg=f"unsupported language: {str}. supported languages are: {', '.join(cls.all_language_strs())}",
-                spans=[],  # rule.languages_span.with_context(before=1, after=1)],
+                short_msg=f"invalid language: {lang_str}",
+                long_msg=f"unsupported language: {lang_str}. supported languages are: {', '.join(cls.all_language_strs())}",
+                spans=[span.with_context(before=1, after=1)]
+                if span
+                else [],  # rule.languages_span.with_context(before=1, after=1)],
             )
 
     @classmethod
-    def all_language_strs(cls) -> KeysView[str]:
-        return cls.str_to_language.keys()
+    def all_language_strs(cls) -> List[str]:
+        return sorted(cls.str_to_language.keys())
 
 
 class OPERATORS:

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -14,7 +14,6 @@ import attr
 
 from semgrep.rule_lang import YamlMap
 
-# Language = NewType("Language", str)
 Mode = NewType("Mode", str)
 PatternId = NewType("PatternId", str)
 Operator = NewType("Operator", str)

--- a/semgrep/semgrep/stats.py
+++ b/semgrep/semgrep/stats.py
@@ -5,7 +5,7 @@ from typing import cast
 from typing import Dict
 from typing import Set
 
-from semgrep.target_manager_extensions import ext_to_langs
+from semgrep.target_manager_extensions import ext_to_lang
 from semgrep.target_manager_extensions import FileExtension
 from semgrep.target_manager_extensions import Language
 
@@ -28,7 +28,7 @@ def make_target_stats(all_targets: Set[Path]) -> Dict[str, Any]:
         suffix: FileExtension = cast(FileExtension, path.suffix)
         extensions[suffix] += 1
         # an extension could map to multiple languages; just take the first one
-        lang = ext_to_langs(suffix)
+        lang = ext_to_lang(suffix)
         languages[lang] += 1
 
     return {

--- a/semgrep/semgrep/stats.py
+++ b/semgrep/semgrep/stats.py
@@ -28,7 +28,7 @@ def make_target_stats(all_targets: Set[Path]) -> Dict[str, Any]:
         suffix: FileExtension = cast(FileExtension, path.suffix)
         extensions[suffix] += 1
         # an extension could map to multiple languages; just take the first one
-        lang = sorted(ext_to_langs(suffix))[0]
+        lang = ext_to_langs(suffix)
         languages[lang] += 1
 
     return {

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -168,7 +168,7 @@ class TargetManager:
 
     @staticmethod
     def expand_targets(
-        targets: Collection[Path], lang: Language, respect_git_ignore: bool
+        targets: Collection[Path], language: Language, respect_git_ignore: bool
     ) -> Set[Path]:
         """
         Explore all directories. Remove duplicates
@@ -180,7 +180,7 @@ class TargetManager:
 
             if target.is_dir():
                 expanded.update(
-                    TargetManager._expand_dir(target, lang, respect_git_ignore)
+                    TargetManager._expand_dir(target, language, respect_git_ignore)
                 )
             else:
                 expanded.add(target)
@@ -243,8 +243,8 @@ class TargetManager:
 
         Note also filters out any directory and decendants of `.git`
         """
-        if lang in self._filtered_targets:
-            return self._filtered_targets[lang]
+        if lang.value in self._filtered_targets:
+            return self._filtered_targets[lang.value]
 
         targets = self.resolve_targets(self.targets)
 
@@ -278,11 +278,11 @@ class TargetManager:
             )
             targets = targets.union(explicit_files_with_unknown_extensions)
 
-        self._filtered_targets[lang] = targets
-        return self._filtered_targets[lang]
+        self._filtered_targets[lang.value] = targets
+        return self._filtered_targets[lang.value]
 
     def get_files(
-        self, lang: Language, includes: List[str], excludes: List[str]
+        self, language: Language, includes: List[str], excludes: List[str]
     ) -> List[Path]:
         """
         Returns list of files that should be analyzed for a LANG
@@ -295,7 +295,7 @@ class TargetManager:
         in TARGET will bypass this global INCLUDE/EXCLUDE filter. The local INCLUDE/EXCLUDE
         filter is then applied.
         """
-        targets = self.filtered_files(lang)
+        targets = self.filtered_files(language)
         targets = self.filter_includes(targets, includes)
         targets = self.filter_excludes(targets, excludes)
         targets = self.filter_by_size(targets, self.max_target_bytes)

--- a/semgrep/semgrep/target_manager.py
+++ b/semgrep/semgrep/target_manager.py
@@ -61,7 +61,7 @@ class TargetManager:
     output_handler: OutputHandler
     skip_unknown_extensions: bool
 
-    _filtered_targets: Dict[str, Set[Path]] = attr.ib(factory=dict)
+    _filtered_targets: Dict[Language, Set[Path]] = attr.ib(factory=dict)
 
     @staticmethod
     def resolve_targets(targets: List[str]) -> Set[Path]:
@@ -168,7 +168,7 @@ class TargetManager:
 
     @staticmethod
     def expand_targets(
-        targets: Collection[Path], language: Language, respect_git_ignore: bool
+        targets: Collection[Path], lang: Language, respect_git_ignore: bool
     ) -> Set[Path]:
         """
         Explore all directories. Remove duplicates
@@ -180,7 +180,7 @@ class TargetManager:
 
             if target.is_dir():
                 expanded.update(
-                    TargetManager._expand_dir(target, language, respect_git_ignore)
+                    TargetManager._expand_dir(target, lang, respect_git_ignore)
                 )
             else:
                 expanded.add(target)
@@ -243,8 +243,8 @@ class TargetManager:
 
         Note also filters out any directory and decendants of `.git`
         """
-        if lang.value in self._filtered_targets:
-            return self._filtered_targets[lang.value]
+        if lang in self._filtered_targets:
+            return self._filtered_targets[lang]
 
         targets = self.resolve_targets(self.targets)
 
@@ -278,11 +278,11 @@ class TargetManager:
             )
             targets = targets.union(explicit_files_with_unknown_extensions)
 
-        self._filtered_targets[lang.value] = targets
-        return self._filtered_targets[lang.value]
+        self._filtered_targets[lang] = targets
+        return self._filtered_targets[lang]
 
     def get_files(
-        self, language: Language, includes: List[str], excludes: List[str]
+        self, lang: Language, includes: List[str], excludes: List[str]
     ) -> List[Path]:
         """
         Returns list of files that should be analyzed for a LANG
@@ -295,7 +295,7 @@ class TargetManager:
         in TARGET will bypass this global INCLUDE/EXCLUDE filter. The local INCLUDE/EXCLUDE
         filter is then applied.
         """
-        targets = self.filtered_files(language)
+        targets = self.filtered_files(lang)
         targets = self.filter_includes(targets, includes)
         targets = self.filter_excludes(targets, excludes)
         targets = self.filter_by_size(targets, self.max_target_bytes)

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -5,7 +5,7 @@ from semgrep.error import _UnknownExtensionError
 from semgrep.error import _UnknownLanguageError
 from semgrep.semgrep_types import FileExtension
 from semgrep.semgrep_types import Language
-from semgrep.semgrep_types import User_language as L
+from semgrep.semgrep_types import User_language
 
 
 # coupling: if you add a constant here, modify also ALL_EXTENSIONS below
@@ -77,7 +77,7 @@ def all_supported_languages() -> List[str]:
     """
     We want the list of languages to be deterministic, so sort it
     """
-    return sorted(L.canonical_languages.keys())
+    return sorted(User_language.canonical_languages.keys())
 
 
 # create a dictionary for fast lookup and reverse lookup

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -90,7 +90,7 @@ for language in _LANGS_TO_EXTS.keys():
             _EXTS_TO_LANG[extension] = language
 
 
-def ext_to_langs(ext: FileExtension) -> Language:
+def ext_to_lang(ext: FileExtension) -> Language:
     langs = _EXTS_TO_LANG.get(ext)
     if langs is None:
         raise _UnknownExtensionError(f"Unsupported extension: {ext}")

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -5,7 +5,7 @@ from semgrep.error import _UnknownExtensionError
 from semgrep.error import _UnknownLanguageError
 from semgrep.semgrep_types import FileExtension
 from semgrep.semgrep_types import Language
-from semgrep.semgrep_types import User_language
+from semgrep.semgrep_types import Language_util
 
 
 # coupling: if you add a constant here, modify also ALL_EXTENSIONS below
@@ -77,7 +77,7 @@ def all_supported_languages() -> List[str]:
     """
     We want the list of languages to be deterministic, so sort it
     """
-    return sorted(User_language.canonical_languages.keys())
+    return sorted(Language_util.all_language_strs())
 
 
 # create a dictionary for fast lookup and reverse lookup

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -77,7 +77,7 @@ def all_supported_languages() -> List[str]:
     """
     We want the list of languages to be deterministic, so sort it
     """
-    return sorted(Language_util.all_language_strs())
+    return Language_util.all_language_strs()
 
 
 # create a dictionary for fast lookup and reverse lookup

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -1,4 +1,3 @@
-running 1 rules...
 [31msemgrep error[39m: invalid language: intercal
   --> rules/syntax/badlanguage.yaml:7
 [94m6 | [39m    message: "$X is being assigned to one or two"

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -28,6 +28,12 @@ def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
     snapshot.assert_match(str(excinfo.value.returncode), "returncode.txt")
 
 
+def test_regex_with_bad_language(run_semgrep_in_tmp, snapshot):
+    with pytest.raises(CalledProcessError) as excinfo:
+        run_semgrep_in_tmp("rules/badlanguage.yaml")
+    assert excinfo.value.returncode != 0
+
+
 def test_rule_parser__empty(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp(f"rules/syntax/empty.yaml")

--- a/semgrep/tests/unit/test_target_manager.py
+++ b/semgrep/tests/unit/test_target_manager.py
@@ -7,6 +7,7 @@ from semgrep.constants import OutputFormat
 from semgrep.output import OutputHandler
 from semgrep.output import OutputSettings
 from semgrep.semgrep_types import Language
+from semgrep.semgrep_types import Language_util
 from semgrep.target_manager import TargetManager
 
 
@@ -99,7 +100,7 @@ def test_filter_by_size():
         fp.write(b"0123456789")
         fp.flush()
         path = Path(fp.name)
-        targets = [path]
+        targets = {path}
 
         # no max size
         assert len(TargetManager.filter_by_size(targets, 0)) == 1
@@ -129,7 +130,10 @@ def test_delete_git(tmp_path, monkeypatch):
     subprocess.run(["git", "status"])
 
     assert cmp_path_sets(
-        TargetManager.expand_targets([Path(".")], Language("python"), True), {bar}
+        TargetManager.expand_targets(
+            [Path(".")], Language_util.resolve("python"), True
+        ),
+        {bar},
     )
 
 
@@ -177,7 +181,7 @@ def test_expand_targets_git(tmp_path, monkeypatch):
     in_bar = {bar_a, bar_b}
     in_all = in_foo.union(in_bar)
 
-    python_language = Language("python")
+    python_language = Language_util.resolve("python")
 
     monkeypatch.chdir(tmp_path)
     assert cmp_path_sets(


### PR DESCRIPTION
Define a language enum and map user given strings (eg "csharp", "cs", "C#") to the appropriate language enum, which has a specific value. This allows the list of languages to be treated as a set, so that there will never be duplicate languages.

This fixes a bug where `--optimizations` returned typescript results multiple times

Test plan: run 

```
semgrep --config ../semgrep-core/tests/OTHER/experimental_diff/array_access.yaml ../perf/bench/semgrep-app/input/semgrep-app/ --time --optimizations
```

and 

```
semgrep --config ../semgrep-core/tests/OTHER/experimental_diff/array_access.yaml ../perf/bench/semgrep-app/input/semgrep-app/ --time --optimizations
```

and compare the number of results


PR checklist:
- [x] changelog is up to date

