### PR TITLE
Fixed metavariable name collision during interpolation of message / autofix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Java varargs are now correctly matched (#3455)
 - Support for partial statements (e.g., `try { ... }`) for Java (#3417)
 - Constant propagation now works inside Python `with` statements (#3402)
+- Metavariable value replacement in message/autofix no longer mixes up short and long names like $X vs $X2 (#3458)
 
 ### Changed
 - Faster matching times for generic mode

--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -492,12 +492,17 @@ def interpolate_string_with_metavariables(
     text: str, pattern_match: PatternMatch, propagated_metavariables: Dict[str, str]
 ) -> str:
     """Interpolates a string with the metavariables contained in it, returning a new string"""
-    for metavariable in pattern_match.metavariables:
+
+    # Sort by metavariable length to avoid name collisions (eg. $X2 must be handled before $X)
+    for metavariable in sorted(pattern_match.metavariables, key=len, reverse=True):
         text = text.replace(
             metavariable, pattern_match.get_metavariable_value(metavariable)
         )
-    for metavariable, metavariable_text in propagated_metavariables.items():
-        text = text.replace(metavariable, metavariable_text)
+
+    # Sort by metavariable length to avoid name collisions (eg. $X2 must be handled before $X)
+    for metavariable in sorted(propagated_metavariables.keys(), key=len, reverse=True):
+        text = text.replace(metavariable, propagated_metavariables[metavariable])
+
     return text
 
 

--- a/semgrep/tests/unit/test_evaluation.py
+++ b/semgrep/tests/unit/test_evaluation.py
@@ -12,6 +12,7 @@ import pytest
 from semgrep.error import SemgrepError
 from semgrep.evaluation import enumerate_patterns_in_boolean_expression
 from semgrep.evaluation import evaluate_expression as raw_evaluate_expression
+from semgrep.evaluation import interpolate_string_with_metavariables
 from semgrep.pattern_match import PatternMatch
 from semgrep.rule import Rule
 from semgrep.semgrep_types import BooleanRuleExpression
@@ -558,3 +559,14 @@ def test_single_pattern_match_filtering() -> None:
     ]
     result = evaluate_expression(expression, results)
     assert result == set(), f"{result}"
+
+
+def test_interpolation() -> None:
+    pattern_match = PatternMatchMock(0, 100, {"$X": {"abstract_content": "VALUE1"}})
+
+    text = "Expect $X to be VALUE1"
+    expected = "Expect VALUE1 to be VALUE1"
+
+    result = interpolate_string_with_metavariables(text, pattern_match, {})
+
+    assert result == expected

--- a/semgrep/tests/unit/test_evaluation.py
+++ b/semgrep/tests/unit/test_evaluation.py
@@ -562,10 +562,14 @@ def test_single_pattern_match_filtering() -> None:
 
 
 def test_interpolation() -> None:
-    pattern_match = PatternMatchMock(0, 100, {"$X": {"abstract_content": "VALUE1"}})
+    pattern_match = PatternMatchMock(
+        0,
+        100,
+        {"$X": {"abstract_content": "VALUE1"}, "$X2": {"abstract_content": "VALUE2"}},
+    )
 
-    text = "Expect $X to be VALUE1"
-    expected = "Expect VALUE1 to be VALUE1"
+    text = "Expect $X to be VALUE1 and $X2 to be VALUE2"
+    expected = "Expect VALUE1 to be VALUE1 and VALUE2 to be VALUE2"
 
     result = interpolate_string_with_metavariables(text, pattern_match, {})
 


### PR DESCRIPTION
Fixes #3458 where the string interpolation process used for both `message` display and `autofix` replacement was having issues with name collisions. This was happening if there were two metavariables in which one name was a subset of another name (eg. `$X` vs `$X2`); since the metavariables are replaced one-by-one in no particular order the shorter one could be hit first and replace part of the longer one. In the previous example this would replace `$X` with its value and `$X2` with the value of `$X` with `2` tacked on the end.

This PR sorts the metavariable names in descending length order so that longer names such as `$X2` will always be resolved before the shorter ones. To keep behavior consistent, it also combines the two interpolation functions into one and adds a unit test for them.

Original example snippet from the issue: https://semgrep.dev/s/xePj

PR checklist:
- [x] changelog is up to date

