### PR TITLE
Refactoring: move MatchPattern from an expr to a stmt

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -510,7 +510,7 @@ and expr_aux env eorig =
               )));
       lvalexp
   | G.Xml _ -> todo (G.E eorig)
-  | G.Constructor (_, _) | G.MatchPattern (_, _) -> todo (G.E eorig)
+  | G.Constructor (_, _) -> todo (G.E eorig)
   | G.Yield (_, _, _) | G.Await (_, _) -> todo (G.E eorig)
   | G.Cast (typ, e) ->
       let e = expr env e in
@@ -832,6 +832,7 @@ let rec stmt_aux env st =
         | manager -> (None, manager)
       in
       python_with_stmt env manager opt_pat body
+  | G.Match (_, _, _) -> todo (G.S st)
   | G.OtherStmt _ | G.OtherStmtWithStmt _ -> todo (G.S st)
 
 (*s: function [[AST_to_IL.stmt]] *)

--- a/semgrep-core/src/analyzing/controlflow.ml
+++ b/semgrep-core/src/analyzing/controlflow.ml
@@ -174,6 +174,7 @@ let simple_node_of_stmt_opt stmt =
   | G.DoWhile (_, _, _)
   | G.For (_, _, _)
   | G.Switch (_, _, _)
+  | G.Match (_, _, _)
   | G.Return _ | G.Continue _ | G.Break _
   | G.Label (_, _)
   | G.Goto _ | G.Throw _

--- a/semgrep-core/src/analyzing/controlflow_build.ml
+++ b/semgrep-core/src/analyzing/controlflow_build.ml
@@ -555,7 +555,8 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
    * Note that DefStmt are not the only form of lambdas ... you can have
    * lambdas inside expressions too! (need a proper instr type really)
    *)
-  | DefStmt _ | ExprStmt _ | Assert _ | DirectiveStmt _ | OtherStmt _ ->
+  | DefStmt _ | ExprStmt _ | Assert _ | DirectiveStmt _ | OtherStmt _ | Match _
+    ->
       cfg_simple_node state previ stmt
   | DisjStmt _ -> raise Impossible
 

--- a/semgrep-core/src/analyzing/lrvalue.ml
+++ b/semgrep-core/src/analyzing/lrvalue.ml
@@ -168,7 +168,6 @@ let rec visit_expr hook lhs expr =
   | LetPattern (pat, e) ->
       anyhook hook Lhs (P pat);
       recr e
-  | MatchPattern (_, _) -> error_todo (E expr)
   | Seq xs -> List.iter recr xs
   (* we should not be called on a sgrep pattern *)
   | TypedMetavar (_id, _, _t) -> raise Impossible

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -262,9 +262,6 @@ and map_expr x : B.expr =
   | TypedMetavar (v1, v2, v3) ->
       let v1 = map_ident v1 and v2 = map_tok v2 and v3 = map_type_ v3 in
       `TypedMetavar (v1, v2, v3)
-  | MatchPattern (v1, v2) ->
-      let v1 = map_expr v1 and v2 = map_of_list map_action v2 in
-      `MatchPattern (v1, v2)
   | Yield (t, v1, v2) ->
       let t = map_tok t in
       let v1 = map_of_option map_expr v1 and v2 = map_of_bool v2 in
@@ -624,6 +621,10 @@ and map_other_attribute_operator _x = "TODO"
 and map_stmt x : B.stmt =
   let skind =
     match x.s with
