### PR TITLE
Correction to #3358 on readme image distortion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Semgrep analyzes code locally on your computer or in your build environment: **c
 Its rules look like the code you already write; no abstract syntax trees, regex wrestling, or painful DSLs. Here's a quick rule for finding Python `print()` statements, run it online in Semgrep's Playground by clicking the image:
 
 <p align="center">
-    <a href="https://semgrep.dev/s/ievans:print-to-logger"><img src="https://github.com/returntocorp/semgrep/blob/develop/doc/playground-example.png" width="582" height="316" alt="Semgrep rule example for finding Python print() statements"/></a>
+    <a href="https://semgrep.dev/s/ievans:print-to-logger"><img src="https://github.com/returntocorp/semgrep/blob/develop/doc/playground-example.png" width="582" alt="Semgrep rule example for finding Python print() statements"/></a>
 </p>
 
 The Semgrep ecosystem includes:


### PR DESCRIPTION
Because github uses max-width: 100%, we actually want to specify width but not height (instead of both), to avoid distortion.
