### PR TITLE
Bash support, continued

### DIFF
--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -426,7 +426,8 @@ and map_arithmetic_operator = function
   | BitClear -> `BitClear
   | And -> `And
   | Or -> `Or
-  | Xor -> `Xor
+  | Xor -> `Xor (* new: *)
+  | Pipe -> `Pipe
   | Not -> `Not
   | Eq -> `Eq
   | NotEq -> `NotEq
@@ -450,7 +451,8 @@ and map_arithmetic_operator = function
   | In -> `In
   | NotIn -> `NotIn
   | Is -> `Is
-  | NotIs -> `NotIs
+  | NotIs -> `NotIs (* new: *)
+  | Background -> `Background
 
 and map_arguments v = map_bracket (map_of_list map_argument) v
 

--- a/semgrep-core/src/api/AST_generic_v1.atd
+++ b/semgrep-core/src/api/AST_generic_v1.atd
@@ -374,7 +374,8 @@ type operator = [
   | FloorDiv | MatMult (* Python *)
   | LSL | LSR | ASR (* L = logic, A = Arithmetic, SL = shift left *)
   | BitOr | BitXor | BitAnd | BitNot (* unary *) | BitClear (* Go *)
-  | And | Or (* also shortcut operator *) | Xor (* PHP*) | Not (* unary *)
+  | And | Or (* also shortcut operator *) | Xor (* PHP*) | Pipe (* shell *)
+  | Not (* unary *)
   | Eq (* '=' in OCaml, '==' in Go/... *)
   | NotEq
   | PhysEq (* '==' in OCaml, '===' in JS/... *)
@@ -398,6 +399,7 @@ type operator = [
   | Nullish (* ?? in Javascript *)
   | In (* in: checks that value belongs to a collection *) | NotIn (* !in *)
   | Is (* is: checks value has type *)| NotIs (* !is: *)
+  | Background (* & in shell *)
   ]
 
 type incr_decr = [Incr | Decr] (* '++', '--' *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -629,6 +629,8 @@ and operator =
   | Or
   (* PHP has a xor shortcut operator ... hmmm *)
   | Xor
+  (* Shell *)
+  | Pipe
   (* unary *)
   | Not
   | Eq (* '=' in OCaml, '==' in Go/... *)
@@ -662,6 +664,10 @@ and operator =
   | Is
   (* !is: *)
   | NotIs
+  (* Shell *)
+  | Background
+
+(* & *)
 
 (*e: type [[AST_generic.arithmetic_operator]] *)
 (*s: type [[AST_generic.incr_decr]] *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -665,9 +665,7 @@ and operator =
   (* !is: *)
   | NotIs
   (* Shell *)
-  | Background
-
-(* & *)
+  | (* & *) Background
 
 (*e: type [[AST_generic.arithmetic_operator]] *)
 (*s: type [[AST_generic.incr_decr]] *)

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -412,6 +412,7 @@ and vof_arithmetic_operator = function
   | Or -> OCaml.VSum ("Or", [])
   | Not -> OCaml.VSum ("Not", [])
   | Xor -> OCaml.VSum ("Xor", [])
+  | Pipe -> OCaml.VSum ("Pipe", [])
   | Eq -> OCaml.VSum ("Eq", [])
   | NotEq -> OCaml.VSum ("NotEq", [])
   | PhysEq -> OCaml.VSum ("PhysEq", [])
@@ -422,6 +423,7 @@ and vof_arithmetic_operator = function
   | GtE -> OCaml.VSum ("GtE", [])
   | Cmp -> OCaml.VSum ("Cmp", [])
   | Length -> OCaml.VSum ("Length", [])
+  | Background -> OCaml.VSum ("Background", [])
 
 and vof_arguments v = vof_bracket (OCaml.vof_list vof_argument) v
 

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -23,7 +23,7 @@ module G = AST_generic
 (* Intermediate Language (IL) for static analysis.
  *
  * Just like for the CST -> AST, the goal of an AST -> IL transformation
- * is to simplify things even more for program analysis purpose.
+ * is to simplify things even more for program analysis purposes.
  *
  * Here are the simplifications done compared to the generic AST:
  *  - intermediate 'instr' type (instr for instruction), for expressions with
@@ -31,17 +31,17 @@ module G = AST_generic
  *    moving Assign/Seq/Call/Conditional out of 'expr' and
  *    moving Assert out of 'stmt'
  *  - new expression type 'exp' for side-effect free expressions
- *  - intermediate 'lvalue' type; expressions are splitted in
+ *  - intermediate 'lvalue' type; expressions are split into
  *    lvalue vs regular expressions, moved Dot/Index out of expr
  *
  *  - Assign/Calls are now instructions, not expressions, and no more Seq
  *  - no AssignOp, or Decr/Incr, just Assign
  *  - Lambdas are now instructions (not nested again)
  *
- *  - no For/Foreach/DoWhile/While, converted all in Loop,
- *  - no Foreach, converted in a Loop and 2 new special
- *  - TODO no Switch, converted in Ifs
- *  - TODO no Continue/Break, converted in goto
+ *  - no For/Foreach/DoWhile/While, converted all to Loop,
+ *  - no Foreach, converted to a Loop and 2 new special
+ *  - TODO no Switch, converted to Ifs
+ *  - TODO no Continue/Break, converted to goto
  *  - less use of expr option (in Return/Assert/...), use Unit in those cases
  *
  *  - no Sgrep constructs
@@ -241,7 +241,7 @@ type argument = exp [@@deriving show]
 
 (*s: type [[IL.instr]] *)
 (* Easier type to compute lvalue/rvalue set of a too general 'expr', which
- * is now split in  instr vs exp vs lval.
+ * is now split into  instr vs exp vs lval.
  *)
 type instr = { i : instr_kind; iorig : G.expr }
 

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -90,6 +90,7 @@ let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =
           with
           | Timeout -> raise Timeout
           | exn ->
+              (* TODO: print where the exception was raised or reraise *)
               logger#debug "exn (%s) with Pfff parser" (Common.exn_to_s exn);
               Error exn)
   | TreeSitter f -> (
@@ -116,6 +117,7 @@ let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =
       with
       | Timeout -> raise Timeout
       | exn ->
+          (* TODO: print where the exception was raised or reraise *)
           logger#debug "exn (%s) with TreeSitter parser" (Common.exn_to_s exn);
           Error exn)
 

--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -5,6 +5,12 @@
    - man page: https://man7.org/linux/man-pages/man1/bash.1.html#SHELL_GRAMMAR
 *)
 
+(*
+   Disable warnings against records with identical field names.
+   Typically, it's the 'loc' field.
+*)
+[@@@warning "-30"]
+
 (*****************************************************************************)
 (* Token info *)
 (*****************************************************************************)
@@ -15,6 +21,13 @@
 
 type tok = Parse_info.t [@@deriving show]
 
+(*
+   A location is made of the first token and the last token in the source
+   code. Each node of the AST has a field that's either a loc or a
+   single tok.
+*)
+type loc = tok * tok
+
 type 'a wrap = 'a * tok [@@deriving show]
 
 type 'a bracket = tok * 'a * tok [@@deriving show]
@@ -23,7 +36,7 @@ type 'a bracket = tok * 'a * tok [@@deriving show]
 (* AST definition *)
 (*****************************************************************************)
 
-type todo = TODO
+type todo = TODO of loc
 
 type pipeline_bar = Bar of tok | Bar_ampersand of tok
 
@@ -37,7 +50,11 @@ type redirect = todo
    Redirections can occur anywhere within a simple command. We extract
    them into a list while preserving their order, which matters.
 *)
-type command_with_redirects = { command : command; redirects : redirect list }
+type command_with_redirects = {
+  loc : loc;
+  command : command;
+  redirects : redirect list;
+}
 
 (*
    A command is anything that can be chained into a pipeline.
@@ -53,13 +70,13 @@ type command_with_redirects = { command : command; redirects : redirect list }
    anything below that.
 *)
 and command =
-  | Simple_command of simple_command
-  | Compound_command of compound_command
-  | Coprocess of string option * (* simple or compound *) command
-  | Assignment of assignment
-  | Declaration of declaration
-  | Negated_command of tok * command
-  | Function_definition of function_definition
+  | Simple_command of loc * simple_command
+  | Compound_command of loc * compound_command
+  | Coprocess of loc * string option * (* simple or compound *) command
+  | Assignment of loc * assignment
+  | Declaration of loc * declaration
+  | Negated_command of loc * tok * command
+  | Function_definition of loc * function_definition
 
 (*
    Example of a so-called simple command:
@@ -83,6 +100,7 @@ and command =
    of actual arguments for the command to run (argument 0 after expansion).
 *)
 and simple_command = {
+  loc : loc;
   assignments : assignment list;
   arguments : expression list;
 }
@@ -105,9 +123,9 @@ and simple_command = {
      a | b && c | d
 *)
 and pipeline =
-  | Command of command_with_redirects
-  | Pipeline of pipeline * pipeline_bar * command_with_redirects
-  | Control_operator of pipeline * unary_control_operator
+  | Command of loc * command_with_redirects
+  | Pipeline of loc * pipeline * pipeline_bar * command_with_redirects
+  | Control_operator of loc * pipeline * unary_control_operator
 
 (*
    Sample bash list (blist)
@@ -122,27 +140,27 @@ and pipeline =
    to construct and to read from:
 *)
 and blist =
-  | Seq of (blist * blist)
-  | And of (blist * tok (* && *) * blist)
-  | Or of (blist * tok (* || *) * blist)
-  | Pipelines of pipeline list
-  | Empty
+  | Seq of loc * blist * blist
+  | And of loc * blist * tok (* && *) * blist
+  | Or of loc * blist * tok (* || *) * blist
+  | Pipelines of loc * pipeline list
+  | Empty of loc
 
 (*
    All the commands that are called "compound commands" in the man page.
 *)
 and compound_command =
-  | Subshell of subshell
-  | Command_group of command_group
-  | Arithmetic_expression of arithmetic_expression
-  | Conditional_expression of conditional_expression
-  | For_loop of for_loop
-  | For_loop_c_style of for_loop_c_style
-  | Select of select
-  | Case of case
-  | If of if_
-  | While_loop of while_
-  | Until_loop of until_
+  | Subshell of loc * subshell
+  | Command_group of loc * command_group
+  | Arithmetic_expression of loc * arithmetic_expression
+  | Conditional_expression of loc * conditional_expression
+  | For_loop of loc * for_loop
+  | For_loop_c_style of loc * for_loop_c_style
+  | Select of loc * select
+  | Case of loc * case
+  | If of loc * if_
+  | While_loop of loc * while_
+  | Until_loop of loc * until_
 
 (*
    Bash syntax allows the body of a function definition only to a
@@ -150,7 +168,8 @@ and compound_command =
    allow simple commands.
 *)
 and function_definition = {
-  func_function : string wrap option;
+  loc : loc;
+  function_ : string wrap option;
   func_name : string wrap;
   func_body : command;
 }
@@ -184,43 +203,244 @@ and declaration = todo
 and expression =
   | Word of string wrap
   | String of string_fragment list bracket
-  | String_fragment of string_fragment
+  | String_fragment of loc * string_fragment
   | Raw_string of string wrap
   | Ansii_c_string of string wrap
   | Special_character of string wrap
   | String_expansion of string wrap
-  | Concatenation of expression list
+  | Concatenation of loc * expression list
   | Semgrep_ellipsis of tok
   | Semgrep_metavariable of string wrap
-  | Expression_TODO
+  | Equality_test of loc * eq_op * right_eq_operand
+  | Expression_TODO of loc
 
 (* Fragment of a double-quoted string *)
 and string_fragment =
   | String_content of string wrap
-  | Expansion of expansion
-  | Command_substitution of blist bracket
+  | Expansion of loc * expansion
+  | Command_substitution of (* $(foo; bar) or `foo; bar` *) blist bracket
 
 (* $foo or something like ${foo ...} *)
 and expansion =
-  | Simple_expansion of (tok * variable_name)
+  | Simple_expansion of loc * tok * variable_name
   | Complex_expansion of complex_expansion bracket
 
 and variable_name =
   | Simple_variable_name of string wrap
   | Special_variable_name of string wrap
 
-and complex_expansion = Variable of variable_name | Complex_expansion_TODO
+and complex_expansion =
+  | Variable of loc * variable_name
+  | Complex_expansion_TODO of loc
 
-(* $(foo; bar) or `foo; bar` *)
-and command_substitution = blist bracket
+and eq_op = EQTILDE of (* "=~" *) tok | EQEQ of (* "==" *) tok
+
+and right_eq_operand = Literal of loc * expression | Regexp of string wrap
 
 (* A program is a list of pipelines *)
 type program = blist
 
 (*[@@deriving show { with_path = false }]*)
 
-let concat_lists (x : blist list) : blist =
+(*****************************************************************************)
+(* Extraction of the first token, used for its location info *)
+(*****************************************************************************)
+
+let left_loc_tok (left, right) = if Parse_info.is_fake left then right else left
+
+let right_loc_tok (left, right) =
+  if Parse_info.is_fake right then left else right
+
+(*
+   Form a new location from a leftmost location and a rightmost location.
+   We try to mitigate problems due to fake tokens.
+*)
+let range a b =
+  let start_tok = left_loc_tok a in
+  let end_tok = right_loc_tok b in
+  if Parse_info.is_fake end_tok then (start_tok, start_tok)
+  else if Parse_info.is_fake start_tok then (end_tok, end_tok)
+  else (start_tok, end_tok)
+
+let fake_tok = Parse_info.fake_info "fake"
+
+let fake_loc = (fake_tok, fake_tok)
+
+let compare_loc (a, _) (b, _) = Parse_info.compare_pos a b
+
+let min_loc_tok a b =
+  let tok_a = left_loc_tok a in
+  let tok_b = left_loc_tok b in
+  if Parse_info.is_fake tok_a then tok_b
+  else if Parse_info.is_fake tok_b then tok_a
+  else if Parse_info.compare_pos tok_a tok_b <= 0 then tok_a
+  else tok_b
+
+let max_loc_tok a b =
+  let tok_a = right_loc_tok a in
+  let tok_b = right_loc_tok b in
+  if Parse_info.is_fake tok_b then tok_a
+  else if Parse_info.is_fake tok_a then tok_b
+  else if Parse_info.compare_pos tok_a tok_b <= 0 then tok_b
+  else tok_a
+
+(*
+   Return the span of two ranges (locations) while trying to eliminate
+   fake positions (fake tokens).
+   If it's known that 'a' starts before 'b' and doesn't overlap,
+   then use 'range' instead.
+*)
+let union_loc a b = (min_loc_tok a b, max_loc_tok a b)
+
+(*
+   Return the span of a list of ranges (locations).
+   The location is extracted with the provided 'get_loc' function.
+*)
+let list_loc get_loc l =
+  match l with
+  | [] -> fake_loc
+  | first :: other ->
+      List.fold_left
+        (fun loc x -> union_loc loc (get_loc x))
+        (get_loc first) other
+
+let wrap_loc (_, tok) : loc = (tok, tok)
+
+let bracket_loc (start_tok, _, end_tok) : loc = (start_tok, end_tok)
+
+let todo_loc (TODO loc) = loc
+
+let pipeline_bar_loc = function
+  | Bar tok -> (tok, tok)
+  | Bar_ampersand tok -> (tok, tok)
+
+let unary_control_operator_loc = function
+  | Foreground tok -> (tok, tok)
+  | Background tok -> (tok, tok)
+
+let redirect_loc x = todo_loc x
+
+let command_with_redirects_loc x = x.loc
+
+let command_loc = function
+  | Simple_command (loc, _) -> loc
+  | Compound_command (loc, _) -> loc
+  | Coprocess (loc, _, _) -> loc
+  | Assignment (loc, _) -> loc
+  | Declaration (loc, _) -> loc
+  | Negated_command (loc, _, _) -> loc
+  | Function_definition (loc, _) -> loc
+
+let simple_command_loc (x : simple_command) = x.loc
+
+let pipeline_loc = function
+  | Command (loc, _) -> loc
+  | Pipeline (loc, _, _, _) -> loc
+  | Control_operator (loc, _, _) -> loc
+
+let blist_loc = function
+  | Seq (loc, _, _) -> loc
+  | And (loc, _, _, _) -> loc
+  | Or (loc, _, _, _) -> loc
+  | Pipelines (loc, _) -> loc
+  | Empty loc -> loc
+
+let compound_command_loc = function
+  | Subshell (loc, _) -> loc
+  | Command_group (loc, _) -> loc
+  | Arithmetic_expression (loc, _) -> loc
+  | Conditional_expression (loc, _) -> loc
+  | For_loop (loc, _) -> loc
+  | For_loop_c_style (loc, _) -> loc
+  | Select (loc, _) -> loc
+  | Case (loc, _) -> loc
+  | If (loc, _) -> loc
+  | While_loop (loc, _) -> loc
+  | Until_loop (loc, _) -> loc
+
+let function_definition_loc (x : function_definition) = x.loc
+
+let subshell_loc (x : subshell) = todo_loc x
+
+let command_group_loc (x : command_group) = todo_loc x
+
+let arithmetic_expression_loc (x : arithmetic_expression) = todo_loc x
+
+let conditional_expression_loc (x : conditional_expression) = todo_loc x
+
+let for_loop_loc (x : for_loop) = todo_loc x
+
+let for_loop_c_style_loc (x : for_loop_c_style) = todo_loc x
+
+let select_loc (x : select) = todo_loc x
+
+let case_loc (x : case) = todo_loc x
+
+let if_loc (x : if_) = todo_loc x
+
+let while_loc (x : while_) = todo_loc x
+
+let until_loc (x : until_) = todo_loc x
+
+let assignment_loc (x : assignment) = todo_loc x
+
+let assignment_list_loc (x : assignment list) = list_loc assignment_loc x
+
+let declaration_loc (x : declaration) = todo_loc x
+
+let expression_loc = function
+  | Word x -> wrap_loc x
+  | String x -> bracket_loc x
+  | String_fragment (loc, _) -> loc
+  | Raw_string x -> wrap_loc x
+  | Ansii_c_string x -> wrap_loc x
+  | Special_character x -> wrap_loc x
+  | String_expansion x -> wrap_loc x
+  | Concatenation (loc, _) -> loc
+  | Semgrep_ellipsis tok -> (tok, tok)
+  | Semgrep_metavariable x -> wrap_loc x
+  | Equality_test (loc, _, _) -> loc
+  | Expression_TODO loc -> loc
+
+let string_fragment_loc = function
+  | String_content x -> wrap_loc x
+  | Expansion (loc, _) -> loc
+  | Command_substitution x -> bracket_loc x
+
+let expansion_loc = function
+  | Simple_expansion (loc, _, _) -> loc
+  | Complex_expansion x -> bracket_loc x
+
+let variable_name_loc = function
+  | Simple_variable_name x -> wrap_loc x
+  | Special_variable_name x -> wrap_loc x
+
+let complex_expansion_loc = function
+  | Variable (loc, _) -> loc
+  | Complex_expansion_TODO loc -> loc
+
+let command_substitution_loc x = bracket_loc x
+
+let eq_op_loc = function
+  | EQTILDE (* "=~" *) tok -> (tok, tok)
+  | EQEQ (* "==" *) tok -> (tok, tok)
+
+let right_eq_operand_loc = function
+  | Literal (loc, _) -> loc
+  | Regexp x -> wrap_loc x
+
+(*****************************************************************************)
+(* Helpers for users of the module *)
+(*****************************************************************************)
+
+let concat_blists (x : blist list) : blist =
   match List.rev x with
-  | [] -> Empty
-  | last_list :: lists ->
-      List.fold_left (fun acc list -> Seq (list, acc)) last_list lists
+  | [] -> assert false
+  | last_blist :: blists ->
+      let end_ = blist_loc last_blist in
+      List.fold_left
+        (fun acc blist ->
+          let start = blist_loc blist in
+          let loc = range start end_ in
+          Seq (loc, blist, acc))
+        last_blist blists

--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -28,10 +28,8 @@ type todo = TODO
 type pipeline_bar = Bar of tok | Bar_ampersand of tok
 
 type unary_control_operator =
-  | Foreground of tok (* ';' or '\n' or ';;' *)
-  | Background of tok
-
-(* & *)
+  | Foreground of (* ';' or '\n' or ';;' *) tok
+  | Background of (* & *) tok
 
 type redirect = todo
 
@@ -112,7 +110,7 @@ and pipeline =
   | Control_operator of pipeline * unary_control_operator
 
 (*
-   Sample list
+   Sample bash list (blist)
 
    foo | bar; baz
    ^^^^^^^^^
@@ -120,12 +118,13 @@ and pipeline =
               ^^^
             pipeline 1
 
-   Not a great type definition but easy to construct:
+   The following type definition is redundant but it's meant to be easy
+   to construct and to read from:
 *)
-and list_ =
-  | Seq of (list_ * list_)
-  | And of (list_ * tok (* && *) * list_)
-  | Or of (list_ * tok (* || *) * list_)
+and blist =
+  | Seq of (blist * blist)
+  | And of (blist * tok (* && *) * blist)
+  | Or of (blist * tok (* || *) * blist)
   | Pipelines of pipeline list
   | Empty
 
@@ -199,7 +198,7 @@ and expression =
 and string_fragment =
   | String_content of string wrap
   | Expansion of expansion
-  | Command_substitution of list_ bracket
+  | Command_substitution of blist bracket
 
 (* $foo or something like ${foo ...} *)
 and expansion =
@@ -213,14 +212,14 @@ and variable_name =
 and complex_expansion = Variable of variable_name | Complex_expansion_TODO
 
 (* $(foo; bar) or `foo; bar` *)
-and command_substitution = list_ bracket
+and command_substitution = blist bracket
 
 (* A program is a list of pipelines *)
-type program = list_
+type program = blist
 
 (*[@@deriving show { with_path = false }]*)
 
-let concat_lists (x : list_ list) : list_ =
+let concat_lists (x : blist list) : blist =
   match List.rev x with
   | [] -> Empty
   | last_list :: lists ->

--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -341,6 +341,10 @@ let range a b =
   else if Parse_info.is_fake start_tok then (end_tok, end_tok)
   else (start_tok, end_tok)
 
+let extend_left new_start_tok (_, end_) : loc = (new_start_tok, end_)
+
+let extend_right (start, _) new_end_tok : loc = (start, new_end_tok)
+
 let fake_tok = Parse_info.fake_info "fake"
 
 let fake_loc = (fake_tok, fake_tok)

--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -375,6 +375,22 @@ let fake_tok = Parse_info.fake_info "fake"
 
 let fake_loc = (fake_tok, fake_tok)
 
+(*
+   Convert a pair (loc, x) to a wrap, which uses a single token to indicate
+   the location of the object in the generic AST.
+*)
+let wrap (loc : loc) x : 'a wrap =
+  let start, _ = loc in
+  (x, start)
+
+(*
+   Convert a pair (loc, x) to a bracket, which uses a leading and trailing
+   token to indicate the location.
+*)
+let bracket (loc : loc) x : 'a bracket =
+  let start, end_ = loc in
+  (start, x, end_)
+
 let compare_loc (a, _) (b, _) = Parse_info.compare_pos a b
 
 let min_loc_tok a b =
@@ -549,7 +565,10 @@ let test_expression_loc = function
 
 let concat_blists (x : blist list) : blist =
   match List.rev x with
-  | [] -> assert false
+  | [] ->
+      (* TODO: use actual location in the program rather than completely
+         fake location *)
+      Empty fake_loc
   | last_blist :: blists ->
       let end_ = blist_loc last_blist in
       List.fold_left

--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -44,12 +44,7 @@ type todo = TODO of loc
   - integer variables (created with 'declare -i'): add to the previous value
   - array variables: append to the previous array
 *)
-type assignment_operator =
-  | Set
-  (* = *)
-  | Add
-
-(* += *)
+type assignment_operator = (* = *) Set | (* += *) Add
 
 (* See list and descriptions at
    https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html
@@ -143,7 +138,7 @@ type command_with_redirects = {
    anything below that.
 *)
 and command =
-  | Simple_command of loc * simple_command
+  | Simple_command of simple_command
   (* What the manual refers to as "compound commands" *)
   | Subshell of loc * blist bracket
   | Command_group of loc * blist bracket
@@ -429,7 +424,7 @@ let redirect_loc x = todo_loc x
 let command_with_redirects_loc x = x.loc
 
 let command_loc = function
-  | Simple_command (loc, _) -> loc
+  | Simple_command x -> x.loc
   | Subshell (loc, _) -> loc
   | Command_group (loc, _) -> loc
   | Sh_test (loc, _) -> loc

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -42,12 +42,33 @@
 
    Mapping to the generic AST:
 
-   pipeline -> pipeline statement, made of a sequence of statements
-   command -> statement
-   simple command -> function call, which is an expression
-   variable assignment -> variable assignment
-   function definition -> function definition
-   for loop -> for loop, which is a statement
+   We use statements wherever we need to represent a control flow.
+   This means all declarations and assignments must be statements.
+   Members of a pipeline on the other hand execute independently and
+   can be expressions.
+
+   pipeline -> expression with '|' operator between commands
+   command -> expression or pure statement
+   simple command -> expression: Constructor ("sh_cmd", args)
+   variable assignment -> statement: variable assignment
+   function definition -> statement: function definition
+   for loop -> statement: for loop
+
+   Note that a bash pipeline may contain definitions. This is legal but
+   useless and it has no effect:
+
+     a=42 | echo hello
+     echo "$a"  # variable 'a' is undefined!
+
+   It makes more sense when a command group is used within a pipeline:
+
+     { a=42; echo "$a"; } | cat  # prints '42'
+
+   So, some shell commands are represented preferentially as statements
+   (definitions, command groups, loops, if-then-else) and others
+   are represented preferentially as expressions (simple commands, pipelines),
+   and we wrap expressions in statements and vice-versa as required by
+   the context.
 *)
 
 open! Common
@@ -56,16 +77,136 @@ module G = AST_generic
 
 (*module H = AST_generic_helpers*)
 
-let rec list_ (x : list_) : G.stmt list = List.map pipeline x |> List.flatten
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
 
-and pipeline (x : pipeline) : G.stmt list =
-  let commands, _control_op = x in
-  (* for now, unsupported constructs are simply omitted from the generic AST *)
-  List.filter_map
-    (fun (_opt_bar, cmd_redir) -> command_with_redirects cmd_redir)
-    commands
+(* Temporary representation *)
+type stmt_or_expr = Stmt of G.stmt | Expr of G.expr
 
-and command_with_redirects (x : command_with_redirects) : G.stmt option =
+let fake_tok = G.fake ""
+
+let as_stmt : stmt_or_expr -> G.stmt = function
+  | Stmt st -> st
+  | Expr e -> G.s (G.ExprStmt (e, fake_tok))
+
+let as_expr : stmt_or_expr -> G.expr = function
+  | Stmt st -> G.OtherExpr (G.OE_StmtExpr, [ G.S st ])
+  | Expr e -> e
+
+let list_as_expr : stmt_or_expr list -> G.expr = function
+  | [x] -> as_expr x
+  | several ->
+      (* make sequence of statements, then wrap in an expression *)
+      ???
+
+module C = struct
+  let mk (name : string) =
+    let id = "!sh_" ^ name ^ "!" in
+    let id_info = G.empty_id_info () in
+    G.N (G.Id ((id, fake_tok), id_info))
+
+  (* For simple commands, e.g.
+       $echo "$@"
+  *)
+  let cmd = mk "cmd"
+
+  (* Split a string according to whitespace defined by "$IFS".
+     This is done on the result of unquoted $ expansions:
+       $args
+       $(cat foo.txt)
+       `cat foo.txt`
+       ${args}
+       ${args%.c}
+  *)
+  let split = mk "split"
+
+  (* Concatenate two string fragments e.g.
+       foo"$bar"
+  *)
+  let concat = mk "concat"
+
+  (* Represents a pipeline terminator: ';', '&', '||', '&&' *)
+  let ctrl_op = mk "ctrl_op"
+end
+
+(*
+   Constructors used to represent bash expressions that don't have
+   an equivalent in the generic AST.
+
+   Usage: call C.cmd args
+*)
+let call name exprs =
+  G.Call (name, exprs)
+
+let todo_stmt = G.OtherStmt (G.OS_Todo, [])
+let todo_expr = G.OtherExpr (G.OE_Todo, [])
+
+(*****************************************************************************)
+(* Converter from bash AST to generic AST *)
+(*****************************************************************************)
+
+let apply_control_operator (e : G.expr) (op : unary_control_operator)
+  : stmt_or_expr =
+  match op with
+  | Foreground tok -> Stmt (G.s (G.ExprStmt (e, tok)))
+  | Background tok ->
+      let function_ = G.IdSpecial ((G.Op G.Background), tok) in
+      Expr (G.Call (function_, G.fake_bracket [G.Arg e]))
+
+let rec list_ (l : list_) : stmt_or_expr list =
+  match l with
+  | Seq (l1, l2) -> list_ l1 @ list_ l2
+  | And (l1, tok, l2) ->
+      (* TODO: can't compile this to an expression because the left-handside
+         updates the environment, affecting the right-handside.
+         Maybe translate to an if-then-else, which is also a statement.
+
+         a && b
+
+         -->
+
+         a
+         if [[ $? = 0 ]]; then
+           b
+         fi
+
+      *)
+      let e1 = list_ l1 |> as_expr in
+      let e2 = list_ l2 |> as_expr in
+      let function_ = G.IdSpecial ((G.Op G.And), tok) in
+      (*[Expr (G.Call (function_, G.fake_bracket [G.Arg e1; G.Arg e2]))]*)
+  | Or (l1, tok, l2) ->
+      let e1 = list_ l1 |> as_expr in
+      let e2 = list_ l2 |> as_expr in
+      let function_ = G.IdSpecial ((G.Op G.Or), tok) in
+      (*[Expr (G.Call (function_, G.fake_bracket [G.Arg e1; G.Arg e2]))]*)
+  | Pipelines pl -> List.map (fun x -> pipeline x) pl
+  | Empty -> []
+
+and pipeline (x : pipeline) : stmt_or_expr list =
+  let commands, control_op = x in
+  match commands with
+  | [] -> assert false
+  | [ (_none, single_cmd) ] -> single_cmd
+  | (_none, first) :: other ->
+      let init = command_with_redirects first |> as_expr in
+      let e =
+        List.fold_left
+          (fun left (opt_bar, cmd_redir) ->
+             let bar, tok =
+               match opt_bar with
+               | None -> assert false
+               | Some bar -> bar
+             in
+             let op = G.IdSpecial ((G.Op G.Pipe), tok) in
+             let right = command_with_redirects cmd_redir |> as_expr in
+             G.Call (op, [left; right])
+          ) init other
+      in
+      Expr e
+
+and command_with_redirects (x : command_with_redirects) : stmt_or_expr =
   let { command = cmd; redirects } = x in
   ignore redirects;
   command cmd

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -142,9 +142,9 @@ end
 let call name exprs =
   G.Call (name, G.fake_bracket (List.map (fun e -> G.Arg e) exprs))
 
-let todo_stmt = G.s (G.OtherStmt (G.OS_Todo, []))
+let todo_stmt tok = G.s (G.OtherStmt (G.OS_Todo, [ G.TodoK tok ]))
 
-let todo_expr = G.OtherExpr (G.OE_Todo, [])
+let todo_expr tok = G.OtherExpr (G.OE_Todo, [ G.TodoK tok ])
 
 (*****************************************************************************)
 (* Converter from bash AST to generic AST *)
@@ -287,12 +287,15 @@ and expansion (x : expansion) : G.expr =
 
      if a; then
        b
+     else
+       false
      fi
 *)
 and transpile_and (left : blist) tok_and (right : blist) : stmt_or_expr =
   let cond = blist left |> block |> as_expr in
   let body = blist right |> block |> as_stmt in
-  Stmt (G.s (G.If (tok_and, cond, body, None)))
+  let fail = stmt_of_expr (G.L (G.Bool (false, G.fake "false"))) in
+  Stmt (G.s (G.If (tok_and, cond, body, Some fail)))
 
 (*
    This is similar to 'transpile_and', with a negated condition.

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -159,11 +159,11 @@ let redirect_pipeline_stderr_to_stdout pip =
 
 let rec blist (l : blist) : stmt_or_expr list =
   match l with
-  | Seq (left, right) -> blist left @ blist right
-  | And (left, and_tok, right) -> [ transpile_and left and_tok right ]
-  | Or (left, or_tok, right) -> [ transpile_or left or_tok right ]
-  | Pipelines pl -> List.map (fun x -> pipeline x) pl
-  | Empty -> []
+  | Seq (loc, left, right) -> blist left @ blist right
+  | And (loc, left, and_tok, right) -> [ transpile_and left and_tok right ]
+  | Or (loc, left, or_tok, right) -> [ transpile_or left or_tok right ]
+  | Pipelines (loc, pl) -> List.map (fun x -> pipeline x) pl
+  | Empty loc -> []
 
 and pipeline (x : pipeline) : stmt_or_expr =
   match x with

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -193,7 +193,7 @@ and pipeline (x : pipeline) : stmt_or_expr =
       | Background amp_tok ->
           let func = G.IdSpecial (G.Op G.Pipe, amp_tok) in
           let arg = pipeline pip |> as_expr in
-          Expr (G.Call (func, G.fake_bracket [ G.Arg arg ])) )
+          Expr (G.Call (func, G.fake_bracket [ G.Arg arg ])))
 
 and command_with_redirects (x : command_with_redirects) : stmt_or_expr =
   (* TODO: don't ignore redirects *)
@@ -203,21 +203,6 @@ and command_with_redirects (x : command_with_redirects) : stmt_or_expr =
 
 and command (cmd : command) : stmt_or_expr =
   match cmd with
-<<<<<<< HEAD
-  | Simple_command { assignments = _; arguments } -> (
-      match arguments with
-      | [] -> None
-      | arg0 :: args ->
-          let args = List.map (fun x -> G.Arg (expression x)) args in
-          let e = G.Call (expression arg0, G.fake_bracket args) in
-          Some (G.s (ExprStmt (e, G.fake ""))))
-  | Compound_command _ -> None
-  | Coprocess _ -> None
-  | Assignment _ -> None
-  | Declaration _ -> None
-  | Negated_command _ -> None
-  | Function_definition _ -> None
-=======
   | Simple_command { assignments = _; arguments } ->
       let args = List.map expression arguments in
       Expr (call C.cmd args)
@@ -227,7 +212,6 @@ and command (cmd : command) : stmt_or_expr =
   | Declaration _ -> Stmt todo_stmt
   | Negated_command _ -> Expr todo_expr
   | Function_definition _ -> Stmt todo_stmt
->>>>>>> 0199c628... New mapping from the bash AST to the generic AST (compiles, but
 
 and expression (e : expression) : G.expr =
   match e with
@@ -237,18 +221,7 @@ and expression (e : expression) : G.expr =
       match frag with
       | String_content x -> G.L (G.Atom (G.fake "", x))
       | Expansion ex -> expansion ex
-<<<<<<< HEAD
-      | Command_substitution (_open, _x, _close) -> todo)
-  | Raw_string _ -> todo
-  | Ansii_c_string _ -> todo
-  | Special_character _ -> todo
-  | String_expansion _ -> todo
-  | Concatenation _ -> todo
-  | Semgrep_ellipsis _ -> todo
-  | Semgrep_metavariable _ -> todo
-  | Expression_TODO -> todo
-=======
-      | Command_substitution (_open, _x, _close) -> todo_expr )
+      | Command_substitution (_open, _x, _close) -> todo_expr)
   | Raw_string _ -> todo_expr
   | Ansii_c_string _ -> todo_expr
   | Special_character _ -> todo_expr
@@ -257,7 +230,6 @@ and expression (e : expression) : G.expr =
   | Semgrep_ellipsis _ -> todo_expr
   | Semgrep_metavariable _ -> todo_expr
   | Expression_TODO -> todo_expr
->>>>>>> 0199c628... New mapping from the bash AST to the generic AST (compiles, but
 
 (*
    '$' followed by a variable to transform and expand into a list.

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -167,7 +167,7 @@ let rec blist (l : blist) : stmt_or_expr list =
 
 and pipeline (x : pipeline) : stmt_or_expr =
   match x with
-  | Command cmd_redir -> command_with_redirects cmd_redir
+  | Command (loc, cmd_redir) -> command_with_redirects cmd_redir
   | Pipeline (pip, pipe_op, cmd_redir) ->
       let pip, bar_tok =
         match pipe_op with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -314,6 +314,8 @@ and command (env : env) ((v1, v2, v3) : CST.command) : command_with_redirects =
         match x with
         | `Choice_conc x -> literal env x
         | `Choice_EQTILDE_choice_choice_conc (v1, v2) ->
+            (* Not sure why we have this here. Should be only within
+               test commands [[ ... ]]. *)
             let eq =
               match v1 with
               | `EQTILDE tok -> (* "=~" *) EQTILDE (token env tok)
