### PR TITLE
Basic Vue to generic AST

### DIFF
--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -299,8 +299,7 @@ let just_parse_with_lang lang file =
   | Lang.HTML ->
       (* less: there is an html parser in pfff too we could use as backup *)
       run file [ TreeSitter Parse_html_tree_sitter.parse ] (fun x -> x)
-  | Lang.Vue ->
-      run file [ TreeSitter Parse_vue_tree_sitter.parse ] Js_to_generic.program
+  | Lang.Vue -> run file [ TreeSitter Parse_vue_tree_sitter.parse ] (fun x -> x)
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -24,30 +24,19 @@ module G = AST_generic
 (* Vue parser using tree-sitter-lang/semgrep-vue and converting
  * to ast_js.ml
  *
+ * There are similarities with the code in Parse_html_tree_sitter.ml.
  *)
-
-[@@@warning "-32"]
-
-(* Disable warnings against unused variables *)
-[@@@warning "-26-27"]
-
-(* Disable warning against unused 'rec' *)
-[@@@warning "-39"]
 
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 type env = unit H.env
 
-let _fake = AST_generic.fake
+let fake = AST_generic.fake
 
 let token = H.token
 
 let str = H.str
-
-let fb = fake_bracket
-
-let sc = PI.fake_info ";"
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -59,317 +48,279 @@ let sc = PI.fake_info ";"
    to another type of tree.
 *)
 
-let todo (env : env) _ = failwith "not implemented"
-
-let map_end_tag_name (env : env) (tok : CST.end_tag_name) = token env tok
-
-(* end_tag_name *)
-
-let map_pat_98d585a (env : env) (tok : CST.pat_98d585a) = token env tok
-
-(* pattern "[^\"]+" *)
-
-let map_interpolation_text (env : env) (tok : CST.interpolation_text) =
-  token env tok
-
-(* interpolation_text *)
-
-let map_text_fragment (env : env) (tok : CST.text_fragment) = token env tok
-
-(* text_fragment *)
-
-let map_attribute_name (env : env) (tok : CST.attribute_name) = token env tok
-
-(* pattern "[^<>\"'=/\\s]+" *)
-
-let map_attribute_value (env : env) (tok : CST.attribute_value) = token env tok
-
-(* pattern "[^<>\"'=\\s]+" *)
-
-let map_script_start_tag_name (env : env) (tok : CST.script_start_tag_name) =
-  token env tok
-
-(* script_start_tag_name *)
-
-let map_pat_58fbb2e (env : env) (tok : CST.pat_58fbb2e) = token env tok
-
-(* pattern "[^']+" *)
-
-let map_directive_name (env : env) (tok : CST.directive_name) = token env tok
-
-(* directive_name *)
-
-let map_implicit_end_tag (env : env) (tok : CST.implicit_end_tag) =
-  token env tok
-
-(* implicit_end_tag *)
-
-let map_start_tag_name (env : env) (tok : CST.start_tag_name) = token env tok
-
-(* start_tag_name *)
-
-let map_style_start_tag_name (env : env) (tok : CST.style_start_tag_name) =
-  token env tok
-
-(* style_start_tag_name *)
-
-let map_comment (env : env) (tok : CST.comment) = token env tok
-
-(* comment *)
-
-let map_directive_shorthand (env : env) (tok : CST.directive_shorthand) =
-  token env tok
-
-(* directive_shorthand *)
-
-let map_raw_text (env : env) (tok : CST.raw_text) = token env tok
-
-(* raw_text *)
-
-let map_template_start_tag_name (env : env) (tok : CST.template_start_tag_name)
-    =
-  token env tok
-
-(* template_start_tag_name *)
-
-let map_directive_dynamic_argument_value (env : env)
-    (tok : CST.directive_dynamic_argument_value) =
-  token env tok
-
-(* pattern "[^<>\"'/=\\s\\]]+" *)
-
-let map_directive_modifier (env : env) (tok : CST.directive_modifier) =
-  token env tok
-
-(* pattern "[^<>\"'/=\\s.]+" *)
-
-let map_directive_argument (env : env) (tok : CST.directive_argument) =
-  token env tok
-
-(* pattern "[^<>\"'/=\\s.]+" *)
-
-let map_erroneous_end_tag_name (env : env) (tok : CST.erroneous_end_tag_name) =
-  token env tok
-
-(* erroneous_end_tag_name *)
-
-let map_end_tag (env : env) ((v1, v2, v3) : CST.end_tag) =
+let map_end_tag (env : env) ((v1, v2, v3) : CST.end_tag) : tok =
   let v1 = token env v1 (* "</" *) in
   let v2 = token env v2 (* end_tag_name *) in
   let v3 = token env v3 (* ">" *) in
