### PR TITLE
analyzing: constness: Do not print div-by-zero warning to stderr

### DIFF
--- a/semgrep-core/src/analyzing/Dataflow_constness.ml
+++ b/semgrep-core/src/analyzing/Dataflow_constness.ml
@@ -41,11 +41,8 @@ end)
 (*****************************************************************************)
 
 let warning tok s =
-  let opt_loc =
-    try Some (Parse_info.string_of_info tok)
-    with Parse_info.NoTokenLocation _ -> None
-  in
-  match opt_loc with Some loc -> pr2 (spf "%s: %s" loc s) | None -> pr2 s
+  (* TODO: Report these errors as matches of a builtin_div_by_zero rule. *)
+  Error_code.warning tok (Error_code.CFGError s)
 
 (*****************************************************************************)
 (* Helpers *)


### PR DESCRIPTION
This seems to cause some problems, we should instead report this in a
proper way to the user, perhaps as yet another match?

test plan:
semgrep-core -lang py -e '1/0' tests/python/dataflow/div-by-zero.py
 #^ no longer prints a div-by-zero warning



PR checklist:
- [ ] changelog is up to date

