### PR TITLE
New options: field in a rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   (e.g., `foo(/.../)`)
 - Associative-commutative matching for bitwise OR, AND, and XOR operations
 - Add support for $...MVAR in generic patterns
-- Add per-rule settings object to enable/disable certain matching features
 - Add support for $...MVAR in generic patterns.
 - metavariable-pattern: Add support for nested Spacegrep/regex/Comby patterns
 - C#: support ellipsis in method parameters (#3289)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Unreleased
 
 ### Added
+- new `options:` field in a YAML rule to enable/disable certain features
+  (e.g., constant propagation). See https://github.com/returntocorp/semgrep/blob/develop/semgrep-core/src/core/Config_semgrep.atd
+  for the list of available features one can enable/disable.
 - Capture groups in pattern-regex: in $1, $2, etc. (#3356)
 - Support metavariables inside atoms (e.g., `foo(:$ATOM)`)
 - Support metavariables and ellipsis inside regexp literals

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -184,7 +184,7 @@ type rule = {
   (* for metachecking error location *)
   (* optional fields *)
   equivalences : string list option;
-  settings : Config_semgrep.t option;
+  options : Config_semgrep.t option;
   (* TODO: parse them *)
   fix : string option;
   fix_regexp : (regexp * int option * string) option;

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -1000,7 +1000,7 @@ let check hook default_config rules equivs file_and_more =
                RP.empty_semgrep_result )
              else
                let formula = Rule.formula_of_rule r in
-               let config = r.settings ||| default_config in
+               let config = r.options ||| default_config in
                let dummy_matches = Hashtbl.create 1 in
                let env =
                  {

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -193,11 +193,17 @@ let parse_paths = function
       pr2_gen x;
       error "parse_paths"
 
-let parse_settings json =
+let parse_options json =
   let s = J.string_of_json json in
   Common.save_excursion Atdgen_runtime.Util.Json.unknown_field_handler
     (fun _src_loc field_name ->
-      raise (E.InvalidYamlException (spf "unknown setting: %s" field_name)))
+      (* for forward compatibility, better to not raise an exn and just
+       * ignore the new fields.
+       * TODO: we should use a warning/logging infra to report
+       * this in the JSON to the semgrep wrapper and user.
+       *)
+      (*raise (E.InvalidYamlException (spf "unknown option: %s" field_name))*)
+      pr2 (spf "WARNING: unknown option: %s" field_name))
     (fun () -> Config_semgrep_j.t_of_string s)
 
 (*****************************************************************************)
@@ -422,7 +428,7 @@ let top_fields =
     "fix-regex";
     "paths";
     "equivalences";
-    "settings";
+    "options";
   ]
 
 let parse_json file json =
@@ -445,7 +451,7 @@ let parse_json file json =
                        ("fix-regex", fix_regex_opt);
                        ("paths", paths_opt);
                        ("equivalences", equivs_opt);
-                       ("settings", settings_opt);
+                       ("options", options_opt);
                      ],
                      rest ) ->
                      let languages = parse_languages ~id langs in
@@ -473,7 +479,7 @@ let parse_json file json =
                        paths = Common.map_opt parse_paths paths_opt;
                        equivalences =
                          Common.map_opt parse_equivalences equivs_opt;
-                       settings = Common.map_opt parse_settings settings_opt;
+                       options = Common.map_opt parse_options options_opt;
                      }
                  | x ->
                      pr2_gen x;

--- a/semgrep-core/tests/OTHER/rules/ac_matching.yaml
+++ b/semgrep-core/tests/OTHER/rules/ac_matching.yaml
@@ -3,7 +3,7 @@ rules:
     languages:
       - php
     message: Working!
-    settings:
+    options:
       commutative_boolop: true
     pattern: |
       !check1($stuff) && !check2($stuff)

--- a/semgrep-core/tests/OTHER/rules/settings.yaml
+++ b/semgrep-core/tests/OTHER/rules/settings.yaml
@@ -1,9 +1,9 @@
 rules:
-- id: test-settings
+- id: test-options
   patterns:
   - pattern: |
         foo(1)
-  settings:
+  options:
     constant_propagation: false
   message: Working!
   severity: WARNING

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -291,8 +291,8 @@ properties:
         metadata:
           title: Arbitrary structured data for your own reference
           type: object
-        settings:
-          title: Settings object to enable/disable certain matching features in semgrep-core
+        options:
+          title: Options object to enable/disable certain matching features in semgrep-core
           type: object
         pattern:
           title: Return finding where Semgrep pattern matches exactly


### PR DESCRIPTION
This replaces the old settings: to options: and make it public
by adding it in the CHANGELOG

test plan:
make test




PR checklist:
- [ ] changelog is up to date