-  todo env (v1, v2, v3)
+  PI.combine_infos v1 [ v2; v3 ]
 
 let map_text (env : env) (x : CST.text) =
   match x with
-  | `Text_frag tok -> token env tok (* text_fragment *)
-  | `LCURLLCURL tok -> token env tok
+  | `Text_frag tok -> str env tok (* text_fragment *)
+  (* ?? not an interpolation? *)
+  | `LCURLLCURL tok -> str env tok
 
 (* "{{" *)
 
-let map_quoted_attribute_value (env : env) (x : CST.quoted_attribute_value) =
+let map_quoted_attribute_value (env : env) (x : CST.quoted_attribute_value) :
+    string wrap =
   match x with
   | `SQUOT_opt_pat_58fbb2e_SQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "'" *) in
-      let v2 =
+      let s, ts =
         match v2 with
-        | Some tok -> token env tok (* pattern "[^']+" *)
-        | None -> todo env ()
+        | Some tok ->
+            let s, t = str env tok (* pattern "[^']+" *) in
+            (s, [ t ])
+        | None -> ("", [])
       in
       let v3 = token env v3 (* "'" *) in
-      todo env (v1, v2, v3)
+      (s, PI.combine_infos v1 (ts @ [ v3 ]))
   | `DQUOT_opt_pat_98d585a_DQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "\"" *) in
-      let v2 =
+      let s, ts =
         match v2 with
-        | Some tok -> token env tok (* pattern "[^\"]+" *)
-        | None -> todo env ()
+        | Some tok ->
+            let s, t = str env tok (* pattern "[^\"]+" *) in
+            (s, [ t ])
+        | None -> ("", [])
       in
       let v3 = token env v3 (* "\"" *) in
-      todo env (v1, v2, v3)
+      (s, PI.combine_infos v1 (ts @ [ v3 ]))
 
 let map_directive_modifiers (env : env) (xs : CST.directive_modifiers) =
   List.map
     (fun (v1, v2) ->
       let v1 = token env v1 (* "." *) in
-      let v2 = token env v2 (* pattern "[^<>\"'/=\\s.]+" *) in
-      todo env (v1, v2))
+      let v2 = str env v2 (* pattern "[^<>\"'/=\\s.]+" *) in
+      (v1, v2))
     xs
 
 let map_anon_choice_attr_value_5986531 (env : env)
-    (x : CST.anon_choice_attr_value_5986531) =
+    (x : CST.anon_choice_attr_value_5986531) : xml_attr_value =
   match x with
-  | `Attr_value tok -> token env tok (* pattern "[^<>\"'=\\s]+" *)
-  | `Quoted_attr_value x -> map_quoted_attribute_value env x
+  | `Attr_value tok ->
+      let x = str env tok (* pattern "[^<>\"'=\\s]+" *) in
+      N (Id (x, G.empty_id_info ()))
+  | `Quoted_attr_value x ->
+      let x = map_quoted_attribute_value env x in
+      L (String x)
 
 let map_anon_choice_dire_arg_b33821e (env : env)
     (x : CST.anon_choice_dire_arg_b33821e) =
   match x with
-  | `Dire_arg tok -> token env tok (* pattern "[^<>\"'/=\\s.]+" *)
+  | `Dire_arg tok ->
+      let id = str env tok (* pattern "[^<>\"'/=\\s.]+" *) in
+      Left id
   | `Dire_dyna_arg (v1, v2, v3) ->
       let v1 = token env v1 (* "[" *) in
       let v2 =
         match v2 with
-        | Some tok -> token env tok (* pattern "[^<>\"'/=\\s\\]]+" *)
-        | None -> todo env ()
+        | Some tok -> Some (str env tok) (* pattern "[^<>\"'/=\\s\\]]+" *)
+        | None -> None
       in
       let v3 = token env v3 (* "]" *) in
-      todo env (v1, v2, v3)
+      Right (v1, v2, v3)
 
 let map_anon_choice_attr_a1991da (env : env) (x : CST.anon_choice_attr_a1991da)
-    =
+    : xml_attribute =
   match x with
   | `Attr (v1, v2) ->
