### PR TITLE
semgrep-core: Add metavariable-patttern operator

### DIFF
--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -253,6 +253,7 @@ and xpat_step1 pat =
 and metavarcond_step1 x =
   match x with
   | R.CondGeneric _ -> None
+  | R.CondPattern _ -> None
   | R.CondRegexp (mvar, re) ->
       (* bugfix: if the metavariable-regexp is "^(foo|bar)$" we
        * don't want to keep it because it can't be used on the whole file.

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_either.js
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_either.js
@@ -1,0 +1,21 @@
+
+function f1() {
+    // ruleid: test-mvp-either
+    var constants = require('crypto');
+    var sslOptions = {};
+    https.createServer(sslOptions);
+}
+
+function f2() {
+    // ruleid: test-mvp-either
+    var constants = require('constants');
+    var sslOptions = {};
+    https.createServer(sslOptions);
+}
+
+function f1() {
+    // OK: test-mvp-either
+    var constants = require('foobar');
+    var sslOptions = {};
+    https.createServer(sslOptions);
+}

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_either.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_either.yaml
@@ -1,0 +1,19 @@
+rules:
+- id: test-mvp-either
+  patterns:
+  - pattern: |
+        $CONST = require($PKG);
+        ...
+        $OPTIONS = ...;
+        ...
+        https.createServer($OPTIONS, ...);
+  - metavariable-pattern:
+        metavariable: $PKG
+        pattern-either:
+            - pattern: |
+                  'crypto'
+            - pattern: |
+                  'constants'
+  message: Working!
+  severity: WARNING
+  languages: [javascript]

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_nested.py
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_nested.py
@@ -1,0 +1,6 @@
+# ruleid:test-mvp-nested
+foo(bar(a + b), 2, 3)
+# OK:test-mvp-nested
+foo(a + b, 2, 3)
+# OK:test-mvp-nested
+bar(a + b)

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_nested.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_nested.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: test-mvp-nested
+    languages:
+      - python
+    message: Working!
+    patterns:
+      - pattern: foo($P, ...)
+      - metavariable-pattern:
+          metavariable: $P
+          patterns:
+              - pattern: |
+                  bar($X)
+              - metavariable-pattern:
+                  metavariable: $X
+                  patterns:
+                    - pattern: ... + ...
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_not.py
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_not.py
@@ -1,0 +1,4 @@
+# ruleid:test-mvp-not
+foo(a * b, 2, 3)
+# OK:test-mvp-not
+foo(a + b, 2, 3)

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_not.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_not.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-mvp-not
+    languages:
+      - python
+    message: Working!
+    patterns:
+      - pattern: foo($P, ...)
+      - metavariable-pattern:
+          metavariable: $P
+          patterns:
+              - pattern-not: |
+                  ... + ...
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_old_tls_versions.js
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_old_tls_versions.js
@@ -1,0 +1,86 @@
+
+function ok1() {
+    // ok: disallow-old-tls-versions2
+    var constants = require('crypto');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    secureOptions: constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_TLSv1 | constants.SSL_OP_NO_SSLv3
+    };
+    https.createServer(sslOptions);
+}
+
+function ok2() {
+    // ok: disallow-old-tls-versions2
+    var constants = require('crypto');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    secureOptions: constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3 | constants.SSL_OP_NO_TLSv1
+    };
+    https.createServer(sslOptions);
+}
+
+function ok3() {
+    // ok: disallow-old-tls-versions2
+    var constants = require('crypto');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    secureOptions: constants.SSL_OP_NO_TLSv1 | constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3
+    };
+    https.createServer(sslOptions);
+}
+
+function ok4() {
+    // ok: disallow-old-tls-versions2
+    var constants = require('constants');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    secureOptions: constants.SSL_OP_NO_TLSv1 | constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3
+    };
+    https.createServer(sslOptions);
+}
+
+function bad1() {
+    // ruleid: disallow-old-tls-versions2
+    var constants = require('crypto');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    secureOptions: constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3
+    };
+    https.createServer(sslOptions);
+}
+
+function bad2() {
+    // ruleid: disallow-old-tls-versions2
+    var constants = require('crypto');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    secureOptions: constants.SSL_OP_NO_SSLv2
+    };
+    https.createServer(sslOptions);
+}
+
+function bad3() {
+    // ruleid: disallow-old-tls-versions2
+    var constants = require('crypto');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    };
+    https.createServer(sslOptions);
+}
+
+function bad4() {
+    // ruleid: disallow-old-tls-versions2
+    var constants = require('constants');
+    var sslOptions = {
+    key: fs.readFileSync('/etc/ssl/private/private.key'),
+    secureProtocol: 'SSLv23_server_method',
+    };
+    https.createServer(sslOptions);
+}

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_old_tls_versions.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_old_tls_versions.yaml
@@ -1,0 +1,45 @@
+# problem-based-packs.insecure-transport.js-node.disallow-old-tls-versions2
+rules:
+- id: disallow-old-tls-versions2
+  patterns:
+  - pattern: |
+      $CONST = require($PKG);
+      ...
+      $OPTIONS = $OPTS;
+      ...
+      https.createServer($OPTIONS, ...);
+  - metavariable-pattern:
+        metavariable: $PKG
+        pattern-either:
+            - pattern: |
+                'crypto'
+            - pattern: |
+                'constants'
+  - metavariable-pattern:
+        metavariable: $OPTS
+        patterns:
+            - pattern-not: |
+                {secureOptions: $CONST.SSL_OP_NO_TLSv1 | $CONST.SSL_OP_NO_SSLv3 | $CONST.SSL_OP_NO_SSLv2}
+            - pattern-not: |
+                {secureOptions: $CONST.SSL_OP_NO_TLSv1 | $CONST.SSL_OP_NO_SSLv2 | $CONST.SSL_OP_NO_SSLv3}
+            - pattern-not: |
+                {secureOptions: $CONST.SSL_OP_NO_SSLv2  | $CONST.SSL_OP_NO_TLSv1 | $CONST.SSL_OP_NO_SSLv3}
+            - pattern-not: |
+                {secureOptions: $CONST.SSL_OP_NO_SSLv2 | $CONST.SSL_OP_NO_SSLv3 | $CONST.SSL_OP_NO_TLSv1}
+            - pattern-not: |
+                {secureOptions: $CONST.SSL_OP_NO_SSLv3 | $CONST.SSL_OP_NO_SSLv2 | $CONST.SSL_OP_NO_TLSv1}
+            - pattern-not: |
+                {secureOptions: $CONST.SSL_OP_NO_SSLv3 | $CONST.SSL_OP_NO_TLSv1 | $CONST.SSL_OP_NO_SSLv2}
+  message: |
+    Detects creations of https servers from option objects that don't disallow SSL v2, SSL v3, and TLS v1.
+    These protocols are deprecated due to POODLE, man in the middle attacks, and other vulnerabilities.
+  metadata:
+    vulnerability: Insecure Transport
+    owasp: 'A3: Sensitive Data Exposure'
+    cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
+    references:
+    - https://us-cert.cisa.gov/ncas/alerts/TA14-290A
+    - https://stackoverflow.com/questions/40434934/how-to-disable-the-ssl-3-0-and-tls-1-0-in-nodejs
+    - https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
+  severity: WARNING
+  languages: [javascript]


### PR DESCRIPTION
This new (semgrep-core only) operator allows filtering results based on
the program fragment matched by a metavariable, like metavariable-regex
but using an arbitrary pattern formula!

test plan:
make test # tests included

PR checklist:
- [ ] changelog is up to date

