### PR TITLE
parsing-stats: Set parsing_stat.have_timeout when a timeout occurs

### DIFF
--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -192,9 +192,11 @@ let parsing_common ?(verbose = true) lang xs =
                      lang file)
              in
              res.Parse_target.stat
-           with exn ->
+           with exn -> (
              if verbose then pr2 (spf "%s: exn = %s" file (Common.exn_to_s exn));
-             PI.bad_stat file
+             match exn with
+             | Timeout -> { (PI.bad_stat file) with have_timeout = true }
+             | _else_ -> PI.bad_stat file )
          in
          stat)
 


### PR DESCRIPTION
Follows: a60be2a9c88 ("parsing-stats: Set a timeout of 10s per file (#3434)")



PR checklist:
- [ ] changelog is up to date

