### PR TITLE
[C/C++] Prevent stack overflows with tailrec functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Fixed
+- C/C++: Fixed stack overflows (segmentation faults) when processing very large
+  files (#3538)
+
 ### Changed
 - Added precise error location for the semgrep metachecker, to detect for example
   duplicate patterns in a rule

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -33,7 +33,7 @@ let id x = x
 
 let option = Common.map_opt
 
-let list = List.map
+let list = Common.map
 
 let either f g x = match x with Left x -> Left (f x) | Right x -> Right (g x)
 


### PR DESCRIPTION
Helps #3538

test plan:
1. make -C semgrep-core test install
2. parsing-stats/run-lang c
  #^ now works



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
