### PR TITLE
Use new interface for timeouts

### DIFF
--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -273,7 +273,7 @@ let parse_metavar_cond key s =
     | AST_generic.E e -> e
     | _ -> error_at_key key "not an expression"
   with
-  | Timeout -> raise Timeout
+  | Timeout _ as e -> raise e
   | UnixExit n -> raise (UnixExit n)
   | exn -> error_at_key key ("exn: " ^ Common.exn_to_s exn)
 
@@ -350,7 +350,7 @@ let parse_pattern ~id ~lang (pattern, t) =
      *)
     any
   with
-  | Timeout -> raise Timeout
+  | Timeout _ as e -> raise e
   | UnixExit n -> raise (UnixExit n)
   (* TODO: capture and adjust pos of parsing error exns instead of using [t] *)
   | exn ->

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -88,7 +88,7 @@ let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =
             let res = f file in
             Ok res
           with
-          | Timeout -> raise Timeout
+          | Timeout _ as e -> raise e
           | exn ->
               (* TODO: print where the exception was raised or reraise *)
               logger#debug "exn (%s) with Pfff parser" (Common.exn_to_s exn);
@@ -115,7 +115,7 @@ let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =
             let err = E.exn_to_error file exn in
             Partial (ast, [ err ], stat)
       with
-      | Timeout -> raise Timeout
+      | Timeout _ as e -> raise e
       | exn ->
           (* TODO: print where the exception was raised or reraise *)
           logger#debug "exn (%s) with TreeSitter parser" (Common.exn_to_s exn);

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -185,7 +185,7 @@ let test_parse_tree_sitter lang xs =
    semgrep scans.
 *)
 let parsing_common ?(verbose = true) lang xs =
-  let timeout_seconds = 10 in
+  let timeout_seconds = 10.0 in
   let xs = List.map Common.fullpath xs in
   let fullxs =
     Lang.files_of_dirs_or_files lang xs
@@ -199,17 +199,20 @@ let parsing_common ?(verbose = true) lang xs =
               file);
          let stat =
            try
-             let res =
-               Common.timeout_function ~verbose:false timeout_seconds (fun () ->
+             match
+               Common.set_timeout ~verbose:false
+                 ~name:"Test_parsing.parsing_common" timeout_seconds (fun () ->
                    Parse_target.parse_and_resolve_name_use_pfff_or_treesitter
                      lang file)
-             in
-             res.Parse_target.stat
-           with exn -> (
-             if verbose then pr2 (spf "%s: exn = %s" file (Common.exn_to_s exn));
-             match exn with
-             | Timeout -> { (PI.bad_stat file) with have_timeout = true }
-             | _else_ -> PI.bad_stat file)
+             with
+             | Some res -> res.Parse_target.stat
+             | None -> { (PI.bad_stat file) with have_timeout = true }
+           with
+           | Timeout _ -> assert false
+           | exn ->
+               if verbose then
+                 pr2 (spf "%s: exn = %s" file (Common.exn_to_s exn));
+               PI.bad_stat file
          in
          stat)
 


### PR DESCRIPTION
`set_timeout` now returns an option rather than raising an exception.

See https://github.com/returntocorp/pfff/pull/458 for details.

Makes https://github.com/returntocorp/semgrep/pull/3599 unnecessary.

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
