### PR TITLE
Ensure that scanned paths aren't directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - core: Fix parsing of numeric literals in rule files
+- Generic parser no longer tries to open submodule folders as files
 
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -284,8 +284,7 @@ class CoreRunner:
                         targets = [
                             target
                             for target in targets
-                            if target not in max_timeout_files
-                            and not target.is_dir()
+                            if target not in max_timeout_files and not target.is_dir()
                         ]
 
                         # opti: no need to call semgrep-core if no target files

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -285,6 +285,7 @@ class CoreRunner:
                             target
                             for target in targets
                             if target not in max_timeout_files
+                            and not target.is_dir()
                         ]
 
                         # opti: no need to call semgrep-core if no target files


### PR DESCRIPTION
Workaround for issue with git submodules and `git ls-files`, see #3660 for details.

Someone who knows more about semgrep internals should definitely take a closer look at this and ensure that I didn't miss any cases where passing folders into the list of targets is desired - I didn't find any, but I'm new to the codebase :). One could also replace it with an `is_file`, but again, I don't know if there are any non-file things you want to be able to investigate.

Note that at least on my machine, this code has [a bunch of failing `pytest` tests](https://gist.github.com/malexmave/aa61e2acf30de02e838d90049f0a3c52). However, the tests [also fail for the unmodified code](https://gist.github.com/malexmave/1d94f4ff68f5725a8ff57a5d523f5141) on my machine, so I don't quite know what to make of this.

PR checklist:
- [x] documentation is up to date (no changes necessary)
- [x] changelog is up to date
