### PR TITLE
metavariable-pattern: Fix nested language implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - C#: parse __makeref, __reftype, __refvalue (#3364)
 - Java: parsing of dots inside function annotations with brackets (#3389)
 - Do not pretend that short-circuit Boolean AND and OR operators are commutative (#3399)
+- metavariable-pattern: Fix crash when nesting a non-generic pattern within
+  a generic rule
+- metavariable-pattern: Fix parse info when matching content of a metavariable
+  under a different language
 
 ### Changed
 

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_lang1.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_lang1.yaml
@@ -10,7 +10,6 @@ rules:
           metavariable: $CODE
           language: C
           patterns:
-              - pattern: ...
               - pattern-not: |
                   $X++;
     severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.generic
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.generic
@@ -1,0 +1,9 @@
+<!-- ruleid:test-mvp-lang -->
+<script>
+console.log("hello")
+</script>
+
+<!-- OK:test-mvp-lang -->
+<script>
+foo()
+</script>

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: test-mvp-lang
+    languages:
+      - generic
+    message: Working!
+    patterns:
+      - pattern: |
+          <script ...>$...JS</script>
+      - metavariable-pattern:
+          metavariable: $...JS
+          language: javascript
+          patterns:
+              - pattern: |
+                  console.log(...)
+    severity: WARNING


### PR DESCRIPTION
1. Pass the right xlang to `mini_rule_of_pattern`, this fixes a crash
(`Impossible` exception) when using a non-generic pattern within a
generic rule.

2. Adjust parse info after `with_tmp_file`, this fixes the ranges given
of the matches obtained by metavariable-pattern/language (which dumps
the content of the metavariable into a temporary file in order to call
the parsing functions), so that these refer to the correct original file
and position. This alllows to start a patterns op with a pattern-not.

Fixes: 70a20605ae4 ("metavariable-pattern: Allow matching content under another language (#3366)")

test plan:
make test # tests included



PR checklist:
- [x] changelog is up to date

