### PR TITLE
parse_rule: Parse pattern-not-regex patterns

### DIFF
--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -265,6 +265,9 @@ let rec parse_formula_old env (x : string * J.t) : R.formula_old =
   | "pattern-regex", J.String s ->
       let xpat = R.mk_xpat (Regexp (parse_regexp s)) s in
       R.Pat xpat
+  | "pattern-not-regex", J.String s ->
+      let xpat = R.mk_xpat (Regexp (parse_regexp s)) s in
+      R.PatNot xpat
   | x ->
       let extra = parse_extra env x in
       R.PatExtra extra


### PR DESCRIPTION
test plan:
semgrep-core -test_rules path/to/semgrep-rules/generic/secrets # now works



PR checklist:
- [ ] changelog is up to date

