### PR TITLE
Put back warnings for Parse_rust_tree_sitter.ml and "fix" them

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -56,12 +56,6 @@ let name_of_id id = (id, G.empty_name_info)
    to another type of tree.
 *)
 
-(* Disable warnings against unused variables *)
-[@@@warning "-26-27"]
-
-(* Disable warning against unused 'rec' *)
-[@@@warning "-39"]
-
 type function_declaration_rs = {
   name : G.name_or_dynamic;
   type_params : G.type_parameter list;
@@ -170,7 +164,7 @@ let map_reserved_identifier (env : env) (x : CST.reserved_identifier) =
 
 (* "union" *)
 
-let map_primitive_type_token (env : env) (x : CST.anon_choice_u8_6dad923) =
+let map_primitive_type_token (_env : env) (x : CST.anon_choice_u8_6dad923) =
   match x with
   | `U8 tok (* "u8" *)
   | `I8 tok (* "i8" *)
@@ -324,23 +318,23 @@ and map_simple_path_ident (env : env) (x : CST.simple_path) :
 and map_simple_scoped_identifier (env : env)
     ((v1, v2, v3) : CST.simple_scoped_identifier) : G.dotted_ident * G.ident =
   let path = map_simple_path env v1 in
-  let colons = token env v2 (* "::" *) in
+  let _colons = token env v2 (* "::" *) in
   let ident = ident env v3 (* identifier *) in
   (path, ident)
 
 and map_simple_scoped_identifier_name (env : env)
     ((v1, v2, v3) : CST.simple_scoped_identifier) : G.ident * G.name_info =
   let path = map_simple_path env v1 in
-  let colons = token env v2 (* "::" *) in
+  let _colons = token env v2 (* "::" *) in
   let ident = ident env v3 (* identifier *) in
   (ident, { G.name_qualifier = Some (G.QDots path); G.name_typeargs = None })
 
 let map_foreign_item_type (env : env) ((v1, v2, v3) : CST.foreign_item_type) :
     G.stmt =
-  let type_ = token env v1 (* "type" *) in
+  let _type_TODO = token env v1 (* "type" *) in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let semicolon = token env v3 (* ";" *) in
+  let _semicolon = token env v3 (* ";" *) in
   let type_def =
     { G.tbody = G.NewType (G.TyN (G.Id (ident, G.empty_id_info ()))) }
   in
@@ -354,13 +348,13 @@ let map_foreign_item_type (env : env) ((v1, v2, v3) : CST.foreign_item_type) :
   G.DefStmt (ent, G.TypeDef type_def) |> G.s
 
 let map_lifetime (env : env) ((v1, v2) : CST.lifetime) : lifetime =
-  let apostrophe = token env v1 (* "'" *) in
+  let _apostropheTODO = token env v1 (* "'" *) in
   let id = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   id
 
 let map_loop_label (env : env) ((v1, v2) : CST.loop_label) : G.label_ident =
-  let apostophe = token env v1 (* "'" *) in
+  let _apostopheTODO = token env v1 (* "'" *) in
   let label = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   G.LId label
@@ -427,21 +421,21 @@ let map_function_modifiers (env : env) (xs : CST.function_modifiers) :
     xs
   |> List.flatten
 
-let map_for_lifetimes (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_lifetimes)
+let map_for_lifetimes (env : env) ((v1, v2, v3, v4, _v5TODO, v6) : CST.for_lifetimes)
     : lifetime list =
-  let for_ = token env v1 (* "for" *) in
-  let lthan = token env v2 (* "<" *) in
+  let _for_ = token env v1 (* "for" *) in
+  let _lthan = token env v2 (* "<" *) in
   let lifetime_first = map_lifetime env v3 in
   let lifetime_rest =
     List.map
       (fun (v1, v2) ->
-        let comma = token env v1 (* "," *) in
+        let _comma = token env v1 (* "," *) in
         let lifetime = map_lifetime env v2 in
         lifetime)
       v4
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) in
-  let gthan = token env v6 (* ">" *) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) in
+  let _gthan = token env v6 (* ">" *) in
   lifetime_first :: lifetime_rest
 
 let rec map_token_tree (env : env) (x : CST.token_tree) :
@@ -467,7 +461,7 @@ and map_tokens (env : env) (x : CST.tokens) : rust_macro_item =
   match x with
   | `Tok_tree x -> MacTkTree (map_token_tree env x)
   | `Tok_repe (v1, v2, v3, v4, v5, v6) ->
-      let dollar = token env v1 (* "$" *) in
+      let _dollarTODO = token env v1 (* "$" *) in
       let lparen = token env v2 (* "(" *) in
       let tokens = List.map (map_tokens env) v3 in
       let rparen = token env v4 (* ")" *) in
@@ -482,7 +476,7 @@ let rec map_token_pattern (env : env) (x : CST.token_pattern) :
   match x with
   | `Tok_tree_pat x -> RustMacPatTree (map_token_tree_pattern env x)
   | `Tok_repe_pat (v1, v2, v3, v4, v5, v6) ->
-      let dollar = token env v1 (* "$" *) in
+      let _dollarTODO = token env v1 (* "$" *) in
       let lparen = token env v2 (* "(" *) in
       let patterns = List.map (map_token_pattern env) v3 in
       let rparen = token env v4 (* ")" *) in
@@ -492,7 +486,7 @@ let rec map_token_pattern (env : env) (x : CST.token_pattern) :
       RustMacPatRepetition ((lparen, patterns, rparen), ident, quantifier)
   | `Tok_bind_pat (v1, v2, v3) ->
       let ident = ident env v1 (* pattern \$[a-zA-Z_]\w* *) in
-      let colon = token env v2 (* ":" *) in
+      let _colon = token env v2 (* ":" *) in
       let fragment_specifier = map_fragment_specifier env v3 in
       RustMacPatBinding (ident, fragment_specifier)
   | `Choice_lit x -> RustMacPatToken (map_non_special_token env x)
@@ -501,25 +495,25 @@ and map_token_tree_pattern (env : env) (x : CST.token_tree_pattern) :
     rust_macro_pattern list =
   match x with
   | `LPAR_rep_tok_pat_RPAR (v1, v2, v3) ->
-      let lparen = token env v1 (* "(" *) in
+      let _lparen = token env v1 (* "(" *) in
       let patterns = List.map (map_token_pattern env) v2 in
-      let rparen = token env v3 (* ")" *) in
+      let _rparen = token env v3 (* ")" *) in
       patterns
   | `LBRACK_rep_tok_pat_RBRACK (v1, v2, v3) ->
-      let lbracket = token env v1 (* "[" *) in
+      let _lbracket = token env v1 (* "[" *) in
       let patterns = List.map (map_token_pattern env) v2 in
-      let rbracket = token env v3 (* "]" *) in
+      let _rbracket = token env v3 (* "]" *) in
       patterns
   | `LCURL_rep_tok_pat_RCURL (v1, v2, v3) ->
-      let lbrace = token env v1 (* "{" *) in
+      let _lbrace = token env v1 (* "{" *) in
       let patterns = List.map (map_token_pattern env) v2 in
-      let rbrace = token env v3 (* "}" *) in
+      let _rbrace = token env v3 (* "}" *) in
       patterns
 
 and map_macro_rule (env : env) ((v1, v2, v3) : CST.macro_rule) : rust_macro_rule
     =
   let rules = map_token_tree_pattern env v1 in
-  let arrow = token env v2 (* "=>" *) in
+  let _arrow = token env v2 (* "=>" *) in
   let body = map_token_tree env v3 in
   { rules; body }
 
@@ -557,10 +551,10 @@ and map_tuple_struct_name (env : env) (x : CST.anon_choice_type_id_f1f5a37) :
 and map_struct_pattern_field (env : env) (x : CST.anon_choice_field_pat_8e757e8)
     : G.dotted_ident * G.pattern =
   match x with
-  | `Field_pat (v1, v2, v3) -> (
-      let ref_ = Option.map (fun tok -> token env tok) in
+  | `Field_pat (_v1, v2, v3) -> (
+      let _ref_ = Option.map (fun tok -> token env tok) in
       (* "ref" *)
-      let mutability_attr =
+      let _mutability_attr =
         Option.map
           (fun tok ->
             let t = token env tok in
@@ -576,7 +570,7 @@ and map_struct_pattern_field (env : env) (x : CST.anon_choice_field_pat_8e757e8)
       | `Id_COLON_pat (v1, v2, v3) ->
           let ident = ident env v1 in
           (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-          let colon = token env v2 (* ":" *) in
+          let _colon = token env v2 (* ":" *) in
           let pat = map_pattern env v3 in
           ([ ident ], pat) )
   | `Rema_field_pat tok ->
@@ -609,15 +603,15 @@ and map_type_parameter (env : env) (x : CST.anon_choice_life_859e88f) :
             (ident, [ G.OtherTypeParam (G.OTP_Ident, []) ])
         | `Cons_type_param x -> map_constrained_type_parameter env x
       in
-      let equal = token env v2 (* "=" *) in
-      let default_ty = map_type_ env v3 in
+      let _equal = token env v2 (* "=" *) in
+      let _default_ty = map_type_ env v3 in
       type_param
   | `Const_param (v1, v2, v3, v4) ->
-      let const = token env v1 in
+      let _const = token env v1 in
       (* "const" *)
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-      let colon = token env v3 in
+      let _colon = token env v3 in
       (* ":" *)
       let ty = map_type_ env v4 in
       (ident, [ G.OtherTypeParam (G.OTP_Const, [ G.T ty ]) ])
@@ -641,13 +635,13 @@ and map_meta_argument (env : env) (x : CST.anon_choice_meta_item_fefa160) :
   | `Meta_item x -> MetaArgMetaItem (map_meta_item env x)
   | `Lit x -> MetaArgLiteral (map_literal env x)
 
-and map_anon_choice_param_2c23cdc (env : env) outer_attr
+and map_anon_choice_param_2c23cdc (env : env) _outer_attrTODO
     (x : CST.anon_choice_param_2c23cdc) : G.parameter =
   match x with
   | `Param x -> map_parameter env x
   | `Self_param (v1, v2, v3, v4) ->
       let borrow = Option.map (fun tok -> token env tok (* "&" *)) v1 in
-      let lifetime = Option.map (fun x -> map_lifetime env x) v2 in
+      let _lifetime = Option.map (fun x -> map_lifetime env x) v2 in
       let mutability =
         Option.map
           (fun tok ->
@@ -703,7 +697,7 @@ and map_field_initializer (env : env)
     (x : CST.anon_choice_shor_field_init_9cb4441) : G.expr =
   match x with
   | `Shor_field_init (v1, v2) ->
-      let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+      let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let lhs = G.N (G.Id (ident, G.empty_id_info ())) in
@@ -711,7 +705,7 @@ and map_field_initializer (env : env)
       let rhs = G.N (G.Id (ident, G.empty_id_info ())) in
       G.Assign (lhs, G.fake ":", rhs)
   | `Field_init (v1, v2, v3, v4) ->
-      let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+      let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let lhs = G.N (G.Id (ident, G.empty_id_info ())) in
@@ -726,9 +720,9 @@ and map_type_argument (env : env) (x : CST.anon_choice_type_39799c3) :
   | `Type x -> G.TypeArg (map_type_ env x)
   | `Type_bind (v1, v2, v3) ->
       (* TODO *)
-      let ident = ident env v1 in
+      let _identTODO = ident env v1 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-      let equals = token env v2 (* "=" *) in
+      let _equals = token env v2 (* "=" *) in
       let ty = map_type_ env v3 in
       G.TypeArg ty
   | `Life x -> G.TypeLifetime (map_lifetime env x)
@@ -745,26 +739,26 @@ and map_tuple_pattern_list (env : env)
   let pattern_rest =
     List.map
       (fun (v1, v2) ->
-        let comma = token env v1 (* "," *) in
+        let _comma = token env v1 (* "," *) in
         let pattern = map_pattern env v2 in
         pattern)
       v2
   in
   pattern_first :: pattern_rest
 
-and map_arguments (env : env) ((v1, v2, v3, v4) : CST.arguments) :
+and map_arguments (env : env) ((v1, v2, _v3TODO, v4) : CST.arguments) :
     G.arguments G.bracket =
   let lparen = token env v1 (* "(" *) in
   let args =
     match v2 with
     | Some (v1, v2, v3) ->
-        let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+        let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
         let expr_first = G.Arg (map_expression env v2) in
         let expr_rest =
           List.map
             (fun (v1, v2, v3) ->
-              let comma = token env v1 (* "," *) in
-              let outer_attrs = List.map (map_outer_attribute_item env) v2 in
+              let _comma = token env v1 (* "," *) in
+              let _outer_attrs = List.map (map_outer_attribute_item env) v2 in
               let expr = map_expression env v3 in
               G.Arg expr)
             v3
@@ -772,30 +766,30 @@ and map_arguments (env : env) ((v1, v2, v3, v4) : CST.arguments) :
         expr_first :: expr_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) in
   let rparen = token env v4 (* ")" *) in
   (lparen, args, rparen)
 
 and map_associated_type (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.associated_type) : G.stmt =
