### PR TITLE
Add support for metavariable-pattern in Semgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Added
+- Added new metavariable-pattern operator (available only via --optimizations),
+  thanks to Kai Zhong for the feature request (#3257).
 
 ### Fixed
 - Scala: parse correctly symbol literals and interpolated strings containing

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -449,6 +449,17 @@ class CoreRunner:
                 if language == Language.REGEX:
                     continue
 
+                # metatavarible-pattern is only available via --optimizations
+                metavariable_patterns = [
+                    pattern
+                    for pattern in patterns
+                    if pattern.expression.operator == OPERATORS.METAVARIABLE_PATTERN
+                ]
+                if len(metavariable_patterns) > 0:
+                    raise SemgrepError(
+                        "Operator metavariable-pattern is only supported by semgrep-core"
+                    )
+
                 # semgrep-core doesn't know about the following operators -
                 # they are strictly semgrep Python features:
                 #   - OPERATORS.METAVARIABLE_REGEX

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -16,6 +16,7 @@ definitions:
       - $ref: '#/definitions/pattern-not-regex'
       - $ref: '#/definitions/pattern-where-python'
       - $ref: '#/definitions/metavariable-regex'
+      - $ref: '#/definitions/metavariable-pattern'
       - $ref: '#/definitions/metavariable-comparison'
   pattern-either-content:
     type: array
@@ -48,6 +49,37 @@ definitions:
         additionalProperties: false
     required:
     - metavariable-regex
+    additionalProperties: false
+  metavariable-pattern:
+    type: object
+    properties:
+      metavariable-pattern:
+        type: object
+        properties:
+          metavariable:
+            type: string
+          patterns:
+            $ref: '#/definitions/patterns-content'
+          pattern-either:
+            $ref: '#/definitions/pattern-either-content'
+        required:
+          - metavariable
+        oneOf:
+          - required:
+              - patterns
+            not:
+              anyOf:
+                - required:
+                    - pattern-either
+          - required:
+              - pattern-either
+            not:
+              anyOf:
+                - required:
+                    - patterns
+        additionalProperties: false
+    required:
+    - metavariable-pattern
     additionalProperties: false
   metavariable-comparison:
     type: object

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -120,6 +120,7 @@ class OPERATORS:
     REGEX: Operator = Operator("regex")
     NOT_REGEX: Operator = Operator("not_regex")
     METAVARIABLE_REGEX: Operator = Operator("metavariable_regex")
+    METAVARIABLE_PATTERN: Operator = Operator("metavariable_pattern")
     METAVARIABLE_COMPARISON: Operator = Operator("metavariable_comparison")
 
 
@@ -139,6 +140,7 @@ OPERATOR_PATTERN_NAMES_MAP = {
     OPERATORS.REGEX: ["pattern-regex"],
     OPERATORS.NOT_REGEX: ["pattern-not-regex"],
     OPERATORS.METAVARIABLE_REGEX: ["metavariable-regex"],
+    OPERATORS.METAVARIABLE_PATTERN: ["metavariable-pattern"],
     OPERATORS.METAVARIABLE_COMPARISON: ["metavariable-comparison"],
 }
 PATTERN_NAMES_OPERATOR_MAP = {


### PR DESCRIPTION
NOTE: This is only available via semgrep-core (requires --optimizations)!

Closes #3257

test plan:
semgrep --config semgrep-core/tests/OTHER/rules/metavar_pattern_nested.yaml \
    semgrep-core/tests/OTHER/rules/metavar_pattern_nested.py
    #^ works!



PR checklist:
- [x] changelog is up to date

