### PR TITLE
core: engine: metavariable-pattern: Fix location info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   "is this variable passed to an HTML template, and is it rendered in that template?"
   with several Semgrep rules.
 
+### Fixed
+- metavariable-pattern: `pattern-not-regex` now works (#3503)
+
 ## [0.58.2](https://github.com/returntocorp/semgrep/releases/tag/v0.58.2) - 2021-07-15
 
 ### Fixed

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -1099,3 +1099,21 @@ let (mk_visitor : visitor_in -> visitor_out) =
     }
   in
   all_functions
+
+(*****************************************************************************)
+(* Fix token locations *)
+(*****************************************************************************)
+
+let mk_fix_token_locations fix =
+  mk_visitor
+    {
+      default_visitor with
+      kstmt =
+        (fun (k, _) s ->
+          k
+            {
+              s with
+              s_range = Common.map_opt (fun (x, y) -> (fix x, fix y)) s.s_range;
+            });
+      kinfo = (fun (_, _) t -> Parse_info.fix_token_location fix t);
+    }

--- a/semgrep-core/src/core/ast/Map_AST.mli
+++ b/semgrep-core/src/core/ast/Map_AST.mli
@@ -30,4 +30,9 @@ val default_visitor : visitor_in
 val mk_visitor : visitor_in -> visitor_out
 
 (*e: signature [[Map_AST.mk_visitor]] *)
+
+val mk_fix_token_locations :
+  (Parse_info.token_location -> Parse_info.token_location) -> visitor_out
+(** Make a visitor that fixes token locations.  *)
+
 (*e: pfff/lang_GENERIC/parsing/Map_AST.mli *)

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex1.js
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex1.js
@@ -1,0 +1,4 @@
+//ok:test-mvp-regex-1
+let x = 1
+//ruleid:test-mvp-regex-1
+let y = "abc"

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex1.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex1.yaml
@@ -1,0 +1,14 @@
+# https://github.com/returntocorp/semgrep/issues/3503
+rules:
+  - id: test-mvp-regex-1
+    languages:
+      - ts
+      - js
+    message: Test
+    patterns:
+      - pattern: let $VAR = $VALUE
+      - metavariable-pattern:
+          metavariable: $VALUE
+          patterns:
+            - pattern-not-regex: ^[0-9]+$
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex2.js
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex2.js
@@ -1,0 +1,4 @@
+//ruleid:test-mvp-regex-2
+let x = 1
+//ok:test-mvp-regex-2
+let y = "abc"

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex2.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex2.yaml
@@ -1,0 +1,15 @@
+# https://github.com/returntocorp/semgrep/issues/3503
+rules:
+  - id: test-mvp-regex-2
+    languages:
+      - ts
+      - js
+    message: Test
+    patterns:
+      - pattern: let $VAR = $VALUE
+      - metavariable-pattern:
+          metavariable: $VALUE
+          patterns:
+            - pattern: ...
+            - pattern-regex: ^[0-9]+$
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex3.js
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex3.js
@@ -1,0 +1,3 @@
+foo(1);
+//ok:test-mvp-regex-3
+let y = "abc"

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex3.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex3.yaml
@@ -1,0 +1,13 @@
+# https://github.com/returntocorp/semgrep/issues/3503
+rules:
+  - id: test-mvp-regex-3
+    languages:
+      - ts
+      - js
+    message: Test
+    patterns:
+      - pattern: let $VAR = $VALUE
+      - metavariable-pattern:
+          metavariable: $VALUE
+          pattern-regex: ^[0-9]+$
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex4.js
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex4.js
@@ -1,0 +1,4 @@
+//ruleid:test-mvp-regex-4
+let x = "123"
+//ok:test-mvp-regex-4
+let y = "abc"

--- a/semgrep-core/tests/OTHER/rules/metavar_pattern_regex4.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_pattern_regex4.yaml
@@ -1,0 +1,15 @@
+# https://github.com/returntocorp/semgrep/issues/3503
+rules:
+  - id: test-mvp-regex-4
+    languages:
+      - ts
+      - js
+    message: Test
+    patterns:
+      - pattern: let $VAR = $VALUE
+      - metavariable-pattern:
+          metavariable: $VALUE
+          language: js
+          patterns:
+            - pattern-not-regex: ^[a-z]+$
+    severity: WARNING


### PR DESCRIPTION
File, file content, and Generic AST, must all have consistent location
info. This was being done when using the `language` sub-key but not
otherwise, yet it is still needed e.g. when using `pattern-regex`.

Closes #3503

test plan:
make test # tests included



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
