### PR TITLE
rule_schema: Fix metavariable-pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Support for partial statements (e.g., `try { ... }`) for Java (#3417)
 - Constant propagation now works inside Python `with` statements (#3402)
 - Revert `pattern: $X` optimization (#3476)
+- metavariable-pattern: Allow filtering using a single `pattern` or
+  `pattern-regex`
 
 ### Changed
 - Faster matching times for generic mode

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_lang.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_lang.yaml
@@ -9,7 +9,6 @@ rules:
       - metavariable-pattern:
           metavariable: $CODE
           language: C
-          patterns:
-              - pattern: |
-                  $X++;
+          pattern: |
+            $X++;
     severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.yaml
@@ -9,7 +9,6 @@ rules:
       - metavariable-pattern:
           metavariable: $...JS
           language: javascript
-          patterns:
-              - pattern: |
-                  console.log(...)
+          pattern: |
+            console.log(...)
     severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex.yaml
@@ -8,6 +8,5 @@ rules:
       - metavariable-pattern:
           metavariable: $1
           language: generic
-          patterns:
-            - pattern: google-cloud-storage
+          pattern: google-cloud-storage
     severity: INFO

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -113,6 +113,12 @@ definitions:
             type: string
           language:
             type: string
+          pattern:
+            title: Return finding where Semgrep pattern matches exactly
+            type: string
+          pattern-regex:
+            title: Return finding where regular expression matches exactly
+            type: string
           patterns:
             $ref: '#/definitions/patterns-content'
           pattern-either:


### PR DESCRIPTION
Allow filtering based on a single `pattern` or `pattern-regex`, without
need for a parent `patterns` or `pattern-either`.

test plan:
semgrep --config semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.yaml semgrep-core/tests/OTHER/rules/metavar_pattern_lang2.generic
  #^ now works



PR checklist:
- [x] changelog is up to date

