### PR TITLE
Bind pattern-regexp capture groups to metavariables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,26 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.56.0](https://github.com/returntocorp/semgrep/releases/tag/v0.56.0) - 2021-06-15
+### Unreleased
 
-- C#: parse __makeref, __reftype, __refvalue (#3364)
+### Added
+- Capture groups in pattern-regex: in $1, $2, etc. (#3356)
+- Support metavariables inside atoms (e.g., `foo(:$ATOM)`)
 - Support metavariables and ellipsis inside regexp literals
   (e.g., `foo(/.../)`)
 - Associative-commutative matching for bitwise OR, AND, and XOR operations
+
+### Fixed
+- C#: parse __makeref, __reftype, __refvalue (#3364)
+
+### Changed
+
+## [0.56.0](https://github.com/returntocorp/semgrep/releases/tag/v0.56.0) - 2021-06-15
 
 ### Added
 - Associative-commutative matching for Boolean AND and OR operations
   (#3198)
 - Support metavariables inside strings (e.g., `foo("$VAR")`)
-- Support metavariables inside atoms (e.g., `foo(:$ATOM)`)
 - metavariable-pattern: Allow matching the content of a metavariable under
   a different language.
 

--- a/semgrep-core/tests/OTHER/rules/regexp_capture_empty_group.gem
+++ b/semgrep-core/tests/OTHER/rules/regexp_capture_empty_group.gem
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
-#ruleid: 
+#ruleid:
 gem "functions_framework", "~> 0.7"
-#ruleid: 
+#ruleid:
 gem "google-cloud-storage", "~> 1.29"
 #ruleid:
 gem "", "~> 1.29"

--- a/semgrep-core/tests/OTHER/rules/regexp_capture_empty_group.yaml
+++ b/semgrep-core/tests/OTHER/rules/regexp_capture_empty_group.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: new-Gemfile-dependency
+    languages:
+      - generic
+    message: New dependency with name $1 and version $3
+    pattern-regex: gem "(.+)?", "(.*)"
+    severity: INFO

--- a/semgrep-core/tests/OTHER/rules/regexp_capture_groups.gem
+++ b/semgrep-core/tests/OTHER/rules/regexp_capture_groups.gem
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+#ruleid: 
+gem "functions_framework", "~> 0.7"
+#ruleid: 
+gem "google-cloud-storage", "~> 1.29"

--- a/semgrep-core/tests/OTHER/rules/regexp_capture_groups.yaml
+++ b/semgrep-core/tests/OTHER/rules/regexp_capture_groups.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: new-Gemfile-dependency
+    languages:
+      - generic
+    message: New dependency with name $1 and version $2
+    pattern-regex: gem "(.*)", "(.*)"
+    severity: INFO

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__nosemgrep/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__nosemgrep/results.json
@@ -14,7 +14,76 @@
         "metadata": {
           "source-rule-url": "https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go"
         },
-        "metavars": {},
+        "metavars": {
+          "$2": {
+            "abstract_content": "aws",
+            "end": {
+              "col": 4,
+              "line": 3,
+              "offset": 47
+            },
+            "start": {
+              "col": 1,
+              "line": 3,
+              "offset": 44
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$3": {
+            "abstract_content": "account",
+            "end": {
+              "col": 12,
+              "line": 3,
+              "offset": 55
+            },
+            "start": {
+              "col": 5,
+              "line": 3,
+              "offset": 48
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$4": {
+            "abstract_content": "id",
+            "end": {
+              "col": 15,
+              "line": 3,
+              "offset": 58
+            },
+            "start": {
+              "col": 13,
+              "line": 3,
+              "offset": 56
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$6": {
+            "abstract_content": ":",
+            "end": {
+              "col": 16,
+              "line": 3,
+              "offset": 59
+            },
+            "start": {
+              "col": 15,
+              "line": 3,
+              "offset": 58
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "ERROR"
       },
       "path": "targets/basic/regex-nosemgrep.txt",

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -12,7 +12,8 @@
         "lines": "console.log(x == x)",
         "message": "Detected a useless comparison operation `x == x` or `x != x`. This\noperation is always true.\nIf testing for floating point NaN, use `math.isnan`, or\n`cmath.isnan` if the number is complex.\n",
         "metadata": {
-          "category": "correctness"
+          "category": "correctness",
+          "source": "https://semgrep.dev/r/javascript.lang.correctness.useless-eqeq.eqeq-is-bad"
         },
         "metavars": {
           "$X": {
@@ -52,7 +53,8 @@
         "lines": "    return a + b == a + b",
         "message": "This expression is always True: `a + b == a + b` or `a + b != a + b`. If testing for floating point NaN, use `math.isnan(a + b)`, or `cmath.isnan(a + b)` if the number is complex.",
         "metadata": {
-          "category": "correctness"
+          "category": "correctness",
+          "source": "https://semgrep.dev/r/python.lang.correctness.useless-eqeq.useless-eqeq"
         },
         "metavars": {
           "$X": {


### PR DESCRIPTION
This closes #3356

test plan:
```
$ semgrep-core -lang generic -config
tests/OTHER/rules/regexp_capture_groups.yaml
tests/OTHER/rules/regexp_capture_groups.gem -json |jq
...
      "metavars": {
          "$1": {
            "start": {
              "line": 5,
              "col": 6,
              "offset": 91
            },
            "end": {
              "line": 5,
              "col": 26,
              "offset": 111
            },
            "abstract_content": "google-cloud-storage",
            "unique_id": {
              "type": "AST",
              "md5sum": "f57552512d4701f50efed06c43308f6e"
            }
```




PR checklist:
- [x] changelog is up to date