### PR TITLE
Remove unused fields in Semgrep.atd

### DIFF
--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -32,17 +32,6 @@ module SJ = Spacegrep.Semgrep_j (* JSON conversions *)
 (* Unique ID *)
 (*****************************************************************************)
 (*s: function [[JSON_report.string_of_resolved]] *)
-let string_of_resolved = function
-  | Global -> "Global"
-  | Local -> "Local"
-  | Param -> "Param"
-  | EnclosedVar -> "EnclosedVar"
-  | ImportedEntity _ -> "ImportedEntity"
-  | ImportedModule _ -> "ImportedModule"
-  | TypeName -> "TypeName"
-  | Macro -> "Macro"
-  | EnumConstant -> "EnumConstant"
-
 (*e: function [[JSON_report.string_of_resolved]] *)
 
 (*s: function [[JSON_report.unique_id]] *)
@@ -53,23 +42,8 @@ let string_of_resolved = function
  *)
 let unique_id any =
   match any with
-  | E
-      (N
-        (Id
-          ((str, _tok), { id_resolved = { contents = Some (resolved, sid) }; _ })))
-    ->
-      {
-        ST.type_ = `ID;
-        md5sum = None;
-        sid = Some sid;
-        (* old: we were using extra fields before, but they seem unused
-         * by the python side, so we should skip them. They seem
-         * just used in our test snapshots.
-         *)
-        kind = Some (string_of_resolved resolved);
-        (*  *)
-        value = Some str;
-      }
+  | E (N (Id (_, { id_resolved = { contents = Some (_, sid) }; _ }))) ->
+      { ST.type_ = `ID; md5sum = None; sid = Some sid }
   (* not an Id, return a md5sum of its AST as a "single unique id" *)
   | _ ->
       (* todo? note that if the any use a parameter, or a local,
@@ -84,13 +58,7 @@ let unique_id any =
        *)
       let s = Marshal.to_string any [] in
       let md5 = Digest.string s in
-      {
-        ST.type_ = `AST;
-        md5sum = Some (Digest.to_hex md5);
-        sid = None;
-        kind = None;
-        value = None;
-      }
+      { ST.type_ = `AST; md5sum = Some (Digest.to_hex md5); sid = None }
 
 (*e: function [[JSON_report.unique_id]] *)
 

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/results.json
@@ -27,10 +27,8 @@
               "offset": 45
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "inputs"
+              "type": "id"
             }
           },
           "$KEY": {
@@ -46,10 +44,8 @@
               "offset": 52
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 2,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -87,10 +83,8 @@
               "offset": 64
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "inputs"
+              "type": "id"
             }
           },
           "$KEY": {

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py/results.json
@@ -36,10 +36,8 @@
               "offset": 2376
             },
             "unique_id": {
-              "kind": "Local",
               "sid": 18,
-              "type": "id",
-              "value": "user"
+              "type": "id"
             }
           },
           "$VAR": {
@@ -55,10 +53,8 @@
               "offset": 2269
             },
             "unique_id": {
-              "kind": "Local",
               "sid": 20,
-              "type": "id",
-              "value": "new_password"
+              "type": "id"
             }
           },
           "$W": {
@@ -156,10 +152,8 @@
               "offset": 2977
             },
             "unique_id": {
-              "kind": "Local",
               "sid": 25,
-              "type": "id",
-              "value": "user"
+              "type": "id"
             }
           },
           "$VAR": {
@@ -175,10 +169,8 @@
               "offset": 2712
             },
             "unique_id": {
-              "kind": "Param",
               "sid": 24,
-              "type": "id",
-              "value": "password"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiline/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiline/results.json
@@ -26,10 +26,8 @@
               "offset": 115
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
@@ -64,10 +64,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -26,10 +26,8 @@
               "offset": 61
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-include/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-include/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude0/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude0/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude1/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude1/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-exclude/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-exclude/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include0/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include0/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -106,10 +102,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -146,10 +140,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include1/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include1/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -106,10 +102,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -146,10 +140,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include0/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include0/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include1/results.json
+++ b/semgrep/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include1/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
@@ -26,10 +26,8 @@
               "offset": 91
             },
             "unique_id": {
-              "kind": "Local",
               "sid": 2,
-              "type": "id",
-              "value": "path"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 260
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 6,
-              "type": "id",
-              "value": "z"
+              "type": "id"
             }
           }
         },

--- a/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
+++ b/semgrep/tests/e2e/snapshots/test_paths/test_paths/results.json
@@ -26,10 +26,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -66,10 +64,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -106,10 +102,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -146,10 +140,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -186,10 +178,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -226,10 +216,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -266,10 +254,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -306,10 +292,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -346,10 +330,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -386,10 +368,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -426,10 +406,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -466,10 +444,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -506,10 +482,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },
@@ -546,10 +520,8 @@
               "offset": 24
             },
             "unique_id": {
-              "kind": "Global",
               "sid": 1,
-              "type": "id",
-              "value": "x"
+              "type": "id"
             }
           }
         },

--- a/spacegrep/src/lib/Semgrep.atd
+++ b/spacegrep/src/lib/Semgrep.atd
@@ -103,8 +103,6 @@ type unique_id = {
   ?md5sum: string option;
   (* ID case *)
   ?sid: int option;
-  ?kind: string option; (* used just in snapshots? *)
-  ?value: string option; (* used just in snapshots? *)
 }
 
 type unique_id_type = [

--- a/spacegrep/src/lib/Semgrep.ml
+++ b/spacegrep/src/lib/Semgrep.ml
@@ -17,7 +17,7 @@ let semgrep_pos (x : Lexing.position) : Semgrep_t.position =
 
 let unique_id_of_capture ~captured_string : unique_id =
   let md5sum = captured_string |> Digest.string |> Digest.to_hex in
-  { type_ = `AST; md5sum = Some md5sum; sid = None; kind = None; value = None }
+  { type_ = `AST; md5sum = Some md5sum; sid = None }
 
 let convert_capture (name, x) =
   assert (name <> "" && name.[0] <> '$');


### PR DESCRIPTION
Those fields were not used Python side, so no need to generate them
OCaml side

test plan:
make test




PR checklist:
- [x] changelog is up to date