### PR TITLE
Detect duplicate key in YAML dictionary in our semgrep rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+- Detect duplicate keys in YAML dictionaries in semgrep rules when parsing a rule
+  (e.g., detect multiple 'metavariable' inside one 'metavariable-regex')
+
 ### Changed
 - Added precise error location for the semgrep metachecker, to detect for example
   duplicate patterns in a rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 - Detect duplicate keys in YAML dictionaries in semgrep rules when parsing a rule
   (e.g., detect multiple 'metavariable' inside one 'metavariable-regex')
+  
 ### Fixed
 - C/C++: Fixed stack overflows (segmentation faults) when processing very large
   files (#3538)

--- a/semgrep-core/tests/OTHER/errors/ignored_metavar_regex.yaml
+++ b/semgrep-core/tests/OTHER/errors/ignored_metavar_regex.yaml
@@ -1,0 +1,25 @@
+rules:
+- id: eslint.detect-object-injection
+  patterns:
+    - pattern: $O[$ARG]
+    - pattern-not: $O["..."]
+    - pattern-not-inside: |
+        $ARG = [$V];
+        ...
+    - pattern-not-inside: |
+        $ARG = $V;
+        ...
+    - metavariable-regex:
+        metavariable: "$V"
+        regex: "[0-9]+"
+        #ERROR: duplicate key in dictionary! Bad YAML
+        metavariable: "$ARG"
+        regex: "[^0-9]+"
+  message: "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution."
+  languages:
+    - javascript
+    - typescript
+  severity: WARNING
+  metadata:
+    cwe: "CWE-94: Improper Control of Generation of Code ('Code Injection')"
+    


### PR DESCRIPTION
This will help avoid silly mistakes.

Test plan:
test file included, also
```
[pad@yrax yy (check_duplicate_field)]$ yy -check_rules ~/yy/tests/OTHER/errors/ignored_metavar_regex.yaml
+ /home/pad/yy/_build/default/src/cli/Main.exe -check_rules /home/pad/yy/tests/OTHER/errors/ignored_metavar_regex.yaml
[0.039  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.040  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -check_rules /home/pad/yy/tests/OTHER/errors/ignored_metavar_regex.yaml
[0.040  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.59.0-6-ga525cec1-dirty, pfff: 0.42
[0.040  Info       Main.Check_rule      ] processing /home/pad/yy/tests/OTHER/errors/ignored_metavar_regex.yaml
Uncaught exception:

  Parse_rule.InvalidYaml("duplicate key 'metavariable' in dictionary. You should use multiple metavariable-regex", _)

Raised at Parse_rule.parse_extra in file "src/parsing/Parse_rule.ml", line 498, characters 10-87
```




PR checklist:
- [ ] documentation is up to date
- [x] changelog is up to date