### PR TITLE
remove update-docker calls

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,13 +47,6 @@ jobs:
           docker build -t "$tag" .
           docker push "$tag"
 
-      - name: update dev.semgrep.dev
-        run: curl --fail -X POST https://dev.semgrep.dev/api/admin/update-docker
-      - name: update staging.semgrep.dev
-        run: curl --fail -X POST https://staging.semgrep.dev/api/admin/update-docker
-      - name: update semgrep.dev
-        run: curl --fail -X POST https://semgrep.dev/api/admin/update-docker
-
       # Extend the semgrep image, changing the entry point to bash and
       # adding some utilities. This image is meant for internal uses
       # such as benchmarks.


### PR DESCRIPTION
update-docker no longer needs to be called (it's being removed from semgrep-app). The k8s job will pull the docker image.

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
