### PR TITLE
Update PRIVACY.md

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -83,7 +83,10 @@ Using a deterministic hash, however, implies:
 * An entity that independently knows the value of an input datum AND who has access to r2c's metrics data could access metrics for that known datum
 
 r2c will:
-* Protect these metrics data using application-security best practices
+* Treat collected metrics data as secret, using application-security best practices, including (but not limited to)
+  * Encryption during transit and rest
+  * Strict access control to data-storage systems
+  * Application-security-policy requirements for third parties (e.g. cloud-service providers; see "data sharing" below)
 * Only correlate hashed data to input data when these inputs are publicly known (e.g. publicly available project URLs for open-source projects)
 
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Semgrep Privacy Policy
 
-Semgrep may collect non-identifiable aggregate metrics to help improve the product. This document describes:
+Semgrep may collect aggregate metrics to help improve the product. This document describes:
 
 * the principles that guide our data-collection decisions
 * how to opt-in to Semgrep’s metrics
@@ -13,7 +13,7 @@ These principles inform our decisions around data collection:
 
 1. **Transparency**: Collect and use data in a way that is clearly explained to the user and benefits them
 2. **User control**: Put users in control of their data at all times
-3. **Limited data**: Collect what is needed, de-identify where possible, and delete when no longer necessary
+3. **Limited data**: Collect what is needed, pseduoanonymize where possible, and delete when no longer necessary
 
 ## Opt-in behavior
 
@@ -23,11 +23,11 @@ Note that certain Semgrep integrators set this environment variable by default. 
 
 ## Collected data
 
-Semgrep collects non-identifiable data to improve the user experience. Four types of data are collected:
+Semgrep collects data to improve the user experience. Four types of data are collected:
 
 ### Environmental
 
-Environmental data provides contextual data about Semgrep’s runtime environment, as well as information that helps debug any issues users may be facing; e.g.
+Environmental data provide contextual data about Semgrep’s runtime environment, as well as information that helps debug any issues users may be facing; e.g.
 
 * How long the command took to run
 * The version of Semgrep
@@ -37,7 +37,7 @@ Environmental data provides contextual data about Semgrep’s runtime environmen
 
 ### Performance
 
-Performance data enables understanding of which rules and types of files are slow in the aggregate so r2c can improve the Semgrep program-analysis engine, query optimizer, and debug slow rules; e.g.
+Performance data enable understanding of which rules and types of files are slow in the aggregate so r2c can improve the Semgrep program-analysis engine, query optimizer, and debug slow rules; e.g.
 
 * Runtime duration
 * Total number of rules
@@ -92,7 +92,7 @@ r2c will:
 
 ## Description of fields
 
-|Category   |Field  |Description    |Use Case   |Example Data   |Type   |
+|Category   |Field  |Description    |Use Case   |Example Datum   |Type   |
 |---    |---    |---    |---    |---    |---    |
 |Environment    |   |   |   |   |   |
 |   |Timestamp  |Time when the event fired                              |Understanding tool usage over time                     |2021-05-10T21:05:06+00:00  |String |

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -71,7 +71,9 @@ We strive to balance our desire to collect data for improving Semgrep with our u
 
 ### Pseudoanonymization
 
-Certain identifying data (e.g. project URLs) are pseudoanonymized before being sent to the r2c backend. "Pseudoanonymized" means the data are transformed using a deterministic cryptographically secure hash.
+Certain identifying data (e.g. project URLs) are pseudoanonymized before being sent to the r2c backend.
+
+"Pseudoanonymized" means the data are transformed using a deterministic cryptographically secure hash. When the input data are unknown, this hash is expensive to reverse. However, when input data are known, a reverse dictionary of identifiers to hashes can be built. Hence, data are anonymous only when the source values are unknown.
 
 We use a deterministic hash to:
 * Track performance and value improvements over succesive runs on projects

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -125,7 +125,7 @@ r2c will:
 
 ### Sample metrics
 
-This is a sample blob of the non-identifiable aggregate metrics described above:
+This is a sample blob of the aggregate metrics described above:
 
 ```
 {

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -134,10 +134,7 @@ This is a sample blob of the non-identifiable aggregate metrics described above:
         "runTime": 37.1234233823,
         "numRules": 2,
         "numTargets": 573,
-        "totalBytesScanned": 33938923
-    },
-    "errors": {
-        "returnCode": 1,
+        "totalBytesScanned": 33938923,
         "ruleStats": [{
           "ruleHash": "7c43c962dfdbc52882f80021e4d0ef2396e6a950867e81e5f61e68390ee9e166",
           "parseTime": 0,
@@ -151,7 +148,10 @@ This is a sample blob of the non-identifiable aggregate metrics described above:
           "parseTime": 0.013289928436279297,
           "matchTime": 0.05480456352233887,
           "runTime": 0.20836973190307617
-        }],
+        }]
+    },
+    "errors": {
+        "returnCode": 1,
         "errors": ["UnknownLanguage"],
         "warnings": ["MaxFileSizeExceeded", "TimeoutExceeded"]
     },


### PR DESCRIPTION
This commit
- Updates `PRIVACY.md` to match the truth in `semgrep/semgrep/metric_manager.py`
- Clarify the privacy implications of pseudoanonymization
- Note that integrators may use opt-out metrics
