### PR TITLE
Add OCaml module for filtering files based on name + exec perm + first line

### DIFF
--- a/semgrep-core/src/core/ast/Guess_lang.ml
+++ b/semgrep-core/src/core/ast/Guess_lang.ml
@@ -1,0 +1,187 @@
+(*
+   Guess whether a given file is indeed written in the specified
+   programming language.
+*)
+
+(*
+   Evaluation will be left-to-right and lazy, using the usual (&&) and (||)
+   operators.
+*)
+type test =
+  | And of test * test
+  | Or of test * test
+  | Not of test
+  | Test_path of (string -> bool)
+
+let eval test path =
+  let rec eval = function
+    | And (f, g) -> eval f && eval g
+    | Or (f, g) -> eval f || eval g
+    | Not f -> not (eval f)
+    | Test_path f -> f path
+  in
+  eval test
+
+let string_chop_prefix ~pref s =
+  let len = String.length s in
+  let preflen = String.length pref in
+  if len >= preflen && String.sub s 0 preflen = pref then
+    Some (String.sub s preflen (len - preflen))
+  else None
+
+let has_suffix suffixes =
+  let f path =
+    List.exists (fun suf -> Filename.check_suffix path suf) suffixes
+  in
+  Test_path f
+
+let prepend_period_if_needed s =
+  match s with "" -> "." | s -> if s.[0] <> '.' then "." ^ s else s
+
+(*
+   Both '.d.ts' and '.ts' are considered extensions of 'hello.d.ts'.
+*)
+let has_extension extensions =
+  has_suffix (List.map prepend_period_if_needed extensions)
+
+let has_lang_extension lang = has_extension (Lang.ext_of_lang lang)
+
+let has_an_extension =
+  let f path = Filename.extension path <> "" in
+  Test_path f
+
+let is_executable =
+  let f path =
+    Sys.file_exists path
+    &&
+    let st = Unix.stat path in
+    match st.st_kind with
+    | S_REG ->
+        (* at least some user has exec permission *)
+        st.st_perm land 0o111 <> 0
+    | _ -> false
+  in
+  (* ".exe" is intended for Windows, although this would be a binary file, not
+     a script. *)
+  Or (has_extension [ ".exe" ], Test_path f)
+
+let get_first_line path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () -> input_line ic)
+
+let shebang_re = lazy (Pcre.regexp "^#![ \t]*([^ \t]*)[ \t]*([^ \t].*)?$")
+
+let split_cmd_re = lazy (Pcre.regexp "[ \t]+")
+
+(*
+   A shebang supports at most the name of the script and one argument:
+
+   #!/bin/bash -e -u
+     ^^^^^^^^^ ^^^^^
+       arg0    arg1
+
+   To deal with that, the '/usr/bin/env' command offer the '-S' option prefix,
+   which will split what follows '-S' into multiple arguments. So we
+   may find things like these:
+
+   #!/usr/bin/env -S bash -e -u
+     ^^^^^^^^^^^^ ^^^^^^^^^^^^^
+         arg0         arg1
+
+   It's 'env' that will parse its argument and execute the command
+   ['bash'; '-e'; '-u'] as expected.
+
+   Examples:
+
+     "#!/bin/bash -e -u"            -> ["/bin/bash"; "-e -u"]
+     "#!/usr/bin/env -S bash -e -u" -> ["/usr/bin/env"; "bash"; "-e"; "-u"]
+*)
+let parse_shebang_line s =
+  let matched = Pcre.exec ~rex:(Lazy.force shebang_re) s in
+  match Pcre.get_substrings matched with
+  | [| _; arg0; "" |] -> Some [ arg0 ]
+  | [| _; "/usr/bin/env" as arg0; arg1 |] -> (
+      (* approximate emulation of 'env -S'; should work if the command
+         contains no quotes around the arguments. *)
+      match string_chop_prefix ~pref:"-S" arg1 with
+      | Some packed_args ->
+          let args =
+            Pcre.split ~rex:(Lazy.force split_cmd_re) packed_args
+            |> List.filter (fun fragment -> fragment <> "")
+          in
+          Some (arg0 :: args)
+      | None -> Some [ arg0; arg1 ])
+  | [| _; arg0; arg1 |] -> Some [ arg0; arg1 ]
+  | [| _ |] -> None
+  | _ -> assert false
+
+let get_shebang_command path = get_first_line path |> parse_shebang_line
+
+let uses_shebang_command_name cmd_names =
+  let f path =
+    match get_shebang_command path with
+    | Some ("/usr/bin/env" :: cmd_name :: _) -> List.mem cmd_name cmd_names
+    | Some (cmd_path :: _) ->
+        let cmd_name = Filename.basename cmd_path in
+        List.mem cmd_name cmd_names
+    | _ -> false
+  in
+  Test_path f
+
+(*
+   General test for a script:
+   - must have one of the approved extensions (e.g. "bash" or "sh")
+   - or has no extension but has executable permission
+     and one of the approved commands occurs on the shebang line.
+     Example:
+
+       #!/bin/bash -e
+              ^^^^
+
+       #!/usr/bin/env bash
+                      ^^^^
+*)
+let is_script lang cmd_names =
+  Or
+    ( And
+        ( Not has_an_extension,
+          And (is_executable, uses_shebang_command_name cmd_names) ),
+      has_lang_extension lang )
+
+let is_python2 = is_script Lang.Python2 [ "python"; "python2" ]
+
+let is_python3 = is_script Lang.Python3 [ "python"; "python3" ]
+
+let is_acceptable (lang : Lang.t) path =
+  let test =
+    match lang with
+    | Bash -> is_script lang [ "bash"; "sh" ]
+    | C -> has_lang_extension lang
+    | Cplusplus -> has_lang_extension lang
+    | Csharp -> has_lang_extension lang
+    | Go -> has_lang_extension lang
+    | HTML -> has_lang_extension lang
+    | Hack -> has_lang_extension lang
+    | JSON -> has_lang_extension lang
+    | Java -> has_lang_extension lang
+    | Javascript ->
+        And
+          ( Not (has_extension [ ".min.js" ]),
+            is_script lang [ "node"; "nodejs"; "js" ] )
+    | Kotlin -> has_lang_extension lang
+    | Lua -> is_script lang [ "lua" ]
+    | OCaml -> is_script lang [ "ocaml"; "ocamlscript" ]
+    | PHP -> is_script lang [ "php" ]
+    | Python -> Or (is_python2, is_python3)
+    | Python2 -> is_python2
+    | Python3 -> is_python3
+    | R -> is_script lang [ "Rscript" ]
+    | Ruby -> is_script lang [ "ruby" ]
+    | Rust -> is_script lang [ "run-cargo-script" ]
+    | Scala -> is_script lang [ "scala" ]
+    | Typescript ->
+        And (Not (has_extension [ ".d.ts" ]), is_script lang [ "ts-node" ])
+    | Vue -> has_lang_extension lang
+    | Yaml -> has_lang_extension lang
+  in
+  eval test path

