### PR TITLE
fix: stablize project_hash even if username passwords are set

### DIFF
--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -1,5 +1,4 @@
 import hashlib
-import logging
 from pathlib import Path
 from typing import Any
 from typing import Dict

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -52,13 +53,18 @@ class _MetricManager:
         if project_url is None:
             self._project_hash = None
         else:
-            parsed_url = urlparse(project_url)
-            if parsed_url.scheme == "https":
-                # Remove optional username/password from project_url
-                sanitized_url = f"{parsed_url.hostname}{parsed_url.path}"
-            else:
-                # For now don't do anything special with other git-url formats
+            try:
+                parsed_url = urlparse(project_url)
+                if parsed_url.scheme == "https":
+                    # Remove optional username/password from project_url
+                    sanitized_url = f"{parsed_url.hostname}{parsed_url.path}"
+                else:
+                    # For now don't do anything special with other git-url formats
+                    sanitized_url = project_url
+            except ValueError as e:
+                logger.debug(f"Failed to parse url {project_url}")
                 sanitized_url = project_url
+
 
             project_hash = hashlib.sha256(sanitized_url.encode()).hexdigest()
             self._project_hash = project_hash

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -292,6 +292,7 @@ The two most popular are:
     stats_line = f"ran {len(filtered_rules)} rules on {len(all_targets)} files: {num_findings} findings"
 
     if metric_manager.is_enabled:
+        project_url = None
         try:
             project_url = sub_check_output(
                 ["git", "ls-remote", "--get-url"],
@@ -306,11 +307,7 @@ The two most popular are:
             except Exception as e:
                 logger.debug(f"Failed to get project url from .git/config: {e}")
 
-        project_hash = (
-            hashlib.sha256(project_url.encode()).hexdigest() if project_url else None
-        )
-
-        metric_manager.set_project_hash(project_hash)
+        metric_manager.set_project_hash(project_url)
         metric_manager.set_configs_hash(configs)
         metric_manager.set_rules_hash(filtered_rules)
         metric_manager.set_num_rules(len(filtered_rules))

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import logging
 import subprocess

--- a/semgrep/tests/unit/test_metric_manager.py
+++ b/semgrep/tests/unit/test_metric_manager.py
@@ -194,3 +194,18 @@ def test_timings(snapshot) -> None:
             "runTime": 1.4,
         },
     ]
+
+
+def test_project_hash():
+    metric_manager.set_project_hash("https://foo.bar.com/org/project.git")
+    no_username_password = metric_manager._project_hash
+    metric_manager.set_project_hash(
+        "https://username:password@foo.bar.com/org/project.git"
+    )
+    with_username_password_1 = metric_manager._project_hash
+    metric_manager.set_project_hash(
+        "https://username1:password2@foo.bar.com/org/project.git"
+    )
+    with_username_password_2 = metric_manager._project_hash
+    assert no_username_password == with_username_password_1
+    assert with_username_password_1 == with_username_password_2


### PR DESCRIPTION
Gitlab SAST adds username and password to their git ls-remote that changes per-run of CI. This PR stabilizes by removing username and password when the url is of the format: `scheme://username:password@hostname/path`

For now if the format is not of that form we don't do any sanitation of the url.