### PR TITLE
Allow users to disable certain matching features in a rule

### DIFF
--- a/semgrep-core/src/core/Config_semgrep.atd
+++ b/semgrep-core/src/core/Config_semgrep.atd
@@ -1,0 +1,56 @@
+(*s: semgrep/core/Config_semgrep.ml *)
+(*s: pad/r2c copyright *)
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2019-2021 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+(*e: pad/r2c copyright *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Semgrep engine configuration.
+ *
+ * The goal of this module is to gather in one place all the possible
+ * ways to configure the semgrep matching engine. We now let
+ * the user enable/disable certain features on a per-rule (could do even
+ * per-pattern basis?). For example, constant propagation may be too powerful
+ * sometimes and prevent people to find certain code.
+ *
+ * Note that each feature in this file will change the matching results;
+ * for non-functinal settings such as optimizations (e.g., using a
+ * cache) use instead Flag_semgrep.ml
+ *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+(* !!Do not rename the fields because they can be referenced in rules!! *)
+type t = {
+  ~constant_propagation <ocaml default="true"> : bool;
+  (* associative-commutative matching *)
+  ~ac_matching <ocaml default="true"> : bool;
+
+  (* !experimental: a bit hacky, and may introduce big perf regressions! *)
+  (* should be used with DeepEllipsis; do it implicitely has issues *)
+  ~go_deeper_expr <ocaml default="true"> : bool;
+  (* this ultimately should go away once '...' works on the CFG *)
+  ~go_deeper_stmt <ocaml default="true"> : bool;
+
+  (* TODO: equivalences:
+   *   - const_let_to_var
+   *   - require_to_import (but need pass config to Js_to_generic)
+   *)
+}
+(*e: semgrep/core/Config_semgrep.ml *)

--- a/semgrep-core/src/core/Config_semgrep.ml
+++ b/semgrep-core/src/core/Config_semgrep.ml
@@ -1,65 +1,7 @@
-(*s: semgrep/core/Config_semgrep.ml *)
-(*s: pad/r2c copyright *)
-(* Yoann Padioleau
- *
- * Copyright (C) 2019-2021 r2c
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
- *
- * This library is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
- *)
-(*e: pad/r2c copyright *)
+type t = Config_semgrep_t.t
 
-(*****************************************************************************)
-(* Prelude *)
-(*****************************************************************************)
-(* Semgrep engine configuration.
- *
- * The goal of this module is to gather in one place all the possible
- * ways to configure the semgrep matching engine. At some point, we
- * may let the user enable/disable certain features on a per-rule or even
- * per-pattern basis. For example, constant propagation may be too powerful
- * sometimes and prevent people to find certain code.
- *
- * Note that each feature in this file will change the matching results;
- * for non-functinal settings such as optimizations (e.g., using a
- * cache) use instead Flag_semgrep.ml
- *)
+let default_config = Config_semgrep_j.t_of_string "{}"
 
-(*****************************************************************************)
-(* Types *)
-(*****************************************************************************)
-type t = {
-  constant_propagation : bool;
-  (* associative-commutative matching *)
-  ac_matching : bool;
-  (* !experimental: a bit hacky, and may introduce big perf regressions! *)
-  (* should be used with DeepEllipsis; do it implicitely has issues *)
-  go_deeper_expr : bool;
-  (* this ultimately should go away once '...' works on the CFG *)
-  go_deeper_stmt : bool;
-      (* TODO: equivalences:
-       *   - const_let_to_var
-       *   - require_to_import (but need pass config to Js_to_generic)
-       *)
-}
-
-(*****************************************************************************)
-(* Default config *)
-(*****************************************************************************)
-
-let default_config =
-  {
-    constant_propagation = true;
-    ac_matching = true;
-    go_deeper_expr = true;
-    go_deeper_stmt = true;
-  }
-
-(*e: semgrep/core/Config_semgrep.ml *)
+let pp fmt t =
+  let s = Config_semgrep_j.string_of_t t in
+  Format.fprintf fmt "%s" s

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -21,7 +21,7 @@ module MV = Metavariable
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* Data structure representing a semgrep rule.
+(* Data structure representing a Semgrep rule.
  *
  * See also Mini_rule.ml where formula and many other features disappears.
  *
@@ -183,6 +183,7 @@ type rule = {
   (* for metachecking error location *)
   (* optional fields *)
   equivalences : string list option;
+  settings : Config_semgrep.t option;
   (* TODO: parse them *)
   fix : string option;
   fix_regexp : (regexp * int option * string) option;

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -234,7 +234,7 @@ let ac_matching_nf op args =
     |> List.map (function
          | Arg e -> e
          | ArgKwd _ | ArgType _ | ArgOther _ -> raise_notrace Exit)
-    |> List.concat_map nf_one
+    |> List.map nf_one |> List.flatten
   and nf_one = function
     | Call (IdSpecial (Op op1, _tok1), (_, args1, _)) when op = op1 -> nf args1
     | x -> [ x ]

--- a/semgrep-core/src/core/dune
+++ b/semgrep-core/src/core/dune
@@ -21,3 +21,13 @@
    )
  )
 )
