### PR TITLE
Parsing embedded JS in <script> in vue files

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -1456,6 +1456,9 @@ let options () =
             Common.profile := Common.ProfAll;
             profile := true),
         " output profiling information" );
+      ( "-keep_tmp_files",
+        Arg.Set Common.save_tmp_files,
+        " keep temporary generated files" );
     ]
   (*x: [[Main_semgrep_core.options]] concatenated flags *)
   @ Meta_parse_info.cmdline_flags_precision ()

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -323,7 +323,13 @@ let map_component (env : env) (xs : CST.component) : stmt list =
       | `Temp_elem x ->
           let xml = map_template_element env x in
           [ G.exprstmt (Xml xml) ]
-      (* TODO: parse as JS *)
+      (* Note that right now the AST will not contain the enclosing
+       * <script>, because XmlExpr contain single expressions, not
+       * full programs, so it's simpler to just lift up the
+       * program and remove the enclosing <script>. If at some point
+       * people want to explicitly restrict their code search to
+       * the <script> part we might revisit that.
+       *)
       | `Script_elem x -> (
           let _l, _id, _r, _rend, _xml_attrs, body_opt =
             map_script_element env x

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -30,7 +30,13 @@ module G = AST_generic
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
-type env = unit H.env
+type extra = {
+  (* todo: later we should also propagate parsing errors *)
+  parse_js_program : string wrap -> AST_generic.program;
+  parse_js_expr : string wrap -> AST_generic.expr;
+}
+
+type env = extra H.env
 
 let fake = AST_generic.fake
 
@@ -218,15 +224,13 @@ let map_style_element (env : env) ((v1, v2, v3) : CST.style_element) : xml =
   let v3 = map_end_tag env v3 in
   { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
 
-let map_script_element (env : env) ((v1, v2, v3) : CST.script_element) : xml =
+let map_script_element (env : env) ((v1, v2, v3) : CST.script_element) =
   let l, id, attrs, r = map_script_start_tag env v1 in
   let v2 =
-    match v2 with
-    | Some tok -> [ XmlText (str env tok) (* raw_text *) ]
-    | None -> []
+    match v2 with Some tok -> Some (str env tok) (* raw_text *) | None -> None
   in
   let v3 = map_end_tag env v3 in
-  { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
+  (l, id, r, v3, attrs, v2)
 
 let rec map_element (env : env) (x : CST.element) : xml =
   match x with
@@ -273,9 +277,17 @@ and map_node (env : env) (x : CST.node) : xml_body list =
   | `Temp_elem x ->
       let xml = map_template_element env x in
       [ XmlXml xml ]
-  (* TODO: parse as JS *)
   | `Script_elem x ->
-      let xml = map_script_element env x in
+      let l, id, r, rend, xml_attrs, body_opt = map_script_element env x in
+      let xml_body =
+        match body_opt with
+        (* TODO: parse as JS *)
+        | Some s -> [ XmlText s ]
+        | None -> []
+      in
+      let xml =
+        { xml_kind = XmlClassic (l, id, r, rend); xml_attrs; xml_body }
+      in
       [ XmlXml xml ]
   (* less: parse as CSS *)
   | `Style_elem x ->
@@ -298,7 +310,7 @@ and map_template_element (env : env) ((v1, v2, v3) : CST.template_element) : xml
   let v3 = map_end_tag env v3 in
   { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
 
-let map_component (env : env) (xs : CST.component) : xml list =
+let map_component (env : env) (xs : CST.component) : stmt list =
   List.map
     (fun x ->
       match x with
@@ -307,44 +319,54 @@ let map_component (env : env) (xs : CST.component) : xml list =
           []
       | `Elem x ->
           let xml = map_element env x in
-          [ xml ]
+          [ G.exprstmt (Xml xml) ]
       | `Temp_elem x ->
           let xml = map_template_element env x in
-          [ xml ]
+          [ G.exprstmt (Xml xml) ]
       (* TODO: parse as JS *)
-      | `Script_elem x ->
-          let xml = map_script_element env x in
-          [ xml ]
+      | `Script_elem x -> (
+          let _l, _id, _r, _rend, _xml_attrs, body_opt =
+            map_script_element env x
+          in
+          match body_opt with
+          | Some s -> env.extra.parse_js_program s
+          | None -> [] )
       (* less: parse as CSS *)
       | `Style_elem x ->
           let xml = map_style_element env x in
-          [ xml ])
+          [ G.exprstmt (Xml xml) ])
     xs
   |> List.flatten
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
-let parse file =
+
+(* TODO: move in Parse_tree_sitter_helpers.ml *)
+let parse_string_and_adjust_wrt_base content _tbaseTODO fparse =
+  Common2.with_tmp_file ~str:content ~ext:"js" (fun file -> fparse file)
+
+let parse parse_js file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
       Parallel.invoke Tree_sitter_vue.Parse.file file ())
     (fun cst ->
-      let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
+      let extra =
+        {
+          parse_js_program =
+            (fun (s, t) -> parse_string_and_adjust_wrt_base s t parse_js);
+          parse_js_expr =
+            (fun (s, t) ->
+              let _xs = parse_string_and_adjust_wrt_base s t parse_js in
+              failwith "TODO: extract expr");
+        }
+      in
+      let env = { H.file; conv = H.line_col_to_pos file; extra } in
 
       try
         let xs = map_component env cst in
-        let xml =
-          {
-            xml_kind = XmlFragment (fake "", fake "");
-            xml_attrs = [];
-            xml_body = xs |> List.map (fun xml -> XmlXml xml);
-          }
-        in
-        let e = Xml xml in
-        let st = G.exprstmt e in
-        [ st ]
+        xs
       with Failure "not implemented" as exn ->
         let s = Printexc.get_backtrace () in
         pr2 "Some constructs are not handled yet";

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.mli
@@ -1,2 +1,5 @@
 val parse :
-  Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t
+  ((* to parse the JS inside <script> *)
+   Common.filename -> AST_generic.program) ->
+  Common.filename ->
+  AST_generic.program Tree_sitter_run.Parsing_result.t

--- a/semgrep-core/tests/vue/parsing/single_line_script.vue
+++ b/semgrep-core/tests/vue/parsing/single_line_script.vue
@@ -1,0 +1,3 @@
+<script>
+foo(1, 2)
+</script>


### PR DESCRIPTION
test plan:
```
pad@yrax yy (vue_p2)]$ yy -lang vue -dump_ast tests/vue/parsing/single_line_script.vue
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang vue -dump_ast tests/vue/parsing/single_line_script.vue
[0.111  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.111  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang vue -dump_ast tests/vue/parsing/single_line_script.vue
[0.111  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.57.0-26-g6a669dcb-dirty, pfff: 0.42
[0.112  Info       Main.Parse_target    ] trying to parse with TreeSitter parser tests/vue/parsing/single_line_script.vue
[0.112  Info       Main.Parse_target    ] trying to parse with TreeSitter parser /tmp/tmp-21439-4f2ff5.js
Pr(
  [ExprStmt(
     Call(
       N(
         Id(("foo", ()),
           {id_resolved=Ref(None); id_type=Ref(None); id_constness=Ref(None); })),
       [Arg(L(Float((Some(1.000000), ()))));
        Arg(L(Float((Some(2.000000), ()))))]), ())])
```

I have a problem with multi-lines scripts, but that's for another PR.




PR checklist:
- [x] changelog is up to date