### PR TITLE
core: Avoid crashing due to fake tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Go: Match import module paths correctly (#3484)
+- core: Do not crash when is not possible to compute range info
 
 ## [0.60.0](https://github.com/returntocorp/semgrep/releases/tag/v0.60.0) - 2021-07-27
 
@@ -28,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - taint-mode: Do not crash when is not possible to compute range info
 - Rust: recognize ellipsis in macro calls patterns (#3600)
 - Ruby: represent correctly a.(b) in the AST (#3603)
+- Rust: recognize ellipsis in macro calls patterns
 
 ### Changed
 - Added precise error location for the semgrep metachecker, to detect for example

--- a/semgrep-core/src/core/Metavariable.ml
+++ b/semgrep-core/src/core/Metavariable.ml
@@ -113,8 +113,9 @@ let program_of_mvalue : mvalue -> G.program option =
       None
 
 let range_of_mvalue mval =
-  let tok_start, tok_end = Visitor_AST.range_of_any (mvalue_to_any mval) in
-  Range.range_of_token_locations tok_start tok_end
+  let ( let* ) = Common.( >>= ) in
+  let* tok_start, tok_end = Visitor_AST.range_of_any_opt (mvalue_to_any mval) in
+  Some (Range.range_of_token_locations tok_start tok_end)
 
 let ii_of_mval x = x |> mvalue_to_any |> Visitor_AST.ii_of_any
 

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1294,9 +1294,3 @@ let range_of_tokens tokens =
 let range_of_any_opt any =
   extract_ranges (fun visitor -> visitor any)
   [@@profiling]
-
-let range_of_any any =
-  match range_of_any_opt any with
-  | Some range -> range
-  | None -> failwith "no tokens found"
-  [@@profiling]

--- a/semgrep-core/src/core/ast/Visitor_AST.mli
+++ b/semgrep-core/src/core/ast/Visitor_AST.mli
@@ -62,9 +62,6 @@ val first_info_of_any : AST_generic.any -> Parse_info.t
 
 val range_of_tokens : Parse_info.t list -> Parse_info.t * Parse_info.t
 
-val range_of_any :
-  AST_generic.any -> Parse_info.token_location * Parse_info.token_location
-
 val range_of_any_opt :
   AST_generic.any ->
   (Parse_info.token_location * Parse_info.token_location) option

--- a/semgrep-core/src/engine/Match_patterns.ml
+++ b/semgrep-core/src/engine/Match_patterns.ml
@@ -167,13 +167,20 @@ let match_rules_and_recurse config (file, hook, matches) rules matcher k any x =
            matches_with_env
            |> List.iter (fun (env : MG.tin) ->
                   let env = env.mv.full_env in
-                  let range_loc = V.range_of_any (any x) in
-                  let tokens = lazy (V.ii_of_any (any x)) in
-                  let rule_id = rule_id_of_mini_rule rule in
-                  Common.push
-                    { PM.rule_id; file; env; range_loc; tokens }
-                    matches;
-                  hook env tokens));
+                  match V.range_of_any_opt (any x) with
+                  | None ->
+                      (* TODO: Report a warning to the user? *)
+                      logger#error
+                        "Cannot report match because we lack range info: %s"
+                        (show_any (any x));
+                      ()
+                  | Some range_loc ->
+                      let tokens = lazy (V.ii_of_any (any x)) in
+                      let rule_id = rule_id_of_mini_rule rule in
+                      Common.push
+                        { PM.rule_id; file; env; range_loc; tokens }
+                        matches;
+                      hook env tokens));
   (* try the rules on substatements and subexpressions *)
   k x
 
@@ -287,13 +294,21 @@ let check2 ~hook config rules equivs (file, lang, ast) =
                      matches_with_env
                      |> List.iter (fun (env : MG.tin) ->
                             let env = env.mv.full_env in
-                            let range_loc = V.range_of_any (E x) in
-                            let tokens = lazy (V.ii_of_any (E x)) in
-                            let rule_id = rule_id_of_mini_rule rule in
-                            Common.push
-                              { PM.rule_id; file; env; range_loc; tokens }
-                              matches;
-                            hook env tokens));
+                            match V.range_of_any_opt (E x) with
+                            | None ->
+                                (* TODO: Report a warning to the user? *)
+                                logger#error
+                                  "Cannot report match because we lack range \
+                                   info: %s"
+                                  (show_expr x);
+                                ()
+                            | Some range_loc ->
+                                let tokens = lazy (V.ii_of_any (E x)) in
+                                let rule_id = rule_id_of_mini_rule rule in
+                                Common.push
+                                  { PM.rule_id; file; env; range_loc; tokens }
+                                  matches;
+                                hook env tokens));
             (* try the rules on subexpressions *)
             (* this can recurse to find nested matching inside the
              * matched code itself *)
