### PR TITLE
Rename files following Emma's critics

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -702,7 +702,7 @@ let iter_files_and_get_matches_and_exn_to_errors f files =
  * files or dirs.
  *)
 (*s: function [[Main_semgrep_core.semgrep_with_rules]] *)
-let semgrep_with_rules lang (rules, rule_parse_time) files_or_dirs =
+let semgrep_with_patterns lang (rules, rule_parse_time) files_or_dirs =
   let files = get_final_files lang files_or_dirs in
   logger#info "processing %d files" (List.length files);
   let file_results =
@@ -759,7 +759,7 @@ let semgrep_with_rules lang (rules, rule_parse_time) files_or_dirs =
 
 (*e: function [[Main_semgrep_core.semgrep_with_rules]] *)
 
-let semgrep_with_rules_file lang rules_file files_or_dirs =
+let semgrep_with_patterns_file lang rules_file files_or_dirs =
   try
     (*s: [[Main_semgrep_core.semgrep_with_rules()]] if [[verbose]] *)
     logger#info "Parsing %s" rules_file;
@@ -767,7 +767,7 @@ let semgrep_with_rules_file lang rules_file files_or_dirs =
     let timed_rules =
       Common.with_time (fun () -> Parse_mini_rule.parse rules_file)
     in
-    semgrep_with_rules lang timed_rules files_or_dirs;
+    semgrep_with_patterns lang timed_rules files_or_dirs;
     if !profile then save_rules_file_in_tmp ()
   with exn ->
     logger#debug "exn before exit %s" (Common.exn_to_s exn);
@@ -781,7 +781,7 @@ let semgrep_with_rules_file lang rules_file files_or_dirs =
 (* Semgrep -config *)
 (*****************************************************************************)
 
-let semgrep_with_real_rules (rules, rule_parse_time) files_or_dirs =
+let semgrep_with_rules (rules, rule_parse_time) files_or_dirs =
   (* todo: at some point we should infer the lang from the rules and
    * apply different rules with different languages and different files
    * automatically, like the semgrep python wrapper.
@@ -850,13 +850,13 @@ let semgrep_with_real_rules (rules, rule_parse_time) files_or_dirs =
       (* pr (spf "number of errors: %d" (List.length errs)); *)
       errors |> List.iter (fun err -> pr (E.string_of_error err))
 
-let semgrep_with_real_rules_file rules_file files_or_dirs =
+let semgrep_with_rules_file rules_file files_or_dirs =
   try
     logger#info "Parsing %s" rules_file;
     let timed_rules =
       Common.with_time (fun () -> Parse_rule.parse rules_file)
     in
-    semgrep_with_real_rules timed_rules files_or_dirs
+    semgrep_with_rules timed_rules files_or_dirs
   with exn when !output_format = Json ->
     logger#debug "exn before exit %s" (Common.exn_to_s exn);
     let json = JSON_report.json_of_exn exn in
@@ -917,7 +917,7 @@ let semgrep_with_one_pattern lang xs =
   match !output_format with
   | Json ->
       (* closer to -rules_file, but no incremental match output *)
-      semgrep_with_rules lang (rule, rule_parse_time) xs
+      semgrep_with_patterns lang (rule, rule_parse_time) xs
   | Text ->
       (* simpler code path than in semgrep_with_rules *)
       let files = Lang.files_of_dirs_or_files lang xs in
@@ -1514,11 +1514,11 @@ let main () =
       | x :: xs -> (
           match () with
           | _ when !config_file <> "" ->
-              semgrep_with_real_rules_file !config_file (x :: xs)
+              semgrep_with_rules_file !config_file (x :: xs)
           (*s: [[Main_semgrep_core.main()]] main entry match cases *)
           | _ when !rules_file <> "" ->
               let lang = lang_of_string !lang in
-              semgrep_with_rules_file lang !rules_file (x :: xs)
+              semgrep_with_patterns_file lang !rules_file (x :: xs)
           (*x: [[Main_semgrep_core.main()]] main entry match cases *)
           | _ when !tainting_rules_file <> "" ->
               let lang = lang_of_string !lang in
@@ -1536,7 +1536,7 @@ let main () =
       (* TODO: should not need that, semgrep should not call us when there
        * are no files to process. *)
       | [] when !target_file <> "" && !config_file <> "" ->
-          semgrep_with_real_rules_file !config_file []
+          semgrep_with_rules_file !config_file []
       | [] -> Common.usage usage_msg (options ()))
 
 (*e: function [[Main_semgrep_core.main]] *)

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -651,7 +651,7 @@ let iter_files_and_get_matches_and_exn_to_errors f files =
                 *)
                | (Timeout | Out_of_memory) as exn ->
                    let str_opt =
