### PR TITLE
[Vue] fix wrong <script> content with missing newlines

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
@@ -80,11 +80,46 @@ let token env (tok : Tree_sitter_run.Token.t) =
   in
   let file = env.file in
   let tok_loc = { PI.str; charpos; line; column; file } in
-  { PI.token = PI.OriginTok tok_loc; transfo = PI.NoTransfo }
+  PI.mk_info_of_loc tok_loc
 
 let str env (tok : Tree_sitter_run.Token.t) =
   let _, s = tok in
   (s, token env tok)
+
+(* This is a temporary fix until
+ * https://github.com/returntocorp/ocaml-tree-sitter-core/issues/5
+ * is fixed.
+ *)
+let str_if_wrong_content_temporary_fix env (tok : Tree_sitter_run.Token.t) =
+  let loc, _wrong_str = tok in
+
+  let file = env.file in
+  let h = env.conv in
+
+  let charpos, line, column =
+    let pos = loc.Tree_sitter_run.Loc.start in
+    (* Parse_info is 1-line based and 0-column based, like Emacs *)
+    let line = pos.Tree_sitter_run.Loc.row + 1 in
+    let column = pos.Tree_sitter_run.Loc.column in
+    try (Hashtbl.find h (line, column), line, column)
+    with Not_found ->
+      failwith (spf "could not find line:%d x col:%d in %s" line column file)
+  in
+  let charpos2 =
+    let pos = loc.Tree_sitter_run.Loc.end_ in
+    (* Parse_info is 1-line based and 0-column based, like Emacs *)
+    let line = pos.Tree_sitter_run.Loc.row + 1 in
+    let column = pos.Tree_sitter_run.Loc.column in
+    try Hashtbl.find h (line, column)
+    with Not_found ->
+      failwith (spf "could not find line:%d x col:%d in %s" line column file)
+  in
+  (* Range.t is inclusive, so we need -1 to remove the char at the pos *)
+  let charpos2 = charpos2 - 1 in
+  let r = { Range.start = charpos; end_ = charpos2 } in
+  let str = Range.content_at_range file r in
+  let tok_loc = { PI.str; charpos; line; column; file } in
+  (str, PI.mk_info_of_loc tok_loc)
 
 let combine_tokens_DEPRECATED env xs =
   match xs with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
@@ -11,6 +11,9 @@ val token : 'a env -> Tree_sitter_run.Token.t -> Parse_info.t
 
 val str : 'a env -> Tree_sitter_run.Token.t -> string * Parse_info.t
 
+val str_if_wrong_content_temporary_fix :
+  'a env -> Tree_sitter_run.Token.t -> string * Parse_info.t
+
 (* Use Parse_info.combine_infos instead *)
 val combine_tokens_DEPRECATED :
   'a env -> Tree_sitter_run.Token.t list -> Parse_info.t

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -227,7 +227,13 @@ let map_style_element (env : env) ((v1, v2, v3) : CST.style_element) : xml =
 let map_script_element (env : env) ((v1, v2, v3) : CST.script_element) =
   let l, id, attrs, r = map_script_start_tag env v1 in
   let v2 =
-    match v2 with Some tok -> Some (str env tok) (* raw_text *) | None -> None
+    match v2 with
+    | Some tok ->
+        (* TODO: https://github.com/returntocorp/ocaml-tree-sitter-core/issues/5 *)
+        let v = H.str_if_wrong_content_temporary_fix env tok in
+        Some v
+        (* raw_text *)
+    | None -> None
   in
   let v3 = map_end_tag env v3 in
   (l, id, r, v3, attrs, v2)

--- a/semgrep-core/src/parsing/tree_sitter/dune
+++ b/semgrep-core/src/parsing/tree_sitter/dune
@@ -24,6 +24,7 @@
 
    commons
    pfff-lang_GENERIC
+   semgrep_core; just for Range
 
  )
  (preprocess (pps ppx_profiling ppx_sexp_conv ppx_deriving.show))


### PR DESCRIPTION
This is a temporary fix.

test plan:
```
 /home/pad/yy/_build/default/src/cli/Main.exe -keep_tmp_files -lang vue -dump_ast tests/vue/parsing/basic.vue
[0.105  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.105  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -keep_tmp_files -lang vue -dump_ast tests/vue/parsing/basic.vue
[0.105  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.57.0-30-g6f427678-dirty, pfff: 0.42
[0.105  Info       Main.Parse_target    ] trying to parse with TreeSitter parser tests/vue/parsing/basic.vue
[0.107  Info       Main.Parse_target    ] trying to parse with TreeSitter parser /tmp/tmp-30179-e34cc1.js
Pr(
  [ExprStmt(
     Xml(
       {xml_tag=XmlClassic((), ("template", ()), (), ()); xml_attrs=[
        ];
        xml_body=[XmlText(("  ", ()));
                  XmlXml(
                    {xml_tag=XmlClassic((), ("p", ()), (), ()); xml_attrs=[
                     ];
                     xml_body=[XmlText(("    Hello, ", ()));
                               XmlXml(
                                 {xml_tag=XmlClassic((), ("a", ()), (), ());
                                  xml_attrs=[XmlAttr((":", ()), (),
                                               L(String(("url", ()))))];
                                  xml_body=[XmlExpr(
                                              Some(L(String((" name ", ())))))];
                                  }); XmlText(("!  ", ()))];
                     }); XmlText(("", ()))];
        }), ());
   ExprStmt(
     Assign(
       DotAccess(OtherExpr(OE_Module, [Tk(())]), (),
         EN(
           Id(("exports", ()),
             {id_resolved=Ref(None); id_type=Ref(None);
              id_constness=Ref(None); }))), (),

```




PR checklist:
- [ ] changelog is up to date