@@ -317,13 +332,21 @@ let check2 ~hook config rules equivs (file, lang, ast) =
                        matches_with_env
                        |> List.iter (fun (env : MG.tin) ->
                               let env = env.mv.full_env in
-                              let range_loc = V.range_of_any (S x) in
-                              let tokens = lazy (V.ii_of_any (S x)) in
-                              let rule_id = rule_id_of_mini_rule rule in
-                              Common.push
-                                { PM.rule_id; file; env; range_loc; tokens }
-                                matches;
-                              hook env tokens));
+                              match V.range_of_any_opt (S x) with
+                              | None ->
+                                  (* TODO: Report a warning to the user? *)
+                                  logger#error
+                                    "Cannot report match because we lack range \
+                                     info: %s"
+                                    (show_stmt x);
+                                  ()
+                              | Some range_loc ->
+                                  let tokens = lazy (V.ii_of_any (S x)) in
+                                  let rule_id = rule_id_of_mini_rule rule in
+                                  Common.push
+                                    { PM.rule_id; file; env; range_loc; tokens }
+                                    matches;
+                                  hook env tokens));
               k x
             in
             (* If bloom_filter is not enabled, always visit the statement *)

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -41,32 +41,33 @@ let match_selector ?err:(msg = "no match") (sel_opt : selector option) :
 let select_from_ranges file (sel_opt : selector option) (ranges : RM.ranges) :
     RM.ranges =
   let pattern_match_from_binding selector (mvar, mval) =
-    {
-      PM.rule_id = fake_rule_id (selector.pid, fst selector.pstr);
-      PM.file;
-      PM.range_loc = Visitor_AST.range_of_any (M.mvalue_to_any mval);
-      PM.tokens = lazy (M.ii_of_mval mval);
-      PM.env = [ (mvar, mval) ];
-    }
+    match Visitor_AST.range_of_any_opt (M.mvalue_to_any mval) with
+    | None -> None
+    | Some range_loc ->
+        Some
+          {
+            PM.rule_id = fake_rule_id (selector.pid, fst selector.pstr);
+            PM.file;
+            PM.range_loc;
+            PM.tokens = lazy (M.ii_of_mval mval);
+            PM.env = [ (mvar, mval) ];
+          }
   in
   let select_from_range range =
     match sel_opt with
-    | None -> [ range ]
+    | None -> Some range
     | Some selector -> (
         match
           List.find_opt
             (fun (mvar, _mval) -> M.equal_mvar selector.mvar mvar)
             range.RM.mvars
         with
-        | None -> []
+        | None -> None
         | Some binding ->
-            (* make a pattern match, then use RM.match_result_to_range *)
-            [
-              RM.match_result_to_range
-                (pattern_match_from_binding selector binding);
-            ])
+            pattern_match_from_binding selector binding
+            |> Common.map_opt RM.match_result_to_range)
   in
-  List.flatten (List.map select_from_range ranges)
+  Common.map_filter select_from_range ranges
 
 let selector_equal s1 s2 = s1.mvar = s2.mvar
 

--- a/semgrep-core/src/engine/Tainting_generic.ml
+++ b/semgrep-core/src/engine/Tainting_generic.ml
@@ -113,12 +113,20 @@ let check hook default_config (taint_rules : (Rule.rule * Rule.taint_spec) list)
              }
            in
            let found_tainted_sink code _env =
-             let range_loc = V.range_of_any code in
-             let tokens = lazy (V.ii_of_any code) in
-             (* todo: use env from sink matching func?  *)
-             Common.push
-               { PM.rule_id; file; range_loc; tokens; env = [] }
-               matches
+             match V.range_of_any_opt code with
+             | None ->
+                 (* TODO: Report a warning to the user? *)
+                 logger#error
+                   "Cannot report taint-mode match because we lack range info: \
+                    %s"
+                   (G.show_any code);
+                 ()
+             | Some range_loc ->
+                 let tokens = lazy (V.ii_of_any code) in
+                 (* todo: use env from sink matching func?  *)
+                 Common.push
+                   { PM.rule_id; file; range_loc; tokens; env = [] }
+                   matches
            in
            taint_config_of_rule default_config equivs file (ast, []) rule
              taint_spec found_tainted_sink)

