### PR TITLE
Add a backup way of obtaining git url if docker image does not have git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 - Scala alpha support
-
+- Metrics collection of project_hash in cases where git is not available
 ### Fixed
 
 - Running with `--strict` will now return results if there are `nosem` mismatches. Semgrep will report a nonzero exit code if `--strict` is set and there are `nosem` mismathces. [#3099](https://github.com/returntocorp/semgrep/issues/3099)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -301,8 +301,11 @@ The two most popular are:
         )
     except Exception as e:
         logger.debug(f"Failed to get project url from 'git ls-remote': {e}")
-        # add \n to match urls from git ls-remote (backwards compatability)
-        project_url = manually_search_file(".git/config", ".com", "\n")
+        try:
+            # add \n to match urls from git ls-remote (backwards compatability)
+            project_url = manually_search_file(".git/config", ".com", "\n")
+        except Exception as e:
+            logger.debug(f"Failed to get project url from .git/config: {e}")
 
     project_hash = (
         hashlib.sha256(project_url.encode()).hexdigest() if project_url else None

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -6,10 +6,11 @@ import time
 from io import StringIO
 from pathlib import Path
 from re import sub
-from typing import Any, Tuple
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import attr
@@ -21,7 +22,8 @@ from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import NOSEM_INLINE_RE
 from semgrep.constants import OutputFormat
 from semgrep.core_runner import CoreRunner
-from semgrep.error import Level, MISSING_CONFIG_EXIT_CODE
+from semgrep.error import Level
+from semgrep.error import MISSING_CONFIG_EXIT_CODE
 from semgrep.error import SemgrepError
 from semgrep.metric_manager import metric_manager
 from semgrep.output import OutputHandler
@@ -30,6 +32,7 @@ from semgrep.profile_manager import ProfileManager
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.target_manager import TargetManager
+from semgrep.util import manually_search_file
 from semgrep.util import sub_check_output
 
 logger = logging.getLogger(__name__)
@@ -62,7 +65,9 @@ def notify_user_of_work(
             logger.info(f"- {rule.id}")
 
 
-def rule_match_nosem(rule_match: RuleMatch, strict: bool) -> Tuple[bool, List[SemgrepError]]:
+def rule_match_nosem(
+    rule_match: RuleMatch, strict: bool
+) -> Tuple[bool, List[SemgrepError]]:
     if not rule_match.lines:
         return False, []
 
@@ -288,16 +293,20 @@ The two most popular are:
     num_findings = sum(len(v) for v in rule_matches_by_rule.values())
     stats_line = f"ran {len(filtered_rules)} rules on {len(all_targets)} files: {num_findings} findings"
 
-    project_hash = None
     try:
         project_url = sub_check_output(
             ["git", "ls-remote", "--get-url"],
             encoding="utf-8",
             stderr=subprocess.DEVNULL,
         )
-        project_hash = hashlib.sha256(project_url.encode()).hexdigest()
     except Exception as e:
-        logger.debug(f"Failed to generate project hash: {e}")
+        logger.debug(f"Failed to get project url from 'git ls-remote': {e}")
+        # add \n to match urls from git ls-remote (backwards compatability)
+        project_url = manually_search_file(".git/config", ".com", "\n")
+
+    project_hash = (
+        hashlib.sha256(project_url.encode()).hexdigest() if project_url else None
+    )
 
     metric_manager.set_project_hash(project_hash)
     metric_manager.set_configs_hash(configs)

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -169,9 +169,9 @@ def manually_search_file(path: str, search_term: str, suffix: str) -> Optional[s
     """
     if not os.path.isfile(path):
         return None
-    fd = open(path, mode="r")
-    contents = fd.read()
-    words = contents.split()
+    with open(path, mode="r") as fd:
+        contents = fd.read()
+        words = contents.split()
     # Find all of the individual words that contain the search_term
     matches = [w for w in words if search_term in w]
     return matches[0] + suffix if len(matches) > 0 else None

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -10,6 +10,7 @@ from typing import Callable
 from typing import IO
 from typing import Iterable
 from typing import List
+from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import TypeVar
@@ -159,6 +160,19 @@ def sub_check_output(cmd: List[str], **kwargs: Any) -> Any:
     result = subprocess.check_output(cmd, **kwargs)  # nosem: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
     # fmt: on
     return result
+
+
+def manually_search_file(path: str, search_term: str, suffix: str) -> Optional[str]:
+    """
+    Searches a file for the given search term and, if found,
+    returns the first word that contains that search term
+    """
+    fd = open(path, mode="r")
+    contents = fd.read()
+    words = contents.split()
+    # Find all of the individual words that contain the search_term
+    matches = [w for w in words if search_term in w]
+    return matches[0] + suffix if len(matches) > 0 else None
 
 
 def compute_executable_path(exec_name: str) -> str:

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -167,6 +167,8 @@ def manually_search_file(path: str, search_term: str, suffix: str) -> Optional[s
     Searches a file for the given search term and, if found,
     returns the first word that contains that search term
     """
+    if not os.path.isfile(path):
+        return None
     fd = open(path, mode="r")
     contents = fd.read()
     words = contents.split()


### PR DESCRIPTION
This should work for any git configuration. 
First, we try to obtain the project url through git ls-remote --get-url
If that fails, we manually look at the .git/config file to pull out the url ourselves

I also considered using the environment variable CI_PROJECT_URL from GitLab.
I decided to go this route because it was easier to test, and works for all git projects, not just for GitLab.
The tradeoff is this is slower and a little more complicated - requires file IO rather than an env variable that might "just work"
I am definitely open to reversing that decision, though!

PR checklist:
- [x] changelog is up to date

