### PR TITLE
update to ocamlformat 0.16.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,8 @@ jobs:
 
   pre-commit-ocaml:
     runs-on: ubuntu-latest
-    # Custom image provides 'ocamlformat', needed to check ocaml code
+    # Custom image provides 'ocamlformat' with a specific version needed to check
+    # ocaml code (must be the same than the one in semgrep-core/dev/dev.opam)
     container: returntocorp/ocaml:ubuntu
     steps:
       - name: Pre-checkout fixes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           sudo chmod -R 777 "$github_cache_dir"
       - uses: actions/checkout@v2
       - name: Check OCaml code
-        run: sudo -u user opam exec -- pre-commit run --all lint-ocaml
+        run: sudo -u user opam exec -- pre-commit run --verbose --all lint-ocaml
 
   semgrep-run-r2c-config:
     name: semgrep with r2c registry

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
           sudo mkdir -p "$github_cache_dir"
           sudo chmod -R 777 "$github_cache_dir"
       - uses: actions/checkout@v2
-      - name: Check OCaml code
+      - name: Check Some OCaml code XXX
         run: sudo -u user opam exec -- pre-commit run --verbose --all lint-ocaml
 
   semgrep-run-r2c-config:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
 
 jobs:
   pre-commit:

--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -8,6 +8,9 @@ set -eu
 eval $(opam env)
 
 if $(ocamlformat --version > /dev/null 2>&1); then
+  # in theory you don't need this opam install, but if ocaml-layer
+  # is behind, we need to force the right ocamlformat
+  opam install -y ocamlformat.0.16.0
   ocamlformat --inplace --enable-outside-detected-project "$@"
 else
   cat <<EOF

--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -6,8 +6,6 @@
 set -eu
 
 eval $(opam env)
-ocamlformat --version
-echo "$@"
 
 if $(ocamlformat --version > /dev/null 2>&1); then
   #TODO: we should require a specific version, like the one in dev.opam

--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -8,9 +8,7 @@ set -eu
 eval $(opam env)
 
 if $(ocamlformat --version > /dev/null 2>&1); then
-  # in theory you don't need this opam install, but if ocaml-layer
-  # is behind, we need to force the right ocamlformat
-  opam install -y ocamlformat.0.16.0
+  #TODO: we should require a specific version, like the one in dev.opam
   ocamlformat --inplace --enable-outside-detected-project "$@"
 else
   cat <<EOF

--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -6,6 +6,8 @@
 set -eu
 
 eval $(opam env)
+ocamlformat --version
+echo "$@"
 
 if $(ocamlformat --version > /dev/null 2>&1); then
   #TODO: we should require a specific version, like the one in dev.opam

--- a/scripts/oncall-email/oncall.ml
+++ b/scripts/oncall-email/oncall.ml
@@ -117,7 +117,7 @@ let parse_card j =
             Some (parse_issue (J.Object rest))
         | J.Null -> None
         | J.Object [ ("__typename", J.String "PullRequest") ] -> None
-        | _ -> error j "not a card" )
+        | _ -> error j "not a card")
   | _ -> error j "not a card"
 
 let parse_column j =

--- a/semgrep-core/dev/dev.opam
+++ b/semgrep-core/dev/dev.opam
@@ -9,5 +9,5 @@ synopsis: "OCaml development dependencies"
 
 depends: [
   "merlin"  # used by the various text editors with ocaml support
-  "ocamlformat" {= "0.15.0" }  # used by the pre-commit hook
+  "ocamlformat" {= "0.16.0" }  # used by the pre-commit hook
 ]

--- a/semgrep-core/dev/dev.opam
+++ b/semgrep-core/dev/dev.opam
@@ -9,5 +9,8 @@ synopsis: "OCaml development dependencies"
 
 depends: [
   "merlin"  # used by the various text editors with ocaml support
+  #coupling: if you modify this, you probably need to update
+  # https://github.com/returntocorp/ocaml-layer/blob/master/common-config.sh
+  # and also scripts/lint-ocaml
   "ocamlformat" {= "0.16.0" }  # used by the pre-commit hook
 ]

--- a/semgrep-core/old/lang_php/metavars_php.ml
+++ b/semgrep-core/old/lang_php/metavars_php.ml
@@ -74,8 +74,8 @@ let check_pattern any =
                 let s = Ast.str_of_dname dname in
                 if s =~ "V\\(_[A-Z]*\\)?" then
                   failwith
-                    ( "Lvalue metavariables are deprecated, just use "
-                    ^ "expression metavariables as in X->foo()" );
+                    ("Lvalue metavariables are deprecated, just use "
+                   ^ "expression metavariables as in X->foo()");
                 k x
             | _ -> k x);
       }

--- a/semgrep-core/old/lang_php/php_vs_php.ml
+++ b/semgrep-core/old/lang_php/php_vs_php.ml
@@ -317,7 +317,7 @@ functor
         when MV.is_metavar_name name -> (
           X.envf (name, info_name) (B.Ident2 b) >>= function
           | (name, info_name), B.Ident2 b -> return (A.Name (name, info_name), b)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       | A.Name a1, B.Name b1 ->
           (m_wrap m_string_case) a1 b1 >>= fun (a1, b1) ->
           return (A.Name a1, B.Name b1)
@@ -326,7 +326,7 @@ functor
           X.envf (name, info_name) (B.Ident2 b) >>= function
           | (name, info_name), B.Ident2 b ->
               return (A.XhpName ([ name ], info_name), b)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       | A.XhpName a1, B.XhpName b1 ->
           (m_wrap (m_list m_string)) a1 b1 >>= fun (a1, b1) ->
           return (A.XhpName a1, B.XhpName b1)
@@ -531,7 +531,7 @@ functor
                 ( A.Arg a1,
                   B.Arg (B.Assign (B.IdVar (bname, bscope), btok, bexpr)) )
           | a1, b1 ->
-              m_expr a1 b1 >>= fun (a1, b1) -> return (A.Arg a1, B.Arg b1) )
+              m_expr a1 b1 >>= fun (a1, b1) -> return (A.Arg a1, B.Arg b1))
       (* an expression metavariable should also match a reference argument *)
       | ( A.Arg (A.Id (A.XName [ A.QI (A.Name (name, info_name)) ])),
           B.ArgRef (_, _) )
@@ -540,7 +540,7 @@ functor
           | (name, info_name), B.Argument b ->
               return
                 (A.Arg (A.Id (A.XName [ A.QI (A.Name (name, info_name)) ])), b)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       | A.ArgRef (a1, a2), B.ArgRef (b1, b2) ->
           m_tok a1 b1 >>= fun (a1, b1) ->
           m_w_variable a2 b2 >>= fun (a2, b2) ->
@@ -562,7 +562,7 @@ functor
           X.envf (name, info_name) (B.Expr e2) >>= function
           | (name, info_name), B.Expr e2 ->
               return (A.Id (A.XName [ A.QI (A.Name (name, info_name)) ]), e2)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       (* pad *)
       | A.SgrepExprDots _, _ -> fail ()
       | _, B.SgrepExprDots _ ->
@@ -589,7 +589,7 @@ functor
           >>= function
           | (dname, info_dname), B.Expr b ->
               return (A.IdVar (A.DName (dname, info_dname), a2), b)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       | A.IdVar (a1, a2), B.IdVar (b1, b2) ->
           m_dname a1 b1 >>= fun (a1, b1) ->
           m_ref m_xxx_scope a2 b2 >>= fun (a2, b2) ->
@@ -950,7 +950,7 @@ functor
           X.envf (name, i_name) (B.XhpAttrValue b) >>= function
           | (name, i_name), B.XhpAttrValue b ->
               return (A.SgrepXhpAttrValueMvar (name, i_name), b)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       | A.XhpAttrString (a1, a2, a3), B.XhpAttrString (b1, b2, b3) ->
           m_tok a1 b1 >>= fun (a1, b1) ->
           (m_list m_encaps) a2 b2 >>= fun (a2, b2) ->
@@ -1090,7 +1090,7 @@ functor
           | ( (name, info_name),
               (_any1, B.Expr (B.Sc (B.C (B.String (sb, info_sb))))) ) ->
               return (A.String (name, info_name), B.String (sb, info_sb))
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       (* pad, iso on  name *)
       | A.String ("...", a), B.String (s, b) ->
           m_info a b >>= fun (a, b) ->
@@ -1179,7 +1179,7 @@ functor
                          (A.Id (A.XName [ A.QI (A.Name (name, info_name)) ])));
                   ],
                   bbs )
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       (* bugfix: we can have some Replace or AddAfter in the token of
        * the comma. We need to apply it to the code.
        *)
@@ -1195,10 +1195,10 @@ functor
           if is_NoTransfo a || is_Remove a then return (xsa, xsb)
           else
             failwith
-              ( "transformation (- or +) on ',' not allowed when used with "
-              ^ "'...'. Rewrite your spatch: put your trailing comma on the \
-                 line " ^ "with the '...'. See also "
-              ^ "https://github.com/facebook/pfff/wiki/Spatch#wiki-spacing-issues"
+              ("transformation (- or +) on ',' not allowed when used with "
+             ^ "'...'. Rewrite your spatch: put your trailing comma on the \
+                line " ^ "with the '...'. See also "
+             ^ "https://github.com/facebook/pfff/wiki/Spatch#wiki-spacing-issues"
               )
       | ( [
             Right _;
@@ -1208,7 +1208,7 @@ functor
         when MV.is_metavar_manyargs_name name -> (
           X.envf (name, info_name) (B.Arguments []) >>= function
           | (_name, _info_name), B.Arguments [] -> return (xsa, xsb)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       | [ Right _; Left (A.Arg (A.SgrepExprDots _)) ], _bbs -> raise Impossible
       | Left (A.Arg (A.SgrepExprDots _)) :: _, _ ->
           failwith
@@ -1522,7 +1522,7 @@ functor
           | (name, info_name), B.Hint2 b ->
               return
                 (A.Hint (A.XName [ A.QI (A.Name (name, info_name)) ], None), b)
-          | _ -> raise Impossible )
+          | _ -> raise Impossible)
       | A.Hint (a1, a2), B.Hint (b1, b2) ->
           m_name a1 b1 >>= fun (a1, b1) ->
           m_option m_type_args a2 b2 >>= fun (a2, b2) ->

--- a/semgrep-core/old/lang_php/refactoring_code_php.ml
+++ b/semgrep-core/old/lang_php/refactoring_code_php.ml
@@ -77,7 +77,7 @@ let refactor refactorings (ast, tokens) =
                            in
                            tok_close_paren.PI.transfo <-
                              PI.AddAfter (PI.AddStr (": " ^ str));
-                           was_modifed := true );
+                           was_modifed := true);
                          k def
                      (* lambda f_name are an abstract token and so don't have
                       * any line/col position information for now
@@ -92,7 +92,7 @@ let refactor refactorings (ast, tokens) =
                      let tok = Ast.info_of_dname p.p_name in
                      if tok_pos_equal_refactor_pos tok pos_opt then (
                        tok.PI.transfo <- PI.AddBefore (PI.AddStr (str ^ " "));
-                       was_modifed := true );
+                       was_modifed := true);
                      k p);
                }
            | R.OptionizeTypeParameter ->
@@ -100,7 +100,7 @@ let refactor refactorings (ast, tokens) =
                  V.default_visitor with
                  V.kparameter =
                    (fun (k, _) p ->
-                     ( match p.p_type with
+                     (match p.p_type with
                      | None -> ()
                      | Some x ->
                          let rec leftmost_tok x =
@@ -117,7 +117,7 @@ let refactor refactorings (ast, tokens) =
                          let tok = leftmost_tok x in
                          if tok_pos_equal_refactor_pos tok pos_opt then (
                            tok.PI.transfo <- PI.AddBefore (PI.AddStr "?");
-                           was_modifed := true ) );
+                           was_modifed := true));
                      k p);
                }
            | R.AddTypeMember str ->
@@ -133,7 +133,7 @@ let refactor refactorings (ast, tokens) =
                              if tok_pos_equal_refactor_pos tok pos_opt then (
                                tok.PI.transfo <-
                                  PI.AddBefore (PI.AddStr (str ^ " "));
-                               was_modifed := true );
+                               was_modifed := true);
                              k x
                          | xs ->
                              xs |> Ast.uncomma
@@ -143,7 +143,7 @@ let refactor refactorings (ast, tokens) =
                                     then
                                       failwith
                                         "Do a SPLIT_MEMBERS refactoring first");
-                             k x )
+                             k x)
                      | _ -> k x);
                }
            | R.SplitMembers ->
@@ -178,9 +178,9 @@ let refactor refactorings (ast, tokens) =
                                  | _ -> raise Impossible
                                in
                                aux rest;
-                               was_modifed := true );
+                               was_modifed := true);
                              k x
-                         | _ -> raise Impossible )
+                         | _ -> raise Impossible)
                      | _ -> k x);
                }
            | R.AddInterface (class_opt, interface) ->
@@ -252,11 +252,11 @@ let refactor refactorings (ast, tokens) =
                                      was_modifed := true
                                  | _x :: xs -> aux xs
                                in
-                               aux xs ));
+                               aux xs));
                }
          in
          (V.mk_visitor visitor) (Program ast);
          if not !was_modifed then (
            pr2_gen (kind, pos_opt);
-           failwith "refactoring didn't apply" ));
+           failwith "refactoring didn't apply"));
   Unparse_php.string_of_program_with_comments_using_transfo (ast, tokens)

--- a/semgrep-core/old/lang_php/sgrep_php.ml
+++ b/semgrep-core/old/lang_php/sgrep_php.ml
@@ -129,8 +129,8 @@ let sgrep_ast ?(case_sensitive = false) ~hook pattern ast =
         }
     | _ ->
         failwith
-          ( spf "pattern not yet supported:"
-          ^ "TODO" (*    Export_ast_php.ml_pattern_string_of_any pattern *) )
+          (spf "pattern not yet supported:"
+          ^ "TODO" (*    Export_ast_php.ml_pattern_string_of_any pattern *))
   in
   (* opti ? dont analyze func if no constant in it ?*)
   Common.save_excursion Php_vs_php.case_sensitive case_sensitive (fun () ->

--- a/semgrep-core/old/lang_php/spatch_php.ml
+++ b/semgrep-core/old/lang_php/spatch_php.ml
@@ -183,7 +183,7 @@ let parse file =
         (* if the next line was a +, then associate with the last token
          * on this line
          *)
-        ( match Common2.hfind_option (line + 1) hline_env with
+        (match Common2.hfind_option (line + 1) hline_env with
         | None ->
             (* probably because was last line *)
             ()
@@ -201,8 +201,8 @@ let parse file =
             match last_tok.transfo with
             | Remove -> last_tok.transfo <- Replace (AddStr toadd)
             | NoTransfo -> last_tok.transfo <- AddAfter (AddStr toadd)
-            | _ -> raise Impossible )
-        | Some _ -> () );
+            | _ -> raise Impossible)
+        | Some _ -> ());
         aux rest
     | [] -> ()
   in
@@ -241,7 +241,7 @@ let spatch ?(case_sensitive = false) pattern file =
                 was_modifed := true;
                 Transforming_php.transform_xhp_xhp xhp x
                   (* TODO, maybe could get multiple matching env *)
-                  (List.hd matches_with_env) ));
+                  (List.hd matches_with_env)));
         }
     | Expr pattern_expr ->
         {
@@ -254,7 +254,7 @@ let spatch ?(case_sensitive = false) pattern file =
                 was_modifed := true;
                 Transforming_php.transform_e_e pattern_expr x
                   (* TODO, maybe could get multiple matching env *)
-                  (List.hd matches_with_env) ));
+                  (List.hd matches_with_env)));
         }
     | Stmt2 pattern ->
         {
@@ -267,7 +267,7 @@ let spatch ?(case_sensitive = false) pattern file =
                 was_modifed := true;
                 Transforming_php.transform_st_st pattern x
                   (* TODO, maybe could get multiple matching env *)
-                  (List.hd matches_with_env) ));
+                  (List.hd matches_with_env)));
         }
     | Hint2 pattern ->
         {
@@ -280,12 +280,12 @@ let spatch ?(case_sensitive = false) pattern file =
                 was_modifed := true;
                 Transforming_php.transform_hint_hint pattern x
                   (* TODO, maybe could get multiple matching env *)
-                  (List.hd matches_with_env) ));
+                  (List.hd matches_with_env)));
         }
     | _ ->
         failwith
-          ( spf "pattern not yet supported:"
-          ^ "TODO" (* Export_ast_php.ml_pattern_string_of_any pattern*) )
+          (spf "pattern not yet supported:"
+          ^ "TODO" (* Export_ast_php.ml_pattern_string_of_any pattern*))
   in
   Common.save_excursion Php_vs_php.case_sensitive case_sensitive (fun () ->
       (V.mk_visitor hook) (Program ast));

--- a/semgrep-core/old/lang_php/transforming_php.ml
+++ b/semgrep-core/old/lang_php/transforming_php.ml
@@ -171,8 +171,7 @@ module XMATCH = struct
                  try List.assoc matched env
                  with Not_found ->
                    failwith
-                     (spf "metavariable %s was not found in environment"
-                        matched))
+                     (spf "metavariable %s was not found in environment" matched))
         in
 
         let s =
@@ -182,8 +181,7 @@ module XMATCH = struct
                  try List.assoc matched env
                  with Not_found ->
                    failwith
-                     (spf "metavariable %s was not found in environment"
-                        matched))
+                     (spf "metavariable %s was not found in environment" matched))
         in
         PI.AddStr s
 

--- a/semgrep-core/old/lang_php/unit_matcher_php.ml
+++ b/semgrep-core/old/lang_php/unit_matcher_php.ml
@@ -248,7 +248,7 @@ let spatch_unittest =
                (spf "spatch %s on %s should have resulted in %s"
                   (Filename.basename spatchfile)
                   (Filename.basename phpfile)
-                  (Filename.basename expfile)) )
+                  (Filename.basename expfile)))
          else failwith ("wrong format for expfile: " ^ expfile))
 
 (*****************************************************************************)

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -234,7 +234,7 @@ let rec lval env eorig =
           { base; offset = Index attr; constness = base_constness }
       | G.EDynamic e2orig ->
           let attr = expr env e2orig in
-          { base; offset = Index attr; constness = base_constness } )
+          { base; offset = Index attr; constness = base_constness })
   | G.ArrayAccess (e1orig, (_, e2orig, _)) ->
       let tok = G.fake "[]" in
       let base, constness = nested_lval env tok e1orig in
@@ -322,7 +322,7 @@ and assign env lhs _tok rhs_exp eorig =
         mk_e (Fetch lval) lhs
       with Fixme (kind, any_generic) ->
         add_instr env (fixme_instr kind any_generic eorig);
-        fixme_exp kind any_generic lhs )
+        fixme_exp kind any_generic lhs)
   | G.Tuple (tok1, lhss, tok2) ->
       (* E1, ..., En = RHS *)
       (* tmp = RHS*)
@@ -382,7 +382,7 @@ and expr_aux env eorig =
           let opexp = mk_e (Operator (op, [ lvalexp; one_exp ])) eorig in
           add_instr env (mk_i (Assign (lval, opexp)) eorig);
           lvalexp
-      | _ -> impossible (G.E eorig) )
+      | _ -> impossible (G.E eorig))
   (* todo: if the xxx_to_generic forgot to generate Eval *)
   | G.Call
       ( G.N (G.Id (("eval", tok), { G.id_resolved = { contents = None }; _ })),
@@ -439,7 +439,7 @@ and expr_aux env eorig =
           |> List.iter (fun e ->
                  let _eIGNORE = expr env e in
                  ());
-          expr env last )
+          expr env last)
   | G.Container (kind, xs) ->
       let xs = bracket_keep (List.map (expr env)) xs in
       let kind = composite_kind kind in
@@ -473,7 +473,7 @@ and expr_aux env eorig =
       | Some var_special ->
           let lval = lval_of_base (VarSpecial (var_special, tok)) in
           mk_e (Fetch lval) eorig
-      | None -> impossible (G.E eorig) )
+      | None -> impossible (G.E eorig))
   | G.SliceAccess (_, _) -> todo (G.E eorig)
   (* e1 ? e2 : e3 ==>
    *  pre: lval = e1;
@@ -551,7 +551,7 @@ and call_generic env tok e args =
   mk_e (Fetch lval) eorig
 
 and call_special _env (x, tok) =
-  ( ( match x with
+  ( (match x with
     | G.Op _ | G.IncrDecr _ | G.This | G.Super | G.Self | G.Parent
     | G.InterpolatedElement ->
         impossible (G.E (G.IdSpecial (x, tok)))
@@ -565,7 +565,7 @@ and call_special _env (x, tok) =
     | G.Spread -> Spread
     | G.EncodedString _ | G.Defined | G.HashSplat | G.ForOf | G.NextArrayIndex
       ->
-        todo (G.E (G.IdSpecial (x, tok))) ),
+        todo (G.E (G.IdSpecial (x, tok)))),
     tok )
 
 and composite_kind = function
@@ -667,7 +667,7 @@ let for_var_or_expr_list env xs =
                let ss, e' = expr_with_pre_stmts env e in
                let lv = lval_of_ent env ent in
                ss @ [ mk_s (Instr (mk_i (Assign (lv, e')) e)) ]
-           | _ -> [] ))
+           | _ -> []))
   |> List.flatten
 
 (*e: function [[AST_to_IL.for_var_or_expr_list]] *)

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -162,7 +162,7 @@ let rec cfg_stmt : state -> F.nodei option -> stmt -> cfg_stmt_result =
           let lasti = state.g#add_node { F.n = F.Join } in
           state.g |> add_arc (n1, lasti);
           state.g |> add_arc (n2, lasti);
-          CfgFirstLast (newi, Some lasti) )
+          CfgFirstLast (newi, Some lasti))
   | Loop (tok, e, st) ->
       (* previ -> newi ---> newfakethen -> ... -> finalthen -
        *             |---|-----------------------------------|

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -238,7 +238,7 @@ and eval_op env op args =
           int_of_literal l >>= fun i -> Some (literal_of_int i)
       | Minus, Some (Int _ as l) ->
           int_of_literal l >>= fun i -> Some (literal_of_int (-i))
-      | __else__ -> None )
+      | __else__ -> None)
   | [ Arg e1; Arg e2 ] -> (
       match (eval_expr env e1, eval_expr env e2) with
       | Some (Bool _ as l1), Some (Bool _ as l2) ->
@@ -253,7 +253,7 @@ and eval_op env op args =
           string_of_literal l1 >>= fun s1 ->
           string_of_literal l2 >>= fun s2 ->
           eval_bop_string op s1 s2 >>= fun r -> Some (literal_of_string r)
-      | __else__ -> None )
+      | __else__ -> None)
   | __else__ -> None
 
 and eval_concat_string env args : literal option =
@@ -322,12 +322,12 @@ let propagate_basic lang prog =
           | N (Id (id, id_info)) when not !(env.in_lvalue) -> (
               match find_id env id id_info with
               | Some literal -> id_info.id_constness := Some (Lit literal)
-              | _ -> () )
+              | _ -> ())
           | DotAccess (IdSpecial (This, _), _, EN (Id (id, id_info)))
             when not !(env.in_lvalue) -> (
               match find_id env id id_info with
               | Some literal -> id_info.id_constness := Some (Lit literal)
-              | _ -> () )
+              | _ -> ())
           | ArrayAccess (e1, (_, e2, _)) ->
               v (E e1);
               Common.save_excursion env.in_lvalue false (fun () -> v (E e2))
@@ -345,8 +345,8 @@ let propagate_basic lang prog =
                      if
                        !(stats.lvalue) = 1
                        (* restrict to Python/Ruby/PHP/JS/TS Globals for now *)
-                       && ( lang = Lang.Python || lang = Lang.Ruby
-                          || lang = Lang.PHP || Lang.is_js lang )
+                       && (lang = Lang.Python || lang = Lang.Ruby
+                         || lang = Lang.PHP || Lang.is_js lang)
                        && kind = Global
                      then add_constant_env id (sid, literal) env);
               v (E rexp)

--- a/semgrep-core/src/analyzing/Dataflow.ml
+++ b/semgrep-core/src/analyzing/Dataflow.ml
@@ -259,7 +259,7 @@ module Make (F : Flow) = struct
         if eq_inout eq old new_ then work'
         else (
           mapping.(ni) <- new_;
-          NodeiSet.union work' (succs flow ni) )
+          NodeiSet.union work' (succs flow ni))
       in
       fixpoint_worker eq mapping trans flow succs work''
 

--- a/semgrep-core/src/analyzing/Dataflow_constness.ml
+++ b/semgrep-core/src/analyzing/Dataflow_constness.ml
@@ -62,7 +62,7 @@ let string_of_constness = function
       | G.Bool (b, _) -> Printf.sprintf "lit(%b)" b
       | G.Int (Some i, _) -> Printf.sprintf "lit(%d)" i
       | G.String (s, _) -> Printf.sprintf "lit(\"%s\")" s
-      | ___else___ -> "lit(???)" )
+      | ___else___ -> "lit(???)")
 
 let str_of_name ((s, _tok), sid) = spf "%s:%d" s sid
 
@@ -174,12 +174,12 @@ let eval_binop_int tok op opt_i1 opt_i2 =
   | G.Mult, Some i1, Some i2 ->
       let overflow =
         i1 <> 0 && i2 <> 0
-        && ( (i1 < 0 && i2 = min_int) (* >max_int *)
+        && ((i1 < 0 && i2 = min_int) (* >max_int *)
            || (i1 = min_int && i2 < 0) (* >max_int *)
            ||
            if sign i1 * sign i2 = 1 then abs i1 > abs (max_int / i2)
              (* >max_int *)
-           else abs i1 > abs (min_int / i2) (* <min_int *) )
+           else abs i1 > abs (min_int / i2) (* <min_int *))
       in
       if overflow then G.Cst G.Cint else G.Lit (literal_of_int (i1 * i2))
   | G.Div, Some i1, Some i2 -> (
@@ -188,7 +188,7 @@ let eval_binop_int tok op opt_i1 opt_i2 =
         try G.Lit (literal_of_int (i1 / i2))
         with Division_by_zero ->
           warning tok "Found division by zero";
-          G.Cst G.Cint )
+          G.Cst G.Cint)
   | ___else____ -> G.Cst G.Cint
 
 let eval_binop_string op s1 s2 =
@@ -210,7 +210,7 @@ and eval_lval env lval =
       match (!constness, opt_c) with
       | None, None -> G.NotCst
       | Some c, None | None, Some c -> c
-      | Some c1, Some c2 -> refine c1 c2 )
+      | Some c1, Some c2 -> refine c1 c2)
   | ___else___ -> G.NotCst
 
 and eval_op env wop args =
@@ -307,7 +307,7 @@ let transfer :
             let lvar_opt = IL.lvar_of_instr_opt instr in
             match lvar_opt with
             | None -> inp'
-            | Some lvar -> D.VarMap.add (str_of_name lvar) G.NotCst inp' ) )
+            | Some lvar -> D.VarMap.add (str_of_name lvar) G.NotCst inp'))
   in
 
   { D.in_env = inp'; out_env = out' }
@@ -343,7 +343,7 @@ let update_constness (flow : F.cfg) mapping =
                     D.VarMap.find_opt (str_of_name var) ni_info.D.in_env
                   with
                   | None -> ()
