### PR TITLE
Change the threshold for reporting a performance improvement from -15% to -20%

### DIFF
--- a/scripts/compare-perf
+++ b/scripts/compare-perf
@@ -130,7 +130,7 @@ def main() -> None:
                 f"⚠️  Potential non-blocking slowdown in benchmark {name}: "
                 f"+{perc:.1f}% (+{diff:.3f} s)"
             )
-        elif rel_dur < 0.85:
+        elif rel_dur < 0.8:
             messages.append(
                 f"🔥 Potential speedup in benchmark {name}: "
                 f"{perc:.1f}% ({diff:.3f} s)"


### PR DESCRIPTION
... as promised in the PR comments from the bot.

I know -20% is not the inverse of +20% but it's simpler to interpret this way.

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
