### PR TITLE
More fixes for parsing-stats CI job

### DIFF
--- a/parsing-stats/lang/c/projects.txt
+++ b/parsing-stats/lang/c/projects.txt
@@ -10,7 +10,6 @@
 https://github.com/coolsnowwolf/lede
 https://github.com/FFmpeg/FFmpeg
 https://github.com/php/php-src
-https://github.com/radareorg/radare2
 https://github.com/arendst/Tasmota
 https://github.com/openssl/openssl
 https://github.com/Awesome-HarmonyOS/HarmonyOS
@@ -22,3 +21,6 @@ https://github.com/curl/curl
 https://github.com/ventoy/Ventoy
 https://github.com/redis/redis
 https://github.com/mpv-player/mpv
+
+#TODO: get some hard-to-recover out of memory error, so skipped for now
+#https://github.com/radareorg/radare2

--- a/parsing-stats/lang/typescript/projects.txt
+++ b/parsing-stats/lang/typescript/projects.txt
@@ -44,7 +44,6 @@ https://github.com/basarat/typescript-book
 #
 https://github.com/omariosouto/lucasflix
 https://github.com/EmmaRamirez/nuzlocke-generator
-https://github.com/ant-design/ant-design
 https://github.com/FaridSafi/react-native-gifted-chat
 https://github.com/microsoft/reactxp
 https://github.com/react-component/slider


### PR DESCRIPTION
The main change is that we just skip big files. They cause
too much problems and anyway those files are not real,
they are autogenerated, or test files for benchmarks, or just
huge data converted as code (e.g., unicode tables).

Do we do similar filtering in semgrep itself? I remember martin
at some point was looking at the size of files in spacegrep.

test plan:
make test
./run-lang c

```
pad@yrax parsing-stats (more_fix_parsing_stats)]$ yy -lang ocaml -parsing_stats ~/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang ocaml -parsing_stats /home/pad/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/
skipping /home/pad/github/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/refmt_main3.ml, too big
skipping /home/pad/github/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/unstable/js_compiler.ml, too big
skipping /home/pad/github/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/whole_compiler.ml, too big
000.0s: [ocaml] processing /home/pad/github/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/bsb_helper.ml
000.1s: [ocaml] processing /home/pad/github/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/bsb_helper.mli
000.1s: [ocaml] processing /home/pad/github/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/bspp.mli
000.1s: [ocaml] processing /home/pad/github/semgrep/parsing-stats/lang/ocaml/tmp/rescript-lang-rescript-compiler/lib/4.06.1/refmt_main3.mli
```




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date