### PR TITLE
core: Fix parsing of numeric literals in rule files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - OCaml: support module aliasing, so looking for `List.map` will also
   find code that renamed `List` as `L` via `module L = List`.
 
+### Fixed
+- core: Fix parsing of numeric literals in rule files
+
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 
 ### Added

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -257,22 +257,21 @@ let json_of_profile_info profile_start =
  *)
 let json_of_exn e =
   match e with
-  | Parse_rule.InvalidRule (pattern_id, msg, _posTODO) ->
+  | Parse_rule.InvalidRule (rule_id, msg, _posTODO) ->
       J.Object
         [
-          ("pattern_id", J.String pattern_id);
+          ("rule_id", J.String rule_id);
           ("error", J.String "invalid rule");
           ("message", J.String msg);
         ]
-  | Parse_rule.InvalidLanguage (pattern_id, language, _posTODO) ->
+  | Parse_rule.InvalidLanguage (rule_id, language, _posTODO) ->
       J.Object
         [
-          ("pattern_id", J.String pattern_id);
+          ("rule_id", J.String rule_id);
           ("error", J.String "invalid language");
           ("language", J.String language);
         ]
-  | Parse_rule.InvalidPattern (pattern_id, pattern, xlang, message, pos, path)
-    ->
+  | Parse_rule.InvalidPattern (rule_id, pattern, xlang, message, pos, path) ->
       let lang = Rule.string_of_xlang xlang in
       let range_json =
         match pos with
@@ -296,17 +295,17 @@ let json_of_exn e =
       in
       J.Object
         [
-          ("pattern_id", J.String pattern_id);
+          ("rule_id", J.String rule_id);
           ("error", J.String "invalid pattern");
           ("pattern", J.String pattern);
           ("language", J.String lang);
           ("message", J.String message);
           ("range", range_json);
         ]
-  | Parse_rule.InvalidRegexp (pattern_id, message, _posTODO) ->
+  | Parse_rule.InvalidRegexp (rule_id, message, _posTODO) ->
       J.Object
         [
-          ("pattern_id", J.String pattern_id);
+          ("rule_id", J.String rule_id);
           ("error", J.String "invalid regexp in rule");
           ("message", J.String message);
         ]

--- a/semgrep-core/tests/OTHER/rules/message_int.py
+++ b/semgrep-core/tests/OTHER/rules/message_int.py
@@ -1,0 +1,3 @@
+def foo():
+  #ruleid:test
+  return x

--- a/semgrep-core/tests/OTHER/rules/message_int.yaml
+++ b/semgrep-core/tests/OTHER/rules/message_int.yaml
@@ -1,0 +1,6 @@
+rules:
+- id: test
+  languages: [python]
+  pattern: x
+  message: 42
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/pattern_int.py
+++ b/semgrep-core/tests/OTHER/rules/pattern_int.py
@@ -1,0 +1,3 @@
+def foo():
+  #ruleid:test
+  return 1

--- a/semgrep-core/tests/OTHER/rules/pattern_int.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern_int.yaml
@@ -1,0 +1,6 @@
+rules:
+- id: test
+  languages: [python]
+  pattern: 1
+  message: Test
+  severity: ERROR


### PR DESCRIPTION
test plan:
1. make test # tests included
2. semgrep -l py -e '42' any_file.py



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
