### PR TITLE
Fix wrong line/column reported on multi-line match in generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - JSON: handle correctly metavariables as field (#3279)
 - JS: support partial field definitions pattern, like in JSON
+- Fixed wrong line numbers for multi-lines match in generic mode (#3315)
 
 ## Unreleased
 

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -399,7 +399,7 @@ type ('target_content, 'xpattern) xpattern_matcher = {
     'target_content ->
     filename ->
     'xpattern ->
-    (Parse_info.token_location * MV.bindings) list;
+    (Parse_info.token_location * Parse_info.token_location * MV.bindings) list;
 }
 
 (* this will be adjusted later in range_to_pattern_match_adjusted *)
@@ -430,15 +430,15 @@ let (matches_of_matcher :
               |> List.map (fun (xpat, id, pstr) ->
                      let xs = matcher.matcher target_content file xpat in
                      xs
-                     |> List.map (fun (loc, env) ->
+                     |> List.map (fun (loc1, loc2, env) ->
                             (* this will be adjusted later *)
                             let rule_id = fake_rule_id (id, pstr) in
                             {
                               PM.rule_id;
                               file;
-                              range_loc = (loc, loc);
+                              range_loc = (loc1, loc2);
                               env;
-                              tokens = lazy [ info_of_token_location loc ];
+                              tokens = lazy [ info_of_token_location loc1 ];
                             }))
               |> List.flatten)
         in
@@ -484,7 +484,7 @@ let spacegrep_matcher (doc, src) file pat =
   let matches = Spacegrep.Match.search ~case_sensitive:true src pat doc in
   matches
   |> List.map (fun m ->
-         let (pos1, _), (_pos2, _) = m.Spacegrep.Match.region in
+         let (pos1, _), (_, pos2) = m.Spacegrep.Match.region in
          let { Spacegrep.Match.value = str; _ } = m.Spacegrep.Match.capture in
          let env =
            m.Spacegrep.Match.named_captures
@@ -496,8 +496,9 @@ let spacegrep_matcher (doc, src) file pat =
                   let mval = mval_of_string str t in
                   (mvar, mval))
          in
-         let loc = lexing_pos_to_loc file pos1 str in
-         (loc, env))
+         let loc1 = lexing_pos_to_loc file pos1 str in
+         let loc2 = lexing_pos_to_loc file pos2 "" in
+         (loc1, loc2, env))
 
 let matches_of_spacegrep spacegreps file =
   matches_of_matcher spacegreps
@@ -544,10 +545,16 @@ let regexp_matcher big_str file (_s, re) =
          let charpos, _ = Pcre.get_substring_ofs sub 0 in
          let str = Pcre.get_substring sub 0 in
          let line, column = line_col_of_charpos file charpos in
-         let loc = { PI.str; charpos; file; line; column } in
+         let loc1 = { PI.str; charpos; file; line; column } in
+
+         let charpos = charpos + String.length str in
+         let str = "" in
+         let line, column = line_col_of_charpos file charpos in
+         let loc2 = { PI.str; charpos; file; line; column } in
+
          (* TODO? return regexp binded group? $1 $2 etc? *)
          let env = [] in
-         (loc, env))
+         (loc1, loc2, env))
 
 let matches_of_regexs regexps lazy_content file =
   matches_of_matcher regexps
@@ -604,8 +611,13 @@ let comby_matcher (m_all, source) file pat =
          let line, column, charpos =
            line_col_charpos_of_comby_range file range
          in
-         let loc = { PI.str = matched; charpos; file; line; column } in
-         (loc, env))
+         let loc1 = { PI.str = matched; charpos; file; line; column } in
+
+         let charpos2 = charpos + String.length matched in
+         let line, column = line_col_of_charpos file charpos2 in
+         let loc2 = { PI.str = ""; charpos = charpos2; file; line; column } in
+
+         (loc1, loc2, env))
 
 let matches_of_combys combys lazy_content file =
   matches_of_matcher combys

--- a/semgrep-core/tests/OTHER/rules/generic_multilines.generic
+++ b/semgrep-core/tests/OTHER/rules/generic_multilines.generic
@@ -1,0 +1,12 @@
+class Foo {
+  void foo() {
+    //ruleid:
+    myfile = open();
+    try {
+      foo(myfile);
+    }
+    finally {
+      close(myfile);
+    }
+  }
+}

--- a/semgrep-core/tests/OTHER/rules/generic_multilines.yaml
+++ b/semgrep-core/tests/OTHER/rules/generic_multilines.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: multi-lines
+  languages:
+  - generic
+  pattern: |
+    $V = open();
+    ...
+    close($V);
+  message: found
+  severity: ERROR
+

--- a/semgrep/tests/e2e/rules/spacegrep/multi-lines.yaml
+++ b/semgrep/tests/e2e/rules/spacegrep/multi-lines.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: multi-lines
+  languages:
+  - generic
+  pattern: |
+    $V = open();
+    ...
+    close($V);
+  message: found
+  severity: ERROR

--- a/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmulti-lines.yaml-spacegrepmulti-lines.java/results.json
+++ b/semgrep/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmulti-lines.yaml-spacegrepmulti-lines.java/results.json
@@ -1,0 +1,43 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.spacegrep.multi-lines",
+      "end": {
+        "col": 21,
+        "line": 9
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "    myfile = open();\n    try {\n      foo(myfile);\n    }\n    finally {\n      close(myfile);",
+        "message": "found",
+        "metadata": {},
+        "metavars": {
+          "$V": {
+            "abstract_content": "myfile",
+            "end": {
+              "col": 11,
+              "line": 4,
+              "offset": 51
+            },
+            "start": {
+              "col": 5,
+              "line": 4,
+              "offset": 45
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/spacegrep/multi-lines.java",
+      "start": {
+        "col": 5,
+        "line": 4
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/spacegrep/multi-lines.java
+++ b/semgrep/tests/e2e/targets/spacegrep/multi-lines.java
@@ -1,0 +1,12 @@
+class Foo {
+  void foo() {
+    //ruleid:
+    myfile = open();
+    try {
+      foo(myfile);
+    }
+    finally {
+      close(myfile);
+    }
+  }
+}

--- a/semgrep/tests/e2e/test_spacegrep.py
+++ b/semgrep/tests/e2e/test_spacegrep.py
@@ -9,6 +9,7 @@ import pytest
         ("rules/spacegrep/markdown.yaml", "spacegrep/markdown.md"),
         ("rules/spacegrep/httpresponse.yaml", "spacegrep/httpresponse.txt"),
         ("rules/spacegrep/dockerfile.yaml", "spacegrep/root.Dockerfile"),
+        ("rules/spacegrep/multi-lines.yaml", "spacegrep/multi-lines.java"),
     ],
 )
 def test_spacegrep(run_semgrep_in_tmp, snapshot, rule, target):


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/3315

test plan:
test file included
Also below the line for "end" is now 9, and not anymore 4.
```
semgrep --lang generic -e "$(cat ~/yy/tests/generic/metavar_equality_var.sgrep)" ~/yy/tests/generic/metavar_equality_var.generic  --json | jq
ran 1 rules on 1 files: 1 findings
{
  "errors": [],
  "results": [
    {
      "check_id": "-",
      "end": {
        "col": 21,
        "line": 9
      },
```




PR checklist:
- [x] changelog is up to date