-                  | Some c -> refine_constness_ref constness c )
+                  | Some c -> refine_constness_ref constness c)
               | ___else___ -> ())
          (* Should not update the LHS constness since in x = E, x is a "ref",
           * and it should not be substituted for the value it holds. *))

--- a/semgrep-core/src/analyzing/Dataflow_tainting.ml
+++ b/semgrep-core/src/analyzing/Dataflow_tainting.ml
@@ -202,9 +202,9 @@ let (transfer :
         else None
     (* if just a single return is tainted then the function is tainted *)
     | NReturn (tok, e) when check_tainted_return config fun_env in' tok e ->
-        ( match opt_name with
+        (match opt_name with
         | Some var -> Hashtbl.add fun_env (str_of_name var) ()
-        | None -> () );
+        | None -> ());
         None
     | Enter | Exit | TrueNode | FalseNode | Join | NCond _ | NGoto _ | NReturn _
     | NThrow _ | NOther _ | NTodo _ ->

--- a/semgrep-core/src/analyzing/Naming_AST.ml
+++ b/semgrep-core/src/analyzing/Naming_AST.ml
@@ -217,7 +217,7 @@ let rec lookup s xxs =
   | xs :: xxs -> (
       match List.assoc_opt s xs with
       | None -> lookup s xxs
-      | Some res -> Some res )
+      | Some res -> Some res)
 
 (*e: function [[Naming_AST.lookup]] *)
 
@@ -330,7 +330,7 @@ let lookup_scope_opt (s, _) env =
              (* just look current scope! no access to nested scopes or global *)
              [xs;                            !(scopes.imported)]
         *)
-        | _ -> [ xs ] @ xxs @ [ !(scopes.global); !(scopes.imported) ] )
+        | _ -> [ xs ] @ xxs @ [ !(scopes.global); !(scopes.imported) ])
   in
   lookup s actual_scopes
 
@@ -363,7 +363,7 @@ let is_resolvable_name_ctx env lang =
       (* true for JS/TS so that we can resolve class methods *)
       | Lang.Javascript | Lang.Typescript ->
           true
-      | _ -> false )
+      | _ -> false)
 
 (*e: function [[Naming_AST.is_local_or_global_ctx]] *)
 
@@ -381,7 +381,7 @@ let resolved_name_kind env lang =
       (* true for JS/TS to resolve class methods. *)
       | Lang.Javascript | Lang.Typescript ->
           EnclosedVar
-      | _ -> raise Impossible )
+      | _ -> raise Impossible)
 
 (*e: function [[Naming_AST.resolved_name_kind]] *)
 
@@ -480,7 +480,7 @@ let resolve2 lang prog =
               declare_var env lang id id_info ~explicit:true vinit vtype
           | { name = EN (Id (id, id_info)); _ }, FuncDef _
             when is_resolvable_name_ctx env lang ->
-              ( match lang with
+              (match lang with
               (* We restrict function-name resolution to JS/TS.
                *
                * Note that this causes problems with Python rule/test:
@@ -514,7 +514,7 @@ let resolve2 lang prog =
                    *)
                   add_ident_imported_scope id resolved env.names;
                   set_resolved env id_info resolved
-              | ___else___ -> () );
+              | ___else___ -> ());
               k x
           | { name = EN (Id (id, id_info)); _ }, UseOuterDecl tok ->
               let s = Parse_info.str_of_info tok in
@@ -526,20 +526,20 @@ let resolve2 lang prog =
                     error tok (spf "unrecognized UseOuterDecl directive: %s" s);
                     lookup_global_scope
               in
-              ( match flookup id env.names with
+              (match flookup id env.names with
               | Some resolved ->
                   set_resolved env id_info resolved;
                   add_ident_current_scope id resolved env.names
               | None ->
                   error tok
                     (spf "could not find '%s' for directive %s"
-                       (H.str_of_ident id) s) );
+                       (H.str_of_ident id) s));
               k x
           | _ -> k x);
       (* sgrep: the import aliases *)
       V.kdir =
         (fun (k, _v) x ->
-          ( match x with
+          (match x with
           | ImportFrom (_, DottedName xs, id, Some (alias, id_info)) ->
               (* for python *)
               let sid = H.gensym () in
@@ -599,7 +599,7 @@ let resolve2 lang prog =
               in
               set_resolved env id_info resolved;
               add_ident_imported_scope alias resolved env.names
-          | _ -> () );
+          | _ -> ());
           k x);
       V.kpattern =
         (fun (k, _vout) x ->
@@ -631,7 +631,7 @@ let resolve2 lang prog =
       V.kexpr =
         (fun (k, vout) x ->
           let recurse = ref true in
-          ( match x with
+          (match x with
           (* Go: This is `x := E`, a single-variable short variable declaration.
            * When this declaration is legal, and that is when the same variable
            * has not yet been declared in the same scope, it *always* introduces
@@ -686,7 +686,7 @@ let resolve2 lang prog =
                      * currently tagged
                      *)
                     let s, tok = id in
-                    error tok (spf "could not find '%s' in environment" s) )
+                    error tok (spf "could not find '%s' in environment" s))
           | DotAccess (IdSpecial (This, _), _, EN (Id (id, id_info))) -> (
               match lookup_scope_opt id env with
               (* TODO: this is a v0 for doing naming and typing of fields.
@@ -698,30 +698,30 @@ let resolve2 lang prog =
                   set_resolved env id_info resolved
               | _ ->
                   let s, tok = id in
-                  error tok (spf "could not find '%s' field in environment" s) )
-          | _ -> () );
+                  error tok (spf "could not find '%s' field in environment" s))
+          | _ -> ());
           if !recurse then k x);
       V.kattr =
         (fun (k, _v) x ->
-          ( match x with
+          (match x with
           | NamedAttr (_, Id (id, id_info), _args) -> (
               match lookup_scope_opt id env with
               | Some resolved ->
                   (* name resolution *)
                   set_resolved env id_info resolved
-              | _ -> () )
-          | _ -> () );
+              | _ -> ())
+          | _ -> ());
           k x);
       V.ktype_ =
         (fun (k, _v) x ->
           let f x =
-            ( match x with
+            (match x with
             (* TODO: factorize in kname? *)
             | TyN (Id (id, id_info)) -> (
                 match lookup_scope_opt id env with
                 | Some resolved -> set_resolved env id_info resolved
-                | _ -> () )
-            | _ -> () );
+                | _ -> ())
+            | _ -> ());
             k x
           in
           (* when we are inside a type, especially in  (OtherType (OT_Expr)),

--- a/semgrep-core/src/analyzing/Normalize_AST.ml
+++ b/semgrep-core/src/analyzing/Normalize_AST.ml
@@ -61,7 +61,7 @@ let normalize2 any lang =
                             Arg
                               (Call (IdSpecial (Op other_op, tok), fb [ a; b ]));
                           ],
-                          rp ) ) )
+                          rp ) ))
             | _ -> e);
       }
   in

--- a/semgrep-core/src/analyzing/Typing.ml
+++ b/semgrep-core/src/analyzing/Typing.ml
@@ -31,4 +31,4 @@ let get_resolved_type lang (vinit, vtype) =
       | Some (L (Null tok)) -> make_type "null" tok
       | Some (L (Imag (_, tok))) -> make_type "imag" tok
       | Some (N (Id (_, { id_type; _ }))) -> !id_type
-      | _ -> None )
+      | _ -> None)

--- a/semgrep-core/src/analyzing/Unit_typing_generic.ml
+++ b/semgrep-core/src/analyzing/Unit_typing_generic.ml
@@ -35,7 +35,7 @@ let unittest parse_program parse_pattern =
                            | _ ->
                                assert_failure
                                  "Variable referenced did not have expected \
-                                  type String" )
+                                  type String")
                        | _ -> ());
                  }
              in
@@ -57,15 +57,15 @@ let unittest parse_program parse_pattern =
                      (fun (_k, _) exp ->
                        match exp with
                        | A.Call (_, (_, [ x; y ], _)) -> (
-                           ( match x with
+                           (match x with
                            | A.Arg (A.N (A.Id (_, { A.id_type; _ }))) -> (
                                match !id_type with
                                | Some (A.TyN (A.Id (("String", _), _))) -> ()
                                | _ ->
                                    assert_failure
                                      "Variable 1 referenced did not have \
-                                      expected type String" )
-                           | _ -> () );
+                                      expected type String")
+                           | _ -> ());
                            match y with
                            | A.Arg (A.N (A.Id (_, { A.id_type; _ }))) -> (
                                match !id_type with
@@ -73,15 +73,15 @@ let unittest parse_program parse_pattern =
                                | _ ->
                                    assert_failure
                                      "Variable 2 referenced did not have \
-                                      expected type int" )
-                           | _ -> () )
+                                      expected type int")
+                           | _ -> ())
                        | A.Assign (A.N (A.Id (_, { A.id_type; _ })), _, _) -> (
                            match !id_type with
                            | Some (A.TyN (A.Id (("String", _), _))) -> ()
                            | _ ->
                                assert_failure
                                  "Variable 1 referenced did not have expected \
-                                  type String" )
+                                  type String")
                        | _ -> ());
                  }
              in
@@ -103,15 +103,15 @@ let unittest parse_program parse_pattern =
                      (fun (_k, _) exp ->
                        match exp with
                        | A.Call (_, (_, [ x; y ], _)) -> (
-                           ( match x with
+                           (match x with
                            | A.Arg (A.N (A.Id (_, { A.id_type; _ }))) -> (
                                match !id_type with
                                | Some (A.TyBuiltin ("int", _)) -> ()
                                | _ ->
                                    assert_failure
                                      "Variable 1 referenced did not have \
-                                      expected type String" )
-                           | _ -> () );
+                                      expected type String")
+                           | _ -> ());
                            match y with
                            | A.Arg (A.N (A.Id (_, { A.id_type; _ }))) -> (
                                match !id_type with
@@ -119,8 +119,8 @@ let unittest parse_program parse_pattern =
                                | _ ->
                                    assert_failure
                                      "Variable 2 referenced did not have \
-                                      expected type int" )
-                           | _ -> () )
+                                      expected type int")
+                           | _ -> ())
                        | _ -> ());
                  }
              in
@@ -147,14 +147,14 @@ let unittest parse_program parse_pattern =
                            | _ ->
                                assert_failure
                                  "Variable referenced did not have expected \
-                                  type int" )
+                                  type int")
                        | A.N (A.Id (("default_age", _), { A.id_type; _ })) -> (
                            match !id_type with
                            | Some (A.TyBuiltin ("int", _)) -> ()
                            | _ ->
                                assert_failure
                                  "Variable referenced did not have expected \
-                                  type int" )
+                                  type int")
                        | _ -> ());
                  }
              in
@@ -201,7 +201,7 @@ let unittest parse_program parse_pattern =
                            | _ ->
                                assert_failure
                                  "Variable referenced did not have expected \
-                                  type int" )
+                                  type int")
                        | _ -> ());
                  }
              in
@@ -223,7 +223,7 @@ let unittest parse_program parse_pattern =
                      (fun (_k, _) exp ->
                        match exp with
                        | A.Call (_, (_, [ x; y ], _)) -> (
-                           ( match x with
+                           (match x with
                            | A.Arg (A.N (A.Id (("a", _), { A.id_type; _ })))
                              -> (
                                match !id_type with
@@ -231,11 +231,11 @@ let unittest parse_program parse_pattern =
                                | _ ->
                                    assert_failure
                                      "Variable referenced did not have \
-                                      expected type int" )
+                                      expected type int")
                            | _ ->
                                assert_failure
                                  "Expected function call to be with int a as \
-                                  first argument" );
+                                  first argument");
                            match y with
                            | A.Arg (A.N (A.Id (("c", _), { A.id_type; _ })))
                              -> (
@@ -244,11 +244,11 @@ let unittest parse_program parse_pattern =
                                | _ ->
                                    assert_failure
                                      "Variable referenced did not have \
-                                      expected type bool" )
+                                      expected type bool")
                            | _ ->
                                assert_failure
                                  "Epected function call to have bool c as \
-                                  second argument" )
+                                  second argument")
                        | _ -> ());
                  }
              in
@@ -275,21 +275,21 @@ let unittest parse_program parse_pattern =
                            | _ ->
                                assert_failure
                                  "Variable referenced did not have expected \
-                                  type char" )
+                                  type char")
                        | A.N (A.Id (("b", _), { A.id_type; _ })) -> (
                            match !id_type with
                            | Some (A.TyN (A.Id (("int", _), _))) -> ()
                            | _ ->
                                assert_failure
                                  "Variable referenced did not have expected \
-                                  type int" )
+                                  type int")
                        | A.N (A.Id (("c", _), { A.id_type; _ })) -> (
                            match !id_type with
                            | Some (A.TyN (A.Id (("char", _), _))) -> ()
                            | _ ->
                                assert_failure
                                  "Variable referenced did not have expected \
-                                  type char" )
+                                  type char")
                        | _ -> ());
                  }
              in

--- a/semgrep-core/src/analyzing/controlflow.ml
+++ b/semgrep-core/src/analyzing/controlflow.ml
@@ -154,7 +154,7 @@ let short_string_of_node_kind nkind =
       | DirectiveStmt _ -> "<directive>"
       | Assert _ -> "<assert>"
       | Parameter _ -> "<param>"
-      | OtherStmt _ -> "<other_stmt>" )
+      | OtherStmt _ -> "<other_stmt>")
 
 let short_string_of_node node = short_string_of_node_kind node.n
 

--- a/semgrep-core/src/analyzing/controlflow_build.ml
+++ b/semgrep-core/src/analyzing/controlflow_build.ml
@@ -89,7 +89,7 @@ let (lookup_some_ctx :
     | x :: xs -> (
         match ctx_filter x with
         | None -> aux depth xs
-        | Some a -> if depth = level then Some a else aux (depth + 1) xs )
+        | Some a -> if depth = level then Some a else aux (depth + 1) xs)
   in
   aux 1 xs
 
@@ -131,11 +131,11 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
         match stmt.s with
         | While (_, e, stmt) -> (F.WhileHeader e, stmt)
         | For (_, forheader, stmt) ->
-            ( ( match forheader with
+            ( (match forheader with
               | ForClassic _ -> raise Todo
               | ForEach (pat, _, e) -> F.ForeachHeader (pat, e)
               | ForEllipsis _ -> raise Todo
-              | ForIn _ -> raise Todo ),
+              | ForIn _ -> raise Todo),
               stmt )
         | _ -> raise Impossible
       in
@@ -279,7 +279,7 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
           None
       | Some finalthen ->
           state.g |> add_arc (finalthen, taili);
-          Some newfakeelse )
+          Some newfakeelse)
   | If (_, e, st_then, st_else) -> (
       (* previ -> newi --->  newfakethen -> ... -> finalthen --> lasti -> <rest>
        *                |                                     |
@@ -314,7 +314,7 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
           let lasti = state.g#add_node { F.n = F.Join; i = None } in
           state.g |> add_arc (n1, lasti);
           state.g |> add_arc (n2, lasti);
-          Some lasti )
+          Some lasti)
   | Return (_, e, _) ->
       let newi = state.g#add_node { F.n = F.Return e; i = i () } in
       state.g |> add_arc_opt (previ, newi);
@@ -359,9 +359,9 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
                  Some endi
              | TryCtx _ | NoCtx -> None)
       in
-      ( match nodei_to_jump_to with
+      (match nodei_to_jump_to with
       | Some nodei -> state.g |> add_arc (newi, nodei)
-      | None -> raise (Error (NoEnclosingLoop, i ())) );
+      | None -> raise (Error (NoEnclosingLoop, i ())));
       None
   | Switch (_, e, cases_and_body) ->
       let newi = state.g#add_node { F.n = F.SwitchHeader e; i = i () } in
@@ -377,14 +377,14 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
        *)
       if
         not
-          ( cases_and_body
+          (cases_and_body
           |> List.exists (function
                | CasesAndBody (cases, _body) ->
                    cases
                    |> List.exists (function
                         | Ast.Default _ -> true
                         | _ -> false)
-               | CaseEllipsis _ -> raise Impossible) )
+               | CaseEllipsis _ -> raise Impossible))
       then state.g |> add_arc (newi, endi);
       (* let's process all cases *)
       let last_stmt_opt = cfg_cases (newi, endi) state None cases_and_body in
@@ -394,7 +394,7 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
       if (state.g#predecessors endi)#null then (
         (* coupling: make sure Dataflow.new_node_array handle that case *)
         state.g#del_node endi;
-        None )
+        None)
       else Some endi
   (*
    * Handling try part 1. See the case for Throw below and the
@@ -488,16 +488,16 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
              | TryCtx nextcatchi -> Some nextcatchi
              | LoopCtx _ | SwitchCtx _ | NoCtx -> None)
       in
-      ( match nodei_to_jump_to with
+      (match nodei_to_jump_to with
       | Some nextcatchi -> state.g |> add_arc (last_false_node, nextcatchi)
-      | None -> state.g |> add_arc (last_false_node, state.exiti) );
+      | None -> state.g |> add_arc (last_false_node, state.exiti));
 
       (* if nobody connected to endi erase the node. For instance
        * if have only return in the try body.
        *)
       if (state.g#predecessors endi)#null then (
         state.g#del_node endi;
-        None )
+        None)
       else Some endi
   (*
    * For now we don't do any fancy analysis to statically detect
@@ -521,11 +521,11 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
              | TryCtx catchi -> Some catchi
              | LoopCtx _ | SwitchCtx _ | NoCtx -> None)
       in
-      ( match nodei_to_jump_to with
+      (match nodei_to_jump_to with
       | Some catchi -> state.g |> add_arc (newi, catchi)
       | None ->
           (* no enclosing handler, branch to exit node of the function *)
-          state.g |> add_arc (newi, state.exiti) );
+          state.g |> add_arc (newi, state.exiti));
       None
   (* TODO? should create a OtherStmtWithStmtFooter and arc to it? *)
   | OtherStmtWithStmt (op, eopt, st) ->

--- a/semgrep-core/src/analyzing/controlflow_visitor.ml
+++ b/semgrep-core/src/analyzing/controlflow_visitor.ml
@@ -97,7 +97,7 @@ let exprs_of_node node =
       (* TODO: should use visitor! *)
       | OtherStmt _ -> []
       (* TODO: should transform in Assign *)
-      | Parameter _p -> [] )
+      | Parameter _p -> [])
 
 (* this can also be used as an iter; just pass () to acc *)
 let fold_on_node_and_expr hook (flow : flow) acc =

--- a/semgrep-core/src/analyzing/lrvalue.ml
+++ b/semgrep-core/src/analyzing/lrvalue.ml
@@ -104,7 +104,7 @@ let rec visit_expr hook lhs expr =
       (* used on lhs? *)
       | Array | List -> xs |> unbracket |> List.iter recl
       (* never used on lhs *)
