### PR TITLE
Remove location information in cli errors with temp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   full expressions, types, patterns, etc.).
 - OCaml: match cases patterns are now matched in any order, and ellipsis are
   handled correctly
+- Improved error messages sent to the playground
 
 ### Changed
 - Run version check and print upgrade message after scan instead of before

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -219,8 +219,11 @@ class ErrorWithSpan(SemgrepError):
         header = f"{with_color(Fore.RED, 'semgrep ' + self.level.name.lower())}: {self.short_msg}"
         snippets = []
         for span in self.spans:
-            location_hint = f"  --> {span.file}:{span.start.line}"
-            snippet = [location_hint]
+            if span.file != "semgrep temp file":
+                location_hint = f"  --> {span.file}:{span.start.line}"
+                snippet = [location_hint]
+            else:
+                snippet = []
 
             # all the lines of code in the file this comes from
             source: List[str] = SourceTracker.source(span.source_hash)
@@ -253,7 +256,13 @@ class ErrorWithSpan(SemgrepError):
             help_str = f"= {with_color(Fore.CYAN, 'help', bold=True)}: {self.help}"
         else:
             help_str = ""
-        return f"{header}\n{snippet_str}\n{help_str}\n{with_color(Fore.RED, self.long_msg or '')}\n"
+
+        # TODO remove this when temp files are no longer in error messages
+        if snippet_str == "":
+            snippet_str_with_newline = ""
+        else:
+            snippet_str_with_newline = f"{snippet_str}\n"
+        return f"{header}\n{snippet_str_with_newline}{help_str}\n{with_color(Fore.RED, self.long_msg or '')}\n"
 
 
 @attr.s(frozen=True, eq=True)

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
@@ -1,6 +1,5 @@
 running 1 rules...
 [31msemgrep error[39m: invalid pattern
-  --> semgrep temp file:5
 
 [31mPattern `$X == $X 3` could not be parsed as a Python semgrep pattern[39m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
@@ -1,5 +1,4 @@
 semgrep error: invalid pattern
-  --> semgrep temp file:4
 
 Pattern `#include<asdf><<>>><$X>` could not be parsed as a C semgrep pattern
 


### PR DESCRIPTION
Since the temp file error message is not helpful, remove it.

Test plan:

Modify `metavar_pattern_lang.yaml` in tests/OTHER/rules to have the pattern `bad eval_C("$CODE")`. Then run

```
(semgrep) ➜  rules git:(develop) ✗ semgrep --config metavar_pattern_lang.yaml metavar_pattern_lang.py
running 1 rules...
semgrep error: invalid pattern

Pattern `bad eval_C("$CODE")` could not be parsed as a Python semgrep pattern
```



PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
