### PR TITLE
report precise error location on TAB indentation pb in YAML file

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1872,9 +1872,9 @@ let special_multivardef_pattern = AST_generic_.special_multivardef_pattern
 (*****************************************************************************)
 
 (*s: exception [[AST_generic.Error]] *)
-(* this can be used in the xxx_to_generic.ml file to signal limitations,
- * and can be captured in Error_code.exn_to_error to pinpoint the error
- * location.
+(* This can be used in the xxx_to_generic.ml file to signal limitations.
+ * This is captured in Main.exn_to_error to pinpoint the error location.
+ * alt: reuse Parse_info.Ast_builder_error exn.
  *)
 exception Error of string * Parse_info.t
 

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -157,11 +157,13 @@ let check_files fparser xs =
   fullxs
   |> List.iter (fun file ->
          logger#info "processing %s" file;
-         let rs = fparser file in
-         rs
-         |> List.iter (fun file ->
-                let errs = check file in
-                errs |> List.iter (fun err -> pr2 (E.string_of_error err))))
+         try
+           let rs = fparser file in
+           rs
+           |> List.iter (fun file ->
+                  let errs = check file in
+                  errs |> List.iter (fun err -> pr2 (E.string_of_error err)))
+         with exn -> pr2 (E.string_of_error (E.exn_to_error file exn)))
 
 let stat_files fparser xs =
   let fullxs =

--- a/semgrep-core/tests/OTHER/errors/bad_indentation.yaml
+++ b/semgrep-core/tests/OTHER/errors/bad_indentation.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test-template
+  patterns:
+  - pattern: foo($X)
+  #ERROR: bad indentation below, use spaces not TAB
+  - pattern-inside: |
+        bar($Y);
+        # the TAB is below, but the error is reported earlier by the yaml parser
+	other_stuff($X);
+  message: Working!
+  severity: WARNING
+  languages: [javascript]

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -519,7 +519,9 @@ let metachecker_regression_tests =
               Error_code.g_errors := errs @ !Error_code.g_errors
             )
           with
-          (* convert to things handled by E.try_with_exn_to_error *)
+          (* convert to something handled by E.try_with_exn_to_error.
+           * coupling: JSON_report.json_of_exn
+           *)
           | Parse_rule.InvalidRule (_, s, t)
           | Parse_rule.InvalidYaml (s, t)
           | Parse_rule.InvalidRegexp (_, s, t)


### PR DESCRIPTION
I made this mistake recently and the yaml parser in semgrep-core
could not tell me where the TAB was.

test plan:
test file included, and also
```
[pad@yrax yy (develop)]$ yy -check_rules tests/OTHER/errors/bad_indentation.yaml
+ /home/pad/yy/_build/default/src/cli/Main.exe -check_rules tests/OTHER/errors/bad_indentation.yaml
[0.041  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.041  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -check_rules tests/OTHER/errors/bad_indentation.yaml
[0.041  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.59.0-11-g19dda48f-dirty, pfff: 0.42
[0.041  Info       Main.Check_rule      ] processing tests/OTHER/errors/bad_indentation.yaml
tests/OTHER/errors/bad_indentation.yaml:6:4: Other parsing error: (approximate error location; error nearby after) error calling parser: found a tab character where an indentation space is expected character 0 position 0 returned: 0
```




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date