### PR TITLE
Allow nested 'pattern-either'

### DIFF
--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -19,9 +19,11 @@ definitions:
       - $ref: '#/definitions/metavariable-comparison'
   pattern-either-content:
     type: array
+    title: "Return finding where any of the nested conditions are true"
     items:
       anyOf:
       - $ref: '#/definitions/patterns'
+      - $ref: '#/definitions/pattern-either'
       - $ref: '#/definitions/pattern-inside'
       - $ref: '#/definitions/pattern'
       - $ref: '#/definitions/pattern-regex'

--- a/semgrep/tests/e2e/rules/nested-pattern-either.yaml
+++ b/semgrep/tests/e2e/rules/nested-pattern-either.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test
+  message: test
+  severity: WARNING
+  languages: [javascript]
+  pattern-either:
+    - pattern-either:
+      - pattern: nested_patterns_func('foo', ...)
+      - pattern: nested_patterns_func('bar', ...)
+    - pattern-either:
+      - pattern: nested_patterns_func($X, 1, ...)
+      - pattern: nested_patterns_func($X, 2, ...)

--- a/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
@@ -1,0 +1,103 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.test",
+      "end": {
+        "col": 35,
+        "line": 2
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    nested_patterns_func('foo', 1)",
+        "message": "test",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nested-patterns.js",
+      "start": {
+        "col": 5,
+        "line": 2
+      }
+    },
+    {
+      "check_id": "rules.test",
+      "end": {
+        "col": 35,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    nested_patterns_func('bar', 2)",
+        "message": "test",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nested-patterns.js",
+      "start": {
+        "col": 5,
+        "line": 3
+      }
+    },
+    {
+      "check_id": "rules.test",
+      "end": {
+        "col": 35,
+        "line": 4
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    nested_patterns_func('bar', 3)",
+        "message": "test",
+        "metadata": {},
+        "metavars": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nested-patterns.js",
+      "start": {
+        "col": 5,
+        "line": 4
+      }
+    },
+    {
+      "check_id": "rules.test",
+      "end": {
+        "col": 35,
+        "line": 5
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    nested_patterns_func('baz', 1)",
+        "message": "test",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "'baz'",
+            "end": {
+              "col": 31,
+              "line": 5,
+              "offset": 153
+            },
+            "start": {
+              "col": 26,
+              "line": 5,
+              "offset": 148
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/basic/nested-patterns.js",
+      "start": {
+        "col": 5,
+        "line": 5
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -231,6 +231,12 @@ def test_nested_patterns_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
+def test_nested_pattern_either_rule(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/nested-pattern-either.yaml"), "results.json"
+    )
+
+
 def test_nosem_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/nosem.yaml"), "results.json")
 


### PR DESCRIPTION
Fixes #3168.

I'm still on the fence as to whether we actually want this or not. A nested `pattern-either` can always be combined with it's parent `pattern-either` to produce an equivalent rule. Currently I'm leaning toward allowing this for a few reasons:

1. Users often aren't concerned about the technical precision of their rule, and want it to Just Work.
  i. This is especially apparent in very long rules. It can be difficult to tell at first glance you're in a very long `pattern-either`.
2. We allow other, basic noop operations as seen in #3168.
3. We can easily write a meta rule to catch and warn on this behavior rather than hard fail.

Overall, I think being liberal in what we accept ([Robustness principle](https://en.wikipedia.org/wiki/Robustness_principle)) and getting out of the user's way is best. Thoughts?