### PR TITLE
[php] Only coerce stmt-expr patterns into expr patterns in taint mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Handle regexp parse errors gracefully when using optimizations (#3266)
 - Support equivalences when using optimizations (#3259)
 - PHP: Support ellipsis in include/require and echo (#3191, #3245)
-- PHP: Prefer expression patterns over statement patterns (#3191)
+- Taint mode: Allow statement-patterns when these are represented as
+  statement-expressions in the Generic AST (#3191)
 
 ### Changed
 - Run rules in semgrep-core (rather than patterns) by default (aka optimizations all)

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -636,13 +636,6 @@ let any = function
   | Program v1 ->
       let v1 = program v1 in
       G.Ss v1
-  (* We prefer an expr-pattern over a stmt-pattern, because expr-patterns can
-   * match anywhere. Also, in the current taint-mode, sources/sanitizers/sinks
-   * must be expr-patterns; so, without this, you could not e.g. use `echo` as
-   * a sink. *)
-  | Stmt (Expr (v1, _t)) ->
-      let v1 = expr v1 in
-      G.E v1
   | Stmt v1 ->
       let v1 = stmt v1 in
       G.S v1

--- a/semgrep-core/src/tainting/Tainting_generic.ml
+++ b/semgrep-core/src/tainting/Tainting_generic.ml
@@ -56,6 +56,12 @@ let match_pat_eorig pat =
         xs
         |> List.map (function
              | AST.E e -> e
+             | AST.S { AST.s = AST.ExprStmt (e, _); _ } ->
+                 (* Some statements in the input language are translated into
+                  * expressions in the Generic AST. This is e.g. the case of
+                  * `echo' in PHP. This small hack allows us to annotate those
+                  * statements as souces/sanitizers/sinks. *)
+                 e
              | _ ->
                  failwith "Only Expr patterns are supported in tainting rules")
       in


### PR DESCRIPTION
PR #3288 messed up with the column numbers reported for matches in PHP
(where e.g. the ';' was no longer included in the match). We thus revert
PR #3288 (partially) and only do this transformation where we need it,
which is in taint-mode.

Fixes: 9ec7768caf1 ("[php] parsing: Convert stmt-expr patterns into pure expr patterns (#3288)")



PR checklist:
- [x] changelog is up to date

