### PR TITLE
Propagate metavariables into match results in experimental

### DIFF
--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -196,7 +196,9 @@ let (range_to_pattern_match_adjusted :
       message = r.R.message (* keep pattern_str which can be useful to debug *);
     }
   in
-  { m with rule_id }
+  (* Need env to be the result of evalaute_formula, which propagates metavariables *)
+  (* rather than the original metavariables for the match                          *)
+  { m with rule_id; env = range.mvars }
 
 let (match_result_to_range : Pattern_match.t -> range_with_mvars) =
  fun m ->

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -196,7 +196,7 @@ let (range_to_pattern_match_adjusted :
       message = r.R.message (* keep pattern_str which can be useful to debug *);
     }
   in
-  (* Need env to be the result of evalaute_formula, which propagates metavariables *)
+  (* Need env to be the result of evaluate_formula, which propagates metavariables *)
   (* rather than the original metavariables for the match                          *)
   { m with rule_id; env = range.mvars }
 


### PR DESCRIPTION
After a pattern composition is performed, there may be more metavariables pertain to the actual result range. When reporting results, report those metavariables in addition

Test plan:

In semgrep/semgrep/tests/e2e/ run

semgrep --config rules/metavariable_propagation/metavariable-regex-propagation.yaml targets/metavariable_propagation/metavariable-regex-propagation.py --json --optimizations

to confirm that the message returned uses foo, not $FUNC.

To ensure this does not affect anything else, make optimizations default in core_runner and run all tests, checking against known errors



PR checklist:
- [ ] changelog is up to date

