### PR TITLE
[Comby] handle bounded metavariable correctly

### DIFF
--- a/semgrep-core/tests/OTHER/rules/comby_metavar.js
+++ b/semgrep-core/tests/OTHER/rules/comby_metavar.js
@@ -1,0 +1,19 @@
+function foo() {
+    //ruleid:
+    foo(1, 2)
+
+    //unfortunately it does not match
+    foo(1,2)
+    //neither this one :(
+    foo (1, 2)
+
+    //ruleid: this is detected
+    foo(1,
+	2)
+
+    //ruleid: this is detectedtoo
+    foo(1, // comment
+	 2)
+
+    foo(2,1)
+}

--- a/semgrep-core/tests/OTHER/rules/comby_metavar.yaml
+++ b/semgrep-core/tests/OTHER/rules/comby_metavar.yaml
@@ -1,0 +1,8 @@
+rules:
+- id: comby_basic
+  languages:
+  - javascript
+  - python
+  pattern-comby: foo($X, $Y)
+  message: found a comby match
+  severity: ERROR


### PR DESCRIPTION
test plan:
test file included
semgrep-core -lang js -config tests/OTHER/rules/comby_metavar.yaml
tests/OTHER/rules/comby_metavar.js  -json | jq

will show the content of $X, $Y.




PR checklist:
- [ ] changelog is up to date