### PR TITLE
Remove update-docker call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: returntocorp/semgrep
           tags: ${{ steps.get_version.outputs.VERSION }}, latest
-      - name: update semgrep.dev
-        run: curl --fail -X POST https://semgrep.dev/api/admin/update-docker
 
   build-core:
     name: semgrep-core make test and semgrep make test/qa-test


### PR DESCRIPTION
The `update-docker` call is no longer necessary. This should fix future release failures like: https://github.com/returntocorp/semgrep/pull/3668/checks?check_run_id=3244923465