### PR TITLE
Report semgrep-core's message upon a parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Run version check and print upgrade message after scan instead of before
 - OCaml: skip ocamllex and ocamlyacc files. Process only .ml and .mli files.
 - Memoize range computation for expressions and speed up taint mode
+- Report semgrep-core's message upon a parse error
 
 ### Fixed
 - Go: Match import module paths correctly (#3484)

--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -112,7 +112,12 @@ class CoreException:
             )
             return SourceParseError(
                 short_msg="parse error",
-                long_msg=f"Could not parse {self._path.name} as {self._language}",
+                long_msg=f"Could not parse {self._path.name} as {self._language}"
+                + (
+                    f"\n\nsemgrep-core message:\n\n\t{self._extra['message']}"
+                    if self._check_id != "ParseError" and "message" in self._extra
+                    else ""
+                ),
                 spans=[error_span],
                 help="If the code appears to be valid, this may be a semgrep bug.",
             )


### PR DESCRIPTION
Sometimes it's not actually a parse error even though we report it as
such, so it is useful to know what semgrep-core actually reported.

Related-to: #3547

test plan:
```
$ cat bad.py
def foo():
    return 1
}
$ semgrep -v -l py -e '$X' bad.py
...
Could not parse bad.py as python

semgrep-core message:

    Fatal Error: (Failure "Lexer_python.top_mode: empty stack")

#^ now we understand better what is going on
```

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
