### PR TITLE
Fix some minor test warnings

### DIFF
--- a/semgrep/tests/unit/test_yaml_parsing.py
+++ b/semgrep/tests/unit/test_yaml_parsing.py
@@ -117,7 +117,7 @@ def test_invalid_metavariable_regex():
           - pattern-inside: $MODULE.client(host=$HOST)
           - metavariable-regex:
               metavariable: $HOST
-              regex: '192.168\.\d{1,3}\.\d{1,3}'
+              regex: '192.168\\.\\d{1,3}\\.\\d{1,3}'
               metavariable: $MODULE
               regex: (boto|boto3)
           message: "Boto3 connection to internal network"

--- a/semgrep/tox.ini
+++ b/semgrep/tox.ini
@@ -3,6 +3,7 @@
 envlist = py36, py37, py38, py39
 
 [testenv]
+allowlist_externals = pipenv
 commands =
     pipenv install --sequential --dev
     pipenv run pytest --ignore=tests/qa/test_public_repos.py -n auto


### PR DESCRIPTION
I noticed a few warnings when running tests. This should clean up the following:

```
tests/unit/test_yaml_parsing.py:113
tests/unit/test_yaml_parsing.py:113
  /home/runner/work/semgrep/semgrep/semgrep/tests/unit/test_yaml_parsing.py:113: DeprecationWarning: invalid escape sequence \.
    """
```

```
py run-test: commands[0] | pipenv install --sequential --dev
WARNING: test command found but not installed in testenv
  cmd: /opt/hostedtoolcache/Python/3.9.5/x64/bin/pipenv
  env: /home/runner/work/semgrep/semgrep/semgrep/.tox/py
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Installing dependencies from Pipfile.lock (c7aed3)…
py run-test: commands[1] | pipenv run pytest --ignore=tests/qa/test_public_repos.py -n auto
WARNING: test command found but not installed in testenv
  cmd: /opt/hostedtoolcache/Python/3.9.5/x64/bin/pipenv
  env: /home/runner/work/semgrep/semgrep/semgrep/.tox/py
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
```

Source: https://github.com/returntocorp/semgrep/runs/2916425554