### PR TITLE
[OCaml] module aliasing for Constructor/PatConstructor via m_name

### DIFF
--- a/semgrep-core/tests/ocaml/aliasing_qualified_contructor.ml
+++ b/semgrep-core/tests/ocaml/aliasing_qualified_contructor.ml
@@ -1,4 +1,6 @@
 module G = AST_generic
 
 let foo () =
-  G.Call (1,2)
+  (* ERROR: match *)
+  G.Call (1,2);
+  E.Call (1,2)


### PR DESCRIPTION
We should be able to factorize more code and move more
aliasing logic in m_name, for TyN and NamedAttr too
(and maybe m_expr).

test plan:
test file included




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date