### PR TITLE
[OCaml] support open XXx entity aliasing by using LSP

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -45,7 +45,8 @@ dump:
 
 pr:
 	git push origin `git rev-parse --abbrev-ref HEAD`
-	hub pull-request -b develop -r mjambon -r IagoAbal -r emjin
+	hub pull-request -b develop -r mjambon -r IagoAbal
+#not this month: -r emjin
 
 push:
 	git push origin `git rev-parse --abbrev-ref HEAD`

--- a/semgrep-core/src/core/Hooks.ml
+++ b/semgrep-core/src/core/Hooks.ml
@@ -24,3 +24,5 @@
 let exit = ref []
 
 let get_type = ref (fun _id -> None)
+
+let get_def = ref (fun _id -> None)

--- a/semgrep-core/src/core/Hooks.mli
+++ b/semgrep-core/src/core/Hooks.mli
@@ -1,3 +1,5 @@
 val exit : (unit -> unit) list ref
 
 val get_type : (AST_generic.ident -> AST_generic.type_ option) ref
+
+val get_def : (AST_generic.ident -> Common.filename option) ref

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -146,6 +146,12 @@ let _ =
   Common2.example
     (all_suffix_of_list [ 1; 2; 3 ] = [ [ 1; 2; 3 ]; [ 2; 3 ]; [ 3 ]; [] ])
 
+(* copy paste of pfff/lang_ml/analyze/module_ml.ml *)
+let module_name_of_filename file =
+  let _d, b, _e = Common2.dbe_of_filename file in
+  let module_name = String.capitalize_ascii b in
+  module_name
+
 (*****************************************************************************)
 (* Optimisations (caching, bloom filter) *)
 (*****************************************************************************)
@@ -378,6 +384,21 @@ let rec m_name a b =
                { nameinfo with name_qualifier = Some (B.QDots new_qualifier) }
              ),
              B.empty_id_info () ))
+  (* semantic! try to handle open in OCaml by querying LSP! The
+   * target code is using an unqualified Id possibly because of some open!
+   *)
+  | G.IdQualified ((ida, _namea), _infoa), B.Id (idb, _infob)
+    when fst ida = fst idb -> (
+      match !Hooks.get_def idb with
+      | None -> fail ()
+      | Some file ->
+          let m = module_name_of_filename file in
+          let t = snd idb in
+          pr2_gen m;
+          let _n = H.name_of_ids [ (m, t); idb ] in
+          (* retry with qualified target *)
+          (* m_name a n *)
+          return ())
   (* boilerplate *)
   | G.IdQualified (a1, a2), B.IdQualified (b1, b2) ->
       m_name_ a1 b1 >>= fun () -> m_id_info a2 b2
@@ -405,6 +426,8 @@ and m_qualifier a b =
   | G.QExpr (a1, a2), B.QExpr (b1, b2) -> m_expr a1 b1 >>= fun () -> m_tok a2 b2
   | G.QDots _, _ | G.QTop _, _ | G.QExpr _, _ -> fail ()
 
+(* semantic! try to handle typed metavariables by querying LSP
+ * to get inferred type info (only for OCaml for now) *)
 and m_type_option_with_hook idb taopt tbopt =
   match (taopt, tbopt) with
   | Some ta, Some tb -> m_type_ ta tb
@@ -533,6 +556,10 @@ and m_expr a b =
   (*e: [[Generic_vs_generic.m_expr()]] disjunction case *)
   (*s: [[Generic_vs_generic.m_expr()]] resolving alias case *)
   (* equivalence: name resolving! *)
