### PR TITLE
Many fixes to improve the parsing_stat CI job

### DIFF
--- a/parsing-stats/lang/csharp/projects.txt
+++ b/parsing-stats/lang/csharp/projects.txt
@@ -1,5 +1,7 @@
 # Sample large C# projects
 
+#TODO? skip the C# compiler as it may contain lots of test files?
+https://github.com/dotnet/roslyn.git
 https://github.com/shadowsocks/shadowsocks-windows.git
 https://github.com/CodeHubApp/CodeHub.git
 https://github.com/PowerShell/PowerShell.git
@@ -9,4 +11,3 @@ https://github.com/0xd4d/dnSpy.git
 https://github.com/mxgmn/WaveFunctionCollapse.git
 https://github.com/dotnet-architecture/eShopOnContainers.git
 https://github.com/ShareX/ShareX.git
-https://github.com/dotnet/roslyn.git

--- a/parsing-stats/lang/go/projects.txt
+++ b/parsing-stats/lang/go/projects.txt
@@ -1,3 +1,4 @@
+#TODO? skip the compiler as it may contain lots of test files?
 https://github.com/golang/go.git
 https://github.com/kubernetes/kubernetes.git
 https://github.com/moby/moby.git

--- a/parsing-stats/lang/hack/projects.txt
+++ b/parsing-stats/lang/hack/projects.txt
@@ -1,6 +1,9 @@
 # Git URLs of publicly-accessible projects to be used for parsing stats,
 # one per line.
 #
+#TODO: right now semgrep will only consider .hck and .hack files as Hack
+# files, so the parsing line count is only at 8000 right now, even with
+# all those projects
 https://github.com/facebookarchive/hack-example-site.git
 https://github.com/titon/framework.git
 https://github.com/facebookarchive/oss-performance.git

--- a/parsing-stats/lang/kotlin/projects.txt
+++ b/parsing-stats/lang/kotlin/projects.txt
@@ -1,4 +1,7 @@
-https://github.com/JetBrains/kotlin
+# we skip the compiler repository for now because it contains
+# lots of test files including test files with real parse errors
+#https://github.com/JetBrains/kotlin
+
 https://github.com/hussien89aa/KotlinUdemy
 https://github.com/git-xuhao/KotlinMvp
 https://github.com/Kotlin/kotlin-koans

--- a/parsing-stats/lang/lua/projects.txt
+++ b/parsing-stats/lang/lua/projects.txt
@@ -1,5 +1,7 @@
+# TODO? should we skip the interpreter? it may contain lots of test files.
 https://github.com/lua/lua
-https://git.net-core.org/tome/t-engine4.git
+#RPC error at clone so skipped for now
+#https://git.net-core.org/tome/t-engine4.git
 https://github.com/EmmyLua/VSCode-EmmyLua
 https://github.com/EvandroLG/pegasus.lua
 https://github.com/Kong/kong

--- a/parsing-stats/lang/ocaml/projects.txt
+++ b/parsing-stats/lang/ocaml/projects.txt
@@ -11,14 +11,14 @@ https://github.com/returntocorp/pfff
 # (we could add more, we're looking for large amounts of handwritten
 # code rather than popularity)
 #
+# TODO? should we skip the compiler repo? it contains lots of test files.
+# https://github.com/ocaml/ocaml.git
 https://github.com/facebook/flow.git
 https://github.com/reasonml/reason.git
 https://github.com/facebook/pyre-check.git
-https://github.com/rescript-lang/rescript-compiler.git
 https://github.com/astrada/google-drive-ocamlfuse.git
 https://github.com/batsh-dev-team/Batsh.git
 https://github.com/coq/coq.git
-https://github.com/ocaml/ocaml.git
 https://github.com/fastpack/fastpack.git
 https://github.com/bcpierce00/unison.git
 https://github.com/mirage/mirage.git
@@ -29,3 +29,7 @@ https://github.com/ocaml/merlin.git
 https://github.com/MLstate/opalang.git
 https://github.com/airbus-seclab/bincat.git
 https://github.com/ocaml/dune.git
+
+# this contains a 22MB whole_compiler.ml file that requires 4GB
+# of memory to parse.
+https://github.com/rescript-lang/rescript-compiler.git

--- a/parsing-stats/lang/php/projects.txt
+++ b/parsing-stats/lang/php/projects.txt
@@ -19,6 +19,7 @@ https://github.com/briannesbitt/Carbon
 https://github.com/WordPress/WordPress
 https://github.com/matomo-org/matomo
 https://github.com/easychen/howto-make-more-money
