### PR TITLE
Revert "ci: be able to run semgrep linter from forked projects"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Reverts returntocorp/semgrep#3464

Reverting since 3464 was not reviewed. But based on https://github.com/returntocorp/semgrep/pull/3466 works as we want it to. Will reopen PR for review with this change