### PR TITLE
fix: don't do file extension filtering in semgrep-core

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -349,13 +349,6 @@ let xlang_of_string s =
       let lang = lang_of_string s in
       R.L (lang, [])
 
-let xlang_files_of_dirs_or_files xlang files_or_dirs =
-  match xlang with
-  | R.LNone | R.LGeneric ->
-      (* TODO: assert is_file ? spacegrep filter files? *)
-      files_or_dirs
-  | R.L (lang, _) -> Lang.files_of_dirs_or_files lang files_or_dirs
-
 (*****************************************************************************)
 (* Caching *)
 (*****************************************************************************)
@@ -781,13 +774,14 @@ let semgrep_with_patterns_file lang rules_file files_or_dirs =
 (* Semgrep -config *)
 (*****************************************************************************)
 
-let semgrep_with_rules (rules, rule_parse_time) files_or_dirs =
+let semgrep_with_rules (rules, rule_parse_time) files =
   (* todo: at some point we should infer the lang from the rules and
    * apply different rules with different languages and different files
    * automatically, like the semgrep python wrapper.
+   *
+   * For now python wrapper passes down all files that should be scanned
    *)
   let xlang = xlang_of_string !lang in
-  let files = xlang_files_of_dirs_or_files xlang files_or_dirs in
   logger#info "processing %d files" (List.length files);
 
   let file_results =

--- a/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering_optimizations/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_noextension_filtering_optimizations/results.json
@@ -1,0 +1,43 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.eqeq-is-bad",
+      "end": {
+        "col": 26,
+        "line": 3
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    return a + b == a + b",
+        "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "a+b",
+            "end": {
+              "col": 17,
+              "line": 3,
+              "offset": 60
+            },
+            "start": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/stupid_no_extension",
+      "start": {
+        "col": 12,
+        "line": 3
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -65,6 +65,21 @@ def test_noextension_filtering(run_semgrep_in_tmp, snapshot):
     )
 
 
+def test_noextension_filtering_optimizations(run_semgrep_in_tmp, snapshot):
+    """
+    Check that semgrep does not filter out files without extensions when
+    said file is explicitly passed
+    """
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/eqeq-python.yaml",
+            target_name="basic/stupid_no_extension",
+            options=["--optimizations", "all"],
+        ),
+        "results.json",
+    )
+
+
 def test_basic_rule__absolute(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(Path.cwd() / "rules" / "eqeq.yaml"),


### PR DESCRIPTION
semgrep-cli has logic that allows files without the correct extension to
be explicitly passed and scanned for a given language. With `--optimizations all`
this behavior is broken since semgrep-core is filtering out files without expected
filenames when doing whole rule matching. This PR removes that filtering.



PR checklist:
- [ ] changelog is up to date

