### PR TITLE
[csharp] Fix syntax error in tests/csharp/metavar_call.cs

### DIFF
--- a/semgrep-core/tests/csharp/dots_args.cs
+++ b/semgrep-core/tests/csharp/dots_args.cs
@@ -1,4 +1,10 @@
-// ERROR:
-Foo(1, 2, 3, 4, 5);
-// ERROR:
-Foo(5);
+public class Test
+{
+    public static void Test()
+    {
+        // ERROR:
+        Foo(1, 2, 3, 4, 5);
+        // ERROR:
+        Foo(5);
+    }
+}

--- a/semgrep-core/tests/csharp/dots_nested_stmts.cs
+++ b/semgrep-core/tests/csharp/dots_nested_stmts.cs
@@ -1,8 +1,11 @@
-public static void Foo()
+public class Test
 {
-    //ERROR:
-    if (x == some_cond)
-        Console.WriteLine("matched");
-    else
-        Console.WriteLine("not matched");
+    public static void Test()
+    {
+        //ERROR:
+        if (x == some_cond)
+            Console.WriteLine("matched");
+        else
+            Console.WriteLine("not matched");
+    }
 }

--- a/semgrep-core/tests/csharp/dots_stmts.cs
+++ b/semgrep-core/tests/csharp/dots_stmts.cs
@@ -1,9 +1,12 @@
-public static void Foo()
+public class Test
 {
-    //ERROR:
-    userData = Get();
-    Console.WriteLine("do stuff");
-    FooBar();
-    Eval(userData);
-    FooBar();
+    public static void Test()
+    {
+        //ERROR:
+        userData = Get();
+        Console.WriteLine("do stuff");
+        FooBar();
+        Eval(userData);
+        FooBar();
+    }
 }

--- a/semgrep-core/tests/csharp/metavar_call.cs
+++ b/semgrep-core/tests/csharp/metavar_call.cs
@@ -1,7 +1,9 @@
-public static void Test()
+public class Test
 {
-    // ERROR:
-    Foo(1, 2);
-
-    return 1;
+    public static int Test()
+    {
+        // ERROR:
+        Foo(1, 2);
+        return 1;
+    }
 }

--- a/semgrep-core/tests/csharp/metavar_call.cs
+++ b/semgrep-core/tests/csharp/metavar_call.cs
@@ -1,4 +1,4 @@
-public static void Test
+public static void Test()
 {
     // ERROR:
     Foo(1, 2);

--- a/semgrep-core/tests/csharp/metavar_equality_var.cs
+++ b/semgrep-core/tests/csharp/metavar_equality_var.cs
@@ -1,6 +1,9 @@
-public static void Foo()
+public class Test
 {
-    // ERROR:
-    myFile = Open();
-    Close(myFile);
+    public static void Test()
+    {
+        // ERROR:
+        myFile = Open();
+        Close(myFile);
+    }
 }


### PR DESCRIPTION
Fixes: 4ca2980cf55 ("C# alpha support (#3121)")

Closes #3161



PR checklist:
- [ ] changelog is up to date

