### PR TITLE
[OCaml] basic support for module aliasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+- OCaml: support module aliasing, so looking for `List.map` will also
+  find code that renamed `List` as `L` via `module L = List`.
+
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 
 ### Added

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1713,6 +1713,7 @@ and module_definition = { mbody : module_definition_kind }
 
 (*s: type [[AST_generic.module_definition_kind]] *)
 and module_definition_kind =
+  (* note that those could be converted also in ImportAs *)
   | ModuleAlias of dotted_ident
   (* newscope: *)
   | ModuleStruct of dotted_ident option * item list

--- a/semgrep-core/tests/ocaml/aliasing_qualified.ml
+++ b/semgrep-core/tests/ocaml/aliasing_qualified.ml
@@ -1,0 +1,13 @@
+module G = AST_generic
+
+let foo () =
+  (* ERROR: match *)
+  G.fb [];
+  E.fb [];
+  (* ERROR: match *)
+  AST_generic.fb [];
+
+  ()
+
+
+    

--- a/semgrep-core/tests/ocaml/aliasing_qualified.sgrep
+++ b/semgrep-core/tests/ocaml/aliasing_qualified.sgrep
@@ -1,0 +1,1 @@
+AST_generic.fb $X


### PR DESCRIPTION
It is quite common in OCaml (at least in my OCaml codebases),
to use module aliasing such as 'module G = AST_generic'.
We want that a pattern like 'AST_generic.foo' also match
code where the AST_generic module has been aliased, just
like we do in Python or Go where we handle import aliasing.

test plan:
test file included




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date