@@ -696,7 +698,12 @@ and primary_expression (env : env) (x : CST.primary_expression) : expression =
       Expression_TODO loc
 
 and program (env : env) (opt : CST.program) : blist =
-  match opt with Some x -> statements env x | None -> Empty fake_loc
+  match opt with
+  | Some x -> statements env x
+  | None ->
+      (* TODO: use an empty token at the current position in the source
+         file rather than a completely fake token. *)
+      Empty fake_loc
 
 (*
    Read a statement as a list (of pipelines).

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -336,7 +336,7 @@ and command (env : env) ((v1, v2, v3) : CST.command) : command_with_redirects =
     let loc2 = list_loc expression_loc arguments in
     union_loc loc1 loc2
   in
-  let command = Simple_command (loc, { loc; assignments; arguments }) in
+  let command = Simple_command { loc; assignments; arguments } in
   { loc; command; redirects }
 
 and command_name (env : env) (x : CST.command_name) : expression =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -426,17 +426,19 @@ and expansion (env : env) ((v1, v2, v3, v4) : CST.expansion) :
   let close = token env v4 (* "}" *) in
   let complex_expansion =
     match opt_variable with
-    | Some variable_name -> Variable variable_name
-    | None -> Complex_expansion_TODO
+    | Some varname ->
+        let loc = variable_name_loc varname in
+        Variable (loc, varname)
+    | None ->
+        let loc = (open_, close) in
+        Complex_expansion_TODO loc
   in
   (open_, complex_expansion, close)
 
 (* These are expressions used in [[ ... ]], in C-style for loops, etc. *)
 and expression (env : env) (x : CST.expression) : expression =
   match x with
-  | `Choice_conc x ->
-      literal env x |> ignore;
-      Expression_TODO
+  | `Choice_conc x -> literal env x
   | `Un_exp (v1, v2) ->
       let _v1 =
         match v1 with


### PR DESCRIPTION
A week after Hack Week, I have something that can build again. In the style of camlp4, I added a `loc` field to (almost) each node of the bash AST. A loc is a pair (first token, last token) that's used to map to a region in the source code. This works fine. Now we can search for patterns like `sudo ...` and get some of the expected matches, so that's something. Some things are working, many are not. I haven't started a test suite yet. I think it's still a little early to worry about regressions just yet.

For testing, run:
```
semgrep-core -lang bash foo.bash -e 'sudo ...'
```
Also, `-dump_ast` is handy:
```
semgrep-core -lang bash foo.bash -dump_ast
```

PR checklist:
- [x] changelog is up to date

