### PR TITLE
Basic support for Vue files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+- Vue.js alpha support (#1751)
+
 ### Fixed
 - Apple M1: Semgrep installed from HomeBrew no longer hangs (#2432)
 - Ruby command shells are distinguished from strings (#3343)

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -262,6 +262,12 @@ let lang_parsing_tests =
       let lang = Lang.HTML in
       parsing_tests_for_lang files lang
     );
+    "Vue" >::: (
+      let dir = Filename.concat tests_path "vue/parsing" in
+      let files = Common2.glob (spf "%s/*.vue" dir) in
+      let lang = Lang.Vue in
+      parsing_tests_for_lang files lang
+    );
   ]
 
 (*s: constant [[Test.lang_regression_tests]] *)
@@ -369,6 +375,12 @@ let lang_regression_tests ~with_caching =
     let dir = Filename.concat tests_path "scala" in
     let files = Common2.glob (spf "%s/*.scala" dir) in
     let lang = Lang.Scala in
+    regression_tests_for_lang files lang
+  );
+  "semgrep Vue" >::: (
+    let dir = Filename.concat tests_path "vue" in
+    let files = Common2.glob (spf "%s/*.vue" dir) in
+    let lang = Lang.Vue in
     regression_tests_for_lang files lang
   );
  ]

--- a/semgrep-core/tests/vue/concrete_syntax.vue
+++ b/semgrep-core/tests/vue/concrete_syntax.vue
@@ -1,0 +1,20 @@
+<script>
+function foo() {
+ //ERROR:
+    foo(1, 2);
+ //ERROR:
+    foo(1,2);
+ //ERROR:
+    foo (1, 2);
+ //ERROR:
+ foo(1,
+     2);
+ //ERROR:
+ foo(1, // comment
+     2);
+
+ foo(2,1)
+}
+
+
+</script>

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -45,6 +45,7 @@ class Language(Enum):
     YAML: str = "yaml"
     ML: str = "ml"
     SCALA: str = "scala"
+    VUE: str = "vue"
     JSON: str = "json"
     REGEX: str = "regex"
     GENERIC: str = "generic"
@@ -68,6 +69,7 @@ class Language_util:
         Language.KOTLIN: [Language.KOTLIN.value, "Kotlin", "kotlin"],
         Language.YAML: [Language.YAML.value, "Yaml"],
         Language.SCALA: [Language.SCALA.value],
+        Language.VUE: [Language.VUE.value],
         Language.ML: [Language.ML.value, "ocaml"],
         Language.JSON: [Language.JSON.value, "JSON", "Json"],
         Language.REGEX: [Language.REGEX.value, "none"],

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -29,6 +29,7 @@ YAML_EXTENSIONS = [FileExtension(".yaml"), FileExtension(".yml")]
 ML_EXTENSIONS = [FileExtension(".mli"), FileExtension(".ml")]
 JSON_EXTENSIONS = [FileExtension(".json")]
 SCALA_EXTENSIONS = [FileExtension(".scala")]
+VUE_EXTENSIONS = [FileExtension(".vue")]
 
 # This is used to determine the set of files with known extensions,
 # i.e. those for which we have a proper parser.
@@ -46,6 +47,7 @@ ALL_EXTENSIONS = (
     + KOTLIN_EXTENSIONS
     + YAML_EXTENSIONS
     + SCALA_EXTENSIONS
+    + VUE_EXTENSIONS
 )
 
 # This is used to select the files suitable for spacegrep, which is
@@ -74,6 +76,7 @@ _LANGS_TO_EXTS: Dict[Language, List[FileExtension]] = {
     Language.REGEX: GENERIC_EXTENSIONS,
     Language.GENERIC: GENERIC_EXTENSIONS,
     Language.SCALA: SCALA_EXTENSIONS,
+    Language.VUE: VUE_EXTENSIONS,
 }
 
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -5,5 +5,5 @@
 [94m  | [39m               [31m^^^^^^^^^^[39m
 [94m8 | [39m    severity: WARNING
 
-[31munsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, yaml[39m
+[31munsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml[39m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,7 +3,7 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, yaml",
+      "long_msg": "unsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml",
       "short_msg": "invalid language: intercal",
       "spans": [
         {


### PR DESCRIPTION
This is the final PR in a series of PRs to add support for Vue.
For now, you can write Javascript patterns to match code
in the <script> part of Vue files. You can also
use JSX patterns to match code in the <template> part.

This closes #1751

Remaining todos:
 - parse JS expressions in templates
 - allow Vue template syntax, not JSX, to express HTML snippets
 - better error management when some JS code can not be parsed
 - more tests

test plan:
make test and
```
semgrep) [pad@yrax semgrep (vue_p3)]$ semgrep -l vue -e 'foo(...)' ~/yy/tests/vue/
/home/pad/yy/tests/vue/concrete_syntax.vue
4:    foo(1, 2);
--------------------------------------------------------------------------------
6:    foo(1,2);
--------------------------------------------------------------------------------
8:    foo (1, 2);
--------------------------------------------------------------------------------
10: foo(1,
11:     2);
--------------------------------------------------------------------------------
13: foo(1, // comment
14:     2);
--------------------------------------------------------------------------------
16: foo(2,1)

/home/pad/yy/tests/vue/parsing/single_line_script.vue
2:foo(1, 2)
ran 1 rules on 3 files: 7 findings
```




PR checklist:
- [x] changelog is up to date