### PR TITLE
update to ppxlib 0.20.0 and OCaml 4.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Support metavariables and ellipsis inside regexp literals
   (e.g., `foo(/.../)`)
 - Associative-commutative matching for bitwise OR, AND, and XOR operations
-- Add support for $...MVAR in generic patterns
 - Add support for $...MVAR in generic patterns.
 - metavariable-pattern: Add support for nested Spacegrep/regex/Comby patterns
 - C#: support ellipsis in method parameters (#3289)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@
 # The same applies to the 'spacegrep' executable.
 #
 
-FROM returntocorp/ocaml:alpine-2021-04-08 as build-semgrep-core
+# This currently uses OCaml 4.10.2+flambda
+FROM returntocorp/ocaml:alpine-2021-06-23 as build-semgrep-core
 
 USER root
 # for ocaml-pcre now used in semgrep-core

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -40,7 +40,7 @@ depends: [
   "re"
   "pcre"
   "parmap"
-  "ppxlib" {= "0.15.0" }
+  "ppxlib" {= "0.20.0" }
   "lsp" {= "1.3.0"}
   "comby-kernel" {= "1.4.1"}
 ]


### PR DESCRIPTION
This is needed to be able to compile pfff (and so semgrep) with
OCaml 4.12.0 (which itself is needed to compile correctly on Homebrew
and recent macOS)

This should help #3027

test plan:
make test




PR checklist:
- [x] changelog is up to date