### PR TITLE
Naming: resolve names for Constructor and PatConstructor

### DIFF
--- a/semgrep-core/tests/ocaml/aliasing_qualified_contructor.ml
+++ b/semgrep-core/tests/ocaml/aliasing_qualified_contructor.ml
@@ -1,0 +1,4 @@
+module G = AST_generic
+
+let foo () =
+  G.Call (1,2)

--- a/semgrep-core/tests/ocaml/aliasing_qualified_contructor.sgrep
+++ b/semgrep-core/tests/ocaml/aliasing_qualified_contructor.sgrep
@@ -1,0 +1,1 @@
+AST_generic.Call ($X, $Y)


### PR DESCRIPTION
This also factorize a bit name resolution for all 'name' types.

test plan:
```
pad@yrax yy (naming_ctor)]$ yy -lang ocaml -dump_named_ast tests/ocaml/aliasing_qualified_contructor.ml
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang ocaml -dump_named_ast tests/ocaml/aliasing_qualified_contructor.ml
[0.038  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.038  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang ocaml -dump_named_ast tests/ocaml/aliasing_qualified_contructor.ml
[0.038  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.61.0-9-g14616953-dirty, pfff: 0.42
[0.038  Info       Main.Parse_target    ] trying to parse with Pfff parser tests/ocaml/aliasing_qualified_contructor.ml
[0.038  Info       Main.Parse_target    ] Parse_target.parse_and_resolve_name_use_pfff_or_treesitter done
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("G", ()),
                {
                 id_resolved=Ref(Some((ImportedModule(
                                         DottedName([("AST_generic", ())])),
                                       1)));
                 id_type=Ref(None); id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      ModuleDef({mbody=ModuleAlias([("AST_generic", ())]); })));
   DefStmt(
     ({
       name=EN(
              Id(("foo", ()),
                {id_resolved=Ref(None); id_type=Ref(None);
                 id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      FuncDef(
        {fkind=(Function, ()); fparams=[ParamPattern(PatLiteral(Unit(())))];
         frettype=None;
         fbody=OtherStmt(OS_ExprStmt2,
                 [E(
                    Constructor(
                      IdQualified(
                        (("Call", ()),
                         {name_qualifier=Some(QDots([("G", ())]));
                          name_typeargs=None; }),
                        {
                         id_resolved=Ref(Some((ImportedEntity(
                                                 [("AST_generic", ());
                                                  ("Call", ())]),
                                               0)));
                         id_type=Ref(None); id_constness=Ref(None); }),
                      [L(Int((Some(1), ()))); L(Int((Some(2), ())))]))]);
         })))])
```




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date