-      | Set | Dict -> xs |> unbracket |> List.iter recr )
+      | Set | Dict -> xs |> unbracket |> List.iter recr)
   (* composite lvalues that are actually not themselves lvalues *)
   | DotAccess (e, _, _id) ->
       (* bugfix: this is not recl here! in 'x.fld = 2', x itself is not

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -576,7 +576,7 @@ and map_attribute = function
       let v1 = map_wrap map_keyword_attribute v1 in
       match v1 with
       | Left v1, tok -> `KeywordAttr (v1, tok)
-      | Right s, tok -> `OtherAttribute (s, [ `Tk tok ]) )
+      | Right s, tok -> `OtherAttribute (s, [ `Tk tok ]))
   | NamedAttr (t, v1, v3) ->
       let t = map_tok t in
       let v1 = map_name v1 and v3 = map_bracket (map_of_list map_argument) v3 in

--- a/semgrep-core/src/cli/Experiments.ml
+++ b/semgrep-core/src/cli/Experiments.ml
@@ -57,7 +57,7 @@ let ebnf_to_menhir file =
              if s =~ "^[A-Z]" then lower s
              else (
                Hashtbl.replace htokens (upper s) true;
-               upper s )
+               upper s)
          | T.Int _ | T.Float _ | T.Char _ -> raise Impossible
          | T.String s ->
              Hashtbl.replace hkwd s true;

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -292,8 +292,8 @@ let print_match ?str mvars mvar_binding ii_of_any tokens_matched_code =
   (* there are a few fake tokens in the generic ASTs now (e.g.,
    * for DotAccess generated outside the grammar) *)
   let toks = tokens_matched_code |> List.filter PI.is_origintok in
-  ( if mvars = [] then
-    Matching_report.print_match ?str ~format:!match_format toks
+  (if mvars = [] then
+   Matching_report.print_match ?str ~format:!match_format toks
   else
     (*s: [[Main_semgrep_core.print_match()]] when non empty [[mvars]] *)
     (* similar to the code of Lib_matcher.print_match, maybe could
@@ -315,7 +315,7 @@ let print_match ?str mvars mvar_binding ii_of_any tokens_matched_code =
     in
     pr (spf "%s:%d: %s" file line (Common.join ":" strings_metavars));
     (*e: [[Main_semgrep_core.print_match()]] when non empty [[mvars]] *)
-    () );
+    ());
   (*s: [[Main_semgrep_core.print_match()]] hook *)
   toks |> List.iter (fun x -> Common.push x _matching_tokens)
 
@@ -365,7 +365,7 @@ let cache_computation file cache_file_of_file f =
   else if not (Sys.file_exists file) then (
     pr2 ("WARNING: cache_computation: can't find file " ^ file);
     pr2 "defaulting to calling the function";
-    f () )
+    f ())
   else
     Common.profile_code "Main.cache_computation" (fun () ->
         let file_cache = cache_file_of_file file in
@@ -382,7 +382,7 @@ let cache_computation file cache_file_of_file f =
                  "Not the same file! Md5sum collision! Clean the cache file %s"
                  file_cache);
 
-          res )
+          res)
         else
           let res = f () in
           Common2.write_value (Version.version, file, res) file_cache;
@@ -433,7 +433,7 @@ let run_with_memory_limit limit_mb f =
       let mem = (Gc.quick_stat ()).Gc.heap_words in
       if mem > limit / (Sys.word_size / 8) then (
         logger#info "maxout allocated memory: %d" (mem * (Sys.word_size / 8));
-        raise Out_of_memory )
+        raise Out_of_memory)
     in
     let alarm = Gc.create_alarm limit_memory in
     Fun.protect f ~finally:(fun () ->
@@ -659,14 +659,14 @@ let iter_files_and_get_matches_and_exn_to_errors f files =
                      errors =
                        [
                          Error_code.mk_error_loc loc
-                           ( match exn with
+                           (match exn with
                            | Timeout ->
                                logger#info "Timeout on %s" file;
                                Error_code.Timeout str_opt
                            | Out_of_memory ->
                                logger#info "OutOfMemory on %s" file;
                                Error_code.OutOfMemory str_opt
-                           | _ -> raise Impossible );
+                           | _ -> raise Impossible);
                        ];
                      profiling = RP.empty_partial_profiling file;
                    }
@@ -829,10 +829,10 @@ let semgrep_with_rules (rules, rule_parse_time) files_or_dirs =
            in
            let lazy_ast_and_errors =
              lazy
-               ( match xlang with
+               (match xlang with
                | R.L (lang, _) -> parse_generic lang file
                | R.LRegex | R.LGeneric ->
-                   failwith "requesting generic AST for LRegex|LGeneric" )
+                   failwith "requesting generic AST for LRegex|LGeneric")
            in
            let res =
              Run_rules.check hook Config_semgrep.default_config rules
@@ -1038,7 +1038,7 @@ let json_of_v (v : OCaml.v) =
         match xs with
         | [] -> J.String (spf "%s" s)
         | [ one_element ] -> J.Object [ (s, aux one_element) ]
-        | _ -> J.Object [ (s, J.Array (List.map aux xs)) ] )
+        | _ -> J.Object [ (s, J.Array (List.map aux xs)) ])
     | OCaml.VVar (s, i64) -> J.String (spf "%s_%d" s (Int64.to_int i64))
     | OCaml.VArrow _ -> failwith "Arrow TODO"
     | OCaml.VNone -> J.Null
@@ -1086,7 +1086,7 @@ let dump_ast ?(naming = false) lang file =
       pr s;
       if errors <> [] then (
         pr2 (spf "WARNING: fail to fully parse %s" file);
-        exit 1 ))
+        exit 1))
 
 (*e: function [[Main_semgrep_core.dump_ast]] *)
 let dump_v1_json file =
@@ -1460,20 +1460,20 @@ let main () =
 
   if Sys.file_exists !log_config_file then (
     Logging.load_config_file !log_config_file;
-    logger#info "loaded %s" !log_config_file );
+    logger#info "loaded %s" !log_config_file);
   if !debug then (
     let open Easy_logging in
     let h = Handlers.make (CliErr Debug) in
     logger#add_handler h;
     logger#set_level Debug;
-    () );
+    ());
 
   logger#info "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " ");
   logger#info "Version: %s" version;
   if !profile then (
     logger#info "Profile mode On";
     logger#info "disabling -j when in profiling mode";
-    ncores := 1 );
+    ncores := 1);
 
   (* must be done after Arg.parse, because Common.profile is set by it *)
   Common.profile_code "Main total" (fun () ->

--- a/semgrep-core/src/core/Range.ml
+++ b/semgrep-core/src/core/Range.ml
@@ -72,7 +72,7 @@ let range_of_linecol_spec str file =
       if (l, c) = (line2, col2) then end_ := i
     done;
     if !start <> -1 && !end_ <> -1 then { start = !start; end_ = !end_ }
-    else failwith (spf "could not find range %s in %s" str file) )
+    else failwith (spf "could not find range %s in %s" str file))
   else failwith (spf "wrong format for linecol range spec: %s" str)
 
 let range_of_token_locations (start_loc : PI.token_location)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -283,7 +283,7 @@ let convert_extra x =
             | None | Some false -> comparison
             | Some true -> rewrite_metavar_comparison_strip mvar comparison
           in
-          CondEval cond )
+          CondEval cond)
   | PatWherePython _ ->
       (*
   logger#debug "convert_extra: %s" s;

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -246,7 +246,7 @@ let ac_matching_nf op args =
       logger#error
         "ac_matching_nf: %s(%s): unexpected ArgKwd | ArgType | ArgOther"
         (show_operator op) (show_arguments args);
-      None )
+      None)
   else None
 
 let undo_ac_matching_nf tok op : expr list -> expr option = function
@@ -339,21 +339,21 @@ let (conv_class_kind :
       AST_generic_.class_kind * Parse_info.t ->
       AST_generic.class_kind * Parse_info.t) =
  fun (c, t) ->
-  ( ( match c with
+  ( (match c with
     | G_.Class -> G.Class
     | G_.Interface -> G.Interface
-    | G_.Trait -> G.Trait ),
+    | G_.Trait -> G.Trait),
     t )
 
 let (conv_function_kind :
       AST_generic_.function_kind * Parse_info.t ->
       AST_generic.function_kind * Parse_info.t) =
  fun (c, t) ->
-  ( ( match c with
+  ( (match c with
     | G_.Function -> G.Function
     | G_.Method -> G.Method
     | G_.LambdaKind -> G.LambdaKind
-    | G_.Arrow -> G.Arrow ),
+    | G_.Arrow -> G.Arrow),
     t )
 
 (*e: pfff/lang_GENERIC_base/AST_generic_helpers.ml *)

--- a/semgrep-core/src/core/ast/AST_utils.ml
+++ b/semgrep-core/src/core/ast/AST_utils.ml
@@ -44,7 +44,7 @@ end = struct
       if id = -1 then failwith "Node_ID.create: int overflow"
       else (
         incr counter;
-        id )
+        id)
 end
 
 (*

--- a/semgrep-core/src/core/ast/Bloom_filter.ml
+++ b/semgrep-core/src/core/ast/Bloom_filter.ml
@@ -62,8 +62,8 @@ let create set_instead_of_bloom =
   {
     added = false;
     filter =
-      ( if set_instead_of_bloom then Set (ref Set.empty)
-      else Bloom (B.create ~error_rate:0.01 2500) );
+      (if set_instead_of_bloom then Set (ref Set.empty)
+      else Bloom (B.create ~error_rate:0.01 2500));
   }
 
 let is_empty bf = not bf.added

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -252,7 +252,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
           let v1 = v_bracket v_expr v1 in
           ()
       | Container (v1, v2) ->
-          ( match v1 with
+          (match v1 with
           | Dict ->
               v2 |> unbracket
               |> List.iter (function
@@ -268,7 +268,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
                        let t = PI.fake_info ":" in
                        v_partial ~recurse:false (PartialSingleField (id, t, e))
                    | _ -> ())
-          | _ -> () );
+          | _ -> ());
           let v1 = v_container_operator v1
           and v2 = v_bracket (v_list v_expr) v2 in
           ()
@@ -551,7 +551,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
         | None -> ()
         | Some (v1, v2) ->
             v_wrap v_bool v1;
-            v_type_ v2 )
+            v_type_ v2)
     | TypeLifetime v1 ->
         let v1 = v_ident v1 in
         ()
@@ -877,26 +877,26 @@ let (mk_visitor : visitor_in -> visitor_out) =
           (* Do not call v_def here, otherwise you'll get infinite loop *)
           if recurse then (
             v_entity v1;
-            v_def_kind v2 );
+            v_def_kind v2);
           ()
       | PartialIf (v1, v2) ->
           if recurse then (
             v_tok v1;
-            v_expr v2 )
+            v_expr v2)
       | PartialTry (v1, v2) ->
           if recurse then (
             v_tok v1;
-            v_stmt v2 )
+            v_stmt v2)
       | PartialCatch v1 -> if recurse then v_catch v1
       | PartialFinally (v1, v2) ->
           if recurse then (
             v_tok v1;
-            v_stmt v2 )
+            v_stmt v2)
       | PartialSingleField (v1, v2, v3) ->
           if recurse then (
             v_wrap v_string v1;
             v_tok v2;
-            v_expr v3 )
+            v_expr v3)
       | PartialLambdaOrFuncDef v1 -> if recurse then v_function_definition v1
     in
     vin.kpartial (k, all_functions) x
@@ -1015,13 +1015,13 @@ let (mk_visitor : visitor_in -> visitor_out) =
           let v1 = v_expr v1 in
           ()
       | FieldStmt v1 ->
-          ( match v1.s with
+          (match v1.s with
           | DefStmt
               ( { name = EN (Id (id, _)); _ },
                 FieldDefColon { vinit = Some e; _ } ) ->
               let t = PI.fake_info ":" in
               v_partial ~recurse:false (PartialSingleField (id, t, e))
-          | _ -> () );
+          | _ -> ());
           let v1 = v_stmt v1 in
           ()
     in
@@ -1272,7 +1272,7 @@ let extract_ranges recursor =
               stmt.s_range <- !ranges;
               match saved_ranges with
               | None -> ()
-              | Some r -> incorporate_tokens r )
+              | Some r -> incorporate_tokens r)
           | Some range -> incorporate_tokens range);
     }
   in

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -1,10 +1,10 @@
 open IL
 
 let string_of_lval x =
-  ( match x.base with
+  (match x.base with
   | Var n -> str_of_name n
   | VarSpecial _ -> "<varspecial>"
-  | Mem _ -> "<Mem>" )
+  | Mem _ -> "<Mem>")
   ^
   match x.offset with
   | NoOffset -> ""
@@ -32,7 +32,7 @@ let short_string_of_node_kind nkind =
       | AssignAnon _ -> " ... = <lambda|class>"
       | Call (_lopt, exp, _) -> string_of_exp exp ^ "(...)"
       | CallSpecial _ -> "<special>"
-      | FixmeInstr _ -> "<fix-me instr>" )
+      | FixmeInstr _ -> "<fix-me instr>")
   | NTodo _ -> "<to-do stmt>"
 
 (* using internally graphviz dot and ghostview on X11 *)

--- a/semgrep-core/src/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/datalog/Datalog_experiment.ml
@@ -116,7 +116,7 @@ let instr env x =
           let v = var_of_name env n in
           let h = heap_of_int env s in
           add env (D.PointTo (v, h))
-      | _ -> todo (I x) )
+      | _ -> todo (I x))
   | _ -> todo (I x)
 
 let stmt env x = match x.IL.s with Instr x -> instr env x | _ -> todo (S x)

--- a/semgrep-core/src/datalog/Datalog_fact.ml
+++ b/semgrep-core/src/datalog/Datalog_fact.ml
@@ -157,8 +157,8 @@ let meta_fact = function
 let string_of_fact fact =
   let str, xs = meta_fact fact in
   spf "%s(%s)" str
-    ( xs
+    (xs
     |> List.map (function
          | V x | F x | N x | I x -> spf "'%s'" x
          | Z i -> spf "%d" i)
-    |> Common.join ", " )
+    |> Common.join ", ")

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -95,7 +95,7 @@ let parse_json file =
             xs |> List.map (fun (s, json) -> (s, metavar_of_json s json))
           in
           (Common.hash_of_list metavars, code)
-      | _ -> failwith "wrong json format" )
+      | _ -> failwith "wrong json format")
   | _ -> failwith "wrong json format"
 
 (*****************************************************************************)
@@ -123,7 +123,7 @@ let print_result xopt =
       (* allow to abuse int to encode boolean ... ugly C tradition *)
       | Int 0 -> pr (string_of_bool false)
       | Int _ -> pr (string_of_bool true)
-      | _ -> pr "NONE" )
+      | _ -> pr "NONE")
   [@@action]
 
 (*****************************************************************************)
@@ -139,13 +139,13 @@ let rec eval env code =
       (* big integers or floats can't be evaluated (Int (None, ...)) *)
       | G.Int (Some i, _t) -> Int i
       | G.Float (Some f, _t) -> Float f
-      | _ -> raise (NotHandled code) )
+      | _ -> raise (NotHandled code))
   (* less: sanity check that s is a metavar_name? *)
   | G.N (G.Id ((s, _t), _idinfo)) -> (
       try Hashtbl.find env s
       with Not_found ->
         logger#debug "could not find a value for %s in env" s;
-        raise Not_found )
+        raise Not_found)
   | G.Call (G.N (G.Id (("int", _), _)), (_, [ Arg e ], _)) -> (
       let v = eval env e in
       match v with
@@ -153,8 +153,8 @@ let rec eval env code =
       | String s -> (
           match int_of_string_opt s with
           | None -> raise (NotHandled code)
-          | Some i -> Int i )
-      | __else__ -> raise (NotHandled code) )
+          | Some i -> Int i)
+      | __else__ -> raise (NotHandled code))
   | G.Call (G.IdSpecial (G.Op op, _t), (_, args, _)) ->
       let values =
         args
@@ -186,7 +186,7 @@ let rec eval env code =
           let v = Bool res in
           logger#info "regexp %s on %s return %s" re s (show_value v);
           v
-      | _ -> raise (NotHandled code) )
+      | _ -> raise (NotHandled code))
   | _ -> raise (NotHandled code)
 
 and eval_op op values code =
@@ -241,7 +241,7 @@ and eval_op op values code =
   | G.NotEq, [ Float v1; Int v2 ] -> Bool (v1 <> float_of_int v2)
   | G.NotEq, [ v1; v2 ] -> Bool (v1 <> v2)
   | G.In, [ v1; v2 ] -> (
-      match v2 with List xs -> Bool (List.mem v1 xs) | _ -> Bool false )
+      match v2 with List xs -> Bool (List.mem v1 xs) | _ -> Bool false)
   | _ -> raise (NotHandled code)
 
 (*****************************************************************************)
@@ -285,7 +285,7 @@ let bindings_to_env xs =
              with NotHandled _e ->
                logger#debug "can't eval %s value %s" mvar (MV.show_mvalue mval);
                (* todo: if not a value, could default to AST of range *)
-               None )
+               None)
          | x ->
              logger#debug "filtering mvar %s, not an expr %s" mvar
                (MV.show_mvalue x);

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -204,9 +204,9 @@ let (mini_rule_of_pattern :
     message = "";
     severity = MR.Error;
     languages =
-      ( match xlang with
+      (match xlang with
       | R.L (x, xs) -> x :: xs
-      | R.LRegex | R.LGeneric -> raise Impossible );
+      | R.LRegex | R.LGeneric -> raise Impossible);
     (* useful for debugging timeout *)
     pattern_string = pstr;
   }
@@ -669,7 +669,7 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
               in
               nested_formula_has_matches env formula lazy_ast_and_errors
                 lazy_content
-                (Some { r with r = mval_range }) )
+                (Some { r with r = mval_range }))
       | Some xlang, MV.Text (content, _tok)
       | Some xlang, MV.E (G.L (G.String (content, _tok))) ->
           (* We reinterpret the matched text as `xlang`. *)
@@ -679,12 +679,12 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
             | R.L (lang, _) -> (
                 match Lang.ext_of_lang lang with
                 | x :: _ -> x
-                | [] -> assert false )
+                | [] -> assert false)
           in
           Common2.with_tmp_file ~str:content ~ext (fun file ->
               let lazy_ast_and_errors =
                 lazy
-                  ( match xlang with
+                  (match xlang with
                   | R.L (lang, _) ->
                       let { Parse_target.ast; errors; _ } =
                         Parse_target
@@ -700,7 +700,7 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
                              env.rule_id mvar);
                       (ast, errors)
                   | R.LRegex | R.LGeneric ->
-                      failwith "requesting generic AST for LRegex|LGeneric" )
+                      failwith "requesting generic AST for LRegex|LGeneric")
               in
               let r' =
                 (* Fix the range wrt the temporary file that we now use for
@@ -719,7 +719,7 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
           logger#error
             "rule %s: metavariable-pattern: the content of %s is not text"
             env.rule_id mvar;
-          false )
+          false)
 
 and nested_formula_has_matches env formula lazy_ast_and_errors lazy_content
     opt_context =
@@ -792,7 +792,7 @@ and (evaluate_formula : env -> RM.t option -> S.sformula -> RM.t list) =
                   S.match_selector ~err:"empty And; no positive terms in And"
                     selector_opt;
                 ]
-            | Some r -> [ [ r ] ] )
+            | Some r -> [ [ r ] ])
         | ps -> ps
       in
       match all_posr with
@@ -835,7 +835,7 @@ and (evaluate_formula : env -> RM.t option -> S.sformula -> RM.t list) =
             conds
             |> List.fold_left (fun acc cond -> filter_ranges env acc cond) res
           in
-          S.select_from_ranges env.file selector_opt res )
+          S.select_from_ranges env.file selector_opt res)
   | S.Not _ -> failwith "Invalid Not; you can only negate inside an And"
   | S.Leaf (R.MetavarCond _) ->
       failwith "Invalid MetavarCond; you can MetavarCond only inside an And"
@@ -883,7 +883,7 @@ let check hook default_config rules equivs file_and_more =
   if rules = [] then logger#error "empty rules";
   if !Common.profile = Common.ProfAll then (
     logger#info "forcing eval of ast outside of rules, for better profile";
-    lazy_force lazy_ast_and_errors |> ignore );
+    lazy_force lazy_ast_and_errors |> ignore);
 
   let lazy_content = lazy (Common.read_file file) in
   rules
@@ -896,12 +896,12 @@ let check hook default_config rules equivs file_and_more =
                  | Some (re, f) ->
                      let content = Lazy.force lazy_content in
                      logger#info "looking for %s in %s" re file;
-                     f content )
+                     f content)
                else true
              in
              if not relevant_rule then (
                logger#info "skipping rule %s for %s" r.R.id file;
-               RP.empty_semgrep_result )
+               RP.empty_semgrep_result)
              else
                let config = r.options ||| default_config in
                let formula = R.formula_of_pformula pformula in

--- a/semgrep-core/src/engine/Range_with_metavars.ml
+++ b/semgrep-core/src/engine/Range_with_metavars.ml
@@ -103,7 +103,7 @@ let difference_ranges config pos neg =
     pos
     |> List.filter (fun x ->
            not
-             ( neg
+             (neg
              |> List.exists (fun y ->
                     (* pattern-not vs pattern-not-inside vs pattern-not-regex,
                      * the difference matters!

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -64,7 +64,7 @@ let select_from_ranges file (sel_opt : selector option) (ranges : RM.ranges) :
             [
               RM.match_result_to_range
                 (pattern_match_from_binding selector binding);
-            ] )
+            ])
   in
   List.flatten (List.map select_from_range ranges)
 
@@ -86,7 +86,7 @@ let selector_from_formula match_func f =
               pstr;
               lazy_matches = lazy (match_func [ (pattern, pid, pstr) ]);
             }
-      | _ -> None )
+      | _ -> None)
   | _ -> None
 
 let formula_to_sformula match_func formula =

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -133,14 +133,14 @@ let test_rules ?(ounit_context = false) xs =
          (* actual *)
          let lazy_ast_and_errors =
            lazy
-             ( match xlang with
+             (match xlang with
              | R.L (lang, _) ->
                  let { Parse_target.ast; errors; _ } =
                    Parse_target.parse_and_resolve_name_use_pfff_or_treesitter
                      lang target
                  in
                  (ast, errors)
-             | R.LRegex | R.LGeneric -> raise Impossible )
+             | R.LRegex | R.LGeneric -> raise Impossible)
          in
          E.g_errors := [];
          Flag_semgrep.with_opt_cache := false;
@@ -188,5 +188,5 @@ let test_rules ?(ounit_context = false) xs =
            else failwith (spf "wrong unit failure format: %s" s));
   if not ounit_context then (
     Parse_info.print_regression_information ~ext xs newscore;
-    pr2 (spf "total mismatch: %d" !total_mismatch) );
+    pr2 (spf "total mismatch: %d" !total_mismatch));
   ()

--- a/semgrep-core/src/matching/Apply_equivalences.ml
+++ b/semgrep-core/src/matching/Apply_equivalences.ml
@@ -67,12 +67,10 @@ let subst_e (env : Env.t) e =
                     e
                 | Some _ ->
                     failwith
-                      (spf "incompatible metavar: %s, was expecting an expr"
-                         str)
+                      (spf "incompatible metavar: %s, was expecting an expr" str)
                 | None ->
                     failwith
-                      (spf "could not find metavariable %s in environment" str)
-                )
+                      (spf "could not find metavariable %s in environment" str))
             | _ -> k x);
       }
   in
@@ -130,7 +128,7 @@ let apply equivs any =
                       then x' (* disjunction (if different) *)
                       else DisjExpr (x', alt)
                   (* no match yet, trying another equivalence *)
-                  | [] -> aux xs )
+                  | [] -> aux xs)
             in
             aux expr_rules);
         M.kstmt = (fun (_k, _) x -> x);

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -177,7 +177,7 @@ let stmts_may_match pattern_stmts (stmts : AST_generic.stmt list) =
       | stmt :: rest -> (
           match acc with
           | F.No -> pattern_in_any_stmt pat rest (pat_in_stmt pat stmt)
-          | F.Maybe -> acc )
+          | F.Maybe -> acc)
     in
     let patterns_all_in_stmts acc x =
       match acc with
@@ -367,7 +367,7 @@ and m_type_option_with_hook idb taopt tbopt =
   | Some ta, None -> (
       match !Hooks.get_type idb with
       | Some tb -> m_type_ ta tb
-      | None -> fail () )
+      | None -> fail ())
   (* less-is-ok:, like m_option_none_can_match_some *)
   | None, _ -> return ()
 
@@ -575,11 +575,11 @@ and m_expr a b =
       if_config
         (fun x -> x.Config.constant_propagation)
         ~then_:
-          ( match
-              Normalize_generic.constant_propagation_and_evaluate_literal b1
-            with
+          (match
+             Normalize_generic.constant_propagation_and_evaluate_literal b1
+           with
           | Some b1 -> m_literal_constness a1 b1
-          | None -> fail () )
+          | None -> fail ())
         ~else_:(fail ())
   (*e: [[Generic_vs_generic.m_expr()]] propagated constant case *)
   (*s: [[Generic_vs_generic.m_expr()]] sequencable container cases *)
@@ -655,7 +655,7 @@ and m_expr a b =
             match xs with [] -> fail () | x :: xs -> m_expr a x >||> aux xs
           in
           aux mult_assigns
-      | _, _ -> fail () )
+      | _, _ -> fail ())
   | A.DotAccess (a1, at, a2), B.DotAccess (b1, bt, b2) ->
       m_expr a1 b1 >>= fun () ->
       m_tok at bt >>= fun () -> m_name_or_dynamic a2 b2
@@ -800,7 +800,7 @@ and m_literal a b =
       (* less_is_ok: *)
       | None, _ -> return ()
       | Some a, Some b -> m_ellipsis_or_metavar_or_string a b
-      | Some _, None -> fail () )
+      | Some _, None -> fail ())
   (*x: [[Generic_vs_generic.m_literal()]] ellipsis case *)
   (*e: [[Generic_vs_generic.m_literal()]] ellipsis case *)
   (*s: [[Generic_vs_generic.m_literal()]] regexp case *)
@@ -859,7 +859,7 @@ and m_literal_constness a b =
   match b with
   | B.Lit b1 -> m_literal a b1
   | B.Cst B.Cstr -> (
-      match a with A.String ("...", _) -> return () | ___else___ -> fail () )
+      match a with A.String ("...", _) -> return () | ___else___ -> fail ())
   | B.Cst _ | B.NotCst -> fail ()
 
 (*s: function [[Generic_vs_generic.m_action]] *)
@@ -1182,7 +1182,7 @@ and m_list__m_argument (xsa : A.argument list) (xsb : A.argument list) =
               m_ident ida idb >>= fun () ->
               m_expr ea eb >>= fun () -> m_list__m_argument xsa (before @ after)
           | _ -> raise Impossible
-        with Not_found -> fail () )
+        with Not_found -> fail ())
   (*e: [[Generic_vs_generic.m_list__m_argument()]] [[ArgKwd]] pattern case *)
   (* the general case *)
   | xa :: aas, xb :: bbs ->
@@ -1216,7 +1216,7 @@ and m_arguments_concat a b =
       (* interpolated, and ellipsis implicitly is                   *)
       match (xa, xb) with
       | A.Arg (A.Ellipsis _), A.Arg (A.L (A.String _)) -> fail ()
-      | _ -> m_argument xa xb >>= fun () -> m_arguments_concat aas bbs )
+      | _ -> m_argument xa xb >>= fun () -> m_arguments_concat aas bbs)
   | [], _ | _ :: _, _ -> fail ()
 
 (*e: function [[Generic_vs_generic.m_arguments_concat]] *)
@@ -1274,7 +1274,7 @@ and m_call_op aop toka aargs bop tokb bargs tin =
            convert operands to AC normal form: %s ~ %s"
           (A.show_expr (A.Call (A.IdSpecial (A.Op aop, toka), aargs)))
           (B.show_expr (B.Call (B.IdSpecial (B.Op bop, tokb), bargs)));
-        m_op_default tin )
+        m_op_default tin)
   else m_op_default tin
 
 (* Associative-matching of operators.
@@ -1303,7 +1303,7 @@ and m_assoc_op tok op aargs_ac bargs_ac =
                 m_expr xa op_bs'
                 >>= (fun () -> m_assoc_op tok op xsa rest)
                 >||> aux xs
-            | None -> aux xs )
+            | None -> aux xs)
       in
       aux candidates
   | A.Ellipsis i :: xsa, xb :: xsb ->
@@ -1703,11 +1703,11 @@ and m_stmts_deep_uncached ~less_is_ok (xsa : A.stmt list) (xsb : A.stmt list) =
       if_config
         (fun x -> x.go_deeper_stmt)
         ~then_:
-          ( match SubAST_generic.flatten_substmts_of_stmts xsb with
+          (match SubAST_generic.flatten_substmts_of_stmts xsb with
           | None -> fail () (* was already flat *)
           | Some (xsb, last_stmt) ->
               m_list__m_stmt ~list_kind:(CK.Flattened_until last_stmt.s_id) xsa
-                xsb )
+                xsb)
         ~else_:(fail ())
   (* dots: metavars: $...BODY *)
   | ({ s = A.ExprStmt (A.N (A.Id ((s, _), _idinfo)), _); _ } :: _ as xsa), xsb
@@ -1746,9 +1746,9 @@ and m_list__m_stmt_uncached ?(less_is_ok = true) ~list_kind (xsa : A.stmt list)
   | Maybe -> (
       (*s: [[Generic_vs_generic.m_list__m_stmt]] if [[debug]] *)
       logger#ldebug
-        ( lazy
+        (lazy
           (spf "m_list__m_stmt_uncached: %d vs %d" (List.length xsa)
-             (List.length xsb)) );
+             (List.length xsb)));
       (*e: [[Generic_vs_generic.m_list__m_stmt]] if [[debug]] *)
       match (xsa, xsb) with
       | [], [] -> return ()
@@ -1798,7 +1798,7 @@ and m_list__m_stmt_uncached ?(less_is_ok = true) ~list_kind (xsa : A.stmt list)
           m_stmt xa xb >>= fun () ->
           env_add_matched_stmt xb >>= fun () ->
           m_list__m_stmt ~list_kind aas bbs
-      | _ :: _, _ -> fail () )
+      | _ :: _, _ -> fail ())
 
 (*e: function [[Generic_vs_generic.m_list__m_stmt]] *)
 
@@ -1830,7 +1830,7 @@ and m_stmt a b =
       match b.s with
       | B.ExprStmt (subb, _) when not (Parse_info.is_fake sc) ->
           m_expr suba subb
-      | _ -> fail () )
+      | _ -> fail ())
   (*e: [[Generic_vs_generic.m_stmt()]] metavariable case *)
   (*s: [[Generic_vs_generic.m_stmt()]] ellipsis cases *)
   (* dots: '...' can to match any statememt *)
@@ -2083,7 +2083,7 @@ and m_pattern a b =
         (* this can happen with PatAs in exception handler in Python *)
       with H.NotAnExpr ->
         envf (str, tok) (MV.P b2)
-        (*e: [[Generic_vs_generic.m_pattern()]] metavariable case *) )
+        (*e: [[Generic_vs_generic.m_pattern()]] metavariable case *))
   (* dots: *)
   | A.PatEllipsis _, _ -> return ()
   (* boilerplate *)
@@ -2427,7 +2427,7 @@ and m_list__m_field ~less_is_ok (xsa : A.field list) (xsb : A.field list) =
             m_definition adef bdef >>= fun () ->
             m_list__m_field ~less_is_ok xsa (before @ after)
         | _ -> raise Impossible
-      with Not_found -> fail () )
+      with Not_found -> fail ())
   (*e: [[Generic_vs_generic.m_list__m_field()]] [[DefStmt]] pattern case *)
   (* the general case *)
   (* This applies to definitions where the field name is a metavariable,
@@ -2656,7 +2656,7 @@ and m_directive a b =
       match (normal_a, normal_b) with
       | Some (a0, a1), Some (b0, b1) ->
           m_tok a0 b0 >>= fun () -> m_module_name_prefix a1 b1
-      | _ -> fail () )
+      | _ -> fail ())
   (* more complex pattern should not be normalized *)
   | A.ImportFrom _ | A.ImportAs _
   (* definitely do not normalize the pattern for ImportAll *)

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -380,10 +380,10 @@ let rec inits_and_rest_of_list = function
 
 let _ =
   Common2.example
-    ( inits_and_rest_of_list [ 'a'; 'b'; 'c' ]
+    (inits_and_rest_of_list [ 'a'; 'b'; 'c' ]
     = [
         ([ 'a' ], [ 'b'; 'c' ]); ([ 'a'; 'b' ], [ 'c' ]); ([ 'a'; 'b'; 'c' ], []);
-      ] )
+      ])
 
 let inits_and_rest_of_list_empty_ok = function
   | [] -> [ ([], []) ]
@@ -391,13 +391,13 @@ let inits_and_rest_of_list_empty_ok = function
 
 let _ =
   Common2.example
-    ( inits_and_rest_of_list_empty_ok [ 'a'; 'b'; 'c' ]
+    (inits_and_rest_of_list_empty_ok [ 'a'; 'b'; 'c' ]
     = [
         ([], [ 'a'; 'b'; 'c' ]);
         ([ 'a' ], [ 'b'; 'c' ]);
         ([ 'a'; 'b' ], [ 'c' ]);
         ([ 'a'; 'b'; 'c' ], []);
-      ] )
+      ])
 
 (*s: function [[Matching_generic.all_elem_and_rest_of_list]] *)
 (* todo? optimize, probably not the optimal version ... *)
@@ -469,7 +469,7 @@ let regexp_matcher_of_regexp_string s =
     fun s2 ->
       Re.Pcre.pmatch ~rex:re s2 |> fun b ->
       logger#debug "regexp match: %s on %s, result = %b" s s2 b;
-      b )
+      b)
   else failwith (spf "This is not a PCRE-compatible regexp: " ^ s)
 
 (*e: function [[Matching_generic.regexp_of_regexp_string]] *)

--- a/semgrep-core/src/matching/Normalize_generic.ml
+++ b/semgrep-core/src/matching/Normalize_generic.ml
@@ -102,7 +102,7 @@ let rec eval x : constness option =
       match List.nth_opt literals 0 with
       | Some (Lit (String (_s1, t1))) when all_args_are_string ->
           Some (Lit (String (concated, t1)))
-      | _ -> None )
+      | _ -> None)
   | Call (IdSpecial (InterpolatedElement, _), (_, [ Arg e ], _)) -> eval e
   (* TODO: partial evaluation for ints/floats/... *)
   | _ -> None

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -56,10 +56,10 @@ let subexprs_of_stmt st =
       Common.opt_to_list eopt
   (* n *)
   | For (_, ForClassic (xs, eopt1, eopt2), _) ->
-      ( xs
+      (xs
       |> Common.map_filter (function
            | ForInitExpr e -> Some e
-           | ForInitVar (_, vdef) -> vdef.vinit) )
+           | ForInitVar (_, vdef) -> vdef.vinit))
       @ Common.opt_to_list eopt1 @ Common.opt_to_list eopt2
   | Assert (_, e1, e2opt, _) -> e1 :: Common.opt_to_list e2opt
   | For (_, ForIn (_, es), _) -> es
@@ -100,16 +100,16 @@ let subexprs_of_expr e =
   | Call (e, args) ->
       (* not sure we want to return 'e' here *)
       e
-      :: ( args |> unbracket
+      :: (args |> unbracket
          |> Common.map_filter (function
               | Arg e | ArgKwd (_, e) -> Some e
-              | ArgType _ | ArgOther _ -> None) )
+              | ArgType _ | ArgOther _ -> None))
   | SliceAccess (e1, e2) ->
       e1
-      :: ( e2 |> unbracket
+      :: (e2 |> unbracket
          |> (fun (a, b, c) -> [ a; b; c ])
          |> List.map Common.opt_to_list
-         |> List.flatten )
+         |> List.flatten)
   | Yield (_, eopt, _) -> Common.opt_to_list eopt
   | OtherExpr (_, anys) ->
       (* in theory we should go deeper in any *)
@@ -154,7 +154,7 @@ let substmts_of_stmt st =
   | Try (_, st, xs, opt) -> (
       [ st ]
       @ (xs |> List.map Common2.thd3)
-      @ match opt with None -> [] | Some (_, st) -> [ st ] )
+      @ match opt with None -> [] | Some (_, st) -> [ st ])
   | DisjStmt _ -> raise Common.Impossible
   (* this may slow down things quite a bit *)
   | DefStmt (_ent, def) -> (
@@ -172,7 +172,7 @@ let substmts_of_stmt st =
             def.cbody |> unbracket
             |> Common.map_filter (function
                  | FieldStmt st -> Some st
-                 | FieldSpread _ -> None) )
+                 | FieldSpread _ -> None))
 
 (*e: function [[SubAST_generic.substmts_of_stmt]] *)
 
@@ -239,11 +239,11 @@ let flatten_substmts_of_stmts xs =
      * a zillion times on big files (see tests/PERF/) if we do the
      * matching naively in m_stmts_deep.
      *)
-    ( if !go_really_deeper_stmt then
-      let es = subexprs_of_stmt x in
-      (* getting deeply nested lambdas stmts *)
-      let lambdas = es |> List.map lambdas_in_expr_memo |> List.flatten in
-      lambdas |> List.map (fun def -> def.fbody) |> List.iter aux );
+    (if !go_really_deeper_stmt then
+     let es = subexprs_of_stmt x in
+     (* getting deeply nested lambdas stmts *)
+     let lambdas = es |> List.map lambdas_in_expr_memo |> List.flatten in
+     lambdas |> List.map (fun def -> def.fbody) |> List.iter aux);
 
     let xs = substmts_of_stmt x in
     match xs with

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -123,7 +123,7 @@ let rec (remove_not : Rule.formula -> Rule.formula option) =
       | R.Not f -> remove_not f
       (* todo? apply De Morgan's law? *)
       | R.Or _xs -> failwith "Not Or"
-      | R.And _xs -> failwith "Not And" )
+      | R.And _xs -> failwith "Not And")
   | R.Leaf x -> Some (R.Leaf x)
 
 let remove_not_final f =
@@ -164,7 +164,7 @@ let rec (cnf : Rule.formula -> cnf_step0) =
         | [ x ] -> x
         | [ And ps; And qs ] ->
             And
-              ( ps
+              (ps
               |> List.map (fun pi ->
                      let ands =
                        qs
@@ -175,7 +175,7 @@ let rec (cnf : Rule.formula -> cnf_step0) =
                               Or ors)
                      in
                      ands)
-              |> List.flatten )
+              |> List.flatten)
         | x :: xs ->
             let y = aux xs in
             aux [ x; y ]

--- a/semgrep-core/src/optimizing/Bloom_annotation.ml
+++ b/semgrep-core/src/optimizing/Bloom_annotation.ml
@@ -101,7 +101,7 @@ let rec statement_strings stmt =
             (* First statement visited is the current statement *)
             if !top_level then (
               top_level := false;
-              k x )
+              k x)
             else
               (* For any other statement, recurse to add the filter *)
               let strs = statement_strings x in

--- a/semgrep-core/src/optimizing/Caching.ml
+++ b/semgrep-core/src/optimizing/Caching.ml
@@ -247,7 +247,7 @@ let prepare_pattern any =
                   printf "post backref counts:\n%a" print_name_counts
                     post_backref_counts;
                   printf "backrefs:\n%a" print_names backrefs;
-                  printf "\n" ));
+                  printf "\n"));
             (* continue scanning the current subtree. *)
             k stmt);
       }
@@ -325,10 +325,10 @@ module Cache_key = struct
   let show_compact k =
     sprintf "%s %s %s %B %i %i" (show_env k.min_env)
       (match k.function_id with Match_deep -> "deep" | Match_list -> "list")
-      ( match k.list_kind with
+      (match k.list_kind with
       | Original -> "orig"
       | Flattened_until last_id ->
-          sprintf "flat[%i-%i]" (k.target_stmt_id :> int) (last_id :> int) )
+          sprintf "flat[%i-%i]" (k.target_stmt_id :> int) (last_id :> int))
       k.less_is_ok
       (k.pattern_stmt_id :> int)
       (k.target_stmt_id :> int)
@@ -476,12 +476,12 @@ module Cache = struct
                 List.map
                   (fun cached_acc ->
                     patch_result_from_cache ~access backrefs a acc cached_acc)
-                  res )
+                  res)
         | None ->
             incr cache_misses;
             let res = compute pattern target acc in
             Tbl.replace cache key res;
-            res )
+            res)
 end
 
 let print_stats () =

--- a/semgrep-core/src/optimizing/Stmts_match_span.ml
+++ b/semgrep-core/src/optimizing/Stmts_match_span.ml
@@ -82,7 +82,7 @@ let merge_and_deduplicate get_key a b =
         let k = get_key v in
         if not (Hashtbl.mem tbl k) then (
           Hashtbl.add tbl k ();
-          acc := v :: !acc ))
+          acc := v :: !acc))
       values
   in
   add a;

--- a/semgrep-core/src/parsing/Parse_equivalences.ml
+++ b/semgrep-core/src/parsing/Parse_equivalences.ml
@@ -55,7 +55,7 @@ let parse file =
                                     match Lang.lang_of_string_opt s with
                                     | None ->
                                         error (spf "unsupported language: %s" s)
-                                    | Some l -> l )
+                                    | Some l -> l)
                                 | _ ->
                                     error
                                       (spf "expecting a string for languages"))
@@ -99,11 +99,11 @@ let parse file =
                          { Eq.id; left; op; right; languages }
                      | x ->
                          pr2_gen x;
-                         error "wrong equivalence fields" )
+                         error "wrong equivalence fields")
                  | x ->
                      pr2_gen x;
                      error "wrong equivalence fields")
-      | _ -> error "missing equivalences entry" )
+      | _ -> error "missing equivalences entry")
   | Result.Error (`Msg s) ->
       failwith (spf "sgrep_equivalence: could not parse %s (error = %s)" file s)
 

--- a/semgrep-core/src/parsing/Parse_mini_rule.ml
+++ b/semgrep-core/src/parsing/Parse_mini_rule.ml
@@ -82,7 +82,7 @@ let parse_languages ~id langs =
                  raise
                    (InvalidLanguageException
                       (id, spf "unsupported language: %s" s))
-             | Some l -> l )
+             | Some l -> l)
          | _ ->
              raise
                (InvalidRuleException (id, spf "expecting a string for languages")))
@@ -133,7 +133,7 @@ let parse file =
                          }
                      | x ->
                          pr2_gen x;
