### PR TITLE
matching: Make record matching more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   using arbitrary pattern formulas. This provides plenty of flexibility. Note
   that we breaks compatibility with the previous taint-mode format, e.g.
   `- source(...)` must now be written as `- pattern: source(...)`.
+- New matching option `implicit_ellipsis` that allows to disable the implicit
+  `...` that are added to record patterns, plus allow matching "spread fields"
+  (JS `...x`) at any position (#3120)
 
 ### Fixed
 - Apple M1: Semgrep installed from HomeBrew no longer hangs (#2432)

--- a/semgrep-core/src/core/Config_semgrep.atd
+++ b/semgrep-core/src/core/Config_semgrep.atd
@@ -51,6 +51,10 @@ type t = {
   (* this ultimately should go away once '...' works on the CFG *)
   ~go_deeper_stmt <ocaml default="true"> : bool;
 
+  (* implicitly assume ellipsis in record patterns *)
+  (* TODO: eventually the default should be 'false'. *)
+  ~implicit_ellipsis <ocaml default="true"> : bool;
+
   (* TODO: equivalences:
    *   - const_let_to_var
    *   - require_to_import (but need pass config to Js_to_generic)

--- a/semgrep-core/tests/OTHER/rules/record_any.js
+++ b/semgrep-core/tests/OTHER/rules/record_any.js
@@ -1,0 +1,8 @@
+//ruleid:test
+a = {};
+//ruleid:test
+a = {x:1};
+//ruleid:test
+a = {x:1, y:2};
+//ruleid:test
+a = {...b, x:1}

--- a/semgrep-core/tests/OTHER/rules/record_any.yaml
+++ b/semgrep-core/tests/OTHER/rules/record_any.yaml
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/3120
+rules:
+- id: test-3120
+  options:
+    implicit_ellipsis: false
+  pattern: '{...}'
+  message: Test
+  languages: [js]
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/record_empty.js
+++ b/semgrep-core/tests/OTHER/rules/record_empty.js
@@ -1,0 +1,6 @@
+//ruleid:test
+a = {};
+//ok:test
+a = {x:1};
+//ok:test
+a = {x:1, y:2};

--- a/semgrep-core/tests/OTHER/rules/record_empty.yaml
+++ b/semgrep-core/tests/OTHER/rules/record_empty.yaml
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/3120
+rules:
+- id: test-3120
+  options:
+    implicit_ellipsis: false
+  pattern: '{}'
+  message: Test
+  languages: [js]
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/record_field_ellipsis.js
+++ b/semgrep-core/tests/OTHER/rules/record_field_ellipsis.js
@@ -1,0 +1,10 @@
+//ok:test
+a = {};
+//ok:test
+a = {...x};
+//ruleid:test
+a = {x:1};
+//ruleid:test
+a = {x:1, y:2}
+//ruleid:test
+a = {z:0, x:1, y:2, ...u}

--- a/semgrep-core/tests/OTHER/rules/record_field_ellipsis.yaml
+++ b/semgrep-core/tests/OTHER/rules/record_field_ellipsis.yaml
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/3120
+rules:
+- id: test-3120
+  options:
+    implicit_ellipsis: false
+  pattern: '{x:$X, ...}'
+  message: Test
+  languages: [js]
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/record_mixed.js
+++ b/semgrep-core/tests/OTHER/rules/record_mixed.js
@@ -1,0 +1,10 @@
+//ok:test
+a = {};
+//ok:test
+a = {...x};
+//ruleid:test
+a = {x:1, ...y};
+//ok:test
+a = {x:1, y:2}
+//ruleid:test
+a = {u:0, ...z, x:1, y:2}

--- a/semgrep-core/tests/OTHER/rules/record_mixed.yaml
+++ b/semgrep-core/tests/OTHER/rules/record_mixed.yaml
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/3120
+rules:
+- id: test-3120
+  options:
+    implicit_ellipsis: false
+  pattern: '{x:$X, ..., ...$Y}'
+  message: Test
+  languages: [js]
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/record_one_field.js
+++ b/semgrep-core/tests/OTHER/rules/record_one_field.js
@@ -1,0 +1,8 @@
+//ok:test
+a = {};
+//ok:test
+a = {...x};
+//ruleid:test
+a = {x:1};
+//ok:test
+a = {x:1, y:2}

--- a/semgrep-core/tests/OTHER/rules/record_one_field.yaml
+++ b/semgrep-core/tests/OTHER/rules/record_one_field.yaml
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/3120
+rules:
+- id: test-3120
+  options:
+    implicit_ellipsis: false
+  pattern: '{x:$X}'
+  message: Test
+  languages: [js]
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/record_one_spread.js
+++ b/semgrep-core/tests/OTHER/rules/record_one_spread.js
@@ -1,0 +1,8 @@
+//ok:test
+a = {};
+//ok:test
+a = {...x, ...y};
+//ruleid:test
+a = {...x};
+//ok:test
+a = {...x, y:1}

--- a/semgrep-core/tests/OTHER/rules/record_one_spread.yaml
+++ b/semgrep-core/tests/OTHER/rules/record_one_spread.yaml
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/3120
+rules:
+- id: test-3120
+  options:
+    implicit_ellipsis: false
+  pattern: '{...$X}'
+  message: Test
+  languages: [js]
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/record_spread_ellipsis.js
+++ b/semgrep-core/tests/OTHER/rules/record_spread_ellipsis.js
@@ -1,0 +1,10 @@
+//ok:test
+a = {};
+//ruleid:test
+a = {...x, ...y};
+//ruleid:test
+a = {...x};
+//ruleid:test
+a = {...x, y:1}
+//ruleid:test
+a = {y:1, ...x}

--- a/semgrep-core/tests/OTHER/rules/record_spread_ellipsis.yaml
+++ b/semgrep-core/tests/OTHER/rules/record_spread_ellipsis.yaml
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/3120
+rules:
+- id: test-3120
+  options:
+    implicit_ellipsis: false
+  pattern: '{...$X, ...}'
+  message: Test
+  languages: [js]
+  severity: ERROR


### PR DESCRIPTION
1. Allow disabling the implicit ... for record patterns via `options:`.
2. Match "spread fields" (JS `...x`), or any other kind of field, at any
   position; same as we already do for definitions.

Closes #3120

test plan:
make test # tests included



PR checklist:
- [x] changelog is up to date