-      let v1 = token env v1 (* pattern "[^<>\"'=/\\s]+" *) in
-      let v2 =
+      let id = str env v1 (* pattern "[^<>\"'=/\\s]+" *) in
+      let teq, v2 =
         match v2 with
         | Some (v1, v2) ->
             let v1 = token env v1 (* "=" *) in
             let v2 = map_anon_choice_attr_value_5986531 env v2 in
-            todo env (v1, v2)
-        | None -> todo env ()
+            (v1, v2)
+        | None ->
+            (* <foo a /> <=> <foo a=true>? That's what we do for JSX, but should
+             * we instead introduce a XmlAttrNoValue in AST_generic?
+             *)
+            let v = L (Bool (true, fake "true")) in
+            (fake "=", v)
       in
-      todo env (v1, v2)
+      XmlAttr (id, teq, v2)
   | `Dire_attr (v1, v2, v3) ->
-      let v1 =
+      let id =
         match v1 with
         | `Dire_name_opt_COLON_choice_dire_arg (v1, v2) ->
-            let v1 = token env v1 (* directive_name *) in
-            let v2 =
+            let v1 = str env v1 (* directive_name *) in
+            let _v2TODO =
               match v2 with
               | Some (v1, v2) ->
                   let v1 = token env v1 (* ":" *) in
                   let v2 = map_anon_choice_dire_arg_b33821e env v2 in
-                  todo env (v1, v2)
-              | None -> todo env ()
+                  Some (v1, v2)
+              | None -> None
             in
-            todo env (v1, v2)
+            v1
         | `Dire_shor_choice_dire_arg (v1, v2) ->
-            let v1 = token env v1 (* directive_shorthand *) in
-            let v2 = map_anon_choice_dire_arg_b33821e env v2 in
-            todo env (v1, v2)
+            let v1 = str env v1 (* directive_shorthand *) in
+            let _v2 = map_anon_choice_dire_arg_b33821e env v2 in
+            v1
       in
-      let v2 =
-        match v2 with
-        | Some x -> map_directive_modifiers env x
-        | None -> todo env ()
+      let _v2TODO =
+        match v2 with Some x -> map_directive_modifiers env x | None -> []
       in
-      let v3 =
+      let teq, v3 =
         match v3 with
         | Some (v1, v2) ->
             let v1 = token env v1 (* "=" *) in
             let v2 = map_anon_choice_attr_value_5986531 env v2 in
-            todo env (v1, v2)
-        | None -> todo env ()
+            (v1, v2)
+        | None ->
+            (* <foo a /> <=> <foo a=true>? That's what we do for JSX, but should
+             * we instead introduce a XmlAttrNoValue in AST_generic?
+             *)
+            let v = L (Bool (true, fake "true")) in
+            (fake "=", v)
       in
-      todo env (v1, v2, v3)
+      (* TODO: XmlDynAttr? *)
+      XmlAttr (id, teq, v3)
 
 let map_start_tag (env : env) ((v1, v2, v3, v4) : CST.start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* start_tag_name *) in
+  let v2 = str env v2 (* start_tag_name *) in
   let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+  (v1, v2, v3, v4)
 
 let map_template_start_tag (env : env)
     ((v1, v2, v3, v4) : CST.template_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* template_start_tag_name *) in
+  let v2 = str env v2 (* template_start_tag_name *) in
   let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+  (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* style_start_tag_name *) in
+  let v2 = str env v2 (* style_start_tag_name *) in
   let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+  (v1, v2, v3, v4)
 
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = token env v2 (* script_start_tag_name *) in
+  let v2 = str env v2 (* script_start_tag_name *) in
   let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
-  todo env (v1, v2, v3, v4)
+  (v1, v2, v3, v4)
 
-let map_style_element (env : env) ((v1, v2, v3) : CST.style_element) =
-  let v1 = map_style_start_tag env v1 in
+let map_style_element (env : env) ((v1, v2, v3) : CST.style_element) : xml =
+  let l, id, attrs, r = map_style_start_tag env v1 in
   let v2 =
     match v2 with
-    | Some tok -> token env tok (* raw_text *)
-    | None -> todo env ()
+    | Some tok -> [ XmlText (str env tok) (* raw_text *) ]
+    | None -> []
   in
   let v3 = map_end_tag env v3 in
-  todo env (v1, v2, v3)
+  { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
 
-let map_script_element (env : env) ((v1, v2, v3) : CST.script_element) =
-  let v1 = map_script_start_tag env v1 in
+let map_script_element (env : env) ((v1, v2, v3) : CST.script_element) : xml =
+  let l, id, attrs, r = map_script_start_tag env v1 in
   let v2 =
     match v2 with
-    | Some tok -> token env tok (* raw_text *)
-    | None -> todo env ()
+    | Some tok -> [ XmlText (str env tok) (* raw_text *) ]
+    | None -> []
   in
   let v3 = map_end_tag env v3 in
-  todo env (v1, v2, v3)
+  { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
 
-let rec map_element (env : env) (x : CST.element) =
+let rec map_element (env : env) (x : CST.element) : xml =
   match x with
   | `Start_tag_rep_node_choice_end_tag (v1, v2, v3) ->
