### PR TITLE
Memoize range_of_any for statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   under a different language
 
 ### Changed
+- Memoize getting ranges to speed up rules with large ranges
 
 ## [0.56.0](https://github.com/returntocorp/semgrep/releases/tag/v0.56.0) - 2021-06-15
 

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -897,7 +897,11 @@ and stmt = {
      and before matching.
   *)
   (* used in semgrep to skip some AST matching *)
-  mutable s_bf : Bloom_filter.t option; [@equal fun _a _b -> true] [@hash.ignore]
+  mutable s_bf : Bloom_filter.t option;
+      [@equal fun _a _b -> true] [@hash.ignore]
+  mutable s_range :
+    (Parse_info.token_location * Parse_info.token_location) option;
+      [@hash.ignore]
 }
 
 and stmt_kind =
@@ -1976,6 +1980,7 @@ let s skind =
     s_use_cache = false;
     s_backrefs = None;
     s_bf = None;
+    s_range = None;
   }
 
 (*s: function [[AST_generic.basic_field]] *)

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -15,6 +15,7 @@
 open OCaml
 open AST_generic
 module H = AST_generic_helpers
+module PI = Parse_info
 
 (* Disable warnings against unused variables *)
 [@@@warning "-26"]
@@ -103,11 +104,11 @@ let (mk_visitor : visitor_in -> visitor_out) =
   let rec v_info x =
     let k x =
       match x with
-      | { Parse_info.token = _v_pinfox; transfo = _v_transfo } ->
+      | { PI.token = _v_pinfox; transfo = _v_transfo } ->
           (*
-    let arg = Parse_info.v_pinfo v_pinfox in
+    let arg = PI.v_pinfo v_pinfox in
     let arg = v_unit v_comments in
-    let arg = Parse_info.v_transformation v_transfo in
+    let arg = PI.v_transformation v_transfo in
 *)
           ()
     in
@@ -256,7 +257,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
               v2 |> unbracket
               |> List.iter (function
                    | Tuple (_, [ L (String id); e ], _) ->
-                       let t = Parse_info.fake_info ":" in
+                       let t = PI.fake_info ":" in
                        v_partial ~recurse:false (PartialSingleField (id, t, e))
                    | _ -> ())
           (* for Go where we use List for composite literals *)
@@ -264,7 +265,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
               v2 |> unbracket
               |> List.iter (function
                    | Tuple (_, [ N (Id (id, _)); e ], _) ->
-                       let t = Parse_info.fake_info ":" in
+                       let t = PI.fake_info ":" in
                        v_partial ~recurse:false (PartialSingleField (id, t, e))
                    | _ -> ())
           | _ -> () );
@@ -1018,7 +1019,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
           | DefStmt
               ( { name = EN (Id (id, _)); _ },
                 FieldDefColon { vinit = Some e; _ } ) ->
-              let t = Parse_info.fake_info ":" in
+              let t = PI.fake_info ":" in
               v_partial ~recurse:false (PartialSingleField (id, t, e))
           | _ -> () );
           let v1 = v_stmt v1 in
@@ -1211,7 +1212,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
 (*****************************************************************************)
 
 (*****************************************************************************)
-(* Extract infos *)
+(* Extract tokens *)
 (*****************************************************************************)
 
 (*s: function [[Lib_AST.extract_info_visitor]] *)
@@ -1233,12 +1234,54 @@ let ii_of_any any =
 
 (*e: function [[Lib_AST.ii_of_any]] *)
 
+(*****************************************************************************)
+(* Extract ranges *)
+(*****************************************************************************)
+
+(*s: function [[Lib_AST.extract_info_visitor]] *)
+let extract_ranges recursor =
+  let ranges = ref None in
+  let smaller t1 t2 =
+    if compare t1.PI.charpos t2.PI.charpos < 0 then t1 else t2
+  in
+  let larger t1 t2 =
+    if compare t1.PI.charpos t2.PI.charpos > 0 then t1 else t2
+  in
+  let incorporate_tokens (left, right) =
+    match !ranges with
+    | None -> ranges := Some (left, right)
+    | Some (orig_left, orig_right) ->
+        ranges := Some (smaller orig_left left, larger orig_right right)
+  in
+  let incorporate_token tok =
+    if PI.is_origintok tok then
+      let tok_loc = PI.token_location_of_info tok in
+      incorporate_tokens (tok_loc, tok_loc)
+  in
+  let hooks =
+    {
+      default_visitor with
+      kinfo = (fun (_k, _) i -> incorporate_token i);
+      kstmt =
+        (fun (k, _) stmt ->
+          match stmt.s_range with
+          | None -> (
+              let saved_ranges = !ranges in
+              ranges := None;
+              k stmt;
+              stmt.s_range <- !ranges;
+              match saved_ranges with
+              | None -> ()
+              | Some r -> incorporate_tokens r )
+          | Some range -> incorporate_tokens range);
+    }
+  in
+  let vout = mk_visitor hooks in
+  recursor vout;
+  match !ranges with Some range -> range | None -> failwith "no tokens found"
+
 let range_of_tokens tokens =
-  List.filter Parse_info.is_origintok tokens |> Parse_info.min_max_ii_by_pos
+  List.filter PI.is_origintok tokens |> PI.min_max_ii_by_pos
   [@@profiling]
 
-let range_of_any any =
-  let leftmost_token, rightmost_token = ii_of_any any |> range_of_tokens in
-  ( Parse_info.token_location_of_info leftmost_token,
-    Parse_info.token_location_of_info rightmost_token )
-  [@@profiling]
+let range_of_any any = extract_ranges (fun visitor -> visitor any) [@@profiling]

--- a/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
@@ -164,8 +164,7 @@ let get_id env e =
 (* Helpers *)
 (*****************************************************************************)
 
-let replace_sk { s = _s; s_id; s_use_cache; s_backrefs; s_bf } s_kind =
-  { s = s_kind; s_id; s_use_cache; s_backrefs; s_bf }
+let replace_sk stmt s_kind = { stmt with s = s_kind }
 
 let add_pattern s pattern = Set.add (p_any pattern) s
 


### PR DESCRIPTION
Save the range of statements so that range_of_any is much faster.

Test plan:

make test



PR checklist:
- [x] changelog is up to date