+#TODO? should we skip it? Does it contain many test files?
 https://github.com/nikic/PHP-Parser
 https://github.com/nextcloud/server
 https://github.com/yiisoft/yii2

--- a/parsing-stats/lang/ruby/projects.txt
+++ b/parsing-stats/lang/ruby/projects.txt
@@ -1,54 +1,56 @@
 #
 # Popular Ruby projects
 #
-git@github.com:helpyio/helpy.git
-git@github.com:rubygems/rubygems.org.git
-git@github.com:huginn/huginn.git
+https://github.com/helpyio/helpy
+https://github.com/rubygems/rubygems.org
+https://github.com/huginn/huginn
 
 # Ruby parts of Travis CI
-git@github.com:travis-ci/travis-build.git
-git@github.com:travis-ci/travis-api.git
-git@github.com:travis-ci/travis-cookbooks.git
-git@github.com:travis-ci/travis-hub.git
-git@github.com:travis-ci/travis-listener.git
-git@github.com:travis-ci/travis-logs.git
-git@github.com:travis-ci/travis-support.git
-git@github.com:travis-ci/travis-tasks.git
+https://github.com/travis-ci/travis-build
+https://github.com/travis-ci/travis-api
+https://github.com/travis-ci/travis-cookbooks
+https://github.com/travis-ci/travis-hub
+https://github.com/travis-ci/travis-listener
+https://github.com/travis-ci/travis-logs
+https://github.com/travis-ci/travis-support
+https://github.com/travis-ci/travis-tasks
 
-git@github.com:OWASP/railsgoat.git
+https://github.com/OWASP/railsgoat
+
+# TODO? skip? may contain many test files?
+https://github.com/ruby/ruby
 
 # Most starred on GitHub:
 #   https://github.com/topics/ruby?l=ruby&o=desc&s=stars
 #
 # These were gathered by hand. Maybe next time we can automate this.
 #
-git@github.com:rails/rails.git
-git@github.com:jekyll/jekyll.git
-git@github.com:discourse/discourse.git
-git@github.com:fastlane/fastlane.git
-git@github.com:gitlabhq/gitlabhq.git
-git@github.com:Homebrew/brew.git
-git@github.com:heartcombo/devise.git
-git@github.com:hashicorp/vagrant.git
-git@github.com:ruby/ruby.git
-git@github.com:diaspora/diaspora.git
-git@github.com:capistrano/capistrano.git
-git@github.com:sinatra/sinatra.git
-git@github.com:rubocop-hq/rubocop.git
-git@github.com:spree/spree.git
-git@github.com:mperham/sidekiq.git
-git@github.com:postalhq/postal.git
-git@github.com:fluent/fluentd.git
-git@github.com:ruby-grape/grape.git
-git@github.com:activeadmin/activeadmin.git
-git@github.com:faker-ruby/faker.git
-git@github.com:kaminari/kaminari.git
-git@github.com:heartcombo/simple_form.git
-git@github.com:Homebrew/homebrew-core.git
-git@github.com:thoughtbot/factory_bot.git
-git@github.com:lewagon/setup.git
-git@github.com:realm/jazzy.git
-git@github.com:chef/chef.git
-git@github.com:puma/puma.git
-git@github.com:pry/pry.git
-git@github.com:github-changelog-generator/github-changelog-generator.git
+https://github.com/rails/rails
+https://github.com/jekyll/jekyll
+https://github.com/discourse/discourse
+https://github.com/fastlane/fastlane
+https://github.com/gitlabhq/gitlabhq
+https://github.com/Homebrew/brew
+https://github.com/heartcombo/devise
+https://github.com/hashicorp/vagrant
+https://github.com/diaspora/diaspora
+https://github.com/capistrano/capistrano
+https://github.com/sinatra/sinatra
+https://github.com/rubocop-hq/rubocop
+https://github.com/spree/spree
+https://github.com/mperham/sidekiq
+https://github.com/postalhq/postal
+https://github.com/fluent/fluentd
+https://github.com/ruby-grape/grape
+https://github.com/activeadmin/activeadmin
+https://github.com/faker-ruby/faker
+https://github.com/kaminari/kaminari
+https://github.com/heartcombo/simple_form
+https://github.com/Homebrew/homebrew-core
+https://github.com/thoughtbot/factory_bot
+https://github.com/lewagon/setup
+https://github.com/realm/jazzy
+https://github.com/chef/chef
+https://github.com/puma/puma
+https://github.com/pry/pry
+https://github.com/github-changelog-generator/github-changelog-generator

