### PR TITLE
Parse HTML CST in generic AST

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
@@ -14,11 +14,9 @@
 open Common
 module CST = Tree_sitter_html.CST
 module H = Parse_tree_sitter_helpers
-
-(*
-module PI = Parse_info
 open AST_generic
-*)
+module G = AST_generic
+module PI = Parse_info
 
 (*****************************************************************************)
 (* Prelude *)
@@ -33,6 +31,12 @@ open AST_generic
 (*****************************************************************************)
 type env = unit H.env
 
+let fake = AST_generic.fake
+
+let token = H.token
+
+let str = H.str
+
 (*****************************************************************************)
 (* Boilerplate converter *)
 (*****************************************************************************)
@@ -43,147 +47,86 @@ type env = unit H.env
    to another type of tree.
 *)
 
-[@@@warning "-32"]
-
-(* Disable warnings against unused variables *)
-[@@@warning "-26-27"]
-
-(* Disable warning against unused 'rec' *)
-[@@@warning "-39"]
-
-let token (env : env) (_tok : Tree_sitter_run.Token.t) =
-  failwith "not implemented"
-
-let todo (env : env) _ = failwith "not implemented"
-
-let map_start_tag_name (env : env) (tok : CST.start_tag_name) = token env tok
-
-(* start_tag_name *)
-
-let map_script_start_tag_name (env : env) (tok : CST.script_start_tag_name) =
-  token env tok
-
-(* script_start_tag_name *)
-
-let map_attribute_name (env : env) (tok : CST.attribute_name) = token env tok
-
-(* pattern "[^<>\"'/=\\s]+" *)
-
-let map_style_start_tag_name (env : env) (tok : CST.style_start_tag_name) =
-  token env tok
-
-(* style_start_tag_name *)
-
-let map_doctype (env : env) (tok : CST.doctype) = token env tok
-
-(* pattern [Dd][Oo][Cc][Tt][Yy][Pp][Ee] *)
-
-let map_raw_text (env : env) (tok : CST.raw_text) = token env tok
-
-(* raw_text *)
-
-let map_pat_98d585a (env : env) (tok : CST.pat_98d585a) = token env tok
-
-(* pattern "[^\"]+" *)
-
-let map_text (env : env) (tok : CST.text) = token env tok
-
-(* pattern [^<>]+ *)
-
-let map_erroneous_end_tag_name (env : env) (tok : CST.erroneous_end_tag_name) =
-  token env tok
-
-(* erroneous_end_tag_name *)
-
-let map_implicit_end_tag (env : env) (tok : CST.implicit_end_tag) =
-  token env tok
-
-(* implicit_end_tag *)
-
-let map_pat_03aa317 (env : env) (tok : CST.pat_03aa317) = token env tok
-
-(* pattern [^>]+ *)
-
-let map_pat_58fbb2e (env : env) (tok : CST.pat_58fbb2e) = token env tok
-
-(* pattern "[^']+" *)
-
-let map_end_tag_name (env : env) (tok : CST.end_tag_name) = token env tok
-
-(* end_tag_name *)
-
-let map_attribute_value (env : env) (tok : CST.attribute_value) = token env tok
-
-(* pattern "[^<>\"'=\\s]+" *)
-
-let map_quoted_attribute_value (env : env) (x : CST.quoted_attribute_value) =
+let map_quoted_attribute_value (env : env) (x : CST.quoted_attribute_value) :
+    string wrap =
   match x with
   | `SQUOT_opt_pat_58fbb2e_SQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "'" *) in
-      let v2 =
+      let s, ts =
         match v2 with
-        | Some tok -> token env tok (* pattern "[^']+" *)
-        | None -> todo env ()
+        | Some tok ->
+            let s, t = str env tok (* pattern "[^']+" *) in
+            (s, [ t ])
+        | None -> ("", [])
       in
       let v3 = token env v3 (* "'" *) in
-      todo env (v1, v2, v3)
+      (s, PI.combine_infos v1 (ts @ [ v3 ]))
   | `DQUOT_opt_pat_98d585a_DQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "\"" *) in
-      let v2 =
+      let s, ts =
         match v2 with
-        | Some tok -> token env tok (* pattern "[^\"]+" *)
-        | None -> todo env ()
+        | Some tok ->
+            let s, t = str env tok (* pattern "[^\"]+" *) in
+            (s, [ t ])
+        | None -> ("", [])
       in
       let v3 = token env v3 (* "\"" *) in
-      todo env (v1, v2, v3)
+      (s, PI.combine_infos v1 (ts @ [ v3 ]))
 
-let map_end_tag (env : env) ((v1, v2, v3) : CST.end_tag) =
+let map_end_tag (env : env) ((v1, v2, v3) : CST.end_tag) : tok =
   let v1 = token env v1 (* "</" *) in
   let v2 = token env v2 (* end_tag_name *) in
   let v3 = token env v3 (* ">" *) in
