### PR TITLE
spacegrep: Fix non-portable use of zcat

### DIFF
--- a/semgrep-core/src/spacegrep/scripts/show-perf
+++ b/semgrep-core/src/spacegrep/scripts/show-perf
@@ -85,7 +85,7 @@ tr '\n' ' ' < big > big.oneline
 head -c 1000000 /dev/random > big-blob
 
 # A big target that we keep under version control
-zcat "$perf_data_dir"/django-template.po.gz > django-template.po
+zcat < "$perf_data_dir"/django-template.po.gz > django-template.po
 
 print() {
   echo "[spacecat] $*" >&2


### PR DESCRIPTION
scripts/show-perf was failing on MacOS 11.

Fixes: 5128b066302 ("spacegrep: add post-parse/pre-match optimization (#3460)")



PR checklist:
- [ ] changelog is up to date

