### PR TITLE
[PHP] parsing correctly semgrep metavar and ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 
 ### Fixed
+- PHP: parsing correctly ... and metavariables in parameters
 
 ### Changed
 

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -94,7 +94,10 @@ let parse_pattern lang ?(print_errors = false) str =
         Ruby_to_generic.any any
     | Lang.PHP ->
         let any_cst = Parse_php.any_of_string str in
-        let any = Ast_php_build.any any_cst in
+        let any =
+          Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->
+              Ast_php_build.any any_cst)
+        in
         Php_to_generic.any any
     | Lang.Cplusplus -> failwith "No C++ generic parser yet"
     | Lang.R -> failwith "No R generic parser yet"

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -479,7 +479,13 @@ and function_kind (kind, t) =
 
 and parameters x = list parameter x
 
-and parameter { p_type; p_ref; p_name; p_default; p_attrs; p_variadic } =
+and parameter x =
+  match x with
+  | ParamClassic x -> parameter_classic x
+  | ParamEllipsis t -> G.ParamEllipsis t
+
+and parameter_classic { p_type; p_ref; p_name; p_default; p_attrs; p_variadic }
+    =
   let p_type = option hint_type p_type in
   let p_name = var p_name in
   let p_default = option expr p_default in

--- a/semgrep-core/tests/php/metavar_param.php
+++ b/semgrep-core/tests/php/metavar_param.php
@@ -1,0 +1,5 @@
+<?php
+//ERROR: match
+function foo($x, $y) {
+  do_something($y);
+}

--- a/semgrep-core/tests/php/metavar_param.sgrep
+++ b/semgrep-core/tests/php/metavar_param.sgrep
@@ -1,0 +1,3 @@
+function $FUNC(..., $ARG, ...) {
+  do_something($ARG);
+}


### PR DESCRIPTION
I've introduced a new token T_METAVAR separated from T_IDENT and
T_VARIABLE to avoid grammar conflicts. This is also cleaner I think.

This closes https://github.com/returntocorp/semgrep/issues/3095

test plan:
test files included




PR checklist:
- [x] changelog is up to date