### PR TITLE
metavariable-pattern: Add support for non-Semgrep patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Associative-commutative matching for bitwise OR, AND, and XOR operations
 - Add support for $...MVAR in generic patterns
 - Add per-rule settings object to enable/disable certain matching features
+- Add support for $...MVAR in generic patterns.
+- metavariable-pattern: Add support for nested Spacegrep/regex/Comby patterns
 
 ### Fixed
 - C#: parse __makeref, __reftype, __refvalue (#3364)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -41,7 +41,7 @@ type xlang =
   | LNone
   (* for spacegrep *)
   | LGeneric
-[@@deriving show]
+[@@deriving show, eq]
 
 type regexp = Regexp_engine.Pcre_engine.t [@@deriving show, eq]
 
@@ -121,7 +121,7 @@ and metavar_cond =
    * the "regexpizer" optimizer (see Analyze_rule.ml).
    *)
   | CondRegexp of MV.mvar * regexp
-  | CondPattern of MV.mvar * Lang.t option * formula
+  | CondPattern of MV.mvar * xlang option * formula
 [@@deriving show, eq]
 
 (*****************************************************************************)
@@ -150,7 +150,7 @@ type formula_old =
 and extra =
   | MetavarRegexp of MV.mvar * regexp
   (* TODO: Generalize `Lang.t option` to `xlang`. *)
-  | MetavarPattern of MV.mvar * Lang.t option * formula
+  | MetavarPattern of MV.mvar * xlang option * formula
   | MetavarComparison of metavariable_comparison
   | PatWherePython of string
 
@@ -242,8 +242,8 @@ let rewrite_metavar_comparison_strip mvar cond =
 let convert_extra x =
   match x with
   | MetavarRegexp (mvar, re) -> CondRegexp (mvar, re)
-  | MetavarPattern (mvar, opt_lang, formula) ->
-      CondPattern (mvar, opt_lang, formula)
+  | MetavarPattern (mvar, opt_xlang, formula) ->
+      CondPattern (mvar, opt_xlang, formula)
   | MetavarComparison comp -> (
       match comp with
       (* do we care about strip and base? should not Eval_generic handle it?

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -321,19 +321,23 @@ and parse_extra env x =
       match find_fields [ "metavariable" ] xs with
       | [ ("metavariable", Some (J.String metavar)) ], rest ->
           let id, _ = env in
-          let env', opt_lang, rest' =
+          let env', opt_xlang, rest' =
             match find_fields [ "language" ] rest with
             | [ ("language", Some (J.String s)) ], rest' ->
-                let lang =
-                  match Lang.lang_of_string_opt s with
-                  | None ->
-                      raise
-                        (E.InvalidLanguageException
-                           (id, spf "unsupported language: %s" s))
-                  | Some l -> l
+                let xlang =
+                  (* TODO: This code is similar to Main.xlang_of_string. *)
+                  if s =$= "none" || s =$= "regex" then R.LNone
+                  else if s =$= "generic" then R.LGeneric
+                  else
+                    match Lang.lang_of_string_opt s with
+                    | None ->
+                        raise
+                          (E.InvalidLanguageException
+                             (id, spf "unsupported language: %s" s))
+                    | Some l -> R.L (l, [])
                 in
-                let env' = (id, R.L (lang, [])) in
-                (env', Some lang, rest')
+                let env' = (id, xlang) in
+                (env', Some xlang, rest')
             | ___else___ -> (env, None, rest)
           in
           let pformula =
@@ -344,7 +348,7 @@ and parse_extra env x =
                 error "wrong rule fields"
           in
           let formula = R.formula_of_pformula pformula in
-          R.MetavarPattern (metavar, opt_lang, formula)
+          R.MetavarPattern (metavar, opt_xlang, formula)
       | x ->
           pr2_gen x;
           error "metavariable-pattern:  wrong parse_extra fields" )

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex.generic
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex.generic
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+#OK:test-mvp-regex
+gem "functions_framework", "~> 0.7"
+#ruleid:test-mvp-regex
+gem "google-cloud-storage", "~> 1.29"

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-mvp-regex
+    languages:
+      - generic
+    message: New dependency with name $1 and version $2
+    patterns:
+      - pattern-regex: gem "(.*)", "(.*)"
+      - metavariable-pattern:
+          metavariable: $1
+          language: generic
+          patterns:
+            - pattern: google-cloud-storage
+    severity: INFO


### PR DESCRIPTION
This allows metavariable-pattern to invoke the Spacegrep, regex, and
Comby engines.

Closes #3411

test plan:
make test # test included



PR checklist:
- [x] changelog is up to date