-                         raise (InvalidYamlException "wrong rule fields") )
+                         raise (InvalidYamlException "wrong rule fields"))
                  | x ->
                      pr2_gen x;
                      raise (InvalidYamlException "wrong rule fields"))

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -28,9 +28,9 @@ open Common
 (*****************************************************************************)
 
 let dump_and_print_errors dumper (res : 'a Tree_sitter_run.Parsing_result.t) =
-  ( match res.program with
+  (match res.program with
   | Some cst -> dumper cst
-  | None -> failwith "unknown error from tree-sitter parser" );
+  | None -> failwith "unknown error from tree-sitter parser");
   res.errors
   |> List.iter (fun err ->
          pr2 (Tree_sitter_run.Tree_sitter_error.to_string ~color:true err))

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -91,13 +91,13 @@ let parse_bool ctx = function
 let parse_int ctx = function
   | J.String s -> (
       try int_of_string s
-      with Failure _ -> error (spf "parse_int  for %s" ctx) )
+      with Failure _ -> error (spf "parse_int  for %s" ctx))
   | J.Float f ->
       let i = int_of_float f in
       if float_of_int i = f then i
       else (
         pr2_gen f;
-        error "not an int" )
+        error "not an int")
   | x ->
       pr2_gen x;
       error (spf "parse_int for %s" ctx)
@@ -155,7 +155,7 @@ let parse_fix_regex env = function
             replacement )
       | x ->
           pr2_gen x;
-          error "parse_fix_regex" )
+          error "parse_fix_regex")
   | x ->
       pr2_gen x;
       error "parse_fix_regex"
@@ -178,17 +178,17 @@ let parse_paths = function
       | [ ("include", inc_opt); ("exclude", exc_opt) ], [] ->
           {
             R.include_ =
-              ( match inc_opt with
+              (match inc_opt with
               | None -> []
-              | Some xs -> parse_strings "include" xs );
+              | Some xs -> parse_strings "include" xs);
             exclude =
-              ( match exc_opt with
+              (match exc_opt with
               | None -> []
-              | Some xs -> parse_strings "exclude" xs );
+              | Some xs -> parse_strings "exclude" xs);
           }
       | x ->
           pr2_gen x;
-          error "parse_paths" )
+          error "parse_paths")
   | x ->
       pr2_gen x;
       error "parse_paths"
@@ -221,7 +221,7 @@ let parse_pattern (id, lang) s =
       match Spacegrep.Parse_pattern.of_src src with
       | Ok ast -> R.mk_xpat (Spacegrep ast) s
       | Error err ->
-          raise (H.InvalidPatternException (id, s, "generic", err.msg)) )
+          raise (H.InvalidPatternException (id, s, "generic", err.msg)))
 
 let rec parse_formula env (x : string * J.t) : R.pformula =
   match x with
@@ -303,7 +303,7 @@ and parse_formula_new env (x : J.t) : R.formula =
           R.Leaf (R.MetavarCond (R.CondRegexp (mvar, parse_regexp env re)))
       | _ ->
           pr2_gen x;
-          error "parse_formula_new" )
+          error "parse_formula_new")
   | _ ->
       pr2_gen x;
       error "parse_formula_new"
@@ -322,7 +322,7 @@ and parse_extra env x =
           R.MetavarRegexp (metavar, parse_regexp env regexp)
       | x ->
           pr2_gen x;
-          error "metavariable-regex: wrong parse_extra fields" )
+          error "metavariable-regex: wrong parse_extra fields")
   | "metavariable-pattern", J.Object xs -> (
       match find_fields [ "metavariable" ] xs with
       | [ ("metavariable", Some (J.String metavar)) ], rest ->
@@ -357,7 +357,7 @@ and parse_extra env x =
           R.MetavarPattern (metavar, opt_xlang, formula)
       | x ->
           pr2_gen x;
-          error "metavariable-pattern:  wrong parse_extra fields" )
+          error "metavariable-pattern:  wrong parse_extra fields")
   | "metavariable-comparison", J.Object xs -> (
       match
         find_fields [ "metavariable"; "comparison"; "strip"; "base" ] xs
@@ -379,7 +379,7 @@ and parse_extra env x =
             }
       | x ->
           pr2_gen x;
-          error "metavariable-comparison: wrong parse_extra fields" )
+          error "metavariable-comparison: wrong parse_extra fields")
   | "pattern-where-python", J.String s -> R.PatWherePython s
   | x ->
       pr2_gen x;
@@ -399,7 +399,7 @@ let parse_languages ~id langs =
                      raise
                        (E.InvalidLanguageException
                           (id, spf "unsupported language: %s" s))
-                 | Some l -> l )
+                 | Some l -> l)
              | _ ->
                  raise
                    (E.InvalidRuleException
@@ -408,7 +408,7 @@ let parse_languages ~id langs =
       match languages with
       | [] ->
           raise (E.InvalidRuleException (id, "we need at least one language"))
-      | x :: xs -> R.L (x, xs) )
+      | x :: xs -> R.L (x, xs))
 
 (*****************************************************************************)
 (* Main entry point *)
@@ -475,7 +475,7 @@ let parse_mode env mode_opt (xs : (string * J.t) list) : R.mode =
           R.Taint { sources; sanitizers; sinks }
       | x ->
           pr2_gen x;
-          error "wrong rule fields" )
+          error "wrong rule fields")
   | _ ->
       pr2_gen xs;
       error "wrong rule fields"
@@ -526,7 +526,7 @@ let parse_json file json =
                      }
                  | x ->
                      pr2_gen x;
-                     error "wrong rule fields" )
+                     error "wrong rule fields")
              | x ->
                  pr2_gen x;
                  error "wrong rule fields")
@@ -540,7 +540,7 @@ let parse file =
         let yaml_res = Yaml.of_string str in
         match yaml_res with
         | Result.Ok v -> yaml_to_json v
-        | Result.Error (`Msg s) -> raise (E.UnparsableYamlException s) )
+        | Result.Error (`Msg s) -> raise (E.UnparsableYamlException s))
     | FT.Config FT.Json -> J.load_json file
     | FT.Config FT.Jsonnet ->
         Common2.with_tmp_file ~str:"parse_rule" ~ext:"json" (fun tmpfile ->

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -117,7 +117,7 @@ let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =
       | Timeout -> raise Timeout
       | exn ->
           logger#debug "exn (%s) with TreeSitter parser" (Common.exn_to_s exn);
-          Error exn )
+          Error exn)
 
 let rec (run_either :
           Common.filename -> 'ast parser list -> 'ast internal_result) =
@@ -139,7 +139,7 @@ let rec (run_either :
               Partial (ast, errs, stat)
           | Partial _ ->
               logger#debug "Partial again but return first Partial";
-              Partial (ast, errs, stat) )
+              Partial (ast, errs, stat))
       | Error exn -> (
           let res = run_either file xs in
           match res with
@@ -152,7 +152,7 @@ let rec (run_either :
               logger#debug "exn again (%s) but return original exn (%s)"
                 (Common.exn_to_s exn2) (Common.exn_to_s exn);
               (* prefer the first error *)
-              Error exn ) )
+              Error exn))
 
 let (run :
       Common.filename ->

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -28,9 +28,9 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 
 let dump_and_print_errors dumper (res : 'a Tree_sitter_run.Parsing_result.t) =
-  ( match res.program with
+  (match res.program with
   | Some cst -> dumper cst
-  | None -> failwith "unknown error from tree-sitter parser" );
+  | None -> failwith "unknown error from tree-sitter parser");
   res.errors
   |> List.iter (fun err ->
          pr2 (Tree_sitter_run.Tree_sitter_error.to_string ~color:true err))
@@ -127,7 +127,7 @@ let test_parse_tree_sitter lang xs =
              logger#info "processing %s" file;
              let stat =
                try
-                 ( match lang with
+                 (match lang with
                  (* less: factorize with dump_tree_sitter_cst_lang *)
                  | Lang.Ruby ->
                      Tree_sitter_ruby.Parse.file file |> fail_on_error |> ignore
@@ -163,7 +163,7 @@ let test_parse_tree_sitter lang xs =
                  | _ ->
                      failwith
                        (spf "lang %s not supported with tree-sitter"
-                          (Lang.string_of_lang lang)) );
+                          (Lang.string_of_lang lang)));
                  PI.correct_stat file
                with exn ->
                  pr2 (spf "%s: exn = %s" file (Common.exn_to_s exn));
@@ -206,7 +206,7 @@ let parsing_common ?(verbose = true) lang xs =
              if verbose then pr2 (spf "%s: exn = %s" file (Common.exn_to_s exn));
              match exn with
              | Timeout -> { (PI.bad_stat file) with have_timeout = true }
-             | _else_ -> PI.bad_stat file )
+             | _else_ -> PI.bad_stat file)
          in
          stat)
 

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -78,7 +78,7 @@ and command (cmd : command) : G.stmt option =
       | arg0 :: args ->
           let args = List.map (fun x -> G.Arg (expression x)) args in
           let e = G.Call (expression arg0, G.fake_bracket args) in
-          Some (G.s (ExprStmt (e, G.fake ""))) )
+          Some (G.s (ExprStmt (e, G.fake ""))))
   | Compound_command _ -> None
   | Coprocess _ -> None
   | Assignment _ -> None
@@ -95,7 +95,7 @@ and expression (e : expression) : G.expr =
       match frag with
       | String_content x -> G.L (G.Atom (G.fake "", x))
       | Expansion ex -> expansion ex
-      | Command_substitution (_open, _x, _close) -> todo )
+      | Command_substitution (_open, _x, _close) -> todo)
   | Raw_string _ -> todo
   | Ansii_c_string _ -> todo
   | Special_character _ -> todo

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -160,7 +160,7 @@ let make_scalar _anchor _tag pos value env : A.expr =
     | ".nan" | ".NaN" | ".NAN" -> A.L (A.Float (Some nan, token))
     | _ -> (
         try A.L (A.Float (Some (float_of_string value), token))
-        with _ -> A.L (A.String (value, token)) )
+        with _ -> A.L (A.String (value, token)))
 
 (* Sequences are arrays in the generic AST *)
 let make_sequence _anchor _tag start_pos (es, end_pos) env =
@@ -344,7 +344,7 @@ let split_on_ellipses line =
           | 2 ->
               substring line 0 ellipses_start
               :: split (substring line (i + 1) line_length) 0 0 0
-          | _ -> raise ImpossibleDots )
+          | _ -> raise ImpossibleDots)
       | _ -> split line (i + 1) 0 0
   in
   let pieces = split line 0 0 0 in
@@ -377,7 +377,7 @@ let preprocess_yaml str =
               in
               match last_same_whitespace ws context with
               | Some ws -> (context, conv @ [ ws ^ sgrep_ellipses ], ellipses')
-              | None -> (context, conv, (ws_len, ws) :: ellipses') )
+              | None -> (context, conv, (ws_len, ws) :: ellipses'))
           | _ ->
               let conv, ellipses' =
                 convert_leftover_ellipses (hyphen_loc, ws) ~is_line:true

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -183,18 +183,18 @@ let rec expr (x : expr) =
       G.Call
         ( G.IdSpecial (G.ConcatString G.FString, fake "concat"),
           fb
-            ( xs
+            (xs
             |> List.map (fun x ->
                    let x = expr x in
-                   G.Arg x) ) )
+                   G.Arg x)) )
   | ConcatenatedString xs ->
       G.Call
         ( G.IdSpecial (G.ConcatString G.SequenceConcat, fake "concat"),
           fb
-            ( xs
+            (xs
             |> List.map (fun x ->
                    let x = expr x in
-                   G.Arg x) ) )
+                   G.Arg x)) )
   | TypedExpr (v1, v2) ->
       let v1 = expr v1 in
       let v2 = type_ v2 in
@@ -231,7 +231,7 @@ let rec expr (x : expr) =
       | l1, [ x ], l2 -> slice1 e (l1, x, l2)
       | _, xs, _ ->
           let xs = list (slice e) xs in
-          G.OtherExpr (G.OE_Slices, xs |> List.map (fun x -> G.E x)) )
+          G.OtherExpr (G.OE_Slices, xs |> List.map (fun x -> G.E x)))
   | Attribute (v1, t, v2, v3) ->
       let v1 = expr v1
       and t = info t
@@ -268,7 +268,7 @@ let rec expr (x : expr) =
       match v1 with
       | Left op ->
           G.Call (G.IdSpecial (G.Op op, tok), fb ([ v2 ] |> List.map G.arg))
-      | Right oe -> G.OtherExpr (oe, [ G.E v2 ]) )
+      | Right oe -> G.OtherExpr (oe, [ G.E v2 ]))
   | Compare (v1, v2, v3) -> (
       let v1 = expr v1 and v2 = list cmpop v2 and v3 = list expr v3 in
       match (v2, v3) with
@@ -281,7 +281,7 @@ let rec expr (x : expr) =
                    G.E (G.IdSpecial (G.Op arith, tok)))
           in
           let any = anyops @ (v3 |> List.map (fun e -> G.E e)) in
-          G.OtherExpr (G.OE_CmpOps, any) )
+          G.OtherExpr (G.OE_CmpOps, any))
   | Call (v1, v2) ->
       let v1 = expr v1 in
       let v2 = bracket (list argument) v2 in
@@ -618,8 +618,8 @@ and stmt_aux x =
            * No because we have some magic equivalences to convert some
            * Vardef back in Assign in Generic_vs_generic.
            *)
-          | _ -> [ G.exprstmt (G.Assign (a, v2, v3)) ] )
-      | xs -> [ G.exprstmt (G.Assign (G.Tuple (G.fake_bracket xs), v2, v3)) ] )
+          | _ -> [ G.exprstmt (G.Assign (a, v2, v3)) ])
+      | xs -> [ G.exprstmt (G.Assign (G.Tuple (G.fake_bracket xs), v2, v3)) ])
   | AugAssign (v1, (v2, tok), v3) ->
       let v1 = expr v1 and v2 = operator v2 and v3 = expr v3 in
       [ G.exprstmt (G.AssignOp (v1, (v2, tok), v3)) ]
@@ -647,7 +647,7 @@ and stmt_aux x =
                    |> G.s;
                  ])
             |> G.s;
-          ] )
+          ])
   | For (t, v1, t2, v2, v3, v4) -> (
       let foreach = pattern v1
       and ins = expr v2
@@ -667,7 +667,7 @@ and stmt_aux x =
                    |> G.s;
                  ])
             |> G.s;
-          ] )
+          ])
   (* TODO: unsugar in sequence? *)
   | With (_t, v1, v2, v3) ->
       let v1 = expr v1 and v2 = option expr v2 and v3 = list_stmt1 v3 in
@@ -687,7 +687,7 @@ and stmt_aux x =
           let from = expr from in
           let st = G.Throw (t, e, G.sc) |> G.s in
           [ G.OtherStmt (G.OS_ThrowFrom, [ G.E from; G.S st ]) |> G.s ]
-      | None -> [ G.OtherStmt (G.OS_ThrowNothing, [ G.Tk t ]) |> G.s ] )
+      | None -> [ G.OtherStmt (G.OS_ThrowNothing, [ G.Tk t ]) |> G.s ])
   | RaisePython2 (t, e, v2, v3) -> (
       let e = expr e in
       let st = G.Throw (t, e, G.sc) |> G.s in
@@ -701,7 +701,7 @@ and stmt_aux x =
       | Some args, None ->
           let args = expr args in
           [ G.OtherStmt (G.OS_ThrowArgsLocation, [ G.E args; G.S st ]) |> G.s ]
-      | None, _ -> [ st ] )
+      | None, _ -> [ st ])
   | TryExcept (t, v1, v2, v3) -> (
       let v1 = list_stmt1 v1
       and v2 = list excepthandler v2
@@ -719,7 +719,7 @@ and stmt_aux x =
                    |> G.s;
                  ])
             |> G.s;
-          ] )
+          ])
   | TryFinally (t, v1, t2, v2) ->
       let v1 = list_stmt1 v1 and v2 = list_stmt1 v2 in
       (* could lift down the Try in v1 *)
@@ -756,7 +756,7 @@ and stmt_aux x =
               ({ ent with G.attrs = G.attr G.Async t :: ent.G.attrs }, func)
             |> G.s;
           ]
-      | _ -> [ G.OtherStmt (G.OS_Async, [ G.S x ]) |> G.s ] )
+      | _ -> [ G.OtherStmt (G.OS_Async, [ G.S x ]) |> G.s ])
   | Pass t -> [ G.OtherStmt (G.OS_Pass, [ G.Tk t ]) |> G.s ]
   | Break t -> [ G.Break (t, G.LNone, G.sc) |> G.s ]
   | Continue t -> [ G.Continue (t, G.LNone, G.sc) |> G.s ]
@@ -792,7 +792,7 @@ and excepthandler = function
       and v2 = option name v2
       and v3 = list_stmt1 v3 in
       ( t,
-        ( match (v1, v2) with
+        (match (v1, v2) with
         | Some e, None -> (
             match e with
             | G.Ellipsis tok -> G.PatEllipsis tok
@@ -803,7 +803,7 @@ and excepthandler = function
         | None, None -> G.PatUnderscore (fake "_")
         | None, Some _ -> raise Impossible (* see the grammar *)
         | Some e, Some n ->
-            G.PatVar (H.expr_to_type e, Some (n, G.empty_id_info ())) ),
+            G.PatVar (H.expr_to_type e, Some (n, G.empty_id_info ()))),
         v3 )
 
 (*e: function [[Python_to_generic.excepthandler]] *)
@@ -845,7 +845,7 @@ let any = function
   | Stmt v1 -> (
       let v1 = stmt v1 in
       (* in Python Assign is a stmt but in the generic AST it's an expression*)
-      match v1.G.s with G.ExprStmt (x, _t) -> G.E x | _ -> G.S v1 )
+      match v1.G.s with G.ExprStmt (x, _t) -> G.E x | _ -> G.S v1)
   (* TODO? should use list stmt_aux here? Some intermediate Block
    * could be inserted preventing some sgrep matching?
    *)

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -199,7 +199,7 @@ and expr = function
       let v1 = assignOp v1 and v2 = expr v2 and v3 = expr v3 in
       match v1 with
       | Left tok -> G.Assign (v2, tok, v3)
-      | Right (op, tok) -> G.AssignOp (v2, (op, tok), v3) )
+      | Right (op, tok) -> G.AssignOp (v2, (op, tok), v3))
   | ArrayAccess (v1, v2) ->
       let v1 = expr v1 and v2 = bracket expr v2 in
       G.ArrayAccess (v1, v2)
@@ -274,7 +274,7 @@ and argument v =
 and const_expr v = expr v
 
 let rec stmt st =
-  ( match st with
+  (match st with
   | DefStmt x -> definition x
   | DirStmt x -> directive x
   | CaseStmt x -> case_stmt x
@@ -321,7 +321,7 @@ let rec stmt st =
       (G.stmt1 (v1 |> List.map (fun v -> G.s (G.DefStmt v)))).G.s
   | Asm v1 ->
       let v1 = list expr v1 in
-      G.OtherStmt (G.OS_Asm, v1 |> List.map (fun e -> G.E e)) )
+      G.OtherStmt (G.OS_Asm, v1 |> List.map (fun e -> G.E e)))
   |> G.s
 
 and expr_or_vars v1 =

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -69,12 +69,12 @@ let return_type_of_results results =
   | xs ->
       Some
         (G.TyTuple
-           ( xs
+           (xs
            |> List.map (function
                 | G.ParamClassic { G.ptype = Some t; _ } -> t
                 | G.ParamClassic { G.ptype = None; _ } -> raise Impossible
                 | _ -> raise Impossible)
-           |> fb ))
+           |> fb))
 
 let list_to_tuple_or_expr xs =
   match xs with
@@ -118,7 +118,7 @@ let top_func () =
         | Left id -> G.TyN (G.Id (id, G.empty_id_info ()))
         | Right _ ->
             G.TyN
-              (G.IdQualified (name_of_qualified_ident v1, G.empty_id_info ())) )
+              (G.IdQualified (name_of_qualified_ident v1, G.empty_id_info ())))
     | TPtr (t, v1) ->
         let v1 = type_ v1 in
         G.TyPointer (t, v1)
@@ -177,7 +177,7 @@ let top_func () =
         in
         match arg3 with
         | None -> G.ParamClassic pclassic
-        | Some tok -> G.ParamRest (tok, pclassic) )
+        | Some tok -> G.ParamRest (tok, pclassic))
   and struct_field (v1, v2) =
     let v1 = struct_field_kind v1 and _v2TODO = option tag v2 in
     v1
