### PR TITLE
fix: _raw in Rule object accurately reflects raw rule file

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -128,7 +128,7 @@ class Config:
         configs = self.valid
         if not no_rewrite_rule_ids:
             # re-write the configs to have the hierarchical rule ids
-            configs = self._rename_rule_ids(configs)
+            self._rename_rule_ids(configs)
 
         return list(
             OrderedDict.fromkeys([rule for rules in configs.values() for rule in rules])
@@ -153,16 +153,12 @@ class Config:
         return prefix
 
     @staticmethod
-    def _rename_rule_ids(valid_configs: Dict[str, List[Rule]]) -> Dict[str, List[Rule]]:
-        transformed = {}
+    def _rename_rule_ids(valid_configs: Dict[str, List[Rule]]) -> None:
         for config_id, rules in valid_configs.items():
-            transformed[config_id] = [
-                rule.with_id(
+            for rule in rules:
+                rule.rename_id(
                     f"{Config._convert_config_id_to_prefix(config_id)}{rule.id or MISSING_RULE_ID}"
                 )
-                for rule in rules
-            ]
-        return transformed
 
     # the mypy ignore is cause YamlTree puts an Any inside the @staticmethod decorator
     @staticmethod

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -572,7 +572,7 @@ class CoreRunner:
             for rule in progress_bar(
                 rules, bar_format="{l_bar}{bar}|{n_fmt}/{total_fmt}"
             ):
-                debug_tqdm_write(f"Running rule {rule._raw.get('id')}...")
+                debug_tqdm_write(f"Running rule {rule.id}...")
                 rule_matches, debugging_steps, errors, rule_targets = self._run_rule(
                     rule,
                     target_manager,
@@ -634,7 +634,7 @@ class CoreRunner:
                     )
                 )
             ):
-                debug_tqdm_write(f"Running rule {rule._raw.get('id')}...")
+                debug_tqdm_write(f"Running rule {rule.id}...")
                 with tempfile.NamedTemporaryFile(
                     "w", suffix=".yaml"
                 ) as rule_file, tempfile.NamedTemporaryFile("w") as target_file:

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -37,6 +37,8 @@ class Rule:
         self._yaml = raw
         self._raw: Dict[str, Any] = raw.unroll_dict()
 
+        self._id = str(self._raw["id"])
+
         # For tracking errors from semgrep-core
         self._pattern_spans: Dict[PatternId, Span] = {}
 
@@ -251,7 +253,7 @@ class Rule:
 
     @property
     def id(self) -> str:
-        return str(self._raw["id"])
+        return self._id
 
     @property
     def message(self) -> str:
@@ -313,14 +315,8 @@ class Rule:
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} id={self.id}>"
 
-    def with_id(self, new_id: str) -> "Rule":
-        new_yaml = YamlTree(
-            value=YamlMap(dict(self._yaml.value._internal)), span=self._yaml.span
-        )
-        new_yaml.value[self._yaml.value.key_tree("id")] = YamlTree(
-            value=new_id, span=new_yaml.value["id"].span
-        )
-        return Rule(new_yaml)
+    def rename_id(self, new_id: str) -> None:
+        self._id = new_id
 
     @property
     def pattern_spans(self) -> Dict[PatternId, Span]:


### PR DESCRIPTION
Rule._raw will now accurate reflect the unchanged rule as it was read instead of modifying the rule_id in that yaml
when rewriting the rule_id to reflect path

Closes https://github.com/returntocorp/semgrep/issues/3179


PR checklist:
- [ ] changelog is up to date

