### PR TITLE
Upgrade to tree-sitter javascript version extended with preliminary semgrep pattern support

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_javascript_tree_sitter.ml
@@ -324,7 +324,6 @@ let from_clause (env : env) ((v1, v2) : CST.from_clause) =
     match v2 with
     | `Str x -> string_ env x
     | `Semg_meta tok -> todo_semgrep_pattern env tok
-    (* metavariable *)
   in
   (v1, v2)
 
@@ -418,7 +417,6 @@ and jsx_attribute_ (env : env) (x : CST.jsx_attribute_) : xml_attribute =
   | `Jsx_exp x -> XmlAttrExpr (jsx_expression_some env x)
   | `Semg_dots tok -> todo_semgrep_pattern env tok
 
-(* "..." *)
 and jsx_expression_some env x =
   let t1, eopt, t2 = jsx_expression env x in
   match eopt with
@@ -443,7 +441,6 @@ and jsx_attribute_value (env : env) (x : CST.jsx_attribute_value) =
   | `Semg_dots tok -> todo_semgrep_pattern env tok (* "..." *)
   | `Semg_meta tok -> todo_semgrep_pattern env tok
 
-(* metavariable *)
 and jsx_child (env : env) (x : CST.jsx_child) : xml_body =
   match x with
   | `Jsx_text tok ->
@@ -697,8 +694,7 @@ and class_body (env : env) ((v1, v2, v3) : CST.class_body) =
             let v1 = public_field_definition env v1 in
             let _v2 = semicolon env v2 in
             v1
-        | `Semg_dots tok -> todo_semgrep_pattern env tok
-        (* "..." *))
+        | `Semg_dots tok -> todo_semgrep_pattern env tok)
       v2
   in
   let v3 = token env v3 (* "}" *) in
@@ -722,7 +718,6 @@ and member_expression (env : env) ((v1, v2, v3) : CST.member_expression) : expr
     match v3 with
     | `Id tok -> identifier env tok (* identifier *)
     | `Semg_dots tok -> todo_semgrep_pattern env tok
-    (* "..." *)
   in
   ObjAccess (v1, v2, PN v3)
 
@@ -1626,7 +1621,6 @@ and anon_choice_pair_5c8e4b4 (env : env) (x : CST.anon_choice_pair_5c8e4b4) :
         }
   | `Semg_dots tok -> todo_semgrep_pattern env tok
 
-(* "..." *)
 and lhs_expression (env : env) (x : CST.lhs_expression) : expr =
   match x with
   | `Member_exp x -> member_expression env x
@@ -1769,8 +1763,6 @@ and formal_parameter (env : env) (x : CST.formal_parameter) : parameter =
             }
       | Right pat -> todo_any "`Rest_param with pattern" v1 (Expr pat) )
   | `Semg_dots tok -> todo_semgrep_pattern env tok
-
-(* "..." *)
 
 let toplevel env x = statement env x
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -58,6 +58,13 @@ module JS_CST = Parse_javascript_tree_sitter.CST
 module JS = Parse_javascript_tree_sitter
 module CST = CST_tree_sitter_typescript (* typescript+tsx, merged *)
 
+(*
+   After adding semgrep pattern support, we'll be able to use
+   JS.from_clause directly.
+*)
+let from_clause env (undefined, from_clause) =
+  JS.from_clause env (undefined, `Str from_clause)
+
 let accessibility_modifier (env : env) (x : CST.accessibility_modifier) =
   match x with
   | `Public tok -> (Public, JS.token env tok) (* "public" *)
@@ -1635,7 +1642,7 @@ and statement (env : env) (x : CST.statement) : stmt list =
         match v3 with
         | `Import_clause_from_clause (v1, v2) ->
             let f = import_clause env v1 in
-            let _t, path = JS.from_clause env v2 in
+            let _t, path = from_clause env v2 in
             f tok path
         | `Import_requ_clause x -> [ import_require_clause v1 env x ]
         | `Str x ->
@@ -1864,12 +1871,12 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
             match v2 with
             | `STAR_from_clause_choice_auto_semi (v1, v2, v3) ->
                 let v1 = JS.token env v1 (* "*" *) in
-                let tok2, path = JS.from_clause env v2 in
+                let tok2, path = from_clause env v2 in
                 let _v3 = JS.semicolon env v3 in
                 [ M (ReExportNamespace (tok, v1, tok2, path)) ]
             | `Export_clause_from_clause_choice_auto_semi (v1, v2, v3) ->
                 let v1 = export_clause env v1 in
-                let tok2, path = JS.from_clause env v2 in
+                let tok2, path = from_clause env v2 in
                 let _v3 = JS.semicolon env v3 in
                 v1
                 |> List.map (fun (n1, n2opt) ->


### PR DESCRIPTION
The implementation is not ready for use on semgrep patterns. This is based on old tree-sitter-javascript from Feb 9, 2021 (see
fyi/versions in semgrep-javascript).

PR checklist:
- [x] changelog is up to date