@@ -337,7 +337,7 @@ let top_func () =
         let _v2 = tok v2 and v3 = init v3 in
         match v1 with
         | InitExpr (Id id) -> G.ArgKwd (id, v3)
-        | _ -> G.Arg (G.Tuple (G.fake_bracket [ init v1; v3 ])) )
+        | _ -> G.Arg (G.Tuple (G.fake_bracket [ init v1; v3 ])))
     | InitBraces v1 ->
         let v1 = bracket (list init) v1 in
         G.Arg (G.Container (G.List, v1))
@@ -410,7 +410,7 @@ let top_func () =
           | None -> None
           | Some s ->
               Some
-                ( match s with
+                (match s with
                 | ExprStmt (TypeSwitchExpr (e, tok1)) ->
                     let e = expr e in
                     G.Call (G.IdSpecial (G.Typeof, tok1), fb [ G.Arg e ])
@@ -421,7 +421,7 @@ let top_func () =
                       ( list_to_tuple_or_expr xs,
                         tok1,
                         G.Call (G.IdSpecial (G.Typeof, tok2), fb [ G.Arg e ]) )
-                | s -> simple s )
+                | s -> simple s)
         and v3 = list case_clause v3 in
         wrap_init_in_block_maybe v1 (G.Switch (v0, v2, v3) |> G.s)
     | Select (v1, v2) ->
@@ -483,7 +483,7 @@ let top_func () =
             let pattern =
               G.PatTuple (xs |> List.map H.expr_to_pattern |> G.fake_bracket)
             in
-            G.ForEach (pattern, v2, v3) )
+            G.ForEach (pattern, v2, v3))
   and case_clause = function
     | CaseClause (v1, v2) ->
         let v1 = case_kind v1 and v2 = stmt v2 in
@@ -497,7 +497,7 @@ let top_func () =
     | x -> (
         match expr_or_type x with
         | Left e -> H.expr_to_pattern e
-        | Right t -> G.PatType t )
+        | Right t -> G.PatType t)
   and case_kind = function
     | CaseExprs (tok, v1) ->
         v1 |> List.map (fun x -> G.Case (tok, expr_or_type_to_pattern x))
@@ -595,7 +595,7 @@ let top_func () =
         let x = top_decl x in
         match x.G.s with
         | G.DefStmt def -> G.Partial (G.PartialDef def)
-        | _ -> failwith "partial supported only for definitions" )
+        | _ -> failwith "partial supported only for definitions")
     | PartialSingleField (v1, v2, v3) ->
         let v1 = ident v1 in
         let v3 = init v3 in

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -273,7 +273,7 @@ and expr e =
                 cbody = decls |> bracket (List.map (fun x -> G.FieldStmt x));
               }
           in
-          G.Call (G.IdSpecial (G.New, v0), (lp, G.Arg anonclass :: v2, rp)) )
+          G.Call (G.IdSpecial (G.New, v0), (lp, G.Arg anonclass :: v2, rp)))
   | NewArray (v0, v1, v2, v3, v4) -> (
       let v1 = typ v1
       and v2 = list argument v2
@@ -289,7 +289,7 @@ and expr e =
       match v4 with
       | None -> G.Call (G.IdSpecial (G.New, v0), fb (G.ArgType t :: v2))
       | Some e ->
-          G.Call (G.IdSpecial (G.New, v0), fb (G.ArgType t :: G.Arg e :: v2)) )
+          G.Call (G.IdSpecial (G.New, v0), fb (G.ArgType t :: G.Arg e :: v2)))
   (* x.new Y(...) {...} *)
   | NewQualifiedClass (v0, _tok1, _tok2, v2, v3, v4) ->
       let v0 = expr v0
@@ -299,8 +299,8 @@ and expr e =
       let any =
         [ G.E v0; G.T v2 ]
         @ (v3 |> G.unbracket |> List.map (fun arg -> G.Ar arg))
-        @ ( Common.opt_to_list v4 |> List.map G.unbracket |> List.flatten
-          |> List.map (fun st -> G.S st) )
+        @ (Common.opt_to_list v4 |> List.map G.unbracket |> List.flatten
+          |> List.map (fun st -> G.S st))
       in
       G.OtherExpr (G.OE_NewQualifiedClass, any)
   | MethodRef (v1, v2, v3, v4) ->
@@ -600,11 +600,11 @@ and class_decl
   (ent, cdef)
 
 and class_kind (x, t) =
-  ( ( match x with
+  ( (match x with
     | ClassRegular -> G.Class
     | Interface -> G.Interface
     | AtInterface -> G.AtInterface
-    | Record -> G.RecordClass ),
+    | Record -> G.RecordClass),
     t )
 
 and decl decl =
@@ -650,7 +650,7 @@ let partial = function
       let x = decl x in
       match x.G.s with
       | G.DefStmt def -> G.PartialDef def
-      | _ -> failwith "unsupported PartialDecl" )
+      | _ -> failwith "unsupported PartialDecl")
   | PartialIf (v1, v2) ->
       let v2 = expr v2 in
       G.PartialIf (v1, v2)

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -252,7 +252,7 @@ and expr (x : expr) =
       | SR_NeedArgs _ ->
           error (snd v1) "Impossible: should have been matched in Call first"
       | SR_Literal l -> G.L l
-      | SR_Other (x, tok) -> G.OtherExpr (x, [ G.Tk tok ]) )
+      | SR_Other (x, tok) -> G.OtherExpr (x, [ G.Tk tok ]))
   | Assign (v1, tok, v2) ->
       let v1 = expr v1 and v2 = expr v2 in
       let tok = info tok in
@@ -282,7 +282,7 @@ and expr (x : expr) =
       let t = info t in
       match v2 with
       | Left n -> G.DotAccess (v1, t, G.EN (G.Id (n, G.empty_id_info ())))
-      | Right e -> G.DotAccess (v1, t, G.EDynamic e) )
+      | Right e -> G.DotAccess (v1, t, G.EDynamic e))
   | Fun (v1, _v2TODO) ->
       let def, _more_attrs = fun_ v1 in
       (* todo? assert more_attrs = []? *)
@@ -299,7 +299,7 @@ and expr (x : expr) =
           G.Call
             ( G.OtherExpr (x, [ G.Tk tok ]),
               bracket (List.map (fun e -> G.Arg e)) v2 )
-      | SR_NeedArgs f -> f (G.unbracket v2) )
+      | SR_NeedArgs f -> f (G.unbracket v2))
   | Apply (v1, v2) ->
       let v1 = expr v1 and v2 = bracket (list expr) v2 in
       G.Call (v1, bracket (List.map (fun e -> G.Arg e)) v2)
@@ -403,7 +403,7 @@ and for_header = function
           G.ForClassic (vars, v2, v3)
       | Right e ->
           let e = expr e in
-          G.ForClassic ([ G.ForInitExpr e ], v2, v3) )
+          G.ForClassic ([ G.ForInitExpr e ], v2, v3))
   | ForIn (v1, t, v2) ->
       let v2 = expr v2 in
       let pattern =
@@ -566,7 +566,7 @@ and parameter x =
       in
       match v3 with
       | None -> G.ParamClassic pclassic
-      | Some tok -> G.ParamRest (tok, pclassic) )
+      | Some tok -> G.ParamRest (tok, pclassic))
 
 and argument x = expr x
 
@@ -581,7 +581,7 @@ and attribute = function
       G.NamedAttr (t, name, (t1, args, t2))
 
 and keyword_attribute (x, tok) =
-  ( ( match x with
+  ( (match x with
     (* methods *)
     | Get -> G.Getter
     | Set -> G.Setter
@@ -595,7 +595,7 @@ and keyword_attribute (x, tok) =
     | Readonly -> G.Const
     | Optional -> G.Optional
     | Abstract -> G.Abstract
-    | NotNull -> G.NotNull ),
+    | NotNull -> G.NotNull),
     tok )
 
 and obj_ v = bracket (list property) v
@@ -747,7 +747,7 @@ and require_to_import_in_stmt_opt st =
             let orig = stmt st in
             Some (ys @ [ orig ])
         | _ -> raise ComplicatedCase
-      with ComplicatedCase -> None )
+      with ComplicatedCase -> None)
   | _ -> None
 
 and list_stmt xs =
@@ -800,7 +800,7 @@ and any = function
       | Some xs -> G.Ss xs
       | None ->
           let v1 = stmt v1 in
-          G.S v1 )
+          G.S v1)
   | Stmts v1 ->
       let v1 = list_stmt v1 in
       G.Ss v1

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -169,7 +169,7 @@ and stmt e : G.stmt =
        *)
       match e with
       | G.Ellipsis _ | G.DeepEllipsis _ -> G.exprstmt e
-      | _ -> G.OtherStmt (G.OS_ExprStmt2, [ G.E e ]) |> G.s )
+      | _ -> G.OtherStmt (G.OS_ExprStmt2, [ G.E e ]) |> G.s)
 
 and expr e =
   match e with
@@ -179,7 +179,7 @@ and expr e =
       match v1 with
       | G.N (G.Id (id, _idinfo)) when AST_generic_.is_metavar_name (fst id) ->
           G.TypedMetavar (id, v2, v3)
-      | _ -> G.Cast (v3, v1) )
+      | _ -> G.Cast (v3, v1))
   | Ellipsis v1 ->
       let v1 = tok v1 in
       G.Ellipsis v1
@@ -255,7 +255,7 @@ and expr e =
       let obj = G.Record v2 in
       match v1 with
       | None -> obj
-      | Some e -> G.OtherExpr (G.OE_RecordWith, [ G.E e; G.E obj ]) )
+      | Some e -> G.OtherExpr (G.OE_RecordWith, [ G.E e; G.E obj ]))
   | New (v1, v2) ->
       let v1 = tok v1 and v2 = name v2 in
       G.Call (G.IdSpecial (G.New, v1), fb [ G.Arg (G.N v2) ])
@@ -425,7 +425,7 @@ and let_binding = function
       match v1 with
       | G.PatTyped (G.PatId (id, _idinfo), ty) ->
           let ent = G.basic_entity id [] in
-          ( match ent.G.name with
+          (match ent.G.name with
           | G.EN (G.Id (_, idinfo)) ->
               (* less: abusing id_type? Do we asume id_info is populated
                * by further static analysis (naming/typing)? But the info
@@ -433,9 +433,9 @@ and let_binding = function
                * a form of TypedMetavar, so let's abuse it for now.
                *)
               idinfo.G.id_type := Some ty
-          | _ -> raise Impossible );
+          | _ -> raise Impossible);
           Left (ent, [], None, G.exprstmt v2)
-      | _ -> Right (v1, v2) )
+      | _ -> Right (v1, v2))
 
 and let_def { lname; lparams; lrettype; lbody } =
   let v1 = ident lname in
@@ -453,7 +453,7 @@ and parameter = function
       | G.PatId (id, _idinfo) -> G.ParamClassic (G.param_of_id id)
       | G.PatTyped (G.PatId (id, _idinfo), ty) ->
           G.ParamClassic { (G.param_of_id id) with G.ptype = Some ty }
-      | _ -> G.ParamPattern v )
+      | _ -> G.ParamPattern v)
   | ParamTodo t -> G.OtherParam (G.OPO_Todo, [ G.Tk t ])
 
 and type_declaration { tname; tparams; tbody } =
@@ -487,14 +487,14 @@ and type_def_kind = function
                let v1 = ident v1 and v2 = type_ v2 and v3 = option tok v3 in
                let ent =
                  G.basic_entity v1
-                   ( match v3 with
+                   (match v3 with
                    | Some tok -> [ G.attr G.Mutable tok ]
-                   | None -> [] )
+                   | None -> [])
                in
                G.FieldStmt
-                 ( G.DefStmt
-                     (ent, G.FieldDefColon { G.vinit = None; vtype = Some v2 })
-                 |> G.s )))
+                 (G.DefStmt
+                    (ent, G.FieldDefColon { G.vinit = None; vtype = Some v2 })
+                 |> G.s)))
           v1
       in
       G.AndType v1
@@ -613,12 +613,12 @@ and any = function
       let x = expr x in
       match x with
       | G.OtherExpr (G.OE_StmtExpr, [ G.S s ]) -> G.S s
-      | _ -> G.E x )
+      | _ -> G.E x)
   | I x -> (
       match item x with
       | [] -> raise Impossible
       | [ x ] -> G.S x
-      | xs -> G.Ss xs )
+      | xs -> G.Ss xs)
   | T x ->
       let x = type_ x in
       G.T x

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -215,7 +215,7 @@ and opt_expr_to_label_ident = function
       | Id [ label ] -> G.LId label
       | _ ->
           let e = expr e in
-          G.LDynamic e )
+          G.LDynamic e)
 
 and case = function
   | Case (t, v1, v2) ->
@@ -342,7 +342,7 @@ and expr = function
       match v2 with
       | Left (op, t) ->
           G.Call (G.IdSpecial (G.Op op, t), fb [ G.Arg v1; G.Arg v3 ])
-      | Right x -> G.Call (G.IdSpecial x, fb [ G.Arg v1; G.Arg v3 ]) )
+      | Right x -> G.Call (G.IdSpecial x, fb [ G.Arg v1; G.Arg v3 ]))
   | Unop ((v1, t), v2) ->
       let v1 = unaryOp v1 and v2 = expr v2 in
       G.Call (G.IdSpecial (G.Op (H.conv_op v1), t), fb [ G.Arg v2 ])
@@ -393,7 +393,7 @@ and expr = function
               fbody = body;
               fkind = (G.LambdaKind, t);
             }
-      | _ -> error tok "TODO: Lambda" )
+      | _ -> error tok "TODO: Lambda")
 
 and argument e =
   let e = expr e in
@@ -471,11 +471,11 @@ and func_def
   (ent, def)
 
 and function_kind (kind, t) =
-  ( ( match kind with
+  ( (match kind with
     | Function -> G.Function
     | AnonLambda -> G.LambdaKind
     | ShortLambda -> G.Arrow
-    | Method -> G.Method ),
+    | Method -> G.Method),
     t )
 
 and parameters x = list parameter x

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -74,7 +74,7 @@ let rec expr = function
       match kind with
       | ID_Self -> G.IdSpecial (G.Self, snd id)
       | ID_Super -> G.IdSpecial (G.Super, snd id)
-      | _ -> G.N (G.Id (ident id, G.empty_id_info ())) )
+      | _ -> G.N (G.Id (ident id, G.empty_id_info ())))
   | ScopedId x ->
       let name = scope_resolution x in
       G.N (G.IdQualified (name, G.empty_id_info ()))
@@ -224,7 +224,7 @@ and variable_or_method_name = function
   | SM m -> (
       match method_name m with
       | Left id -> id
-      | Right _ -> failwith "TODO: variable_or_method_name" )
+      | Right _ -> failwith "TODO: variable_or_method_name")
 
 and method_name mn =
   match mn with
@@ -243,7 +243,7 @@ and method_name mn =
           | [ StrChars (s, t2) ] ->
               let t = PI.combine_infos l [ t2; r ] in
               Left (s, t)
-          | _ -> Right (string_contents_list (l, xs, r)) ) )
+          | _ -> Right (string_contents_list (l, xs, r))))
 
 and string_contents_list (t1, xs, t2) =
   let xs = list string_contents xs in
@@ -338,7 +338,7 @@ and atom tcolon x =
       | [ StrChars (s, t2) ] ->
           let t = PI.combine_infos l [ t2; r ] in
           G.L (G.Atom (tcolon, (s, t)))
-      | _ -> string_contents_list (l, xs, r) )
+      | _ -> string_contents_list (l, xs, r))
 
 and literal x =
   match x with
@@ -374,7 +374,7 @@ and literal x =
       | [ StrChars (s, t) ] -> G.L (G.Regexp ((l, (s, t), r), opt))
       | _ ->
           (* TODO *)
-          string_contents_list (l, xs, r) )
+          string_contents_list (l, xs, r))
 
 and expr_as_stmt = function
   | S x -> stmt x
@@ -506,12 +506,12 @@ and definition def =
           | Right e ->
               let ent = G.basic_entity ("", fake "") [] in
               G.OtherStmt (G.OS_Todo, [ G.E e; G.Def (ent, G.FuncDef funcdef) ])
-              |> G.s )
+              |> G.s)
       | SingletonM e ->
           let e = expr e in
           let ent = G.basic_entity ("", fake "") [] in
           G.OtherStmt (G.OS_Todo, [ G.E e; G.Def (ent, G.FuncDef funcdef) ])
-          |> G.s )
+          |> G.s)
   | ClassDef (t, kind, body) -> (
       let body = body_exn body in
       match kind with
@@ -545,7 +545,7 @@ and definition def =
           G.DefStmt (ent, G.ClassDef def) |> G.s
       | SingletonC (t, e) ->
           let e = expr e in
-          G.OtherStmt (G.OS_Todo, [ G.Tk t; G.E e; G.S body ]) |> G.s )
+          G.OtherStmt (G.OS_Todo, [ G.Tk t; G.E e; G.S body ]) |> G.s)
   | ModuleDef (_t, name, body) ->
       let body = body_exn body in
       let ent =
@@ -604,7 +604,7 @@ and body_exn x =
           let st = list_stmt1 sts in
           let try_ = G.Try (fake "try", body, catches, finally_opt) |> G.s in
           let st = G.Block (fb [ try_; st ]) |> G.s in
-          G.OtherStmtWithStmt (G.OSWS_Else_in_try, None, st) |> G.s )
+          G.OtherStmtWithStmt (G.OSWS_Else_in_try, None, st) |> G.s)
 
 and rescue_clause (t, exns, exnvaropt, sts) =
   let st = list_stmt1 sts in
@@ -674,7 +674,7 @@ let any x =
       match x with
       | S x -> G.S (stmt x)
       | D x -> G.S (definition x)
-      | _ -> G.E (expr x) )
+      | _ -> G.E (expr x))
   | S2 x -> G.S (stmt x)
   | Ss xs -> G.Ss (list_stmts xs)
   | Pr xs -> G.Ss (list_stmts xs)

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -224,7 +224,7 @@ and v_type_ = function
       let v1 = v_literal v1 in
       match v1 with
       | Left lit -> todo_type "TyLiteralLit" [ G.E (G.L lit) ]
-      | Right e -> todo_type "TyLiteralExpr" [ G.E e ] )
+      | Right e -> todo_type "TyLiteralExpr" [ G.E e ])
   | TyName v1 ->
       let xs = v_dotted_name_of_stable_id v1 in
       let name = name_of_ids xs in
@@ -240,7 +240,7 @@ and v_type_ = function
       | G.TyN n -> G.TyApply (G.TyN n, (lp, args, rp))
       | _ ->
           todo_type "TyAppliedComplex"
-            (G.T v1 :: (xs |> List.map (fun x -> G.T x))) )
+            (G.T v1 :: (xs |> List.map (fun x -> G.T x))))
   | TyInfix (v1, v2, v3) ->
       let v1 = v_type_ v1 and v2 = v_ident v2 and v3 = v_type_ v3 in
       G.TyApply (G.TyN (H.name_of_ids [ v2 ]), fb [ G.TypeArg v1; G.TypeArg v3 ])
@@ -268,8 +268,8 @@ and v_type_ = function
   | TyRefined (v1, v2) ->
       let v1 = v_option v_type_ v1 and _lb, defs, _rb = v_refinement v2 in
       todo_type "TyRefined"
-        ( (match v1 with None -> [] | Some t -> [ G.T t ])
-        @ (defs |> List.map (fun def -> G.Def def)) )
+        ((match v1 with None -> [] | Some t -> [ G.T t ])
+        @ (defs |> List.map (fun def -> G.Def def)))
   | TyExistential (v1, v2, v3) ->
       let v1 = v_type_ v1 in
       let _v2 = v_tok v2 in
@@ -313,7 +313,7 @@ and v_pattern = function
       let v1 = v_literal v1 in
       match v1 with
       | Left lit -> G.PatLiteral lit
-      | Right e -> todo_pattern "PatLiteralExpr" [ G.E e ] )
+      | Right e -> todo_pattern "PatLiteralExpr" [ G.E e ])
   | PatName v1 ->
       let ids = v_dotted_name_of_stable_id v1 in
       G.PatConstructor (ids, [])
@@ -353,7 +353,7 @@ and v_expr = function
   | DeepEllipsis v1 -> G.DeepEllipsis (v_bracket v_expr v1)
   | L v1 -> (
       let v1 = v_literal v1 in
-      match v1 with Left lit -> G.L lit | Right e -> e )
+      match v1 with Left lit -> G.L lit | Right e -> e)
   | Tuple v1 ->
       let v1 = v_bracket (v_list v_expr) v1 in
       G.Tuple v1
@@ -412,7 +412,7 @@ and v_expr = function
       let lb, kind, _rb = v_block_expr v1 in
       match kind with
       | Left stats -> expr_of_block stats
-      | Right cases -> G.Lambda (cases_to_lambda lb cases) )
+      | Right cases -> G.Lambda (cases_to_lambda lb cases))
   | S v1 ->
       let v1 = v_stmt v1 in
       G.OtherExpr (G.OE_StmtExpr, [ G.S v1 ])
@@ -749,7 +749,7 @@ and v_fbody = function
       | Left stats -> G.Block (lb, stats, rb) |> G.s
       | Right cases ->
           let def = cases_to_lambda lb cases in
-          G.exprstmt (G.Lambda def) )
+          G.exprstmt (G.Lambda def))
   | FExpr (v1, v2) ->
       let _v1 = v_tok v1 and v2 = v_expr_for_stmt v2 in
       v2
@@ -787,7 +787,7 @@ and v_binding v : G.parameter =
             }
       | Some (PTRepeatedApplication (v1, v2)) ->
           let v1 = v_type_ v1 and v2 = v_tok v2 in
-          G.ParamRest (v2, { pclassic with ptype = Some v1 }) )
+          G.ParamRest (v2, { pclassic with ptype = Some v1 }))
 
 and v_template_definition
     {
@@ -864,10 +864,10 @@ let v_any = function
   | Ex e -> (
       match v_expr_for_stmt e with
       | { G.s = G.ExprStmt (e, _); _ } -> G.E e
-      | st -> G.S st )
+      | st -> G.S st)
   | Ss b -> (
       let xs = v_block b in
-      match xs with [ s ] -> G.S s | xs -> G.Ss xs )
+      match xs with [ s ] -> G.S s | xs -> G.Ss xs)
 
 (*****************************************************************************)
 (* Entry points *)

--- a/semgrep-core/src/parsing/tree_sitter/CST_tree_sitter_typescript.ml
+++ b/semgrep-core/src/parsing/tree_sitter/CST_tree_sitter_typescript.ml
@@ -265,9 +265,8 @@ type import_clause =
   | `Named_imports of named_imports
   | `Id_opt_COMMA_choice_name_import of
     identifier (*tok*)
-    * ( Token.t (* "," *)
-      * [ `Name_import of namespace_import | `Named_imports of named_imports ]
-      )
+    * (Token.t (* "," *)
+      * [ `Name_import of namespace_import | `Named_imports of named_imports ])
       option ]
 [@@deriving sexp_of]
 
@@ -437,10 +436,10 @@ and call_signature_ = call_signature
 
 and catch_clause =
   Token.t (* "catch" *)
-  * ( Token.t (* "(" *)
+  * (Token.t (* "(" *)
     * anon_choice_type_id_940079a
     * type_annotation option
-    * Token.t )
+    * Token.t)
     (* ")" *)
     option
   * statement_block
@@ -562,16 +561,16 @@ and default_type = Token.t (* "=" *) * type_
 and destructuring_pattern =
   [ `Obj_pat of
     Token.t (* "{" *)
-    * ( anon_choice_pair_pat_3ff9cbe option
-      * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option) list )
+    * (anon_choice_pair_pat_3ff9cbe option
+      * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option) list)
       (* zero or more *)
       option
     * Token.t
     (* "}" *)
   | `Array_pat of
     Token.t (* "[" *)
-    * ( anon_choice_pat_3297d92 option
-      * (Token.t (* "," *) * anon_choice_pat_3297d92 option) list )
+    * (anon_choice_pat_3297d92 option
+      * (Token.t (* "," *) * anon_choice_pat_3297d92 option) list)
       (* zero or more *)
       option
     * Token.t
@@ -581,10 +580,10 @@ and else_clause = Token.t (* "else" *) * statement
 
 and enum_body =
   Token.t (* "{" *)
-  * ( anon_choice_prop_name_6cc9e4b
+  * (anon_choice_prop_name_6cc9e4b
     * (Token.t (* "," *) * anon_choice_prop_name_6cc9e4b) list
     (* zero or more *)
-    * Token.t (* "," *) option )
+    * Token.t (* "," *) option)
     option
   * Token.t
 
@@ -703,10 +702,10 @@ and formal_parameter =
 
 and formal_parameters =
   Token.t (* "(" *)
-  * ( formal_parameter
+  * (formal_parameter
     * (Token.t (* "," *) * formal_parameter) list
     (* zero or more *)
-    * Token.t (* "," *) option )
+    * Token.t (* "," *) option)
     option
   * Token.t
 
@@ -881,8 +880,8 @@ and non_null_expression = expression * Token.t
 (* "!" *)
 and object_ =
   Token.t (* "{" *)
-  * ( anon_choice_pair_20c9acd option
-    * (Token.t (* "," *) * anon_choice_pair_20c9acd option) list )
+  * (anon_choice_pair_20c9acd option
+    * (Token.t (* "," *) * anon_choice_pair_20c9acd option) list)
     (* zero or more *)
     option
   * Token.t
@@ -890,11 +889,11 @@ and object_ =
 (* "}" *)
 and object_type =
   [ `LCURL of Token.t (* "{" *) | `LCURLBAR of Token.t (* "{|" *) ]
-  * ( [ `COMMA of Token.t (* "," *) | `SEMI of Token.t (* ";" *) ] option
+  * ([ `COMMA of Token.t (* "," *) | `SEMI of Token.t (* ";" *) ] option
     * anon_choice_export_stmt_f90d83f
     * (anon_choice_COMMA_5194cb4 * anon_choice_export_stmt_f90d83f) list
     (* zero or more *)
-    * anon_choice_COMMA_5194cb4 option )
+    * anon_choice_COMMA_5194cb4 option)
     option
   * [ `RCURL of Token.t (* "}" *) | `BARRCURL of Token.t (* "|}" *) ]
 
@@ -1320,8 +1319,8 @@ type ambient_declaration =
 
 type array_pattern =
   Token.t (* "[" *)
-  * ( anon_choice_pat_3297d92 option
-    * (Token.t (* "," *) * anon_choice_pat_3297d92 option) list )
+  * (anon_choice_pat_3297d92 option
+    * (Token.t (* "," *) * anon_choice_pat_3297d92 option) list)
     (* zero or more *)
     option
   * Token.t
@@ -1572,8 +1571,8 @@ type object_assignment_pattern =
 
 type object_pattern =
   Token.t (* "{" *)
-  * ( anon_choice_pair_pat_3ff9cbe option
-    * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option) list )
+  * (anon_choice_pair_pat_3ff9cbe option
+    * (Token.t (* "," *) * anon_choice_pair_pat_3ff9cbe option) list)
     (* zero or more *)
     option
   * Token.t

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -231,7 +231,7 @@ and case_item (env : env) ((v1, v2, v3, v4, v5) : CST.case_item) =
     | `Choice_SEMIAMP x -> (
         match x with
         | `SEMIAMP tok -> token env tok (* ";&" *)