-                     match !Semgrep_generic.last_matched_rule with
+                     match !Match_patterns.last_matched_rule with
                      | None -> None
                      | Some rule ->
                          logger#info "critical exn while matching ruleid %s"
@@ -716,7 +716,7 @@ let semgrep_with_rules lang (rules, rule_parse_time) files_or_dirs =
                  let rules =
                    rules |> List.filter (fun r -> List.mem lang r.MR.languages)
                  in
-                 ( Semgrep_generic.check
+                 ( Match_patterns.check
                      ~hook:(fun _ _ -> ())
                      Config_semgrep.default_config rules (parse_equivalences ())
                      (file, lang, ast),
@@ -814,7 +814,7 @@ let semgrep_with_real_rules (rules, rule_parse_time) files_or_dirs =
                    failwith "requesting generic AST for LNone|LGeneric" )
            in
            let res =
-             Semgrep.check hook Config_semgrep.default_config rules
+             Match_rules.check hook Config_semgrep.default_config rules
                (file, xlang, lazy_ast_and_errors)
            in
            RP.add_file file res)
@@ -935,7 +935,7 @@ let semgrep_with_one_pattern lang xs =
                    let ast, errors = parse_generic lang file in
                    if errors <> [] then
                      pr2 (spf "WARNING: fail to fully parse %s" file);
-                   Semgrep_generic.check
+                   Match_patterns.check
                      ~hook:(fun env matched_tokens ->
                        let xs = Lazy.force matched_tokens in
                        print_match !mvars env Metavariable.ii_of_mval xs)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -88,6 +88,8 @@
  *    https://doc.bblf.sh/uast/uast-specification-v2.html
  *  - Coverity common program representation?
  *  - Semmle internal common representation?
+ *  - Sonarcube generic language
+ *    https://github.com/SonarSource/slang
  *  - Infer SIL (for C++, Java, Objective-C)
  *  - Dawson Engler and Fraser Brown micro-checkers for multiple languages
  *  - Lightweight Multi-language syntax transformation paper, but does not
@@ -1239,11 +1241,11 @@ and other_type_argument_operator =
 (*****************************************************************************)
 (* Attribute *)
 (*****************************************************************************)
-(* a.k.a decorators, annotations *)
 (*s: type [[AST_generic.attribute]] *)
 and attribute =
+  (* a.k.a modifiers *)
   | KeywordAttr of keyword_attribute wrap
-  (* for general @annotations. *)
+  (* a.k.a decorators, annotations *)
   | NamedAttr of tok (* @ *) * name * arguments bracket
   (*s: [[AST_generic.attribute]] OtherXxx case *)
   | OtherAttribute of other_attribute_operator * any list

--- a/semgrep-core/src/core/ast/Lang.ml
+++ b/semgrep-core/src/core/ast/Lang.ml
@@ -61,7 +61,9 @@ type t =
   (* config files *)
   | JSON
   | Yaml
+
 (*e: type [[Lang.t]] *)
+[@@ocamlformat "disable"]
 [@@deriving show, eq]
 
 let is_js = function Javascript | Typescript -> true | _ -> false

--- a/semgrep-core/src/core/ast/Lang.mli
+++ b/semgrep-core/src/core/ast/Lang.mli
@@ -33,6 +33,8 @@ type t =
   | Yaml
 
 (*e: type [[Lang.t]] *)
