### PR TITLE
Simplify verbosity flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 ### Changed
+- Moved some debug logging to verbose logging
 
 ## [0.53.0](https://github.com/returntocorp/semgrep/releases/tag/v0.53.0) - 2021-05-26
 

--- a/semgrep/semgrep/__main__.py
+++ b/semgrep/semgrep/__main__.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-from semgrep.verbose_logging import install_verbose_logging
-
-install_verbose_logging()
-
-import logging.handlers
 import sys
 
 from semgrep import __VERSION__
@@ -11,13 +6,14 @@ from semgrep.cli import cli
 from semgrep.error import OK_EXIT_CODE
 from semgrep.error import SemgrepError
 from semgrep.metric_manager import metric_manager
+from semgrep.verbose_logging import getLogger
 
 
 def main() -> int:
     # When running semgrep as a command line tool
     # silence root level logger otherwise logs higher
     # than warning are handled twice
-    logger = logging.getLogger("semgrep")
+    logger = getLogger("semgrep")
     logger.propagate = False
     metric_manager.set_version(__VERSION__)
     try:

--- a/semgrep/semgrep/__main__.py
+++ b/semgrep/semgrep/__main__.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+from semgrep.verbose_logging import install_verbose_logging
+
+install_verbose_logging()
+
 import logging.handlers
 import sys
 

--- a/semgrep/semgrep/autofix.py
+++ b/semgrep/semgrep/autofix.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from pathlib import Path
 from typing import Dict
@@ -9,8 +8,9 @@ from typing import Tuple
 from semgrep.error import SemgrepError
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 SPLIT_CHAR = "\n"
 

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import logging
 import multiprocessing
 import os
 
@@ -26,10 +25,10 @@ from semgrep.output import managed_output
 from semgrep.output import OutputSettings
 from semgrep.synthesize_patterns import synthesize_patterns
 from semgrep.target_manager import optional_stdin_target
+from semgrep.verbose_logging import getLogger
 from semgrep.version import is_running_latest
 
-
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 try:
     CPU_COUNT = multiprocessing.cpu_count()
 except NotImplementedError:

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -229,16 +229,6 @@ def cli() -> None:
     output = parser.add_argument_group("output")
 
     output.add_argument(
-        "-q",
-        "--quiet",
-        action="store_true",
-        help=(
-            "Do not print any logging messages to stderr. Finding output will still be sent to stdout. Exit code "
-            "provides success status."
-        ),
-    )
-
-    output.add_argument(
         "--no-rewrite-rule-ids",
         action="store_true",
         help=(
@@ -346,10 +336,16 @@ def cli() -> None:
         help=("Maximum number of characters to show per line."),
     )
 
-    # logging options
-    logging_ = parser.add_argument_group("logging")
-
-    logging_.add_argument(
+    # verbosity options
+    verbosity_group = parser.add_argument_group("verbosity")
+    verbosity_ex = verbosity_group.add_mutually_exclusive_group()
+    verbosity_ex.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help=("Only output findings"),
+    )
+    verbosity_ex.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -357,11 +353,10 @@ def cli() -> None:
             "Show more details about what rules are running, which files failed to parse, etc."
         ),
     )
