### PR TITLE
Use 0.55.1 instead of 0.46.0 for timing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,9 +171,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: Run 0.46.0 Timing Benchmark
+      - name: Run 0.55.1 Timing Benchmark
         run: |
-          pip3 install semgrep==0.46.0
+          pip3 install semgrep==0.55.1
           semgrep --version
           python3 -m semgrep --version
           export PATH=/github/home/.local/bin:$PATH


### PR DESCRIPTION
Do this to get rid of the PR comment but also because experimental made some benchmarks significantly faster

PR checklist:
- [x] changelog is up to date

