### PR TITLE
metavariable-pattern: Allow same pattern operators as in search mode

### DIFF
--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -66,17 +66,45 @@ definitions:
           - metavariable
         oneOf:
           - required:
+              - pattern
+            not:
+              anyOf:
+                - required:
+                  - patterns
+                - required:
+                  - pattern-either
+                - required:
+                  - pattern-regex
+          - required:
               - patterns
             not:
               anyOf:
                 - required:
+                    - pattern
+                - required:
                     - pattern-either
+                - required:
+                    - pattern-regex
           - required:
               - pattern-either
             not:
               anyOf:
                 - required:
+                    - pattern
+                - required:
                     - patterns
+                - required:
+                    - pattern-regex
+          - required:
+              - pattern-regex
+            not:
+              anyOf:
+                - required:
+                    - pattern
+                - required:
+                    - patterns
+                - required:
+                    - pattern-either
         additionalProperties: false
     required:
     - metavariable-pattern


### PR DESCRIPTION
Follows: f7f4cd9bf6e ("Add support for metavariable-pattern in Semgrep (#3292)")

In f7f4cd9bf6e (PR #3292) it was restricted to just `patterns` or
`pattern-either`. But there could be legit use cases for the other two
operators, so let's not restrict it without a good reason.



PR checklist:
- changelog update not relevant

