### PR TITLE
ci: don't fail if repeating pypi release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_upload_token }}
+          skip_existing: true
 
   homebrew-core-pr:
     name: Update on Homebrew-Core


### PR DESCRIPTION
When rerunning the release scripts, pypi uploading would fail if a version already existed, this stops jobs further down
like homebrew releasing from rerunning as intended. This PR treats trying to upload to pypi with a version collision as
a non-error.