-  todo env (v1, v2, v3)
+  PI.combine_infos v1 [ v2; v3 ]
 
-let map_attribute (env : env) ((v1, v2) : CST.attribute) =
-  let v1 = token env v1 (* pattern "[^<>\"'/=\\s]+" *) in
-  let v2 =
-    match v2 with
-    | Some (v1, v2) ->
-        let v1 = token env v1 (* "=" *) in
-        let v2 =
-          match v2 with
-          | `Attr_value tok -> token env tok (* pattern "[^<>\"'=\\s]+" *)
-          | `Quoted_attr_value x -> map_quoted_attribute_value env x
-        in
-        todo env (v1, v2)
-    | None -> todo env ()
-  in
-  todo env (v1, v2)
+let map_attribute (env : env) ((v1, v2) : CST.attribute) : xml_attribute =
+  let id = str env v1 (* pattern "[^<>\"'/=\\s]+" *) in
+  match v2 with
+  | Some (v1, v2) ->
+      let v1 = token env v1 (* "=" *) in
+      let v2 =
+        match v2 with
+        | `Attr_value tok ->
+            (* todo: remove quotes? *)
+            let v = str env tok (* pattern "[^<>\"'=\\s]+" *) in
+            L (String v)
+        | `Quoted_attr_value x ->
+            let v = map_quoted_attribute_value env x in
+            L (String v)
+      in
+      XmlAttr (id, v1, v2)
+  | None ->
+      (* <foo a /> <=> <foo a=true>? That's what we do for JSX, but should
+       * we instead introduce a XmlAttrNoValue in AST_generic?
+       *)
+      let v = L (Bool (true, fake "true")) in
+      XmlAttr (id, fake "=", v)
 
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* script_start_tag_name *) in
+  let v2 = str env v2 (* script_start_tag_name *) in
   let v3 = List.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+  (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* style_start_tag_name *) in
+  let v2 = str env v2 (* style_start_tag_name *) in
   let v3 = List.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+  (v1, v2, v3, v4)
 
 let map_start_tag (env : env) ((v1, v2, v3, v4) : CST.start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* start_tag_name *) in
+  let v2 = str env v2 (* start_tag_name *) in
   let v3 = List.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+  (v1, v2, v3, v4)
 
-let rec map_element (env : env) (x : CST.element) =
+let rec map_element (env : env) (x : CST.element) : xml =
   match x with
   | `Start_tag_rep_node_choice_end_tag (v1, v2, v3) ->
-      let v1 = map_start_tag env v1 in
+      let l, id, attrs, r = map_start_tag env v1 in
       let v2 = map_fragment env v2 in
       let v3 =
         match v3 with
@@ -191,49 +134,80 @@ let rec map_element (env : env) (x : CST.element) =
         | `Impl_end_tag tok -> token env tok
         (* implicit_end_tag *)
       in
