### PR TITLE
Experimental support for HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Added
+- HTML experimental support. This does not rely on the "generic" mode
+  but instead really parses the HTML using tree-sitter-html. This allows
+  some semantic matching (e.g., matching attributes in any order).
 - Vue.js alpha support (#1751)
 - New iteration of taint-mode that allows to specify sources/sanitizers/sinks
   using arbitrary pattern formulas. This provides plenty of flexibility. Note

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -383,6 +383,12 @@ let lang_regression_tests ~with_caching =
     let lang = Lang.Scala in
     regression_tests_for_lang files lang
   );
+  "semgrep HTML" >::: (
+    let dir = Filename.concat tests_path "html" in
+    let files = Common2.glob (spf "%s/*.html" dir) in
+    let lang = Lang.HTML in
+    regression_tests_for_lang files lang
+  );
   "semgrep Vue" >::: (
     let dir = Filename.concat tests_path "vue" in
     let files = Common2.glob (spf "%s/*.vue" dir) in

--- a/semgrep-core/tests/html/metavar_attr_value.html
+++ b/semgrep-core/tests/html/metavar_attr_value.html
@@ -1,0 +1,1 @@
+<script src="https://example.com/no-sri.js"></script>

--- a/semgrep-core/tests/html/metavar_attr_value.html
+++ b/semgrep-core/tests/html/metavar_attr_value.html
@@ -1,1 +1,2 @@
+//ERROR: match
 <script src="https://example.com/no-sri.js"></script>

--- a/semgrep-core/tests/html/metavar_attr_value.sgrep
+++ b/semgrep-core/tests/html/metavar_attr_value.sgrep
@@ -1,0 +1,1 @@
+<script ... src="$SRC" ...>...</script>

--- a/semgrep-core/tests/html/misc_many_features.html
+++ b/semgrep-core/tests/html/misc_many_features.html
@@ -1,0 +1,4 @@
+//ERROR: match
+<html attr1="a" attr2="b" attr3="c" attr4="d" >some text</html>
+//ERROR: match
+<html attr2="b" attr1="a" attr3="c" attr4="d" >some other text</html>

--- a/semgrep-core/tests/html/misc_many_features.sgrep
+++ b/semgrep-core/tests/html/misc_many_features.sgrep
@@ -1,0 +1,1 @@
+<html attr2="b" attr1="a" ... $X="c" >...</html>

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -46,6 +46,7 @@ class Language(Enum):
     ML: str = "ml"
     SCALA: str = "scala"
     VUE: str = "vue"
+    HTML: str = "html"
     JSON: str = "json"
     REGEX: str = "regex"
     GENERIC: str = "generic"
@@ -70,6 +71,7 @@ class Language_util:
         Language.YAML: [Language.YAML.value, "Yaml"],
         Language.SCALA: [Language.SCALA.value],
         Language.VUE: [Language.VUE.value],
+        Language.HTML: [Language.HTML.value],
         Language.ML: [Language.ML.value, "ocaml"],
         Language.JSON: [Language.JSON.value, "JSON", "Json"],
         Language.REGEX: [Language.REGEX.value, "none"],

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -30,6 +30,7 @@ ML_EXTENSIONS = [FileExtension(".mli"), FileExtension(".ml")]
 JSON_EXTENSIONS = [FileExtension(".json")]
 SCALA_EXTENSIONS = [FileExtension(".scala")]
 VUE_EXTENSIONS = [FileExtension(".vue")]
+HTML_EXTENSIONS = [FileExtension(".html"), FileExtension(".html")]
 
 # This is used to determine the set of files with known extensions,
 # i.e. those for which we have a proper parser.
@@ -48,6 +49,7 @@ ALL_EXTENSIONS = (
     + YAML_EXTENSIONS
     + SCALA_EXTENSIONS
     + VUE_EXTENSIONS
+    + HTML_EXTENSIONS
 )
 
 # This is used to select the files suitable for spacegrep, which is
@@ -77,6 +79,7 @@ _LANGS_TO_EXTS: Dict[Language, List[FileExtension]] = {
     Language.GENERIC: GENERIC_EXTENSIONS,
     Language.SCALA: SCALA_EXTENSIONS,
     Language.VUE: VUE_EXTENSIONS,
+    Language.HTML: HTML_EXTENSIONS,
 }
 
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -5,5 +5,5 @@
 [94m  | [39m               [31m^^^^^^^^^^[39m
 [94m8 | [39m    severity: WARNING
 
-[31munsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml[39m
+[31munsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml[39m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,7 +3,7 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml",
+      "long_msg": "unsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml",
       "short_msg": "invalid language: intercal",
       "spans": [
         {


### PR DESCRIPTION
This does not rely on the generic (spacegrep) mode but
really parse HTML. This allows more semantic matching
(e.g., matching attributes in any order)

test plan:
test files included
make test

```
semgrep) [pad@yrax yy (semantic_html)]$ semgrep -l html -e '<html ...>...</html>' tests/html/
tests/html/misc_many_features.html
2:<html attr1="a" attr2="b" attr3="c" attr4="d" >some text</html>
--------------------------------------------------------------------------------
4:<html attr2="b" attr1="a" attr3="c" attr4="d" >some other text</html>
ran 1 rules on 2 files: 2 findings
```




PR checklist:
- [x] changelog is up to date