### PR TITLE
Add '--add' path functionality

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -132,6 +132,23 @@ def cli() -> None:
         " which is documented at https://docs.python.org/3/library/glob.html",
     )
     parser.add_argument(
+        "--add",
+        action="append",
+        default=[],
+        help="Add files or directories by path. The argument is a"
+        " glob-style pattern such as 'foo.*' that must match the path."
+        " This is an extra path in addition to other applicable paths."
+        " For example, specifying the language with '-l php' will"
+        " preselect files like 'src/foo.php'. Specifying one of"
+        " '--add=src/bar/test.txt' or '--add=*.php5' will add the"
+        " selection to the single file 'src/foo.php'."
+        " A choice of multiple '--add' patterns can be specified."
+        " For example, '--add=*.php5 --add=*.txt' will select"
+        " both 'src/foo.php5' and 'lib/bar.txt'."
+        " Glob-style patterns follow the syntax supported by python,"
+        " which is documented at https://docs.python.org/3/library/glob.html",
+    )
+    parser.add_argument(
         "--no-git-ignore",
         action="store_true",
         help="Don't skip files ignored by git."
@@ -524,6 +541,7 @@ def cli() -> None:
                 jobs=args.jobs,
                 include=args.include,
                 exclude=args.exclude,
+                add=args.add,
                 max_target_bytes=args.max_target_bytes,
                 strict=args.strict,
                 autofix=args.autofix,

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -255,6 +255,8 @@ properties:
               $ref: '#/definitions/path-array'
             exclude:
               $ref: '#/definitions/path-array'
+            add:
+              $ref: '#/definitions/path-array'
           additionalProperties: false
         severity:
           title: Severity to report alongside this finding

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -42,6 +42,7 @@ def notify_user_of_work(
     filtered_rules: List[Rule],
     include: List[str],
     exclude: List[str],
+    add: List[str],
 ) -> None:
     """
     Notify user of what semgrep is about to do, including:
@@ -57,6 +58,10 @@ def notify_user_of_work(
         logger.info(f"excluding files:")
         for exc in exclude:
             logger.info(f"- {exc}")
+    if add:
+        logger.info(f"adding files:")
+        for a in add:
+            logger.info(f"- {a}")
     logger.info(f"running {len(filtered_rules)} rules...")
     logger.verbose("rules:")
     for rule in filtered_rules:
@@ -160,6 +165,7 @@ def main(
     jobs: int = 1,
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
+    add: Optional[List[str]] = None,
     strict: bool = False,
     autofix: bool = False,
     dryrun: bool = False,
@@ -179,6 +185,9 @@ def main(
 
     if exclude is None:
         exclude = []
+
+    if add is None:
+        add = []
 
     configs_obj, errors = get_config(pattern, lang, configs)
     all_rules = configs_obj.get_rules(no_rewrite_rule_ids)
@@ -225,12 +234,13 @@ The two most popular are:
                     code=MISSING_CONFIG_EXIT_CODE,
                 )
 
-        notify_user_of_work(filtered_rules, include, exclude)
+        notify_user_of_work(filtered_rules, include, exclude, add)
 
     respect_git_ignore = not no_git_ignore
     target_manager = TargetManager(
         includes=include,
         excludes=exclude,
+        adds=add,
         max_target_bytes=max_target_bytes,
         targets=target,
         respect_git_ignore=respect_git_ignore,


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/1099.

I finally got around to this because we had another ask for this functionality: https://github.com/returntocorp/semgrep/issues/3090. I stopped short of a full implementation (tests, etc). I noticed that this functionality is now handled by `semgrep-core`, so there's little value in implementing it here. I.e. you have to run with `--optimizations none` for this functionality to work:

```
$ tree php
php
├── test.php
└── test.php5

0 directories, 2 files
```

```shell
$ python -m semgrep --optimizations none --add '*.php5' --lang php --pattern 'test(...);' /tmp/php/
/tmp/php/test.php
3:test('foo bar');

/tmp/php/test.php5
3:test('foo bar');
ran 1 rules on 2 files: 2 findings

$ python -m semgrep --optimizations none --add /tmp/php/test.php5 --lang php --pattern 'test(...);' /tmp/php/
/tmp/php/test.php
3:test('foo bar');

/tmp/php/test.php5
3:test('foo bar');
ran 1 rules on 2 files: 2 findings
```

This implementation is also missing `add` functionality from the YAML [`paths`](https://semgrep.dev/docs/writing-rules/rule-syntax/#paths) configuration. We would need the equivalent functionality in `semgrep-core` for this change to be effective. I took a brief look at this and it seemed non-trivial.

I'm mostly posting this for posterity's sake. We can always revive it in the future if we'd like :+1: 

PR checklist:
- [ ] changelog is up to date

