### PR TITLE
[JSON] do not transform $FLD: 1 in "$FLD" : 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## After cut
+
+- JSON: handle correctly metavariables as field (#3279)
+
 ## Unreleased
 
 ### Added

--- a/semgrep-core/src/parsing/pfff/json_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/json_to_generic.ml
@@ -52,7 +52,15 @@ let expr x =
                   ys
                   |> List.map (function
                        | Left (id, e) ->
-                           G.Tuple (G.fake_bracket [ G.L (G.String id); e ])
+                           let key =
+                             (* we don't want $FLD: 1 to be transformed
+                              * in "$FLD" : 1, which currently would not match
+                              * anything in Semgrep (this may change though) *)
+                             if AST_generic_.is_metavar_name (fst id) then
+                               G.N (G.Id (id, G.empty_id_info ()))
+                             else G.L (G.String id)
+                           in
+                           G.Tuple (G.fake_bracket [ key; e ])
                        | Right t -> G.Ellipsis t)
                 in
                 G.Container (G.Dict, (lp, zs, rp))

--- a/semgrep-core/tests/json/metavar_field.json
+++ b/semgrep-core/tests/json/metavar_field.json
@@ -1,0 +1,30 @@
+//ERROR: match
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.32",
+    "@fortawesome/free-regular-svg-icons": "^5.15.1",
+    "@fortawesome/free-solid-svg-icons": "^5.15.1",
+    "@fortawesome/react-fontawesome": "^0.1.12",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^12.0.0",
+    "@types/react": "^16.9.53",
+    "@types/react-dom": "^16.9.8",
+    "@types/react-router-dom": "^5.1.6",
+    "bootstrap": "^4.5.3",
+    "react": "^17.0.1",
+    "react-bootstrap": "^1.4.0",
+    "react-dom": "^17.0.1",
+    "react-dom-confetti": "^0.2.0",
+    "react-router-dom": "^5.2.0",
+    "react-scripts": "4.0.0",
+    "react-toastify": "^6.1.0",
+    "typescript": "^4.0.3",
+    "web-vitals": "^0.2.4"
+  },
+}

--- a/semgrep-core/tests/json/metavar_field.sgrep
+++ b/semgrep-core/tests/json/metavar_field.sgrep
@@ -1,0 +1,7 @@
+{ ...,
+  "dependencies": { 
+    ...,
+    $DEP_NAME: $DEP_VERSION,
+    ...
+  }
+}


### PR DESCRIPTION
With this PR, a user can now use metavariable for fields. They
are not silently transformed in strings.

Note that at some point we may allow "$FLD" to match "a field",
but this is another PR.

test plan:
test file included
also below you can see Id "$DEP_NAME", not anymore L (String "$DEP_NAME")
```
yy -lang json -dump_pattern tests/json/metavar_field.sgrep
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang json -dump_pattern tests/E(
  Container(Dict,
    [Ellipsis(());
     Tuple(
       [L(String(("dependencies", ())));
        Container(Dict,
          [Ellipsis(());
           Tuple(
             [N(
                Id(("$DEP_NAME", ()),
                  {id_resolved=Ref(None); id_type=Ref(None);
                   id_constness=Ref(None); }));
              N(
                Id(("$DEP_VERSION", ()),
                  {id_resolved=Ref(None); id_type=Ref(None);
                   id_constness=Ref(None); }))]); Ellipsis(())])])]))
```




PR checklist:
- [ ] changelog is up to date