--- a/semgrep-core/src/optimizing/Stmts_match_span.ml
+++ b/semgrep-core/src/optimizing/Stmts_match_span.ml
@@ -68,8 +68,13 @@ let location x =
   match x with
   | Empty -> None
   | Span { left_stmts; right_stmts } ->
-      let min_loc, _ = Visitor_AST.range_of_any (AST_generic.Ss left_stmts) in
-      let _, max_loc = Visitor_AST.range_of_any (AST_generic.Ss right_stmts) in
+      let ( let* ) = Common.( >>= ) in
+      let* min_loc, _ =
+        Visitor_AST.range_of_any_opt (AST_generic.Ss left_stmts)
+      in
+      let* _, max_loc =
+        Visitor_AST.range_of_any_opt (AST_generic.Ss right_stmts)
+      in
       Some (min_loc, max_loc)
   [@@profiling]
 

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -370,11 +370,11 @@ let parse_xpattern env e =
    * the yaml parser has tabs removed). Will include a note to this effect when
    * I make my "add ranges to patterns" PR.
    *)
-  let start, end_ = Visitor_AST.range_of_any (G.E e) in
-  let _s_range =
-    (PI.mk_info_of_loc start, PI.mk_info_of_loc end_)
-    (* TODO put in *)
-  in
+  (* let start, end_ = Visitor_AST.range_of_any (G.E e) in
+     let _s_range =
+       (PI.mk_info_of_loc start, PI.mk_info_of_loc end_)
+       (* TODO put in *)
+     in *)
   match env.languages with
   | R.L (lang, _) ->
       R.mk_xpat (Sem (parse_pattern ~id:env.id ~lang (s, t), lang)) (s, t)

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -86,42 +86,43 @@ let position_range min_loc max_loc =
 (*e: function [[JSON_report.json_range]] *)
 
 (*s: function [[JSON_report.range_of_any]] *)
-let range_of_any startp_of_match_range any =
+let range_of_any_opt startp_of_match_range any =
   let empty_range = (startp_of_match_range, startp_of_match_range) in
   match any with
   (* those are ok and we don't want to generate a NoTokenLocation for those.
    * alt: change Semgrep.atd to make optional startp/endp for metavar_value.
    *)
-  | Ss [] | Args [] -> empty_range
+  | Ss [] | Args [] -> Some empty_range
   | _ ->
-      let min_loc, max_loc = V.range_of_any any in
+      let ( let* ) = Common.( >>= ) in
+      let* min_loc, max_loc = V.range_of_any_opt any in
       let startp, endp = position_range min_loc max_loc in
-      (startp, endp)
+      Some (startp, endp)
 
 (*e: function [[JSON_report.range_of_any]] *)
 
 (*s: function [[JSON_report.json_metavar]] *)
 let metavars startp_of_match_range (s, mval) =
   let any = MV.mvalue_to_any mval in
-  let startp, endp =
-    try range_of_any startp_of_match_range any
-    with Parse_info.NoTokenLocation _exn ->
+  match range_of_any_opt startp_of_match_range any with
+  | None ->
       raise
         (Parse_info.NoTokenLocation
            (spf "NoTokenLocation with metavar %s, close location = %s" s
               (SJ.string_of_position startp_of_match_range)))
-  in
-  ( s,
-    {
-      ST.start = startp;
-      end_ = endp;
-      abstract_content =
-        any |> V.ii_of_any
-        |> List.filter PI.is_origintok
-        |> List.sort Parse_info.compare_pos
-        |> List.map PI.str_of_info |> Matching_report.join_with_space_if_needed;
-      unique_id = unique_id any;
-    } )
+  | Some (startp, endp) ->
+      ( s,
+        {
+          ST.start = startp;
+          end_ = endp;
+          abstract_content =
+            any |> V.ii_of_any
+            |> List.filter PI.is_origintok
+            |> List.sort Parse_info.compare_pos
+            |> List.map PI.str_of_info
+            |> Matching_report.join_with_space_if_needed;
+          unique_id = unique_id any;
+        } )
 
 (*e: function [[JSON_report.json_metavar]] *)
 


### PR DESCRIPTION
Hopefully one day we can guarantee that every expression has a known
range. But, in the meantime, if we cannot get a range, we should handle
the situation more gracefully.

Let's remove Visitor_AST.range_of_any in favor of the safer
Visitor_AST.range_of_any_opt. This will force us to think what to do
in each situation where range info is not available. For now we just
log an error and move to something else.

Follows: #3603

test plan:
make test

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
