### PR TITLE
Match GHA workflow name with the corresponding config file name

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,4 +1,4 @@
-name: Build Tests
+name: build-tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,5 @@
-name: Push Semgrep Docker Image
+# Push Semgrep Docker Image
+name: docker
 
 on:
   workflow_dispatch:

--- a/.github/workflows/homebrew-core-head.yml
+++ b/.github/workflows/homebrew-core-head.yml
@@ -1,4 +1,5 @@
-name: Verify Homebrew Core Formula Works
+# Verify Homebrew Core Formula Works
+name: homebrew-core-head
 
 on:
   schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: lint
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-name: Create Draft Release
+# Create Draft Release
+name: release
 
 on:
   push:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,7 @@
 # to run an action that uses the SEMGREP_APP_TOKEN secret
 # Note that any modification of this file in a PR does not reflect on said PR
 # Changes must be merged to develop first
-name: Lint
+name: semgrep
 on:
   workflow_dispatch:
   pull_request_target:

--- a/.github/workflows/semgrepdep.yml
+++ b/.github/workflows/semgrepdep.yml
@@ -1,4 +1,4 @@
-name: Semgrepdep
+name: semgrepdep
 
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,4 +1,5 @@
-name: Validate a Release
+# Validate a Release
+name: validate-release
 
 on:
   push:


### PR DESCRIPTION
There were two workflows named "Lint", and other workflows whose name didn't obviously match their file name, which I find confusing. This PR sets the workflow names to be exactly the file name so they can be found easily. We could rename them if that makes things clearer, but let's avoid discrepancies between file name and workflow name.

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