+
+(* from deriving eq *)
 val pp : Format.formatter -> t -> unit
 
 val show : t -> string

--- a/semgrep-core/src/engine/Match_patterns.ml
+++ b/semgrep-core/src/engine/Match_patterns.ml
@@ -1,4 +1,4 @@
-(*s: semgrep/matching/Semgrep_generic.ml *)
+(*s: semgrep/engine/Match_patterns.ml *)
 (* Yoann Padioleau
  *
  * Copyright (C) 2011 Facebook
@@ -450,4 +450,4 @@ let check ~hook config a b c =
   Common.profile_code "Semgrep_generic.check" (fun () ->
       check2 ~hook config a b c)
 
-(*e: semgrep/matching/Semgrep_generic.ml *)
+(*e: semgrep/engine/Match_patterns.ml *)

--- a/semgrep-core/src/engine/Match_patterns.mli
+++ b/semgrep-core/src/engine/Match_patterns.mli
@@ -19,14 +19,13 @@ val last_matched_rule : Mini_rule.t option ref
 (* used by tainting *)
 
 (*s: signature [[Semgrep_generic.match_e_e]] *)
-val match_e_e :
-  Mini_rule.t -> (AST_generic.expr, AST_generic.expr) Matching_generic.matcher
+val match_e_e : Mini_rule.t -> AST_generic.expr Matching_generic.matcher
 
 (*e: signature [[Semgrep_generic.match_e_e]] *)
 
 (*s: signature [[Semgrep_generic.match_any_any]] *)
 (* for unit testing *)
-val match_any_any : (AST_generic.any, AST_generic.any) Matching_generic.matcher
+val match_any_any : AST_generic.any Matching_generic.matcher
 
 (*e: signature [[Semgrep_generic.match_any_any]] *)
 

--- a/semgrep-core/src/engine/Match_patterns.mli
+++ b/semgrep-core/src/engine/Match_patterns.mli
@@ -1,4 +1,4 @@
-(*s: semgrep/matching/Semgrep_generic.mli *)
+(*s: semgrep/engine/Match_patterns.mli *)
 
 (*s: signature [[Semgrep_generic.check]] *)
 val check :
@@ -30,4 +30,4 @@ val match_any_any : (AST_generic.any, AST_generic.any) Matching_generic.matcher
 
 (*e: signature [[Semgrep_generic.match_any_any]] *)
 
-(*e: semgrep/matching/Semgrep_generic.mli *)
+(*e: semgrep/engine/Match_patterns.mli *)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -1,4 +1,4 @@
-(*s: semgrep/engine/Semgrep.ml *)
+(*s: semgrep/engine/Match_rules.ml *)
 (*s: pad/r2c copyright *)
 (* Yoann Padioleau
  *
@@ -36,12 +36,12 @@ let debug_matches = ref false
 (* The core engine of Semgrep.
  *
  * This module implements the boolean composition of patterns.
- * See Semgrep_generic.ml for the code to handle a single pattern and
+ * See Match_patterns.ml for the code to handle a single pattern and
  * the visitor/matching engine.
  *
  * Thus, we can decompose the engine in 3 main components:
  *  - composing matching results using boolean/set logic (this file)
- *  - visiting code (=~ Semgrep_generic.ml)
+ *  - visiting code (=~ Match_patterns.ml)
  *  - matching code (=~ Generic_vs_generic.ml)
  *
  * There are also "preprocessing" work before that:
@@ -375,7 +375,7 @@ let debug_semgrep config mini_rules equivalences file lang ast =
   |> List.map (fun mr ->
          logger#debug "Checking mini rule with pattern %s" mr.MR.pattern_string;
          let res =
-           Semgrep_generic.check
+           Match_patterns.check
              ~hook:(fun _ _ -> ())
              config [ mr ] equivalences (file, lang, ast)
          in
@@ -537,7 +537,7 @@ let matches_of_xpatterns config orig_rule
                 ( debug_semgrep config mini_rules equivalences file lang ast,
                   errors ) (* regular path *)
               else
-                ( Semgrep_generic.check
+                ( Match_patterns.check
                     ~hook:(fun _ _ -> ())
                     config mini_rules equivalences (file, lang, ast),
                   errors ))
@@ -718,7 +718,7 @@ let check hook config rules file_and_more =
                  matches =
                    final_ranges
                    |> List.map (range_to_pattern_match_adjusted r)
-                   (* dedup similar findings (we do that also in Semgrep_generic.ml,
+                   (* dedup similar findings (we do that also in Match_patterns.ml,
                     * but different mini-rules matches can now become the same match)
                     *)
                    |> Common.uniq_by (AST_utils.with_structural_equal PM.equal)
@@ -733,4 +733,4 @@ let check hook config rules file_and_more =
   |> RP.collate_semgrep_results
   [@@profiling]
 
-(*e: semgrep/engine/Semgrep.ml *)
+(*e: semgrep/engine/Match_rules.ml *)

--- a/semgrep-core/src/engine/Match_rules.mli
+++ b/semgrep-core/src/engine/Match_rules.mli
@@ -1,4 +1,4 @@
-(*s: semgrep/engine/Semgrep.mli *)
+(*s: semgrep/engine/Match_rules.mli *)
 
 (*
    Return matches, errors, match time.
@@ -10,4 +10,4 @@ val check :
   Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t ->
   Report.times Report.match_result
 
-(*e: semgrep/engine/Semgrep.mli *)
+(*e: semgrep/engine/Match_rules.mli *)

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -133,7 +133,7 @@ let test_rules ?(ounit_context = false) xs =
          let config = Config_semgrep.default_config in
          let res =
            try
-             Semgrep.check
+             Match_rules.check
                (fun _ _ _ -> ())
                config rules
                (target, xlang, lazy_ast_and_errors)

--- a/semgrep-core/src/engine/Unit_matcher.ml
+++ b/semgrep-core/src/engine/Unit_matcher.ml
@@ -1,4 +1,4 @@
-(*s: semgrep/matching/Unit_matcher.ml *)
+(*s: semgrep/engine/Unit_matcher.ml *)
 open Common
 open OUnit
 
@@ -116,7 +116,7 @@ let unittest ~any_gen_of_string =
            let config = Config_semgrep.default_config in
            let env = Matching_generic.empty_environment cache config in
            let matches_with_env =
-             Semgrep_generic.match_any_any pattern code env
+             Match_patterns.match_any_any pattern code env
            in
            if should_match then
              assert_bool
@@ -130,4 +130,4 @@ let unittest ~any_gen_of_string =
            failwith (spf "problem parsing %s or %s" spattern scode))
 
 (*e: function [[Unit_matcher.unittest]] *)
-(*e: semgrep/matching/Unit_matcher.ml *)
+(*e: semgrep/engine/Unit_matcher.ml *)

--- a/semgrep-core/src/engine/Unit_matcher.mli
+++ b/semgrep-core/src/engine/Unit_matcher.mli
@@ -1,4 +1,4 @@
-(*s: semgrep/matching/Unit_matcher.mli *)
+(*s: semgrep/engine/Unit_matcher.mli *)
 
 (*s: signature [[Unit_matcher.unittest]] *)
 (* Returns the testsuite for this directory To be concatenated by
@@ -8,4 +8,4 @@
 val unittest : any_gen_of_string:(string -> AST_generic.any) -> OUnit.test
 
 (*e: signature [[Unit_matcher.unittest]] *)
-(*e: semgrep/matching/Unit_matcher.mli *)
+(*e: semgrep/engine/Unit_matcher.mli *)

--- a/semgrep-core/src/matching/Generic_vs_generic.mli
+++ b/semgrep-core/src/matching/Generic_vs_generic.mli
@@ -2,36 +2,32 @@
 
 (* entry points, used in the sgrep_generic visitors *)
 (*s: signature [[Generic_vs_generic.m_expr]] *)
-val m_expr : (AST_generic.expr, AST_generic.expr) Matching_generic.matcher
+val m_expr : AST_generic.expr Matching_generic.matcher
 
 (*e: signature [[Generic_vs_generic.m_expr]] *)
 (*s: signature [[Generic_vs_generic.m_stmt]] *)
-val m_stmt : (AST_generic.stmt, AST_generic.stmt) Matching_generic.matcher
+val m_stmt : AST_generic.stmt Matching_generic.matcher
 
 (*e: signature [[Generic_vs_generic.m_stmt]] *)
 (*s: signature [[Generic_vs_generic.m_stmts_deep]] *)
 val m_stmts_deep :
-  less_is_ok:bool ->
-  (AST_generic.stmt list, AST_generic.stmt list) Matching_generic.matcher
+  less_is_ok:bool -> AST_generic.stmt list Matching_generic.matcher
 
 (*e: signature [[Generic_vs_generic.m_stmts_deep]] *)
 
-val m_type_ : (AST_generic.type_, AST_generic.type_) Matching_generic.matcher
+val m_type_ : AST_generic.type_ Matching_generic.matcher
 
-val m_pattern :
-  (AST_generic.pattern, AST_generic.pattern) Matching_generic.matcher
+val m_pattern : AST_generic.pattern Matching_generic.matcher
 
-val m_attribute :
-  (AST_generic.attribute, AST_generic.attribute) Matching_generic.matcher
+val m_attribute : AST_generic.attribute Matching_generic.matcher
 
-val m_partial :
-  (AST_generic.partial, AST_generic.partial) Matching_generic.matcher
+val m_partial : AST_generic.partial Matching_generic.matcher
 
-val m_field : (AST_generic.field, AST_generic.field) Matching_generic.matcher
+val m_field : AST_generic.field Matching_generic.matcher
 
 (*s: signature [[Generic_vs_generic.m_any]] *)
 (* used only for unit testing *)
-val m_any : (AST_generic.any, AST_generic.any) Matching_generic.matcher
+val m_any : AST_generic.any Matching_generic.matcher
 
 (*e: signature [[Generic_vs_generic.m_any]] *)
 (*e: semgrep/matching/Generic_vs_generic.mli *)

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -100,10 +100,10 @@ and tout = tin list
  * information tin, and it will return something (tout) that will
  * represent a match between element A and B.
  *)
-(* currently 'a and 'b are usually the same type as we use the
+(* currently A and B are usually the same type as we use the
  * same language for the host language and pattern language
  *)
-type ('a, 'b) matcher = 'a -> 'b -> tin -> tout
+type 'a matcher = 'a -> 'a -> tin -> tout
 
 (*e: type [[Matching_generic.matcher]] *)
 
@@ -328,7 +328,7 @@ let check_and_add_metavar_binding ((mvar : MV.mvar), valu) (tin : tin) =
 (*e: function [[Matching_generic.check_and_add_metavar_binding]] *)
 
 (*s: function [[Matching_generic.envf]] *)
-let (envf : (MV.mvar AST.wrap, MV.mvalue) matcher) =
+let (envf : MV.mvar AST.wrap -> MV.mvalue -> tin -> tout) =
  fun (mvar, _imvar) any tin ->
   match check_and_add_metavar_binding (mvar, any) tin with
   | None ->
@@ -448,7 +448,7 @@ let regexp_matcher_of_regexp_string s =
 (* stdlib: option *)
 (* ---------------------------------------------------------------------- *)
 (*s: function [[Matching_generic.m_option]] *)
-let (m_option : ('a, 'b) matcher -> ('a option, 'b option) matcher) =
+let (m_option : 'a matcher -> 'a option matcher) =
  fun f a b ->
   match (a, b) with
   | None, None -> return ()
@@ -484,7 +484,7 @@ let m_option_none_can_match_some f a b =
 (* stdlib: ref *)
 (* ---------------------------------------------------------------------- *)
 (*s: function [[Matching_generic.m_ref]] *)
-let (m_ref : ('a, 'b) matcher -> ('a ref, 'b ref) matcher) =
+let (m_ref : 'a matcher -> 'a ref matcher) =
  fun f a b ->
   match (a, b) with { contents = xa }, { contents = xb } -> f xa xb
 

--- a/semgrep-core/src/matching/Matching_generic.mli
+++ b/semgrep-core/src/matching/Matching_generic.mli
@@ -25,10 +25,10 @@ and tout = tin list
  * information tin, and it will return something (tout) that will
  * represent a match between element A and B.
  *)
-(* currently 'a and 'b are usually the same type as we use the
+(* currently A and B are usually the same type as we use the
  * same language for the host language and pattern language
  *)
-type ('a, 'b) matcher = 'a -> 'b -> tin -> tout
+type 'a matcher = 'a -> 'a -> tin -> tout
 
 (*e: type [[Matching_generic.matcher]] *)
 
@@ -55,7 +55,7 @@ val fail : unit -> tin -> tout
 
 (*e: signature [[Matching_generic.fail]] *)
 
-val or_list : ('a, 'b) matcher -> 'a -> 'b list -> tin -> tout
+val or_list : 'a matcher -> 'a -> 'a list -> tin -> tout
 
 (* shortcut for >>=, since OCaml 4.08 you can define those "extended-let" *)
 val ( let* ) : (tin -> tout) -> (unit -> tin -> tout) -> tin -> tout
@@ -74,7 +74,8 @@ val get_mv_capture : Metavariable.mvar -> tin -> Metavariable.mvalue option
 val extend_stmts_match_span : AST_generic.stmt -> tin -> tin
 
 (*s: signature [[Matching_generic.envf]] *)
-val envf : (Metavariable.mvar AST_generic.wrap, Metavariable.mvalue) matcher
+val envf :
+  Metavariable.mvar AST_generic.wrap -> Metavariable.mvalue -> tin -> tout
 
 (*e: signature [[Matching_generic.envf]] *)
 
@@ -118,7 +119,7 @@ val equal_ast_binded_code :
 
 (* generic matchers *)
 (*s: signature [[Matching_generic.m_option]] *)
-val m_option : ('a, 'b) matcher -> ('a option, 'b option) matcher
+val m_option : 'a matcher -> 'a option matcher
 
 (*e: signature [[Matching_generic.m_option]] *)
 (*s: signature [[Matching_generic.m_option_ellipsis_ok]] *)
@@ -137,39 +138,37 @@ val m_option_none_can_match_some :
 (*e: signature [[Matching_generic.m_option_none_can_match_some]] *)
 
 (*s: signature [[Matching_generic.m_ref]] *)
-val m_ref : ('a, 'b) matcher -> ('a ref, 'b ref) matcher
+val m_ref : 'a matcher -> 'a ref matcher
 
 (*e: signature [[Matching_generic.m_ref]] *)
 
 (*s: signature [[Matching_generic.m_list]] *)
-val m_list : ('a, 'b) matcher -> ('a list, 'b list) matcher
+val m_list : 'a matcher -> 'a list matcher
 
 (*e: signature [[Matching_generic.m_list]] *)
 (*s: signature [[Matching_generic.m_list_prefix]] *)
-val m_list_prefix : ('a, 'b) matcher -> ('a list, 'b list) matcher
+val m_list_prefix : 'a matcher -> 'a list matcher
 
 (*e: signature [[Matching_generic.m_list_prefix]] *)
 (*s: signature [[Matching_generic.m_list_with_dots]] *)
-val m_list_with_dots :
-  ('a, 'b) matcher -> ('a -> bool) -> bool -> ('a list, 'b list) matcher
+val m_list_with_dots : 'a matcher -> ('a -> bool) -> bool -> 'a list matcher
 
 (*e: signature [[Matching_generic.m_list_with_dots]] *)
-val m_list_in_any_order :
-  less_is_ok:bool -> ('a, 'b) matcher -> ('a list, 'b list) matcher
+val m_list_in_any_order : less_is_ok:bool -> 'a matcher -> 'a list matcher
 
 (* use = *)
-val m_eq : ('a, 'a) matcher
+val m_eq : 'a matcher
 
 (*s: signature [[Matching_generic.m_bool]] *)
-val m_bool : (bool, bool) matcher
+val m_bool : bool matcher
 
 (*e: signature [[Matching_generic.m_bool]] *)
 (*s: signature [[Matching_generic.m_int]] *)
-val m_int : (int, int) matcher
+val m_int : int matcher
 
 (*e: signature [[Matching_generic.m_int]] *)
 (*s: signature [[Matching_generic.m_string]] *)
-val m_string : (string, string) matcher
+val m_string : string matcher
 
 (*e: signature [[Matching_generic.m_string]] *)
 (*s: signature [[Matching_generic.string_is_prefix]] *)
@@ -181,11 +180,7 @@ val m_string_prefix : string -> string -> tin -> tout
 
 (*e: signature [[Matching_generic.m_string_prefix]] *)
 val m_string_ellipsis_or_regexp_or_default :
-  ?m_string_for_default:(string, string) matcher ->
-  string ->
-  string ->
-  tin ->
-  tout
+  ?m_string_for_default:string matcher -> string -> string -> tin -> tout
 
 (*s: signature [[Matching_generic.m_info]] *)
 val m_info : 'a -> 'b -> tin -> tout

--- a/semgrep-core/src/matching/Matching_generic.mli
+++ b/semgrep-core/src/matching/Matching_generic.mli
@@ -124,16 +124,11 @@ val m_option : 'a matcher -> 'a option matcher
 (*e: signature [[Matching_generic.m_option]] *)
 (*s: signature [[Matching_generic.m_option_ellipsis_ok]] *)
 val m_option_ellipsis_ok :
-  (AST_generic.expr -> 'a -> tin -> tout) ->
-  AST_generic.expr option ->
-  'a option ->
-  tin ->
-  tout
+  AST_generic.expr matcher -> AST_generic.expr option matcher
 
 (*e: signature [[Matching_generic.m_option_ellipsis_ok]] *)
 (*s: signature [[Matching_generic.m_option_none_can_match_some]] *)
-val m_option_none_can_match_some :
-  ('a -> 'b -> tin -> tout) -> 'a option -> 'b option -> tin -> tout
+val m_option_none_can_match_some : 'a matcher -> 'a option matcher
 
 (*e: signature [[Matching_generic.m_option_none_can_match_some]] *)
 
@@ -176,40 +171,32 @@ val string_is_prefix : string -> string -> bool
 
 (*e: signature [[Matching_generic.string_is_prefix]] *)
 (*s: signature [[Matching_generic.m_string_prefix]] *)
-val m_string_prefix : string -> string -> tin -> tout
+val m_string_prefix : string matcher
 
 (*e: signature [[Matching_generic.m_string_prefix]] *)
 val m_string_ellipsis_or_regexp_or_default :
-  ?m_string_for_default:string matcher -> string -> string -> tin -> tout
+  ?m_string_for_default:string matcher -> string matcher
 
 (*s: signature [[Matching_generic.m_info]] *)
-val m_info : 'a -> 'b -> tin -> tout
+val m_info : Parse_info.t matcher
 
 (*e: signature [[Matching_generic.m_info]] *)
 (*s: signature [[Matching_generic.m_tok]] *)
-val m_tok : 'a -> 'b -> tin -> tout
+val m_tok : Parse_info.t matcher
 
 (*e: signature [[Matching_generic.m_tok]] *)
 (*s: signature [[Matching_generic.m_wrap]] *)
-val m_wrap : ('a -> 'b -> tin -> tout) -> 'a * 'c -> 'b * 'd -> tin -> tout
+val m_wrap : 'a matcher -> 'a AST_generic.wrap matcher
 
 (*e: signature [[Matching_generic.m_wrap]] *)
 (*s: signature [[Matching_generic.m_bracket]] *)
-val m_bracket :
-  ('a -> 'b -> tin -> tout) -> 'c * 'a * 'd -> 'e * 'b * 'f -> tin -> tout
+val m_bracket : 'a matcher -> 'a AST_generic.bracket matcher
 
 (*e: signature [[Matching_generic.m_bracket]] *)
-val m_tuple3 :
-  ('a -> 'b -> tin -> tout) ->
-  ('c -> 'd -> tin -> tout) ->
-  ('e -> 'f -> tin -> tout) ->
-  'a * 'c * 'e ->
-  'b * 'd * 'f ->
-  tin ->
-  tout
+val m_tuple3 : 'a matcher -> 'b matcher -> 'c matcher -> ('a * 'b * 'c) matcher
 
 (*s: signature [[Matching_generic.m_other_xxx]] *)
-val m_other_xxx : 'a -> 'a -> tin -> tout
+val m_other_xxx : 'a matcher
 
 (*e: signature [[Matching_generic.m_other_xxx]] *)
 (*e: semgrep/matching/Matching_generic.mli *)

--- a/semgrep-core/src/synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/src/synthesizing/Unit_synthesizer.ml
@@ -213,7 +213,7 @@ let unittest =
                             Matching_generic.empty_environment None
                               Config_semgrep.default_config
                           in
-                          Semgrep_generic.match_any_any pattern code env
+                          Match_patterns.match_any_any pattern code env
                         in
                         (* Debugging note: uses pattern_to_string for convenience,
                          * but really should match the code in the given file at

--- a/semgrep-core/src/synthesizing/dune
+++ b/semgrep-core/src/synthesizing/dune
@@ -11,6 +11,7 @@
    semgrep_core
    semgrep_parsing
    semgrep_matching
+   semgrep_engine ; just for match_any_any
  )
  (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/src/tainting/Tainting_generic.ml
+++ b/semgrep-core/src/tainting/Tainting_generic.ml
@@ -76,7 +76,7 @@ let match_pat_eorig pat =
         let env =
           Matching_generic.empty_environment None Config_semgrep.default_config
         in
-        let matches_with_env = Semgrep_generic.match_e_e rule pat eorig env in
+        let matches_with_env = Match_patterns.match_e_e rule pat eorig env in
         matches_with_env <> []
 
 let match_pat_exp pat exp =

--- a/semgrep-core/src/tainting/dune
+++ b/semgrep-core/src/tainting/dune
@@ -10,6 +10,7 @@
 
    semgrep_core
    semgrep_matching
+   semgrep_engine ; just for match_e_e
  )
  (preprocess (pps ppx_profiling))
 )

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -117,7 +117,7 @@ let regression_tests_for_lang ~with_caching files lang =
      else []
     in
     Common.save_excursion Flag_semgrep.with_opt_cache with_caching (fun() ->
-     Semgrep_generic.check
+     Match_patterns.check
        ~hook:(fun _env matched_tokens ->
        (* there are a few fake tokens in the generic ASTs now (e.g., 
         * for DotAccess generated outside the grammar) *)
@@ -404,7 +404,7 @@ let lint_regression_tests ~with_caching =
     let { Parse_target. ast; _} = 
         Parse_target.just_parse_with_lang lang file in
     Common.save_excursion Flag_semgrep.with_opt_cache with_caching (fun() ->
-      Semgrep_generic.check ~hook:(fun _ _ -> ())
+      Match_patterns.check ~hook:(fun _ _ -> ())
          Config_semgrep.default_config
          rules equivs 
          (file, lang, ast)


### PR DESCRIPTION
At the last code review, Emma pointed out a few files had bad names.
Maybe Match_rules.ml is better than just Semgrep.ml, and
Match_patterns.ml
better than Semgrep_generic.ml

test plan:
make test




PR checklist:
- [x] changelog is up to date