### PR TITLE
analyzing: dataflow: Optimize env manipulation functions

### DIFF
--- a/semgrep-core/src/analyzing/Dataflow.ml
+++ b/semgrep-core/src/analyzing/Dataflow.ml
@@ -124,50 +124,41 @@ let eq_inout eq io1 io2 =
 
 let (varmap_union : ('a -> 'a -> 'a) -> 'a env -> 'a env -> 'a env) =
  fun union_op env1 env2 ->
-  let acc = env1 in
-  VarMap.fold
-    (fun var x acc ->
-      let x' = try union_op x (VarMap.find var acc) with Not_found -> x in
-      VarMap.add var x' acc)
-    env2 acc
+  let union _ x y = Some (union_op x y) in
+  VarMap.union union env1 env2
 
 let (varmap_diff :
       ('a -> 'a -> 'a) -> ('a -> bool) -> 'a env -> 'a env -> 'a env) =
  fun diff_op is_empty env1 env2 ->
-  let acc = env1 in
-  VarMap.fold
-    (fun var x acc ->
-      try
-        let diff = diff_op (VarMap.find var acc) x in
-        if is_empty diff then VarMap.remove var acc else VarMap.add var diff acc
-      with Not_found -> acc)
-    env2 acc
+  let merge _ opt_x opt_y =
+    match (opt_x, opt_y) with
+    | None, _ -> None
+    | Some x, None -> Some x
+    | Some x, Some y ->
+        let diff = diff_op x y in
+        if is_empty diff then None else Some diff
+  in
+  VarMap.merge merge env1 env2
 
 (* useful helpers when the environment maps to a set of Nodes, e.g.,
  * for reaching definitions.
  *)
 let (union_env : NodeiSet.t env -> NodeiSet.t env -> NodeiSet.t env) =
  fun env1 env2 ->
-  let acc = env1 in
-  VarMap.fold
-    (fun var set acc ->
-      let set2 =
-        try NodeiSet.union set (VarMap.find var acc) with Not_found -> set
-      in
-      VarMap.add var set2 acc)
-    env2 acc
+  let union _ x y = Some (NodeiSet.union x y) in
+  VarMap.union union env1 env2
 
 let (diff_env : NodeiSet.t env -> NodeiSet.t env -> NodeiSet.t env) =
  fun env1 env2 ->
-  let acc = env1 in
-  VarMap.fold
-    (fun var set acc ->
-      try
-        let diff = NodeiSet.diff (VarMap.find var acc) set in
-        if NodeiSet.is_empty diff then VarMap.remove var acc
-        else VarMap.add var diff acc
-      with Not_found -> acc)
-    env2 acc
+  let merge _ opt_x opt_y =
+    match (opt_x, opt_y) with
+    | None, _ -> None
+    | Some x, None -> Some x
+    | Some x, Some y ->
+        let diff = NodeiSet.diff x y in
+        if NodeiSet.is_empty diff then None else Some diff
+  in
+  VarMap.merge merge env1 env2
 
 let (add_var_and_nodei_to_env :
       var -> nodei -> NodeiSet.t env -> NodeiSet.t env) =


### PR DESCRIPTION
Re-implemented union/diff functions in terms of Map.merge. The Map.fold
based implementations re-allocated the entire map `env2` even if `env1`
was empty. If the map is large then this triggers too much GC slowing
down the execution.

Most of the perf gain just required adding:

    if VarMap.is_empty ... then ... else ...

But we went with Map.merge anyways because the implementations are more
concise.

Closes #3410

test plan:
time semgrep-core/bin/semgrep-core -lang csharp -dump_named_ast parsing-stats/lang/csharp/tmp/aspnetcore/src/Http/Routing/perf/Microbenchmarks/Matching/MatcherAzureBenchmarkBase.generated.cs &>/dev/null
  #^ now takes less than a minute



PR checklist:
- [ ] changelog is up to date

