### PR TITLE
[OCaml] allow metavar on module names or constructors

### DIFF
--- a/semgrep-core/tests/ocaml/metavar_module.ml
+++ b/semgrep-core/tests/ocaml/metavar_module.ml
@@ -1,0 +1,6 @@
+(* ERROR: match *)
+module A = AST_generic
+(* ERROR: match *)
+module B = AST_generic
+
+module C = OtherStuff

--- a/semgrep-core/tests/ocaml/metavar_module.sgrep
+++ b/semgrep-core/tests/ocaml/metavar_module.sgrep
@@ -1,0 +1,4 @@
+(* a bit ugly, but to match an uppercase entity (module, constructor)
+ * you need to start the metavar with one uppercase letter and an _
+ *)
+module $M_ = AST_generic


### PR DESCRIPTION
This is ugly

test plan:
test file included




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date