--- a/parsing-stats/lang/rust/projects.txt
+++ b/parsing-stats/lang/rust/projects.txt
@@ -1,4 +1,6 @@
+#TODO? skip compiler? it may contain many test files
 https://github.com/rust-lang/rust
+
 https://github.com/rust-lang/rustlings
 https://github.com/RustPython/RustPython
 https://github.com/RustScan/RustScan

--- a/parsing-stats/lang/typescript/projects.txt
+++ b/parsing-stats/lang/typescript/projects.txt
@@ -8,47 +8,47 @@
 #   sort by: most forks
 #
 
-git@github.com:ant-design/ant-design.git
-git@github.com:angular/angular.git
-git@github.com:microsoft/vscode.git
-git@github.com:ionic-team/ionic.git
-git@github.com:angular/angular-cli.git
-git@github.com:akveo/ngx-admin.git
-git@github.com:desktop/desktop.git
-git@github.com:storybookjs/storybook.git
-git@github.com:vuetifyjs/vuetify.git
-git@github.com:angular-ui/ui-router.git
-git@github.com:typeorm/typeorm.git
-git@github.com:denoland/deno.git
-git@github.com:primefaces/primeng.git
-git@github.com:nestjs/nest.git
-git@github.com:NG-ZORRO/ng-zorro-antd.git
-git@github.com:BabylonJS/Babylon.js.git
-git@github.com:alibaba/ice.git
-git@github.com:apollographql/apollo-client.git
-git@github.com:palantir/blueprint.git
-git@github.com:mgechev/angular-seed.git
-git@github.com:swimlane/ngx-datatable.git
-git@github.com:NativeScript/NativeScript.git
-git@github.com:ant-design/ant-design-mobile.git
-git@github.com:basarat/typescript-book.git
+https://github.com/ant-design/ant-design
+https://github.com/angular/angular
+https://github.com/microsoft/vscode
+https://github.com/ionic-team/ionic
+https://github.com/angular/angular-cli
+https://github.com/akveo/ngx-admin
+https://github.com/desktop/desktop
+https://github.com/storybookjs/storybook
+https://github.com/vuetifyjs/vuetify
+https://github.com/angular-ui/ui-router
+https://github.com/typeorm/typeorm
+https://github.com/denoland/deno
+https://github.com/primefaces/primeng
+https://github.com/nestjs/nest
+https://github.com/NG-ZORRO/ng-zorro-antd
+https://github.com/BabylonJS/Babylon.js
+https://github.com/alibaba/ice
+https://github.com/apollographql/apollo-client
+https://github.com/palantir/blueprint
+https://github.com/mgechev/angular-seed
+https://github.com/swimlane/ngx-datatable
+https://github.com/NativeScript/NativeScript
+https://github.com/ant-design/ant-design-mobile
+https://github.com/basarat/typescript-book
 
 # Too many weird test cases in the following:
-# git@github.com:DefinitelyTyped/DefinitelyTyped.git
-# git@github.com:microsoft/TypeScript.git
+# https://github.com/DefinitelyTyped/DefinitelyTyped
+# https://github.com/microsoft/TypeScript
 
 #
 # Public projects with .tsx files, obtained from GitHub search
 # by searching for the keyword "react" and filter by language "typescript".
 # (Filtering by language "TSX" or by extension "tsx" didn't work.)
 #
-https://github.com/omariosouto/lucasflix.git
-https://github.com/EmmaRamirez/nuzlocke-generator.git
-https://github.com/ant-design/ant-design.git
-https://github.com/FaridSafi/react-native-gifted-chat.git
-https://github.com/microsoft/reactxp.git
-https://github.com/react-component/slider.git
-https://github.com/formium/formik.git
-https://github.com/tannerlinsley/react-query.git
-https://github.com/material-components/material-components-web-react.git
-https://github.com/projectstorm/react-diagrams.git
+https://github.com/omariosouto/lucasflix
+https://github.com/EmmaRamirez/nuzlocke-generator
+https://github.com/ant-design/ant-design
+https://github.com/FaridSafi/react-native-gifted-chat
+https://github.com/microsoft/reactxp
+https://github.com/react-component/slider
+https://github.com/formium/formik
+https://github.com/tannerlinsley/react-query
+https://github.com/material-components/material-components-web-react
+https://github.com/projectstorm/react-diagrams

