### PR TITLE
Show benchmark names in the automatic PR warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,4 +243,4 @@ jobs:
           jq . timing2.json
       - name: Compare timing infos
         run: |
-          python scripts/compare_perf.py semgrep/baseline_timing1.json semgrep/baseline_timing2.json semgrep/timing1.json semgrep/timing2.json ${{ secrets.GITHUB_TOKEN }} ${{ github.event.number }}
+          ./scripts/compare-perf semgrep/baseline_timing1.json semgrep/baseline_timing2.json semgrep/timing1.json semgrep/timing2.json ${{ secrets.GITHUB_TOKEN }} ${{ github.event.number }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,10 +237,10 @@ jobs:
           pipenv run semgrep --version
           pipenv run python -m semgrep --version
           pipenv run semgrep-core -version
-          pipenv run python3 ../perf/run-benchmarks --small-only --std-only --save-to timing1.txt
-          cat timing1.txt
-          pipenv run python3 ../perf/run-benchmarks --small-only --std-only --save-to timing2.txt
-          cat timing2.txt
+          pipenv run python3 ../perf/run-benchmarks --small-only --std-only --save-to timing1.json
+          jq . timing1.json
+          pipenv run python3 ../perf/run-benchmarks --small-only --std-only --save-to timing2.json
+          jq . timing2.json
       - name: Compare timing infos
         run: |
-          python scripts/compare_perf.py semgrep/baseline_timing1.txt semgrep/baseline_timing2.txt semgrep/timing1.txt semgrep/timing2.txt ${{ secrets.GITHUB_TOKEN }} ${{ github.event.number }}
+          python scripts/compare_perf.py semgrep/baseline_timing1.json semgrep/baseline_timing2.json semgrep/timing1.json semgrep/timing2.json ${{ secrets.GITHUB_TOKEN }} ${{ github.event.number }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,10 +213,10 @@ jobs:
           python3 -m semgrep --version
           export PATH=/github/home/.local/bin:$PATH
 
-          python3 perf/run-benchmarks --small-only --std-only --save-to semgrep/baseline_timing1.txt --no-time
-          cat semgrep/baseline_timing1.txt
-          python3 perf/run-benchmarks --small-only --std-only --save-to semgrep/baseline_timing2.txt --no-time
-          cat semgrep/baseline_timing2.txt
+          python3 perf/run-benchmarks --small-only --std-only --save-to semgrep/baseline_timing1.json --no-time
+          jq . semgrep/baseline_timing1.json
+          python3 perf/run-benchmarks --small-only --std-only --save-to semgrep/baseline_timing2.json --no-time
+          jq . semgrep/baseline_timing2.json
           pip3 uninstall -y semgrep
       - name: Download artifacts
         uses: actions/download-artifact@v1

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -400,7 +400,7 @@ def run_benchmarks(
         variants = STD_VARIANTS
 
     results_msgs = []
-    durations = ""
+    durations = []
     results: dict = {variant.name: [] for variant in variants}
     output_per_rule_json_results = RepositoryTimePerRule(
         output_file=output_time_per_rule_json
@@ -469,7 +469,12 @@ def run_benchmarks(
                 msg = f"{metric_name} = {duration:.3f} s"
                 print(msg)
                 results_msgs.append(msg)
-                durations += f"{duration:.3f}\n"
+                durations.append(
+                    {
+                        "name": name,
+                        "time": duration,
+                    }
+                )
                 results[variant.name].append(duration)
 
                 findings, timings = standardize_findings(semgrep_results, include_time)
@@ -499,9 +504,8 @@ def run_benchmarks(
 
     if summary_file_path:
         with chdir(called_dir):
-            summary_file = open(summary_file_path, "w+")
-            summary_file.write(durations)
-            summary_file.close()
+            with open(summary_file_path, "w") as f:
+                json.dump(durations, f)
 
     if plot_benchmarks:
         import matplotlib.pyplot as plt
@@ -578,7 +582,7 @@ def main() -> None:
         "--save-to",
         metavar="FILE_NAME",
         type=str,
-        help="save timing summary to the file given by the argument",
+        help="save timing summary to the json file given by the argument",
     )
     parser.add_argument(
         "--plot-benchmarks",
@@ -616,25 +620,26 @@ def main() -> None:
         if args.semgrep_core:
             semgrep_core_benchmark.run_benchmarks(args.dummy, args.upload)
         else:
+            config_file = (Path(called_dir) / args.config) if args.config else None
             run_benchmarks(
-                args.docker,
-                args.dummy,
-                args.small_only,
-                args.all,
-                args.internal,
-                args.gitlab,
-                args.std_only,
-                (Path(called_dir) / args.config) if args.config else None,
-                args.filter_corpus,
-                args.filter_variant,
-                args.hard_timeout,
-                args.output_time_per_rule_json,
-                args.plot_benchmarks,
-                args.upload,
-                not args.no_time,
-                args.clean,
-                args.save_to,
-                called_dir,
+                docker=args.docker,
+                dummy=args.dummy,
+                small_only=args.small_only,
+                all=args.all,
+                internal=args.internal,
+                gitlab=args.gitlab,
+                std_only=args.std_only,
+                config_file=config_file,
+                filter_corpus=args.filter_corpus,
+                filter_variant=args.filter_variant,
+                hard_timeout=args.hard_timeout,
+                output_time_per_rule_json=args.output_time_per_rule_json,
+                plot_benchmarks=args.plot_benchmarks,
+                upload=args.upload,
+                include_time=not args.no_time,
+                clean=args.clean,
+                summary_file_path=args.save_to,
+                called_dir=called_dir,
             )
 
 

--- a/scripts/compare-perf
+++ b/scripts/compare-perf
@@ -91,8 +91,8 @@ def main() -> None:
     total_baseline = 0.0
     total_latest = 0.0
     total_rel_dur = 0.0
-    min_rel_dur = 1.0
-    max_rel_dur = 1.0
+    min_rel_dur = 10000.0
+    max_rel_dur = 0.0
 
     # Accumulators of warning messages and error messages in the format
     # expected by GitHub comments.
@@ -108,6 +108,7 @@ def main() -> None:
         total_latest += latest_time
 
         rel_dur = latest_time / baseline_time
+        diff = latest_time - baseline_time
         total_rel_dur += rel_dur
         min_rel_dur = min(min_rel_dur, rel_dur)
         max_rel_dur = max(max_rel_dur, rel_dur)
@@ -119,18 +120,22 @@ def main() -> None:
 
         perc = 100 * (rel_dur - 1)
 
-        # Assert latest time is not more than 20% slower than baseline
-        # or is within a fixed "probably environmental" range
-        if latest_time > baseline_time * 1.2 and latest_time - baseline_time > 5.0:
+        # Assert latest time is not more than 30% slower than baseline.
+        if rel_dur > 1.3:
             errors += 1
-            messages.append(f"🚫 Benchmark {name} is too slow: " f"+{perc:.1f}%")
-        elif rel_dur > 1.1:
             messages.append(
-                f"⚠ Potential non-blocking slowdown in benchmark {name}: "
-                f"+{perc:.1f}%"
+                f"🚫 Benchmark {name} is too slow: " f"+{perc:.1f}% (+{diff:.3f} s)"
             )
-        elif rel_dur < 0.9:
-            messages.append(f"🔥 Potential speedup in benchmark {name}: " f"{perc:.1f}%")
+        elif rel_dur > 1.2:
+            messages.append(
+                f"⚠️  Potential non-blocking slowdown in benchmark {name}: "
+                f"+{perc:.1f}% (+{diff:.3f} s)"
+            )
+        elif rel_dur < 0.85:
+            messages.append(
+                f"🔥 Potential speedup in benchmark {name}: "
+                f"{perc:.1f}% ({diff:.3f} s)"
+            )
 
     mean_rel_dur = total_rel_dur / n
     mean_perc = 100 * (mean_rel_dur - 1)
@@ -149,9 +154,16 @@ def main() -> None:
     # Send PR comment if anything's weird or really wrong
     if messages:
         messages.append(f"{n} benchmarks, {mean_perc_str} on average.")
+        # TODO: link to the job output. It seems not possible at the moment
+        # without using the GitHub API.
+        # See https://github.community/t/github-actions-url-to-run/16029
         messages.append(
-            "Deviations greater than 10% from the baseline are reported. "
-            "See run output for more details."
+            "Individual deviations greater than 20% from the baseline are reported. "
+            "An individual performance degradation of over 30% or "
+            "an average degradation of over 7% is an error and will block "
+            "the pull request. "
+            "See run output for full results "
+            "('Show all checks' > 'Tests / semgrep benchmark tests' 'Details')."
         )
         msg = "\n\n".join(messages)
         print(f"Sending warnings and errors as a PR comment:\n{msg}")
@@ -164,8 +176,8 @@ def main() -> None:
     # Fail only after printing and sending all messages
     assert not errors
 
-    # Assert the rules in aggregate are not more than 6% slower than baseline
-    assert mean_rel_dur < 1.06
+    # Assert the rules in aggregate are not more than 7% slower than baseline
+    assert mean_rel_dur < 1.07
 
 
 if __name__ == "__main__":

--- a/scripts/compare-perf
+++ b/scripts/compare-perf
@@ -1,3 +1,13 @@
+#! /usr/bin/env python3
+#
+# Compare the benchmarks run for two different versions of semgrep.
+# It's meant to run within a semgrep pull request.
+# This posts a GitHub PR comment if a performance anomaly is detected.
+# It fails if the anomaly is really big.
+#
+# Testing: run locally with dummy GitHub credentials. It produces a log
+# that includes what would be posted as a PR comment.
+#
 import json
 import os
 import sys

--- a/scripts/compare-perf
+++ b/scripts/compare-perf
@@ -160,7 +160,7 @@ def main() -> None:
         messages.append(
             "Individual deviations greater than 20% from the baseline are reported. "
             "An individual performance degradation of over 30% or "
-            "an average degradation of over 7% is an error and will block "
+            "a global degradation of over 7% is an error and will block "
             "the pull request. "
             "See run output for full results "
             "('Show all checks' > 'Tests / semgrep benchmark tests' 'Details')."

--- a/scripts/compare-perf
+++ b/scripts/compare-perf
@@ -5,8 +5,7 @@
 # This posts a GitHub PR comment if a performance anomaly is detected.
 # It fails if the anomaly is really big.
 #
-# Testing: run locally with dummy GitHub credentials. It produces a log
-# that includes what would be posted as a PR comment.
+# Testing: run the companion 'test-compare-perf' script.
 #
 import json
 import os

--- a/scripts/test-compare-perf
+++ b/scripts/test-compare-perf
@@ -1,0 +1,47 @@
+#! /usr/bin/env bash
+#
+# Test the 'compare-perf' locally.
+#
+set -eu
+
+mkdir -p tmp
+
+cat > tmp/baseline1.json <<EOF
+[
+{"name": "semgrep.bench.a.std", "time": 1.0},
+{"name": "semgrep.bench.b.std", "time": 2.0},
+{"name": "semgrep.bench.c.std", "time": 4.0},
+{"name": "semgrep.bench.d.std", "time": 99.0}
+]
+EOF
+
+cat > tmp/baseline2.json <<EOF
+[
+{"name": "semgrep.bench.a.std", "time": 1.02},
+{"name": "semgrep.bench.b.std", "time": 2.01},
+{"name": "semgrep.bench.c.std", "time": 7.7},
+{"name": "semgrep.bench.d.std", "time": 95}
+]
+EOF
+
+cat > tmp/latest1.json <<EOF
+[
+{"name": "semgrep.bench.a.std", "time": 0.99},
+{"name": "semgrep.bench.b.std", "time": 2.41},
+{"name": "semgrep.bench.c.std", "time": 3.2},
+{"name": "semgrep.bench.d.std", "time": 167}
+]
+EOF
+
+cat > tmp/latest2.json <<EOF
+[
+{"name": "semgrep.bench.a.std", "time": 0.98},
+{"name": "semgrep.bench.b.std", "time": 2.43},
+{"name": "semgrep.bench.c.std", "time": 3.1},
+{"name": "semgrep.bench.d.std", "time": 180}
+]
+EOF
+
+exec_path=$(dirname "$0")
+"$exec_path"/compare-perf \
+  tmp/baseline1.json tmp/baseline2.json tmp/latest1.json tmp/latest2.json xxx

--- a/scripts/test-compare-perf
+++ b/scripts/test-compare-perf
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 #
-# Test the 'compare-perf' locally.
+# Test the 'compare-perf' script locally.
 #
 set -eu
 


### PR DESCRIPTION
Now we'll see which benchmark fails. This changes the output format of 'run-benchmarks --save-to xxx' to json.

Test plan: run `./scripts/test-compare-perf` and inspect the output (it should fail from a fatal threshold being exceeded)

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
