### PR TITLE
Add to timing output to test.py

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -488,7 +488,7 @@ def cli() -> None:
     if args.test:
         # the test code (which isn't a "test" per se but is actually machinery to evaluate semgrep performance)
         # uses managed_output internally
-        semgrep.test.test_main(args)
+        semgrep.test.test_main(args, output_settings)
 
     # The 'optional_stdin_target' context manager must remain before
     # 'managed_output'. Output depends on file contents so we cannot have

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -488,7 +488,11 @@ def cli() -> None:
     if args.test:
         # the test code (which isn't a "test" per se but is actually machinery to evaluate semgrep performance)
         # uses managed_output internally
-        semgrep.test.test_main(args, output_settings)
+        test_output_settings = OutputSettings(
+            output_format = OutputFormat.JSON,
+            output_time = output_time,
+        )
+        semgrep.test.test_main(args, test_output_settings)
 
     # The 'optional_stdin_target' context manager must remain before
     # 'managed_output'. Output depends on file contents so we cannot have

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -26,7 +26,6 @@ from typing import Mapping
 from typing import Optional
 from typing import Set
 from typing import Tuple
-import ipdb
 
 from semgrep.constants import BREAK_LINE
 from semgrep.semgrep_main import invoke_semgrep

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -262,8 +262,8 @@ def generate_matches_line(check_results: Mapping[str, Any]) -> str:
 
 def invoke_semgrep_multi(
     config: Path, 
-    targets: List[Path], 
-    output_settings: OutputSettings, 
+    targets: List[Path],
+    output_settings: OutputSettings,
     **kwargs: Any
 ) -> Tuple[Path, Optional[Exception], Any]:
     try:


### PR DESCRIPTION
This PR makes it so that you can run the command:
` semgrep --test --test-ignore-todo --dangerously-allow-arbitrary-code-execution-from-rules --time --json $$PWD`
and receive timing information in the outputted json.