### PR TITLE
Refactor Match_rules somewhat

### DIFF
--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -93,6 +93,7 @@ type formula =
    * should always be inside an And to be intersected with "positive" formula.
    *)
   | Not of formula
+[@@deriving show, eq]
 
 (* todo: try to remove this at some point, but difficult. See
  * https://github.com/returntocorp/semgrep/issues/1218

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -93,7 +93,6 @@ type formula =
    * should always be inside an And to be intersected with "positive" formula.
    *)
   | Not of formula
-[@@deriving show, eq]
 
 (* todo: try to remove this at some point, but difficult. See
  * https://github.com/returntocorp/semgrep/issues/1218

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -945,7 +945,6 @@ and nested_formula_has_matches env formula lazy_ast_and_errors lazy_content
     evaluate_formula env formula lazy_ast_and_errors lazy_content opt_context
   in
   match final_ranges with [] -> false | _ :: _ -> true
-  [@@profiling]
 
 and evaluate_formula env formula lazy_ast_and_errors lazy_content opt_context =
   let xpatterns = xpatterns_in_formula formula in


### PR DESCRIPTION
Factorize the repeated code in `check` and what was `evaluate_nested_formula`. This function takes a formula and produces the matching ranges, so we call it `evaluate_formula`. The old `evaluate_formula` is now renamed to `compose_patterns`.

Also, rename the methods that return bools to make it more obvious. Am taking suggestions for names; I just moved around words in the original names

Test plan: this should change no functionality



PR checklist:
- [x] changelog is up to date

