### PR TITLE
Csharp function attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   (#3198)
 - Upgrade TypeScript parser (#3102)
 
+### Fixed
+- C#: Parse attributes for local functions (#3348)
+
 ## [0.55.1](https://github.com/returntocorp/semgrep/releases/tag/v0.55.1) - 2021-06-9
 
 ### Added

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1699,27 +1699,28 @@ and statement (env : env) (x : CST.statement) =
       let v4 = variable_declaration env v4 in
       let v5 = token env v5 (* ";" *) in
       var_def_stmt v4 v3
-  | `Local_func_stmt (vtodo, v1, v2, v3, v4, v5, v6, v7) ->
-      let v1 = List.map (modifier env) v1 in
-      let v2 = return_type env v2 in
-      let v3 = identifier env v3 (* identifier *) in
-      let _, tok = v3 in
-      let v4 =
-        match v4 with Some x -> type_parameter_list env x | None -> []
+  | `Local_func_stmt (v1, v2, v3, v4, v5, v6, v7, v8) ->
+      let v1 = List.concat_map (attribute_list env) v1 in
+      let v2 = List.map (modifier env) v2 in
+      let v3 = return_type env v3 in
+      let v4 = identifier env v4 (* identifier *) in
+      let _, tok = v4 in
+      let v5 =
+        match v5 with Some x -> type_parameter_list env x | None -> []
       in
-      let v5 = parameter_list env v5 in
-      let v6 = List.map (type_parameter_constraints_clause env) v6 in
-      let v7 = function_body env v7 in
-      let tparams = type_parameters_with_constraints v4 v6 in
+      let v6 = parameter_list env v6 in
+      let v7 = List.map (type_parameter_constraints_clause env) v7 in
+      let v8 = function_body env v8 in
+      let tparams = type_parameters_with_constraints v5 v7 in
       let idinfo = empty_id_info () in
-      let ent = { name = EN (Id (v3, idinfo)); attrs = v1; tparams } in
+      let ent = { name = EN (Id (v4, idinfo)); attrs = v1 @ v2; tparams } in
       let def =
         AST.FuncDef
           {
             fkind = (AST.Method, tok);
-            fparams = v5;
-            frettype = Some v2;
-            fbody = v7;
+            fparams = v6;
+            frettype = Some v3;
+            fbody = v8;
           }
       in
       AST.DefStmt (ent, def) |> AST.s


### PR DESCRIPTION
Also, rename all variables v1..v8 to keep consistent numbering for variables.

Closes #3348.

I added a line to the changelog.

