### PR TITLE
metavariable-pattern: Update Semgrep CLI's rule schema

### DIFF
--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -58,6 +58,8 @@ definitions:
         properties:
           metavariable:
             type: string
+          language:
+            type: string
           patterns:
             $ref: '#/definitions/patterns-content'
           pattern-either:


### PR DESCRIPTION
Fixes: 70a20605ae4 ("metavariable-pattern: Allow matching content under another language (#3366)")

PR checklist:
- changelog update not needed