-  let type_ = token env v1 (* "type" *) in
+  let _type_TODO = token env v1 (* "type" *) in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   let type_params =
     match v3 with Some x -> map_type_parameters env x | None -> []
   in
-  let trait_bounds =
+  let _trait_bounds =
     match v4 with Some x -> map_trait_bounds env x | None -> []
   in
   let ty =
     Option.map
       (fun (v1, v2) ->
-        let equals = token env v1 (* "=" *) in
+        let _equals = token env v1 (* "=" *) in
         let ty = map_type_ env v2 in
         ty)
       v5
   in
-  let semicolon = token env v6 (* ";" *) in
+  let _semicolon = token env v6 (* ";" *) in
   let type_def_kind =
     match ty with
     | Some ty -> G.AliasType ty
@@ -812,9 +806,9 @@ and map_associated_type (env : env)
   G.DefStmt (ent, G.TypeDef type_def) |> G.s
 
 and map_attribute (env : env) ((v1, v2, v3) : CST.attribute) : rust_meta_item =
-  let lbracket = token env v1 (* "[" *) in
+  let _lbracket = token env v1 (* "[" *) in
   let meta_item = map_meta_item env v2 in
-  let rbracket = token env v3 (* "]" *) in
+  let _rbracket = token env v3 (* "]" *) in
   meta_item
 
 and map_base_field_initializer (env : env)
@@ -903,7 +897,7 @@ and map_binary_expression (env : env) (x : CST.binary_expression) : G.expr =
 and map_block (env : env) ((v1, v2, v3, v4) : CST.block) : G.stmt =
   let lbrace = token env v1 (* "{" *) in
   let stmts = List.map (map_statement env) v2 |> List.flatten in
-  let stmts_and_expr =
+  let _stmts_and_exprTODO =
     match v3 with
     | Some x ->
         let expr = map_expression env x in
@@ -948,7 +942,7 @@ and map_bracketed_type (env : env) ((v1, v2, v3) : CST.bracketed_type) =
 
 and map_closure_parameters (env : env) ((v1, v2, v3) : CST.closure_parameters) :
     G.parameter list =
-  let lpipe = token env v1 (* "|" *) in
+  let _lpipe = token env v1 (* "|" *) in
   let params =
     match v2 with
     | Some (v1, v2) ->
@@ -956,7 +950,7 @@ and map_closure_parameters (env : env) ((v1, v2, v3) : CST.closure_parameters) :
         let param_rest =
           List.map
             (fun (v1, v2) ->
-              let comma = token env v1 (* "," *) in
+              let _comma = token env v1 (* "," *) in
               let param = map_closure_parameter env v2 in
               param)
             v2
@@ -964,11 +958,11 @@ and map_closure_parameters (env : env) ((v1, v2, v3) : CST.closure_parameters) :
         param_first :: param_rest
     | None -> []
   in
-  let rpipe = token env v3 (* "|" *) in
+  let _rpipe = token env v3 (* "|" *) in
   params
 
 and map_const_block (env : env) ((v1, v2) : CST.const_block) : G.expr =
-  let const = token env v1 (* "const" *) in
+  let _constTODO = token env v1 (* "const" *) in
   let block = map_block env v2 in
   let stmt = G.OtherStmtWithStmt (G.OSWS_ConstBlock, None, block) |> G.s in
   stmt_to_expr stmt
@@ -979,17 +973,17 @@ and map_const_item (env : env) ((v1, v2, v3, v4, v5, v6) : CST.const_item) :
   let attrs = [ G.KeywordAttr (G.Const, const) ] in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let colon = token env v3 (* ":" *) in
+  let _colon = token env v3 (* ":" *) in
   let type_ = map_type_ env v4 in
   let init =
     Option.map
       (fun (v1, v2) ->
-        let equals = token env v1 (* "=" *) in
+        let _equals = token env v1 (* "=" *) in
         let expr = map_expression env v2 in
         expr)
       v5
   in
