### PR TITLE
Add special case for whole rule pattern parse errors

### DIFF
--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -254,6 +254,27 @@ class InvalidPatternError(ErrorWithSpan):
 
 
 @attr.s(frozen=True, eq=True)
+class InvalidPatternErrorNoSpan(SemgrepError):
+    rule_id: str = attr.ib()
+    pattern: str = attr.ib()
+    language: str = attr.ib()
+
+    code = INVALID_PATTERN_EXIT_CODE
+    level = Level.ERROR
+
+    def __str__(self) -> str:
+        msg = f"Rule id: {self.rule_id} contains a pattern that could not be parsed as a pattern for language {self.language}: `{self.pattern}`"
+        return with_color(Fore.RED, msg)
+
+    def to_dict_base(self) -> Dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "pattern": self.pattern,
+            "language": self.language,
+        }
+
+
+@attr.s(frozen=True, eq=True)
 class InvalidRuleSchemaError(ErrorWithSpan):
     code = INVALID_PATTERN_EXIT_CODE
     level = Level.ERROR

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -274,8 +274,9 @@ The two most popular are:
         timeout=timeout,
         max_memory=max_memory,
         timeout_threshold=timeout_threshold,
+        optimizations=optimizations,
     ).invoke_semgrep(
-        target_manager, profiler, filtered_rules, optimizations
+        target_manager, profiler, filtered_rules
     )
     profiler.save("total_time", start_time)
 

--- a/semgrep/tests/unit/test_error.py
+++ b/semgrep/tests/unit/test_error.py
@@ -86,6 +86,7 @@ def test_raise_semgrep_error_from_json_unknown_error():
         timeout=0,
         max_memory=0,
         timeout_threshold=0,
+        optimizations="all",
     )
 
     patterns: List[Pattern] = list(core_runner._flatten_rule_patterns([rule]))


### PR DESCRIPTION
With whole rule running, semgrep can no longer use the
pattern -> character numbers mapping that it uses to pretty print
pattern parse errors. We currently do not have access to the correct
character offsets in the yaml parser in semgrep-core but are thinking
of moving to a differnt parser that does give us character offsets.

For now special case the pattern-parse errors when running with
whole rule running optimization.



PR checklist:
- [ ] changelog is up to date