+  (* todo: it would be nice to factorize the aliasing code by just calling
+   * m_name, but below we use make_dotted, which is different from what
+   * we do in m_name.
+   *)
   | ( _a,
       B.N
         (B.Id
@@ -561,7 +588,8 @@ and m_expr a b =
       m_expr a (make_dotted dotted)
   (* equivalence: name resolving on qualified ids (for OCaml) *)
   (* Put this before the next case to prevent overly eager dealiasing *)
-  | G.N (G.IdQualified (_, _) as na), B.N (B.IdQualified (_, _) as nb) ->
+  | ( G.N (G.IdQualified (_, _) as na),
+      B.N ((B.IdQualified (_, _) | B.Id _) as nb) ) ->
       m_name na nb
   (* Matches pattern
    *   a.b.C.x

--- a/semgrep-core/tests/test_lsp.ml
+++ b/semgrep-core/tests/test_lsp.ml
@@ -1,0 +1,19 @@
+(* test file for semgrep-core -lsp -e '...' test_lsp.ml  after dune build *)
+module G = AST_generic
+open AST_generic
+
+let foo e =
+  let res0 = AST_generic.Call (Int (None, fake ""), fb []) in
+  let res1 = G.Call (Int (None, fake ""), fb []) in
+  let res2 = Call (Int (None, fake ""), fb []) in
+  match e.e with
+  | AST_generic.Call (x, (_, [], _)) -> 1
+  | G.Call (x, (_, [_], _)) -> 1
+  | Call (x, y) -> 1
+  | _ -> 2
+
+
+let bar () =
+  AST_generic.fake_bracket [] |> ignore;
+  G.fake_bracket [] |> ignore;
+  fake_bracket [] |> ignore;


### PR DESCRIPTION
test plan:
```
yy -no_bloom_filter -lsp -lang ocaml -e 'AST_generic.fake_bracket $X' tests/test_lsp.ml -log_config_file /tmp/xxx
+ /home/pad/yy/_build/default/src/cli/Main.exe -no_bloom_filter -lsp -lang ocaml -e 'AST_generic.fake_bracket $X' tests/test_lsp.ml -log_config_file /tmp/xxx
START
tests/test_lsp.ml:17
   AST_generic.fake_bracket [] |> ignore;
tests/test_lsp.ml:18
   G.fake_bracket [] |> ignore;
"AST_generic"
tests/test_lsp.ml:19
   fake_bracket [] |> ignore;

yy -no_bloom_filter -lsp -lang ocaml -e 'AST_generic.Call ($X, $Y)' tests/test_lsp.ml -log_config_file /tmp/xxx
+ /home/pad/yy/_build/default/src/cli/Main.exe -no_bloom_filter -lsp -lang ocaml -e 'AST_generic.Call ($X, $Y)' tests/test_lsp.ml -log_config_file /tmp/xxx
START
tests/test_lsp.ml:6
   let res0 = AST_generic.Call (Int (None, fake ""), fb []) in
tests/test_lsp.ml:6
   let res0 = AST_generic.Call (Int (None, fake ""), fb []) in
tests/test_lsp.ml:7
   let res1 = G.Call (Int (None, fake ""), fb []) in
tests/test_lsp.ml:7
   let res1 = G.Call (Int (None, fake ""), fb []) in
"AST_generic"
tests/test_lsp.ml:8
   let res2 = Call (Int (None, fake ""), fb []) in
"AST_generic"
tests/test_lsp.ml:8
   let res2 = Call (Int (None, fake ""), fb []) in

yy -no_bloom_filter -lsp -lang ocaml -e '| AST_generic.Call ($X, $Y)' tests/test_lsp.ml -log_config_file /tmp/xxx
+ /home/pad/yy/_build/default/src/cli/Main.exe -no_bloom_filter -lsp -lang ocaml -e '| AST_generic.Call ($X, $Y)' tests/test_lsp.ml -log_config_file /tmp/xxx
START
tests/test_lsp.ml:10
   | AST_generic.Call (x, (_, [], _)) -> 1
tests/test_lsp.ml:11
   | G.Call (x, (_, [_], _)) -> 1
"AST_generic"
tests/test_lsp.ml:12
   | Call (x, y) -> 1

```




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date