### PR TITLE
Wrap the parsing Timeout exception from into an Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 - Detect duplicate keys in YAML dictionaries in semgrep rules when parsing a rule
   (e.g., detect multiple 'metavariable' inside one 'metavariable-regex')
-  
+
 ### Fixed
 - C/C++: Fixed stack overflows (segmentation faults) when processing very large
   files (#3538)
 - JS: Fixed stack overflows (segmentation faults) when processing very large
   files (#3538)
 - JS: Detect numeric object keys `1` and `0x1` as equal (#3579)
+- Fewer parsing timeouts due to a fix in the retry logic involving two
+  different parsers. Affects JavaScript and TypeScript, among
+  others. (#3599)
 
 ### Changed
 - Added precise error location for the semgrep metachecker, to detect for example

--- a/parsing-stats/log_config.json.ignored
+++ b/parsing-stats/log_config.json.ignored
@@ -1,0 +1,13 @@
+{
+    "loggers":
+        [
+            { "name": "Main", "level": "debug",
+              "handlers": [ {"cli_err": {"level" : "debug"}} ]
+            },
+            { "name": "Main.Parse_target", "level": "debug" },
+            { "name": "Main.Test_parsing", "level": "debug" }
+        ],
+   "handlers": {
+        "file_handlers": { "logs_folder" : "logs", "truncate" : false }
+    }
+}

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -169,6 +169,7 @@ let test_parse_tree_sitter lang xs =
                  pr2 (spf "%s: exn = %s" file (Common.exn_to_s exn));
                  PI.bad_stat file
              in
+             logger#info "stat: %s" (PI.summary_of_stat stat);
              Common.push stat stat_list));
   Parse_info.print_parsing_stat_list !stat_list;
   ()
@@ -211,6 +212,7 @@ let parsing_common ?(verbose = true) lang xs =
              | Timeout -> { (PI.bad_stat file) with have_timeout = true }
              | _else_ -> PI.bad_stat file)
          in
+         pr2 (spf "stat: %s" (PI.summary_of_stat stat));
          stat)
 
 (*


### PR DESCRIPTION
Wrap the parsing Timeout exception from into an Error like other exceptions so as to not break the retry logic. I hope this doesn't break other stuff.

The problem we have in parsing stats, as well as in production (presumably) is the following:
1. tree-sitter parser returns Partial result
2. pfff parser times out
3. the whole result is marked as timed out and failed

The fix makes step (3) return the Partial result instead of an Error.

**Update**:
I see two problems right now:
* The default timeout is "no timeout" and I don't see why or where the `Timeout` exception is raised when running `-parsing-stats`.
* We're not supposed to resume any work after reaching the time limit ~~since~~ if it's a global timeout rather than just a parsing timeout. We could mitigate this by allotting half of the "timeout" setting to parsing but it gets complicated.

**Update 2**:

1. In another branch I changed the interface of the timeout wrapper so that it _returns_ an option rather than raising an exception. This solves the problem cleanly, so we no longer needs this branch.
2. I found there's a 10-second timeout for two different parsers. I'm leaving them in place.

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
