### PR TITLE
Using "var" when an explicit type is expected is an error

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2221,8 +2221,9 @@ and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
 and type_ (env : env) (x : CST.type_) : AST.type_ =
   match x with
   | `Impl_type tok ->
-      let tok = token env tok (* "var" *) in
-      todo_type env tok
+      (* When type_ is called, we expect an explicit type, not "var".
+         The implicit type is handled in local_variable_type. *)
+      raise Impossible
   | `Array_type x -> array_type env x
   | `Name x ->
       let n = name env x in


### PR DESCRIPTION
The parser sees "var" as just any type, but it can't be used in many places
where a specific type is required. We disallow it in `type_`, and only allow it
in `local_variable_type`.

This was already more or less the case, but now it's explicit and explained in
a comment.

Technical change, so no changelog update needed.
