### PR TITLE
Hmmm, switch to native compilation

### DIFF
--- a/semgrep-core/src/cli/dune
+++ b/semgrep-core/src/cli/dune
@@ -45,7 +45,7 @@
  )
  (preprocess (pps ppx_profiling))
  ; for ocamldebug
- (modes byte)
+ (modes native byte)
  (flags (:include flags.sexp))
 )
 


### PR DESCRIPTION
This introduces some very clever optimizations to speedup semgrep by
more than 2! The algorithms are quite complicated, look at the code.

test plan:
OMG, we shipped a bytecode program all this time ...

BEFORE:

semgrep-core -test_rules ~/semgrep-rules: 20s
make test in semgrep-rules: 2m51s (real)

perf/run-benchmarks --small-only --std-only: 2m33 (real)
semgrep.bench.zulip.std.duration = 7.039 s
semgrep.bench.dropbox.std.duration = 3.460 s
semgrep.bench.coinbase.std.duration = 17.352 s
semgrep.bench.apache.std.duration = 12.362 s
semgrep.bench.0c34.std.duration = 2.719 s
semgrep.bench.lodash.std.duration = 5.979 s
semgrep.bench.njs-old-dvna.std.duration = 19.079 s
semgrep.bench.DVWA.std.duration = 13.937 s
semgrep.bench.juice-shop.std.duration = 25.761 s
semgrep.bench.Vulnerable-Flask-App.std.duration = 14.952 s
semgrep.bench.pallets.std.duration = 10.450 s
semgrep.bench.socketio.std.duration = 5.246 s
semgrep.bench.coolMenu.std.duration = 4.512 s
semgrep.bench.t00sh.std.duration = 4.293 s
semgrep.bench.grpc.std.duration = 5.562 s

Main.exe size: 47MB
startup time (semgrep-core --help): 0.160s

AFTER:

semgrep-core -test_rules ~/semgrep-rules: 10s
make test in semgrep-rules:  2m36s (real)

perf/run-benchmarks --small-only --std-only: 1m15s
semgrep.bench.zulip.std.duration = 3.491 s
semgrep.bench.dropbox.std.duration = 1.517 s
semgrep.bench.coinbase.std.duration = 9.234 s
semgrep.bench.apache.std.duration = 5.977 s
semgrep.bench.0c34.std.duration = 1.422 s
semgrep.bench.lodash.std.duration = 3.271 s
semgrep.bench.njs-old-dvna.std.duration = 8.239 s
semgrep.bench.DVWA.std.duration = 6.460 s
semgrep.bench.juice-shop.std.duration = 13.027 s
semgrep.bench.Vulnerable-Flask-App.std.duration = 7.575 s
semgrep.bench.pallets.std.duration = 4.601 s
semgrep.bench.socketio.std.duration = 2.754 s
semgrep.bench.coolMenu.std.duration = 1.966 s
semgrep.bench.t00sh.std.duration = 2.947 s
semgrep.bench.grpc.std.duration = 2.820 s

Main.exe size: 94MB
startup time (semgrep-core --help): 0.068s




PR checklist:
- [x] changelog is up to date