### PR TITLE
Refactor Atom type to split the leading symbol from ident

### DIFF
--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -324,7 +324,8 @@ and map_literal = function
   | Ratio v1 ->
       let v1 = map_wrap map_of_string v1 in
       `Ratio v1
-  | Atom v1 ->
+  (* new: _v0 skipped *)
+  | Atom (_v0, v1) ->
       let v1 = map_wrap map_of_string v1 in
       `Atom v1
   | Char v1 ->

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -519,18 +519,14 @@ and literal =
   | Char of string wrap
   | String of string wrap (* TODO? bracket *)
   | Regexp of string wrap (* TODO? bracket * string wrap option (modifiers) *)
+  | Atom of tok (* ':' in Ruby, ''' in Scala *) * string wrap
   | Unit of tok
   (* a.k.a Void *)
   | Null of tok
   | Undefined of tok (* JS *)
   | Imag of string wrap
   (* Go, Python *)
-  | Ratio of string wrap (* Ruby *)
-  | Atom of string wrap
-
-(* TODO? tok * string wrap? *)
-
-(* Ruby *)
+  | Ratio of string wrap
 
 (*e: type [[AST_generic.literal]] *)
 

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -321,9 +321,10 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | Ratio v1 ->
         let v1 = map_wrap map_of_string v1 in
         Ratio v1
-    | Atom v1 ->
+    | Atom (v0, v1) ->
+        let v0 = map_tok v0 in
         let v1 = map_wrap map_of_string v1 in
-        Atom v1
+        Atom (v0, v1)
     | Char v1 ->
         let v1 = map_wrap map_of_string v1 in
         Char v1

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -289,9 +289,10 @@ and vof_literal = function
   | Ratio v1 ->
       let v1 = vof_wrap OCaml.vof_string v1 in
       OCaml.VSum ("Ratio", [ v1 ])
-  | Atom v1 ->
+  | Atom (v0, v1) ->
+      let v0 = vof_tok v0 in
       let v1 = vof_wrap OCaml.vof_string v1 in
-      OCaml.VSum ("Atom", [ v1 ])
+      OCaml.VSum ("Atom", [ v0; v1 ])
   | Char v1 ->
       let v1 = vof_wrap OCaml.vof_string v1 in
       OCaml.VSum ("Char", [ v1 ])

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -387,7 +387,8 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | Ratio v1 ->
         let v1 = v_wrap v_string v1 in
         ()
-    | Atom v1 ->
+    | Atom (v0, v1) ->
+        let v0 = v_tok v0 in
         let v1 = v_wrap v_string v1 in
         ()
     | Char v1 ->

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -790,7 +790,7 @@ and m_literal a b =
   (*s: [[Generic_vs_generic.m_literal()]] ellipsis case *)
   (* dots: metavar: '...' and metavars on string/regexps/atoms *)
   | A.String a, B.String b -> m_string_ellipsis_or_metavar_or_default a b
-  | A.Atom a, B.Atom b -> m_atom_ellipsis_or_metavar_or_default a b
+  | A.Atom (_, a), B.Atom (_, b) -> m_atom_ellipsis_or_metavar_or_default a b
   | A.Regexp a, B.Regexp b -> m_regexp_ellipsis_or_metavar_or_default a b
   (*x: [[Generic_vs_generic.m_literal()]] ellipsis case *)
   (*e: [[Generic_vs_generic.m_literal()]] ellipsis case *)

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -757,10 +757,8 @@ let m_string_ellipsis_or_metavar_or_default ?(m_string_for_default = m_string) a
 let m_atom_ellipsis_or_metavar_or_default ?(m_string_for_default = m_string) a b
     =
   match fst a with
-  | s when s =~ "^:\\(.*\\)" && MV.is_metavar_name (Common.matched1 s) ->
-      let mvar = Common.matched1 s in
-      let tok = snd a in
-      envf (mvar, tok) (MV.E (B.L (B.Atom b)))
+  | s when MV.is_metavar_name s ->
+      envf a (MV.E (B.L (B.Atom (PI.fake_info ":", b))))
   | _ -> m_wrap m_string_for_default a b
 
 let m_regexp_ellipsis_or_metavar_or_default ?(m_string_for_default = m_string) a

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -69,7 +69,7 @@ let ident x = wrap string x
 
 let rec expr = function
   | Literal x -> literal x
-  | Atom x -> atom x
+  | Atom (tk, x) -> atom tk x
   | Id (id, kind) -> (
       match kind with
       | ID_Self -> G.IdSpecial (G.Self, snd id)
@@ -234,7 +234,8 @@ and method_name mn =
       Left (s ^ "=", PI.combine_infos t [ teq ])
   | MethodUOperator (_, t) | MethodOperator (_, t) -> Left (PI.str_of_info t, t)
   | MethodDynamic e -> Right (expr e)
-  | MethodAtom x -> (
+  | MethodAtom (_tcolon, x) -> (
+      (* todo? add ":" in name? *)
       match x with
       | AtomSimple x -> Left x
       | AtomFromString (l, xs, r) -> (
@@ -329,14 +330,14 @@ and unary (op, t) e =
   (* should be only in arguments, to pass procs. I abuse Ref for now *)
   | Op_UAmper -> G.Ref (t, e)
 
-and atom x =
+and atom tcolon x =
   match x with
-  | AtomSimple x -> G.L (G.Atom x)
+  | AtomSimple x -> G.L (G.Atom (tcolon, x))
   | AtomFromString (l, xs, r) -> (
       match xs with
       | [ StrChars (s, t2) ] ->
           let t = PI.combine_infos l [ t2; r ] in
-          G.L (G.Atom (s, t))
+          G.L (G.Atom (tcolon, (s, t)))
       | _ -> string_contents_list (l, xs, r) )
 
 and literal x =

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -182,7 +182,7 @@ let v_package (v1, v2) =
   (v1, v2)
 
 let rec v_literal = function
-  | Symbol (s, t) -> Left (G.Atom (s, t))
+  | Symbol (tquote, id) -> Left (G.Atom (tquote, id))
   | Int v1 ->
       let v1 = v_wrap (v_option v_int) v1 in
       Left (G.Int v1)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -631,7 +631,7 @@ and primary (env : env) (x : CST.primary) : AST.expr =
       let v5 = token2 env v5 (* string_end *) in
       Literal (String (Double (v1, v3 |> List.flatten, v5)))
   | `Symb_array (v1, v2, v3, v4, v5) ->
-      let v1 = token2 env v1 in
+      let v1 = token2 env v1 (* %i( *) in
       let _v2 =
         match v2 with Some tok -> Some (token2 env tok) | None -> None
       in
@@ -643,8 +643,8 @@ and primary (env : env) (x : CST.primary) : AST.expr =
       let _v4 =
         match v4 with Some tok -> Some (token2 env tok) | None -> None
       in
-      let v5 = token2 env v5 in
-      Atom (AtomFromString (v1, v3 |> List.flatten, v5))
+      let v5 = token2 env v5 (* ) *) in
+      Atom (v1, AtomFromString (v1, v3 |> List.flatten, v5))
   | `Hash (v1, v2, v3) ->
       let v1 = token2 env v1 in
       let v2 =
@@ -1425,14 +1425,19 @@ and string_ (env : env) ((v1, v2, v3) : CST.string_) : AST.interp list bracket =
   (* single or double quote *)
   (v1, v2, v3)
 
-and simple_symbol (env : env) (tok : CST.simple_symbol) =
-  AtomSimple (str env tok)
+and simple_symbol (env : env) (tok : CST.simple_symbol) : atom =
+  (* TODO: split tok *)
+  let t = token2 env tok in
+  let tcolon, tafter = PI.split_info_at_pos 1 t in
+  let str = PI.str_of_info tafter in
+  (tcolon, AtomSimple (str, tafter))
 
-and delimited_symbol (env : env) ((v1, v2, v3) : CST.delimited_symbol) =
-  let v1 = token2 env v1 (* symbol_start *) in
-  let v2 = match v2 with Some x -> literal_contents env x | None -> [] in
-  let v3 = token2 env v3 (* string_end *) in
-  AtomFromString (v1, v2, v3)
+and delimited_symbol (env : env) ((v1, v2, v3) : CST.delimited_symbol) : atom =
+  (* TODO: split v1 *)
+  let v1 = token2 env v1 (* symbol_start :" "*) in
+  let res = match v2 with Some x -> literal_contents env x | None -> [] in
+  let v3 = token2 env v3 (* string_end " "*) in
+  (Parse_info.fake_info ":", AtomFromString (v1, res, v3))
 
 and literal_contents (env : env) (xs : CST.literal_contents) : AST.interp list =
   List.filter_map

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -249,7 +249,7 @@ let map_literal_token (env : env) (x : CST.literal) : PI.token_mutable =
   | Undefined tok
   | Imag (_, tok)
   | Ratio (_, tok)
-  | Atom (_, tok) ->
+  | Atom (_, (_, tok)) ->
       tok
 
 let map_literal_pattern (env : env) (x : CST.literal_pattern) : G.pattern =


### PR DESCRIPTION
This will help using metavar to match atoms.

test plan:
make test




PR checklist:
- [x] changelog is up to date