### PR TITLE
Update lingering use of anonymized language in PRIVACY.md

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -31,8 +31,8 @@ Environmental data provides contextual data about Semgrep’s runtime environmen
 * If the command ran in a CI environment
 * The version of Semgrep
 * The user’s OS and shell
-* Anonymized hash of the scanned project’s name
-* Anonymized hash of the rules run
+* De-identified hash of the scanned project’s name
+* De-identified hash of the rules run
 
 ### Performance
 


### PR DESCRIPTION
Cleaning up lingering use of "anonymized" in PRIVACY.md to accurately reflect the nature of hashes: they are de-identified data.