### PR TITLE
Add deprecation notice if using any experimental features not in optimized semgrep-core

### DIFF
--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -12,6 +12,7 @@ from typing import Tuple
 from typing import Union
 
 import attr
+from colorama import Fore
 
 from semgrep.autofix import apply_fixes
 from semgrep.config_resolver import get_config
@@ -34,6 +35,7 @@ from semgrep.semgrep_types import TAINT_MODE
 from semgrep.target_manager import TargetManager
 from semgrep.util import manually_search_file
 from semgrep.util import sub_check_output
+from semgrep.util import with_color
 from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
@@ -259,6 +261,9 @@ The two most popular are:
                 "Running without optimizations since running pattern-where-python rules"
             )
             optimizations = "none"
+        elif any(len(rule.equivalences) > 0 for rule in filtered_rules):
+            logger.info("Running without optimizations since running equivalence rules")
+            optimizations = "none"
 
     start_time = time.time()
     # actually invoke semgrep
@@ -370,6 +375,21 @@ The two most popular are:
         filtered_rules,
         profiling_data,
     )
+
+    if optimizations == "none":
+        logger.warning(
+            with_color(
+                Fore.RED,
+                "Deprecation Notice: running with `--optimizations none` will be deprecated by 0.60.0\n"
+                "This includes the following functionality:\n"
+                "- pattern-where-python\n"
+                "- taint-mode\n"
+                "- equivalences\n"
+                "- step-by-step evaluation output\n"
+                "If you are seeing this notice, without specifing `--optimizations none` it means the rules\n"
+                "you are running are using some of this functionality.",
+            )
+        )
 
     if autofix:
         apply_fixes(rule_matches_by_rule, dryrun)

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -265,6 +265,21 @@ The two most popular are:
             logger.info("Running without optimizations since running equivalence rules")
             optimizations = "none"
 
+    if optimizations == "none":
+        logger.warning(
+            with_color(
+                Fore.RED,
+                "Deprecation Notice: running with `--optimizations none` will be deprecated by 0.60.0\n"
+                "This includes the following functionality:\n"
+                "- pattern-where-python\n"
+                "- taint-mode\n"
+                "- equivalences\n"
+                "- step-by-step evaluation output\n"
+                "If you are seeing this notice, without specifing `--optimizations none` it means the rules\n"
+                "you are running are using some of this functionality.",
+            )
+        )
+
     start_time = time.time()
     # actually invoke semgrep
     if optimizations == "none":
@@ -375,21 +390,6 @@ The two most popular are:
         filtered_rules,
         profiling_data,
     )
-
-    if optimizations == "none":
-        logger.warning(
-            with_color(
-                Fore.RED,
-                "Deprecation Notice: running with `--optimizations none` will be deprecated by 0.60.0\n"
-                "This includes the following functionality:\n"
-                "- pattern-where-python\n"
-                "- taint-mode\n"
-                "- equivalences\n"
-                "- step-by-step evaluation output\n"
-                "If you are seeing this notice, without specifing `--optimizations none` it means the rules\n"
-                "you are running are using some of this functionality.",
-            )
-        )
 
     if autofix:
         apply_fixes(rule_matches_by_rule, dryrun)

--- a/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
+++ b/semgrep/tests/e2e/snapshots/test_equivalence/test_equivalence/results.json
@@ -13,23 +13,6 @@
         "message": "",
         "metadata": {},
         "metavars": {
-          "$FUNC": {
-            "abstract_content": "arg",
-            "end": {
-              "col": 8,
-              "line": 7,
-              "offset": 171
-            },
-            "start": {
-              "col": 5,
-              "line": 7,
-              "offset": 168
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          },
           "$W": {
             "abstract_content": "POST",
             "end": {
@@ -68,23 +51,6 @@
         "message": "",
         "metadata": {},
         "metavars": {
-          "$FUNC": {
-            "abstract_content": "argh",
-            "end": {
-              "col": 9,
-              "line": 12,
-              "offset": 266
-            },
-            "start": {
-              "col": 5,
-              "line": 12,
-              "offset": 262
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          },
           "$W": {
             "abstract_content": "get_host",
             "end": {

--- a/semgrep/tests/e2e/test_api.py
+++ b/semgrep/tests/e2e/test_api.py
@@ -31,4 +31,13 @@ def test_api(capsys, run_semgrep_in_tmp):
         stderr=subprocess.PIPE,
     )
     assert x.stdout == ""
-    assert x.stderr == ""
+    assert x.stderr == (
+        "Deprecation Notice: running with `--optimizations none` will be deprecated by 0.60.0\n"
+        "This includes the following functionality:\n"
+        "- pattern-where-python\n"
+        "- taint-mode\n"
+        "- equivalences\n"
+        "- step-by-step evaluation output\n"
+        "If you are seeing this notice, without specifing `--optimizations none` it means the rules\n"
+        "you are running are using some of this functionality.\n"
+    )


### PR DESCRIPTION
Returns to using `--optimizations none` when running any rule with equivalences.

Informs user that the following features will be deprecated by 0.60.0 if we detect they are using them
- pattern-where-python
- taint-mode
- equivalences
- step-by-step evaluation output
