### PR TITLE
fix: stabalize rules_hash metric by sorting

### DIFF
--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -55,8 +55,10 @@ class _MetricManager:
 
     def set_rules_hash(self, rules: List[Rule]) -> None:
         m = hashlib.sha256()
-        for r in rules:
-            m.update(r.full_hash.encode())
+        rule_hashes = [r.full_hash for r in rules]
+        rule_hashes.sort()  # sort hashes to have a stable rules_hash
+        for rule_hash in rule_hashes:
+            m.update(rule_hash.encode())
         self._rules_hash = m.hexdigest()
 
     def set_return_code(self, return_code: int) -> None:


### PR DESCRIPTION
For now it's a little involved to get the raw rule yaml files in this part of the code so instead of wiring all that up, just sort before doing a hash of hashes for stability.