-  let semicolon = token env v6 (* ";" *) in
+  let _semicolon = token env v6 (* ";" *) in
   let var_def = { G.vinit = init; G.vtype = Some type_ } in
   let ent =
     {
@@ -1006,11 +1000,11 @@ and map_constrained_type_parameter (env : env)
     match v1 with `Life x -> map_lifetime env x | `Id tok -> ident env tok
     (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   in
-  let bounds = map_trait_bounds env v2 in
+  let _boundsTODO = map_trait_bounds env v2 in
   (ident, [ G.OtherTypeParam (G.OTP_Constrained, []) ])
 
 and map_else_clause (env : env) ((v1, v2) : CST.else_clause) : G.stmt =
-  let else_ = token env v1 (* "else" *) in
+  let _else_ = token env v1 (* "else" *) in
   match v2 with
   | `Blk x ->
       (* plain else *)
@@ -1026,7 +1020,7 @@ and map_else_clause (env : env) ((v1, v2) : CST.else_clause) : G.stmt =
 
 and map_enum_variant (env : env) ((v1, v2, v3, v4) : CST.enum_variant) :
     G.or_type_element =
-  let visibility =
+  let _visibilityTODO =
     match v1 with Some x -> map_visibility_modifier env x | None -> []
   in
   let ident = ident env v2 in
@@ -1034,7 +1028,7 @@ and map_enum_variant (env : env) ((v1, v2, v3, v4) : CST.enum_variant) :
   let init =
     Option.map
       (fun (v1, v2) ->
-        let equals = token env v1 (* "=" *) in
+        let _equals = token env v1 (* "=" *) in
         let expr = map_expression env v2 in
         expr)
       v4
@@ -1052,17 +1046,17 @@ and map_enum_variant (env : env) ((v1, v2, v3, v4) : CST.enum_variant) :
 
 and map_enum_variant_list (env : env) ((v1, v2, v3, v4) : CST.enum_variant_list)
     : G.type_definition_kind =
-  let lbrace = token env v1 (* "{" *) in
+  let _lbrace = token env v1 (* "{" *) in
   let variants =
     match v2 with
     | Some (v1, v2, v3) ->
-        let outer_attributes = List.map (map_outer_attribute_item env) v1 in
+        let _outer_attributes = List.map (map_outer_attribute_item env) v1 in
         let variant_first = map_enum_variant env v2 in
         let variant_rest =
           List.map
             (fun (v1, v2, v3) ->
-              let comma = token env v1 (* "," *) in
-              let outer_attributes =
+              let _comma = token env v1 (* "," *) in
+              let _outer_attributes =
                 List.map (map_outer_attribute_item env) v2
               in
               let variant = map_enum_variant env v3 in
@@ -1072,8 +1066,8 @@ and map_enum_variant_list (env : env) ((v1, v2, v3, v4) : CST.enum_variant_list)
         variant_first :: variant_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
-  let rbrace = token env v4 (* "}" *) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
+  let _rbrace = token env v4 (* "}" *) in
   G.OrType variants
 
 and map_expression (env : env) (x : CST.expression) =
@@ -1095,7 +1089,7 @@ and map_expression (env : env) (x : CST.expression) =
           G.Call (G.IdSpecial (G.Op G.Not, tok), fb [ G.Arg expr ]) )
   | `Ref_exp (v1, v2, v3) ->
       let ref_ = token env v1 (* "&" *) in
-      let mutability =
+      let _mutabilityTODO =
         Option.map
           (fun tok ->
             let tok = token env tok (* "mut" *) in
@@ -1136,7 +1130,7 @@ and map_expression (env : env) (x : CST.expression) =
       G.AssignOp (lhs, (op, tok), rhs)
   | `Type_cast_exp (v1, v2, v3) ->
       let expr = map_expression env v1 in
-      let as_ = token env v2 (* "as" *) in
+      let _as_ = token env v2 (* "as" *) in
       let type_ = map_type_ env v3 in
       G.Cast (type_, expr)
   | `Range_exp x -> map_range_expression env x
@@ -1158,7 +1152,7 @@ and map_expression (env : env) (x : CST.expression) =
   | `Self tok -> G.IdSpecial (G.Self, token env tok) (* "self" *)
   | `Scoped_id x -> map_scoped_identifier env x
   | `Gene_func (v1, v2, v3) -> (
-      let colons = token env v2 (* "::" *) in
+      let _colons = token env v2 (* "::" *) in
       let typeargs = map_type_arguments env v3 in
       match v1 with
       | `Id tok ->
@@ -1186,18 +1180,18 @@ and map_expression (env : env) (x : CST.expression) =
       | `Field_exp x -> map_field_expression env x (Some typeargs) )
   | `Await_exp (v1, v2, v3) ->
       let expr = map_expression env v1 in
-      let dot = token env v2 (* "." *) in
+      let _dot = token env v2 (* "." *) in
       let await = token env v3 (* "await" *) in
       G.Await (await, expr)
   | `Field_exp x -> map_field_expression env x None
   | `Array_exp (v1, v2, v3, v4) ->
       let lbracket = token env v1 (* "[" *) in
-      let outer_attrs = List.map (map_outer_attribute_item env) v2 in
+      let _outer_attrs = List.map (map_outer_attribute_item env) v2 in
       let exprs =
         match v3 with
         | `Exp_SEMI_exp (v1, v2, v3) ->
             let ty = map_expression env v1 in
-            let semicolon = token env v2 (* ";" *) in
+            let _semicolon = token env v2 (* ";" *) in
             let init = map_expression env v3 in
             [ ty; init ]
             (* TODO? *)
@@ -1209,7 +1203,7 @@ and map_expression (env : env) (x : CST.expression) =
                   let expr_rest =
                     List.map
                       (fun (v1, v2) ->
-                        let comma = token env v1 (* "," *) in
+                        let _comma = token env v1 (* "," *) in
                         let expr = map_expression env v2 in
                         expr)
                       v2
@@ -1217,21 +1211,21 @@ and map_expression (env : env) (x : CST.expression) =
                   expr_first :: expr_rest
               | None -> []
             in
-            let comma = Option.map (fun tok -> token env tok (* "," *)) v2 in
+            let _comma = Option.map (fun tok -> token env tok (* "," *)) v2 in
             exprs
       in
       let rbracket = token env v4 (* "]" *) in
       G.Container (G.Array, (lbracket, exprs, rbracket))
   | `Tuple_exp (v1, v2, v3, v4, v5, v6, v7) ->
       let lparen = token env v1 (* "(" *) in
-      let outer_attrs = List.map (map_outer_attribute_item env) v2 in
+      let _outer_attrs = List.map (map_outer_attribute_item env) v2 in
       let expr_first = map_expression env v3 in
-      let comma = token env v4 (* "," *) in
+      let _comma = token env v4 (* "," *) in
       let expr_rest =
         List.map
           (fun (v1, v2) ->
             let expr = map_expression env v1 in
-            let comma = token env v2 (* "," *) in
+            let _comma = token env v2 (* "," *) in
             expr)
           v5
       in
@@ -1244,7 +1238,7 @@ and map_expression (env : env) (x : CST.expression) =
   | `Macro_invo x -> map_macro_invocation env x
   | `Unit_exp (v1, v2) ->
       let lparen = token env v1 (* "(" *) in
-      let rparen = token env v2 (* ")" *) in
+      let _rparen = token env v2 (* ")" *) in
       G.L (G.Unit lparen)
   | `Choice_unsafe_blk x -> map_expression_ending_with_block env x
   | `Brk_exp (v1, v2, v3) ->
@@ -1252,7 +1246,7 @@ and map_expression (env : env) (x : CST.expression) =
       let label =
         match v2 with Some x -> map_loop_label env x | None -> G.LNone
       in
-      let expr = Option.map (fun x -> map_expression env x) v3 in
+      let _exprTODO = Option.map (fun x -> map_expression env x) v3 in
       let break_stmt = G.Break (break, label, sc) |> G.s in
       (* TODO expr *)
       stmt_to_expr break_stmt
@@ -1274,7 +1268,7 @@ and map_expression (env : env) (x : CST.expression) =
       (* pattern \$[a-zA-Z_]\w* *)
       G.N (G.Id (meta, G.empty_id_info ()))
   | `Clos_exp (v1, v2, v3) ->
-      let is_move =
+      let _is_moveTODO =
         Option.map
           (fun tok ->
             let tok = token env tok in
@@ -1289,7 +1283,7 @@ and map_expression (env : env) (x : CST.expression) =
             let ret_type =
               Option.map
                 (fun (v1, v2) ->
-                  let arrow = token env v1 (* "->" *) in
+                  let _arrow = token env v1 (* "->" *) in
                   let ty = map_type_ env v2 in
                   ty)
                 v1
@@ -1310,9 +1304,9 @@ and map_expression (env : env) (x : CST.expression) =
       in
       G.Lambda func_def
   | `Paren_exp (v1, v2, v3) ->
-      let lparen = token env v1 (* "(" *) in
+      let _lparen = token env v1 (* "(" *) in
       let expr = map_expression env v2 in
-      let rparen = token env v3 (* ")" *) in
+      let _rparen = token env v3 (* ")" *) in
       expr
   | `Struct_exp (v1, v2) ->
       let name : G.ident * G.name_info =
@@ -1338,18 +1332,18 @@ and map_expression_ending_with_block (env : env)
     (x : CST.expression_ending_with_block) : G.expr =
   let map_loop_label_ (v1, v2) =
     let loop_label = map_loop_label env v1 in
-    let colon = token env v2 (* ":" *) in
+    let _colon = token env v2 (* ":" *) in
     loop_label
   in
   match x with
   | `Unsafe_blk (v1, v2) ->
-      let unsafe = token env v1 (* "unsafe" *) in
+      let _unsafeTODO = token env v1 (* "unsafe" *) in
       let block = map_block env v2 in
       let stmt = G.OtherStmtWithStmt (G.OSWS_UnsafeBlock, None, block) |> G.s in
       stmt_to_expr stmt
   | `Async_blk (v1, v2, v3) ->
-      let async = token env v1 (* "async" *) in
-      let move = Option.map (fun tok -> token env tok (* "move" *)) v2 in
+      let _asyncTODO = token env v1 (* "async" *) in
+      let _moveTODO = Option.map (fun tok -> token env tok (* "move" *)) v2 in
       let block = map_block env v3 in
       let stmt = G.OtherStmtWithStmt (G.OSWS_AsyncBlock, None, block) |> G.s in
       stmt_to_expr stmt
@@ -1357,30 +1351,30 @@ and map_expression_ending_with_block (env : env)
   | `If_exp x -> map_if_expression env x
   | `If_let_exp x -> map_if_let_expression env x
   | `Match_exp (v1, v2, v3) ->
-      let match_ = token env v1 (* "match" *) in
+      let _match_TODO = token env v1 (* "match" *) in
       let expr = map_expression env v2 in
       let actions = map_match_block env v3 in
       G.MatchPattern (expr, actions)
   | `While_exp (v1, v2, v3, v4) ->
-      let loop_label = Option.map map_loop_label_ v1 in
+      let _loop_labelTODO = Option.map map_loop_label_ v1 in
       let while_ = token env v2 (* "while" *) in
       let cond = map_expression env v3 in
       let body = map_block env v4 in
       let while_stmt = G.While (while_, cond, body) |> G.s in
       stmt_to_expr while_stmt
   | `While_let_exp (v1, v2, v3, v4, v5, v6, v7) ->
-      let loop_label = Option.map map_loop_label_ v1 in
+      let _loop_labelTODO = Option.map map_loop_label_ v1 in
       let while_ = token env v2 (* "while" *) in
-      let let_ = token env v3 (* "let" *) in
+      let _let_ = token env v3 (* "let" *) in
       let pattern = map_pattern env v4 in
-      let equals = token env v5 (* "=" *) in
+      let _equals = token env v5 (* "=" *) in
       let cond = map_expression env v6 in
       let body = map_block env v7 in
       let while_stmt = G.While (while_, cond, body) |> G.s in
       let expr = G.OtherExpr (G.OE_StmtExpr, [ G.P pattern; G.S while_stmt ]) in
       G.LetPattern (pattern, expr)
   | `Loop_exp (v1, v2, v3) ->
-      let loop_label = Option.map map_loop_label_ v1 in
+      let _loop_labelTODO = Option.map map_loop_label_ v1 in
       let loop = token env v2 (* "loop" *) in
       let cond = G.L (G.Bool (true, G.fake "true")) in
       (* dummy, acts as 'while true' *)
@@ -1388,7 +1382,7 @@ and map_expression_ending_with_block (env : env)
       let loop_stmt = G.While (loop, cond, body) |> G.s in
       stmt_to_expr loop_stmt
   | `For_exp (v1, v2, v3, v4, v5, v6) ->
-      let loop_label = Option.map map_loop_label_ v1 in
+      let _loop_labelTODO = Option.map map_loop_label_ v1 in
       let for_ = token env v2 (* "for" *) in
       let pattern = map_pattern env v3 in
       let in_ = token env v4 (* "in" *) in
@@ -1429,7 +1423,7 @@ and map_field_declaration (env : env) ((v1, v2, v3, v4) : CST.field_declaration)
   in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let colon = token env v3 (* ":" *) in
+  let _colon = token env v3 (* ":" *) in
   let ty = map_type_ env v4 in
   let var_def = { G.vinit = None; G.vtype = Some ty } in
   let ent =
@@ -1448,13 +1442,13 @@ and map_field_declaration_list (env : env)
   let fields =
     match v2 with
     | Some (v1, v2, v3) ->
-        let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+        let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
         let field_first = map_field_declaration env v2 in
         let field_rest =
           List.map
             (fun (v1, v2, v3) ->
-              let comma = token env v1 (* "," *) in
-              let outer_attrs = List.map (map_outer_attribute_item env) v2 in
+              let _comma = token env v1 (* "," *) in
+              let _outer_attrs = List.map (map_outer_attribute_item env) v2 in
               let field = map_field_declaration env v3 in
               field)
             v3
@@ -1462,35 +1456,35 @@ and map_field_declaration_list (env : env)
         field_first :: field_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
   let rbrace = token env v4 (* "}" *) in
   (lbrace, fields, rbrace)
 
 and map_field_declaration_type (env : env)
     ((v1, v2, v3, v4) : CST.field_declaration) : G.type_ =
-  let attrs =
+  let _attrsTODO =
     match v1 with Some x -> map_visibility_modifier env x | None -> []
   in
-  let ident = ident env v2 in
+  let _identTODO = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let colon = token env v3 (* ":" *) in
+  let _colon = token env v3 (* ":" *) in
   let ty = map_type_ env v4 in
   ty
 
 (* for enum definition (OrConstructor) *)
 and map_field_declaration_list_types (env : env)
     ((v1, v2, v3, v4) : CST.field_declaration_list) : G.type_ list =
-  let lbrace = token env v1 (* "{" *) in
+  let _lbrace = token env v1 (* "{" *) in
   let types =
     match v2 with
     | Some (v1, v2, v3) ->
-        let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+        let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
         let type_first = map_field_declaration_type env v2 in
         let type_rest =
           List.map
             (fun (v1, v2, v3) ->
-              let comma = token env v1 (* "," *) in
-              let outer_attrs = List.map (map_outer_attribute_item env) v2 in
+              let _comma = token env v1 (* "," *) in
+              let _outer_attrs = List.map (map_outer_attribute_item env) v2 in
               let ty = map_field_declaration_type env v3 in
               ty)
             v3
@@ -1498,35 +1492,35 @@ and map_field_declaration_list_types (env : env)
         type_first :: type_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
-  let rbrace = token env v4 (* "}" *) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
+  let _rbrace = token env v4 (* "}" *) in
   types
 
 and map_field_declaration_union (env : env)
     ((v1, v2, v3, v4) : CST.field_declaration) : G.or_type_element =
-  let attrs =
+  let _attrsTODO =
     match v1 with Some x -> map_visibility_modifier env x | None -> []
   in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let colon = token env v3 (* ":" *) in
+  let _colon = token env v3 (* ":" *) in
   let ty = map_type_ env v4 in
   G.OrUnion (ident, ty)
 
 (* for union definition *)
 and map_field_declaration_list_union (env : env)
     ((v1, v2, v3, v4) : CST.field_declaration_list) : G.or_type_element list =
-  let lbrace = token env v1 (* "{" *) in
+  let _lbrace = token env v1 (* "{" *) in
   let fields =
     match v2 with
     | Some (v1, v2, v3) ->
-        let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+        let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
         let field_first = map_field_declaration_union env v2 in
         let field_rest =
           List.map
             (fun (v1, v2, v3) ->
-              let comma = token env v1 (* "," *) in
-              let outer_attrs = List.map (map_outer_attribute_item env) v2 in
+              let _comma = token env v1 (* "," *) in
+              let _outer_attrs = List.map (map_outer_attribute_item env) v2 in
               let field = map_field_declaration_union env v3 in
               field)
             v3
@@ -1534,8 +1528,8 @@ and map_field_declaration_list_union (env : env)
         field_first :: field_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
-  let rbrace = token env v4 (* "}" *) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
+  let _rbrace = token env v4 (* "}" *) in
   fields
 
 and map_field_expression (env : env) ((v1, v2, v3) : CST.field_expression)
@@ -1558,14 +1552,14 @@ and map_field_expression (env : env) ((v1, v2, v3) : CST.field_expression)
         let literal = G.L (G.Int (integer_literal env tok)) in
         (* integer_literal *)
         match typeargs with
-        | Some tas -> raise Impossible
+        | Some _tas -> raise Impossible
         | None -> G.EDynamic literal )
   in
   G.DotAccess (expr, dot, ident_or_dyn)
 
 and map_field_initializer_list (env : env)
     ((v1, v2, v3, v4) : CST.field_initializer_list) : G.expr list =
-  let lbrace = token env v1 (* "{" *) in
+  let _lbrace = token env v1 (* "{" *) in
   let fields =
     match v2 with
     | Some (v1, v2) ->
@@ -1573,7 +1567,7 @@ and map_field_initializer_list (env : env)
         let field_rest =
           List.map
             (fun (v1, v2) ->
-              let comma = token env v1 (* "," *) in
+              let _comma = token env v1 (* "," *) in
               let field = map_field_initializer env v2 in
               field)
             v2
@@ -1581,14 +1575,14 @@ and map_field_initializer_list (env : env)
         field_first :: field_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
-  let rbrace = token env v4 (* "}" *) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
+  let _rbrace = token env v4 (* "}" *) in
   fields
 
 and map_foreign_block_item (env : env) ((v1, v2, v3) : CST.foreign_block_item) :
     G.stmt =
-  let outer_attrs = List.map (map_outer_attribute_item env) v1 in
-  let visibility =
+  let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
+  let _visibilityTODO =
     match v2 with Some x -> map_visibility_modifier env x | None -> []
   in
   match v3 with
@@ -1614,9 +1608,9 @@ and map_foreign_item_static (env : env)
   in
   let ident = ident env v3 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let colon = token env v4 (* ":" *) in
+  let _colon = token env v4 (* ":" *) in
   let ty = map_type_ env v5 in
-  let semicolon = token env v6 (* ";" *) in
+  let _semicolon = token env v6 (* ";" *) in
   let var_def = { G.vinit = None; G.vtype = Some ty } in
   let ent =
     {
@@ -1630,7 +1624,7 @@ and map_foreign_item_static (env : env)
 and map_foreign_mod_block (env : env) ((v1, v2, v3, v4) : CST.foreign_mod_block)
     : G.stmt =
   let lbrace = token env v1 (* "{" *) in
-  let inner_attrs = List.map (map_inner_attribute_item env) v2 in
+  let _inner_attrsTODO = List.map (map_inner_attribute_item env) v2 in
   let items = List.map (map_foreign_block_item env) v3 in
   let rbrace = token env v4 (* "}" *) in
   let block = G.Block (lbrace, items, rbrace) |> G.s in
@@ -1657,11 +1651,11 @@ and map_function_declaration (env : env)
   let retval =
     Option.map
       (fun (v1, v2) ->
-        let arrow = token env v1 (* "->" *) in
+        let _arrow = token env v1 (* "->" *) in
         map_type_ env v2)
       v4
   in
-  let where_clause = Option.map (fun x -> map_where_clause env x) v5 in
+  let _where_clauseTODO = Option.map (fun x -> map_where_clause env x) v5 in
   { name; type_params; params; retval }
 
 and map_function_item (env : env) ((v1, v2, v3, v4) : CST.function_item) :
@@ -1688,13 +1682,13 @@ and map_function_item (env : env) ((v1, v2, v3, v4) : CST.function_item) :
 and map_function_signature_with_default_item (env : env)
     ((v1, v2, v3, v4) : CST.function_signature_with_default_item) : G.definition
     =
-  let modifiers = Option.map (fun x -> map_function_modifiers env x) v1 in
+  let _modifiersTODO = Option.map (fun x -> map_function_modifiers env x) v1 in
   let fn = token env v2 (* "fn" *) in
   let fn_decl = map_function_declaration env v3 in
   let default_impl =
     match v4 with
     | `SEMI tok ->
-        let semicolon = token env tok in
+        let _semicolon = token env tok in
         (* ";" *)
         (* No default implementation *)
         G.Block (G.fake_bracket []) |> G.s
@@ -1715,10 +1709,10 @@ and map_function_signature_with_default_item (env : env)
 
 and map_function_type (env : env) ((v1, v2, v3, v4) : CST.function_type) :
     G.type_ =
-  let lifetimes =
+  let _lifetimesTODO =
     match v1 with Some x -> map_for_lifetimes env x | None -> []
   in
-  let trait, modifiers =
+  let _traitTODO, _modifiersTODO =
     match v2 with
     | `Choice_id x ->
         let trait_name = map_struct_name env x in
@@ -1726,14 +1720,14 @@ and map_function_type (env : env) ((v1, v2, v3, v4) : CST.function_type) :
         (Some trait_name, None)
     | `Opt_func_modifs_fn (v1, v2) ->
         let modifiers = Option.map (fun x -> map_function_modifiers env x) v1 in
-        let fn = token env v2 (* "fn" *) in
+        let _fnTODO = token env v2 (* "fn" *) in
         (None, modifiers)
   in
   let params = map_parameters env v3 in
   let ret_type =
     match v4 with
     | Some (v1, v2) ->
-        let arrow = token env v1 (* "->" *) in
+        let _arrow = token env v1 (* "->" *) in
         let ty = map_type_ env v2 in
         ty
     | None -> G.TyBuiltin (fake_id "()")
@@ -1756,7 +1750,7 @@ and map_generic_type (env : env) ((v1, v2) : CST.generic_type) : G.type_ =
 and map_generic_type_with_turbofish (env : env)
     ((v1, v2, v3) : CST.generic_type_with_turbofish) : G.ident * G.name_info =
   let ident, info = map_tuple_struct_name env v1 in
-  let colons = token env v2 (* "::" *) in
+  let _colons = token env v2 (* "::" *) in
   let typeargs = map_type_arguments env v3 in
   ( ident,
     { G.name_qualifier = info.name_qualifier; G.name_typeargs = Some typeargs }
@@ -1779,9 +1773,9 @@ and map_if_expression (env : env) ((v1, v2, v3, v4) : CST.if_expression) :
 and map_if_let_expression (env : env)
     ((v1, v2, v3, v4, v5, v6, v7) : CST.if_let_expression) : G.expr =
   let if_ = token env v1 (* "if" *) in
-  let let_ = token env v2 (* "let" *) in
+  let _let_ = token env v2 (* "let" *) in
   let pattern = map_pattern env v3 in
-  let equals = token env v4 (* "=" *) in
+  let _equals = token env v4 (* "=" *) in
   let cond = map_expression env v5 in
   let body = map_block env v6 in
   let else_ = Option.map (fun x -> map_else_clause env x) v7 in
@@ -1791,7 +1785,7 @@ and map_if_let_expression (env : env)
 
 and map_impl_block (env : env) ((v1, v2, v3, v4) : CST.impl_block) : G.stmt =
   let lbrace = token env v1 (* "{" *) in
-  let inner_attrs = List.map (map_inner_attribute_item env) v2 in
+  let _inner_attrs = List.map (map_inner_attribute_item env) v2 in
   let stmts = List.map (map_impl_block_item env) v3 in
   let rbrace = token env v4 (* "}" *) in
   let block = G.Block (lbrace, stmts, rbrace) |> G.s in
@@ -1799,8 +1793,8 @@ and map_impl_block (env : env) ((v1, v2, v3, v4) : CST.impl_block) : G.stmt =
 
 and map_impl_block_item (env : env) ((v1, v2, v3) : CST.impl_block_item) :
     G.stmt =
-  let outer_attrs = List.map (map_outer_attribute_item env) v1 in
-  let visibility =
+  let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
+  let _visibility =
     match v2 with Some x -> map_visibility_modifier env x | None -> []
   in
   match v3 with
@@ -1817,11 +1811,11 @@ and map_impl_block_item_const (env : env)
   let const_attr = G.KeywordAttr (G.Const, const) in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-  let colon = token env v3 (* ":" *) in
+  let _colon = token env v3 (* ":" *) in
   let ty = map_type_ env v4 in
-  let equals = token env v5 (* "=" *) in
+  let _equals = token env v5 (* "=" *) in
   let expr = map_expression env v6 in
-  let semicolon = token env v7 (* ";" *) in
+  let _semicolon = token env v7 (* ";" *) in
   let var_def = { G.vinit = Some expr; G.vtype = Some ty } in
   let ent =
     {
@@ -1834,15 +1828,15 @@ and map_impl_block_item_const (env : env)
 
 and map_impl_block_item_type (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.impl_block_item_type) : G.stmt =
-  let type_ = token env v1 (* "type" *) in
+  let _type_TODO = token env v1 (* "type" *) in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   let type_params =
     match v3 with Some x -> map_type_parameters env x | None -> []
   in
-  let equals = token env v4 (* "=" *) in
+  let _equals = token env v4 (* "=" *) in
   let ty_ = map_type_ env v5 in
-  let semicolon = token env v6 (* ";" *) in
+  let _semicolon = token env v6 (* ";" *) in
   let type_def = { G.tbody = G.NewType ty_ } in
   let ent =
     {
@@ -1855,18 +1849,18 @@ and map_impl_block_item_type (env : env)
 
 and map_inner_attribute_item (env : env)
     ((v1, v2, v3) : CST.inner_attribute_item) : rust_attribute =
-  let hash = token env v1 (* "#" *) in
-  let bang = token env v2 (* "!" *) in
+  let _hash = token env v1 (* "#" *) in
+  let _bang = token env v2 (* "!" *) in
   let meta_item = map_attribute env v3 in
   AttrInner meta_item
 
 and map_last_match_arm (env : env) ((v1, v2, v3, v4, v5) : CST.last_match_arm) :
     G.action =
-  let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+  let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
   let pattern = map_match_pattern env v2 in
-  let arrow = token env v3 (* "=>" *) in
+  let _arrow = token env v3 (* "=>" *) in
   let expr = map_expression env v4 in
-  let comma = Option.map (fun tok -> token env tok) v5 in
+  let _comma = Option.map (fun tok -> token env tok) v5 in
   (pattern, expr)
 
 and map_macro_invocation (env : env) ((v1, v2, v3) : CST.macro_invocation) :
@@ -1877,13 +1871,13 @@ and map_macro_invocation (env : env) ((v1, v2, v3) : CST.macro_invocation) :
     | `Id tok -> name_of_id (ident env tok)
     (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   in
-  let bang = token env v2 (* "!" *) in
-  let tokens = map_token_tree env v3 in
+  let _bangTODO = token env v2 (* "!" *) in
+  let _tokensTODO = map_token_tree env v3 in
   let di = dotted_ident_of_name_ name in
   G.OtherExpr (G.OE_MacroInvocation, [ G.Di di ])
 
 and map_match_arm (env : env) ((v1, v2, v3, v4) : CST.match_arm) : G.action =
-  let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+  let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
   let pattern =
     match v2 with
     | `Macro_invo x ->
@@ -1891,12 +1885,12 @@ and map_match_arm (env : env) ((v1, v2, v3, v4) : CST.match_arm) : G.action =
         G.OtherPat (G.OP_Todo, [ G.E invo ])
     | `Match_pat x -> map_match_pattern env x
   in
-  let arrow = token env v3 (* "=>" *) in
+  let _arrow = token env v3 (* "=>" *) in
   let expr =
     match v4 with
     | `Exp_COMMA (v1, v2) ->
         let expr = map_expression env v1 in
-        let comma = token env v2 (* "," *) in
+        let _comma = token env v2 (* "," *) in
         expr
     | `Choice_unsafe_blk x -> map_expression_ending_with_block env x
   in
@@ -1904,7 +1898,7 @@ and map_match_arm (env : env) ((v1, v2, v3, v4) : CST.match_arm) : G.action =
 
 and map_match_block (env : env) ((v1, v2, v3) : CST.match_block) : G.action list
     =
-  let lbrace = token env v1 (* "{" *) in
+  let _lbrace = token env v1 (* "{" *) in
   let actions =
     match v2 with
     | Some (v1, v2) ->
@@ -1913,21 +1907,21 @@ and map_match_block (env : env) ((v1, v2, v3) : CST.match_block) : G.action list
         List.concat [ match_arms; [ match_arm_last ] ]
     | None -> []
   in
-  let rbrace = token env v3 (* "}" *) in
+  let _rbrace = token env v3 (* "}" *) in
   actions
 
 and map_match_pattern (env : env) ((v1, v2) : CST.match_pattern) : G.pattern =
   let pat = map_pattern env v1 in
   match v2 with
   | Some (v1, v2) ->
-      let if_ = token env v1 (* "if" *) in
+      let _if_TODO = token env v1 (* "if" *) in
       let expr = map_expression env v2 in
       G.PatWhen (pat, expr)
   | None -> pat
 
 and map_meta_arguments (env : env) ((v1, v2, v3, v4) : CST.meta_arguments) :
     rust_meta_argument list =
-  let lparen = token env v1 (* "(" *) in
+  let _lparen = token env v1 (* "(" *) in
   let args =
     match v2 with
     | Some (v1, v2) ->
@@ -1935,7 +1929,7 @@ and map_meta_arguments (env : env) ((v1, v2, v3, v4) : CST.meta_arguments) :
         let arg_rest =
           List.map
             (fun (v1, v2) ->
-              let comma = token env v1 (* "," *) in
+              let _comma = token env v1 (* "," *) in
               let arg = map_meta_argument env v2 in
               arg)
             v2
@@ -1943,8 +1937,8 @@ and map_meta_arguments (env : env) ((v1, v2, v3, v4) : CST.meta_arguments) :
         arg_first :: arg_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok) v3 in
-  let rparen = token env v4 (* ")" *) in
+  let _comma = Option.map (fun tok -> token env tok) v3 in
+  let _rparen = token env v4 (* ")" *) in
   args
 
 and map_meta_item (env : env) ((v1, v2) : CST.meta_item) =
@@ -1954,7 +1948,7 @@ and map_meta_item (env : env) ((v1, v2) : CST.meta_item) =
       (fun x ->
         match x with
         | `EQ_lit (v1, v2) ->
-            let equals = token env v1 (* "=" *) in
+            let _equals = token env v1 (* "=" *) in
             let lit = map_literal env v2 in
             MetaItemLiteral lit
         | `Meta_args x -> MetaItemMetaArgs (map_meta_arguments env x))
@@ -1965,12 +1959,12 @@ and map_meta_item (env : env) ((v1, v2) : CST.meta_item) =
 and map_mod_block (env : env) ((v1, v2, v3, v4) : CST.mod_block) :
     G.stmt list G.bracket =
   let lbrace = token env v1 (* "{" *) in
-  let inner_attrs = List.map (map_inner_attribute_item env) v2 in
+  let _inner_attrs = List.map (map_inner_attribute_item env) v2 in
   let stmts = List.map (map_item env) v3 |> List.flatten in
   let rbrace = token env v4 (* "}" *) in
   (lbrace, stmts, rbrace)
 
-and map_ordered_field (env : env) outer_attrs (attrs : G.attribute list)
+and map_ordered_field (_env : env) _outer_attrsTODO (_attrsTODO : G.attribute list)
     (type_ : G.type_) (index : int) : G.field =
   let index_s = string_of_int index in
   let var_def = { G.vinit = None; G.vtype = Some type_ } in
@@ -2003,14 +1997,14 @@ and map_ordered_field_declaration_list (env : env)
         let field_rest =
           List.mapi
             (fun index (v1, v2, v3, v4) ->
-              let comma = token env v1 (* "," *) in
+              let _comma = token env v1 (* "," *) in
               let outer_attrs = List.map (map_outer_attribute_item env) v2 in
               let visibility =
                 match v3 with
                 | Some x -> map_visibility_modifier env x
                 | None -> []
               in
-              let type_ = map_type_ env v4 in
+              let _type_TODO = map_type_ env v4 in
               let field =
                 map_ordered_field env outer_attrs visibility type_first
                   (index + 1)
@@ -2021,28 +2015,28 @@ and map_ordered_field_declaration_list (env : env)
         field_first :: field_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok) v3 in
+  let _comma = Option.map (fun tok -> token env tok) v3 in
   let rparen = token env v4 (* ")" *) in
   (lparen, fields, rparen)
 
 (* for enum definition (OrConstructor) *)
 and map_ordered_field_declaration_list_types (env : env)
     ((v1, v2, v3, v4) : CST.ordered_field_declaration_list) : G.type_ list =
-  let lparen = token env v1 (* "(" *) in
+  let _lparen = token env v1 (* "(" *) in
   let types =
     match v2 with
     | Some (v1, v2, v3, v4) ->
-        let outer_attrs = List.map (map_outer_attribute_item env) v1 in
-        let visibility =
+        let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
+        let _visibility =
           match v2 with Some x -> map_visibility_modifier env x | None -> []
         in
         let type_first = map_type_ env v3 in
         let type_rest =
           List.mapi
-            (fun index (v1, v2, v3, v4) ->
-              let comma = token env v1 (* "," *) in
-              let outer_attrs = List.map (map_outer_attribute_item env) v2 in
-              let visibility =
+            (fun _index (v1, v2, v3, v4) ->
+              let _comma = token env v1 (* "," *) in
+              let _outer_attrs = List.map (map_outer_attribute_item env) v2 in
+              let _visibility =
                 match v3 with
                 | Some x -> map_visibility_modifier env x
                 | None -> []
@@ -2054,13 +2048,13 @@ and map_ordered_field_declaration_list_types (env : env)
         type_first :: type_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok) v3 in
-  let rparen = token env v4 (* ")" *) in
+  let _comma = Option.map (fun tok -> token env tok) v3 in
+  let _rparen = token env v4 (* ")" *) in
   types
 
 and map_outer_attribute_item (env : env) ((v1, v2) : CST.outer_attribute_item) :
     rust_attribute =
-  let hash = token env v1 (* "#" *) in
+  let _hashTODO = token env v1 (* "#" *) in
   let meta_item = map_attribute env v2 in
   AttrOuter meta_item
 
@@ -2074,7 +2068,7 @@ and map_parameter (env : env) ((v1, v2, v3, v4) : CST.parameter) : G.parameter =
       v1
   in
   let attrs = deoptionalize [ mutability ] in
-  let colon = token env v3 (* ":" *) in
+  let _colon = token env v3 (* ":" *) in
   let ty = map_type_ env v4 in
   match v2 with
   | `Pat x ->
@@ -2109,7 +2103,7 @@ and map_parameter (env : env) ((v1, v2, v3, v4) : CST.parameter) : G.parameter =
 
 and map_parameters (env : env) ((v1, v2, v3, v4) : CST.parameters) :
     G.parameter list =
-  let lparen = token env v1 (* "(" *) in
+  let _lparen = token env v1 (* "(" *) in
   let params =
     match v2 with
     | Some (v1, v2, v3) ->
@@ -2120,7 +2114,7 @@ and map_parameters (env : env) ((v1, v2, v3, v4) : CST.parameters) :
         let param_rest =
           List.map
             (fun (v1, v2, v3) ->
-              let comma = token env v1 (* "," *) in
+              let _comma = token env v1 (* "," *) in
               let outer_attr =
                 Option.map (fun x -> map_outer_attribute_item env x) v2
               in
@@ -2130,8 +2124,8 @@ and map_parameters (env : env) ((v1, v2, v3, v4) : CST.parameters) :
         param_first :: param_rest
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok) v3 in
-  let rparen = token env v4 (* ")" *) in
+  let _comma = Option.map (fun tok -> token env tok) v3 in
+  let _rparen = token env v4 (* ")" *) in
   params
 
 and map_path (env : env) (x : CST.path) : G.expr =
@@ -2207,22 +2201,22 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
       let items =
         match v2 with Some x -> map_tuple_pattern_list env x | None -> []
       in
-      let comma = Option.map (fun tok -> token env tok) v3 in
+      let _comma = Option.map (fun tok -> token env tok) v3 in
       (* "," *)
       let rparen = token env v4 (* ")" *) in
       G.PatTuple (lparen, items, rparen)
   | `Tuple_struct_pat (v1, v2, v3, v4, v5) ->
-      let name = map_tuple_struct_name env v1 in
+      let _nameTODO = map_tuple_struct_name env v1 in
       let lparen = token env v2 (* "(" *) in
       let items =
         match v3 with Some x -> map_tuple_pattern_list env x | None -> []
       in
-      let comma = Option.map (fun tok -> token env tok) v4 in
+      let _comma = Option.map (fun tok -> token env tok) v4 in
       (* "," *)
       let rparen = token env v5 (* ")" *) in
       G.PatTuple (lparen, items, rparen)
   | `Struct_pat (v1, v2, v3, v4, v5) ->
-      let name = map_struct_name env v1 in
+      let _nameTODO = map_struct_name env v1 in
       let lbrace = token env v2 (* "{" *) in
       let fields =
         match v3 with
@@ -2231,7 +2225,7 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
             let field_rest =
               List.map
                 (fun (v1, v2) ->
-                  let comma = token env v1 (* "," *) in
+                  let _comma = token env v1 (* "," *) in
                   let field = map_struct_pattern_field env v2 in
                   field)
                 v2
@@ -2239,12 +2233,12 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
             field_first :: field_rest
         | None -> []
       in
-      let comma = Option.map (fun tok -> token env tok) v4 in
+      let _comma = Option.map (fun tok -> token env tok) v4 in
       (* "," *)
       let rbrace = token env v5 (* "}" *) in
       G.PatRecord (lbrace, fields, rbrace)
   | `Ref_pat_a3d7f54 (v1, v2) ->
-      let ref_ = token env v1 (* "ref" *) in
+      let _ref_TODO = token env v1 (* "ref" *) in
       let pattern = map_pattern env v2 in
       pattern
   | `Slice_pat (v1, v2, v3, v4) ->
@@ -2252,18 +2246,18 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
       let patterns =
         match v2 with Some x -> map_tuple_pattern_list env x | None -> []
       in
-      let comma = Option.map (fun tok -> token env tok) v3 in
+      let _comma = Option.map (fun tok -> token env tok) v3 in
       (* "," *)
       let rbracket = token env v4 (* "]" *) in
       G.PatTuple (lbracket, patterns, rbracket)
   | `Capt_pat (v1, v2, v3) ->
       let ident = ident env v1 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-      let at = token env v2 (* "@" *) in
+      let _at = token env v2 (* "@" *) in
       let pattern = map_pattern env v3 in
       G.PatAs (pattern, (ident, G.empty_id_info ()))
   | `Ref_pat_dbbcf07 (v1, v2, v3) ->
-      let and_ = token env v1 (* "&" *) in
+      let _and_TODO = token env v1 (* "&" *) in
       let mutability =
         Option.map
           (fun tok ->
@@ -2273,25 +2267,25 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
           v2
       in
       let pattern = map_pattern env v3 in
-      let attrs = deoptionalize [ mutability ] in
+      let _attrs = deoptionalize [ mutability ] in
       pattern
   | `Rema_field_pat tok ->
       G.PatId (ident env tok, G.empty_id_info ()) (* ".." *)
   | `Mut_pat (v1, v2) ->
       let mut = token env v1 (* "mut" *) in
-      let mutability = G.KeywordAttr (G.Mutable, mut) in
+      let _mutability = G.KeywordAttr (G.Mutable, mut) in
       let pattern = map_pattern env v2 in
       pattern
   | `Range_pat (v1, v2, v3) ->
       let lbound = map_range_pattern_bound env v1 in
-      let op =
+      let _opTODO =
         match v2 with
         | `DOTDOTDOT tok ->
-            let tok = token env tok in
+            let _tok = token env tok in
             (* "..." *)
             G.Range
         | `DOTDOTEQ tok ->
-            let tok = token env tok in
+            let _tok = token env tok in
             (* "..=" *)
             G.RangeInclusive
       in
@@ -2299,7 +2293,7 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
       G.PatDisj (lbound, rbound)
   | `Or_pat (v1, v2, v3) ->
       let pattern_lhs = map_pattern env v1 in
-      let or_ = token env v2 (* "|" *) in
+      let _or_TODO = token env v2 (* "|" *) in
       let pattern_rhs = map_pattern env v3 in
       G.DisjPat (pattern_lhs, pattern_rhs)
   | `Const_blk x ->
@@ -2310,7 +2304,7 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
 (* "_" *)
 and map_pointer_type (env : env) ((v1, v2, v3) : CST.pointer_type) : G.type_ =
   let star = token env v1 (* "*" *) in
-  let attr =
+  let _attr =
     match v2 with
     | `Const tok -> G.KeywordAttr (G.Const, token env tok) (* "const" *)
     | `Muta_spec tok -> G.KeywordAttr (G.Mutable, token env tok)
@@ -2354,8 +2348,8 @@ and map_range_expression (env : env) (x : CST.range_expression) : G.expr =
 and map_reference_type (env : env) ((v1, v2, v3, v4) : CST.reference_type) :
     G.type_ =
   let ref_ = token env v1 (* "&" *) in
-  let lifetime = Option.map (fun x -> map_lifetime env x) v2 in
-  let mutability =
+  let _lifetime = Option.map (fun x -> map_lifetime env x) v2 in
+  let _mutability =
     Option.map
       (fun tok ->
         let tok = token env tok in
@@ -2460,7 +2454,7 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
   match x with
   | `Exp_stmt x -> [ map_expression_statement env x ]
   | `Let_decl (v1, v2, v3, v4, v5, v6) ->
-      let let_ = token env v1 (* "let" *) in
+      let _let_ = token env v1 (* "let" *) in
       let mutability =
         Option.map
           (fun tok ->
@@ -2474,7 +2468,7 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
       let type_ =
         Option.map
           (fun (v1, v2) ->
-            let colon = token env v1 (* ":" *) in
+            let _colon = token env v1 (* ":" *) in
             let type_ = map_type_ env v2 in
             type_)
           v4
@@ -2482,12 +2476,12 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
       let expr =
         Option.map
           (fun (v1, v2) ->
-            let equals = token env v1 (* "=" *) in
+            let _equals = token env v1 (* "=" *) in
             let expr = map_expression env v2 in
             expr)
           v5
       in
-      let semicolon = token env v6 (* ";" *) in
+      let _semicolon = token env v6 (* ";" *) in
       let var_def = { G.vinit = expr; G.vtype = type_ } in
       let ent =
         {
@@ -2509,7 +2503,7 @@ and map_trait_block (env : env) ((v1, v2, v3) : CST.trait_block) :
 
 and map_trait_block_item (env : env) ((v1, v2) : CST.trait_block_item) : G.field
     =
-  let outer_attrs = List.map (map_outer_attribute_item env) v1 in
+  let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
   match v2 with
   | `Const_item x -> G.FieldStmt (map_const_item env x)
   | `Func_sign_with_defa_item x ->
@@ -2523,7 +2517,7 @@ and map_trait_block_item (env : env) ((v1, v2) : CST.trait_block_item) : G.field
 and map_higher_ranked_trait_bound (env : env)
     ((v1, v2, v3) : CST.higher_ranked_trait_bound) :
     G.type_parameter list * G.type_ =
-  let for_ = token env v1 (* "for" *) in
+  let _for_TODO = token env v1 (* "for" *) in
   let type_parameters = map_type_parameters env v2 in
   let type_ = map_type_ env v3 in
   (type_parameters, type_)
@@ -2541,18 +2535,18 @@ and map_trait_bound (env : env) (x : CST.anon_choice_type_d689819) : trait_bound
       let type_params, type_ = map_higher_ranked_trait_bound env x in
       TraitBoundHigherRanked (type_params, type_)
   | `Remo_trait_bound (v1, v2) ->
-      let qmark = token env v1 (* "?" *) in
+      let _qmark = token env v1 (* "?" *) in
       let ty = map_type_ env v2 in
       TraitBoundRemoved ty
 
 and map_trait_bounds (env : env) ((v1, v2, v3) : CST.trait_bounds) :
     trait_bound list =
-  let colon = token env v1 (* ":" *) in
+  let _colon = token env v1 (* ":" *) in
   let trait_bound_first = map_trait_bound env v2 in
   let trait_bound_rest =
     List.map
       (fun (v1, v2) ->
-        let plus = token env v1 (* "+" *) in
+        let _plus = token env v1 (* "+" *) in
         let trait_bound = map_trait_bound env v2 in
         trait_bound)
       v3
@@ -2566,19 +2560,19 @@ and map_tuple_type (env : env) ((v1, v2, v3, v4, v5) : CST.tuple_type) : G.type_
   let ty_rest =
     List.map
       (fun (v1, v2) ->
-        let comma = token env v1 (* "," *) in
+        let _comma = token env v1 (* "," *) in
         let ty = map_type_ env v2 in
         ty)
       v3
   in
-  let comma = Option.map (fun tok -> token env tok) v4 in
+  let _comma = Option.map (fun tok -> token env tok) v4 in
   let rparen = token env v5 (* ")" *) in
   G.TyTuple (lparen, ty_first :: ty_rest, rparen)
 
 and map_type_ (env : env) (x : CST.type_) : G.type_ =
   match x with
   | `Abst_type (v1, v2) ->
-      let impl = token env v1 (* "impl" *) in
+      let _implTODO = token env v1 (* "impl" *) in
       let trait_type = map_abstract_type_trait_name env v2 in
       trait_type
   | `Ref_type x -> map_reference_type env x
@@ -2601,7 +2595,7 @@ and map_type_ (env : env) (x : CST.type_) : G.type_ =
       let default =
         Option.map
           (fun (v1, v2) ->
-            let semicolon = token env v1 (* ";" *) in
+            let _semicolon = token env v1 (* ";" *) in
             let expr = map_expression env v2 in
             expr)
           v3
@@ -2622,7 +2616,7 @@ and map_type_ (env : env) (x : CST.type_) : G.type_ =
       (* "!" *)
       G.TyBuiltin ("!", bang)
   | `Dyna_type (v1, v2) ->
-      let dyn = token env v1 (* "dyn" *) in
+      let _dynTODO = token env v1 (* "dyn" *) in
       let ty = map_abstract_type_trait_name env v2 in
       ty
   | `Boun_type x -> map_bounded_type env x
@@ -2635,29 +2629,29 @@ and map_type_arguments (env : env) ((v1, v2, v3, v4, v5) : CST.type_arguments) :
   let typearg_rest =
     List.map
       (fun (v1, v2) ->
-        let comma = token env v1 (* "," *) in
+        let _comma = token env v1 (* "," *) in
         let typearg = map_type_argument env v2 in
         typearg)
       v3
   in
-  let comma = Option.map (fun tok -> token env tok) v4 in
+  let _comma = Option.map (fun tok -> token env tok) v4 in
   let gthan = token env v5 (* ">" *) in
   (lthan, typearg_first :: typearg_rest, gthan)
 
 and map_type_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.type_parameters)
     : G.type_parameter list =
-  let lthan = token env v1 (* "<" *) in
+  let _lthan = token env v1 (* "<" *) in
   let type_param_first = map_type_parameter env v2 in
   let type_param_rest =
     List.map
       (fun (v1, v2) ->
-        let comma = token env v1 (* "," *) in
+        let _comma = token env v1 (* "," *) in
         let type_param = map_type_parameter env v2 in
         type_param)
       v3
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v4 in
-  let gthan = token env v5 (* ">" *) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v4 in
+  let _gthan = token env v5 (* ">" *) in
   type_param_first :: type_param_rest
 
 and map_use_clause (env : env) (x : CST.use_clause) use : G.directive list =
@@ -2669,21 +2663,21 @@ and map_use_clause (env : env) (x : CST.use_clause) use : G.directive list =
   | `Use_as_clause (v1, v2, v3) ->
       let dots, ident_ = map_simple_path_ident env v1 in
       let modname = G.DottedName dots in
-      let as_ = token env v2 (* "as" *) in
+      let _as_ = token env v2 (* "as" *) in
       let alias = ident env v3 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       [ G.ImportFrom (use, modname, ident_, Some (alias, G.empty_id_info ())) ]
   | `Use_list x -> map_use_list env x use None
   | `Scoped_use_list (v1, v2, v3) ->
       let scope = Option.map (fun x -> map_simple_path env x) v1 in
-      let colons = token env v2 (* "::" *) in
+      let _colons = token env v2 (* "::" *) in
       map_use_list env v3 use scope
   | `Use_wild (v1, v2) ->
       let dots =
         match v1 with
         | Some (v1, v2) ->
             let path = map_simple_path env v1 in
-            let colons = token env v2 (* "::" *) in
+            let _colons = token env v2 (* "::" *) in
             path
         | None -> []
       in
@@ -2717,7 +2711,7 @@ and prepend_scope (dir : G.directive) (scope : G.dotted_ident option) :
 and map_use_list (env : env) ((v1, v2, v3, v4) : CST.use_list)
     (use : PI.token_mutable) (scope : G.dotted_ident option) : G.directive list
     =
-  let lbracket = token env v1 (* "{" *) in
+  let _lbracket = token env v1 (* "{" *) in
   let directives =
     match v2 with
     | Some (v1, v2) ->
@@ -2727,7 +2721,7 @@ and map_use_list (env : env) ((v1, v2, v3, v4) : CST.use_list)
         let use_clause_rest =
           List.map
             (fun (v1, v2) ->
-              let comma = token env v1 (* "," *) in
+              let _comma = token env v1 (* "," *) in
               let use_clause =
                 match v2 with `Use_clause x -> map_use_clause env x use
               in
@@ -2737,12 +2731,12 @@ and map_use_list (env : env) ((v1, v2, v3, v4) : CST.use_list)
         List.flatten (use_clause_first :: use_clause_rest)
     | None -> []
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
-  let rbracket = token env v4 (* "}" *) in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v3 in
+  let _rbracket = token env v4 (* "}" *) in
   List.map (fun x -> prepend_scope x scope) directives
 
 and map_visibility_quantifier (env : env) (v1, v2, v3) : G.attribute =
-  let lparen = token env v1 (* "(" *) in
+  let _lparen = token env v1 (* "(" *) in
   let attribute =
     match v2 with
     (* TODO *)
@@ -2750,11 +2744,11 @@ and map_visibility_quantifier (env : env) (v1, v2, v3) : G.attribute =
     | `Super tok -> G.KeywordAttr (G.Private, token env tok) (* "super" *)
     | `Crate tok -> G.KeywordAttr (G.Protected, token env tok) (* "crate" *)
     | `In_choice_self (v1, v2) ->
-        let in_ = token env v1 (* "in" *) in
+        let _in_ = token env v1 (* "in" *) in
         let path = map_simple_path env v2 in
         G.OtherAttribute (G.OA_Expr, [ G.Di path ])
   in
-  let rparen = token env v3 (* ")" *) in
+  let _rparen = token env v3 (* ")" *) in
   attribute
 
 and map_visibility_modifier (env : env) (x : CST.visibility_modifier) :
@@ -2776,17 +2770,17 @@ and map_visibility_modifier (env : env) (x : CST.visibility_modifier) :
 
 and map_where_clause (env : env) ((v1, v2, v3, v4) : CST.where_clause) :
     where_clause =
-  let where = token env v1 (* "where" *) in
+  let _whereTODO = token env v1 (* "where" *) in
   let predicate_first = map_where_predicate env v2 in
   let predicate_rest =
     List.map
       (fun (v1, v2) ->
-        let comma = token env v1 (* "," *) in
+        let _comma = token env v1 (* "," *) in
         let predicate = map_where_predicate env v2 in
         predicate)
       v3
   in
-  let comma = Option.map (fun tok -> token env tok (* "," *)) v4 in
+  let _comma = Option.map (fun tok -> token env tok (* "," *)) v4 in
   predicate_first :: predicate_rest
 
 and map_where_predicate (env : env) ((v1, v2) : CST.where_predicate) :
@@ -2821,7 +2815,7 @@ and convert_macro_item (item : rust_macro_item) : G.any list =
 
 and convert_macro_pattern (pattern : rust_macro_pattern) : G.any list =
   match pattern with
-  | RustMacPatTree pats -> []
+  | RustMacPatTree _patsTODO -> []
   | RustMacPatRepetition ((_, pats, _), ident, tok) ->
       let pats = List.flatten (List.map convert_macro_pattern pats) in
       let ident = match ident with Some i -> [ G.I i ] | None -> [] in
@@ -2840,7 +2834,7 @@ and convert_macro_def (macro_def : rust_macro_definition) : G.macro_definition =
   let body = List.flatten (List.map convert_macro_rule rules) in
   { G.macroparams = []; G.macrobody = body }
 
-and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
+and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
     G.stmt list =
   match x with
   | `Const_item x -> [ map_const_item env x ]
@@ -2848,7 +2842,7 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       let invo = map_macro_invocation env x in
       [ G.ExprStmt (invo, sc) |> G.s ]
   | `Macro_defi (v1, v2, v3) ->
-      let macro_rules = token env v1 (* "macro_rules!" *) in
+      let _macro_rulesTODO = token env v1 (* "macro_rules!" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let macro_def : rust_macro_definition =
@@ -2860,7 +2854,7 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
               List.map
                 (fun (v1, v2) ->
                   let rule = map_macro_rule env v1 in
-                  let semicolon = token env v2 (* ";" *) in
+                  let _semicolon = token env v2 (* ";" *) in
                   rule)
                 v2
             in
@@ -2868,7 +2862,7 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
               match v3 with Some x -> [ map_macro_rule env x ] | None -> []
             in
             let rparen = token env v4 (* ")" *) in
-            let semicolon = token env v5 (* ";" *) in
+            let _semicolon = token env v5 (* ";" *) in
             (lparen, List.concat [ rules; rule_last ], rparen)
         | `LCURL_rep_macro_rule_SEMI_opt_macro_rule_RCURL (v1, v2, v3, v4) ->
             let lbrace = token env v1 (* "{" *) in
@@ -2876,7 +2870,7 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
               List.map
                 (fun (v1, v2) ->
                   let rule = map_macro_rule env v1 in
-                  let semicolon = token env v2 (* ";" *) in
+                  let _semicolon = token env v2 (* ";" *) in
                   rule)
                 v2
             in
@@ -2896,17 +2890,17 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       let macro_def = convert_macro_def macro_def in
       [ G.DefStmt (ent, G.MacroDef macro_def) |> G.s ]
   | `Empty_stmt tok ->
-      let semicolon = token env tok in
+      let _semicolon = token env tok in
       (* ";" *)
       []
   | `Mod_item (v1, v2, v3) ->
-      let mod_ = token env v1 (* "mod" *) in
+      let _mod_TODO = token env v1 (* "mod" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let block =
         match v3 with
         | `SEMI tok ->
-            let semicolon = token env tok in
+            let _semicolon = token env tok in
             (* ";" *)
             []
         | `Mod_blk x ->
@@ -2923,11 +2917,11 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       in
       [ G.DefStmt (ent, G.ModuleDef mod_def) |> G.s ]
   | `Fore_mod_item (v1, v2) ->
-      let extern = map_extern_modifier env v1 in
+      let _externTODO = map_extern_modifier env v1 in
       let block =
         match v2 with
         | `SEMI tok ->
-            let semicolon = token env tok in
+            let _semicolon = token env tok in
             (* ";" *)
             G.Block (G.fake_bracket []) |> G.s
         | `Fore_mod_blk x -> map_foreign_mod_block env x
@@ -2940,7 +2934,7 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       let type_params =
         match v3 with Some x -> map_type_parameters env x | None -> []
       in
-      let fields, where_clause =
+      let fields, _where_clauseTODO =
         match v4 with
         | `Opt_where_clause_field_decl_list (v1, v2) ->
             let where_clause =
@@ -2954,10 +2948,10 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
             let where_clause =
               Option.map (fun x -> map_where_clause env x) v2
             in
-            let semicolon = token env v3 (* ";" *) in
+            let _semicolon = token env v3 (* ";" *) in
             (fields, where_clause)
         | `SEMI tok ->
-            let semicolon = token env tok in
+            let _semicolon = token env tok in
             (* ";" *)
             let fields = (G.fake "{", [], G.fake "}") in
             (fields, None)
@@ -2981,13 +2975,13 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       in
       [ G.DefStmt (ent, G.ClassDef class_def) |> G.s ]
   | `Union_item (v1, v2, v3, v4, v5) ->
-      let union = token env v1 (* "union" *) in
+      let _unionTODO = token env v1 (* "union" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
         match v3 with Some x -> map_type_parameters env x | None -> []
       in
-      let where_clause =
+      let _where_clauseTODO =
         match v4 with Some x -> map_where_clause env x | None -> []
       in
       let variants = map_field_declaration_list_union env v5 in
@@ -3001,13 +2995,13 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       in
       [ G.DefStmt (ent, G.TypeDef type_def) |> G.s ]
   | `Enum_item (v1, v2, v3, v4, v5) ->
-      let enum = token env v1 (* "enum" *) in
+      let _enumTODO = token env v1 (* "enum" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
         match v3 with Some x -> map_type_parameters env x | None -> []
       in
-      let where_clause = Option.map (fun x -> map_where_clause env x) v4 in
+      let _where_clause = Option.map (fun x -> map_where_clause env x) v4 in
       let body = map_enum_variant_list env v5 in
       let type_def = { G.tbody = body } in
       let ent =
@@ -3019,15 +3013,15 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       in
       [ G.DefStmt (ent, G.TypeDef type_def) |> G.s ]
   | `Type_item (v1, v2, v3, v4, v5, v6) ->
-      let type_ = token env v1 (* "type" *) in
+      let _type_TODO = token env v1 (* "type" *) in
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
         match v3 with Some x -> map_type_parameters env x | None -> []
       in
-      let equals = token env v4 (* "=" *) in
-      let ty = map_type_ env v5 in
-      let semicolon = token env v6 (* ";" *) in
+      let _equals = token env v4 (* "=" *) in
+      let _tyTODO = map_type_ env v5 in
+      let _semicolon = token env v6 (* ";" *) in
       let type_def =
         { G.tbody = G.NewType (G.TyN (G.Id (ident, G.empty_id_info ()))) }
       in
@@ -3046,7 +3040,7 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       in
       let fn = token env v2 (* "fn" *) in
       let fn_decl = map_function_declaration env v3 in
-      let semicolon = token env v4 (* ";" *) in
+      let _semicolon = token env v4 (* ";" *) in
       let empty_block = G.Block (G.fake "{", [], G.fake "}") |> G.s in
       let fn_def =
         {
@@ -3070,12 +3064,12 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
             G.KeywordAttr (G.Unsafe, tok))
           v1
       in
-      let attrs = deoptionalize [ unsafe_attr ] in
-      let impl = token env v2 (* "impl" *) in
-      let type_params =
+      let _attrs = deoptionalize [ unsafe_attr ] in
+      let _impl = token env v2 (* "impl" *) in
+      let _type_paramsTODO =
         match v3 with Some x -> map_type_parameters env x | None -> []
       in
-      let trait_type =
+      let _trait_typeTODO =
         Option.map
           (fun (v1, v2) ->
             let ty =
@@ -3087,12 +3081,12 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
               | `Scoped_type_id x -> map_scoped_type_identifier env x
               | `Gene_type x -> map_generic_type env x
             in
-            let for_ = token env v2 (* "for" *) in
+            let _for_TODO = token env v2 (* "for" *) in
             ty)
           v4
       in
-      let ty = map_type_ env v5 in
-      let where_clause = Option.map (fun x -> map_where_clause env x) v6 in
+      let _tyTODO = map_type_ env v5 in
+      let _where_clauseTODO = Option.map (fun x -> map_where_clause env x) v6 in
       [ map_impl_block env v7 ]
   | `Trait_item (v1, v2, v3, v4, v5, v6, v7) ->
       let unsafe_attr =
@@ -3107,13 +3101,13 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       let trait = token env v2 (* "trait" *) in
       let ident = ident env v3 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-      let type_params =
+      let _type_paramsTODO =
         match v4 with Some x -> map_type_parameters env x | None -> []
       in
-      let trait_bounds =
+      let _trait_boundsTODO =
         match v5 with Some x -> map_trait_bounds env x | None -> []
       in
-      let where_clause = Option.map (fun x -> map_where_clause env x) v6 in
+      let _where_clauseTODO = Option.map (fun x -> map_where_clause env x) v6 in
       let fields = map_trait_block env v7 in
       let class_def =
         {
@@ -3136,23 +3130,23 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
   | `Use_decl (v1, v2, v3) ->
       let use = token env v1 (* "use" *) in
       let use_clauses = map_use_clause env v2 use in
-      let semicolon = token env v3 (* ";" *) in
+      let _semicolon = token env v3 (* ";" *) in
       List.map (fun x -> G.DirectiveStmt x |> G.s) use_clauses
   | `Extern_crate_decl (v1, v2, v3, v4, v5) ->
-      let extern = token env v1 (* "extern" *) in
-      let crate = token env v2 (* "crate" *) in
+      let _externTODO = token env v1 (* "extern" *) in
+      let _crate = token env v2 (* "crate" *) in
       let ident_ = ident env v3 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let alias =
         Option.map
           (fun (v1, v2) ->
-            let as_ = token env v1 (* "as" *) in
+            let _as_ = token env v1 (* "as" *) in
             let alias = ident env v2 in
             (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
             alias)
           v4
       in
-      let semicolon = token env v5 (* ";" *) in
+      let _semicolon = token env v5 (* ";" *) in
       let any =
         match alias with
         | Some x -> [ G.I ident_; G.I x ]
@@ -3162,7 +3156,7 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       [ G.DirectiveStmt directive |> G.s ]
   | `Static_item (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let static = token env v1 (* "static" *) in
-      let ref_ = Option.map (fun tok -> token env tok (* "ref" *)) v2 in
+      let _ref_ = Option.map (fun tok -> token env tok (* "ref" *)) v2 in
       let mutability_attr =
         Option.map
           (fun tok ->
@@ -3177,17 +3171,17 @@ and map_item_kind (env : env) outer_attrs visibility (x : CST.item_kind) :
       in
       let ident = ident env v4 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-      let colon = token env v5 (* ":" *) in
+      let _colon = token env v5 (* ":" *) in
       let type_ = map_type_ env v6 in
       let init =
         Option.map
           (fun (v1, v2) ->
-            let equals = token env v1 (* "=" *) in
+            let _equals = token env v1 (* "=" *) in
             let expr = map_expression env v2 in
             expr)
           v7
       in
-      let semicolon = token env v8 (* ";" *) in
+      let _semicolon = token env v8 (* ";" *) in
       let var_def = { G.vinit = init; G.vtype = Some type_ } in
       let ent =
         {
@@ -3206,15 +3200,15 @@ and map_item (env : env) ((v1, v2, v3) : CST.item) : G.stmt list =
 let map_source_file (env : env) (x : CST.source_file) : G.any =
   match x with
   | `Rep_inner_attr_item_rep_item (v1, v2) ->
-      let inner_attrs = List.map (map_inner_attribute_item env) v1 in
+      let _inner_attrs = List.map (map_inner_attribute_item env) v1 in
       let items = List.map (map_item env) v2 |> List.flatten in
       G.Pr items
   | `Semg_exp (v1, v2) ->
-      let header = token env v1 (* "__SEMGREP_EXPRESSION" *) in
+      let _header = token env v1 (* "__SEMGREP_EXPRESSION" *) in
       let expr = map_expression env v2 in
       G.E expr
   | `Semg_stmt (v1, v2) ->
-      let header = token env v1 (* "__SEMGREP_STATEMENT" *) in
+      let _header = token env v1 (* "__SEMGREP_STATEMENT" *) in
       let stmts = List.map (map_statement env) v2 |> List.flatten in
       G.Ss stmts
 


### PR DESCRIPTION
Mostly just put underscore in front of unused variable

test plan:
make test




PR checklist:
- [x] changelog is up to date