### PR TITLE
Better InvalidPattern exn, with better location

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -573,8 +573,12 @@ let parse_pattern lang_pattern str =
         res)
   with exn ->
     raise
-      (Parse_rule.InvalidPatternException
-         ("no-id", str, !lang, Common.exn_to_s exn))
+      (Parse_rule.InvalidPattern
+         ( "no-id",
+           str,
+           Rule.L (lang_pattern, []),
+           Common.exn_to_s exn,
+           Parse_info.fake_info "no loc" ))
   [@@profiling]
 
 (*e: function [[Main_semgrep_core.parse_pattern]] *)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -71,6 +71,11 @@ let xlang_of_string ?id:(id_opt = None) s =
                    (id, Common.spf "unsupported language: %s" s)))
       | Some l -> L (l, []))
 
+let string_of_xlang = function
+  | L (l, _) -> Lang.string_of_lang l
+  | LRegex -> "regex"
+  | LGeneric -> "generic"
+
 (*****************************************************************************)
 (* Extended patterns *)
 (*****************************************************************************)

--- a/semgrep-core/src/parsing/Parse_mini_rule.ml
+++ b/semgrep-core/src/parsing/Parse_mini_rule.ml
@@ -92,11 +92,12 @@ let parse file =
                      ] ->
                          let languages, lang = parse_languages ~id t langs in
                          let pattern =
-                           PR.parse_pattern ~id ~lang pattern_string
+                           PR.parse_pattern ~id ~lang
+                             ( pattern_string,
+                               Parse_info.fake_info pattern_string )
                          in
                          let severity =
-                           PR.parse_severity
-                             ~id:(id, Parse_info.fake_info "id")
+                           PR.parse_severity ~id
                              (sev, Parse_info.fake_info "sev")
                          in
                          {

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -319,7 +319,7 @@ let parse_options (key : key) value =
  * by the YAML parser do not correspond exactly to the content
  * in the YAML file. If the pattern is on a single line, as in
  *    pattern: foo($X)
- * then everything is fine, but if it's on multiple line as in
+ * then everything is fine, but if it's on multiple lines as in
  *    pattern: |
  *       foo($X);
  *       bar($X);

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -2,7 +2,8 @@
 
 exception InvalidLanguage of Rule.rule_id * string * Parse_info.t
 
-exception InvalidPatternException of string * string * string * string
+exception
+  InvalidPattern of Rule.rule_id * string * Rule.xlang * string * Parse_info.t
 
 exception InvalidRegexp of Rule.rule_id * string * Parse_info.t
 
@@ -21,8 +22,9 @@ val parse_metavar_cond :
 
 (* internals used by other parsers (e.g., Parse_mini_rule.ml) *)
 
-val parse_severity : id:string Rule.wrap -> string Rule.wrap -> Rule.severity
+val parse_severity : id:Rule.rule_id -> string Rule.wrap -> Rule.severity
 
-val parse_pattern : id:string -> lang:Lang.t -> string -> Pattern.t
+val parse_pattern :
+  id:Rule.rule_id -> lang:Lang.t -> string Rule.wrap -> Pattern.t
 
 (*e: semgrep/parsing/Parse_rule.mli *)

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -243,7 +243,8 @@ let json_of_exn e =
           ("error", J.String "invalid language");
           ("language", J.String language);
         ]
-  | Parse_rule.InvalidPatternException (pattern_id, pattern, lang, message) ->
+  | Parse_rule.InvalidPattern (pattern_id, pattern, xlang, message, _posTODO) ->
+      let lang = Rule.string_of_xlang xlang in
       J.Object
         [
           ("pattern_id", J.String pattern_id);

--- a/semgrep-core/tests/OTHER/errors/bad_pattern1.yaml
+++ b/semgrep-core/tests/OTHER/errors/bad_pattern1.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: test-template
+  patterns:
+  - pattern-inside: |
+        bar($Y);
+        other_stuff($X);
+  #ERROR: bad pattern
+  - pattern: 1 + 
+  message: Working!
+  severity: WARNING
+  languages: [javascript]

--- a/semgrep-core/tests/OTHER/errors/empty_languages.yaml
+++ b/semgrep-core/tests/OTHER/errors/empty_languages.yaml
@@ -1,5 +1,5 @@
 rules:
-#ERROR: empty languages
+#ERROR: empty languages, TODO, would be better closer to languages field
 - id: test-template
   patterns:
   - pattern: |

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -524,6 +524,7 @@ let metachecker_regression_tests =
           | Parse_rule.InvalidYaml (s, t)
           | Parse_rule.InvalidRegexp (_, s, t)
           | Parse_rule.InvalidLanguage (_, s, t)
+          | Parse_rule.InvalidPattern (_, _, _, s, t)
            ->
               raise (Parse_info.Other_error (s, t))
         );


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/3547

Note that the error location is not very precise right now; it will
point to the start of the pattern, but it's better that
before where it was pointing to the start of the yaml file.

test plan:
test file included




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date