-        | `SEMISEMIAMP tok -> token env tok (* ";;&" *) )
+        | `SEMISEMIAMP tok -> token env tok (* ";;&" *))
   in
   TODO
 
@@ -353,7 +353,7 @@ and expansion (env : env) ((v1, v2, v3, v4) : CST.expansion) :
     | Some x -> (
         match x with
         | `HASH tok -> Some (token env tok (* "#" *))
-        | `BANG tok -> Some (token env tok (* "!" *)) )
+        | `BANG tok -> Some (token env tok (* "!" *)))
     | None -> None
   in
   (* TODO: need to handle all the cases other than just a variable
@@ -406,7 +406,7 @@ and expansion (env : env) ((v1, v2, v3, v4) : CST.expansion) :
                   | `HASH tok -> (* "#" *) todo env tok)
                 v3
             in
-            opt_variable )
+            opt_variable)
     | None -> None
   in
   let close = token env v4 (* "}" *) in
@@ -858,10 +858,10 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
       in
       let body =
         Compound_command
-          ( match v2 with
+          (match v2 with
           | `Comp_stmt x -> Command_group (compound_statement env x)
           | `Subs x -> Subshell (subshell env x)
-          | `Test_cmd x -> Conditional_expression (test_command env x) )
+          | `Test_cmd x -> Conditional_expression (test_command env x))
       in
       let command =
         Function_definition

--- a/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
@@ -396,7 +396,7 @@ and number_literal env tok =
       match float_of_string_opt s with
       | Some f -> Float (Some f, t)
       (* could be None because of a suffix in the string *)
-      | None -> Int (None, t) )
+      | None -> Int (None, t))
 
 and preproc_expression (env : env) (x : CST.preproc_expression) : expr =
   match x with
@@ -564,7 +564,7 @@ and anon_choice_param_decl_bdc8cc9 (env : env)
                 { p_type = f v1; p_name = Some id }
             | `Abst_decl x ->
                 let f = abstract_declarator env x in
-                { p_type = f v1; p_name = None } )
+                { p_type = f v1; p_name = None })
         | None -> { p_type = v1; p_name = None }
       in
       ParamClassic v2
@@ -1100,7 +1100,7 @@ and initializer_list (env : env) ((v1, v2, v3, v4) : CST.initializer_list) :
          | Left (designators, _tkeq, e) -> (
              match designators with
              | [ Left (_lc, idx, _rc) ] -> (Some idx, e)
-             | _TODO -> (None, e) ))
+             | _TODO -> (None, e)))
   in
   ArrayInit (v1, elems, v4)
 
@@ -1265,7 +1265,7 @@ and type_specifier (env : env) (x : CST.type_specifier) : type_ =
         | Some x -> (
             match x with
             | `Id tok -> [ identifier env tok ] (* pattern [a-zA-Z_]\w* *)
-            | `Prim_type tok -> [ str env tok ] (* primitive_type *) )
+            | `Prim_type tok -> [ str env tok ] (* primitive_type *))
         | None -> []
       in
       let xs = v1 @ v2 in
@@ -1680,10 +1680,10 @@ and translation_unit (env : env) (xs : CST.translation_unit) : program =
       env.struct_defs_toadd <- [];
       env.enum_defs_toadd <- [];
       env.typedefs_toadd <- [];
-      ( (structs |> List.map (fun x -> StructDef x))
-        @ (enums |> List.map (fun x -> EnumDef x))
-        @ (typedefs |> List.map (fun x -> TypeDef x))
-      |> List.map (fun x -> DefStmt x) )
+      ((structs |> List.map (fun x -> StructDef x))
+       @ (enums |> List.map (fun x -> EnumDef x))
+       @ (typedefs |> List.map (fun x -> TypeDef x))
+      |> List.map (fun x -> DefStmt x))
       @ res)
     xs
   |> List.flatten

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -51,8 +51,8 @@ let ids_of_name (name : name) : dotted_ident =
       | Some q -> (
           match q with
           | QDots ds -> ds @ [ ident ]
-          | _ -> failwith "unexpected qualifier type" )
-      | None -> [ ident ] )
+          | _ -> failwith "unexpected qualifier type")
+      | None -> [ ident ])
 
 let prepend_qualifier_to_name (qualifier : qualifier) (name : name) : name =
   match name with
@@ -262,7 +262,7 @@ let rec linq_remainder_to_expr (query : linq_query_part list) (base_expr : expr)
               [ enum; left_func; right_func; res_func ]
           in
           let lambda_params = lambda_params @ [ into ] in
-          linq_remainder_to_expr tl base_expr lambda_params )
+          linq_remainder_to_expr tl base_expr lambda_params)
 
 let linq_to_expr (from : linq_query_part) (body : linq_query_part list) =
   match from with
@@ -930,7 +930,7 @@ and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
     | Some x -> (
         match x with
         | `In tok -> Some (token env tok) (* "in" *)
-        | `Out tok -> Some (token env tok) (* "out" *) )
+        | `Out tok -> Some (token env tok) (* "out" *))
     | None -> None
   in
   let v3 = identifier env v3 (* identifier *) in
@@ -998,7 +998,7 @@ and argument (env : env) ((v1, v2, v3) : CST.argument) : AST.argument =
         match x with
         | `Ref tok -> Some (token env tok) (* "ref" *)
         | `Out tok -> Some (token env tok) (* "out" *)
-        | `In tok -> Some (token env tok) (* "in" *) )
+        | `In tok -> Some (token env tok) (* "in" *))
     | None -> None
   in
   let v3 =
@@ -1075,7 +1075,7 @@ and ordering (env : env) ((v1, v2) : CST.ordering) =
     | Some x -> (
         match x with
         | `Asce tok -> Ascending (* "ascending" *)
-        | `Desc tok -> Descending (* "descending" *) )
+        | `Desc tok -> Descending (* "descending" *))
     | None -> Ascending
   in
   (v1, v2)
@@ -1606,7 +1606,7 @@ and statement (env : env) (x : CST.statement) =
               | `Tuple_pat x -> tuple_pattern env x
             in
             let v1 = local_variable_type env v1 in
-            match v1 with Some t -> PatTyped (v2, t) | None -> v2 )
+            match v1 with Some t -> PatTyped (v2, t) | None -> v2)
         | `Exp x -> H2.expr_to_pattern (expression env x)
       in
       let v5 = token env v5 (* "in" *) in
@@ -1632,7 +1632,7 @@ and statement (env : env) (x : CST.statement) =
                 let v1 = expression env v1 in
                 let v2 = List.map (interpolation_alignment_clause env) v2 in
                 let exprs = v1 :: v2 in
-                List.map (fun e -> ForInitExpr e) exprs )
+                List.map (fun e -> ForInitExpr e) exprs)
         | None -> []
       in
       let v4 = token env v4 (* ";" *) in
@@ -1662,7 +1662,7 @@ and statement (env : env) (x : CST.statement) =
           todo_stmt env v1
       | `Defa tok ->
           let tok = token env tok (* "default" *) in
-          todo_stmt env tok )
+          todo_stmt env tok)
   | `If_stmt (v1, v2, v3, v4, v5, v6) ->
       let v1 = token env v1 (* "if" *) in
       let v2 = token env v2 (* "(" *) in
@@ -1740,9 +1740,9 @@ and statement (env : env) (x : CST.statement) =
       let v1 = token env v1 (* "throw" *) in
       let v2 = map_opt expression env v2 in
       let v3 = token env v3 (* ";" *) in
-      ( match v2 with
+      (match v2 with
       | Some expr -> Throw (v1, expr, v3)
-      | None -> OtherStmt (OS_ThrowNothing, [ Tk v1; Tk v3 ]) )
+      | None -> OtherStmt (OS_ThrowNothing, [ Tk v1; Tk v3 ]))
       |> AST.s
   | `Try_stmt (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "try" *) in
@@ -1890,7 +1890,7 @@ and attribute_argument (env : env) ((v1, v2) : CST.attribute_argument) =
     | Some x -> (
         match x with
         | `Name_equals x -> Some (name_equals env x)
-        | `Name_colon x -> Some (name_colon env x) )
+        | `Name_colon x -> Some (name_colon env x))
     | None -> None
   in
   let v2 = expression env v2 in
@@ -2422,7 +2422,7 @@ and using_directive (env : env) ((v1, v2, v3, v4) : CST.using_directive) =
             AST.ImportAs
               ( v1,
                 AST.DottedName (ids_of_name v3),
-                Some (alias, empty_id_info ()) ) )
+                Some (alias, empty_id_info ()) ))
     | None ->
         (* using System.IO; *)
         AST.ImportAll (v1, AST.DottedName (ids_of_name v3), v4)
@@ -2777,7 +2777,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                 fbody;
               }
           in
-          DefStmt (ent, funcdef) |> AST.s )
+          DefStmt (ent, funcdef) |> AST.s)
   | `Meth_decl (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
       (*
         [Attr] static int IList<T>.MyMethod<T>(int p1) where T : Iterator { ... }
@@ -2868,18 +2868,18 @@ and declaration (env : env) (x : CST.declaration) : stmt =
                       {
                         fkind = (Method, itok);
                         fparams =
-                          ( if has_params then
-                            [
-                              ParamClassic
-                                {
-                                  pname = Some ("value", fake "value");
-                                  ptype = Some v3;
-                                  pdefault = None;
-                                  pattrs = [];
-                                  pinfo = empty_id_info ();
-                                };
-                            ]
-                          else [] );
+                          (if has_params then
+                           [
+                             ParamClassic
+                               {
+                                 pname = Some ("value", fake "value");
+                                 ptype = Some v3;
+                                 pdefault = None;
+                                 pattrs = [];
+                                 pinfo = empty_id_info ();
+                               };
+                           ]
+                          else []);
                         frettype = (if has_return then Some v3 else None);
                         (* TODO Should this be "void"? *)
                         fbody;

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -158,7 +158,7 @@ let import_spec (env : env) ((v1, v2) : CST.import_spec) =
         match x with
         | `Dot tok -> ImportDot (token env tok) (* "." *)
         | `Blank_id tok -> ImportNamed (identifier env tok) (* "_" *)
-        | `Id tok -> ImportNamed (identifier env tok) (* identifier *) )
+        | `Id tok -> ImportNamed (identifier env tok) (* identifier *))
     | None -> ImportOrig
   in
   let v2 = string_literal env v2 in
@@ -213,7 +213,7 @@ and simple_statement (env : env) (x : CST.simple_statement) : simple =
       let v3 = expression_list env v3 in
       match v2 with
       | G.Eq, t -> Assign (v1, t, v3)
-      | _ -> AssignOp (expr1 v1, v2, expr1 v3) )
+      | _ -> AssignOp (expr1 v1, v2, expr1 v3))
   | `Short_var_decl (v1, v2, v3) ->
       let v1 = expression_list env v1 in
       let v2 = token env v2 (* ":=" *) in
@@ -392,7 +392,7 @@ and anon_choice_param_decl_18823e5 (env : env)
           field_name_list env x
           |> List.map (fun id ->
                  ParamClassic { pname = Some id; ptype = v2; pdots = None })
-      | None -> [ ParamClassic { pname = None; ptype = v2; pdots = None } ] )
+      | None -> [ ParamClassic { pname = None; ptype = v2; pdots = None } ])
   | `Vari_param_decl (v1, v2, v3) ->
       let v1 =
         match v1 with
@@ -522,7 +522,7 @@ and expression (env : env) (x : CST.expression) : expr =
       | `HAT tok -> Unary ((G.Xor, token env tok (* "^" *)), v2)
       | `STAR tok -> Deref (token env tok (* "*" *), v2)
       | `AMP tok -> Ref (token env tok (* "&" *), v2)
-      | `LTDASH tok -> Receive (token env tok (* "<-" *), v2) )
+      | `LTDASH tok -> Receive (token env tok (* "<-" *), v2))
   | `Bin_exp x -> binary_expression env x
   | `Sele_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
@@ -559,7 +559,7 @@ and expression (env : env) (x : CST.expression) : expr =
           let v3 = expression env v3 in
           let _v4 = token env v4 (* ":" *) in
           let v5 = expression env v5 in
-          Slice (v1top, (t1, (v1, Some v3, Some v5), t2)) )
+          Slice (v1top, (t1, (v1, Some v3, Some v5), t2)))
   | `Call_exp x -> call_expression env x
   | `Type_asse_exp (v1, v2, v3, v4, v5) ->
       let v1 = expression env v1 in
@@ -710,8 +710,8 @@ and statement (env : env) (x : CST.statement) : stmt =
           | `For_clause x -> For (v1, for_clause env x, v3)
           | `Range_clause x ->
               let a, b, c = range_clause env x in
-              For (v1, ForRange (a, b, c), v3) )
-      | None -> For (v1, ForClassic (None, None, None), v3) )
+              For (v1, ForRange (a, b, c), v3))
+      | None -> For (v1, ForClassic (None, None, None), v3))
   | `Exp_switch_stmt (v1, v2, v3, v4, v5, v6) ->
       let v1 = token env v1 (* "switch" *) in
       let v2 =
@@ -1135,7 +1135,7 @@ and communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
         match opt with
         | None -> CaseExprs (v1, [ Left e ])
         | Some (xs, (_lr, tk)) ->
-            CaseAssign (v1, xs |> List.map (fun e -> Left e), tk, e) )
+            CaseAssign (v1, xs |> List.map (fun e -> Left e), tk, e))
   in
   let _v3 = token env v3 (* ":" *) in
   let v4 = match v4 with Some x -> statement_list env x | None -> [] in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -533,7 +533,7 @@ and argument (env : env) ((v1, v2) : CST.argument) =
     | Some x -> (
         match x with
         | `Inout_modi tok -> token env tok (* "inout" *)
-        | `Vari_modi tok -> token env tok (* "..." *) )
+        | `Vari_modi tok -> token env tok (* "..." *))
     | None -> todo env ()
   in
   let v2 = expression env v2 in
@@ -1001,7 +1001,7 @@ and declaration (env : env) (x : CST.declaration) =
                   | None -> todo env ()
                 in
                 let v2 = compound_statement env v2 in
-                todo env (v1, v2) )
+                todo env (v1, v2))
         | None -> todo env ()
       in
       todo env (v1, v2)
@@ -1454,7 +1454,7 @@ and parameters (env : env) ((v1, v2, v3) : CST.parameters) =
               | Some tok -> token env tok (* "," *)
               | None -> todo env ()
             in
-            todo env (v1, v2, v3) )
+            todo env (v1, v2, v3))
     | None -> todo env ()
   in
   let v3 = token env v3 (* ")" *) in
@@ -2066,7 +2066,7 @@ and type_parameter (env : env) ((v1, v2, v3, v4) : CST.type_parameter) =
         match x with
         | `PLUS tok -> token env tok (* "+" *)
         | `DASH tok -> token env tok (* "-" *)
-        | `Reify tok -> token env tok (* "reify" *) )
+        | `Reify tok -> token env tok (* "reify" *))
     | None -> todo env ()
   in
   let v3 =
@@ -2194,7 +2194,7 @@ and xhp_attribute (env : env) (x : CST.xhp_attribute) =
   | `Choice_xhp_braced_exp x -> (
       match x with
       | `Xhp_braced_exp x -> xhp_braced_expression env x
-      | `Xhp_spread_exp x -> xhp_spread_expression env x )
+      | `Xhp_spread_exp x -> xhp_spread_expression env x)
 
 and xhp_attribute_declaration (env : env)
     ((v1, v2, v3, v4) : CST.xhp_attribute_declaration) =
@@ -2244,7 +2244,7 @@ and xhp_class_attribute (env : env) ((v1, v2, v3, v4) : CST.xhp_class_attribute)
     | Some x -> (
         match x with
         | `ATre tok -> token env tok (* "@required" *)
-        | `ATla tok -> token env tok (* "@lateinit" *) )
+        | `ATla tok -> token env tok (* "@lateinit" *))
     | None -> todo env ()
   in
   todo env (v1, v2, v3, v4)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -89,14 +89,14 @@ let id_extra env = function
   | `Choice_open x -> (
       match x with
       | `Open tok -> str env tok (* "open" *)
-      | `Module tok -> str env tok (* "module" *) )
+      | `Module tok -> str env tok (* "module" *))
 
 let rec qualifier_extra env = function
   | `Id tok -> [ str env tok ] (* pattern [a-zA-Z_]\w* *)
   | `Choice_open x -> (
       match x with
       | `Open tok -> [ str env tok ] (* "open" *)
-      | `Module tok -> [ str env tok ] (* "module" *) )
+      | `Module tok -> [ str env tok ] (* "module" *))
   | `Scoped_id x -> scoped_identifier env x
 
 and scoped_identifier (env : env) ((v1, v2, v3) : CST.scoped_identifier) :
@@ -244,7 +244,7 @@ let rec expression (env : env) (x : CST.expression) =
         | `Choice_open x -> (
             match x with
             | `Open tok -> name_of_id env tok (* "open" *)
-            | `Module tok -> name_of_id env tok (* "module" *) )
+            | `Module tok -> name_of_id env tok (* "module" *))
         | `Field_access x -> field_access env x
         | `Array_access x -> array_access env x
       in
@@ -267,7 +267,7 @@ let rec expression (env : env) (x : CST.expression) =
       let v3 = expression env v3 in
       match v2 with
       | Left (), t -> Assign (v1, t, v3)
-      | Right op, t -> AssignOp (v1, (op, t), v3) )
+      | Right op, t -> AssignOp (v1, (op, t), v3))
   | `Bin_exp x -> binary_expression env x
   | `Inst_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
@@ -499,7 +499,7 @@ and primary_expression (env : env) (x : CST.primary_expression) =
   | `Choice_open x -> (
       match x with
       | `Open tok -> name_of_id env tok (* "open" *)
-      | `Module tok -> name_of_id env tok (* "module" *) )
+      | `Module tok -> name_of_id env tok (* "module" *))
   | `Paren_exp x -> parenthesized_expression env x
   | `Obj_crea_exp x -> object_creation_expression env x
   | `Field_access x -> field_access env x
@@ -638,7 +638,7 @@ and field_access (env : env) ((v1, v2, v3, v4) : CST.field_access) =
     | `Choice_open x -> (
         match x with
         | `Open tok -> str env tok (* "open" *)
-        | `Module tok -> str env tok (* "module" *) )
+        | `Module tok -> str env tok (* "module" *))
     | `This tok -> str env tok
     (* "this" *)
   in
@@ -1057,7 +1057,7 @@ and annotation_argument_list (env : env)
                 v2
             in
             AnnotArgPairInit (v1 :: v2)
-        | None -> EmptyAnnotArg )
+        | None -> EmptyAnnotArg)
   in
   let v3 = token env v3 (* ")" *) in
   (v1, v2, v3)
@@ -1135,7 +1135,7 @@ and declaration (env : env) (x : CST.declaration) : AST.stmt =
         | None -> (
             match List.rev v3 with
             | [] -> raise Impossible
-            | x :: xs -> ImportFrom (v1, List.rev xs, x) )
+            | x :: xs -> ImportFrom (v1, List.rev xs, x))
       in
       let _v5 = token env v5 (* ";" *) in
       DirectiveStmt (Import (v2, v4))

--- a/semgrep-core/src/parsing/tree_sitter/Parse_javascript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_javascript_tree_sitter.ml
@@ -143,9 +143,9 @@ and anon_choice_type_id (env : env) (x : CST.anon_choice_id_b8f8ced) :
 
 let number (env : env) (tok : CST.number) =
   let s, t = str env tok (* number *) in
-  ( ( match H.int_of_string_c_octal_opt s with
+  ( (match H.int_of_string_c_octal_opt s with
     | Some i -> Some (float_of_int i)
-    | None -> float_of_string_opt s ),
+    | None -> float_of_string_opt s),
     t )
 
 let number_as_string (env : env) (tok : CST.number) = str env tok
@@ -390,12 +390,12 @@ and jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) :
     match v2 with
     | Some x ->
         Some
-          ( match x with
+          (match x with
           | `Exp x -> expression env x
           | `Seq_exp x -> sequence_expression env x
           | `Spread_elem x ->
               let t, e = spread_element env x in
-              Apply (IdSpecial (Spread, t), fb [ e ]) )
+              Apply (IdSpecial (Spread, t), fb [ e ]))
     (* abusing { } in XML to just add comments, e.g. { /* lint-ignore */ } *)
     | None -> None
   in
@@ -928,7 +928,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           let _v2 = token env v2 (* "?." *) in
           let v3 = arguments env v3 in
           (* TODO: distinguish "?." from a simple application *)
-          Apply (v1, v3) )
+          Apply (v1, v3))
   | `Semg_dots tok -> todo_semgrep_pattern env tok (* "..." *)
   | `Semg_deep_exp (v1, v2, v3) ->
       let _TODOv1 = token env v1 (* "<..." *) in
@@ -1001,9 +1001,9 @@ and for_header (env : env) ((v1, v2, v3, v4, v5) : CST.for_header) : for_header
     match v2 with
     | `Choice_choice_member_exp x ->
         Right
-          ( match x with
+          (match x with
           | `Choice_member_exp x -> lhs_expression env x
-          | `Paren_exp x -> parenthesized_expression env x )
+          | `Paren_exp x -> parenthesized_expression env x)
     | `Choice_var_choice_id (v1, v2) ->
         let vkind =
           match v1 with
@@ -1121,7 +1121,7 @@ and expression (env : env) (x : CST.expression) : expr =
             | Some x ->
                 let x = expression env x in
                 Apply (IdSpecial (Yield, v1), fb [ x ])
-            | None -> Apply (IdSpecial (Yield, v1), fb []) )
+            | None -> Apply (IdSpecial (Yield, v1), fb []))
       in
       v2
 
@@ -1376,7 +1376,7 @@ and method_definition (env : env)
         match x with
         | `Get tok -> [ attr (Get, token env tok) ] (* "get" *)
         | `Set tok -> [ attr (Set, token env tok) ] (* "set" *)
-        | `STAR tok -> [ attr (Generator, token env tok) ] (* "*" *) )
+        | `STAR tok -> [ attr (Generator, token env tok) ] (* "*" *))
     | None -> []
   in
   let v5 = property_name env v5 in
@@ -1502,7 +1502,7 @@ and export_statement (env : env) (x : CST.export_statement) : a_toplevel list =
                 let _v2 = semicolon env v2 in
                 let def, n = Ast_js.mk_default_entity_def default_tok e in
                 let def = add_decorators_to_declaration decorators def in
-                [ DefStmt def; M (Export (export_tok, n)) ] )
+                [ DefStmt def; M (Export (export_tok, n)) ])
       in
       v3
 
@@ -1826,7 +1826,7 @@ and parameter_pattern (env : env) (x : CST.pattern) : parameter =
               p_type = None;
               p_attrs = [];
             }
-      | Right pat -> todo_any "`Rest_param with pattern" v1 (Expr pat) )
+      | Right pat -> todo_any "`Rest_param with pattern" v1 (Expr pat))
 
 and formal_parameter (env : env) (x : CST.formal_parameter) : parameter =
   match x with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -456,7 +456,7 @@ let import_header (env : env) ((v1, v2, v3, v4) : CST.import_header) : directive
             ImportAll (v1, DottedName v2, t)
         | `Import_alias x ->
             let t, id = import_alias env x in
-            ImportAs (t, DottedName v2, Some (id, empty_id_info ())) )
+            ImportAs (t, DottedName v2, Some (id, empty_id_info ())))
     | None -> ImportAs (v1, DottedName v2, None)
   in
   let _v4 = token env v4 (* pattern [\r\n]+ *) in
@@ -892,7 +892,7 @@ and declaration (env : env) (x : CST.declaration) : definition =
                 let _v1 = token env v1 (* "=" *) in
                 let v2 = expression env v2 in
                 Some v2
-            | `Prop_dele x -> property_delegate env x )
+            | `Prop_dele x -> property_delegate env x)
         | None -> None
       in
       let _v7 =
@@ -902,13 +902,13 @@ and declaration (env : env) (x : CST.declaration) : definition =
             | Some x ->
                 let x = getter env x in
                 todo env x
-            | None -> None )
+            | None -> None)
         | `Opt_setter opt -> (
             match opt with
             | Some x ->
                 let x = setter env x in
                 todo env x
-            | None -> None )
+            | None -> None)
       in
       let vdef = { vinit = v6; vtype = type_info } in
       let ent = basic_entity tok [] in
@@ -995,7 +995,7 @@ and expression (env : env) (x : CST.expression) : expr =
       match x with
       | `Un_exp x -> unary_expression env x
       | `Bin_exp x -> binary_expression env x
-      | `Prim_exp x -> primary_expression env x )
+      | `Prim_exp x -> primary_expression env x)
   | `Ellips x -> Ellipsis (token env x)
   | `Deep_ellips (x1, x2, x3) ->
       let x1 = token env x1 in
@@ -1202,7 +1202,7 @@ and jump_expression (env : env) (x : CST.jump_expression) =
         | None -> None
       in
       let return_tok, id = v1 in
-      ( match id with
+      (match id with
       | None -> Return (return_tok, v2, sc)
       | Some simple_id -> (
           let id = N (Id (simple_id, empty_id_info ())) in
@@ -1212,7 +1212,7 @@ and jump_expression (env : env) (x : CST.jump_expression) =
               OtherStmt (OS_Todo, list)
           | Some v2_expr ->
               let list = [ TodoK ("return@", return_tok); E id; E v2_expr ] in
-              OtherStmt (OS_Todo, list) ) )
+              OtherStmt (OS_Todo, list)))
       |> G.s
   | `Cont tok ->
       let v1 = token env tok (* "continue" *) in
@@ -1790,7 +1790,7 @@ and unary_expression (env : env) (x : CST.unary_expression) =
       match v2 with
       | Left incr_decr ->
           Call (IdSpecial (IncrDecr (incr_decr, Postfix), v3), fb [ Arg v1 ])
-      | Right operator -> Call (IdSpecial (Op operator, v3), fb [ Arg v1 ]) )
+      | Right operator -> Call (IdSpecial (Op operator, v3), fb [ Arg v1 ]))
   | `Call_exp (v1, v2) ->
       let v1 = expression env v1 in
       let v2 = call_suffix env v2 in
@@ -1820,7 +1820,7 @@ and unary_expression (env : env) (x : CST.unary_expression) =
       | Some (Left incr_decr, tok) ->
           Call (IdSpecial (IncrDecr (incr_decr, Postfix), tok), fb [ Arg v2 ])
       | Some (Right operator, tok) ->
-          Call (IdSpecial (Op operator, tok), fb [ Arg v2 ]) )
+          Call (IdSpecial (Op operator, tok), fb [ Arg v2 ]))
   | `As_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let _v2 = as_operator env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -344,7 +344,7 @@ let rec map_extended_module_path (env : env) (x : CST.extended_module_path) =
           let v1 = map_extended_module_path env v1 in
           let v2 = token env v2 (* "." *) in
           let v3 = token env v3 (* pattern "[A-Z][a-zA-Z0-9_']*" *) in
-          todo env (v1, v2, v3) )
+          todo env (v1, v2, v3))
   | `Exte_module_path_LPAR_exte_module_path_RPAR (v1, v2, v3, v4) ->
       let v1 = map_extended_module_path env v1 in
       let v2 = token env v2 (* "(" *) in
