### PR TITLE
Run version check after scanning not before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Run version check and print upgrade message after scan instead of before
+
 ## [0.60.0](https://github.com/returntocorp/semgrep/releases/tag/v0.60.0) - 2021-07-27
 
 ### Added
 - Detect duplicate keys in YAML dictionaries in semgrep rules when parsing a rule
   (e.g., detect multiple 'metavariable' inside one 'metavariable-regex')
-  
+
 ### Fixed
 - C/C++: Fixed stack overflows (segmentation faults) when processing very large
   files (#3538)
@@ -55,8 +59,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   it will not wait until semgrep-core completely finishes.
 
 ### Changed
-- Switch from OCaml 4.10.0 to OCaml 4.10.2 (and later to OCaml 4.12.0) resulted in 
-  smaller semgrep-core binaries (from 170MB to 47MB) and a smaller docker 
+- Switch from OCaml 4.10.0 to OCaml 4.10.2 (and later to OCaml 4.12.0) resulted in
+  smaller semgrep-core binaries (from 170MB to 47MB) and a smaller docker
   image (from 95MB to 40MB).
 
 ## [0.58.0](https://github.com/returntocorp/semgrep/releases/tag/v0.58.0) - 2021-07-14

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -475,12 +475,6 @@ def cli() -> None:
         output_per_line_max_chars_limit=args.max_chars_per_line,
     )
 
-    if not args.disable_version_check:
-        if not is_running_latest():
-            logger.warning(
-                "A new version of Semgrep is available. Please see https://github.com/returntocorp/semgrep#upgrading for more information."
-            )
-
     if args.test:
         # the test code (which isn't a "test" per se but is actually machinery to evaluate semgrep performance)
         # uses managed_output internally
@@ -537,4 +531,10 @@ def cli() -> None:
                 skip_unknown_extensions=args.skip_unknown_extensions,
                 severity=args.severity,
                 optimizations=args.optimizations,
+            )
+
+    if not args.disable_version_check:
+        if not is_running_latest():
+            logger.warning(
+                "A new version of Semgrep is available. Please see https://github.com/returntocorp/semgrep#upgrading for more information."
             )


### PR DESCRIPTION
Users see results ~100ms faster

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
