### PR TITLE
Handle regexp parse errors gracefully

### DIFF
--- a/semgrep-core/src/parsing/Parse_mini_rule.ml
+++ b/semgrep-core/src/parsing/Parse_mini_rule.ml
@@ -28,6 +28,9 @@ exception InvalidLanguageException of string * string
 exception InvalidPatternException of string * string * string * string
 
 (*e: exception [[Parse_rules.InvalidPatternException]] *)
+
+exception InvalidRegexpException of string * string
+
 (*s: exception [[Parse_rules.UnparsableYamlException]] *)
 exception UnparsableYamlException of string
 

--- a/semgrep-core/src/parsing/Parse_mini_rule.mli
+++ b/semgrep-core/src/parsing/Parse_mini_rule.mli
@@ -17,6 +17,9 @@ exception InvalidLanguageException of string * string
 exception InvalidPatternException of string * string * string * string
 
 (*e: exception [[Parse_rules.InvalidPatternException]] *)
+
+exception InvalidRegexpException of string * string
+
 (*s: exception [[Parse_rules.UnparsableYamlException]] *)
 exception UnparsableYamlException of string
 

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -253,6 +253,13 @@ let json_of_exn e =
           ("language", J.String lang);
           ("message", J.String message);
         ]
+  | Parse_mini_rule.InvalidRegexpException (pattern_id, message) ->
+      J.Object
+        [
+          ("pattern_id", J.String pattern_id);
+          ("error", J.String "invalid regexp in rule");
+          ("message", J.String message);
+        ]
   | Parse_mini_rule.UnparsableYamlException msg ->
       J.Object
         [ ("error", J.String "unparsable yaml"); ("message", J.String msg) ]

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -174,6 +174,8 @@ class CoreRunner:
             raise SemgrepError(
                 f'{error_json["language"]} was accepted by semgrep but rejected by semgrep-core. {PLEASE_FILE_ISSUE_TEXT}'
             )
+        elif error_type == "invalid regexp in rule":
+            raise SemgrepError(f'Invalid regexp in rule: {error_json["message"]}')
         elif error_type == "invalid pattern":
 
             matching_pattern = next(


### PR DESCRIPTION
Create an exception for regexp parse errors with good error messages and handle it python side

Test plan:

In semgrep/semgrep/tests/e2e, run semgrep --config rules/regex-invalid.yaml --optimizations

You should see

running 1 rules...
Invalid regexp in rule: '(abc': missing ) at position 4



PR checklist:
- [x] changelog is up to date

