### PR TITLE
Take innermost matching container when using pattern-inside

### DIFF
--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -440,7 +440,16 @@ def create_output(
             )
             output.append(rule_match)
 
-    return sorted(output, key=lambda rule_match: rule_match._pattern_match.range.start)
+    # Reversing the output is a terrible hack. It is useful because running whole rule in semgrep-core
+    # will return the results backwards compared to running only the patterns in semgrep-core
+    #
+    # While the results can be sorted, without the hack, semgrep-inside will match the outer-most
+    # container rather than the inner-most (as users tend to expect). For an example, see
+    # tests/e2e/test_message_interpolation.py::test_message_interpolation; specifically, the
+    # multi-pattern-inside test
+    return sorted(
+        reversed(output), key=lambda rule_match: rule_match._pattern_match.range.start
+    )
 
 
 def evaluate(


### PR DESCRIPTION
If you have

```
rules:
- id: test_rule_id
   patterns:
   - pattern-inside: |
       def $FUNC(...):
          ...
   - pattern: print($MSG)
```

and

```
class A():
    def B():
        def C():
            print("blah")
```

Expect `$FUNC` to bind `C` rather than `B`

Test plan:

semgrep --config rules/message_interpolation/multi-pattern-inside.yaml targets/message_interpolation/multi_pattern_inside_nested.py



PR checklist:
- [x] changelog is up to date

