### PR TITLE
matching: Prefer Id over E when binding typed metavariables to names

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1000,9 +1000,12 @@ and m_compatible_type typed_mvar t e =
       m_type_ t (A.TyPointer (t1, TyBuiltin ("char", tok))) >>= fun () ->
       envf typed_mvar (MV.E e)
   (* for matching ids *)
+  | ta, B.N (B.Id (idb, ({ B.id_type = tb; _ } as id_infob))) ->
+      (* NOTE: Name values must be represented with MV.Id! *)
+      m_type_option_with_hook idb (Some ta) !tb >>= fun () ->
+      envf typed_mvar (MV.Id (idb, Some id_infob))
   | ( ta,
-      ( B.N (B.Id (idb, { B.id_type = tb; _ }))
-      | B.N (B.IdQualified ((idb, _), { B.id_type = tb; _ }))
+      ( B.N (B.IdQualified ((idb, _), { B.id_type = tb; _ }))
       | B.DotAccess
           (IdSpecial (This, _), _, EN (Id (idb, { B.id_type = tb; _ }))) ) ) ->
       m_type_option_with_hook idb (Some ta) !tb >>= fun () ->

--- a/semgrep-core/tests/OTHER/rules/typed_metavar_not.java
+++ b/semgrep-core/tests/OTHER/rules/typed_metavar_not.java
@@ -1,0 +1,12 @@
+public class BenchmarkTest02388 extends HttpServlet {
+
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // OK because constant string
+        // ok: no-direct-response-writer
+        PrintWriter writer = response.getWriter();
+        writer.println(
+"Hash Test java.security.MessageDigest.getInstance(java.lang.String) executed"
+);
+    }  // end doPost
+
+}

--- a/semgrep-core/tests/OTHER/rules/typed_metavar_not.yaml
+++ b/semgrep-core/tests/OTHER/rules/typed_metavar_not.yaml
@@ -1,0 +1,19 @@
+rules:
+- id: no-direct-response-writer
+  patterns:
+  - pattern: |
+      (PrintWriter $WRITER).println(...)
+  - pattern-not: $WRITER.println("...")
+  message: |
+    Detected a direct write to the HTTP response. This bypasses any
+    view or template environments, including HTML escaping, which may
+    expose this application to cross-site scripting (XSS) vulnerabilities.
+    Consider using a view technology such as JavaServer Faces (JSFs) which
+    automatically escapes HTML views.
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: 'CWE-116: Improper Encoding or Escaping of Output'
+    references:
+    - https://www3.ntu.edu.sg/home/ehchua/programming/java/JavaServerFaces.html
+  severity: WARNING
+  languages: [java]


### PR DESCRIPTION
When a metavar binds to a name this must be represented using the Id
constructor.

This fixes a -config regression wrt Python's Semgrep wrapper affecting:
semgrep-rules/java/lang/security/audit/xss/no-direct-response-writer.java

The problem can be reproduced with a simple pattern-and:

    patterns:
    - pattern: |
        (PrintWriter $WRITER).println(...)
    - pattern-not: $WRITER.println("...")

on this Java code:

    PrintWriter writer = response.getWriter();
    writer.println("foo");

The typed metavar $WRITER used in the positive pattern is bound to
`MV.E (N (Id "writer"))` whereas the non-typed metavar $WRITER used in
the negative pattern is bound to `MV.Id "writer"`. Then, when we check
if there is a negative match that filters out our positive match, we
can't find one because `MV.E` and `MV.Id` are different kinds of
values.

test plan:
make test # test included



PR checklist:
- [ ] changelog is up to date