+    | Match (_, v1, v2) ->
+        let v1 = map_expr v1 and v2 = map_of_list map_action v2 in
+        let e = `MatchPattern (v1, v2) in
+        `OtherStmt ("TODO", [ `E e ])
     | DisjStmt (v1, v2) ->
         let v1 = map_stmt v1 in
         let v2 = map_stmt v2 in

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -127,6 +127,8 @@ let expr_to_type e =
   (* TODO: diconstruct e and generate the right type (TyBuiltin, ...) *)
   OtherType (OT_Expr, [ E e ])
 
+(* See also exprstmt, and stmt_to_expr in AST_generic.ml *)
+
 (*e: function [[AST_generic.expr_to_type]] *)
 
 (* old: there was a stmt_to_item before *)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.mli
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.mli
@@ -1,12 +1,13 @@
 val str_of_ident : AST_generic.ident -> string
 
-val expr_to_pattern : AST_generic.expr -> AST_generic.pattern
-
-val expr_to_type : AST_generic.expr -> AST_generic.type_
-
 exception NotAnExpr
 
+val expr_to_pattern : AST_generic.expr -> AST_generic.pattern
+
+(* may raise NotAnExpr *)
 val pattern_to_expr : AST_generic.pattern -> AST_generic.expr
+
+val expr_to_type : AST_generic.expr -> AST_generic.type_
 
 val name_or_dynamic_to_expr :
   AST_generic.name_or_dynamic -> AST_generic.id_info option -> AST_generic.expr

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -259,9 +259,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
       | TypedMetavar (v1, v2, v3) ->
           let v1 = map_ident v1 and v2 = map_tok v2 and v3 = map_type_ v3 in
           TypedMetavar (v1, v2, v3)
-      | MatchPattern (v1, v2) ->
-          let v1 = map_expr v1 and v2 = map_of_list map_action v2 in
-          MatchPattern (v1, v2)
       | Yield (t, v1, v2) ->
           let t = map_tok t in
           let v1 = map_of_option map_expr v1 and v2 = map_of_bool v2 in
@@ -508,6 +505,10 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let k x =
       let skind =
         match x.s with
+        | Match (v0, v1, v2) ->
+            let v0 = map_tok v0 in
+            let v1 = map_expr v1 and v2 = map_of_list map_action v2 in
+            Match (v0, v1, v2)
         | DisjStmt (v1, v2) ->
             let v1 = map_stmt v1 in
             let v2 = map_stmt v2 in

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -224,9 +224,6 @@ and vof_expr = function
   | Conditional (v1, v2, v3) ->
       let v1 = vof_expr v1 and v2 = vof_expr v2 and v3 = vof_expr v3 in
       OCaml.VSum ("Conditional", [ v1; v2; v3 ])
-  | MatchPattern (v1, v2) ->
-      let v1 = vof_expr v1 and v2 = OCaml.vof_list vof_action v2 in
-      OCaml.VSum ("MatchPattern", [ v1; v2 ])
   | Yield (t, v1, v2) ->
       let t = vof_tok t in
       let v1 = OCaml.vof_option vof_expr v1 and v2 = OCaml.vof_bool v2 in
@@ -652,6 +649,10 @@ and vof_other_attribute_operator = function
 and vof_stmt st =
   (* todo: dump also the s_id? *)
   match st.s with
+  | Match (v0, v1, v2) ->
+      let v0 = vof_tok v0 in
+      let v1 = vof_expr v1 and v2 = OCaml.vof_list vof_action v2 in
+      OCaml.VSum ("Match", [ v0; v1; v2 ])
   | DisjStmt (v1, v2) ->
       let v1 = vof_stmt v1 in
       let v2 = vof_stmt v2 in

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -331,16 +331,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
       | TypedMetavar (v1, v2, v3) ->
           let v1 = v_ident v1 and v2 = v_tok v2 and v3 = v_type_ v3 in
           ()
-      | MatchPattern (v1, v2) ->
-          let v1 = v_expr v1
-          and v2 =
-            v_list
-              (fun (v1, v2) ->
-                let v1 = v_pattern v1 and v2 = v_expr v2 in
-                ())
-              v2
-          in
-          ()
       | Yield (t, v1, v2) ->
           let t = v_tok t in
           let v1 = v_option v_expr v1 and v2 = v_bool v2 in
@@ -612,6 +602,17 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let k x =
       (* todo? visit the s_id too? *)
       match x.s with
+      | Match (v0, v1, v2) ->
+          let v0 = v_tok v0 in
+          let v1 = v_expr v1
+          and v2 =
+            v_list
+              (fun (v1, v2) ->
+                let v1 = v_pattern v1 and v2 = v_expr v2 in
+                ())
+              v2
+          in
+          ()
       | DisjStmt (v1, v2) ->
           let v1 = v_stmt v1 in
           let v2 = v_stmt v2 in

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -707,8 +707,6 @@ and m_expr a b =
   | G.Conditional (a1, a2, a3), B.Conditional (b1, b2, b3) ->
       m_expr a1 b1 >>= fun () ->
       m_expr a2 b2 >>= fun () -> m_expr a3 b3
-  | G.MatchPattern (a1, a2), B.MatchPattern (b1, b2) ->
-      m_expr a1 b1 >>= fun () -> (m_list m_action) a2 b2
   | G.Yield (a0, a1, a2), B.Yield (b0, b1, b2) ->
       m_tok a0 b0 >>= fun () ->
       m_option m_expr a1 b1 >>= fun () -> m_bool a2 b2
@@ -736,7 +734,6 @@ and m_expr a b =
   | G.ArrayAccess _, _
   | G.SliceAccess _, _
   | G.Conditional _, _
-  | G.MatchPattern _, _
   | G.Yield _, _
   | G.Await _, _
   | G.Cast _, _
@@ -1910,6 +1907,9 @@ and m_stmt a b =
   | G.Switch (at, a1, a2), B.Switch (bt, b1, b2) ->
       m_tok at bt >>= fun () ->
       m_option m_expr a1 b1 >>= fun () -> m_case_clauses a2 b2
+  | G.Match (a0, a1, a2), B.Match (b0, b1, b2) ->
+      let* () = m_tok a0 b0 in
+      m_expr a1 b1 >>= fun () -> (m_list m_action) a2 b2
   | G.Continue (a0, a1, asc), B.Continue (b0, b1, bsc) ->
       let* () = m_tok a0 b0 in
       let* () = m_label_ident a1 b1 in
@@ -1952,6 +1952,7 @@ and m_stmt a b =
   | G.DoWhile _, _
   | G.For _, _
   | G.Switch _, _
+  | G.Match _, _
   | G.Return _, _
   | G.Continue _, _
   | G.Break _, _

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -43,6 +43,7 @@ let subexprs_of_stmt st =
   | If (_, e, _, _)
   | While (_, e, _)
   | DoWhile (_, _, e)
+  | Match (_, e, _)
   | DefStmt (_, VarDef { vinit = Some e; _ })
   | DefStmt (_, FieldDefColon { vinit = Some e; _ })
   | For (_, ForEach (_, _, e), _)
@@ -116,7 +117,7 @@ let subexprs_of_expr e =
       subexprs_of_any_list anys
   | Lambda def -> subexprs_of_stmt def.fbody
   (* currently skipped over but could recurse *)
-  | Constructor _ | AnonClass _ | Xml _ | LetPattern _ | MatchPattern _ -> []
+  | Constructor _ | AnonClass _ | Xml _ | LetPattern _ -> []
   | DisjExpr _ -> raise Common.Impossible
   [@@profiling]
 
@@ -173,6 +174,8 @@ let substmts_of_stmt st =
             |> Common.map_filter (function
                  | FieldStmt st -> Some st
                  | FieldSpread _ -> None))
+  (* TODO *)
+  | Match _ -> []
 
 (*e: function [[SubAST_generic.substmts_of_stmt]] *)
 

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -153,6 +153,9 @@ and stmt e : G.stmt =
         G.ForClassic ([ G.ForInitVar (ent, var) ], Some cond, Some next)
       in
       G.For (t, header, v5) |> G.s
+  | Match (t, v1, v2) ->
+      let v1 = expr v1 and v2 = list match_case v2 in
+      G.Match (t, v1, v2) |> G.s
   | e -> (
       let e = expr e in
       (* bugfix: I was using 'G.exprstmt e' before, but then a pattern
@@ -294,8 +297,9 @@ and expr e =
       let xs = list match_case xs in
       let id = ("!_implicit_param!", t) in
       let params = [ G.ParamClassic (G.param_of_id id) ] in
-      let body_exp = G.MatchPattern (G.N (G.Id (id, G.empty_id_info ())), xs) in
-      let body_stmt = G.exprstmt body_exp in
+      let body_stmt =
+        G.Match (t, G.N (G.Id (id, G.empty_id_info ())), xs) |> G.s
+      in
       G.Lambda
         {
           G.fparams = params;
@@ -303,14 +307,11 @@ and expr e =
           fkind = (G.Function, t);
           fbody = body_stmt;
         }
-  | Match (_t, v1, v2) ->
-      let v1 = expr v1 and v2 = list match_case v2 in
-      G.MatchPattern (v1, v2)
   | ExprTodo (t, xs) ->
       let t = todo_category t in
       let xs = list expr xs in
       G.OtherExpr (G.OE_Todo, G.TodoK t :: List.map (fun x -> G.E x) xs)
-  | If _ | Try _ | For _ | While _ | Sequence _ ->
+  | If _ | Try _ | For _ | While _ | Sequence _ | Match _ ->
       let s = stmt e in
       G.OtherExpr (G.OE_StmtExpr, [ G.S s ])
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1404,15 +1404,16 @@ and expression (env : env) (x : CST.expression) : G.expr =
         | None -> []
       in
       let v5 = token env v5 (* "}" *) in
-      MatchPattern (v1, v4)
+      let st = Match (v2, v1, v4) |> G.s in
+      G.stmt_to_expr st
   | `This_exp tok ->
       let t = token env tok (* "this" *) in
       IdSpecial (This, t)
   | `Throw_exp (v1, v2) ->
       let v1 = token env v1 (* "throw" *) in
       let v2 = expression env v2 in
-      let throw = Throw (v1, v2, sc) in
-      OtherExpr (OE_StmtExpr, [ G.S (G.s throw) ])
+      let throw = Throw (v1, v2, sc) |> G.s in
+      G.stmt_to_expr throw
   | `Tuple_exp x -> tuple_expression env x
   | `Type_of_exp (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "typeof" *) in
@@ -2271,7 +2272,8 @@ and declaration_expression (env : env) ((v1, v2) : CST.declaration_expression) =
   | Some t ->
       let ent = basic_entity v2 [] in
       let vardef = { vinit = None; vtype = Some t } in
-      OtherExpr (OE_StmtExpr, [ S (s (DefStmt (ent, VarDef vardef))) ])
+      let st = DefStmt (ent, VarDef vardef) |> G.s in
+      G.stmt_to_expr st
   | None -> N (Id (v2, empty_id_info ()))
 
 and interpolation (env : env) ((v1, v2, v3, v4, v5) : CST.interpolation) :


### PR DESCRIPTION
I want to support some partial patterns for match like
we have for if, and while, so it makes sense to put
MatchPattern closer to the other stmt like the Switch.

test plan:
make test




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date