### PR TITLE
Pattern: $X speedup try 2

### DIFF
--- a/semgrep-core/src/engine/Specialize_formula.mli
+++ b/semgrep-core/src/engine/Specialize_formula.mli
@@ -5,7 +5,7 @@
 (* of that metavariable. *)
 
 type selector = {
-  mvar : Metavariable.mvar;
+  pattern : AST_generic.any;
   pid : int;
   pstr : string Rule.wrap;
   (* lazy_matches necessary in case `$X` is the only pattern *)
@@ -27,11 +27,11 @@ val fake_rule_id : int * string -> Pattern_match.rule_id
 val match_selector :
   ?err:string -> selector option -> Range_with_metavars.ranges
 
-val select_from_ranges :
+(* val select_from_ranges :
   string ->
   selector option ->
   Range_with_metavars.ranges ->
-  Range_with_metavars.ranges
+  Range_with_metavars.ranges *)
 
 val selector_equal : selector -> selector -> bool
 


### PR DESCRIPTION
As before, we want to speed up something like

```
  patterns:
  - pattern-either:
    - pattern-inside: |
        import $STYLE from "...";
        ...
    - pattern-inside: |
        $STYLE = $METHOD(...);
        ...
  - pattern-inside: |
      <$EL style={$STYLE} />
  - pattern: $STYLE
```

In this PR, we try to do this by extracting the AST from the final range matched by everything except `pattern: $STYLE`. Currently does not work

Test plan:

For correctness in the anded case, in semgrep-core/ run (or make test)

```
sc -config tests/OTHER/rules/pattern-x.yaml tests/OTHER/rules/pattern-x.js -lang js
```

The expected results (you can confirm by running semgrep-core) are

```
perf/input/pattern-x.js:17 with rule typescript.react.security.audit.react-css-injection.react-css-injection
             <div style={input}>
perf/input/pattern-x.js:5 with rule typescript.react.security.audit.react-css-injection.react-css-injection
             <div style={input}>
```
To check that this actually worked, you can run

```
sc -config tests/OTHER/rules/pattern-x.js ~/your_root/semgrep/perf/bench/rails/input/rails/actionview/test/ujs/public/vendor/jquery-2.2.0.js -profile -lang js
```

We expect this to drop from ~100 s to 2 s

PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
