### PR TITLE
core: Better communicate errors to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - core: Fix parsing of numeric literals in rule files
 - Java: fix the range and autofix of Cast expressions (#3669)
 
+### Changed
+- Add backtrace to fatal errors reported by semgrep-core
+- Report errors during rule evaluation to the user
+
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 
 ### Added

--- a/semgrep-core/src/engine/Match_rules.mli
+++ b/semgrep-core/src/engine/Match_rules.mli
@@ -15,7 +15,7 @@ val check :
 val matches_of_formula :
   Config_semgrep_t.t ->
   Equivalence.equivalences ->
-  string ->
+  Rule.rule_id ->
   Common.filename
   * Rule.xlang
   * (AST_generic.program * Error_code.error list) lazy_t ->

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -16,6 +16,7 @@
  *)
 (*e: pad/r2c copyright *)
 open Common
+module StrSet = Common2.StringSet
 open AST_generic
 module V = Visitor_AST
 module PI = Parse_info
@@ -201,8 +202,13 @@ let match_results_of_matches_and_errors files res =
   let matches, new_errs =
     Common.partition_either match_to_match res.RP.matches
   in
-  let errs = new_errs @ res.RP.errors in
-  let count_errors = List.length errs in
+  let errs = !Error_code.g_errors @ new_errs @ res.RP.errors in
+  let files_with_errors =
+    List.fold_left
+      (fun acc err -> StrSet.add err.E.loc.file acc)
+      StrSet.empty errs
+  in
+  let count_errors = StrSet.cardinal files_with_errors in
   let count_ok = List.length files - count_errors in
   {
     ST.matches;

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -265,7 +265,7 @@ class OutputHandler:
                 if self.settings.strict:
                     raise ex
                 logger.info(
-                    f"{error_stats}; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed"
+                    f"{error_stats}; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed cleanly"
                 )
         else:
             raise ex
@@ -307,9 +307,9 @@ class OutputHandler:
         elif self.semgrep_structured_errors:
             # make a simplifying assumption that # errors = # files failed
             # it's a quite a bit of work to simplify further because errors may or may not have path, span, etc.
-            error_stats = (
-                f"{len(self.semgrep_structured_errors)} files could not be analyzed"
-            )
+            num_errors = len(self.semgrep_structured_errors)
+            plural = "s" if num_errors > 1 else ""
+            error_stats = f"found problems analyzing {num_errors} file{plural}"
             final_error = self.semgrep_structured_errors[-1]
         self.final_raise(final_error, error_stats)
 

--- a/semgrep/tests/e2e/snapshots/test_check/test_max_memory/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_max_memory/error.txt
@@ -4,4 +4,4 @@ rules:
 - rules.forcetimeout
 Warning: Semgrep exceeded memory when running rules.forcetimeout on targets/equivalence/open_redirect.py. See `--max-memory` for more info.
 ran 1 rules on 1 files: 0 findings
-1 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed
+found problems analyzing 1 file; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed cleanly

--- a/semgrep/tests/e2e/snapshots/test_check/test_spacegrep_timeout/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_spacegrep_timeout/results.json
@@ -1,3 +1,3 @@
 Warning: 1 timeout error(s) in targets/spacegrep_timeout/gnu-lgplv2.txt when running the following rules: [-]
 ran 1 rules on 1 files: 0 findings
-1 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed
+found problems analyzing 1 file; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed cleanly

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
@@ -7,4 +7,4 @@ rules:
 Warning: 1 timeout error(s) in targets/equivalence/open_redirect.py when running the following rules: [rules.forcetimeout]
 Semgrep stopped running rules on targets/equivalence/open_redirect.py after 1 timeout error(s). See `--timeout-threshold` for more info.
 ran 3 rules on 1 files: 0 findings
-1 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed
+found problems analyzing 1 file; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed cleanly

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
@@ -7,4 +7,4 @@ rules:
 Warning: 2 timeout error(s) in targets/equivalence/open_redirect.py when running the following rules: [rules.forcetimeout, rules.forcetimeout2]
 Semgrep stopped running rules on targets/equivalence/open_redirect.py after 2 timeout error(s). See `--timeout-threshold` for more info.
 ran 3 rules on 1 files: 0 findings
-2 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed
+found problems analyzing 2 files; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed cleanly


### PR DESCRIPTION
- Add backtrace to fatal errors to help diagnosing bug reports (Pfff).
- Report rule evaluation errors instead of "silently" logging them.

Helps #3547

test plan:

    % cat fatal.py
    def foo():
    return 1
    }
    % semgrep -l py -e 'x' fatal.py
    running 1 rules...
    semgrep-core reported a fatal error:
    -----
    Fatal Error: (Failure "Lexer_python.top_mode: empty stack")
    Raised at Parse_target.run in file "src/parsing/Parse_target.ml", line 176, characters 17-26
    ...
    -----
    Please file a bug report at https://github.com/returntocorp/semgrep/issues/new/choose
    ...

    % cat warn.yaml
    rules:
    - id: test
      languages: [python]
      patterns:
      - pattern: $X
      - metavariable-pattern:
          metavariable: $Y
          pattern: x
      message: Test
      severity: ERROR
    % cat warn.py
    x
    % semgrep -c warn.yaml -v warn.py
    ...
    semgrep-core reported a matching error
    --> matching internal error: rule test: metavariable-pattern failed because $Y it not in scope, please check your rule
    ...



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
