### PR TITLE
parsing-stats: Set a timeout of 10s per file

### DIFF
--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -175,6 +175,7 @@ let test_parse_tree_sitter lang xs =
    semgrep scans.
 *)
 let parsing_common ?(verbose = true) lang xs =
+  let timeout_seconds = 10 in
   let xs = List.map Common.fullpath xs in
   let fullxs =
     Lang.files_of_dirs_or_files lang xs
@@ -186,8 +187,9 @@ let parsing_common ?(verbose = true) lang xs =
          let stat =
            try
              let res =
-               Parse_target.parse_and_resolve_name_use_pfff_or_treesitter lang
-                 file
+               Common.timeout_function ~verbose:false timeout_seconds (fun () ->
+                   Parse_target.parse_and_resolve_name_use_pfff_or_treesitter
+                     lang file)
              in
              res.Parse_target.stat
            with exn ->


### PR DESCRIPTION
This was motivated by data-flow const-prop being too slow on:

    aspnetcore/src/Http/Routing/perf/Microbenchmarks/Matching/MatcherAzureBenchmarkBase.generated.cs

But we could have bad perf for any other reason, so it is a good idea to set a timeout.

Related-to: #3410



PR checklist:
- [ ] changelog is up to date

