### PR TITLE
parsing-stats: Fix some issues and log output per-lang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ jobs:
           command: |
             cd parsing-stats
             ./run-all --upload
+      - store_artifacts:
+          path: parsing-stats/logs
+      - store_artifacts:
+          path: parsing-stats/results.txt
 
 workflows:
   version: 2

--- a/parsing-stats/run-all
+++ b/parsing-stats/run-all
@@ -40,16 +40,22 @@ done
 pid_map=pids
 rm -f "$pid_map"
 
-# Run the parsing jobs in parallel. Output may be mangled.
+# Run the parsing jobs in parallel.
+mkdir -p logs
 pid_list=''
 for dir in lang/*; do
   lang=$(basename "$dir")
 
-  ./run-lang "$lang" $forwarded_option_list &
+  echo "Running ${lang^} suite (see logs/$lang.log) ..."
+  ./run-lang "$lang" $forwarded_option_list &>logs/"$lang.log" &
 
   pid=$!
   pid_list+=" $pid"
   echo "$pid $lang" >> "$pid_map"
+
+  # Wait a bit to avoid too many concurrent git-clone... otherwise
+  # we start getting network errors.
+  sleep 60
 done
 
 success=true
@@ -58,22 +64,25 @@ rm -f "$exit_statuses"
 
 for pid in $pid_list; do
   # Tolerate failures so as to not block the other jobs
-  lang=$(grep "$pid" "$pid_map" | cut -f2)
+  plang=$(grep "$pid" "$pid_map" | cut -f2)
   if wait "$pid"; then
-    echo "OK $lang" >> "$exit_statuses"
+    echo "OK $plang" >> "$exit_statuses"
   else
-    echo "FAIL $lang" >> "$exit_statuses"
+    echo "FAIL $plang" >> "$exit_statuses"
     success=false
   fi
+  lang=${plang##* }
+  echo "Done with ${lang^}!"
 done
 rm -f "$pid_map"
 
 # Show all the results sequentially at the end
+rm -f results.txt
 for dir in lang/*; do
   lang=$(basename "$dir")
-  echo "------ $lang -----"
+  echo "------ $lang -----" >>results.txt
   if [[ -e "$dir"/stats.json ]]; then
-    cat "$dir"/stats.json
+    cat "$dir"/stats.json >>results.txt
   fi
 done
 
@@ -81,7 +90,7 @@ done
 for dir in lang/*; do
   lang=$(basename "$dir")
   jsonfile="$dir"/stats.json
-  if [[ -e "$jsonfile" && -n "$(cat "$jsonfile")" ]]; then
+  if [[ -s "$jsonfile" ]]; then
     echo "Language: $lang"
     echo "Line count: $(jq .global.line_count "$jsonfile")"
     echo "Parsing rate: $(jq .global.parsing_rate "$jsonfile")"
@@ -89,8 +98,11 @@ for dir in lang/*; do
     echo "Language: $lang"
     echo "no data"
   fi
-  echo
+  echo ""
 done
+
+echo "For the long version, check results.txt."
+echo ""
 
 cat "$exit_statuses"
 rm -f "$exit_statuses"

--- a/parsing-stats/run-lang
+++ b/parsing-stats/run-lang
@@ -58,7 +58,10 @@ if [[ -z "$lang" ]]; then
 fi
 
 fetch_project_files() {
-  name=$(basename "${url%.git}")
+  # Note that project names are not unique
+  project=$(basename "${url%.git}")
+  org=$(basename $(dirname "${url%.git}"))
+  name="$org-$project"
   project_list+=" $name"
 
   mkdir -p tmp

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -193,7 +193,10 @@ let parsing_common ?(verbose = true) lang xs =
   in
   fullxs
   |> List.rev_map (fun file ->
-         pr2 (spf "[%s] processing %s" (Lang.to_lowercase_alnum lang) file);
+         pr2
+           (spf "%05.1fs: [%s] processing %s" (Sys.time ())
+              (Lang.to_lowercase_alnum lang)
+              file);
          let stat =
            try
              let res =
@@ -217,6 +220,10 @@ let parsing_common ?(verbose = true) lang xs =
 *)
 let parse_project ~verbose lang name files_or_dirs =
   let stat_list = parsing_common ~verbose lang files_or_dirs in
+  pr2
+    (spf "%05.1fs: [%s] done parsing %s" (Sys.time ())
+       (Lang.to_lowercase_alnum lang)
+       name);
   (name, stat_list)
 
 (* Json doesn't tolerate NaN values, so we use 1 instead. *)


### PR DESCRIPTION
When a "todo" exception is raised in a tree-sitter parser we tend to
dump the whole CST. These dumps can make the `stats.json` file very
large, which hangs the `-n` test:

    -  if [[ -e "$jsonfile" && -n "$(cat "$jsonfile")" ]]; then
    +  if [[ -s "$jsonfile" ]]; then

Helps #3538

test plan:
Go to https://app.circleci.com/pipelines/gh/returntocorp/semgrep?branch=parsing-stats
and check that the parsing-stats workflow now finishes in under 40
minutes instead of timing out, plus it archives the output of running
each language suite in a separate log file.

PR checklist:
- no need for documentation update
- no need for changelog update