-      let v1 = map_start_tag env v1 in
-      let v2 = List.map (map_node env) v2 in
+      let l, id, attrs, r = map_start_tag env v1 in
+      let v2 = List.map (map_node env) v2 |> List.flatten in
       let v3 =
         match v3 with
         | `End_tag x -> map_end_tag env x
         | `Impl_end_tag tok -> token env tok
         (* implicit_end_tag *)
       in
-      todo env (v1, v2, v3)
+      { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
   | `Self_clos_tag (v1, v2, v3, v4) ->
-      let v1 = token env v1 (* "<" *) in
-      let v2 = token env v2 (* start_tag_name *) in
-      let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
-      let v4 = token env v4 (* "/>" *) in
-      todo env (v1, v2, v3, v4)
+      let l = token env v1 (* "<" *) in
+      let id = str env v2 (* start_tag_name *) in
+      let attrs = List.map (map_anon_choice_attr_a1991da env) v3 in
+      let r = token env v4 (* "/>" *) in
+      { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
 
-and map_node (env : env) (x : CST.node) =
+and map_node (env : env) (x : CST.node) : xml_body list =
   match x with
-  | `Comm tok -> token env tok (* comment *)
-  | `Text x -> map_text env x
+  | `Comm tok ->
+      let _x = token env tok (* comment *) in
+      []
+  | `Text x ->
+      let x = map_text env x in
+      [ XmlText x ]
   | `Interp (v1, v2, v3) ->
       let v1 = token env v1 (* "{{" *) in
       let v2 =
         match v2 with
-        | Some tok -> token env tok (* interpolation_text *)
-        | None -> todo env ()
+        | Some tok ->
+            let x = str env tok (* interpolation_text *) in
+            (* TODO: parse as JS *)
+            Some (L (String x))
+        | None -> None
       in
       let v3 = token env v3 (* "}}" *) in
-      todo env (v1, v2, v3)
-  | `Elem x -> map_element env x
-  | `Temp_elem x -> map_template_element env x
-  | `Script_elem x -> map_script_element env x
-  | `Style_elem x -> map_style_element env x
+      [ XmlExpr (v1, v2, v3) ]
+  | `Elem x ->
+      let xml = map_element env x in
+      [ XmlXml xml ]
+  | `Temp_elem x ->
+      let xml = map_template_element env x in
+      [ XmlXml xml ]
+  (* TODO: parse as JS *)
+  | `Script_elem x ->
+      let xml = map_script_element env x in
+      [ XmlXml xml ]
+  (* less: parse as CSS *)
+  | `Style_elem x ->
+      let xml = map_style_element env x in
+      [ XmlXml xml ]
   | `Errons_end_tag (v1, v2, v3) ->
-      let v1 = token env v1 (* "</" *) in
-      let v2 = token env v2 (* erroneous_end_tag_name *) in
-      let v3 = token env v3 (* ">" *) in
-      todo env (v1, v2, v3)
+      let l = token env v1 (* "</" *) in
+      let id = str env v2 (* erroneous_end_tag_name *) in
+      let r = token env v3 (* ">" *) in
+      (* todo? raise an exn instead? *)
+      let xml =
+        { xml_kind = XmlSingleton (l, id, r); xml_attrs = []; xml_body = [] }
+      in
+      [ XmlXml xml ]
 
-and map_template_element (env : env) ((v1, v2, v3) : CST.template_element) =
-  let v1 = map_template_start_tag env v1 in
-  let v2 = List.map (map_node env) v2 in
+and map_template_element (env : env) ((v1, v2, v3) : CST.template_element) : xml
+    =
+  let l, id, attrs, r = map_template_start_tag env v1 in
+  let v2 = List.map (map_node env) v2 |> List.flatten in
   let v3 = map_end_tag env v3 in
-  todo env (v1, v2, v3)
+  { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
 
-let map_component (env : env) (xs : CST.component) =
+let map_component (env : env) (xs : CST.component) : xml list =
   List.map
     (fun x ->
       match x with
-      | `Comm tok -> token env tok (* comment *)
-      | `Elem x -> map_element env x
-      | `Temp_elem x -> map_template_element env x
-      | `Script_elem x -> map_script_element env x
-      | `Style_elem x -> map_style_element env x)
+      | `Comm tok ->
+          let _x = token env tok (* comment *) in
+          []
+      | `Elem x ->
+          let xml = map_element env x in
+          [ xml ]
+      | `Temp_elem x ->
+          let xml = map_template_element env x in
+          [ xml ]
+      (* TODO: parse as JS *)
+      | `Script_elem x ->
+          let xml = map_script_element env x in
+          [ xml ]
+      (* less: parse as CSS *)
+      | `Style_elem x ->
+          let xml = map_style_element env x in
+          [ xml ])
     xs
+  |> List.flatten
 
 (*****************************************************************************)
 (* Entry point *)
@@ -384,7 +335,16 @@ let parse file =
 
       try
         let xs = map_component env cst in
-        failwith "TODO"
+        let xml =
+          {
+            xml_kind = XmlFragment (fake "", fake "");
+            xml_attrs = [];
+            xml_body = xs |> List.map (fun xml -> XmlXml xml);
+          }
+        in
+        let e = Xml xml in
+        let st = G.exprstmt e in
+        [ st ]
       with Failure "not implemented" as exn ->
         let s = Printexc.get_backtrace () in
         pr2 "Some constructs are not handled yet";

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.mli
@@ -1,1 +1,2 @@
-val parse : Common.filename -> Ast_js.a_program Tree_sitter_run.Parsing_result.t
+val parse :
+  Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t


### PR DESCRIPTION
This does not convert the <script>...</script> part
yet to JS. I'll do that in a separate PR

test plan:
```
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang vue -dump_ast tests/vue/parsing/basic.vue
[0.107  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.107  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang vue -dump_ast tests/vue/parsing/basic.vue
[0.107  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.57.0-25-gd5348a91-dirty, pfff: 0.42
[0.108  Info       Main.Parse_target    ] trying to parse with TreeSitter parser tests/vue/parsing/basic.vue
Pr(
  [ExprStmt(
     Xml(
       {xml_tag=XmlFragment((), ()); xml_attrs=[];
        xml_body=[XmlXml(
                    {xml_tag=XmlClassic((), ("template", ()), (), ());
                     xml_attrs=[];
                     xml_body=[XmlText(("  ", ()));
                               XmlXml(
                                 {xml_tag=XmlClassic((), ("p", ()), (), ());
                                  xml_attrs=[];
                                  xml_body=[XmlText(("    Hello, ", ()));
                                            XmlXml(
                                              {
                                               xml_tag=XmlClassic((),
                                                         ("a", ()), (), ());
                                               xml_attrs=[XmlAttr((":", ()),
                                                            (),
...
```




PR checklist:
- [ ] changelog is up to date