### PR TITLE
Revert `pattern: $X` optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Java varargs are now correctly matched (#3455)
 - Support for partial statements (e.g., `try { ... }`) for Java (#3417)
 - Constant propagation now works inside Python `with` statements (#3402)
+- Revert `pattern: $X` optimization (#3476)
 
 ### Changed
 - Faster matching times for generic mode

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -106,14 +106,15 @@ let formula_to_sformula match_func formula =
           in
           remove_selectors (selector, acc) xs
     in
-    let convert_and_formulas fs =
+    let _convert_and_formulas fs =
+      (* TODO put back this function *)
       let selector, fs = remove_selectors (None, []) fs in
       (selector, List.map formula_to_sformula fs)
     in
     (* Visit formula and convert *)
     match formula with
     | R.Leaf leaf -> Leaf leaf
-    | R.And fs -> And (convert_and_formulas fs)
+    | R.And fs -> And (None, List.map formula_to_sformula fs)
     | R.Or fs -> Or (List.map formula_to_sformula fs)
     | R.Not f -> Not (formula_to_sformula f)
   in

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-range.py
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-range.py
@@ -1,0 +1,6 @@
+#ruleid:test
+f(a, b, c)
+g(c)
+h(b)
+#ruleid:test
+i(a)

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-range.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-range.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: test
+  patterns:
+    - pattern: 
+        $X
+    - pattern-inside: |
+        f($X, ...)
+        ...
+  message: Semgrep found a match
+  languages: [python]
+  severity: WARNING


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep/issues/3476

Turn off the `pattern: $X` optimization for now. To perform it properly, we need to get the sub-AST of the range produced by the other patterns in the `and` and run the pattern on that range.

Test plan: make test



PR checklist:
- [x] changelog is up to date

