### PR TITLE
fix: fallback to no optimizations when unsupported

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -745,12 +745,6 @@ class CoreRunner:
         start = datetime.now()
 
         experimental = optimizations == "all"
-
-        # Fall back to normal mode if there is a tainting rule
-        if experimental and any(rule.mode == TAINT_MODE for rule in rules):
-            logger.info("Running with no optimizations since taint rule found")
-            experimental = False
-
         runner_fxn = (
             self._run_rules_direct_to_semgrep_core if experimental else self._run_rules
         )

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -87,6 +87,35 @@ class Rule:
     def __hash__(self) -> int:
         return hash(self.id)
 
+    def has_pattern_where_python(self) -> bool:
+        """
+        Return true if this rule contains a pattern-where-python pattern
+        """
+
+        def _recursive_dict_key_exists(dictionary: Dict[str, Any], key: str) -> bool:
+            """
+            Returns true if
+            - dictionary contains key KEY or
+            - any value in dictionary that is a dict contains the key
+            - a value that is a list of dictionaries has a dict that contains the key
+            """
+            if key in dictionary:
+                return True
+
+            for val in dictionary.values():
+                if isinstance(val, dict) and _recursive_dict_key_exists(val, key):
+                    return True
+                if isinstance(val, list):
+                    for obj in val:
+                        if isinstance(obj, dict) and _recursive_dict_key_exists(
+                            obj, key
+                        ):
+                            return True
+
+            return False
+
+        return _recursive_dict_key_exists(self._raw, "pattern-where-python")
+
     def _validate_none_language_rule(self) -> None:
         """
         For regex-only rules, only patterns, pattern-either, and pattern-regex is valid.

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -29,6 +29,7 @@ from semgrep.output import OutputSettings
 from semgrep.profile_manager import ProfileManager
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
+from semgrep.semgrep_types import TAINT_MODE
 from semgrep.target_manager import TargetManager
 from semgrep.util import manually_search_file
 from semgrep.util import sub_check_output
@@ -238,6 +239,25 @@ The two most popular are:
     )
 
     profiler = ProfileManager()
+
+    # # Turn off optimizations if using features not supported yet
+    if optimizations == "all":
+        # taint mode rules not yet supported
+        if any(rule.mode == TAINT_MODE for rule in filtered_rules):
+            logger.info("Running without optimizations since taint rule found")
+            optimizations = "none"
+        # step by step evaluation output not yet supported
+        elif output_handler.settings.debug:
+            logger.info(
+                "Running without optimizations since step-by-step evaluation output desired"
+            )
+            optimizations = "none"
+
+        elif any(rule.has_pattern_where_python() for rule in filtered_rules):
+            logger.info(
+                "Running without optimizations since running pattern-where-python rules"
+            )
+            optimizations = "none"
 
     start_time = time.time()
     # actually invoke semgrep


### PR DESCRIPTION
This includes rules that contain pattern-where-python, --debugging-json,
and taint mode rules



PR checklist:
- [ ] changelog is up to date

