### PR TITLE
Pass in Absolute Paths to '--time'

### DIFF
--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -62,7 +62,7 @@ def _build_time_target_json(
 
     target_json["path"] = path_str
     target_json["num_bytes"] = num_bytes
-    timings = [profiling_data.get_run_times(rule.id, path_str) for rule in rules]
+    timings = [profiling_data.get_run_times(rule.id, str(target)) for rule in rules]
     target_json["parse_times"] = [timing.parse_time for timing in timings]
     target_json["match_times"] = [timing.match_time for timing in timings]
     target_json["run_times"] = [timing.run_time for timing in timings]


### PR DESCRIPTION
semgrep-core `--time` doesn't take relative paths, so pass the absolute path instead like before. This should fix https://github.com/returntocorp/semgrep/issues/3195.

_Test Plan:_
1. Change `run-benchmarks` to run `python -m semgrep` instead of `semgrep` in the `run_semgrep` function.
2. Run 
3. `./run-benchmarks --small-only --output-time-per-rule-json test.json`
