### PR TITLE
Refactor Parse_rule.ml

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -575,7 +575,7 @@ let parse_pattern lang_pattern str =
         res)
   with exn ->
     raise
-      (Parse_mini_rule.InvalidPatternException
+      (Parse_rule.InvalidPatternException
          ("no-id", str, !lang, Common.exn_to_s exn))
   [@@profiling]
 

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -874,7 +874,7 @@ let rule_of_pattern lang pattern_string pattern =
     pattern_string;
     pattern;
     message = "";
-    severity = MR.Error;
+    severity = R.Error;
     languages = [ lang ];
   }
 

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -28,8 +28,9 @@ module SJ = Spacegrep.Semgrep_j
  * Right now there is:
  *  - good support for: Python, Java, Go, Ruby,
  *    Javascript (and JSX), Typescript (and TSX), JSON
- *  - partial support for: PHP, C, OCaml, Lua, C#, YAML
- *  - almost support for: Rust, R, Kotlin.
+ *  - partial support for: C, C#, PHP, OCaml, Scala, Rust, Lua,
+ *    YAML, HTML, Vue
+ *  - almost support for: R, Kotlin, Bash, Docker
  *
  * opti: git grep foo | xargs semgrep -e 'foo(...)'
  *

--- a/semgrep-core/src/core/Mini_rule.ml
+++ b/semgrep-core/src/core/Mini_rule.ml
@@ -59,8 +59,10 @@ and rules = rule list
 
 (*e: type [[Rule.rules]] *)
 
-(* TODO? just reuse Error_code.severity *)
 (*s: type [[Rule.severity]] *)
+(* TODO? just reuse Error_code.severity
+ * TODO: move in Rule.ml at some point
+ *)
 and severity = Error | Warning | Info
 (*e: type [[Rule.severity]] *)
 [@@deriving eq, show]