@@ -596,12 +596,12 @@ let map_constant (env : env) (x : CST.constant) : expr =
   | `Num tok ->
       let s, t = str env tok (* number *) in
       L
-        ( try
-            let i = int_of_string s in
-            Int (Some i, t)
-          with _ ->
-            let fopt = float_of_string_opt s in
-            Float (fopt, t) )
+        (try
+           let i = int_of_string s in
+           Int (Some i, t)
+         with _ ->
+           let fopt = float_of_string_opt s in
+           Float (fopt, t))
   | `Char (v1, v2, v3) ->
       let v1 = token env v1 (* "'" *) in
       let v2 = map_character_content env v2 in
@@ -665,7 +665,7 @@ let map_type_param (env : env) ((v1, v2) : CST.type_param) =
               | Some x -> map_anon_choice_PLUS_da42005 env x
               | None -> todo env ()
             in
-            todo env (v1, v2) )
+            todo env (v1, v2))
     | None -> todo env ()
   in
   let v2 =
@@ -740,7 +740,7 @@ let map_toplevel_directive (env : env) ((v1, v2) : CST.toplevel_directive) =
         match x with
         | `Cst x -> map_constant env x
         | `Value_path x -> map_value_path env x
-        | `Module_path x -> map_module_path env x )
+        | `Module_path x -> map_module_path env x)
     | None -> todo env ()
   in
   todo env (v1, v2)
@@ -1321,7 +1321,7 @@ and map_constructor_declaration (env : env)
             let v2 = token env v2 (* ")" *) in
             todo env (v1, v2)
         | `True tok -> token env tok (* "true" *)
-        | `False tok -> token env tok (* "false" *) )
+        | `False tok -> token env tok (* "false" *))
   in
   let v2 =
     match v2 with
@@ -1341,7 +1341,7 @@ and map_constructor_declaration (env : env)
         | `EQ_cons_path (v1, v2) ->
             let v1 = token env v1 (* "=" *) in
             let v2 = map_constructor_path env v2 in
-            todo env (v1, v2) )
+            todo env (v1, v2))
     | None -> todo env ()
   in
   todo env (v1, v2)
@@ -2765,7 +2765,7 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
             | None -> todo env ()
           in
           let v6 = token env v6 (* "]" *) in
-          todo env (v1, v2, v3, v4, v5, v6) )
+          todo env (v1, v2, v3, v4, v5, v6))
   | `Pack_type (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "(" *) in
       let v2 = token env v2 (* "module" *) in
@@ -2814,7 +2814,7 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
                   | None -> todo env ()
                 in
                 todo env (v1, v2, v3)
-            | `DOTDOT tok -> token env tok (* ".." *) )
+            | `DOTDOT tok -> token env tok (* ".." *))
         | None -> todo env ()
       in
       let v3 = token env v3 (* ">" *) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
@@ -472,7 +472,7 @@ and map_program (env : env) (xs : CST.program) =
         | Some x -> (
             match x with
             | `LF tok -> token env tok (* "\n" *)
-            | `SEMI tok -> token env tok (* ";" *) )
+            | `SEMI tok -> token env tok (* ";" *))
         | None -> todo env ()
       in
       todo env (v1, v2))

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -322,7 +322,7 @@ and simple_formal_parameter (env : env) (x : CST.simple_formal_parameter) :
       | Some tok ->
           let id = str env tok in
           Formal_star (v1, id)
-      | None -> Formal_rest v1 )
+      | None -> Formal_rest v1)
   | `Hash_splat_param (v1, v2) ->
       let v1 = token2 env v1 in
       let v2 = match v2 with Some tok -> Some (str env tok) | None -> None in
@@ -389,11 +389,11 @@ and elsif (env : env) ((v1, v2, v3, v4) : CST.elsif) : AST.tok * AST.stmt =
     match v4 with
     | Some x ->
         Some
-          ( match x with
+          (match x with
           | `Else x -> else_ env x
           | `Elsif x ->
               let t, s = elsif env x in
-              (t, [ S s ]) )
+              (t, [ S s ]))
     | None -> None
   in
   (v1, If (v1, v2, v3, v4))
@@ -525,7 +525,7 @@ and expression (env : env) (x : CST.expression) : AST.expr =
         | `Choice_var x -> (
             match x with
             | `Var x -> Id (variable env x)
-            | `Scope_resol x -> ScopedId (scope_resolution env x) )
+            | `Scope_resol x -> ScopedId (scope_resolution env x))
       in
       let v2 = command_argument_list env v2 in
       Call (v1, fb v2, None)
@@ -713,9 +713,9 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         match v2 with
         | Some x ->
             Some
-              ( match x with
+              (match x with
               | `Params x -> parameters env x |> G.unbracket
-              | `Bare_params x -> bare_parameters env x )
+              | `Bare_params x -> bare_parameters env x)
         | None -> None
       in
       let v3 =
@@ -813,11 +813,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         match v4 with
         | Some x ->
             Some
-              ( match x with
+              (match x with
               | `Else x -> else_ env x
               | `Elsif x ->
                   let t, s = elsif env x in
-                  (t, [ S s ]) )
+                  (t, [ S s ]))
         | None -> None
       in
       let _v5 = token2 env v5 in
@@ -836,11 +836,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         match v4 with
         | Some x ->
             Some
-              ( match x with
+              (match x with
               | `Else x -> else_ env x
               | `Elsif x ->
                   let t, s = elsif env x in
-                  (t, [ S s ]) )
+                  (t, [ S s ]))
         | None -> None
       in
       let _v5 = token2 env v5 in
@@ -971,7 +971,7 @@ and anon_choice_id_5ca805c (env : env) (x : CST.anon_choice_id_5ca805c) =
       let op = operator env x in
       match op with
       | Left bin, t -> MethodOperator (bin, t)
-      | Right un, t -> MethodUOperator (un, t) )
+      | Right un, t -> MethodUOperator (un, t))
   | `Cst tok -> MethodId (str env tok, ID_Uppercase)
   | `Arg_list x ->
       (* ?? *)
@@ -1407,7 +1407,7 @@ and method_name (env : env) (x : CST.method_name) : AST.method_name =
       let op = operator env x in
       match op with
       | Left bin, t -> MethodOperator (bin, t)
-      | Right un, t -> MethodUOperator (un, t) )
+      | Right un, t -> MethodUOperator (un, t))
   | `Inst_var tok -> MethodId (str env tok, ID_Instance)
   | `Class_var tok -> MethodId (str env tok, ID_Class)
   | `Global_var tok -> MethodId (str env tok, ID_Global)
@@ -1450,7 +1450,7 @@ and literal_contents (env : env) (xs : CST.literal_contents) : AST.interp list =
       | `Interp x -> (
           match interpolation env x with
           | Some (lb, e, rb) -> Some (StrExpr (lb, e, rb))
-          | None -> None )
+          | None -> None)
       | `Esc_seq tok ->
           let x = str env tok in
           Some (StrChars x))
@@ -1490,7 +1490,7 @@ and pair (env : env) (x : CST.pair) =
       let v3 = arg env v3 in
       match v1 with
       | Id (x, _) -> AST.keyword_arg_to_expr x v2 v3
-      | _ -> Binop (v1, (Op_ASSOC, v2), v3) )
+      | _ -> Binop (v1, (Op_ASSOC, v2), v3))
 
 let program (env : env) ((v1, _v2interpreted) : CST.program) : AST.stmts =
   match v1 with Some x -> statements env x | None -> []
@@ -1518,8 +1518,8 @@ let parse file =
           Parallel.invoke Tree_sitter_ruby.Parse.file file ())
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
-      ( if debug then
-        let sexp = CST.sexp_of_program cst in
-        let s = Sexplib.Sexp.to_string_hum sexp in
-        print_endline s );
+      (if debug then
+       let sexp = CST.sexp_of_program cst in
+       let s = Sexplib.Sexp.to_string_hum sexp in
+       print_endline s);
       program env cst)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -270,7 +270,7 @@ let map_literal_pattern (env : env) (x : CST.literal_pattern) : G.pattern =
           let fopt, t = float_literal env tok in
           (* float_literal *)
           let fopt = match fopt with Some f -> Some (-.f) | None -> None in
-          G.PatLiteral (G.Float (fopt, PI.combine_infos (snd neg) [ t ])) )
+          G.PatLiteral (G.Float (fopt, PI.combine_infos (snd neg) [ t ])))
 
 let map_extern_modifier (env : env) ((v1, v2) : CST.extern_modifier) :
     G.attribute list =
@@ -421,8 +421,8 @@ let map_function_modifiers (env : env) (xs : CST.function_modifiers) :
     xs
   |> List.flatten
 
-let map_for_lifetimes (env : env) ((v1, v2, v3, v4, _v5TODO, v6) : CST.for_lifetimes)
-    : lifetime list =
+let map_for_lifetimes (env : env)
+    ((v1, v2, v3, v4, _v5TODO, v6) : CST.for_lifetimes) : lifetime list =
   let _for_ = token env v1 (* "for" *) in
   let _lthan = token env v2 (* "<" *) in
   let lifetime_first = map_lifetime env v3 in
@@ -572,7 +572,7 @@ and map_struct_pattern_field (env : env) (x : CST.anon_choice_field_pat_8e757e8)
           (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
           let _colon = token env v2 (* ":" *) in
           let pat = map_pattern env v3 in
-          ([ ident ], pat) )
+          ([ ident ], pat))
   | `Rema_field_pat tok ->
       let ident = ident env tok in
       (* ".." *)
@@ -1086,7 +1086,7 @@ and map_expression (env : env) (x : CST.expression) =
       | `BANG tok ->
           let tok = token env tok in
           (* "!" *)
-          G.Call (G.IdSpecial (G.Op G.Not, tok), fb [ G.Arg expr ]) )
+          G.Call (G.IdSpecial (G.Op G.Not, tok), fb [ G.Arg expr ]))
   | `Ref_exp (v1, v2, v3) ->
       let ref_ = token env v1 (* "&" *) in
       let _mutabilityTODO =
@@ -1177,7 +1177,7 @@ and map_expression (env : env) (x : CST.expression) =
             (ident, { G.name_qualifier; G.name_typeargs = Some typeargs })
           in
           G.N (G.IdQualified (name, G.empty_id_info ()))
-      | `Field_exp x -> map_field_expression env x (Some typeargs) )
+      | `Field_exp x -> map_field_expression env x (Some typeargs))
   | `Await_exp (v1, v2, v3) ->
       let expr = map_expression env v1 in
       let _dot = token env v2 (* "." *) in
@@ -1404,7 +1404,7 @@ and map_expression_statement (env : env) (x : CST.expression_statement) : G.stmt
           G.ExprStmt (expr, semicolon) |> G.s
       | `Choice_unsafe_blk x ->
           let expr = map_expression_ending_with_block env x in
-          G.ExprStmt (expr, sc) |> G.s )
+          G.ExprStmt (expr, sc) |> G.s)
   | `Ellips_SEMI (v1, v2) ->
       let ellipsis = token env v1 (* "..." *) in
       let sc = token env v2 (* ";" *) in
@@ -1547,13 +1547,13 @@ and map_field_expression (env : env) ((v1, v2, v3) : CST.field_expression)
               (ident, { G.name_qualifier = None; G.name_typeargs = Some tas })
             in
             G.EN (G.IdQualified (name_, G.empty_id_info ()))
-        | None -> G.EN (G.Id (ident, G.empty_id_info ())) )
+        | None -> G.EN (G.Id (ident, G.empty_id_info ())))
     | `Int_lit tok -> (
         let literal = G.L (G.Int (integer_literal env tok)) in
         (* integer_literal *)
         match typeargs with
         | Some _tas -> raise Impossible
-        | None -> G.EDynamic literal )
+        | None -> G.EDynamic literal)
   in
   G.DotAccess (expr, dot, ident_or_dyn)
 
@@ -1964,8 +1964,8 @@ and map_mod_block (env : env) ((v1, v2, v3, v4) : CST.mod_block) :
   let rbrace = token env v4 (* "}" *) in
   (lbrace, stmts, rbrace)
 
-and map_ordered_field (_env : env) _outer_attrsTODO (_attrsTODO : G.attribute list)
-    (type_ : G.type_) (index : int) : G.field =
+and map_ordered_field (_env : env) _outer_attrsTODO
+    (_attrsTODO : G.attribute list) (type_ : G.type_) (index : int) : G.field =
   let index_s = string_of_int index in
   let var_def = { G.vinit = None; G.vtype = Some type_ } in
   let ent =
@@ -2387,7 +2387,7 @@ and map_scoped_identifier_name (env : env)
             (None, Some ty)
         | `Gene_type_with_turb x ->
             let ty = map_generic_type_with_turbofish_type env x in
-            (None, Some ty) )
+            (None, Some ty))
     | None -> (None, None)
   in
   let colons = token env v2 (* "::" *) in
@@ -2418,7 +2418,7 @@ and map_scoped_type_identifier_name (env : env)
             (None, Some (fb [ G.TypeArg ty ]))
         | `Gene_type x ->
             let ty = map_generic_type env x in
-            (None, Some (fb [ G.TypeArg ty ])) )
+            (None, Some (fb [ G.TypeArg ty ])))
     | None -> (None, None)
   in
   let ident = ident env v3 in
@@ -2443,7 +2443,7 @@ and map_scoped_type_identifier_in_expression_position (env : env)
             (Some (G.QExpr (ident, colons)), None)
         | `Gene_type_with_turb x ->
             let ty = map_generic_type_with_turbofish_type env x in
-            (None, Some (fb [ G.TypeArg ty ])) )
+            (None, Some (fb [ G.TypeArg ty ])))
     | None -> (None, None)
   in
   let ident = ident env v3 in
@@ -2705,7 +2705,7 @@ and prepend_scope (dir : G.directive) (scope : G.dotted_ident option) :
       | ImportAll (tok, modname, wildcard) ->
           let modname = prepend_module_name scope modname in
           G.ImportAll (tok, modname, wildcard)
-      | _ -> dir )
+      | _ -> dir)
   | None -> dir
 
 and map_use_list (env : env) ((v1, v2, v3, v4) : CST.use_list)
@@ -3237,7 +3237,7 @@ let parse_expression_or_source_file str =
       | [] -> expr_res
       | _ ->
           let stmt_str = "__SEMGREP_STATEMENT " ^ str in
-          Tree_sitter_rust.Parse.string stmt_str )
+          Tree_sitter_rust.Parse.string stmt_str)
 
 (* todo: special mode to convert Ellipsis in the right construct! *)
 let parse_pattern str =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -166,7 +166,7 @@ let reserved_identifier (env : env) (x : CST.reserved_identifier) =
       | `Set tok -> identifier env tok (* "set" *)
       | `Async tok -> identifier env tok (* "async" *)
       | `Static tok -> identifier env tok (* "static" *)
-      | `Export tok -> identifier env tok (* export *) )
+      | `Export tok -> identifier env tok (* export *))
 
 let anon_choice_COMMA_5194cb4 (env : env) (x : CST.anon_choice_COMMA_5194cb4) =
   match x with
@@ -342,7 +342,7 @@ let rec parenthesized_expression (env : env)
         | Some x ->
             let tok, ty = type_annotation env x in
             Cast (v1, tok, ty)
-        | None -> v1 )
+        | None -> v1)
     | `Seq_exp x -> sequence_expression env x
   in
   let _v3 = token env v3 (* ")" *) in
@@ -409,12 +409,12 @@ and jsx_expression (env : env) ((v1, v2, v3) : CST.jsx_expression) :
     match v2 with
     | Some x ->
         Some
-          ( match x with
+          (match x with
           | `Exp x -> expression env x
           | `Seq_exp x -> sequence_expression env x
           | `Spread_elem x ->
               let t, e = spread_element env x in
-              Apply (IdSpecial (Spread, t), fb [ e ]) )
+              Apply (IdSpecial (Spread, t), fb [ e ]))
     (* abusing { } in XML to just add comments, e.g. { /* lint-ignore */ } *)
     | None -> None
   in
@@ -885,8 +885,8 @@ and class_body (env : env) ((v1, v2, v3) : CST.class_body) :
             in
             match v1 with
             | None -> aux [] xs
-            | Some x -> add_decorators (List.rev acc_decorators) x :: aux [] xs
-            ) )
+            | Some x -> add_decorators (List.rev acc_decorators) x :: aux [] xs)
+        )
   in
   let v2 = aux [] v2 in
   let v3 = token env v3 (* "}" *) in
@@ -1087,7 +1087,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           let v3 = token env v3 (* "target" *) in
           let t = PI.combine_infos v1 [ v2; v3 ] in
           IdSpecial (NewTarget, t)
-      | `Call_exp x -> call_expression env x )
+      | `Call_exp x -> call_expression env x)
   | `Non_null_exp x -> non_null_expression env x
 
 and call_expression (env : env) (x : CST.call_expression) =
@@ -1196,9 +1196,9 @@ and object_type (env : env) ((v1, v2, v3) : CST.object_type) =
           match v1 with
           | Some x ->
               Some
-                ( match x with
+                (match x with
                 | `COMMA tok -> token env tok (* "," *)
-                | `SEMI tok -> token env tok (* ";" *) )
+                | `SEMI tok -> token env tok (* ";" *))
           | None -> None
         in
         let v2 = anon_choice_export_stmt_f90d83f env v2 in
@@ -1322,7 +1322,7 @@ and expression (env : env) (x : CST.expression) : expr =
           TypeAssert (v1, v2, x)
       | `Temp_str x ->
           let _, xs, _ = template_string env x in
-          ExprTodo (("WeirdCastTemplateString", v2), v1 :: xs) )
+          ExprTodo (("WeirdCastTemplateString", v2), v1 :: xs))
   | `Inte_module x -> (
       (* namespace (deprecated in favor of ES modules) *)
       (* TODO represent namespaces properly in the AST instead of the nonsense
@@ -1340,14 +1340,14 @@ and expression (env : env) (x : CST.expression) : expr =
             }
           in
           Apply (Fun (fun_, Some name), fb [])
-      | None -> idexp name )
+      | None -> idexp name)
   | `Type_asse (v1, v2) -> (
       (* type assertion of the form <string>someValue *)
       let t1, xs, _t2 = type_arguments env v1 in
       let v2 = expression env v2 in
       match xs with
       | [ t ] -> TypeAssert (v2, t1, t)
-      | _ -> raise (PI.Parsing_error t1) )
+      | _ -> raise (PI.Parsing_error t1))
   | `Prim_exp x -> primary_expression env x
   | `Choice_jsx_elem x ->
       let xml = jsx_element_ env x in
@@ -1373,7 +1373,7 @@ and expression (env : env) (x : CST.expression) : expr =
             | `Id tok ->
                 let id = identifier env tok (* identifier *) in
                 idexp id
-            | `Paren_exp x -> parenthesized_expression env x )
+            | `Paren_exp x -> parenthesized_expression env x)
         | `Non_null_exp x -> non_null_expression env x
       in
       let op, is_logical, tok =
@@ -1443,7 +1443,7 @@ and expression (env : env) (x : CST.expression) : expr =
             | Some x ->
                 let x = expression env x in
                 Apply (IdSpecial (Yield, v1), fb [ x ])
-            | None -> Apply (IdSpecial (Yield, v1), fb []) )
+            | None -> Apply (IdSpecial (Yield, v1), fb []))
       in
       v2
 
@@ -2046,9 +2046,9 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
                     let e = expression env v1 in
                     let _semi = semicolon env v2 in
                     let def, n = Ast_js.mk_default_entity_def tok_default e in
-                    [ DefStmt def; M (Export (export_tok, n)) ] )
+                    [ DefStmt def; M (Export (export_tok, n)) ])
           in
-          v3 )
+          v3)
   | `Export_type_export_clause (v1, v2, v3) ->
       let _export = token env v1 (* "export" *) in
       let _type = token env v2 (* "type" *) in
@@ -2217,7 +2217,7 @@ and public_field_definition (env : env)
     | Some x -> (
         match x with
         | `QMARK tok -> [ (Optional, token env tok) ] (* "?" *)
-        | `BANG tok -> [ (NotNull, token env tok) ] (* "!" *) )
+        | `BANG tok -> [ (NotNull, token env tok) ] (* "!" *))
     | None -> []
   in
   let opt_type =
@@ -2401,7 +2401,7 @@ and call_signature (env : env) ((v1, v2, v3) : CST.call_signature) :
               let v3 = type_ env v3 in
               TypeTodo (("IsType", v2), [ Expr v1; Type v3 ])
             in
-            Some v2 )
+            Some v2)
     | None -> None
   in
   (v1, (v2, v3))
@@ -2440,7 +2440,7 @@ and type_ (env : env) (x : CST.type_) : type_ =
           let x = type_ env x in
           TyOr (x, v2, v3)
       | None -> v3
-      (* ?? *) )
+      (* ?? *))
   | `Inte_type (v1, v2, v3) -> (
       let v2 = token env v2 (* "&" *) in
       let v3 = type_ env v3 in
@@ -2449,7 +2449,7 @@ and type_ (env : env) (x : CST.type_) : type_ =
           let x = type_ env x in
           TyAnd (x, v2, v3)
       | None -> v3
-      (* ?? *) )
+      (* ?? *))
   | `Func_type (v1, v2, v3, v4) ->
       let _tparams =
         match v1 with Some x -> type_parameters env x | None -> []
@@ -2531,7 +2531,7 @@ and lhs_expression (env : env) (x : CST.lhs_expression) =
       | `Subs_exp x -> subscript_expression env x
       | `Id tok -> identifier env tok |> idexp (* identifier *)
       | `Choice_decl x -> reserved_identifier env x |> idexp
-      | `Dest_pat x -> destructuring_pattern env x )
+      | `Dest_pat x -> destructuring_pattern env x)
   | `Non_null_exp x -> non_null_expression env x
 
 and statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
@@ -2671,7 +2671,7 @@ and declaration (env : env) (x : CST.declaration) : definition list =
       | `Gene_func_decl x -> [ generator_function_declaration env x ]
       | `Class_decl x -> [ class_declaration env x ]
       | `Lexi_decl x -> lexical_declaration env x |> vars_to_defs
-      | `Var_decl x -> variable_declaration env x |> vars_to_defs )
+      | `Var_decl x -> variable_declaration env x |> vars_to_defs)
   | `Func_sign (v1, v2, v3, v4, v5) ->
       let _v1 =
         match v1 with
@@ -2869,6 +2869,6 @@ let parse ?dialect file =
 
       if debug then (
         Printexc.record_backtrace true;
-        CST.dump_tree cst );
+        CST.dump_tree cst);
 
       program env cst)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -342,7 +342,7 @@ let map_component (env : env) (xs : CST.component) : stmt list =
           in
           match body_opt with
           | Some s -> env.extra.parse_js_program s
-          | None -> [] )
+          | None -> [])
       (* less: parse as CSS *)
       | `Style_elem x ->
           let xml = map_style_element env x in

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -131,19 +131,19 @@ let match_to_match x =
     let min_loc, max_loc = x.range_loc in
     let startp, endp = position_range min_loc max_loc in
     Left
-      ( {
-          ST.check_id = Some x.rule_id.id;
-          path = x.file;
-          start = startp;
-          end_ = endp;
-          extra =
-            {
-              message = Some x.rule_id.message;
-              metavars = x.env |> List.map (metavars startp);
-              lines = [] (* ?? spacegrep? *);
-            };
-        }
-        : ST.match_ )
+      ({
+         ST.check_id = Some x.rule_id.id;
+         path = x.file;
+         start = startp;
+         end_ = endp;
+         extra =
+           {
+             message = Some x.rule_id.message;
+             metavars = x.env |> List.map (metavars startp);
+             lines = [] (* ?? spacegrep? *);
+           };
+       }
+        : ST.match_)
     (* raised by min_max_ii_by_pos in range_of_any when the AST of the
      * pattern in x.code or the metavar does not contain any token
      *)

--- a/semgrep-core/src/reporting/Matching_report.ml
+++ b/semgrep-core/src/reporting/Matching_report.ml
@@ -85,8 +85,8 @@ let print_match ?(format = Normal) ?(str = "") ii =
     | Emacs -> pr (prefix ^ ": " ^ arr.(List.hd lines))
     | OneLine ->
         pr
-          ( prefix ^ ": "
-          ^ (ii |> List.map PI.str_of_info |> join_with_space_if_needed) )
+          (prefix ^ ": "
+          ^ (ii |> List.map PI.str_of_info |> join_with_space_if_needed))
   with Failure "get_pos: Ab or FakeTok" ->
     pr "<could not locate match, FakeTok or AbstractTok>"
 

--- a/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
@@ -106,7 +106,7 @@ let run_all ~case_sensitive ~debug ~force ~warn ~no_skip_search patterns docs :
                   | [] -> None
                   | _ ->
                       incr num_matching_files;
-                      Some (doc_src, matches_in_file, parse_time) ))
+                      Some (doc_src, matches_in_file, parse_time)))
         in
         match matches with
         | None -> None
@@ -132,9 +132,9 @@ let run config =
   apply_timeout config;
   let patterns_or_errors =
     let pattern_files = Find_files.list config.pattern_files in
-    ( match config.pattern with
+    (match config.pattern with
     | None -> []
-    | Some pat_str -> [ Src_file.of_string pat_str ] )
+    | Some pat_str -> [ Src_file.of_string pat_str ])
     @ List.map Src_file.of_file pattern_files
     |> List.map (fun pat_src -> (pat_src, Parse_pattern.of_src pat_src))
   in
@@ -170,15 +170,14 @@ let run config =
       ~debug ~force:config.force ~warn:config.warn
       ~no_skip_search:config.no_skip_search patterns docs
   in
-  ( match config.output_format with
+  (match config.output_format with
   | Text ->
       Match.print_nested_results ~with_time:config.time ~highlight matches
         errors
-  | Semgrep -> Semgrep.print_semgrep_json ~with_time:config.time matches errors
-  );
+  | Semgrep -> Semgrep.print_semgrep_json ~with_time:config.time matches errors);
   if debug then (
     printf "\nanalyzed %i files out of %i\n" num_analyzed num_files;
-    printf "found %i matches in %i files\n" num_matches num_matching_files )
+    printf "found %i matches in %i files\n" num_matches num_matching_files)
 
 let color_conv =
   let parser when_use_color =

--- a/semgrep-core/src/spacegrep/src/lib/Doc_AST.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Doc_AST.ml
@@ -37,7 +37,7 @@ and of_pattern_node acc pat_node =
       | Metavar s ->
           let start, end_ = loc in
           let word_loc = (Loc.Pos.shift start 1, end_) in
-          Atom (word_loc, Word s) :: Atom (Loc.sub loc 0 1, Punct '$') :: acc )
+          Atom (word_loc, Word s) :: Atom (Loc.sub loc 0 1, Punct '$') :: acc)
   | Dots (loc, None) ->
       (* ... *)
       let pos0, pos3 = loc in

--- a/semgrep-core/src/spacegrep/src/lib/Find_files.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Find_files.ml
@@ -73,7 +73,7 @@ let fold_one ~accept_file_name ~accept_dir_name visit_tracker f acc root =
       | Some Unix.S_REG -> if accept_file_name name then f acc path else acc
       | None | Some _ ->
           (* leave broken symlinks and special files alone *)
