### PR TITLE
fix: use --debug flag to gate semgrep-core debug output 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 - Associative-commutative matching for Boolean AND and OR operations (#3198)
 
+### Changed
+- `--debug` now prints out semgrep-core debug logs instead of having this
+  behavior with `--debugging-json`
+
 ## [0.55.1](https://github.com/returntocorp/semgrep/releases/tag/v0.55.1) - 2021-06-9
 
 ### Added

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -49,6 +49,7 @@ from semgrep.spacegrep import run_spacegrep
 from semgrep.target_manager import TargetManager
 from semgrep.target_manager_extensions import all_supported_languages
 from semgrep.util import debug_tqdm_write
+from semgrep.util import is_debug
 from semgrep.util import partition
 from semgrep.util import progress_bar
 from semgrep.util import SEMGREP_PATH
@@ -257,13 +258,15 @@ class CoreRunner:
                 "-max_memory",
                 str(self._max_memory),
                 "-json_time",
-                "-debug",
             ]
 
             equivalences = rule.equivalences
             if equivalences:
                 self._write_equivalences_file(equiv_file, equivalences)
                 cmd += ["-equivalences", equiv_file.name]
+
+            if is_debug():
+                cmd += ["-debug"]
 
             core_run = sub_run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             output_json = self._extract_core_output(rule, patterns, core_run)
@@ -694,13 +697,15 @@ class CoreRunner:
                             "-max_memory",
                             str(self._max_memory),
                             "-json_time",
-                            "-debug",
                         ]
 
                         equivalences = rule.equivalences
                         if equivalences:
                             self._write_equivalences_file(equiv_file, equivalences)
                             cmd += ["-equivalences", equiv_file.name]
+
+                        if is_debug():
+                            cmd += ["-debug"]
 
                         core_run = sub_run(
                             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -257,15 +257,13 @@ class CoreRunner:
                 "-max_memory",
                 str(self._max_memory),
                 "-json_time",
+                "-debug",
             ]
 
             equivalences = rule.equivalences
             if equivalences:
                 self._write_equivalences_file(equiv_file, equivalences)
                 cmd += ["-equivalences", equiv_file.name]
-
-            if self._output_settings.debug:
-                cmd += ["-debug"]
 
             core_run = sub_run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             output_json = self._extract_core_output(rule, patterns, core_run)
@@ -283,13 +281,12 @@ class CoreRunner:
         # If semgrep-core prints anything on stderr when running with default
         # flags, it's a bug that should be fixed in semgrep-core.
         #
-        if semgrep_error_output != "":
-            name = f"[rule '{rule.id}']"
-            logger.info(
-                f"--- semgrep-core stderr {name} ---\n"
-                f"{semgrep_error_output}"
-                f"--- end semgrep-core stderr {name} ---"
-            )
+        name = f"[rule '{rule.id}']"
+        logger.debug(
+            f"--- semgrep-core stderr {name} ---\n"
+            f"{semgrep_error_output}"
+            f"--- end semgrep-core stderr {name} ---"
+        )
 
         returncode = core_run.returncode
         if returncode != 0:
@@ -697,15 +694,13 @@ class CoreRunner:
                             "-max_memory",
                             str(self._max_memory),
                             "-json_time",
+                            "-debug",
                         ]
 
                         equivalences = rule.equivalences
                         if equivalences:
                             self._write_equivalences_file(equiv_file, equivalences)
                             cmd += ["-equivalences", equiv_file.name]
-
-                        if self._output_settings.debug:
-                            cmd += ["-debug"]
 
                         core_run = sub_run(
                             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -40,7 +40,7 @@ def is_quiet() -> bool:
 def is_debug() -> bool:
     """
     Returns true if logging level is debug or noisier (lower)
-    (i.e. want no logs)
+    (i.e. want more logs)
     """
     return logging.getLogger("semgrep").getEffectiveLevel() <= logging.DEBUG
 


### PR DESCRIPTION
Prior to this commit, semgrep-core output was only being printed out when semgrep
was called with `--debugging-json` but not when `--debug` was set. This PR makes
the output of debug info more consistent with the rest of our codebase.

Now `--debugging-json` is only used to add step-by-step pattern match evaluation
logs. Holding off on renaming for now since the OutputSettings class is potentially
used externally.

PR checklist:
- [ ] changelog is up to date