--- a/semgrep-core/src/core/Mini_rule.ml
+++ b/semgrep-core/src/core/Mini_rule.ml
@@ -40,7 +40,7 @@ type rule = {
   id : string;
   pattern : Pattern.t;
   message : string;
-  severity : severity;
+  severity : Rule.severity;
   languages : Lang.t list;
   (* at least one element *)
   (* Useful for debugging, to report bad rules. We could rule.id to
@@ -56,16 +56,11 @@ type rule = {
 
 (*s: type [[Rule.rules]] *)
 and rules = rule list
-
 (*e: type [[Rule.rules]] *)
 
 (*s: type [[Rule.severity]] *)
-(* TODO? just reuse Error_code.severity
- * TODO: move in Rule.ml at some point
- *)
-and severity = Error | Warning | Info
 (*e: type [[Rule.severity]] *)
-[@@deriving eq, show]
+[@@deriving show]
 
 (*s: type [[Rule.t]] *)
 (* alias *)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -216,12 +216,15 @@ type taint_spec = {
 
 type mode = Search of pformula | Taint of taint_spec [@@deriving show]
 
+(* TODO? just reuse Error_code.severity *)
+type severity = Error | Warning | Info [@@deriving show]
+
 type rule = {
   (* MANDATORY fields *)
   id : string;
   mode : mode;
   message : string;
-  severity : Mini_rule.severity;
+  severity : severity;
   languages : xlang;
   (* todo: used for error location (metachecker) but should disappear when
    * using a YAML parser keeping location information and some tok/wrap *)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -202,7 +202,7 @@ let (mini_rule_of_pattern :
      * we just care about the matching result.
      *)
     message = "";
-    severity = MR.Error;
+    severity = R.Error;
     languages =
       (match xlang with
       | R.L (x, xs) -> x :: xs

--- a/semgrep-core/src/parsing/Parse_mini_rule.mli
+++ b/semgrep-core/src/parsing/Parse_mini_rule.mli
@@ -6,42 +6,20 @@ val parse : Common.filename -> Mini_rule.rules
 (*e: signature [[Parse_rules.parse]] *)
 
 (*s: exception [[Parse_rules.InvalidRuleException]] *)
-exception InvalidRuleException of string * string
-
 (*e: exception [[Parse_rules.InvalidRuleException]] *)
 (*s: exception [[Parse_rules.InvalidLanguageException]] *)
-exception InvalidLanguageException of string * string
-
 (*e: exception [[Parse_rules.InvalidLanguageException]] *)
 (*s: exception [[Parse_rules.InvalidPatternException]] *)
-exception InvalidPatternException of string * string * string * string
-
 (*e: exception [[Parse_rules.InvalidPatternException]] *)
-
-exception InvalidRegexpException of string * string
-
 (*s: exception [[Parse_rules.UnparsableYamlException]] *)
-exception UnparsableYamlException of string
-
 (*e: exception [[Parse_rules.UnparsableYamlException]] *)
 (*s: exception [[Parse_rules.InvalidYamlException]] *)
-exception InvalidYamlException of string
-
 (*e: exception [[Parse_rules.InvalidYamlException]] *)
-
-(* internals used by other parsers (e.g., Parse_tainting_rules.ml) *)
-
 (*s: signature [[Parse_rules.parse_languages]] *)
-val parse_languages : id:string -> Yaml.value list -> Lang.t list * Lang.t
-
 (*e: signature [[Parse_rules.parse_languages]] *)
 (*s: signature [[Parse_rules.parse_severity]] *)
-val parse_severity : id:string -> string -> Mini_rule.severity
-
 (*e: signature [[Parse_rules.parse_severity]] *)
 (*s: signature [[Parse_rules.parse_pattern]] *)
-val parse_pattern : id:string -> lang:Lang.t -> string -> Pattern.t
-
 (*e: signature [[Parse_rules.parse_pattern]] *)
 
 (*e: semgrep/parsing/Parse_mini_rule.mli *)

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -19,8 +19,7 @@ open Common
 module J = JSON
 module FT = File_type
 module R = Rule
-module E = Parse_mini_rule
-module H = Parse_mini_rule
+module MR = Mini_rule
 module G = AST_generic
 module PI = Parse_info
 module Set = Set_
@@ -44,13 +43,23 @@ module Set = Set_
  * See the Yaml_to_generic.program function. We then abuse this function
  * to also parse a semgrep rule (which is a yaml file) in this file.
  *
- * TODO:
- *  - Move the H.xxx here and get rid of Parse_mini_rule.ml
  *)
 
 (*****************************************************************************)
-(* Helpers *)
+(* Types *)
 (*****************************************************************************)
+
+exception InvalidRuleException of string * string
+
+exception InvalidLanguageException of string * string
+
+exception InvalidPatternException of string * string * string * string
+
+exception InvalidRegexpException of string * string
+
+exception UnparsableYamlException of string
+
+exception InvalidYamlException of string
 
 type env = {
   (* id of the current rule (needed by some exns) *)
@@ -63,8 +72,12 @@ type env = {
   path : string list;
 }
 
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
 (* TODO: switch to precise error location! *)
-let error s = raise (E.InvalidYamlException s)
+let error s = raise (InvalidYamlException s)
 
 (* Why do we need this generic_to_json function? Why would we want to convert
  * to JSON when we actually did lots of work to convert the YAML/JSON
@@ -211,7 +224,7 @@ let parse_metavar_cond s =
 let parse_regexp env s =
   try (s, Pcre.regexp s)
   with Pcre.Error exn ->
-    raise (E.InvalidRegexpException (env.id, pcre_error_to_string s exn))
+    raise (InvalidRegexpException (env.id, pcre_error_to_string s exn))
 
 let parse_fix_regex env key fields =
   let fix_regex_dict = yaml_to_dict key fields in
@@ -251,7 +264,7 @@ let parse_options key value =
        * TODO: we should use a warning/logging infra to report
        * this in the JSON to the semgrep wrapper and user.
        *)
-      (*raise (E.InvalidYamlException (spf "unknown option: %s" field_name))*)
+      (*raise (InvalidYamlException (spf "unknown option: %s" field_name))*)
       pr2 (spf "WARNING: unknown option: %s" field_name))
     (fun () -> Config_semgrep_j.t_of_string s)
 
@@ -259,7 +272,17 @@ let parse_options key value =
 (* Sub parsers patterns and formulas *)
 (*****************************************************************************)
 
-let parse_pattern env e =
+let parse_pattern ~id ~lang pattern =
+  (* todo? call Normalize_ast.normalize here? *)
+  try Parse_pattern.parse_pattern lang ~print_errors:false pattern with
+  | Timeout -> raise Timeout
+  | UnixExit n -> raise (UnixExit n)
+  | exn ->
+      raise
+        (InvalidPatternException
+           (id, pattern, Lang.string_of_lang lang, Common.exn_to_s exn))
+
+let parse_xpattern env e =
   let s =
     match e with
     | G.L (String (value, _)) -> value
@@ -278,15 +301,14 @@ let parse_pattern env e =
     (* TODO put in *)
   in
   match env.languages with
-  | R.L (lang, _) ->
-      R.mk_xpat (Sem (H.parse_pattern ~id:env.id ~lang s, lang)) s
+  | R.L (lang, _) -> R.mk_xpat (Sem (parse_pattern ~id:env.id ~lang s, lang)) s
   | R.LRegex -> failwith "you should not use real pattern with language = none"
   | R.LGeneric -> (
       let src = Spacegrep.Src_file.of_string s in
       match Spacegrep.Parse_pattern.of_src src with
       | Ok ast -> R.mk_xpat (Spacegrep ast) s
       | Error err ->
-          raise (H.InvalidPatternException (env.id, s, "generic", err.msg)))
+          raise (InvalidPatternException (env.id, s, "generic", err.msg)))
 
 let find_formula_old rule_dict : string * G.expr =
   let find key = (key, Hashtbl.find_opt rule_dict key) in
@@ -320,7 +342,7 @@ let rec parse_formula (env : env) (rule_dict : (string, G.expr) Hashtbl.t) :
 
 and parse_formula_old env ((key, value) : string * G.expr) : R.formula_old =
   let env = { env with path = key :: env.path } in
-  let get_pattern str_e = parse_pattern env str_e in
+  let get_pattern str_e = parse_xpattern env str_e in
   let get_nested_formula i x =
     let env = { env with path = string_of_int i :: env.path } in
     match x with
@@ -367,7 +389,7 @@ and parse_formula_new env (x : G.expr) : R.formula =
       | "and" -> R.And (parse_list key (parse_formula_new env) value)
       | "or" -> R.Or (parse_list key (parse_formula_new env) value)
       | "not" -> R.Not (parse_formula_new env value)
-      | "inside" -> R.Leaf (R.P (parse_pattern env value, Some Inside))
+      | "inside" -> R.Leaf (R.P (parse_xpattern env value, Some Inside))
       | "regex" ->
           let s = parse_string key value in
           let xpat = R.mk_xpat (R.Regexp (parse_regexp env s)) s in
@@ -387,7 +409,7 @@ and parse_formula_new env (x : G.expr) : R.formula =
               R.Leaf (R.MetavarCond (R.CondRegexp (mvar, parse_regexp env re)))
           | _ -> error "Expected a metavariable and regex")
       | _ -> error ("Invalid key for formula_new " ^ key))
-  | _ -> R.Leaf (R.P (parse_pattern env x, None))
+  | _ -> R.Leaf (R.P (parse_xpattern env x, None))
 
 (* This is now mutually recursive because of metavariable-pattern: which can
  * contain itself a formula! *)
@@ -447,14 +469,23 @@ let parse_languages ~id langs =
                (match Lang.lang_of_string_opt s with
                | None ->
                    raise
-                     (E.InvalidLanguageException
+                     (InvalidLanguageException
                         (id, spf "unsupported language: %s" s))
                | Some l -> l))
       in
       match languages with
-      | [] ->
-          raise (E.InvalidRuleException (id, "we need at least one language"))
+      | [] -> raise (InvalidRuleException (id, "we need at least one language"))
       | x :: xs -> R.L (x, xs))
+
+let parse_severity ~id s =
+  match s with
+  | "ERROR" -> MR.Error
+  | "WARNING" -> MR.Warning
+  | "INFO" -> MR.Info
+  | s ->
+      raise
+        (InvalidRuleException
+           (id, spf "Bad severity: %s (expected ERROR, WARNING or INFO)" s))
 
 (*****************************************************************************)
 (* Main entry point *)
@@ -537,7 +568,7 @@ let parse_generic file formula_ast =
            message;
            languages;
            file;
-           severity = H.parse_severity ~id severity;
+           severity = parse_severity ~id severity;
            mode;
            (* optional fields *)
            metadata = metadata_opt;

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -479,9 +479,9 @@ let parse_languages ~id langs =
 
 let parse_severity ~id s =
   match s with
-  | "ERROR" -> MR.Error
-  | "WARNING" -> MR.Warning
-  | "INFO" -> MR.Info
+  | "ERROR" -> R.Error
+  | "WARNING" -> R.Warning
+  | "INFO" -> R.Info
   | s ->
       raise
         (InvalidRuleException

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -19,7 +19,7 @@ val parse_metavar_cond : string -> AST_generic.expr
 
 (* internals used by other parsers (e.g., Parse_mini_rule.ml) *)
 
-val parse_severity : id:string -> string -> Mini_rule.severity
+val parse_severity : id:string -> string -> Rule.severity
 
 val parse_pattern : id:string -> lang:Lang.t -> string -> Pattern.t
 

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -1,8 +1,26 @@
 (*s: semgrep/parsing/Parse_rule.mli *)
 
+exception InvalidRuleException of string * string
+
+exception InvalidLanguageException of string * string
+
+exception InvalidPatternException of string * string * string * string
+
+exception InvalidRegexpException of string * string
+
+exception UnparsableYamlException of string
+
+exception InvalidYamlException of string
+
 val parse : Common.filename -> Rule.rules
 
 (* used also by Convert_rule.ml *)
 val parse_metavar_cond : string -> AST_generic.expr
+
+(* internals used by other parsers (e.g., Parse_mini_rule.ml) *)
+
+val parse_severity : id:string -> string -> Mini_rule.severity
+
+val parse_pattern : id:string -> lang:Lang.t -> string -> Pattern.t
 
 (*e: semgrep/parsing/Parse_rule.mli *)

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -229,22 +229,21 @@ let json_of_profile_info profile_start =
 let json_of_exn e =
   (* if (ouptut_as_json) then *)
   match e with
-  | Parse_mini_rule.InvalidRuleException (pattern_id, msg) ->
+  | Parse_rule.InvalidRuleException (pattern_id, msg) ->
       J.Object
         [
           ("pattern_id", J.String pattern_id);
           ("error", J.String "invalid rule");
           ("message", J.String msg);
         ]
-  | Parse_mini_rule.InvalidLanguageException (pattern_id, language) ->
+  | Parse_rule.InvalidLanguageException (pattern_id, language) ->
       J.Object
         [
           ("pattern_id", J.String pattern_id);
           ("error", J.String "invalid language");
           ("language", J.String language);
         ]
-  | Parse_mini_rule.InvalidPatternException (pattern_id, pattern, lang, message)
-    ->
+  | Parse_rule.InvalidPatternException (pattern_id, pattern, lang, message) ->
       J.Object
         [
           ("pattern_id", J.String pattern_id);
@@ -253,17 +252,17 @@ let json_of_exn e =
           ("language", J.String lang);
           ("message", J.String message);
         ]
-  | Parse_mini_rule.InvalidRegexpException (pattern_id, message) ->
+  | Parse_rule.InvalidRegexpException (pattern_id, message) ->
       J.Object
         [
           ("pattern_id", J.String pattern_id);
           ("error", J.String "invalid regexp in rule");
           ("message", J.String message);
         ]
-  | Parse_mini_rule.UnparsableYamlException msg ->
+  | Parse_rule.UnparsableYamlException msg ->
       J.Object
         [ ("error", J.String "unparsable yaml"); ("message", J.String msg) ]
-  | Parse_mini_rule.InvalidYamlException msg ->
+  | Parse_rule.InvalidYamlException msg ->
       J.Object [ ("error", J.String "invalid yaml"); ("message", J.String msg) ]
   | exn ->
       J.Object

--- a/semgrep-core/src/synthesizing/Unit_synthesizer_targets.ml
+++ b/semgrep-core/src/synthesizing/Unit_synthesizer_targets.ml
@@ -1,7 +1,7 @@
 (*s: semgrep/matching/Unit_matcher.ml *)
 open Common
 open OUnit
-module R = Mini_rule
+module R = Rule
 
 let test_path = "../../../tests/OTHER/synthesizing/targets/"
 
@@ -58,7 +58,7 @@ let ranges_matched lang file pattern : Range.t list =
   let ast = parse_file lang file in
   let rule =
     {
-      R.id = "unit testing";
+      Mini_rule.id = "unit testing";
       pattern;
       message = "";
       severity = R.Error;

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -3,7 +3,8 @@ open Common
 open OUnit
 module E = Error_code
 module P = Pattern_match
-module R = Mini_rule
+module R = Rule
+module MR = Mini_rule
 
 (*****************************************************************************)
 (* Purpose *)
@@ -103,7 +104,7 @@ let regression_tests_for_lang ~with_caching files lang =
     in
     Error_code.g_errors := [];
 
-    let rule = { R.
+    let rule = { MR.
       id = "unit testing"; pattern; message = ""; 
       severity = R.Error; languages = [lang];
       pattern_string = "test: no need for pattern string";


### PR DESCRIPTION
Move exns from Parse_mini_rule.ml (which we should remove at some
point) to Parse_rule.ml

test plan:
make




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date