-          acc )
+          acc)
   in
   fold acc root
 

--- a/semgrep-core/src/spacegrep/src/lib/Match.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Match.ml
@@ -151,7 +151,7 @@ let close_dots conf ~dots:opt_dots env =
       | None -> Some (Env.add name (matched, value) env)
       | Some (_loc0, value0) ->
           (* This must be an exact match even if case-insensitive matching was requested. *)
-          if String.equal value value0 then Some env else None )
+          if String.equal value value0 then Some env else None)
 
 let close_dots_or_fail conf ~dots env f =
   match close_dots conf ~dots env with None -> Fail | Some env' -> f env'
@@ -245,11 +245,11 @@ let rec match_ (conf : conf) ~(dots : dots option) (env : env)
   | [], doc -> (
       match doc_matches_dots ~dots last_loc doc with
       | Some last_loc -> complete_dots conf ~dots env last_loc
-      | None -> Fail )
+      | None -> Fail)
   | [ End ], doc -> (
       match doc_matches_dots ~dots last_loc doc with
       | Some last_loc -> complete_dots conf ~dots env last_loc
-      | None -> Complete (env, last_loc) )
+      | None -> Complete (env, last_loc))
   | End :: _, _ -> assert false
   | List pat1 :: pat2, doc -> (
       match doc with
@@ -280,7 +280,7 @@ let rec match_ (conf : conf) ~(dots : dots option) (env : env)
               close_dots_or_fail conf ~dots env (fun env ->
                   if pat_matches_empty_doc pat1 then
                     match_ conf ~dots:None env last_loc pat2 doc cont
-                  else Fail) ) )
+                  else Fail)))
   | Dots (_, opt_mvar) :: pat_tail, doc ->
       let dots = extend_dots ~dots opt_mvar last_loc in
       match_ conf ~dots env last_loc pat_tail doc cont
@@ -319,7 +319,7 @@ let rec match_ (conf : conf) ~(dots : dots option) (env : env)
                               if String.equal value value0 then
                                 match_ conf ~dots:None env loc pat_tail doc_tail
                                   cont
-                              else Fail )
+                              else Fail)
                       | Word a, Word b when conf.word_equal a b ->
                           match_ conf ~dots:None env loc pat_tail doc_tail cont
                       | Punct a, Punct b when a = b ->
@@ -336,7 +336,7 @@ let rec match_ (conf : conf) ~(dots : dots option) (env : env)
                     match is_skippable_doc_atom ~dots loc with
                     | Some _ as dots' ->
                         match_ conf ~dots:dots' env last_loc pat doc_tail cont
-                    | None -> Fail ) ) ) )
+                    | None -> Fail))))
 
 (*
 let starts_after last_loc loc =

--- a/semgrep-core/src/spacegrep/src/lib/Parse_pattern.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Parse_pattern.ml
@@ -41,16 +41,16 @@ let append_block_to_accumulator open_punct close_punct open_loc close_loc
    opening brace is treated as an ordinary token.
 *)
 let rec parse_line pending_braces acc (tokens : Lexer.token list) :
-    ( Pattern_AST.node list
+    (Pattern_AST.node list
     * pending_brace list
     * Loc.t (* location of the closing brace, if any *)
-    * Lexer.token list )
+    * Lexer.token list)
     option =
   match tokens with
   | [] -> (
       match pending_braces with
       | [] -> Some (close_acc acc, [], Loc.dummy, [])
-      | _ -> None )
+      | _ -> None)
   | Dots (loc, opt_mvar) :: tokens ->
       parse_line pending_braces (Dots (loc, opt_mvar) :: acc) tokens
   | Atom (loc, atom) :: tokens ->
@@ -64,7 +64,7 @@ let rec parse_line pending_braces acc (tokens : Lexer.token list) :
           parse_line pending_braces
             (append_block_to_accumulator open_paren close_paren open_loc
                close_loc nodes acc)
-            tokens )
+            tokens)
   | Open_bracket open_loc :: tokens -> (
       let res = parse_line (Bracket :: pending_braces) [] tokens in
       match res with
@@ -76,7 +76,7 @@ let rec parse_line pending_braces acc (tokens : Lexer.token list) :
           parse_line pending_braces
             (append_block_to_accumulator open_bracket close_bracket open_loc
                close_loc nodes acc)
-            tokens )
+            tokens)
   | Open_curly open_loc :: tokens -> (
       let res = parse_line (Curly :: pending_braces) [] tokens in
       match res with
@@ -86,7 +86,7 @@ let rec parse_line pending_braces acc (tokens : Lexer.token list) :
           parse_line pending_braces
             (append_block_to_accumulator open_curly close_curly open_loc
                close_loc nodes acc)
-            tokens )
+            tokens)
   | Close_paren close_loc :: tokens -> (
       match pending_braces with
       | Paren :: pending_braces ->
@@ -95,7 +95,7 @@ let rec parse_line pending_braces acc (tokens : Lexer.token list) :
       | [] ->
           parse_line pending_braces
             (Atom (close_loc, close_paren) :: acc)
-            tokens )
+            tokens)
   | Close_bracket close_loc :: tokens -> (
       match pending_braces with
       | Bracket :: pending_braces ->
@@ -104,7 +104,7 @@ let rec parse_line pending_braces acc (tokens : Lexer.token list) :
       | [] ->
           parse_line pending_braces
             (Atom (close_loc, close_bracket) :: acc)
-            tokens )
+            tokens)
   | Close_curly close_loc :: tokens -> (
       match pending_braces with
       | Curly :: pending_braces ->
@@ -113,7 +113,7 @@ let rec parse_line pending_braces acc (tokens : Lexer.token list) :
       | [] ->
           parse_line pending_braces
             (Atom (close_loc, close_curly) :: acc)
-            tokens )
+            tokens)
 
 (* Try to match braces within the line. This is intended for documents, not
    for patterns. *)
@@ -173,13 +173,13 @@ let check_pattern pat0 =
   let rec check = function
     | [] -> None
     | List pat1 :: pat2 -> (
-        match check pat1 with Some err -> Some err | None -> check pat2 )
+        match check pat1 with Some err -> Some err | None -> check pat2)
     | Dots (_, opt_mvar1) :: Dots (loc, Some mvar2) :: _ ->
         let msg =
           Printf.sprintf "Invalid pattern sequence: %s $...%s"
-            ( match opt_mvar1 with
+            (match opt_mvar1 with
             | None -> "..."
-            | Some mvar1 -> Printf.sprintf "$...%s" mvar1 )
+            | Some mvar1 -> Printf.sprintf "$...%s" mvar1)
             mvar2
         in
         Some { loc; msg }

--- a/semgrep-core/src/spacegrep/src/lib/Pattern_AST.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Pattern_AST.ml
@@ -40,7 +40,7 @@ let rec as_doc (pat : t) : t =
           let word_loc = (Loc.Pos.shift start 1, end_) in
           Atom (Loc.sub loc 0 1, Punct '$')
           :: Atom (word_loc, Word s)
-          :: as_doc pat )
+          :: as_doc pat)
   | Dots (loc, None) :: pat ->
       let pos0, pos3 = loc in
       let pos1 = Loc.Pos.shift pos0 1 in
@@ -76,7 +76,7 @@ let rec eq a b =
   match (a, b) with
   | [], [] -> true
   | a_head :: a_tail, b_head :: b_tail ->
-      ( match (a_head, b_head) with
+      (match (a_head, b_head) with
       | Atom (_, a), Atom (_, b) -> a = b
       | List a, List b -> eq a b
       | Dots (_, None), Dots (_, None) -> true
@@ -84,6 +84,6 @@ let rec eq a b =
       | Dots (_, None), Dots (_, Some _) | Dots (_, Some _), Dots (_, None) ->
           false
       | End, End -> true
-      | _ -> false )
+      | _ -> false)
       && eq a_tail b_tail
   | _ -> false

--- a/semgrep-core/src/spacegrep/src/lib/Pre_match.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Pre_match.ml
@@ -18,7 +18,7 @@ let pattern_has_bytes (pat : Pattern_AST.t) =
   let open Pattern_AST in
   let rec has_bytes = function
     | Atom (_, atom) -> (
-        match atom with Byte _ -> true | Word _ | Punct _ | Metavar _ -> false )
+        match atom with Byte _ -> true | Word _ | Punct _ | Metavar _ -> false)
     | List nodes -> List.exists has_bytes nodes
     | Dots _ | End -> false
   in

--- a/semgrep-core/src/spacegrep/src/lib/Semgrep.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Semgrep.ml
@@ -58,14 +58,14 @@ let make_semgrep_json ~with_time doc_matches pat_errors :
                       Src_file.list_lines_of_pos_range src pos1 pos2
                     in
                     let extra = { message = None; metavars; lines } in
-                    ( {
-                        check_id;
-                        path;
-                        start = semgrep_pos pos1;
-                        end_ = semgrep_pos pos2;
-                        extra;
-                      }
-                      : match_ ))
+                    ({
+                       check_id;
+                       path;
+                       start = semgrep_pos pos1;
+                       end_ = semgrep_pos pos2;
+                       extra;
+                     }
+                      : match_))
                   matches
               in
               (matches_out @ matches_acc, match_time +. match_time_acc))

--- a/semgrep-core/src/spacegrep/src/lib/Semgrep.mli
+++ b/semgrep-core/src/spacegrep/src/lib/Semgrep.mli
@@ -8,10 +8,10 @@
 *)
 val print_semgrep_json :
   with_time:bool ->
-  ( Src_file.t
+  (Src_file.t
   * (Match.pattern_id * Match.match_ list * float) list
   * float
-  * float )
+  * float)
   list ->
   (Src_file.t * Parse_pattern.error) list ->
   unit

--- a/semgrep-core/src/spacegrep/src/lib/Src_file.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Src_file.ml
@@ -54,7 +54,7 @@ let of_channel ?(source = Channel) ?max_len ic =
     | None -> (
         match get_channel_length ic with
         | None -> input_all_from_nonseekable_channel ic
-        | Some len -> really_input_string ic len )
+        | Some len -> really_input_string ic len)
     | Some max_len -> partial_input max_len ic
   in
   { source; contents }

--- a/semgrep-core/src/spacegrep/src/test/Matcher.ml
+++ b/semgrep-core/src/spacegrep/src/test/Matcher.ml
@@ -37,7 +37,7 @@ let test_pattern_parser () =
         dots;
         metavar "Var_0";
         End;
-      ] )
+      ])
 
 (*
    Compare the structure of two unparsed documents.

--- a/semgrep-core/src/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Code.ml
@@ -101,7 +101,7 @@ let get_id ?(with_type = false) env e =
           | N (Id (_, { id_type; _ })) -> (
               match !id_type with
               | None -> (notype_id, has_type)
-              | Some t -> (default_tyvar (count_to_id env.count) t, true) )
+              | Some t -> (default_tyvar (count_to_id env.count) t, true))
           | L (String (_, tag)) -> (L (String ("...", tag)), false)
           | _ -> (notype_id, has_type)
         else
@@ -205,7 +205,7 @@ let generalize_call env = function
           shallow_dots (e, (lp, rp))
           :: shallow_metavar (e, (lp, es, rp)) env
           :: exact_metavar (e, (lp, es, rp)) env
-          :: optional )
+          :: optional)
   | _ -> []
 
 (* Id *)

--- a/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
@@ -92,10 +92,10 @@ let rec show_patterns (patterns : pattern_instrs) =
   | [] -> pr2 "---"
   | (_any, pattern, replacements) :: pats ->
       pr2
-        ( "( " (* ^ (p_any any) ^ ", " *) ^ p_any pattern
+        ("( " (* ^ (p_any any) ^ ", " *) ^ p_any pattern
         ^ ", "
         ^ show_replacements replacements
-        ^ " )" );
+        ^ " )");
       show_patterns pats
 
 let show_pattern_sets patsets =
@@ -208,7 +208,7 @@ let pattern_from_args env args : pattern_instrs =
         | E x -> Args (Arg (Ellipsis el) :: Arg x :: xs)
         | x ->
             pr2 (show_any x);
-            raise InvalidSubstitution )
+            raise InvalidSubstitution)
     | Args (_ :: _) -> args
     | _ -> raise InvalidSubstitution
   in
@@ -223,11 +223,11 @@ let pattern_from_args env args : pattern_instrs =
     | Args (Arg (Ellipsis el) :: Arg e :: rest) -> (
         match f (Args rest) with
         | Args args' -> Args (Arg (Ellipsis el) :: Arg e :: args')
-        | _ -> raise InvalidSubstitution )
+        | _ -> raise InvalidSubstitution)
     | Args (Arg e :: rest) -> (
         match f (Args rest) with
         | Args args' -> Args (Arg e :: args')
-        | _ -> raise InvalidSubstitution )
+        | _ -> raise InvalidSubstitution)
     | _ -> raise InvalidSubstitution
   in
   let remove_end_ellipsis _f args =
@@ -276,7 +276,7 @@ let pattern_from_call env (e', (lp, args, rp)) : pattern_instrs =
     | E (Call (e, (lp, args, rp))) -> (
         match f (E e) with
         | E x -> E (Call (x, (lp, args, rp)))
-        | _ -> raise InvalidSubstitution )
+        | _ -> raise InvalidSubstitution)
     | _ -> raise InvalidSubstitution
   in
   let replace_args f e =
@@ -284,7 +284,7 @@ let pattern_from_call env (e', (lp, args, rp)) : pattern_instrs =
     | E (Call (e, (lp, args, rp))) -> (
         match f (Args args) with
         | Args x -> E (Call (e, (lp, x, rp)))
-        | _ -> raise InvalidSubstitution )
+        | _ -> raise InvalidSubstitution)
     | _ -> raise InvalidSubstitution
   in
   [
@@ -312,11 +312,11 @@ let pattern_from_assign env (e1, tok, e2) : pattern_instrs =
     | E (Assign (e1, tok, e2)), Left -> (
         match f (E e1) with
         | E x -> E (Assign (x, tok, e2))
-        | _ -> raise InvalidSubstitution )
+        | _ -> raise InvalidSubstitution)
     | E (Assign (e1, tok, e2)), Right -> (
         match f (E e2) with
         | E x -> E (Assign (e1, tok, x))
-        | _ -> raise InvalidSubstitution )
+        | _ -> raise InvalidSubstitution)
     | _ -> raise InvalidSubstitution
   in
   [
@@ -350,7 +350,7 @@ let rec pattern_from_stmt env ({ s; _ } as stmt) : pattern_instrs =
         | S ({ s = ExprStmt (e', _); _ } as stmt) -> (
             match f (E e') with
             | E x -> S (replace_sk stmt (ExprStmt (x, sc)))
-            | _ -> raise InvalidSubstitution )
+            | _ -> raise InvalidSubstitution)
         | _ ->
             pr2 "h1";
             raise InvalidSubstitution
@@ -425,7 +425,7 @@ let get_included_patterns pattern_children =
     | [] -> (
         match holes with
         | [] -> []
-        | _ -> [ (set_prev env pattern, pattern, holes) ] )
+        | _ -> [ (set_prev env pattern, pattern, holes) ])
     | _ -> children
   in
   List.map
@@ -440,7 +440,7 @@ let rec generate_patterns_help (target_patterns : pattern_instrs list) =
   if false then (
     (* Set this for debug info *)
     pr2 "target patterns";
-    show_pattern_sets target_patterns );
+    show_pattern_sets target_patterns);
   let pattern_children =
     List.map (List.map get_one_step_replacements) target_patterns
   in

--- a/semgrep-core/src/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/src/synthesizing/Pretty_print_generic.ml
@@ -71,7 +71,7 @@ let print_bool env = function
       | Lang.Vue | Lang.Csharp | Lang.PHP | Lang.Hack | Lang.Kotlin | Lang.Lua
       | Lang.Bash | Lang.Rust | Lang.Scala | Lang.HTML ->
           "true"
-      | Lang.R -> "TRUE" )
+      | Lang.R -> "TRUE")
   | false -> (
       match env.lang with
       | Lang.Python | Lang.Python2 | Lang.Python3 -> "False"
@@ -80,7 +80,7 @@ let print_bool env = function
       | Lang.Vue | Lang.PHP | Lang.Hack | Lang.Kotlin | Lang.Lua | Lang.Bash
       | Lang.Rust | Lang.Scala | Lang.HTML ->
           "false"
-      | Lang.R -> "FALSE" )
+      | Lang.R -> "FALSE")
 
 let arithop env (op, tok) =
   match op with
@@ -90,7 +90,7 @@ let arithop env (op, tok) =
   | Div -> "/"
   | Mod -> "%"
   | Pow -> "**"
-  | Eq -> ( match env.lang with Lang.OCaml -> "=" | _ -> "==" )
+  | Eq -> ( match env.lang with Lang.OCaml -> "=" | _ -> "==")
   | Lt -> "<"
   | LtE -> "<="
   | Gt -> ">"
@@ -426,7 +426,7 @@ and call env (e, (_, es, _)) =
       let op_str = match i_d with Incr -> "++" | Decr -> "--" in
       match pre_post with
       | Prefix -> F.sprintf "%s%s" op_str (argument env x)
-      | Postfix -> F.sprintf "%s%s" (argument env x) op_str )
+      | Postfix -> F.sprintf "%s%s" (argument env x) op_str)
   | _ -> F.sprintf "%s(%s)" s1 (arguments env es)
 
 and literal env = function
@@ -442,9 +442,9 @@ and literal env = function
       | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.Csharp
       | Lang.Kotlin | Lang.JSON | Lang.Javascript | Lang.Vue | Lang.OCaml
       | Lang.Ruby | Lang.Typescript | Lang.Lua | Lang.Rust | Lang.R ->
-          "\"" ^ s ^ "\"" )
+          "\"" ^ s ^ "\"")
   | Regexp ((_, (s, _), _), rmod) -> (
-      "/" ^ s ^ "/" ^ match rmod with None -> "" | Some (s, _) -> s )
+      "/" ^ s ^ "/" ^ match rmod with None -> "" | Some (s, _) -> s)
   | x -> todo (E (L x))
 
 and arguments env xs =

--- a/semgrep-core/src/synthesizing/Unit_synthesizer.ml
+++ b/semgrep-core/src/synthesizing/Unit_synthesizer.ml
@@ -221,7 +221,7 @@ let unittest =
                         if matches_with_env = [] then (
                           pr2 str;
                           pr2 (AST_generic.show_any pattern);
-                          pr2 (AST_generic.show_any code) );
+                          pr2 (AST_generic.show_any code));
                         assert_bool
                           (spf "pattern:|%s| should match |%s" pat
                              (PPG.pattern_to_string lang code))
@@ -238,6 +238,6 @@ let unittest =
                     "" pats
                 in
                 assert_bool
-                  ( "Patterns do not match solution, where inferred patterns are:\n"
-                  ^ pats_str )
+                  ("Patterns do not match solution, where inferred patterns are:\n"
+                 ^ pats_str)
                   (pats = sols)))

--- a/semgrep-core/src/testing/Test_analyze_generic.ml
+++ b/semgrep-core/src/testing/Test_analyze_generic.ml
@@ -36,7 +36,7 @@ let test_cfg_generic file =
                let flow = Controlflow_build.cfg_of_func def in
                Controlflow.display_flow flow
              with Controlflow_build.Error err ->
-               Controlflow_build.report_error err )
+               Controlflow_build.report_error err)
          | _ -> ())
 
 (*e: function [[Test_analyze_generic.test_cfg_generic]] *)

--- a/semgrep-core/src/typing/LSP_client.ml
+++ b/semgrep-core/src/typing/LSP_client.ml
@@ -136,7 +136,7 @@ let rec read_response (id, req) io =
           | Error err ->
               let json = Jsonrpc.Response.Error.yojson_of_t err in
               let s = Import.Json.to_pretty_string json in
-              failwith (spf "error: %s" s) ) )
+              failwith (spf "error: %s" s)))
 
 (*****************************************************************************)
 (* OCaml LSP get type *)
@@ -197,7 +197,7 @@ let type_at_tok tk uri io =
           in
           if !debug then pr2_gen ty;
           Some ty
-      | _ -> failwith "not a `MarkedContent`" )
+      | _ -> failwith "not a `MarkedContent`")
 
 (*****************************************************************************)
 (* Entry points *)
@@ -222,15 +222,15 @@ let rec get_type id =
   let uri = "file://" ^ file in
   match !global with
   | { io = Some io; last_uri } when last_uri = uri -> (
-      try type_at_tok tok uri io with _exn -> None )
+      try type_at_tok tok uri io with _exn -> None)
   | { io = Some io; last_uri } when last_uri <> uri ->
-      ( if last_uri <> "" then
-        let notif =
-          Client_notification.TextDocumentDidClose
-            (DidCloseTextDocumentParams.create
-               ~textDocument:(TextDocumentIdentifier.create ~uri))
-        in
-        send_notif notif io );
+      (if last_uri <> "" then
+       let notif =
+         Client_notification.TextDocumentDidClose
+           (DidCloseTextDocumentParams.create
+              ~textDocument:(TextDocumentIdentifier.create ~uri))
+       in
+       send_notif notif io);
 
       let notif =
         Client_notification.TextDocumentDidOpen

--- a/semgrep-core/src/typing/Typechecking_generic.ml
+++ b/semgrep-core/src/typing/Typechecking_generic.ml
@@ -49,13 +49,13 @@ let compatible_type t e =
     ->
       true
   | TyBuiltin (t1, _), N (Id (_, { id_type; _ })) -> (
-      match !id_type with Some (TyBuiltin (t2, _)) -> t1 = t2 | _ -> false )
+      match !id_type with Some (TyBuiltin (t2, _)) -> t1 = t2 | _ -> false)
   | TyN (Id ((t1, _), _)), N (Id (_, { id_type; _ })) -> (
-      match !id_type with Some (TyN (Id ((t2, _), _))) -> t1 = t2 | _ -> false )
+      match !id_type with Some (TyN (Id ((t2, _), _))) -> t1 = t2 | _ -> false)
   | TyArray (_, TyN (Id ((t1, _), _))), N (Id (_, { id_type; _ })) -> (
       match !id_type with
       | Some (TyArray (_, TyN (Id ((t2, _), _)))) -> t1 = t2
-      | _ -> false )
+      | _ -> false)
   | _ -> false
 
 (*e: function [[Typechecking_generic.compatible_type]] *)

--- a/toy-matcher/Matcher.ml
+++ b/toy-matcher/Matcher.ml
@@ -99,7 +99,7 @@ let construct_backref_set pat_val =
       | Any_symbol
       | Symbol _
       | Ellipsis ->
-          pat.backrefs )
+          pat.backrefs)
 
 let create_pattern pat_val capture_name =
   let backrefs = construct_backref_set pat_val in
@@ -179,7 +179,7 @@ let rec check_pattern_ env (pat : pattern) =
   | Nil -> (
       match pat.capture_name with
       | None -> ()
-      | Some name -> failwith ("invalid capture of Nil node: " ^ name) )
+      | Some name -> failwith ("invalid capture of Nil node: " ^ name))
   | Cons (atom, pat) ->
       let new_env =
         match orig_pat.capture_name with
@@ -189,13 +189,13 @@ let rec check_pattern_ env (pat : pattern) =
               failwith ("multiple atoms have the same name: " ^ name)
             else name :: env
       in
-      ( match atom with
+      (match atom with
       | Any_symbol -> ()
       | Symbol _ -> ()
       | Ellipsis -> ()
       | Backref name ->
           if not (List.mem name env) then
-            failwith ("backreference to invalid name: " ^ name) );
+            failwith ("backreference to invalid name: " ^ name));
       check_pattern_ new_env pat
 
 let check_pattern pat = check_pattern_ [] pat
@@ -282,14 +282,14 @@ let print_pat_head oc pat =
   match pat.pat_val with
   | Nil -> fprintf oc " _:''"
   | Cons (atom, _tail) -> (
-      ( match pat.capture_name with
+      (match pat.capture_name with
       | None -> fprintf oc " _:"
-      | Some name -> fprintf oc " %s:" name );
+      | Some name -> fprintf oc " %s:" name);
       match atom with
       | Any_symbol -> fprintf oc "_"
       | Symbol c -> fprintf oc "%C" c
       | Ellipsis -> fprintf oc "..."
-      | Backref name -> fprintf oc "%s" name )
+      | Backref name -> fprintf oc "%s" name)
 
 (* to be appended to existing line *)
 let print_input_head oc input =
@@ -433,7 +433,7 @@ let match_input ?(trace = true) ?cache root_pat root_input :
             if in_ellipsis then
               let ellipsis = extend_ellipsis ellipsis symbol in
               match_ ellipsis env orig_pat input
-            else None )
+            else None)
     | Cons (pat_atom, pat) -> (
         match input with
         | [] -> (
@@ -447,10 +447,10 @@ let match_input ?(trace = true) ?cache root_pat root_input :
                 | Some [] ->
                     let env = extend env ellipsis orig_pat [] in
                     match_ Not_in_ellipsis env pat input
-                | _ -> None )
+                | _ -> None)
             | Any_symbol
             | Symbol _ ->
-                None )
+                None)
         | symbol :: input -> (
             let head_match =
               match pat_atom with
@@ -471,7 +471,7 @@ let match_input ?(trace = true) ?cache root_pat root_input :
                   | Some [ symbol0 ] when symbol0 = symbol ->
                       let env = extend env ellipsis orig_pat [ symbol ] in
                       Some (Not_in_ellipsis, env, input)
-                  | _ -> None )
+                  | _ -> None)
             in
             let matches_here =
               match head_match with
@@ -488,20 +488,20 @@ let match_input ?(trace = true) ?cache root_pat root_input :
                   (* skip input symbol and retry *)
                   let ellipsis = extend_ellipsis ellipsis symbol in
                   match_ ellipsis env orig_pat input
-                else None ) )
+                else None))
   in
-  ( match cache with
+  (match cache with
   | Some cache_when ->
       get_from_cache := Memoize.create ~cache_when uncached_match
-  | None -> get_from_cache := uncached_match );
+  | None -> get_from_cache := uncached_match);
 
   let opt_captures =
     match match_ Not_in_ellipsis empty_env root_pat root_input with
     | None -> None
     | Some env ->
         Some
-          ( Bindings.bindings env.full_env
-          |> List.map (fun (k, v) -> (k, unparse v)) )
+          (Bindings.bindings env.full_env
+          |> List.map (fun (k, v) -> (k, unparse v)))
   in
   (opt_captures, stat)
 
@@ -530,13 +530,13 @@ let check_match ?cache ?min_match_calls ?max_match_calls pat input_str
   in
   print_result stdout actual;
   Alcotest.(check bool) "equal" true (expected = actual);
-  ( match min_match_calls with
+  (match min_match_calls with
   | None -> ()
   | Some mini ->
       printf "min number of calls to the match function: %i\n" mini;
       Alcotest.(check bool)
         (sprintf "no more than %i match calls" mini)
-        true (match_calls >= mini) );
+        true (match_calls >= mini));
   match max_match_calls with
   | None -> ()
   | Some maxi ->


### PR DESCRIPTION
This is needed if we want to use ppxlib 0.20 (itself needed
if we want to use OCaml 4.12.0, itself needed if we don't
want errors on macos HomeBrew)

test plan:
pre-commit run --all lint-ocaml




PR checklist:
- [x] changelog is up to date