### PR TITLE
taint-mode: Specify sources/sanitizers/sinks using pattern formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+- New iteration of taint-mode that allows to specify sources/sanitizers/sinks
+  using arbitrary pattern formulas. This provides plenty of flexibility. Note
+  that we breaks compatibility with the previous taint-mode format, e.g.
+  `- source(...)` must now be written as `- pattern: source(...)`.
+
 ### Fixed
 - Apple M1: Semgrep installed from HomeBrew no longer hangs (#2432)
 - Ruby command shells are distinguished from strings (#3343)

--- a/semgrep-core/src/analyzing/Dataflow_tainting.ml
+++ b/semgrep-core/src/analyzing/Dataflow_tainting.ml
@@ -17,6 +17,7 @@
 (*e: pad/r2c copyright *)
 open Common
 open IL
+module G = AST_generic
 module F = IL
 module D = Dataflow
 module VarMap = Dataflow.VarMap
@@ -46,11 +47,10 @@ type fun_env = (Dataflow.var, unit) Hashtbl.t
 
 (*s: type [[Dataflow_tainting.config]] *)
 type config = {
-  is_source : IL.instr -> bool;
-  is_source_exp : IL.exp -> bool;
-  is_sink : IL.instr -> bool;
-  is_sanitizer : IL.instr -> bool;
-  found_tainted_sink : IL.instr -> unit Dataflow.env -> unit;
+  is_source : G.any -> bool;
+  is_sink : G.any -> bool;
+  is_sanitizer : G.any -> bool;
+  found_tainted_sink : G.any -> unit Dataflow.env -> unit;
 }
 (** This can use semgrep patterns under the hood. Note that a source can be an
   * instruction but also an expression. *)
@@ -90,44 +90,81 @@ let option_to_varmap = function
 (* Tainted *)
 (*****************************************************************************)
 
-let sanitized config instr =
+let sanitized_instr config instr =
   match instr.i with
   | Call (_, { e = Fetch { base = Var (("sanitize", _), _); _ }; _ }, []) ->
       true
-  | ___else___ -> config.is_sanitizer instr
+  | ___else___ -> config.is_sanitizer (G.E instr.iorig)
 
-let rec tainted config fun_env env exp =
-  (* We call `tainted` recursively on each subexpression, so each subexpression
-   * is checked against `pattern-sources`. For example, if `location.href` were
-   * a source, this would infer that `"aa" + location.href + "bb"` is tainted.
-   * Also note that any arbitrary expression can be source! *)
-  let is_tainted = tainted config fun_env env in
-  let go_into = function
-    | Fetch { base = Var var; _ } ->
+(* Test whether an expression is tainted, and if it is also a sink,
+ * report the finding too (by side effect).
+ *
+ * When [in_a_sink] we do not report findings but wait for the finding
+ * to be reported by the caller. E.g. if the pattern-sink is `sink(...)`
+ * then `E` in `sink(E)` will also satisfy [config.is_sink], but we
+ * want to report the finding on `sink(E)` rather than on `E`. *)
+let rec check_tainted_expr ~in_a_sink config fun_env env exp =
+  let is_sink = config.is_sink (G.E exp.eorig) in
+  let check =
+    check_tainted_expr ~in_a_sink:(in_a_sink || is_sink) config fun_env env
+  in
+  let check_base = function
+    | Var var ->
         VarMap.mem (str_of_name var) env
         || Hashtbl.mem fun_env (str_of_name var)
+    | VarSpecial _ -> false
+    | Mem e -> check e
+  in
+  let check_offset = function
+    | NoOffset | Dot _ -> false
+    | Index e -> check e
+  in
+  let check_subexpr = function
     | Fetch { base = VarSpecial (This, _); offset = Dot fld; _ } ->
         Hashtbl.mem fun_env (str_of_name fld)
-    | Fetch _ | Literal _ | FixmeExp _ -> false
-    | Composite (_, (_, es, _)) | Operator (_, es) -> List.exists is_tainted es
-    | Record fields -> List.exists (fun (_, e) -> is_tainted e) fields
-    | Cast (_, e) -> is_tainted e
+    | Fetch { base; offset; _ } -> check_base base || check_offset offset
+    | Literal _ | FixmeExp _ -> false
+    | Composite (_, (_, es, _)) | Operator (_, es) -> List.exists check es
+    | Record fields -> List.exists (fun (_, e) -> check e) fields
+    | Cast (_, e) -> check e
   in
-  config.is_source_exp exp || go_into exp.e
+  let is_sanitized = config.is_sanitizer (G.E exp.eorig) in
+  (not is_sanitized)
+  &&
+  let is_tainted = config.is_source (G.E exp.eorig) || check_subexpr exp.e in
+  if is_tainted && is_sink && not in_a_sink then
+    config.found_tainted_sink (G.E exp.eorig) env;
+  is_tainted
 
-let tainted_instr config fun_env env instr =
-  let is_tainted = tainted config fun_env env in
+(* Test whether an instruction is tainted, and if it is also a sink,
+ * report the finding too (by side effect). *)
+let check_tainted_instr config fun_env env instr =
+  let is_sink = config.is_sink (G.E instr.iorig) in
+  let check_expr = check_tainted_expr ~in_a_sink:is_sink config fun_env env in
   let tainted_args = function
-    | Assign (_, e) -> is_tainted e
+    | Assign (_, e) -> check_expr e
     | AssignAnon _ -> false (* TODO *)
     | Call (_, { e = Fetch { base = Var (("source", _), _); _ }; _ }, []) ->
         true
-    | Call (_, e, args) -> is_tainted e || List.exists is_tainted args
-    | CallSpecial (_, _, args) -> List.exists is_tainted args
+    | Call (_, e, args) -> check_expr e || List.exists check_expr args
+    | CallSpecial (_, _, args) -> List.exists check_expr args
     | FixmeInstr _ -> false
   in
-  (not (sanitized config instr))
-  && (config.is_source instr || tainted_args instr.i)
+  let is_sanitized = sanitized_instr config instr in
+  (not is_sanitized)
+  &&
+  let is_tainted = config.is_source (G.E instr.iorig) || tainted_args instr.i in
+  if is_tainted && is_sink then config.found_tainted_sink (G.E instr.iorig) env;
+  is_tainted
+
+(* Test whether a `return' is tainted, and if it is also a sink,
+ * report the finding too (by side effect). *)
+let check_tainted_return config fun_env env tok e =
+  let orig_return = G.s (G.Return (tok, Some e.eorig, tok)) in
+  let is_sink = config.is_sink (G.S orig_return) in
+  let check_expr = check_tainted_expr ~in_a_sink:is_sink config fun_env env e in
+  if check_expr && is_sink then config.found_tainted_sink (G.S orig_return) env;
+  check_expr
 
 (*****************************************************************************)
 (* Transfer *)
@@ -158,27 +195,17 @@ let (transfer :
   in
   let node = flow#nodes#assoc ni in
 
-  (* TODO: do that later? once everything if finished? *)
-  ( match node.F.n with
-  | NInstr x ->
-      (* TODO: use metavar in sink to know which argument we should check
-       * for taint? *)
-      if config.is_sink x && tainted_instr config fun_env in' x then
-        config.found_tainted_sink x in'
-  (* if just a single return is tainted then the function is tainted *)
-  | NReturn (_, e) when tainted config fun_env in' e -> (
-      match opt_name with
-      | Some var -> Hashtbl.add fun_env (str_of_name var) ()
-      | None -> () )
-  | Enter | Exit | TrueNode | FalseNode | Join | NCond _ | NGoto _ | NReturn _
-  | NThrow _ | NOther _ | NTodo _ ->
-      () );
-
   let gen_ni_opt =
     match node.F.n with
     | NInstr x ->
-        if tainted_instr config fun_env in' x then IL.lvar_of_instr_opt x
+        if check_tainted_instr config fun_env in' x then IL.lvar_of_instr_opt x
         else None
+    (* if just a single return is tainted then the function is tainted *)
+    | NReturn (tok, e) when check_tainted_return config fun_env in' tok e ->
+        ( match opt_name with
+        | Some var -> Hashtbl.add fun_env (str_of_name var) ()
+        | None -> () );
+        None
     | Enter | Exit | TrueNode | FalseNode | Join | NCond _ | NGoto _ | NReturn _
     | NThrow _ | NOther _ | NTodo _ ->
         None
@@ -192,7 +219,7 @@ let (transfer :
      *)
     match node.F.n with
     | NInstr x ->
-        if tainted_instr config fun_env in' x then None
+        if check_tainted_instr config fun_env in' x then None
         else
           (* all clean arguments should reset the taint *)
           IL.lvar_of_instr_opt x

--- a/semgrep-core/src/analyzing/Dataflow_tainting.mli
+++ b/semgrep-core/src/analyzing/Dataflow_tainting.mli
@@ -12,11 +12,10 @@ type fun_env = (Dataflow.var, unit) Hashtbl.t
 
 (*s: type [[Dataflow_tainting.config]] *)
 type config = {
-  is_source : IL.instr -> bool;
-  is_source_exp : IL.exp -> bool;
-  is_sink : IL.instr -> bool;
-  is_sanitizer : IL.instr -> bool;
-  found_tainted_sink : IL.instr -> unit Dataflow.env -> unit;
+  is_source : AST_generic.any -> bool;
+  is_sink : AST_generic.any -> bool;
+  is_sanitizer : AST_generic.any -> bool;
+  found_tainted_sink : AST_generic.any -> unit Dataflow.env -> unit;
 }
 (** This can use semgrep patterns under the hood. Note that a source can be an
   * instruction but also an expression. *)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -187,9 +187,9 @@ type pformula = New of formula | Old of formula_old [@@deriving show, eq]
  *)
 
 type taint_spec = {
-  sources : Pattern.t list;
-  sanitizers : Pattern.t list;
-  sinks : Pattern.t list;
+  sources : pformula list;
+  sanitizers : pformula list;
+  sinks : pformula list;
 }
 [@@deriving show]
 

--- a/semgrep-core/src/engine/Match_rules.mli
+++ b/semgrep-core/src/engine/Match_rules.mli
@@ -12,4 +12,16 @@ val check :
   Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t ->
   Report.times Report.match_result
 
+val matches_of_formula :
+  Config_semgrep_t.t ->
+  Equivalence.equivalences ->
+  string ->
+  Common.filename
+  * Rule.xlang
+  * (AST_generic.program * Error_code.error list) lazy_t ->
+  string lazy_t ->
+  Rule.formula ->
+  Range_with_metavars.t option ->
+  Report.times Report.match_result * Range_with_metavars.ranges
+
 (*e: semgrep/engine/Match_rules.mli *)

--- a/semgrep-core/src/engine/Run_rules.ml
+++ b/semgrep-core/src/engine/Run_rules.ml
@@ -18,7 +18,7 @@ module RP = Report
 
 let lazy_force x = Lazy.force x [@@profiling]
 
-let check_taint hook taint_rules file_and_more =
+let check_taint hook default_config taint_rules equivs file_and_more =
   match taint_rules with
   | [] -> RP.empty_semgrep_result
   | __else__ ->
@@ -28,7 +28,8 @@ let check_taint hook taint_rules file_and_more =
       in
       let matches, match_time =
         Common.with_time (fun () ->
-            Tainting_generic.check hook taint_rules file ast)
+            Tainting_generic.check hook default_config taint_rules equivs file
+              ast)
       in
       { RP.matches; errors; profiling = { RP.parse_time; match_time } }
 
@@ -37,5 +38,7 @@ let check hook default_config rules equivs file_and_more =
   let res_search =
     Match_rules.check hook default_config search_rules equivs file_and_more
   in
-  let res_taint = check_taint hook taint_rules file_and_more in
+  let res_taint =
+    check_taint hook default_config taint_rules equivs file_and_more
+  in
   RP.collate_semgrep_results [ res_search; res_taint ]

--- a/semgrep-core/src/engine/Tainting_generic.ml
+++ b/semgrep-core/src/engine/Tainting_generic.ml
@@ -18,7 +18,6 @@
 module AST = AST_generic
 module V = Visitor_AST
 module R = Rule
-module R2 = Mini_rule
 module PM = Pattern_match
 
 (*****************************************************************************)
@@ -47,61 +46,42 @@ module DataflowY = Dataflow.Make (struct
   let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
 end)
 
-let match_pat_eorig pat =
-  match pat with
-  | [] -> fun _ -> false
-  | xs ->
-      let xs =
-        xs
-        |> List.map (function
-             | AST.E e -> e
-             | AST.S { AST.s = AST.ExprStmt (e, _); _ } ->
-                 (* Some statements in the input language are translated into
-                  * expressions in the Generic AST. This is e.g. the case of
-                  * `echo' in PHP. This small hack allows us to annotate those
-                  * statements as souces/sanitizers/sinks. *)
-                 e
-             | _ ->
-                 failwith "Only Expr patterns are supported in tainting rules")
-      in
-      let pat = Common2.foldl1 (fun x acc -> AST.DisjExpr (x, acc)) xs in
-      fun eorig ->
-        (* the rule is just used by match_e_e for profiling stats *)
-        let rule =
-          {
-            R2.id = "<tainting>";
-            pattern = AST.E pat;
-            pattern_string = "<tainting> pat";
-            message = "";
-            severity = R2.Error;
-            languages = [];
-          }
-        in
+let any_in_ranges any ranges =
+  (* This is potentially slow. We may need to store range position in
+   * the AST at some point. *)
+  let tok1, tok2 = Visitor_AST.range_of_any any in
+  let r = { Range.start = tok1.charpos; end_ = tok2.charpos } in
+  List.exists (Range.( $<=$ ) r) ranges
 
-        let env =
-          Matching_generic.empty_environment None Config_semgrep.default_config
-        in
-        let matches_with_env = Match_patterns.match_e_e rule pat eorig env in
-        matches_with_env <> []
-
-let match_pat_exp pat exp =
-  let eorig = exp.IL.eorig in
-  match_pat_eorig pat eorig
-
-(*s: function [[Tainting_generic.match_pat_instr]] *)
-let match_pat_instr pat instr =
-  let eorig = instr.IL.iorig in
-  match_pat_eorig pat eorig
-
-(*e: function [[Tainting_generic.match_pat_instr]] *)
+let ranges_of_pformula config equivs file_and_more rule_id pformula =
+  let file, _, _ = file_and_more in
+  let lazy_content = lazy (Common.read_file file) in
+  let formula = Rule.formula_of_pformula pformula in
+  Match_rules.matches_of_formula config equivs rule_id file_and_more
+    lazy_content formula None
+  |> snd
+  |> List.map (fun rwm -> rwm.Range_with_metavars.r)
 
 (*s: function [[Tainting_generic.config_of_rule]] *)
-let config_of_rule found_tainted_sink spec =
+
+let taint_config_of_rule default_config equivs file ast_and_errors
+    (rule : R.rule) (spec : R.taint_spec) found_tainted_sink =
+  let config = Common.( ||| ) rule.options default_config in
+  let lazy_ast_and_errors = lazy ast_and_errors in
+  let file_and_more = (file, rule.languages, lazy_ast_and_errors) in
+  let find_ranges pfs =
+    (* if perf is a problem, we could build an interval set here *)
+    pfs
+    |> List.map (ranges_of_pformula config equivs file_and_more rule.id)
+    |> List.concat
+  in
+  let sources_ranges = find_ranges spec.sources
+  and sanitizers_ranges = find_ranges spec.sanitizers
+  and sinks_ranges = find_ranges spec.sinks in
   {
-    Dataflow_tainting.is_source = match_pat_instr spec.R.sources;
-    is_source_exp = match_pat_exp spec.R.sources;
-    is_sanitizer = match_pat_instr spec.R.sanitizers;
-    is_sink = match_pat_instr spec.R.sinks;
+    Dataflow_tainting.is_source = (fun x -> any_in_ranges x sources_ranges);
+    is_sanitizer = (fun x -> any_in_ranges x sanitizers_ranges);
+    is_sink = (fun x -> any_in_ranges x sinks_ranges);
     found_tainted_sink;
   }
 
@@ -112,8 +92,31 @@ let config_of_rule found_tainted_sink spec =
 (*****************************************************************************)
 
 (*s: function [[Tainting_generic.check2]] *)
-let check hook (taint_rules : (Rule.rule * Rule.taint_spec) list) file ast =
+let check hook default_config (taint_rules : (Rule.rule * Rule.taint_spec) list)
+    equivs file ast =
   let matches = ref [] in
+
+  let taint_configs =
+    taint_rules
+    |> List.map (fun (rule, taint_spec) ->
+           let rule_id =
+             {
+               Pattern_match.id = rule.Rule.id;
+               message = rule.Rule.message;
+               pattern_string = "TODO: no pattern_string";
+             }
+           in
+           let found_tainted_sink code _env =
+             let range_loc = V.range_of_any code in
+             let tokens = lazy (V.ii_of_any code) in
+             (* todo: use env from sink matching func?  *)
+             Common.push
+               { PM.rule_id; file; range_loc; tokens; env = [] }
+               matches
+           in
+           taint_config_of_rule default_config equivs file (ast, []) rule
+             taint_spec found_tainted_sink)
+  in
 
   let fun_env = Hashtbl.create 8 in
 
@@ -121,27 +124,10 @@ let check hook (taint_rules : (Rule.rule * Rule.taint_spec) list) file ast =
     let xs = AST_to_IL.stmt def_body in
     let flow = CFG_build.cfg_of_stmts xs in
 
-    taint_rules
-    |> List.iter (fun (rule, taint_spec) ->
-           let found_tainted_sink instr _env =
-             let code = AST.E instr.IL.iorig in
-             let range_loc = V.range_of_any code in
-             let tokens = lazy (V.ii_of_any code) in
-             let rule_id =
-               {
-                 Pattern_match.id = rule.Rule.id;
-                 message = rule.Rule.message;
-                 pattern_string = "TODO: no pattern_string";
-               }
-             in
-             (* todo: use env from sink matching func?  *)
-             Common.push
-               { PM.rule_id; file; range_loc; tokens; env = [] }
-               matches
-           in
-           let config = config_of_rule found_tainted_sink taint_spec in
+    taint_configs
+    |> List.iter (fun taint_config ->
            let mapping =
-             Dataflow_tainting.fixpoint config fun_env opt_name flow
+             Dataflow_tainting.fixpoint taint_config fun_env opt_name flow
            in
            ignore mapping
            (* TODO

--- a/semgrep-core/src/engine/Tainting_generic.mli
+++ b/semgrep-core/src/engine/Tainting_generic.mli
@@ -2,7 +2,9 @@
 (*s: signature [[Tainting_generic.check]] *)
 val check :
   (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
+  Config_semgrep.t ->
   (Rule.rule * Rule.taint_spec) list ->
+  Equivalence.equivalences ->
   Common.filename ->
   Target.t ->
   Pattern_match.t list

--- a/semgrep-core/src/testing/Test_analyze_generic.ml
+++ b/semgrep-core/src/testing/Test_analyze_generic.ml
@@ -159,7 +159,6 @@ let test_dfg_tainting file =
              let config =
                {
                  Dataflow_tainting.is_source = (fun _ -> false);
-                 is_source_exp = (fun _ -> false);
                  is_sink = (fun _ -> false);
                  is_sanitizer = (fun _ -> false);
                  found_tainted_sink = (fun _ _ -> ());

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -167,7 +167,13 @@ let tainting_test lang rules_file file =
     in
   let search_rules, taint_rules = Rule.partition_rules rules in
   assert (search_rules = []);
-  let matches = Tainting_generic.check (fun _ _ _ -> ()) taint_rules file ast in
+  let matches =
+    let equivs = [] in
+    Tainting_generic.check
+      (fun _ _ _ -> ())
+      Config_semgrep.default_config
+      taint_rules equivs file ast
+  in
   let actual =
     matches |> List.map (fun m ->
       { E.typ = SemgrepMatchFound(m.P.rule_id.id,m.P.rule_id.message);
@@ -383,6 +389,12 @@ let full_rule_regression_tests =
 let lang_tainting_tests =
   let taint_tests_path = Filename.concat tests_path "tainting_rules" in
   "lang tainting rules testing" >::: [
+    "tainting Go" >::: (
+      let dir = Filename.concat taint_tests_path "go" in
+      let files = Common2.glob (spf "%s/*.go" dir) in
+      let lang = Lang.Go in
+      tainting_tests_for_lang files lang
+    );
     "tainting PHP" >::: (
       let dir = Filename.concat taint_tests_path "php" in
       let files = Common2.glob (spf "%s/*.php" dir) in
@@ -393,6 +405,12 @@ let lang_tainting_tests =
       let dir = Filename.concat taint_tests_path "python" in
       let files = Common2.glob (spf "%s/*.py" dir) in
       let lang = Lang.Python in
+      tainting_tests_for_lang files lang
+    );
+    "tainting Javascript" >::: (
+      let dir = Filename.concat taint_tests_path "js" in
+      let files = Common2.glob (spf "%s/*.js" dir) in
+      let lang = Lang.Javascript in
       tainting_tests_for_lang files lang
     );
     "tainting Typescript" >::: (

--- a/semgrep-core/tests/tainting_rules/go/zip-traversal.go
+++ b/semgrep-core/tests/tainting_rules/go/zip-traversal.go
@@ -1,0 +1,73 @@
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	safe_unzip("/tmp/some-dir")
+	dangerous_unzip("/tmp/some-dir")
+}
+
+func safe_unzip(target string) error {
+	reader, err := zip.OpenReader("example.zip")
+	if err := os.MkdirAll(target, 0750); err != nil {
+		return err
+	}
+	for _, file := range reader.File {
+		path := filepath.Join(target, file.Name)
+
+		if !strings.HasPrefix(path, filepath.Clean(target) + string(os.PathSeparator)){
+		  return filenames, fmt.Errorf("%s is an illegal filepath", path)
+		}
+
+		if file.FileInfo().IsDir() {
+			os.MkdirAll(path, file.Mode())
+			continue
+		}
+		fileReader, err := file.Open()
+		defer fileReader.Close()
+		//OK:
+		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		if err != nil {
+			return err
+		}
+		defer targetFile.Close()
+		if _, err := io.Copy(targetFile, fileReader); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dangerous_unzip(target string) error {
+	reader, err := zip.OpenReader("example.zip")
+	if err := os.MkdirAll(target, 0750); err != nil {
+		return err
+	}
+	for _, file := range reader.File {
+		path := filepath.Join(target, file.Name)
+
+		// No verification / sanitization this can "slip"
+
+		if file.FileInfo().IsDir() {
+			os.MkdirAll(path, file.Mode())
+			continue
+		}
+		fileReader, err := file.Open()
+		defer fileReader.Close()
+		//ERROR:
+		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		if err != nil {
+			return err
+		}
+		defer targetFile.Close()
+		if _, err := io.Copy(targetFile, fileReader); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/semgrep-core/tests/tainting_rules/go/zip-traversal.yaml
+++ b/semgrep-core/tests/tainting_rules/go/zip-traversal.yaml
@@ -1,0 +1,26 @@
+# Based on https://semgrep.dev/s/eKq8/ example by François Proulx
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - go
+    message: |
+      This confirms taint mode works.
+    severity: ERROR
+    pattern-sources:
+      - patterns:
+        - pattern: $READER.File
+        - pattern-inside: |
+            import "archive/zip"
+            ...
+        - pattern-inside: |
+            $READER, $ERR := zip.OpenReader($ARCHIVE)
+            ...
+    pattern-sinks:
+      - patterns:
+        - pattern: $PATH
+        - pattern-inside: os.OpenFile($PATH, ...)
+        - pattern-not-inside: |
+            if !strings.HasPrefix($PATH, <... $TARGET ...>, ...) {...}
+            ...
+            <... os.OpenFile($PATH, ...) ...>

--- a/semgrep-core/tests/tainting_rules/js/eslint_obj_inj.js
+++ b/semgrep-core/tests/tainting_rules/js/eslint_obj_inj.js
@@ -1,0 +1,32 @@
+function test1(x) {
+    var a = x
+    //ERROR:
+    return o[a]
+}
+
+function test2() {
+    var b = baz(0)
+    //ERROR:
+    var z = o[b]
+    return z+1
+}
+
+function test3(x) {
+    var c
+    if (z)
+        c = x
+    else
+        c = 1
+    //ERROR:
+    return o[c]
+}
+
+function test4(x) {
+    var d
+    if (x)
+        d = 1
+    else
+        d = 2
+    //OK:
+    return o[d]
+}

--- a/semgrep-core/tests/tainting_rules/js/eslint_obj_inj.yaml
+++ b/semgrep-core/tests/tainting_rules/js/eslint_obj_inj.yaml
@@ -1,0 +1,22 @@
+# GitLab's eslint.detect-object-injection
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - js
+    message: |
+      This confirms taint mode works.
+    severity: ERROR
+    pattern-sources:
+      - pattern-either:
+        - patterns:
+          - pattern-inside: |
+              function ...(..., $PARAM, ...) {
+                ...
+              }
+          - pattern: $PARAM
+        - pattern: $F(...)
+    pattern-sinks:
+       - patterns:
+         - pattern-inside: $OBJ[$SINK]
+         - pattern: $SINK

--- a/semgrep-core/tests/tainting_rules/js/simpl_nodejs_eval.js
+++ b/semgrep-core/tests/tainting_rules/js/simpl_nodejs_eval.js
@@ -1,0 +1,28 @@
+const Sandbox = require('sandbox');
+const express = require('express');
+const app = express();
+
+const cb = () => {
+    console.log('ok')
+}
+app.get('/test1', function (req, res) {
+    const s = new Sandbox();
+    //ERROR:
+    s.run('lol(' + req.query.userInput + ')', cb);
+    res.send('Hello world');
+})
+
+app.get('/test2', function (req, res) {
+    const s = new Sandbox();
+    var code = 'lol(' + req.query.userInput + ')'
+    //ERROR:
+    s.run(code, cb);
+    res.send('Hello world');
+})
+
+app.get('/test3', function (req, res) {
+    const s = new Sandbox();
+    //ERROR:
+    s.run(`lol(${req.query.userInput})`, cb);
+    res.send('Hello world');
+})

--- a/semgrep-core/tests/tainting_rules/js/simpl_nodejs_eval.yaml
+++ b/semgrep-core/tests/tainting_rules/js/simpl_nodejs_eval.yaml
@@ -1,0 +1,20 @@
+# Simplified version of nodejsscan.eval_sandbox
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - js
+    message: |
+      This confirms taint mode works.
+    severity: ERROR
+    pattern-sources:
+      - patterns:
+        - pattern-inside: |
+            require('sandbox');
+            ...
+        - pattern-inside: function ($REQ, ...) {...}
+        - pattern: $REQ.query
+    pattern-sinks:
+      - patterns:
+        - pattern-inside: $S.run($SINK, ...)
+        - pattern: $SINK

--- a/semgrep-core/tests/tainting_rules/php/echo.yaml
+++ b/semgrep-core/tests/tainting_rules/php/echo.yaml
@@ -5,9 +5,9 @@ rules:
       - php
     message: Working!
     pattern-sources:
-      - $_GET[...]
+      - pattern: $_GET[...]
     pattern-sanitizers:
-      - htmlspecialchars(...)
+      - pattern: htmlspecialchars(...)
     pattern-sinks:
-      - echo ...;
+      - pattern: echo ...;
     severity: ERROR

--- a/semgrep-core/tests/tainting_rules/python/basic_crossfun_top.yaml
+++ b/semgrep-core/tests/tainting_rules/python/basic_crossfun_top.yaml
@@ -6,10 +6,10 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - sink1(...)
+      - pattern: sink1(...)
     pattern-sources:
-      - source1(...)
+      - pattern: source1(...)
     pattern-sanitizers:
-      - sanitize1(...)
+      - pattern: sanitize1(...)
     severity: ERROR
 

--- a/semgrep-core/tests/tainting_rules/python/simpl_django_redirect.py
+++ b/semgrep-core/tests/tainting_rules/python/simpl_django_redirect.py
@@ -1,0 +1,47 @@
+from django.shortcuts import redirect
+from django.http import HttpResponseRedirect, HttpResponse
+from django.utils.http import is_safe_url
+
+def unsafe(request):
+    url = request.headers.get('referrer')
+    print("something")
+    #ERROR:
+    return redirect(url)
+
+def safe(request):
+    url = "https://lmnop.qrs"
+    #OK:
+    return redirect(url)
+
+def unsafe2(request):
+    url = request.POST.get("url")
+    #ERROR:
+    return HttpResponseRedirect(url)
+
+def unsafe3(request):
+    url = request.POST["url"]
+    #ERROR:
+    return HttpResponseRedirect(url)
+
+def fine(request):
+    #OK:
+    return HttpResponseRedirect(request.get_full_path())
+
+def url_validation(request):
+    next = request.POST.get('next', request.GET.get('next'))
+    if (next or not request.is_ajax()) and not is_safe_url(url=next, allowed_hosts=request.get_host()):
+        next = "/index"
+    #OK:
+    response = HttpResponseRedirect(next) if next else HttpResponse(status=204)
+    return response
+
+def url_validation2(request):
+    next = request.POST.get('next', request.GET.get('next'))
+    ok = is_safe_url(url=next, allowed_hosts=request.get_host())
+    if ok:
+        #OK:
+        response = HttpResponseRedirect(next) if next else HttpResponse(status=204)
+    else:
+        #OK:
+        response = HttpResponseRedirect("index")
+    return response

--- a/semgrep-core/tests/tainting_rules/python/simpl_django_redirect.yaml
+++ b/semgrep-core/tests/tainting_rules/python/simpl_django_redirect.yaml
@@ -1,0 +1,35 @@
+# Based on python.django.security.injection.open-redirect
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    severity: ERROR
+    pattern-sources:
+    - patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+            ...
+      - pattern-not-inside: |
+          def $FUNC(...):
+            ...
+            <... django.utils.http.is_safe_url(...) ...>
+            ...
+      - pattern-not-inside: |
+          def $FUNC(...):
+            ...
+            if <... django.utils.http.is_safe_url(...) ...>:
+              ...
+      - pattern-either:
+        - pattern: request.$W.get(...)
+        - pattern: request.$W(...)
+        - pattern: request.$W[...]
+      - metavariable-regex:
+          metavariable: $W
+          regex: (?!get_full_path)
+    pattern-sinks:
+    - pattern-either:
+      - pattern: django.shortcuts.redirect(...)
+      - pattern: django.http.HttpResponseRedirect(...)

--- a/semgrep-core/tests/tainting_rules/python/sink_param.py
+++ b/semgrep-core/tests/tainting_rules/python/sink_param.py
@@ -1,0 +1,7 @@
+def foo():
+  a = source1()
+  b = "safe"
+  #ERROR:
+  sink1(a, b)
+  #OK:
+  sink1(b, a)

--- a/semgrep-core/tests/tainting_rules/python/sink_param.yaml
+++ b/semgrep-core/tests/tainting_rules/python/sink_param.yaml
@@ -6,12 +6,12 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - pattern: sink(...)
-      - pattern: sink1(...)
-      - pattern: eval(...)
+      - patterns:
+        - pattern-inside: sink1($SINK, ...)
+        - pattern: $SINK
     pattern-sources:
       - pattern: source1(...)
     pattern-sanitizers:
-      - pattern: sanitize(...)
+      - pattern: sanitize1(...)
     severity: ERROR
 

--- a/semgrep-core/tests/tainting_rules/python/sink_return.py
+++ b/semgrep-core/tests/tainting_rules/python/sink_return.py
@@ -1,0 +1,9 @@
+def foo():
+  a = source1()
+  b = "safe"
+  if c:
+    #ERROR:
+    return a
+  else:
+    #OK:
+    return b

--- a/semgrep-core/tests/tainting_rules/python/sink_return.yaml
+++ b/semgrep-core/tests/tainting_rules/python/sink_return.yaml
@@ -6,12 +6,10 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - pattern: sink(...)
-      - pattern: sink1(...)
-      - pattern: eval(...)
+      - pattern: return ...
     pattern-sources:
       - pattern: source1(...)
     pattern-sanitizers:
-      - pattern: sanitize(...)
+      - pattern: sanitize1(...)
     severity: ERROR
 

--- a/semgrep-core/tests/tainting_rules/python/source_param.py
+++ b/semgrep-core/tests/tainting_rules/python/source_param.py
@@ -1,0 +1,8 @@
+def foo():
+  source1(a, b, c)
+  #ERROR:
+  sink1(a)
+  #OK:
+  sink1(b)
+  #OK:
+  sink1(c)

--- a/semgrep-core/tests/tainting_rules/python/source_param.yaml
+++ b/semgrep-core/tests/tainting_rules/python/source_param.yaml
@@ -6,12 +6,15 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - pattern: sink(...)
       - pattern: sink1(...)
-      - pattern: eval(...)
     pattern-sources:
-      - pattern: source1(...)
+      - patterns:
+        - pattern-inside: |
+            source1($SRC, ...)
+            ...
+        - patterns: # HACK to disable `pattern: $X` optim
+          - pattern: $SRC
     pattern-sanitizers:
-      - pattern: sanitize(...)
+      - pattern: sanitize1(...)
     severity: ERROR
 

--- a/semgrep-core/tests/tainting_rules/python/tainting.yaml
+++ b/semgrep-core/tests/tainting_rules/python/tainting.yaml
@@ -6,10 +6,10 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - sink1(...)
+      - pattern: sink1(...)
     pattern-sources:
-      - source1(...)
+      - pattern: source1(...)
     pattern-sanitizers:
-      - sanitize1(...)
+      - pattern: sanitize1(...)
     severity: ERROR
 

--- a/semgrep-core/tests/tainting_rules/python/tainting_top.yaml
+++ b/semgrep-core/tests/tainting_rules/python/tainting_top.yaml
@@ -6,10 +6,10 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - sink1(...)
+      - pattern: sink1(...)
     pattern-sources:
-      - source1(...)
+      - pattern: source1(...)
     pattern-sanitizers:
-      - sanitize1(...)
+      - pattern: sanitize1(...)
     severity: ERROR
 

--- a/semgrep-core/tests/tainting_rules/ts/basic_crossfun.yaml
+++ b/semgrep-core/tests/tainting_rules/ts/basic_crossfun.yaml
@@ -6,12 +6,12 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - React.createElement(...)
+      - pattern: React.createElement(...)
     pattern-sources:
-      - location.href
-      - location.hash
-      - location.search
-      - location.pathname
-      - document.referrer
+      - pattern: location.href
+      - pattern: location.hash
+      - pattern: location.search
+      - pattern: location.pathname
+      - pattern: document.referrer
     severity: ERROR
 

--- a/semgrep-core/tests/tainting_rules/ts/source_exp.yaml
+++ b/semgrep-core/tests/tainting_rules/ts/source_exp.yaml
@@ -6,12 +6,12 @@ rules:
     message: |
       This confirms taint mode works.
     pattern-sinks:
-      - React.createElement(...)
+      - pattern: React.createElement(...)
     pattern-sources:
-      - location.href
-      - location.hash
-      - location.search
-      - location.pathname
-      - document.referrer
+      - pattern: location.href
+      - pattern: location.hash
+      - pattern: location.search
+      - pattern: location.pathname
+      - pattern: document.referrer
     severity: ERROR
 

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -33,7 +33,59 @@ definitions:
     type: array
     items:
       anyOf:
-      - type: string
+      - type: object
+        properties:
+          pattern:
+            title: Return finding where Semgrep pattern matches exactly
+            type: string
+          pattern-regex:
+            title: Return finding where regular expression matches exactly
+            type: string
+          patterns:
+            $ref: '#/definitions/patterns-content'
+          pattern-either:
+            $ref: '#/definitions/pattern-either-content'
+        oneOf:
+          - required:
+              - pattern
+            not:
+              anyOf:
+                - required:
+                  - patterns
+                - required:
+                  - pattern-either
+                - required:
+                  - pattern-regex
+          - required:
+              - patterns
+            not:
+              anyOf:
+                - required:
+                    - pattern
+                - required:
+                    - pattern-either
+                - required:
+                    - pattern-regex
+          - required:
+              - pattern-either
+            not:
+              anyOf:
+                - required:
+                    - pattern
+                - required:
+                    - patterns
+                - required:
+                    - pattern-regex
+          - required:
+              - pattern-regex
+            not:
+              anyOf:
+                - required:
+                    - pattern
+                - required:
+                    - patterns
+                - required:
+                    - pattern-either
   metavariable-regex:
     type: object
     properties:

--- a/semgrep/tests/e2e/rules/taint.yaml
+++ b/semgrep/tests/e2e/rules/taint.yaml
@@ -2,15 +2,15 @@ rules:
   - id: classic
     mode: taint
     pattern-sources:
-      - source(...)
-      - source1(...)
+      - pattern: source(...)
+      - pattern: source1(...)
     pattern-sinks:
-      - sink(...)
-      - sink1(...)
-      - eval(...)
+      - pattern: sink(...)
+      - pattern: sink1(...)
+      - pattern: eval(...)
     pattern-sanitizers:
-      - sanitize(...)
-      - sanitize1(...)
+      - pattern: sanitize(...)
+      - pattern: sanitize1(...)
     message: A user input source() went into a dangerous sink()
     languages: [python, javascript]
     severity: WARNING

--- a/semgrep/tests/unit/test_yaml_parsing.py
+++ b/semgrep/tests/unit/test_yaml_parsing.py
@@ -30,15 +30,15 @@ def test_parse_taint_rules():
           - id: example_id
             mode: taint
             pattern-sources:
-              - source(...)
-              - source1(...)
+              - pattern: source(...)
+              - pattern: source1(...)
             pattern-sinks:
-              - sink(...)
-              - sink1(...)
-              - eval(...)
+              - pattern: sink(...)
+              - pattern: sink1(...)
+              - pattern: eval(...)
             pattern-sanitizers:
-              - sanitize(...)
-              - sanitize1(...)
+              - pattern: sanitize(...)
+              - pattern: sanitize1(...)
             message: A user input source() went into a dangerous sink()
             languages: [python, javascript]
             severity: WARNING


### PR DESCRIPTION
We are no longer restricted to single instruction/expression patterns.

Goodbye fake taint?

Helps #3199

test plan:
make test # tests included



PR checklist:
- [x] changelog is up to date

