### PR TITLE
core: Disable Parmap's core pinning feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Unreleased
 
+### Fixed
+- Apple M1: Semgrep installed from HomeBrew no longer hangs (#2432)
+
+### Unreleased
+
 ### Added
 - new `options:` field in a YAML rule to enable/disable certain features
   (e.g., constant propagation). See https://github.com/returntocorp/semgrep/blob/develop/semgrep-core/src/core/Config_semgrep.atd

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -266,6 +266,17 @@ let map f xs =
       | _ -> n / !ncores
     in
     assert (!ncores > 0 && chunksize > 0);
+    (* Quoting Parmap's README:
+     * > To obtain maximum speed, Parmap tries to pin the worker processes to a CPU
+     * Unfortunately, on the new Apple M1, and depending on the number of workers,
+     * Parmap will enter an infinite loop trying (but failing) to pin a worker to
+     * CPU 0. This only happens with HomeBrew installs, presumably because under
+     * HomeBrew's build environment HAVE_MACH_THREAD_POLICY_H is set
+     * (https://github.com/rdicosmo/parmap/blob/1.2.3/src/setcore_stubs.c#L47).
+     * So, despite it may hurt perf a bit, we disable core pinning to work around
+     * this issue until this is fixed in a future version of Parmap.
+     *)
+    Parmap.disable_core_pinning ();
     Parmap.parmap ~ncores:!ncores ~chunksize f (Parmap.L xs)
 
 (*e: function [[Main_semgrep_core.map]] *)


### PR DESCRIPTION
Under some circumstances this feature causes Semgrep to enter an
infinite loop on Apple M1.

Closes #2432

test plan:
1. Get https://github.com/Homebrew/homebrew-core/blob/94d160c5b10/Formula/semgrep.rb
2. Apply these changes:
```
    @@ -3,9 +3,10 @@

    desc "Easily detect and prevent bugs and anti-patterns in your codebase"
    homepage "https://semgrep.dev"
    +  version "0.57.0"
    url "https://github.com/returntocorp/semgrep.git",
    -      tag:      "v0.57.0",
    -      revision: "9dff8bba2ea67c9146977667e079711aec1d4ff4"
    +      branch:   "develop",
    +      revision: "<SHA1 of this commit>"
    license "LGPL-2.1-only"
    head "https://github.com/returntocorp/semgrep.git", branch: "develop"
```
3. % brew install --build-from-source ./semgrep.rb
4. Follow https://github.com/returntocorp/semgrep/issues/2432#issuecomment-868878852
   and check that Semgrep no longer hangs.



PR checklist:
- [x] changelog is up to date

