### PR TITLE
Refactor Constructor to take a name, not a dotted_ident

### DIFF
--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -19,6 +19,7 @@ open AST_generic
 module G = AST_generic
 module B = AST_generic_v1_t
 module PI = Parse_info
+module H = AST_generic_helpers
 
 exception NoInterpolatedElement
 
@@ -218,7 +219,9 @@ and map_expr x : B.expr =
       let v1 = map_bracket (map_of_list map_field) v1 in
       `Record v1
   | Constructor (v1, (_l, v2, _r)) ->
-      let v1 = map_dotted_ident v1 and v2 = map_of_list map_expr v2 in
+      let v1 = H.dotted_ident_of_name v1 in
+      let v1 = map_dotted_ident v1 in
+      let v2 = map_of_list map_expr v2 in
       `Constructor (v1, v2)
   | Lambda v1 ->
       let v1 = map_function_definition v1 in
@@ -830,6 +833,7 @@ and map_pattern = function
       let v1 = map_type_ v1 in
       `PatType v1
   | PatConstructor (v1, v2) ->
+      let v1 = H.dotted_ident_of_name v1 in
       let v1 = map_dotted_ident v1 and v2 = map_of_list map_pattern v2 in
       `PatConstructor (v1, v2)
   | PatTuple v1 ->

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -202,7 +202,10 @@ type ident = string wrap
 [@@deriving show, eq, hash]
 
 (*s: type [[AST_generic.dotted_ident]] *)
-(* usually separated by a '.', but can be used also with '::' separators *)
+(* Usually separated by a '.', but can be used also with '::' separators.
+ * TODO: we often need to get the last elt or adjust the qualifier part,
+ * so maybe we should define it as = ident list * ident
+ *)
 type dotted_ident = ident list (* at least 1 element *)
 (*e: type [[AST_generic.dotted_ident]] *)
 [@@deriving show, eq, hash]
@@ -406,7 +409,6 @@ and expr_kind =
   (* Or-type (could be used instead of Container, Cons, Nil, etc.).
    * (ab)used also for polymorphic variants where qualifier is QTop with
    * the '`' token.
-   * todo: we should probably replace dotted_ident by name here.
    *
    * Note that in OCaml constructors do not always need brackets.
    * For example, you can have 'let x = Foo 1'. However, you often
@@ -418,11 +420,12 @@ and expr_kind =
    * if the argument is a complex expression (e.g., 'let x = Foo(1+2)').
    * And if those parenthesis are not in the AST, then matching range
    * or autofix on such construct may fail.
+   * Finally, in some languages like Scala or Rust, constructors require
+   * the parenthesis.
    * Thus, it is simpler to add the bracket here, because this is mostly
-   * how user think. Finally, in some languages like Scala constructors
-   * require the parenthesis.
+   * how user think.
    *)
