### PR TITLE
[Python] transform assigns in class defs as VarDef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   properties](https://github.com/tree-sitter/tree-sitter-javascript/pull/166)
 - JavaScript parsing: [Allow default export for any declaration](https://github.com/tree-sitter/tree-sitter-javascript/pull/168)
 - Metavariables in messages are filled in when using `--optimizations all`
+- Python: class variables are matched in any order (#3212)
 
 ### Changed
 - $...ARGS can now match an empty list of arguments, just like ... (#3177)

--- a/semgrep-core/tests/python/misc_metavar_field_anyorder.py
+++ b/semgrep-core/tests/python/misc_metavar_field_anyorder.py
@@ -1,0 +1,12 @@
+#from AModule.Part import Vuln
+#from ThisModule import SuperClass
+
+# this used to not match because Assign in Python were not
+# translated in DefStmt, which is the only thing that was matched
+# in any order in Generic_vs_generic.m_fields.
+
+#ERROR: match
+class LOL(SuperClass):
+    hah = 1
+    data = Vuln()
+    

--- a/semgrep-core/tests/python/misc_metavar_field_anyorder.sgrep
+++ b/semgrep-core/tests/python/misc_metavar_field_anyorder.sgrep
@@ -1,0 +1,3 @@
+class LOL(SuperClass):
+  ...
+  $VAR = Vuln(...)


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/3212

test plan:
test file included
also
```
+ /home/pad/yy/_build/default/src/cli/Main.exe -dump_ast misc_metavar_field_anyorder.py
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("LOL", ()),
                {id_resolved=Ref(None); id_type=Ref(None);
                 id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      ClassDef(
        {ckind=(Class, ());
	 ...
         cbody=[FieldStmt(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("hah", ()),
                               {id_resolved=Ref(None); id_type=Ref(None);
                                id_constness=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     VarDef({vinit=Some(L(Int((Some(1), ()))));
		     vtype=None; }))
		     ...
```

which now shows a VarDef for "hah"




PR checklist:
- [x] changelog is up to date