### PR TITLE
Turn on optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - PHP: Prefer expression patterns over statement patterns (#3191)
 
 ### Changed
+- Run rules in semgrep-core (rather than patterns) by default (aka optimizations all)
 
 ## [0.54.0](https://github.com/returntocorp/semgrep/releases/tag/v0.54.0) - 2021-06-2
 

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -102,9 +102,8 @@ def cli() -> None:
     config.add_argument(
         "--optimizations",
         nargs="?",
-        const="all",
-        default="none",
-        help="Turn on/off optimizations. Default = 'none'. Use 'all' to turn all optimizations on.",
+        default="all",
+        help="Turn on/off optimizations. Default = 'all'. Use 'none' to turn all optimizations off.",
     )
 
     parser.add_argument(

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -754,7 +754,7 @@ class CoreRunner:
         """
         start = datetime.now()
 
-        experimental = self._optimizations == "all"
+        experimental = self._optimizations != "none"
         runner_fxn = (
             self._run_rules_direct_to_semgrep_core if experimental else self._run_rules
         )

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py/results.json
@@ -17,7 +17,25 @@
         "lines": "    return json.dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "user",
+            "end": {
+              "col": 9,
+              "line": 7,
+              "offset": 99
+            },
+            "start": {
+              "col": 5,
+              "line": 7,
+              "offset": 95
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "ERROR"
       },
       "path": "targets/autofix/flask-use-jsonify.py",
@@ -42,7 +60,25 @@
         "lines": "    return dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "user",
+            "end": {
+              "col": 9,
+              "line": 15,
+              "offset": 263
+            },
+            "start": {
+              "col": 5,
+              "line": 15,
+              "offset": 259
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "ERROR"
       },
       "path": "targets/autofix/flask-use-jsonify.py",

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_propagation_comparison/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_propagation_comparison/results.json
@@ -12,7 +12,25 @@
         "lines": "    b = 10",
         "message": "Semgrep found a match 2\n",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$INT": {
+            "abstract_content": "2",
+            "end": {
+              "col": 10,
+              "line": 7,
+              "offset": 66
+            },
+            "start": {
+              "col": 9,
+              "line": 7,
+              "offset": 65
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "WARNING"
       },
       "path": "targets/metavariable_propagation/metavariable-comparison-propagation.py",
@@ -32,7 +50,25 @@
         "lines": "    b = 10",
         "message": "Semgrep found a match 3\n",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$INT": {
+            "abstract_content": "3",
+            "end": {
+              "col": 10,
+              "line": 12,
+              "offset": 112
+            },
+            "start": {
+              "col": 9,
+              "line": 12,
+              "offset": 111
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "WARNING"
       },
       "path": "targets/metavariable_propagation/metavariable-comparison-propagation.py",

--- a/semgrep/tests/e2e/snapshots/test_check/test_metavariable_propagation_regex/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_metavariable_propagation_regex/results.json
@@ -12,7 +12,25 @@
         "lines": "    return 1",
         "message": "Semgrep found a match foo\n",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "foo",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 5,
+              "line": 1,
+              "offset": 4
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "WARNING"
       },
       "path": "targets/metavariable_propagation/metavariable-regex-propagation.py",
@@ -32,7 +50,25 @@
         "lines": "    return 2",
         "message": "Semgrep found a match bar\n",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$FUNC": {
+            "abstract_content": "bar",
+            "end": {
+              "col": 8,
+              "line": 4,
+              "offset": 32
+            },
+            "start": {
+              "col": 5,
+              "line": 4,
+              "offset": 29
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "WARNING"
       },
       "path": "targets/metavariable_propagation/metavariable-regex-propagation.py",

--- a/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
@@ -12,25 +12,7 @@
         "lines": "    nested_patterns_func('foo', 1)",
         "message": "test",
         "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "'foo'",
-            "end": {
-              "col": 31,
-              "line": 2,
-              "offset": 48
-            },
-            "start": {
-              "col": 26,
-              "line": 2,
-              "offset": 43
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          }
-        },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/nested-patterns.js",
@@ -50,25 +32,7 @@
         "lines": "    nested_patterns_func('bar', 2)",
         "message": "test",
         "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "'bar'",
-            "end": {
-              "col": 31,
-              "line": 3,
-              "offset": 83
-            },
-            "start": {
-              "col": 26,
-              "line": 3,
-              "offset": 78
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          }
-        },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/nested-patterns.js",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__child/results.json
@@ -12,6 +12,7 @@
         "lines": "boto3.client(host=\"123.123.123.123\")",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex.py",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__invalid_expression/error.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__invalid_expression/error.json
@@ -1,1 +1,1 @@
-{"errors": [{"code": 2, "level": "error", "message": "invalid regular expression specified: missing ), unterminated subpattern at position 0", "type": "SemgrepError"}], "results": []}
+{"errors": [{"code": 2, "level": "error", "message": "Invalid regexp in rule: '(abc': missing ) at position 4", "type": "SemgrepError"}], "results": []}

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__issue2465/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__issue2465/results.json
@@ -12,6 +12,7 @@
         "lines": "Foo==1.1.1",
         "message": "Found $TAG",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/pattern-not-regex/issue2465.requirements.txt",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__nosemgrep/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__nosemgrep/results.json
@@ -14,6 +14,7 @@
         "metadata": {
           "source-rule-url": "https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go"
         },
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-nosemgrep.txt",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__pattern_regex_and_pattern_not_regex/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__pattern_regex_and_pattern_not_regex/results.json
@@ -12,6 +12,7 @@
         "lines": "<h4>From: {{ from_email }}</h4>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -31,6 +32,7 @@
         "lines": "<h4>From: {{ from_email }}</h4>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -50,6 +52,7 @@
         "lines": "<h4>To:",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -69,6 +72,7 @@
         "lines": "</h4>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -88,6 +92,7 @@
         "lines": "<h4>Subject: {{subject}}</h4>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -107,6 +112,7 @@
         "lines": "<h4>Subject: {{subject}}</h4>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -126,6 +132,7 @@
         "lines": "    <pre>{{ body }}</pre>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -145,6 +152,7 @@
         "lines": "    <pre>{{ body }}</pre>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",
@@ -164,6 +172,7 @@
         "lines": "<hr>",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-any-language.html",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__top/results.json
@@ -12,6 +12,7 @@
         "lines": "boto3.client(host=\"123.123.123.123\")",
         "message": "test regex message",
         "metadata": {},
+        "metavars": {},
         "severity": "ERROR"
       },
       "path": "targets/basic/regex.py",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule/results.json
@@ -18,6 +18,7 @@
             "https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup"
           ]
         },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/regex-any-language.html",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule_none_alias/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_multiple_rule_none_alias/results.json
@@ -18,6 +18,7 @@
             "https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup"
           ]
         },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/regex-any-language.html",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule/results.json
@@ -18,6 +18,7 @@
             "https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup"
           ]
         },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/regex-any-language.html",

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule_none_alias/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_with_any_language_rule_none_alias/results.json
@@ -18,6 +18,7 @@
             "https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup"
           ]
         },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/regex-any-language.html",

--- a/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
@@ -13,6 +13,23 @@
         "message": "",
         "metadata": {},
         "metavars": {
+          "$FUNC": {
+            "abstract_content": "arg",
+            "end": {
+              "col": 8,
+              "line": 7,
+              "offset": 171
+            },
+            "start": {
+              "col": 5,
+              "line": 7,
+              "offset": 168
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$W": {
             "abstract_content": "POST",
             "end": {
@@ -51,6 +68,23 @@
         "message": "",
         "metadata": {},
         "metavars": {
+          "$FUNC": {
+            "abstract_content": "argh",
+            "end": {
+              "col": 9,
+              "line": 12,
+              "offset": 266
+            },
+            "start": {
+              "col": 5,
+              "line": 12,
+              "offset": 262
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$W": {
             "abstract_content": "get_host",
             "end": {

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside.py/results.json
@@ -13,6 +13,40 @@
         "message": "'print(\"blah\")' detected in method 'B' in class 'A'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "B",
+            "end": {
+              "col": 10,
+              "line": 2,
+              "offset": 20
+            },
+            "start": {
+              "col": 9,
+              "line": 2,
+              "offset": 19
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "\"blah\"",
             "end": {
@@ -51,6 +85,40 @@
         "message": "'print(\"bla\")' detected in method 'C' in class 'A'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "C",
+            "end": {
+              "col": 10,
+              "line": 5,
+              "offset": 56
+            },
+            "start": {
+              "col": 9,
+              "line": 5,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "\"bla\"",
             "end": {
@@ -89,6 +157,40 @@
         "message": "'print('ble')' detected in method 'D' in class 'A'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "D",
+            "end": {
+              "col": 10,
+              "line": 8,
+              "offset": 91
+            },
+            "start": {
+              "col": 9,
+              "line": 8,
+              "offset": 90
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "'ble'",
             "end": {
@@ -127,6 +229,40 @@
         "message": "'print(\"qwerty\")' detected in method 'G' in class 'F'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "F",
+            "end": {
+              "col": 8,
+              "line": 14,
+              "offset": 152
+            },
+            "start": {
+              "col": 7,
+              "line": 14,
+              "offset": 151
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "G",
+            "end": {
+              "col": 10,
+              "line": 15,
+              "offset": 165
+            },
+            "start": {
+              "col": 9,
+              "line": 15,
+              "offset": 164
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "\"qwerty\"",
             "end": {

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
@@ -13,6 +13,40 @@
         "message": "'print(\"blah\")' detected in method 'C' in class 'A'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "C",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 37
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 36
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "\"blah\"",
             "end": {
@@ -51,6 +85,40 @@
         "message": "'print('ble')' detected in method 'D' in class 'A'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "D",
+            "end": {
+              "col": 10,
+              "line": 6,
+              "offset": 77
+            },
+            "start": {
+              "col": 9,
+              "line": 6,
+              "offset": 76
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "'ble'",
             "end": {
@@ -89,6 +157,40 @@
         "message": "'print(\"asdf\")' detected in method 'E' in class 'A'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "E",
+            "end": {
+              "col": 14,
+              "line": 8,
+              "offset": 115
+            },
+            "start": {
+              "col": 13,
+              "line": 8,
+              "offset": 114
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "\"asdf\"",
             "end": {
@@ -127,6 +229,40 @@
         "message": "'print(\"qwerty\")' detected in method 'G' in class 'F'",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "F",
+            "end": {
+              "col": 8,
+              "line": 11,
+              "offset": 153
+            },
+            "start": {
+              "col": 7,
+              "line": 11,
+              "offset": 152
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$FUNC": {
+            "abstract_content": "G",
+            "end": {
+              "col": 10,
+              "line": 12,
+              "offset": 166
+            },
+            "start": {
+              "col": 9,
+              "line": 12,
+              "offset": 165
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$MSG": {
             "abstract_content": "\"qwerty\"",
             "end": {

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_basic.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_basic.py/results.json
@@ -13,6 +13,23 @@
         "message": "method B is in A",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$FUNC": {
             "abstract_content": "B",
             "end": {
@@ -51,6 +68,23 @@
         "message": "method C is in A",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$FUNC": {
             "abstract_content": "C",
             "end": {

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_complex.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_complex.py/results.json
@@ -13,6 +13,23 @@
         "message": "method B is in A",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$FUNC": {
             "abstract_content": "B",
             "end": {
@@ -51,6 +68,23 @@
         "message": "method C is in A",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "A",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$FUNC": {
             "abstract_content": "C",
             "end": {
@@ -89,6 +123,23 @@
         "message": "method C is in B",
         "metadata": {},
         "metavars": {
+          "$CLASS": {
+            "abstract_content": "B",
+            "end": {
+              "col": 8,
+              "line": 8,
+              "offset": 88
+            },
+            "start": {
+              "col": 7,
+              "line": 8,
+              "offset": 87
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
           "$FUNC": {
             "abstract_content": "C",
             "end": {

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
@@ -1,8 +1,2 @@
 running 1 rules...
-[31msemgrep error[39m: invalid pattern
-  --> rules/syntax/badpattern.yaml:4
-[94m4 | [39m      - pattern: $X == $X 3
-[94m  | [39m                 [31m^^^^^^^^^^[39m
-
-[31mPattern could not be parsed as a Python semgrep pattern[39m
-
+[31mRule id: eqeq-is-bad contains a pattern that could not be parsed as a pattern for language Python: `$X == $X 3`[39m

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -2,26 +2,11 @@
   "errors": [
     {
       "code": 4,
+      "language": "Python",
       "level": "error",
-      "long_msg": "Pattern could not be parsed as a Python semgrep pattern",
-      "short_msg": "invalid pattern",
-      "spans": [
-        {
-          "context_end": null,
-          "context_start": null,
-          "end": {
-            "col": 28,
-            "line": 4
-          },
-          "file": "rules/syntax/badpattern.yaml",
-          "source_hash": "3721310e28daac277c2fc5496749be9e60441abcb6d2e3a99542a30f34628ee3",
-          "start": {
-            "col": 18,
-            "line": 4
-          }
-        }
-      ],
-      "type": "InvalidPatternError"
+      "pattern": "$X == $X 3",
+      "rule_id": "eqeq-is-bad",
+      "type": "InvalidPatternErrorNoSpan"
     }
   ],
   "results": []

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -2,26 +2,11 @@
   "errors": [
     {
       "code": 4,
+      "language": "C",
       "level": "error",
-      "long_msg": "Pattern could not be parsed as a C semgrep pattern",
-      "short_msg": "invalid pattern",
-      "spans": [
-        {
-          "context_end": null,
-          "context_start": null,
-          "end": {
-            "col": 23,
-            "line": 1
-          },
-          "file": "CLI Input",
-          "source_hash": "7efe89db58e7a4017c5cd63dd547745a14f3e4c1fc32fd5e2051b53858d9e85d",
-          "start": {
-            "col": 1,
-            "line": 1
-          }
-        }
-      ],
-      "type": "InvalidPatternError"
+      "pattern": "#include<asdf><<>>><$X>",
+      "rule_id": "-",
+      "type": "InvalidPatternErrorNoSpan"
     }
   ],
   "results": []

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
@@ -1,7 +1,1 @@
-semgrep error: invalid pattern
-  --> CLI Input:1
-1 | #include<asdf><<>>><$X>
-  | ^^^^^^^^^^^^^^^^^^^^^^
-
-Pattern could not be parsed as a C semgrep pattern
-
+Rule id: - contains a pattern that could not be parsed as a pattern for language C: `#include<asdf><<>>><$X>`

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
@@ -12,7 +12,42 @@
         "lines": "Content-Type: text/html",
         "message": "Detected text/html",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$READABLE": {
+            "abstract_content": "OK",
+            "end": {
+              "col": 16,
+              "line": 1,
+              "offset": 15
+            },
+            "start": {
+              "col": 14,
+              "line": 1,
+              "offset": 13
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$STATUS": {
+            "abstract_content": "200",
+            "end": {
+              "col": 13,
+              "line": 1,
+              "offset": 12
+            },
+            "start": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "INFO"
       },
       "path": "targets/spacegrep/httpresponse.txt",


### PR DESCRIPTION
This PR makes it so that `semgrep-core` runs by default on rules, rather than having the rule processed python-side and broken up into patterns which are fed to `semgrep-core`. To turn rules-in-semgrep-core off, use `--optimizations none`. There are a few exceptions: taint analysis and pattern-where-python are not implemented in `semgrep-core`, so they will always be run using the old path. Additionally, some error reporting is not fully implemented; specifically, debugging json is not returned and parse errors do not report ranges.

The implications of these are:
1. Until we implement in `semgrep-core` or deprecate taint analysis/pattern-where-python, we will have to keep around the old path around for CLI (sad)
2. We will run the old path in `semgrep-app` to have `--debugging-json`

Note that this sends each individual rule as a separate file as a config to `semgrep-core`, not all of the rules. If we want to get rid of the python code entirely, we will have to (in addition to addressing all of these TODOs) decide which files to run on in `semgrep-core` based on languages, and probably implement a lot of small things that are currently done python side

TODO still:
Taint analysis: https://github.com/returntocorp/semgrep/issues/3295
debugging-json: https://github.com/returntocorp/semgrep/issues/3295
pattern-where-python: https://github.com/returntocorp/semgrep/issues/3297
parse error reporting: https://github.com/returntocorp/semgrep/issues/3298
A better optimizations flag: https://github.com/returntocorp/semgrep/issues/3299

May be worth thinking about nested pattern-inside behavior? See https://github.com/returntocorp/semgrep/pull/3291

PR checklist:
- [x] changelog is up to date