+
+(rule
+ (targets Config_semgrep_j.ml Config_semgrep_j.mli)
+ (deps    Config_semgrep.atd)
+ (action  (run atdgen -j -j-strict-fields -j-std %{deps})))
+
+(rule
+ (targets Config_semgrep_t.ml Config_semgrep_t.mli)
+ (deps    Config_semgrep.atd)
+ (action  (run atdgen -t %{deps})))

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -876,7 +876,7 @@ and filter_ranges env xs cond =
 (* Main entry point *)
 (*****************************************************************************)
 
-let check hook config rules equivs file_and_more =
+let check hook default_config rules equivs file_and_more =
   let file, xlang, lazy_ast_and_errors = file_and_more in
   logger#info "checking %s with %d rules" file (List.length rules);
   if !Common.profile = Common.ProfAll then (
@@ -902,6 +902,7 @@ let check hook config rules equivs file_and_more =
                RP.empty_semgrep_result )
              else
                let xpatterns = xpatterns_in_formula formula in
+               let config = r.settings ||| default_config in
                let res =
                  matches_of_xpatterns config r equivs
                    (file, xlang, lazy_ast_and_errors, lazy_content)

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -29,7 +29,7 @@ module B = AST_generic
 module MV = Metavariable
 module AST = AST_generic
 module Flag = Flag_semgrep
-module Config = Config_semgrep
+module Config = Config_semgrep_t
 module H = AST_generic_helpers
 
 (* optimisations *)

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -193,6 +193,13 @@ let parse_paths = function
       pr2_gen x;
       error "parse_paths"
 
+let parse_settings json =
+  let s = J.string_of_json json in
+  Common.save_excursion Atdgen_runtime.Util.Json.unknown_field_handler
+    (fun _src_loc field_name ->
+      raise (E.InvalidYamlException (spf "unknown setting: %s" field_name)))
+    (fun () -> Config_semgrep_j.t_of_string s)
+
 (*****************************************************************************)
 (* Sub parsers patterns and formulas *)
 (*****************************************************************************)
@@ -393,6 +400,7 @@ let top_fields =
     "fix-regex";
     "paths";
     "equivalences";
+    "settings";
   ]
 
 let parse_json file json =
@@ -415,6 +423,7 @@ let parse_json file json =
                        ("fix-regex", fix_regex_opt);
                        ("paths", paths_opt);
                        ("equivalences", equivs_opt);
+                       ("settings", settings_opt);
                      ],
                      rest ) ->
                      let languages = parse_languages ~id langs in
@@ -442,6 +451,7 @@ let parse_json file json =
                        paths = Common.map_opt parse_paths paths_opt;
                        equivalences =
                          Common.map_opt parse_equivalences equivs_opt;
+                       settings = Common.map_opt parse_settings settings_opt;
                      }
                  | x ->
                      pr2_gen x;

--- a/semgrep-core/tests/OTHER/rules/TEMPLATE.js
+++ b/semgrep-core/tests/OTHER/rules/TEMPLATE.js
@@ -1,0 +1,4 @@
+function test() {
+    //ruleid: match
+    bar(foo(2));
+}

--- a/semgrep-core/tests/OTHER/rules/TEMPLATE.yaml
+++ b/semgrep-core/tests/OTHER/rules/TEMPLATE.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: test-template
+  patterns:
+  - pattern: |
+        foo($X)
+  - pattern-inside: |
+        bar($Y)
+  message: Working!
+  severity: WARNING
+  languages: [javascript]

--- a/semgrep-core/tests/OTHER/rules/settings.js
+++ b/semgrep-core/tests/OTHER/rules/settings.js
@@ -1,0 +1,8 @@
+const x = 1;
+
+function test() {
+    // not this one when disable constant propagation
+    foo(x);
+    //ruleid:
+    foo(1);
+}

--- a/semgrep-core/tests/OTHER/rules/settings.yaml
+++ b/semgrep-core/tests/OTHER/rules/settings.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: test-settings
+  patterns:
+  - pattern: |
+        foo(1)
+  settings:
+    constant_propagation: false
+  message: Working!
+  severity: WARNING
+  languages: [javascript]


### PR DESCRIPTION
This will allow to disable for example constant propagation
on a per-rule basis.

I've chosen the 'settings' keyword, but we could change it
for 'preferences', or 'config', whatever.

Still need to update the jsonschema after so it can be used
from the semgrep python wrapper.

test plan:
test file included




PR checklist:
- [ ] changelog is up to date