### PR TITLE
ci: wait 10 min after pypi to publish to homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,9 +286,18 @@ jobs:
           password: ${{ secrets.pypi_upload_token }}
           skip_existing: true
 
+  sleep-before-homebrew:
+    name: Sleep 10 min before releasing to homebrew
+    # Need to wait for pypi to propagate ssince pipgrip relies on it being published on pypi
+    needs: [upload-wheels]
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Sleep 10 min
+        run: sleep 10m
+
   homebrew-core-pr:
     name: Update on Homebrew-Core
-    needs: [upload-wheels]  # Needs to run after pypi released so brew can update pypi dependency hashes
+    needs: [sleep-before-homebrew]  # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-latest
     steps:
       - name: Brew update


### PR DESCRIPTION
brew bump-formula-pr depends on pipgrip to update dependencies
and pipgrip seems to not work right after publishing to pypi but seems
to work fine when run a few minutes later. Suspect it is pypi propagating
the latest release. Add a CI job that waits 10 minutes before trying to
publish to homebrew.



PR checklist:
- [ ] changelog is up to date

