### PR TITLE
add: put helpUri in sarif output if source metadata in rule exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,18 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## After cut
+## Unreleased
 
+### Added
+- Add helpUri to sarif output if rule source metadata is defined
+
+### Fixed
 - JSON: handle correctly metavariables as field (#3279)
 - JS: support partial field definitions pattern, like in JSON
 - Fixed wrong line numbers for multi-lines match in generic mode (#3315)
 - Handle correctly ellipsis inside function types (#3119)
 - Taint mode: Allow statement-patterns when these are represented as
   statement-expressions in the Generic AST (#3191)
-
-## Unreleased
 
 ## [0.55.0](https://github.com/returntocorp/semgrep/releases/tag/v0.55.0) - 2021-06-8
 

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -39,7 +39,7 @@ class SarifFormatter(BaseFormatter):
     def _rule_to_sarif(rule: Rule) -> Dict[str, Any]:
         severity = SarifFormatter._rule_to_sarif_severity(rule)
         tags = SarifFormatter._rule_to_sarif_tags(rule)
-        return {
+        rule_json = {
             "id": rule.id,
             "name": rule.id,
             "shortDescription": {"text": rule.message},
@@ -47,6 +47,12 @@ class SarifFormatter(BaseFormatter):
             "defaultConfiguration": {"level": severity},
             "properties": {"precision": "very-high", "tags": tags},
         }
+
+        rule_url = rule.metadata.get("source")
+        if rule_url is not None:
+            rule_json["helpUri"] = rule_url
+
+        return rule_json
 
     @staticmethod
     def _rule_to_sarif_severity(rule: Rule) -> str:

--- a/semgrep/tests/e2e/rules/eqeq-source.yml
+++ b/semgrep/tests/e2e/rules/eqeq-source.yml
@@ -1,0 +1,53 @@
+rules:
+  - id: assert-eqeq-is-ok
+    pattern: |
+      def __eq__():
+          ...
+          $X == $X
+    message: "possibly useless comparison but in eq function"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      source: "https://semgrep.dev/foo/bar/assert"
+  - id: eqeq-is-bad
+    patterns:
+      - pattern-not-inside: |
+          def __eq__(...):
+              ...
+      - pattern-not-inside: assert(...)
+      - pattern-not-inside: assertTrue(...)
+      - pattern-not-inside: assertFalse(...)
+      - pattern-either:
+        - pattern: $X == $X
+        - pattern: $X != $X
+        - patterns:
+          - pattern-inside: |
+              def __init__(...):
+                  ...
+          - pattern: self.$X == self.$X
+      - pattern-not: 1 == 1
+    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: correctness
+      source: "https://semgrep.dev/foo/bar/bad"
+  - id: python37-compatability-os-module
+    patterns:
+      - pattern-not-inside: |
+          if hasattr(os, 'pwrite'):
+              ...
+      - pattern: os.pwrite(...)
+    message: "this function is only available on Python 3.7+"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      source: "https://semgrep.dev/foo/bar/compat"
+  - id: javascript-basic-eqeq-bad
+    patterns:
+      - pattern: "$X == $X"
+    message: "useless comparison"
+    languages: [js]
+    severity: ERROR
+    metadata:
+      source: "https://semgrep.dev/foo/bar/js"

--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output_with_source/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output_with_source/results.sarif
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "toolExecutionNotifications": []
+        }
+      ],
+      "results": [
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "targets/basic/stupid.py",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 26,
+                  "endLine": 3,
+                  "startColumn": 12,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?"
+          },
+          "ruleId": "rules.eqeq-is-bad"
+        },
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "targets/basic/stupid.js",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 19,
+                  "endLine": 3,
+                  "startColumn": 13,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "useless comparison"
+          },
+          "ruleId": "rules.javascript-basic-eqeq-bad"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "semgrep",
+          "rules": [
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "possibly useless comparison but in eq function"
+              },
+              "helpUri": "https://semgrep.dev/foo/bar/assert",
+              "id": "rules.assert-eqeq-is-ok",
+              "name": "rules.assert-eqeq-is-ok",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "possibly useless comparison but in eq function"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+              },
+              "helpUri": "https://semgrep.dev/foo/bar/bad",
+              "id": "rules.eqeq-is-bad",
+              "name": "rules.eqeq-is-bad",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "useless comparison"
+              },
+              "helpUri": "https://semgrep.dev/foo/bar/js",
+              "id": "rules.javascript-basic-eqeq-bad",
+              "name": "rules.javascript-basic-eqeq-bad",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "useless comparison"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "this function is only available on Python 3.7+"
+              },
+              "helpUri": "https://semgrep.dev/foo/bar/compat",
+              "id": "rules.python37-compatability-os-module",
+              "name": "rules.python37-compatability-os-module",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "this function is only available on Python 3.7+"
+              }
+            }
+          ],
+          "semanticVersion": "placeholder"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -134,6 +134,33 @@ def test_sarif_output(run_semgrep_in_tmp, snapshot):
     )
 
 
+def test_sarif_output_with_source(run_semgrep_in_tmp, snapshot):
+    sarif_output = json.loads(
+        run_semgrep_in_tmp("rules/eqeq-source.yml", output_format=OutputFormat.SARIF)
+    )
+
+    # rules are logically a set so the JSON list's order doesn't matter
+    # we make the order deterministic here so that snapshots match across runs
+    # the proper solution will be https://github.com/joseph-roitman/pytest-snapshot/issues/14
+    sarif_output["runs"][0]["tool"]["driver"]["rules"] = sorted(
+        sarif_output["runs"][0]["tool"]["driver"]["rules"],
+        key=lambda rule: str(rule["id"]),
+    )
+
+    # Semgrep version is included in sarif output. Verify this independently so
+    # snapshot does not need to be updated on version bump
+    assert sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] == __VERSION__
+    sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] = "placeholder"
+
+    snapshot.assert_match(
+        json.dumps(sarif_output, indent=2, sort_keys=True), "results.sarif"
+    )
+
+    # Assert that each sarif rule object has a helpURI
+    for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
+        assert rule.get("helpUri", None) is not None
+
+
 def test_url_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(GITHUB_TEST_GIST_URL),


### PR DESCRIPTION
Use https://docs.oasis-open.org/sarif/sarif/v2.0/csprd01/sarif-v2.0-csprd01.html#_Toc517436213 helpUri field in rule object in sarif output to include link back to source if it is defined in the rule metadata object (rule["metadata"]["source"])

PR checklist:
- [ ] changelog is up to date