--- a/semgrep-core/src/core/ast/Guess_lang.mli
+++ b/semgrep-core/src/core/ast/Guess_lang.mli
@@ -1,0 +1,14 @@
+(*
+   Guess whether a given file is indeed written in the specified
+   programming language.
+
+   - uses file name, permissions, file contents
+   - this is used to filter candidates for a given language
+   - a given file may be in multiple languages
+
+   This will exclude files we don't want to handle with semgrep, such
+   as the '.min.js' files (JavaScript minified files which are not human-
+   readable and usually really big) or '.d.ts' (TypeScript typed interfaces
+   for which we don't have a parser).
+*)
+val is_acceptable : Lang.t -> Common.filename -> bool

--- a/semgrep-core/src/core/ast/Unit_guess_lang.ml
+++ b/semgrep-core/src/core/ast/Unit_guess_lang.ml
@@ -1,0 +1,93 @@
+(*
+   Unit tests for Guess_lang
+*)
+
+open OUnit
+
+type exec = Exec | Nonexec
+
+type success = OK | XFAIL
+
+(*
+   For these tests, the file doesn't need to exist.
+*)
+let name_tests : (string * Lang.t * string * success) list =
+  [
+    (* name, language, file name, expected result *)
+    ("js", Javascript, "foo.js", OK);
+    ("js relative path", Javascript, "./a/b.c/foo.js", OK);
+    ("js absolute path", Javascript, "/a/b.c/foo.js", OK);
+    ("js double extension", Javascript, "foo.bar.js", OK);
+    ("min js", Javascript, "foo.min.js", XFAIL);
+    ("not js", Javascript, "foo.bar", XFAIL);
+    ("jsx", Javascript, "foo.jsx", OK);
+    ("typescript", Typescript, "foo.ts", OK);
+    ("typescript .d.ts", Typescript, "foo.d.ts", XFAIL);
+    ("spaces", Ruby, " a b  c.rb", OK);
+  ]
+
+let contents_tests : (string * Lang.t * string * string * exec * success) list =
+  [
+    (* name, language, file name, file contents, executable?, expected result *)
+    ("correct extension nonexec", Javascript, "foo1.js", "", Exec, OK);
+    ("correct extension exec", Javascript, "foo2.js", "", Exec, OK);
+    ("wrong extension exec", Javascript, "foo3.bar", "", Exec, XFAIL);
+    ("bash non-executable", Bash, "hello1.bash", "", Nonexec, OK);
+    ("bash exec", Bash, "hello2", "#!/anything/bash\n", Exec, OK);
+    ("sh exec", Bash, "hello3", "#!/bin/sh\n# hello!", Exec, OK);
+    ("bash exec env", Bash, "hello4", "#! /usr/bin/env bash\n", Exec, OK);
+    ("other exec env", Bash, "hello5", "#!/usr/bin/env bashxxxx\n", Exec, XFAIL);
+    ("env -S", Bash, "hello6", "#!/usr/bin/env -Sbash -eu\n", Exec, OK);
+  ]
+
+let ( // ) = Filename.concat
+
+let mkdir path = if not (Sys.file_exists path) then Unix.mkdir path 0o777
+
+(*
+   Create a temporary file with the specified name, in a local tmp folder.
+   We don't delete the files when we're done because it's easier when
+   troubleshooting tests.
+*)
+let with_file name contents exec f =
+  let dir = "tmp" in
+  mkdir dir;
+  let path = dir // name in
+  let oc = open_out_bin path in
+  (match exec with Exec -> Unix.chmod path 0o755 | Nonexec -> ());
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () ->
+      output_string oc contents;
+      close_out oc;
+      f path)
+
+let test_name_only lang path expectation =
+  match (expectation, Guess_lang.is_acceptable lang path) with
+  | OK, true | XFAIL, false -> ()
+  | _ -> assert false
+
+let test_with_contents lang name contents exec expectation =
+  with_file name contents exec (fun path ->
+      match (expectation, Guess_lang.is_acceptable lang path) with
+      | OK, true | XFAIL, false -> ()
+      | _ -> assert false)
+
+(* This is necessary when running the tests on Windows. *)
+let fix_path s =
+  match Sys.os_type with
+  | "Win32" -> String.map (function '/' -> '\\' | c -> c) s
+  | _ -> s
+
+let test_is_acceptable =
+  List.map
+    (fun (test_name, lang, path, expectation) ->
+      test_name >:: fun () -> test_name_only lang (fix_path path) expectation)
+    name_tests
+  @ List.map
+      (fun (test_name, lang, file_name, contents, exec, expectation) ->
+        test_name >:: fun () ->
+        test_with_contents lang file_name contents exec expectation)
+      contents_tests
+
+let unittest = "Guess_lang" >::: [ "is_acceptable" >::: test_is_acceptable ]

--- a/semgrep-core/src/core/ast/Unit_guess_lang.mli
+++ b/semgrep-core/src/core/ast/Unit_guess_lang.mli
@@ -1,0 +1,5 @@
+(*
+   Unit tests for the Guess_lang module
+*)
+
+val unittest : OUnit.test

--- a/semgrep-core/src/core/ast/dune
+++ b/semgrep-core/src/core/ast/dune
@@ -7,6 +7,7 @@
  (name pfff_lang_GENERIC_base)
  (wrapped false)
  (libraries
+   pcre
    commons
    bloomf
    pfff-h_program-lang

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -190,6 +190,9 @@ let parsing_common ?(verbose = true) lang xs =
   let fullxs =
     Lang.files_of_dirs_or_files lang xs
     |> Skip_code.filter_files_if_skip_list ~root:xs
+    (* extra filtering excluding some extensions like '.d.ts'
+       TODO: should become part of files_of_dirs_or_files *)
+    |> List.filter (Guess_lang.is_acceptable lang)
   in
   fullxs
   |> List.rev_map (fun file ->

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -559,6 +559,7 @@ let test regexp =
         Parse_target.parse_program 
         (fun lang file -> Parse_pattern.parse_pattern lang file);
       Unit_naming_generic.unittest Parse_target.parse_program;
+      Unit_guess_lang.unittest;
 
       lang_parsing_tests;
       (* full testing for many languages *)
@@ -642,6 +643,6 @@ let main () =
 (*e: function [[Test.main]] *)
 
 (*s: toplevel [[Test._1]] *)
-let _ = main ()
+let () = main ()
 (*e: toplevel [[Test._1]] *)
 (*e: semgrep/tests/Test.ml *)


### PR DESCRIPTION
I added a `Guess_lang` module which takes care of filtering target files using whatever criteria we want, including inspecting the contents of the file. For now, this is useful to exclude certain files from the parsing stats, such as the `.d.ts` typescript files that we can't parse. This is the immediate motivation for doing this in OCaml.

Additionally, this also supports shebang line inspection, which will be useful for parsing files without a distinguishing extension. For example, if the language is bash (and some other popular ones including python, ruby, javascript) a file with executable permission and no extension will have its first line inspected. If it's like `#!/bin/bash` or `#!/usr/bin/env bash` or some variation of those, the file is assumed to be a bash script. For using this feature for regular semgrep use, the python wrapper would have to pass those files to semgrep-core, and semgrep-core will have to indicate which of those files were actually accepted or rejected.

Right now, `Guess_lang` is used only for the parsing stats.

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