-  | Constructor of dotted_ident * expr list bracket
+  | Constructor of name * expr list bracket
   (* see also Call(IdSpecial (New,_), [ArgType _;...] for other values *)
   (*e: [[AST_generic.expr]] other composite cases *)
   | N of name
@@ -1118,9 +1121,8 @@ and pattern =
   | PatLiteral of literal
   (* Or-Type, used also to match OCaml exceptions.
    * Used with Rust path expressions, with an empty pattern list.
-   * todo: should probably replace dotted_ident by name here.
    *)
-  | PatConstructor of dotted_ident * pattern list
+  | PatConstructor of name * pattern list (* TODO: bracket also here *)
   (* And-Type*)
   | PatRecord of (dotted_ident * pattern) list bracket
   (* newvar:! *)

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -214,7 +214,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
             let v1 = map_bracket (map_of_list map_field) v1 in
             Record v1
         | Constructor (v1, v2) ->
-            let v1 = map_dotted_ident v1
+            let v1 = map_name v1
             and v2 = map_bracket (map_of_list map_expr) v2 in
             Constructor (v1, v2)
         | Lambda v1 ->
@@ -712,7 +712,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let v1 = map_type_ v1 in
         PatType v1
     | PatConstructor (v1, v2) ->
-        let v1 = map_dotted_ident v1 and v2 = map_of_list map_pattern v2 in
+        let v1 = map_name v1 and v2 = map_of_list map_pattern v2 in
         PatConstructor (v1, v2)
     | PatTuple v1 ->
         let v1 = map_bracket (map_of_list map_pattern) v1 in

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -185,8 +185,7 @@ and vof_expr e =
       let v1 = vof_bracket (OCaml.vof_list vof_field) v1 in
       OCaml.VSum ("Record", [ v1 ])
   | Constructor (v1, v2) ->
-      let v1 = vof_dotted_ident v1
-      and v2 = vof_bracket (OCaml.vof_list vof_expr) v2 in
+      let v1 = vof_name v1 and v2 = vof_bracket (OCaml.vof_list vof_expr) v2 in
       OCaml.VSum ("Constructor", [ v1; v2 ])
   | Lambda v1 ->
       let v1 = vof_function_definition v1 in
@@ -889,7 +888,7 @@ and vof_pattern = function
       in
       OCaml.VSum ("PatRecord", [ v1 ])
   | PatConstructor (v1, v2) ->
-      let v1 = vof_dotted_ident v1 and v2 = OCaml.vof_list vof_pattern v2 in
+      let v1 = vof_name v1 and v2 = OCaml.vof_list vof_pattern v2 in
       OCaml.VSum ("PatConstructor", [ v1; v2 ])
   | PatWhen (v1, v2) ->
       let v1 = vof_pattern v1 and v2 = vof_expr v2 in

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -284,7 +284,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
           let v1 = v_bracket (v_list v_field) v1 in
           ()
       | Constructor (v1, v2) ->
-          let v1 = v_dotted_ident v1 and v2 = v_bracket (v_list v_expr) v2 in
+          let v1 = v_name v1 and v2 = v_bracket (v_list v_expr) v2 in
           ()
       | Lambda v1 ->
           let v1 = v_function_definition v1 in
@@ -794,7 +794,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
           let v1 = v_type_ v1 in
           ()
       | PatConstructor (v1, v2) ->
-          let v1 = v_dotted_ident v1 and v2 = v_list v_pattern v2 in
+          let v1 = v_name v1 and v2 = v_list v_pattern v2 in
           ()
       | PatTuple (_, v1, _) ->
           let v1 = v_list v_pattern v1 in

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -712,7 +712,8 @@ and m_expr a b =
   (*s: [[Generic_vs_generic.m_expr()]] boilerplate cases *)
   | G.Record a1, B.Record b1 -> (m_bracket m_fields) a1 b1
   | G.Constructor (a1, a2), B.Constructor (b1, b2) ->
-      m_dotted_name a1 b1 >>= fun () -> m_bracket (m_list m_expr) a2 b2
+      (* TODO: handle aliasing in m_name, like we do for N in expr *)
+      m_name a1 b1 >>= fun () -> m_bracket (m_list m_expr) a2 b2
   | G.Lambda a1, B.Lambda b1 ->
       m_function_definition a1 b1 >>= fun () -> return ()
   | G.AnonClass a1, B.AnonClass b1 -> m_class_definition a1 b1
@@ -2147,7 +2148,8 @@ and m_pattern a b =
   | G.PatLiteral a1, B.PatLiteral b1 -> m_literal a1 b1
   | G.PatType a1, B.PatType b1 -> m_type_ a1 b1
   | G.PatConstructor (a1, a2), B.PatConstructor (b1, b2) ->
-      m_dotted_name a1 b1 >>= fun () -> (m_list m_pattern) a2 b2
+      (* TODO: handle aliasing in m_name, like we do for N in expr *)
+      m_name a1 b1 >>= fun () -> (m_list m_pattern) a2 b2
   | G.PatTuple a1, B.PatTuple b1 -> m_bracket (m_list m_pattern) a1 b1
   | G.PatList a1, B.PatList b1 -> m_bracket (m_list m_pattern) a1 b1
   | G.PatRecord a1, B.PatRecord b1 -> m_bracket (m_list m_field_pattern) a1 b1

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -252,16 +252,16 @@ and expr e =
       G.L v1
   | Name v1 -> G.N (name v1)
   | Constructor (v1, v2) ->
-      let v1 = dotted_ident_of_name v1 in
+      let v1 = name v1 in
       let v2 = option_expr_to_ctor_arguments v2 in
       G.Constructor (v1, v2)
   | PolyVariant ((v0, v1), v2) ->
       let v0 = tok v0 in
       let v1 = ident v1 in
       let v2 = option_expr_to_ctor_arguments v2 in
-      let dotted_ident = [ ("`", v0); v1 ] in
+      let name = H.name_of_ids [ ("`", v0); v1 ] in
       (* TODO: introduce a new construct in AST_generic instead? *)
-      G.Constructor (dotted_ident, v2)
+      G.Constructor (name, v2)
   | Tuple v1 ->
       let v1 = (list expr) v1 in
       (* the fake brackets might be replaced in the caller if there
@@ -432,17 +432,17 @@ and pattern = function
       let v1 = literal v1 in
       G.PatLiteral v1
   | PatConstructor (v1, v2) ->
-      let v1 = dotted_ident_of_name v1 and v2 = option pattern v2 in
+      let v1 = name v1 and v2 = option pattern v2 in
       G.PatConstructor (v1, Common.opt_to_list v2)
   | PatPolyVariant ((v0, v1), v2) ->
       let v0 = tok v0 in
       let v1 = ident v1 in
       let v2 = option pattern v2 in
-      let dotted_ident = [ ("`", v0); v1 ] in
-      G.PatConstructor (dotted_ident, Common.opt_to_list v2)
+      let name = H.name_of_ids [ ("`", v0); v1 ] in
+      G.PatConstructor (name, Common.opt_to_list v2)
   | PatConsInfix (v1, v2, v3) ->
       let v1 = pattern v1 and v2 = tok v2 and v3 = pattern v3 in
-      let n = [ ("::", v2) ] in
+      let n = H.name_of_ids [ ("::", v2) ] in
       G.PatConstructor (n, [ v1; v3 ])
   | PatTuple v1 ->
       let v1 = bracket (list pattern) v1 in

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -315,7 +315,8 @@ and v_pattern = function
       | Right e -> todo_pattern "PatLiteralExpr" [ G.E e ])
   | PatName v1 ->
       let ids = v_dotted_name_of_stable_id v1 in
-      G.PatConstructor (ids, [])
+      let name = H.name_of_ids ids in
+      G.PatConstructor (name, [])
   | PatTuple v1 ->
       let v1 = v_bracket (v_list v_pattern) v1 in
       G.PatTuple v1
@@ -334,10 +335,12 @@ and v_pattern = function
       let _v2TODO = v_option (v_bracket (v_list v_type_)) v2 in
       let v3 = v_option (v_bracket (v_list v_pattern)) v3 in
       let xs = match v3 with None -> [] | Some (_, xs, _) -> xs in
-      G.PatConstructor (ids, xs)
+      let name = H.name_of_ids ids in
+      G.PatConstructor (name, xs)
   | PatInfix (v1, v2, v3) ->
       let v1 = v_pattern v1 and v2 = v_ident v2 and v3 = v_pattern v3 in
-      G.PatConstructor ([ v2 ], [ v1; v3 ])
+      let name = H.name_of_ids [ v2 ] in
+      G.PatConstructor (name, [ v1; v3 ])
   | PatUnderscoreStar (v1, v2) ->
       let v1 = v_tok v1 and v2 = v_tok v2 in
       todo_pattern "PatUnderscoreStar" [ G.Tk v1; G.Tk v2 ]

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -664,8 +664,7 @@ and map_range_pattern_bound (env : env) (x : CST.anon_choice_lit_pat_0884ef0) :
   | `Lit_pat x -> map_literal_pattern env x
   | `Choice_self x ->
       let name = map_path_name env x in
-      let dotted = H2.dotted_ident_of_name name in
-      G.PatConstructor (dotted, [])
+      G.PatConstructor (name, [])
 
 and map_meta_argument (env : env) (x : CST.anon_choice_meta_item_fefa160) :
     rust_meta_argument =
@@ -1377,7 +1376,7 @@ and map_expression (env : env) (x : CST.expression) =
         | `Gene_type_with_turb x -> map_generic_type_with_turbofish env x
       in
       let l, fields, r = map_field_initializer_list env v2 in
-      G.Constructor (H2.dotted_ident_of_name name, (l, fields, r))
+      G.Constructor (name, (l, fields, r))
   | `Ellips tok -> G.Ellipsis (token env tok) (* "..." *)
   | `Deep_ellips (v1, v2, v3) ->
       let lellips = token env v1 (* "<..." *) in
@@ -2262,9 +2261,7 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
       let ident = ident env tok in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       G.PatId (ident, G.empty_id_info ())
-  | `Scoped_id x ->
-      G.PatConstructor
-        (H2.dotted_ident_of_name (map_scoped_identifier_name env x), [])
+  | `Scoped_id x -> G.PatConstructor (map_scoped_identifier_name env x, [])
   | `Tuple_pat (v1, v2, v3, v4) ->
       let lparen = token env v1 (* "(" *) in
       let items =


### PR DESCRIPTION
This will allow later to perform aliasing also on constructor calls,
e.g. finding 'G.Call (foo, bar)' when looking for AST_generic.Call($X,
$Y)
This PR just do the Constructor refactoring.

test plan:
make




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date