### PR TITLE
Avoid using "chdir"

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -9,15 +9,18 @@ import semgrep.semgrep_main
 import semgrep.test
 from semgrep import __VERSION__
 from semgrep.bytesize import parse_size
+from semgrep.constants import ADJUST_FOR_DOCKER
 from semgrep.constants import DEFAULT_CONFIG_FILE
 from semgrep.constants import DEFAULT_MAX_CHARS_PER_LINE
 from semgrep.constants import DEFAULT_MAX_LINES_PER_FINDING
 from semgrep.constants import DEFAULT_MAX_TARGET_SIZE
+from semgrep.constants import DEFAULT_TARGET
 from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import MAX_CHARS_FLAG_NAME
 from semgrep.constants import MAX_LINES_FLAG_NAME
 from semgrep.constants import OutputFormat
 from semgrep.constants import RCE_RULE_FLAG
+from semgrep.constants import SEMGREP_SRC_DIRECTORY
 from semgrep.constants import SEMGREP_URL
 from semgrep.dump_ast import dump_parsed_ast
 from semgrep.error import SemgrepError
@@ -46,7 +49,7 @@ def cli() -> None:
     parser.add_argument(
         "target",
         nargs="*",
-        default=[os.curdir],
+        default=DEFAULT_TARGET,
         help=(
             "Search these files or directories. Defaults to entire current "
             "working directory. Implied argument if piping to semgrep."
@@ -446,13 +449,6 @@ def cli() -> None:
     # set the flags
     semgrep.util.set_flags(args.debug, args.quiet, args.force_color)
 
-    # change cwd if using docker
-    try:
-        semgrep.config_resolver.adjust_for_docker()
-    except SemgrepError as e:
-        logger.exception(str(e))
-        raise e
-
     output_format = OutputFormat.TEXT
     if args.json or args.json_time or args.debugging_json:
         output_format = OutputFormat.JSON
@@ -490,10 +486,15 @@ def cli() -> None:
         # uses managed_output internally
         semgrep.test.test_main(args)
 
+    if args.target == DEFAULT_TARGET and ADJUST_FOR_DOCKER:
+        target = [str(SEMGREP_SRC_DIRECTORY)]
+    else:
+        target = args.target
+
     # The 'optional_stdin_target' context manager must remain before
     # 'managed_output'. Output depends on file contents so we cannot have
     # already deleted the temporary stdin file.
-    with optional_stdin_target(args.target) as target, managed_output(
+    with optional_stdin_target(target) as target, managed_output(
         output_settings
     ) as output_handler:
         if args.dump_ast:

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -487,14 +487,14 @@ def cli() -> None:
         semgrep.test.test_main(args)
 
     if args.target == DEFAULT_TARGET and ADJUST_FOR_DOCKER:
-        target = [str(SEMGREP_SRC_DIRECTORY)]
+        target_input = [str(SEMGREP_SRC_DIRECTORY)]
     else:
-        target = args.target
+        target_input = args.target
 
     # The 'optional_stdin_target' context manager must remain before
     # 'managed_output'. Output depends on file contents so we cannot have
     # already deleted the temporary stdin file.
-    with optional_stdin_target(target) as target, managed_output(
+    with optional_stdin_target(target_input) as target, managed_output(
         output_settings
     ) as output_handler:
         if args.dump_ast:

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -13,6 +13,7 @@ from typing import Tuple
 from ruamel.yaml import YAML
 from ruamel.yaml import YAMLError
 
+from semgrep.constants import ADJUST_FOR_DOCKER
 from semgrep.constants import CLI_RULE_ID
 from semgrep.constants import DEFAULT_CONFIG_FILE
 from semgrep.constants import DEFAULT_CONFIG_FOLDER
@@ -20,6 +21,8 @@ from semgrep.constants import DEFAULT_SEMGREP_CONFIG_NAME
 from semgrep.constants import ID_KEY
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.constants import RULES_KEY
+from semgrep.constants import SEMGREP_IN_DOCKER
+from semgrep.constants import SEMGREP_SRC_DIRECTORY
 from semgrep.constants import SEMGREP_URL
 from semgrep.constants import SEMGREP_USER_AGENT
 from semgrep.error import InvalidRuleSchemaError
@@ -35,15 +38,7 @@ from semgrep.util import is_url
 
 logger = logging.getLogger(__name__)
 
-IN_DOCKER = "SEMGREP_IN_DOCKER" in os.environ
-IN_GH_ACTION = "GITHUB_WORKSPACE" in os.environ
-
-SRC_DIRECTORY = Path(os.environ.get("SEMGREP_SRC_DIRECTORY", Path("/") / "src"))
-OLD_SRC_DIRECTORY = Path("/") / "home" / "repo"
-
 RULES_REGISTRY = {"r2c": "https://semgrep.dev/c/p/r2c"}
-
-MISSING_RULE_ID = "no-rule-id"
 
 DEFAULT_CONFIG = {
     "rules": [
@@ -144,25 +139,29 @@ class Config:
 
     @staticmethod
     def _convert_config_id_to_prefix(config_id: str) -> str:
-        at_path = Path(config_id)
-        at_path = Config._safe_relative_to(at_path, Path.cwd())
+        if ADJUST_FOR_DOCKER:
+            relative_path = SEMGREP_SRC_DIRECTORY
+        else:
+            relative_path = Path.cwd()
 
-        prefix = ".".join(at_path.parts[:-1]).lstrip("./").lstrip(".")
+        at_path = Path(config_id)
+        at_path = Config._safe_relative_to(at_path, relative_path)
+
+        prefix = ".".join(at_path.parts[:-1]).lstrip("./")
         if len(prefix):
             prefix += "."
+
         return prefix
 
     @staticmethod
     def _rename_rule_ids(valid_configs: Dict[str, List[Rule]]) -> Dict[str, List[Rule]]:
-        transformed = {}
-        for config_id, rules in valid_configs.items():
-            transformed[config_id] = [
-                rule.with_id(
-                    f"{Config._convert_config_id_to_prefix(config_id)}{rule.id or MISSING_RULE_ID}"
-                )
+        return {
+            config_id: [
+                rule.with_id(Config._convert_config_id_to_prefix(config_id) + rule.id)
                 for rule in rules
             ]
-        return transformed
+            for config_id, rules in valid_configs.items()
+        }
 
     # the mypy ignore is cause YamlTree puts an Any inside the @staticmethod decorator
     @staticmethod
@@ -249,21 +248,6 @@ def resolve_targets(targets: List[str]) -> List[Path]:
         Path(target) if Path(target).is_absolute() else base_path.joinpath(target)
         for target in targets
     ]
-
-
-def adjust_for_docker() -> None:
-    # change into this folder so that all paths are relative to it
-    if IN_DOCKER and not IN_GH_ACTION:
-        if OLD_SRC_DIRECTORY.exists():
-            raise SemgrepError(
-                f"Detected Docker environment using old code volume, please use '{SRC_DIRECTORY}' instead of '{OLD_SRC_DIRECTORY}'"
-            )
-        if not SRC_DIRECTORY.exists():
-            raise SemgrepError(
-                f"Detected Docker environment without a code volume, please include '-v \"${{PWD}}:{SRC_DIRECTORY}\"'"
-            )
-    if SRC_DIRECTORY.exists():
-        os.chdir(SRC_DIRECTORY)
 
 
 def get_base_path() -> Path:
@@ -361,7 +345,7 @@ def load_config_from_local_path(location: str) -> Dict[str, YamlTree]:
             raise SemgrepError(f"config location `{loc}` is not a file or folder!")
     else:
         addendum = ""
-        if IN_DOCKER:
+        if SEMGREP_IN_DOCKER:
             addendum = " (since you are running in docker, you cannot specify arbitrary paths on the host; they must be mounted into the container)"
         raise SemgrepError(
             f"unable to find a config; path `{loc}` does not exist{addendum}"

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -140,6 +140,10 @@ class Config:
     @staticmethod
     def _convert_config_id_to_prefix(config_id: str) -> str:
         if ADJUST_FOR_DOCKER:
+            # Avoid prepending filesystem-dependent rule IDs with the source
+            # directory inside Docker. E.g. 'config.rule.id' instead of
+            # 'src.config.rule.id'. This keeps rule IDs consistent even inside
+            # Docker containers.
             relative_path = SEMGREP_SRC_DIRECTORY
         else:
             relative_path = Path.cwd()

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -2,6 +2,7 @@ import os
 import re
 from enum import auto
 from enum import Enum
+from pathlib import Path
 
 from semgrep import __VERSION__
 
@@ -15,6 +16,7 @@ PLEASE_FILE_ISSUE_TEXT = "An error occurred while invoking the semgrep engine; p
 DEFAULT_SEMGREP_CONFIG_NAME = "semgrep"
 DEFAULT_CONFIG_FILE = f".{DEFAULT_SEMGREP_CONFIG_NAME}.yml"
 DEFAULT_CONFIG_FOLDER = f".{DEFAULT_SEMGREP_CONFIG_NAME}"
+DEFAULT_TARGET = [os.curdir]
 
 DEFAULT_TIMEOUT = 30  # seconds
 
@@ -22,6 +24,11 @@ SEMGREP_USER_AGENT = f"Semgrep/{__VERSION__}"
 SEMGREP_USER_AGENT_APPEND = os.environ.get("SEMGREP_USER_AGENT_APPEND")
 if SEMGREP_USER_AGENT_APPEND is not None:
     SEMGREP_USER_AGENT = f"{SEMGREP_USER_AGENT} {SEMGREP_USER_AGENT_APPEND}"
+
+SEMGREP_SRC_DIRECTORY = Path(os.environ.get("SEMGREP_SRC_DIRECTORY", Path("/") / "src"))
+SEMGREP_IN_DOCKER = "SEMGREP_IN_DOCKER" in os.environ
+SEMGREP_IN_GH_ACTION = "GITHUB_WORKSPACE" in os.environ
+ADJUST_FOR_DOCKER = SEMGREP_IN_DOCKER and not SEMGREP_IN_GH_ACTION
 
 YML_EXTENSIONS = {".yml", ".yaml"}
 YML_SUFFIXES = [[ext] for ext in YML_EXTENSIONS]


### PR DESCRIPTION
Fixes #1215.

This thing bit GitLab, and is so often a sharp edge for users. We're well past fixing it at this point :+1: 

I'm not 100% clear on everything `adjust_for_docker` was supposed to accomplish. My understanding is that it provided two things:

1. A sane default target inside Docker environments where we expect the code volume to be.
2. A mechanism for cleaning our filesystem-dependent rule IDs. In other words, the default volume is `/src` and we don't want all rule IDs to be prepended with `src`. Performing a `chdir` to the code directory fixes this.

These code changes account for both of the above issues without performing a `chdir`. The problems with `chdir` have been highlighted extensively in #1215. Let me know if I'm missing any more cases `adjust_for_docker` was covering.

These changes also have the benefit of explicitly stating what state to alter when we're running in Docker vs. implicitly performing a `chdir` and you're supposed to know why we're doing that :+1: 

I manually tested this by hardcoding `ADJUST_FOR_DOCKER` to `True` and `False` and noting that it did the correct thing.