### PR TITLE
Refactoring OCaml code, using semgrep!!

### DIFF
--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -91,8 +91,7 @@ type stmt_or_expr = Stmt of loc * G.stmt | Expr of loc * G.expr
 
 let stmt_of_expr loc (e : G.expr) : G.stmt = G.s (G.ExprStmt (e, fst loc))
 
-let expr_of_stmt loc (st : G.stmt) : G.expr =
-  G.OtherExpr (G.OE_StmtExpr, [ G.S st ])
+let expr_of_stmt loc (st : G.stmt) : G.expr = G.stmt_to_expr st
 
 let as_stmt : stmt_or_expr -> G.stmt = function
   | Stmt (loc, st) -> st

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -368,7 +368,7 @@ and expr e =
           v2
         |> List.map (fun x -> G.CasesAndBody x)
       in
-      G.OtherExpr (G.OE_StmtExpr, [ G.S (G.Switch (v0, Some v1, v2) |> G.s) ])
+      G.stmt_to_expr (G.Switch (v0, Some v1, v2) |> G.s)
 
 and expr_or_type = function Left e -> G.E (expr e) | Right t -> G.T (typ t)
 

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -281,7 +281,7 @@ and expr e =
                  G.exprstmt exp)
       in
       let st = G.Block (fb (defs @ [ G.exprstmt v3 ])) |> G.s in
-      G.OtherExpr (G.OE_StmtExpr, [ G.S st ])
+      G.stmt_to_expr st
   | Fun (t, v1, v2) ->
       let v1 = list parameter v1 and v2 = expr v2 in
       let def =
@@ -313,7 +313,7 @@ and expr e =
       G.OtherExpr (G.OE_Todo, G.TodoK t :: List.map (fun x -> G.E x) xs)
   | If _ | Try _ | For _ | While _ | Sequence _ | Match _ ->
       let s = stmt e in
-      G.OtherExpr (G.OE_StmtExpr, [ G.S s ])
+      G.stmt_to_expr s
 
 and literal = function
   | Int v1 ->

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -126,10 +126,10 @@ let rec expr = function
       G.Lambda def
   | S x ->
       let st = stmt x in
-      G.OtherExpr (G.OE_StmtExpr, [ G.S st ])
+      G.stmt_to_expr st
   | D x ->
       let st = definition x in
-      G.OtherExpr (G.OE_StmtExpr, [ G.S st ])
+      G.stmt_to_expr st
   | Ellipsis x ->
       let x = info x in
       G.Ellipsis x

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -418,7 +418,7 @@ and v_expr = function
 (* alt: transform in a series of Seq? *)
 and expr_of_block xs : G.expr =
   let st = G.Block (fb xs) |> G.s in
-  G.OtherExpr (G.OE_StmtExpr, [ G.S st ])
+  G.stmt_to_expr st
 
 and v_lhs v = v_expr v
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -1499,7 +1499,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
       in
       let v6, v7 = v5 in
       let if_stmt = If (v1, v3, v6, v7) |> G.s in
-      OtherExpr (OE_StmtExpr, [ S if_stmt ])
+      stmt_to_expr if_stmt
   | `When_exp (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "when" *) in
       let v2 = match v2 with Some x -> when_subject env x | None -> None in
@@ -1507,7 +1507,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
       let v4 = List.map (when_entry env) v4 in
       let _v5 = token env v5 (* "}" *) in
       let switch_stmt = Switch (v1, v2, v4) |> G.s in
-      OtherExpr (OE_StmtExpr, [ S switch_stmt ])
+      stmt_to_expr switch_stmt
   | `Try_exp (v1, v2, v3) ->
       let v1 = token env v1 (* "try" *) in
       let v2 = block env v2 in
@@ -1527,10 +1527,10 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
       in
       let catch, finally = v3 in
       let try_stmt = Try (v1, v2, catch, finally) |> G.s in
-      OtherExpr (OE_StmtExpr, [ S try_stmt ])
+      stmt_to_expr try_stmt
   | `Jump_exp x ->
       let v1 = jump_expression env x in
-      OtherExpr (OE_StmtExpr, [ S v1 ])
+      stmt_to_expr v1
 
 and property_delegate (env : env) ((v1, v2) : CST.property_delegate) =
   let _v1 = token env v1 (* "by" *) in


### PR DESCRIPTION
This find more opportunties to use AST_generic.expr_to_stmt.
Dogfood!

test plan:
```
$ cat ~/stmt_to_expr.yaml
rules:
- id: refactoring1
  pattern: G.OtherExpr(G.OE_StmtExpr, [G.S $E])
  fix: G.stmt_to_expr $E
  message: found $E
  severity: WARNING
  languages: [ocaml]
  paths:
    exclude:
    - src/core/ast/AST_generic.ml
$ semgrep --config ~/stmt_to_expr.yaml . --autofix
...
```




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date