### PR TITLE
Use metavariables in messages for experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Basic type inference also for implicit variable declarations (Python, Ruby, PHP, and JS)
 - JS/TS: differentiating tagged template literals in the AST (#3187)
 - Ruby: storing parenthesis in function calls in the AST (#3178)
+- Metavariables in messages are filled in in experimental mode
 
 ### Changed
 

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -17,27 +17,48 @@ import json
 import logging
 import os
 import re
-import requests
 import subprocess
 import sys
 import time
 import urllib.request
 from contextlib import contextmanager
-from typing import Iterator, List, Optional
-from typing import Tuple
 from pathlib import Path
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Tuple
 
+import requests
 import semgrep_core_benchmark  # type: ignore
+from config import BenchmarkRunSetupData
+from config import SemgrepBenchmarkConfig
+from constants import BPS_ENDPOINT
+from constants import DASHBOARD_URL
+from constants import LPS_ENDPOINT
+from constants import PREP_FILE_TEMPLATE
+from constants import RULE_CONFIG_CACHE_DIR
+from constants import SEMGREP_USER_AGENT
+from constants import STATS_URL
+from constants import STD
+from corpus import Corpus
+from corpus import DUMMY_CORPUSES
+from corpus import GITLAB_CORPUSES
+from corpus import INTERNAL_CORPUSES
+from corpus import LARGE_CORPUSES
+from corpus import MEDIUM_CORPUSES
+from corpus import SMALL_CORPUSES
 from RepositoryTimePerRule import RepositoryTimePerRule
-from config import SemgrepBenchmarkConfig, BenchmarkRunSetupData
-from constants import STD, DASHBOARD_URL, STATS_URL, BPS_ENDPOINT, LPS_ENDPOINT, SEMGREP_USER_AGENT, RULE_CONFIG_CACHE_DIR, PREP_FILE_TEMPLATE
-from corpus import Corpus, SMALL_CORPUSES, MEDIUM_CORPUSES, LARGE_CORPUSES, INTERNAL_CORPUSES, GITLAB_CORPUSES, DUMMY_CORPUSES
-from variant import SemgrepVariant, STD_VARIANTS, GITLAB_VARIANTS, SEMGREP_VARIANTS
+from variant import GITLAB_VARIANTS
+from variant import SEMGREP_VARIANTS
+from variant import SemgrepVariant
+from variant import STD_VARIANTS
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
 handler = logging.StreamHandler(stream=sys.stderr)
-handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+handler.setFormatter(
+    logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+)
 logger.addHandler(handler)
 
 
@@ -51,9 +72,6 @@ class SemgrepResult:
         # to abstract away differences
         if "extra" in dict:
             dict2 = copy.deepcopy(dict)
-            # TODO: full-rule does not correctly update message with metavars
-            if "message" in dict2["extra"]:
-                dict2["extra"]["message"] = ""
             # TODO: spacegrep.py calls dedent() on lines (not sure why)
             if "lines" in dict2["extra"]:
                 dict2["extra"]["lines"] = ""
@@ -184,8 +202,13 @@ def output_differences(
     output_diff(s_diff)
     return fd_len, sd_len
 
+
 def run_semgrep(
-    docker: str, corpus: Corpus, variant: SemgrepVariant, include_time: bool, hard_timeout: int = 0
+    docker: str,
+    corpus: Corpus,
+    variant: SemgrepVariant,
+    include_time: bool,
+    hard_timeout: int = 0,
 ) -> Tuple[float, dict]:
     args = []
     common_args = [
@@ -234,7 +257,9 @@ def run_semgrep(
     print(f"extra arguments for semgrep-core: '{variant.semgrep_core_extra}'")
 
     t1 = time.time()
-    res = subprocess.run(args, capture_output=True, timeout=hard_timeout or None)  # nosem
+    res = subprocess.run(
+        args, capture_output=True, timeout=hard_timeout or None
+    )  # nosem
     t2 = time.time()
 
     status = res.returncode
@@ -250,24 +275,28 @@ def run_semgrep(
         print(res.stderr)
         res.check_returncode()
 
-    try: 
-        stdout_decoded = res.stdout.decode('utf-8')
+    try:
+        stdout_decoded = res.stdout.decode("utf-8")
         semgrep_results = json.loads(stdout_decoded)
     except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
         logger.error("Unable to decode the Semgrep result as JSON. Exiting.")
         sys.exit(1)
 
-    return t2 - t1, semgrep_results 
+    return t2 - t1, semgrep_results
 
 
 def normalize_rule_config_name(rule_config_str: str) -> str:
     return rule_config_str.replace("/", ".") + ".yaml"
 
 
-def prepare_rule_cache_for_this_run(setup_data: BenchmarkRunSetupData)-> Tuple[Path, List[Path]]:
+def prepare_rule_cache_for_this_run(
+    setup_data: BenchmarkRunSetupData,
+) -> Tuple[Path, List[Path]]:
     rule_cache_for_this_run: Path = RULE_CONFIG_CACHE_DIR / setup_data.run_name
     rule_cache_for_this_run.mkdir(parents=True, exist_ok=True)
-    logger.info(f"Rule cache for run {setup_data.run_name} created at {rule_cache_for_this_run}")
+    logger.info(
+        f"Rule cache for run {setup_data.run_name} created at {rule_cache_for_this_run}"
+    )
     rule_config_paths = list()
     for rule_config in setup_data.rule_configs:
         logger.info(f"Checking for rule config '{rule_config}' in cache")
@@ -285,12 +314,18 @@ def prepare_rule_cache_for_this_run(setup_data: BenchmarkRunSetupData)-> Tuple[P
                     timeout=60,
                 )
             except requests.Timeout:
-                logger.warning(f"There was a timeout error trying to download the rule config at '{rule_config_url}'. Skipping.")
+                logger.warning(
+                    f"There was a timeout error trying to download the rule config at '{rule_config_url}'. Skipping."
+                )
                 continue
             rule_config_path.write_text(r.text)
-            logger.info(f"Rule config '{rule_config}' has been written to '{rule_config_path}'")
+            logger.info(
+                f"Rule config '{rule_config}' has been written to '{rule_config_path}'"
+            )
         else:
-            logger.info(f"Rule config '{rule_config_path}' already exists, using this one")
+            logger.info(
+                f"Rule config '{rule_config_path}' already exists, using this one"
+            )
         rule_config_paths.append(rule_config_path)
     return rule_cache_for_this_run, rule_config_paths
 
@@ -306,17 +341,30 @@ def prepare_benchmark_run(benchmark_config: SemgrepBenchmarkConfig) -> List[Corp
         logger.info(f"Setting up benchmark run for run '{setup_data.run_name}'")
         rule_cache_dir, _ = prepare_rule_cache_for_this_run(setup_data)
         for repository in setup_data.repositories:
-            repo_name = repository.url.split('/')[-1]
-            generate_prep_file(repo_name, rule_cache_dir.absolute(), repository.url, repository.commit_hash)
-            corpuses.append(Corpus(
+            repo_name = repository.url.split("/")[-1]
+            generate_prep_file(
                 repo_name,
                 rule_cache_dir.absolute(),
-                Path("input") / repo_name,
-            ))
-    
+                repository.url,
+                repository.commit_hash,
+            )
+            corpuses.append(
+                Corpus(
+                    repo_name,
+                    rule_cache_dir.absolute(),
+                    Path("input") / repo_name,
+                )
+            )
+
     return corpuses
 
-def generate_prep_file(name: str, rule_cache_dir: Path, url: str, commit_hash: str, ) -> bool:
+
+def generate_prep_file(
+    name: str,
+    rule_cache_dir: Path,
+    url: str,
+    commit_hash: str,
+) -> bool:
     # make dirs
     benchdir = Path(name)
     benchdir.mkdir(parents=True, exist_ok=True)
@@ -327,12 +375,14 @@ def generate_prep_file(name: str, rule_cache_dir: Path, url: str, commit_hash: s
     else:
         logger.info(f"Generating 'prep' file at {prep_file}")
         prep_file.touch(0o755, exist_ok=True)
-        prep_file.write_text(PREP_FILE_TEMPLATE.format(
-            name=name,
-            rule_cache_dir=rule_cache_dir,
-            url=url,
-            commit_hash=commit_hash
-        ))
+        prep_file.write_text(
+            PREP_FILE_TEMPLATE.format(
+                name=name,
+                rule_cache_dir=rule_cache_dir,
+                url=url,
+                commit_hash=commit_hash,
+            )
+        )
 
 
 def run_benchmarks(
@@ -368,7 +418,9 @@ def run_benchmarks(
     results_msgs = []
     durations = ""
     results: dict = {variant.name: [] for variant in variants}
-    output_per_rule_json_results = RepositoryTimePerRule(output_file=output_time_per_rule_json)
+    output_per_rule_json_results = RepositoryTimePerRule(
+        output_file=output_time_per_rule_json
+    )
 
     corpuses = SMALL_CORPUSES + MEDIUM_CORPUSES
     if dummy:
@@ -383,7 +435,9 @@ def run_benchmarks(
     elif all:
         corpuses = SMALL_CORPUSES + MEDIUM_CORPUSES + LARGE_CORPUSES
     elif config_file:
-        corpuses = prepare_benchmark_run(SemgrepBenchmarkConfig.parse_config(config_file.absolute()))
+        corpuses = prepare_benchmark_run(
+            SemgrepBenchmarkConfig.parse_config(config_file.absolute())
+        )
     if filter_corpus:
         corpuses = [x for x in corpuses if re.search(filter_corpus, x.name) != None]
 
@@ -393,7 +447,9 @@ def run_benchmarks(
             try:
                 corpus.prep()
             except Exception as e:
-                logger.warning(f"Could not execute 'prep' file for {corpus.name}. Please check it exists. Will skip this corpus. Error: {e}")
+                logger.warning(
+                    f"Could not execute 'prep' file for {corpus.name}. Please check it exists. Will skip this corpus. Error: {e}"
+                )
                 continue
 
             std_findings = {}
@@ -405,15 +461,25 @@ def run_benchmarks(
                 print(f"------ {name} ------")
                 try:
                     duration, semgrep_results = run_semgrep(
-                        docker, corpus, variant, include_time, hard_timeout,
+                        docker,
+                        corpus,
+                        variant,
+                        include_time,
+                        hard_timeout,
                     )
                 except subprocess.TimeoutExpired:
-                    logger.warning(f"A hard timeout was set for {hard_timeout} seconds.")
-                    logger.warning(f"The test for '{variant.name}' on '{corpus.name}' exceeded the timeout. This test will be skipped.")
+                    logger.warning(
+                        f"A hard timeout was set for {hard_timeout} seconds."
+                    )
+                    logger.warning(
+                        f"The test for '{variant.name}' on '{corpus.name}' exceeded the timeout. This test will be skipped."
+                    )
                     continue
 
                 if not output_time_per_rule_json is None:
-                    output_per_rule_json_results.times_per_file_to_times_per_rule(corpus.name, semgrep_results)
+                    output_per_rule_json_results.times_per_file_to_times_per_rule(
+                        corpus.name, semgrep_results
+                    )
 
                 # Report results
                 msg = f"{metric_name} = {duration:.3f} s"
@@ -422,9 +488,7 @@ def run_benchmarks(
                 durations += f"{duration:.3f}\n"
                 results[variant.name].append(duration)
 
-                findings, timings = standardize_findings(
-                    semgrep_results, include_time
-                )
+                findings, timings = standardize_findings(semgrep_results, include_time)
 
                 if upload:
                     upload_result(variant.name, metric_name, duration, timings)
@@ -467,6 +531,7 @@ def run_benchmarks(
     if not output_time_per_rule_json is None:
         with chdir(called_dir):
             output_per_rule_json_results.print_repo_to_times_per_rule()
+
 
 def main() -> None:
     parser = argparse.ArgumentParser()
@@ -547,10 +612,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--output-time-per-rule-json",
-        nargs='?',
+        nargs="?",
         default=None,
-        const = 'repo_to_rule_time.json',        
-        help="output a json file that shows timing information for each rule."
+        const="repo_to_rule_time.json",
+        help="output a json file that shows timing information for each rule.",
     )
     parser.add_argument("--no-time", help="disable time-checking", action="store_true")
     args = parser.parse_args()

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -692,21 +692,6 @@ class CoreRunner:
                 ]
                 findings = create_output(rule, pattern_matches)
 
-                """
-                findings = [
-                    RuleMatch.from_pattern_match(
-                        rule.id,
-                        PatternMatch(pattern_match),
-                        message=rule.message,
-                        metadata=rule.metadata,
-                        severity=rule.severity,
-                        fix=rule.fix,
-                        fix_regex=rule.fix_regex,
-                    )
-                    for pattern_match in output_json["matches"]
-                ]
-                """
-
                 # TODO: we should do that in Semgrep_generic.ml instead
                 findings = dedup_output(findings)
                 outputs[rule].extend(findings)

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -30,6 +30,7 @@ from semgrep.error import InvalidPatternError
 from semgrep.error import MatchTimeoutError
 from semgrep.error import SemgrepError
 from semgrep.error import UnknownLanguageError
+from semgrep.evaluation import create_output
 from semgrep.evaluation import enumerate_patterns_in_boolean_expression
 from semgrep.evaluation import evaluate
 from semgrep.output import OutputSettings
@@ -686,6 +687,12 @@ class CoreRunner:
                         self._add_match_times(rule, profiling_data, output_json["time"])
 
                 # end with tempfile.NamedTemporaryFile(...) ...
+                pattern_matches = [
+                    PatternMatch(match) for match in output_json["matches"]
+                ]
+                findings = create_output(rule, pattern_matches)
+
+                """
                 findings = [
                     RuleMatch.from_pattern_match(
                         rule.id,
@@ -698,6 +705,8 @@ class CoreRunner:
                     )
                     for pattern_match in output_json["matches"]
                 ]
+                """
+
                 # TODO: we should do that in Semgrep_generic.ml instead
                 findings = dedup_output(findings)
                 outputs[rule].extend(findings)


### PR DESCRIPTION
Separate metavariable propagation into a different function and use it in run_rules_direct_to_semgrep_core. Re-expose the message check in run-benchmarks

Test plan: ./run-benchmarks



PR checklist:
- [x] changelog is up to date