--- a/parsing-stats/run-lang
+++ b/parsing-stats/run-lang
@@ -10,7 +10,7 @@ progname=$(basename "$0")
 
 usage() {
   cat <<EOF
-Usage: $progname LANG
+Usage: $progname [--upload] LANG
 
 Expects:
 - lang/LANG/projects.txt: contains one git URL per line
@@ -103,9 +103,14 @@ main() {
 
     (
       cd tmp
-      # Set memory limit to avoid killing other processes that run in parallel
-      # if this semgrep-core instance uses too much memory.
-      ulimit -v 4000000  # KiB
+      # old: Set memory limit to avoid killing other processes that run in
+      # parallel if this semgrep-core instance uses too much memory.
+      ### ulimit -v 4000000  # KiB
+      # TODO: we now implement the limit in Test_parsing.parsing_common
+      # because the use of 'ulimit -v' above triggers some unrecoverable
+      # 'Fatal error: out of memory' that even Memory_limit can't intercept.
+      # See the long comment in Test_parsing.parsing_common about
+      # mem_limit_mb.
       semgrep-core -lang "$lang" -parsing_stats -json $project_list
     ) > stats.json
   )

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -202,7 +202,7 @@ let parsing_common ?(verbose = true) lang xs =
    * Seems like the Gc alarm does not trigger, maybe because there is no
    * major GC cycle triggered before reaching the 1 GB ulimit.
    *
-   * So the current workaround is to still put a limit below, but
+   * So the current workaround is to still use mem_limit_mb here, but
    * remove the 'ulimit -v' in the parsing-stat/run-lang script.
    *
    * TODO: The weird thing is that even with the 1Gb limit below, I often

--- a/semgrep-core/src/parsing/dune
+++ b/semgrep-core/src/parsing/dune
@@ -16,6 +16,7 @@
    spacegrep
 
    semgrep_core
+   semgrep_system
    semgrep_optimizing
    semgrep_metachecking
    semgrep_parsing_tree_sitter

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
  *)
-open Common
 module PI = Parse_info
 module CST = Tree_sitter_cpp.CST
 module H = Parse_tree_sitter_helpers
@@ -2619,10 +2618,5 @@ let parse file =
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       try map_translation_unit env cst
       with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
+        H.debug_sexp_cst_after_error (CST.sexp_of_translation_unit cst);
         raise exn)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2954,18 +2954,9 @@ let parse file =
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
-      try
-        match compilation_unit env cst with
-        | G.Pr xs -> xs
-        | _ -> failwith "not a program"
-      with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
-        raise exn)
+      match compilation_unit env cst with
+      | G.Pr xs -> xs
+      | _ -> failwith "not a program")
 
 let parse_pattern_aux str =
   (* ugly: coupling: see grammar.js of csharp.

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2757,12 +2757,7 @@ let parse file =
 
       try script env cst
       with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
+        H.debug_sexp_cst_after_error (CST.sexp_of_script cst);
         raise exn)
 
 let parse_pattern str =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
  *)
-open Common
 module CST = Tree_sitter_html.CST
 module H = Parse_tree_sitter_helpers
 open AST_generic
@@ -229,26 +228,17 @@ let parse file =
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
-      try
-        let xs = map_fragment env cst in
-        let xml =
-          {
-            xml_kind = XmlFragment (fake "", fake "");
-            xml_attrs = [];
-            xml_body = xs;
-          }
-        in
-        let e = Xml xml |> G.e in
-        let st = G.exprstmt e in
-        [ st ]
-      with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
-        raise exn)
+      let xs = map_fragment env cst in
+      let xml =
+        {
+          xml_kind = XmlFragment (fake "", fake "");
+          xml_attrs = [];
+          xml_body = xs;
+        }
+      in
+      let e = Xml xml |> G.e in
+      let st = G.exprstmt e in
+      [ st ])
 
 let parse_pattern str =
   H.wrap_parser

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -2045,12 +2045,7 @@ let parse file =
         | G.Pr xs -> xs
         | _ -> failwith "not a program"
       with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
+        H.debug_sexp_cst_after_error (CST.sexp_of_source_file cst);
         raise exn)
 
 let parse_expression_or_source_file str =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -38,14 +38,10 @@ type env = unit H.env
 
 let token = H.token
 
-let _fake = PI.fake_info
-
-let fb = PI.fake_bracket
-
 let str = H.str
 
 (* like in parser_ml.mly *)
-let seq1 = function [ x ] -> x | xs -> Sequence (Parse_info.fake_bracket xs)
+let seq1 = function [ x ] -> x | xs -> Sequence (PI.fake_bracket xs)
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -973,7 +969,7 @@ and map_binding_pattern (env : env) (x : CST.binding_pattern) : pattern =
       let v1 = map_binding_pattern_ext env v1 in
       let _v2 = token env v2 (* "," *) in
       let v3 = map_binding_pattern_ext env v3 in