-      todo env (v1, v2, v3)
+      { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
   | `Self_clos_tag (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "<" *) in
-      let v2 = token env v2 (* start_tag_name *) in
-      let v3 = List.map (map_attribute env) v3 in
-      let v4 = token env v4 (* "/>" *) in
-      todo env (v1, v2, v3, v4)
+      let l = token env v1 (* "<" *) in
+      let id = str env v2 (* start_tag_name *) in
+      let attrs = List.map (map_attribute env) v3 in
+      let r = token env v4 (* "/>" *) in
+      { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
 
-and map_fragment (env : env) (xs : CST.fragment) = List.map (map_node env) xs
+and map_fragment (env : env) (xs : CST.fragment) : xml_body list =
+  List.map (map_node env) xs
 
-and map_node (env : env) (x : CST.node) =
+and map_node (env : env) (x : CST.node) : xml_body =
   match x with
   | `Doct_ (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "<!" *) in
-      let v2 = token env v2 (* pattern [Dd][Oo][Cc][Tt][Yy][Pp][Ee] *) in
-      let v3 = token env v3 (* pattern [^>]+ *) in
-      let v4 = token env v4 (* ">" *) in
-      todo env (v1, v2, v3, v4)
-  | `Text tok -> token env tok (* pattern [^<>]+ *)
-  | `Elem x -> map_element env x
+      let l = token env v1 (* "<!" *) in
+      let id = str env v2 (* pattern [Dd][Oo][Cc][Tt][Yy][Pp][Ee] *) in
+      let _misc = token env v3 (* pattern [^>]+ *) in
+      let r = token env v4 (* ">" *) in
+      let xml =
+        {
+          xml_kind = XmlSingleton (l, id, r);
+          xml_attrs = [];
+          (* less: use misc? *)
+          xml_body = [];
+        }
+      in
+      XmlXml xml
+  | `Text tok ->
+      let v1 = str env tok (* pattern [^<>]+ *) in
+      XmlText v1
+  | `Elem x ->
+      let v1 = map_element env x in
+      XmlXml v1
   | `Script_elem (v1, v2, v3) ->
-      let v1 = map_script_start_tag env v1 in
+      let l, id, attrs, r = map_script_start_tag env v1 in
       let v2 =
         match v2 with
-        | Some tok -> token env tok (* raw_text *)
-        | None -> todo env ()
+        | Some tok -> [ XmlText (str env tok) ] (* raw_text *)
+        | None -> []
       in
       let v3 = map_end_tag env v3 in
-      todo env (v1, v2, v3)
+      let xml =
+        {
+          xml_kind = XmlClassic (l, id, r, v3);
+          xml_attrs = attrs;
+          xml_body = v2;
+        }
+      in
+      XmlXml xml
   | `Style_elem (v1, v2, v3) ->
-      let v1 = map_style_start_tag env v1 in
+      let l, id, attrs, r = map_style_start_tag env v1 in
       let v2 =
         match v2 with
-        | Some tok -> token env tok (* raw_text *)
-        | None -> todo env ()
+        | Some tok -> [ XmlText (str env tok) ] (* raw_text *)
+        | None -> []
       in
       let v3 = map_end_tag env v3 in
-      todo env (v1, v2, v3)
+      let xml =
+        {
+          xml_kind = XmlClassic (l, id, r, v3);
+          xml_attrs = attrs;
+          xml_body = v2;
+        }
+      in
+      XmlXml xml
   | `Errons_end_tag (v1, v2, v3) ->
-      let v1 = token env v1 (* "</" *) in
-      let v2 = token env v2 (* erroneous_end_tag_name *) in
-      let v3 = token env v3 (* ">" *) in
-      todo env (v1, v2, v3)
+      let l = token env v1 (* "</" *) in
+      let id = str env v2 (* erroneous_end_tag_name *) in
+      let r = token env v3 (* ">" *) in
+      (* todo? raise an exception instead? *)
+      let xml =
+        { xml_kind = XmlSingleton (l, id, r); xml_attrs = []; xml_body = [] }
+      in
+      XmlXml xml
 
 (*****************************************************************************)
 (* Entry point *)
@@ -247,7 +221,18 @@ let parse file =
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
-      try map_fragment env cst
+      try
+        let xs = map_fragment env cst in
+        let xml =
+          {
+            xml_kind = XmlFragment (fake "", fake "");
+            xml_attrs = [];
+            xml_body = xs;
+          }
+        in
+        let e = Xml xml in
+        let st = G.exprstmt e in
+        [ st ]
       with Failure "not implemented" as exn ->
         let s = Printexc.get_backtrace () in
         pr2 "Some constructs are not handled yet";

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -250,6 +250,12 @@ let lang_parsing_tests =
       let lang = Lang.Scala in
       parsing_tests_for_lang files lang
     );
+    "HTML" >::: (
+      let dir = Filename.concat tests_path "html/parsing" in
+      let files = Common2.glob (spf "%s/*.html" dir) in
+      let lang = Lang.HTML in
+      parsing_tests_for_lang files lang
+    );
   ]
 
 (*s: constant [[Test.lang_regression_tests]] *)

--- a/semgrep-core/tests/html/parsing/hello.html
+++ b/semgrep-core/tests/html/parsing/hello.html
@@ -1,5 +1,7 @@
 <html>
   <body>
-  Hello World <a href="foo">xxx</a>
+    Hello World <a href="foo">xxx</a>
+    <p> this is it.
+    <hr>
   </body>
 </html>


### PR DESCRIPTION
We just reuse the constructs we used for JSX/TSX/XHP.

test plan:
```
[pad@yrax yy (html2)]$ yy -lang html -dump_ast tests/html/parsing/hello.html
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang html -dump_ast tests/html/parsing/hello.html
[0.104  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.104  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang html -dump_ast tests/html/parsing/hello.html
[0.105  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.57.0-21-gad17ca23-dirty, pfff: 0.42
[0.105  Info       Main.Parse_target    ] trying to parse with TreeSitter parser tests/html/parsing/hello.html
Pr(
  [ExprStmt(
     Xml(
       {xml_tag=XmlFragment((), ()); xml_attrs=[];
        xml_body=[XmlXml(
                    {xml_tag=XmlClassic((), ("html", ()), (), ());
                     xml_attrs=[];
                     xml_body=[XmlText(("  ", ()));
                               XmlXml(
                                 {
                                  xml_tag=XmlClassic((), ("body", ()), (), ());
                                  xml_attrs=[];
                                  xml_body=[XmlText(("    Hello World ", ()));
                                            XmlXml(
                                              {
                                               xml_tag=XmlClassic((),
...
```




PR checklist:
- [x] changelog is up to date