### PR TITLE
ci: be able to run semgrep linter from forked projects

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Testing if this will allow PRs from forks to run our semgrep linter