-
-    output.add_argument(
+    verbosity_ex.add_argument(
         "--debug",
         action="store_true",
-        help="Set the logging level to DEBUG",
+        help="Output debugging information",
     )
 
     parser.add_argument(
@@ -447,7 +442,7 @@ def cli() -> None:
     output_time = args.time or args.json_time
 
     # set the flags
-    semgrep.util.set_flags(args.debug, args.quiet, args.force_color)
+    semgrep.util.set_flags(args.verbose, args.debug, args.quiet, args.force_color)
 
     # change cwd if using docker
     try:

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import time
 from collections import OrderedDict
@@ -32,8 +31,9 @@ from semgrep.rule_lang import YamlMap
 from semgrep.rule_lang import YamlTree
 from semgrep.util import is_config_suffix
 from semgrep.util import is_url
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 IN_DOCKER = "SEMGREP_IN_DOCKER" in os.environ
 IN_GH_ACTION = "GITHUB_WORKSPACE" in os.environ
@@ -98,7 +98,7 @@ class Config:
                 # Patch config_id to fix https://github.com/returntocorp/semgrep/issues/1912
                 resolved_config = resolve_config(config)
                 if not resolved_config:
-                    logger.debug(f"Could not resolve config for {config}. Skipping.")
+                    logger.verbose(f"Could not resolve config for {config}. Skipping.")
                     continue
 
                 for (
@@ -463,7 +463,7 @@ def resolve_config(config_str: str) -> Dict[str, YamlTree]:
     else:
         config = load_config_from_local_path(config_str)
     if config:
-        logger.debug(f"loaded {len(config)} configs in {time.time() - start_t}")
+        logger.verbose(f"loaded {len(config)} configs in {time.time() - start_t}")
     return config
 
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -1,7 +1,6 @@
 import collections
 import functools
 import json
-import logging
 import re
 import subprocess
 import tempfile
@@ -53,8 +52,9 @@ from semgrep.util import partition
 from semgrep.util import progress_bar
 from semgrep.util import SEMGREP_PATH
 from semgrep.util import sub_run
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def _offset_to_line_no(offset: int, buff: str) -> int:

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 import re
 from collections import defaultdict
 from collections import OrderedDict
@@ -33,8 +32,9 @@ from semgrep.semgrep_types import PatternId
 from semgrep.semgrep_types import Range
 from semgrep.semgrep_types import TAINT_MODE
 from semgrep.util import flatten
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 DebugRanges = Union[Set[Range], Dict[str, Set[Range]]]
 DebugRangesConverted = Union[List[Range], Dict[str, List[Range]]]

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -10,10 +10,11 @@ from typing import Set
 from semgrep.constants import SEMGREP_USER_AGENT
 from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
+from semgrep.verbose_logging import getLogger
 
 METRICS_ENDPOINT = "https://metrics.semgrep.dev"
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class _MetricManager:

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 import pathlib
 import sys
 from collections import defaultdict
@@ -38,8 +37,9 @@ from semgrep.stats import make_loc_stats
 from semgrep.stats import make_target_stats
 from semgrep.util import is_url
 from semgrep.util import with_color
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def get_path_str(target: Path) -> str:
@@ -335,7 +335,9 @@ class OutputHandler:
         logger.info(f"posting to {output_url}...")
         try:
             r = requests.post(output_url, data=output, timeout=10)
-            logger.debug(f"posted to {output_url} and got status_code:{r.status_code}")
+            logger.verbose(
+                f"posted to {output_url} and got status_code:{r.status_code}"
+            )
         except requests.exceptions.Timeout:
             raise SemgrepError(f"posting output to {output_url} timed out")
 

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import logging
 import subprocess
 import time
 from io import StringIO
@@ -34,15 +33,15 @@ from semgrep.rule_match import RuleMatch
 from semgrep.target_manager import TargetManager
 from semgrep.util import manually_search_file
 from semgrep.util import sub_check_output
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def notify_user_of_work(
     filtered_rules: List[Rule],
     include: List[str],
     exclude: List[str],
-    verbose: bool = False,
 ) -> None:
     """
     Notify user of what semgrep is about to do, including:
@@ -59,10 +58,9 @@ def notify_user_of_work(
         for exc in exclude:
             logger.info(f"- {exc}")
     logger.info(f"running {len(filtered_rules)} rules...")
-    if verbose:
-        logger.info("rules:")
-        for rule in filtered_rules:
-            logger.info(f"- {rule.id}")
+    logger.verbose("rules:")
+    for rule in filtered_rules:
+        logger.verbose(f"- {rule.id}")
 
 
 def rule_match_nosem(
@@ -81,7 +79,7 @@ def rule_match_nosem(
 
     ids_str = re_match.groupdict()["ids"]
     if ids_str is None:
-        logger.debug(
+        logger.verbose(
             f"found 'nosem' comment, skipping rule '{rule_match.id}' on line {rule_match.start['line']}"
         )
         return True, []
@@ -103,7 +101,7 @@ def rule_match_nosem(
     result = False
     for pattern_id in pattern_ids:
         if rule_match.id == pattern_id:
-            logger.debug(
+            logger.verbose(
                 f"found 'nosem' comment with id '{pattern_id}', skipping rule '{rule_match.id}' on line {rule_match.start['line']}"
             )
             result = result or True
@@ -112,7 +110,7 @@ def rule_match_nosem(
             if strict:
                 errors.append(SemgrepError(message, level=Level.WARN))
             else:
-                logger.debug(message)
+                logger.verbose(message)
 
     return result, errors
 
@@ -206,7 +204,7 @@ def main(
         invalid_msg = (
             f"({len(errors)} config files were invalid)" if len(errors) else ""
         )
-        logger.debug(
+        logger.verbose(
             f"running {len(filtered_rules)} rules from {len(configs_obj.valid)} config{plural} {config_id_if_single} {invalid_msg}"
         )
 

--- a/semgrep/semgrep/spacegrep.py
+++ b/semgrep/semgrep/spacegrep.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -14,8 +13,9 @@ from semgrep.pattern import Pattern
 from semgrep.rule_lang import Position
 from semgrep.util import SPACEGREP_PATH
 from semgrep.util import sub_run
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def _extract_times(json: Dict[str, Any]) -> Tuple[float, float, float]:
@@ -104,7 +104,7 @@ def run_spacegrep(
                     # aggregate the match times obtained for the different patterns of the rule
                     path_s = str(target)
 
-                    targets_time[path_s] = tuple(
+                    targets_time[path_s] = tuple(  # type: ignore
                         [
                             i + j
                             for i, j in zip(
@@ -112,7 +112,7 @@ def run_spacegrep(
                                 _extract_times(output_json),
                             )
                         ]
-                    )  # type: ignore
+                    )
 
             except subprocess.CalledProcessError as e:
                 raw_error = p.stderr

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -13,7 +13,6 @@ import argparse
 import collections
 import functools
 import json
-import logging
 import multiprocessing
 import sys
 import tarfile
@@ -32,8 +31,9 @@ from semgrep.semgrep_main import invoke_semgrep
 from semgrep.util import is_config_suffix
 from semgrep.util import is_config_test_suffix
 from semgrep.util import partition
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 SAVE_TEST_OUTPUT_JSON = "semgrep_runs_output.json"
 SAVE_TEST_OUTPUT_TAR = "semgrep_runs_output.tar.gz"

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -52,8 +52,10 @@ def flatten(L: Iterable[Iterable[Any]]) -> Iterable[Any]:
             yield item
 
 
-def set_flags(debug_level: bool, quiet: bool, force_color: bool) -> None:
+def set_flags(verbose: bool, debug: bool, quiet: bool, force_color: bool) -> None:
     """Set the global DEBUG and QUIET flags"""
+    # Assumes only one of verbose, debug, quiet is True
+
     logger = logging.getLogger("semgrep")
     logger.handlers = []
     handler = logging.StreamHandler()
@@ -61,10 +63,12 @@ def set_flags(debug_level: bool, quiet: bool, force_color: bool) -> None:
     handler.setFormatter(formatter)
 
     level = logging.INFO
-    if debug_level:
+    if verbose:
+        level = logging.VERBOSE  # type: ignore[attr-defined]
+    elif debug:
         level = logging.DEBUG
     elif quiet:
-        level = logging.ERROR
+        level = logging.CRITICAL
 
     handler.setLevel(level)
     logger.addHandler(handler)
@@ -74,16 +78,13 @@ def set_flags(debug_level: bool, quiet: bool, force_color: bool) -> None:
     global DEBUG
     global QUIET
     global FORCE_COLOR
-    if debug_level:
+    if debug:
         DEBUG = True
-        # debug_print("DEBUG is on")
     if quiet:
         QUIET = True
-        # debug_print("QUIET is on")
 
     if force_color:
         FORCE_COLOR = True
-        # debug_print("Output will use ANSI escapes, even if output is not a TTY")
 
 
 def partition(pred: Callable, iterable: Iterable) -> Tuple[List, List]:

--- a/semgrep/semgrep/verbose_logging.py
+++ b/semgrep/semgrep/verbose_logging.py
@@ -42,6 +42,9 @@ def install_verbose_logging() -> None:
     logging.setLoggerClass(VerboseLogging)
 
 
+install_verbose_logging()
+
+
 def getLogger(name: Optional[str]) -> VerboseLogging:
     """
     Wrapper around logging.getLogger to correctly cast so mypy

--- a/semgrep/semgrep/verbose_logging.py
+++ b/semgrep/semgrep/verbose_logging.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Any
+
+
+class VerboseLogging(logging.Logger):
+    """
+    Extend logging to add a verbose logging level that is between
+    INFO and DEBUG.
+
+    Also expose a logging.verbose() method so there is no need
+    to call log(VERBOSE_LEVEL, msg) every time
+    """
+
+    VERBOSE_LOG_LEVEL = 15
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    def verbose(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        if self.isEnabledFor(self.VERBOSE_LOG_LEVEL):
+            self._log(self.VERBOSE_LOG_LEVEL, msg, args, **kwargs)
+
+
+def install_verbose_logging() -> None:
+    """
+    Makes 3 changes to stdlib logging:
+    - add in logging.VERBOSE constant
+    - add VERBOSE as a logging level
+    - set VerboseLogging as default class returned by logging.getLogger
+        - thus exposing logger.verbose(msg) method
+
+    Any calls to getLogger before this method returns will return base
+    logging.Logger class that doesn't have verbose() convenience method
+    """
+    # Between INFO(20) and DEBUG(10)
+    logging.VERBOSE = 15  # type: ignore[attr-defined]
+    logging.addLevelName(
+        VerboseLogging.VERBOSE_LOG_LEVEL, "VERBOSE"
+    )  # Register VERBOSE as a logging level
+    logging.setLoggerClass(VerboseLogging)

--- a/semgrep/semgrep/verbose_logging.py
+++ b/semgrep/semgrep/verbose_logging.py
@@ -1,5 +1,7 @@
 import logging
 from typing import Any
+from typing import cast
+from typing import Optional
 
 
 class VerboseLogging(logging.Logger):
@@ -38,3 +40,11 @@ def install_verbose_logging() -> None:
         VerboseLogging.VERBOSE_LOG_LEVEL, "VERBOSE"
     )  # Register VERBOSE as a logging level
     logging.setLoggerClass(VerboseLogging)
+
+
+def getLogger(name: Optional[str]) -> VerboseLogging:
+    """
+    Wrapper around logging.getLogger to correctly cast so mypy
+    detects verbose() function
+    """
+    return cast(VerboseLogging, logging.getLogger(name))

--- a/semgrep/semgrep/version.py
+++ b/semgrep/semgrep/version.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import time
 from pathlib import Path
@@ -9,8 +8,9 @@ from packaging.version import Version
 
 from semgrep import __VERSION__
 from semgrep.constants import SEMGREP_USER_AGENT
+from semgrep.verbose_logging import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 VERSION_CHECK_URL = str(
     os.environ.get("SEMGREP_VERSION_CHECK_URL", "https://semgrep.dev/api/check-version")


### PR DESCRIPTION
This PR standardizes our logging so that there is an easy mapping
between desired verbosity (--quiet, normal, --verbose, --debug) and
logging levels.

Moving forward, --quiet, normal, --verbose, and --debug will correspond
to CRITICAL, INFO, VERBOSE, and DEBUG logging levels respectively.
A given verbosity level will see logs that are at its level and lower.

This PR also makes --quiet, --verbose, and --debug mutually exclusive
command line flags.

Closes: https://github.com/returntocorp/semgrep/issues/2016

PR checklist:
- [ ] changelog is up to date

