### PR TITLE
Pin ocamlformat to 0.15.0 for consistent formatting

### DIFF
--- a/semgrep-core/dev/dev.opam
+++ b/semgrep-core/dev/dev.opam
@@ -8,6 +8,6 @@ bug-reports: "n/a"
 synopsis: "OCaml development dependencies"
 
 depends: [
-  "merlin"      # used by the various text editors with ocaml support
-  "ocamlformat" # required for reformatting code, used by the pre-commit hook
+  "merlin"  # used by the various text editors with ocaml support
+  "ocamlformat" {= "0.15.0" }  # used by the pre-commit hook
 ]


### PR DESCRIPTION
This is the latest version supported on ocaml 4.10.0 given our other dependencies.

PR checklist:
- [x] changelog is up to date