-      PatTuple (fb [ v1; v3 ])
+      PatTuple (PI.fake_bracket [ v1; v3 ])
   | `Cons_bind_pat_f2d0ae9 (v1, v2, v3) ->
       let v1 = map_binding_pattern_ext env v1 in
       let v2 = token env v2 (* "::" *) in
@@ -2180,7 +2176,7 @@ and map_pattern (env : env) (x : CST.pattern) : pattern =
       let v1 = map_pattern_ext env v1 in
       let _v2 = token env v2 (* "," *) in
       let v3 = map_pattern_ext env v3 in
-      PatTuple (fb [ v1; v3 ])
+      PatTuple (PI.fake_bracket [ v1; v3 ])
   | `Cons_pat_9b4e481 (v1, v2, v3) ->
       let v1 = map_pattern_ext env v1 in
       let v2 = token env v2 (* "::" *) in
@@ -3175,12 +3171,4 @@ let parse file =
       Parallel.invoke Tree_sitter_ocaml.Parse.file file ())
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
-      try map_compilation_unit env cst
-      with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
-        raise exn)
+      map_compilation_unit env cst)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
@@ -11,7 +11,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
  *)
-open Common
 module CST = Tree_sitter_r.CST
 module H = Parse_tree_sitter_helpers
 
@@ -37,8 +36,6 @@ let token = H.token
 
 (* Disable warning against unused 'rec' *)
 [@@@warning "-39"]
-
-let blank (env : env) () = failwith "not implemented"
 
 let todo (env : env) _ = failwith "not implemented"
 
@@ -509,10 +506,5 @@ let parse file =
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       try map_program env cst
       with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
+        H.debug_sexp_cst_after_error (CST.sexp_of_program cst);
         raise exn)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
@@ -18,6 +18,8 @@ val str_if_wrong_content_temporary_fix :
 val combine_tokens_DEPRECATED :
   'a env -> Tree_sitter_run.Token.t list -> Parse_info.t
 
+val debug_sexp_cst_after_error : Sexplib.Sexp.t -> unit
+
 (*
    Call a tree-sitter parser and then map the CST into an AST
    with the user-provided function. Takes care of error handling.

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -389,14 +389,5 @@ let parse parse_js file =
       in
       let env = { H.file; conv = H.line_col_to_pos file; extra } in
 
-      try
-        let xs = map_component env cst in
-        xs
-      with Failure "not implemented" as exn ->
-        let s = Printexc.get_backtrace () in
-        pr2 "Some constructs are not handled yet";
-        pr2 "CST was:";
-        CST.dump_tree cst;
-        pr2 "Original backtrace:";
-        pr2 s;
-        raise exn)
+      let xs = map_component env cst in
+      xs)

--- a/semgrep-core/src/parsing/tree_sitter/dune
+++ b/semgrep-core/src/parsing/tree_sitter/dune
@@ -3,6 +3,7 @@
  (wrapped false)
  (libraries
    yaml
+   sexplib
 
    tree-sitter-lang.ruby
    tree-sitter-lang.java

--- a/semgrep-core/src/system/Memory_limit.ml
+++ b/semgrep-core/src/system/Memory_limit.ml
@@ -16,6 +16,7 @@ let default_stack_warning_kb = 100
 
    See https://discuss.ocaml.org/t/todays-trick-memory-limits-with-gc-alarms/4431
    for detailed explanations.
+
 *)
 let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
     ~mem_limit_mb f =

--- a/semgrep-core/src/system/Memory_limit.mli
+++ b/semgrep-core/src/system/Memory_limit.mli
@@ -15,6 +15,11 @@
    'Gc.compact ()' is called before re-raising any 'Out_of_memory' exception
    so as to reclaim some space.
 
+   Note that tuning the GC with Gc.set may not interact well with
+   Memory_limit and its use of Gc.alarm. Indeed, the Gc.alarm triggers
+   only at major cycle, so tuning the GC may influence how frequently
+   major cycles occur.
+
    As of ocaml 4.12, segfaults often occur when running out of physical
    memory. Segfaults used to occur also on stack overflows on some
    architectures and/or operating systems, although this


### PR DESCRIPTION
The Lua parsing stat job was failing because it was using
a non-github repo which triggered an RPC error at clone time.

The Kotlin parsing stat job was failing because it was using
CST.dump_tree which output things on stdout, which then messes up
the json.

The C parsing stat job was failing because of some out of memory
fatal errors on huge files. I tried to use Memory_limit
but ran in many issues. It's hard to intercept those Out_of_memory
reliably.

test plan:
./run-lang --upload lua
./run-lang --upload kotlin
./run-lang --upload c




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date