### PR TITLE
[Java] fix the range and autofix of Cast expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - core: Fix parsing of numeric literals in rule files
+- Java: fix the range and autofix of Cast expressions (#3669)
 
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -522,7 +522,7 @@ and expr_aux env eorig =
   | G.Xml _ -> todo (G.E eorig)
   | G.Constructor (_, _) -> todo (G.E eorig)
   | G.Yield (_, _, _) | G.Await (_, _) -> todo (G.E eorig)
-  | G.Cast (typ, e) ->
+  | G.Cast (typ, _, e) ->
       let e = expr env e in
       mk_e (Cast (typ, e)) eorig
   | G.Ref (_, _) -> todo (G.E eorig)

--- a/semgrep-core/src/analyzing/lrvalue.ml
+++ b/semgrep-core/src/analyzing/lrvalue.ml
@@ -134,7 +134,7 @@ let rec visit_expr hook lhs expr =
            | ArgKwd (_id, e) -> recr e
            | ArgType _ -> ()
            | ArgOther (_, anys) -> List.iter (anyhook hook Rhs) anys)
-  | Cast (_t, e) -> recr e
+  | Cast (_t, _, e) -> recr e
   (* Do some languages allow this to be part of an assign? *)
   | Conditional (e, e1, e2) ->
       recr e1;

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -273,7 +273,7 @@ and map_expr x : B.expr =
       let t = map_tok t in
       let v1 = map_expr v1 in
       `Await (t, v1)
-  | Cast (v1, v2) ->
+  | Cast (v1, _t, v2) ->
       let v1 = map_type_ v1 and v2 = map_expr v2 in
       `Cast (v1, v2)
   | Seq v1 ->

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -489,7 +489,7 @@ and expr_kind =
   | Yield of tok * expr option * bool (* 'from' for Python *)
   | Await of tok * expr
   (* Send/Recv of Go are currently in OtherExpr *)
-  | Cast of type_ (* TODO: bracket or colon *) * expr
+  | Cast of type_ * tok (* ':' or leftmost '(' or 'as' *) * expr
   (* less: should be in statement *)
   | Seq of expr list (* at least 2 elements *)
   (* less: could be in Special, but pretty important so I've lifted them here*)

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -270,9 +270,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
             let t = map_tok t in
             let v1 = map_expr v1 in
             Await (t, v1)
-        | Cast (v1, v2) ->
-            let v1 = map_type_ v1 and v2 = map_expr v2 in
-            Cast (v1, v2)
+        | Cast (v1, t, v2) ->
+            let v1 = map_type_ v1 and t = map_tok t and v2 = map_expr v2 in
+            Cast (v1, t, v2)
         | Seq v1 ->
             let v1 = map_of_list map_expr v1 in
             Seq v1

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -234,9 +234,9 @@ and vof_expr e =
       let t = vof_tok t in
       let v1 = vof_expr v1 in
       OCaml.VSum ("Await", [ t; v1 ])
-  | Cast (v1, v2) ->
-      let v1 = vof_type_ v1 and v2 = vof_expr v2 in
-      OCaml.VSum ("Cast", [ v1; v2 ])
+  | Cast (v1, t, v2) ->
+      let v1 = vof_type_ v1 and t = vof_tok t and v2 = vof_expr v2 in
+      OCaml.VSum ("Cast", [ v1; t; v2 ])
   | Seq v1 ->
       let v1 = OCaml.vof_list vof_expr v1 in
       OCaml.VSum ("Seq", [ v1 ])

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -344,8 +344,8 @@ let (mk_visitor : visitor_in -> visitor_out) =
           let t = v_tok t in
           let v1 = v_expr v1 in
           ()
-      | Cast (v1, v2) ->
-          let v1 = v_type_ v1 and v2 = v_expr v2 in
+      | Cast (v1, t, v2) ->
+          let v1 = v_type_ v1 and t = v_tok t and v2 = v_expr v2 in
           ()
       | Seq v1 ->
           let v1 = v_list v_expr v1 in

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -794,7 +794,9 @@ and m_expr a b =
       m_tok a0 b0 >>= fun () ->
       m_option m_expr a1 b1 >>= fun () -> m_bool a2 b2
   | G.Await (a0, a1), B.Await (b0, b1) -> m_tok a0 b0 >>= fun () -> m_expr a1 b1
-  | G.Cast (a1, a2), B.Cast (b1, b2) -> m_type_ a1 b1 >>= fun () -> m_expr a2 b2
+  | G.Cast (a1, at, a2), B.Cast (b1, bt, b2) ->
+      m_type_ a1 b1 >>= fun () ->
+      m_tok at bt >>= fun () -> m_expr a2 b2
   | G.Seq a1, B.Seq b1 -> (m_list m_expr) a1 b1
   | G.Ref (a0, a1), B.Ref (b0, b1) -> m_tok a0 b0 >>= fun () -> m_expr a1 b1
   | G.DeRef (a0, a1), B.DeRef (b0, b1) -> m_tok a0 b0 >>= fun () -> m_expr a1 b1

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -79,7 +79,7 @@ let subexprs_of_expr e =
   | L _ | N _ | IdSpecial _ | Ellipsis _ | TypedMetavar _ -> []
   | DotAccess (e, _, _)
   | Await (_, e)
-  | Cast (_, e)
+  | Cast (_, _, e)
   | Ref (_, e)
   | DeRef (_, e)
   | DeepEllipsis (_, e, _)

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -202,7 +202,7 @@ let rec expr (x : expr) =
   | TypedExpr (v1, v2) ->
       let v1 = expr v1 in
       let v2 = type_ v2 in
-      G.Cast (v2, v1)
+      G.Cast (v2, fake ":", v1)
   | TypedMetavar (v1, v2, v3) ->
       let v1 = name v1 in
       let v3 = type_ v3 in
@@ -624,7 +624,7 @@ and stmt_aux x =
       | [ a ] -> (
           match a.G.e with
           (* x: t = ... is definitely a VarDef *)
-          | G.Cast (t, { e = G.N (G.Id (id, idinfo)); _ }) ->
+          | G.Cast (t, _, { e = G.N (G.Id (id, idinfo)); _ }) ->
               let ent =
                 { G.name = G.EN (G.Id (id, idinfo)); attrs = []; tparams = [] }
               in

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -212,7 +212,7 @@ and expr e =
       G.DotAccess (G.DeRef (t, v1) |> G.e, t, G.EN (Id (v2, G.empty_id_info ())))
   | Cast (v1, v2) ->
       let v1 = type_ v1 and v2 = expr v2 in
-      G.Cast (v1, v2)
+      G.Cast (v1, fake "(", v2)
   | Postfix (v1, (v2, v3)) ->
       let v1 = expr v1 and v2 = fixOp v2 in
       G.Call

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -230,7 +230,7 @@ let top_func () =
         G.Call (e, args)
     | Cast (v1, v2) ->
         let v1 = type_ v1 and v2 = expr v2 in
-        G.Cast (v1, v2)
+        G.Cast (v1, fake "(", v2)
     | Deref (v1, v2) ->
         let v1 = tok v1 and v2 = expr v2 in
         G.DeRef (v1, v2)

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -338,10 +338,10 @@ and expr e =
       G.Call
         ( G.IdSpecial (G.Op (H.conv_op v2), tok) |> G.e,
           fb [ G.Arg v1; G.Arg v3 ] )
-  | Cast ((_, v1, _), v2) ->
+  | Cast ((l, v1, _), v2) ->
       let v1 = list typ v1 and v2 = expr v2 in
       let t = Common2.foldl1 (fun acc e -> G.TyAnd (acc, fake "&", e)) v1 in
-      G.Cast (t, v2)
+      G.Cast (t, l, v2)
   | InstanceOf (v1, v2) ->
       let v1 = expr v1 and v2 = ref_type v2 in
       G.Call

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -103,7 +103,7 @@ let special (x, tok) =
           match args with
           | [ e ] ->
               let tvoid = G.TyBuiltin ("void", tok) in
-              G.Cast (tvoid, e)
+              G.Cast (tvoid, PI.fake_info ":", e)
           | _ -> error tok "Impossible: Too many arguments to Void")
   | Spread -> SR_Special (G.Spread, tok)
   | Yield ->
@@ -229,15 +229,15 @@ and expr (x : expr) =
       let v1 = expr v1 in
       G.DotAccessEllipsis (v1, v2)
   (* not sure this is actually a valid JS/TS construct *)
-  | Cast (v1, _v2, v3) ->
+  | Cast (v1, v2, v3) ->
       let v1 = expr v1 in
       let v3 = type_ v3 in
-      G.Cast (v3, v1)
+      G.Cast (v3, v2, v1)
   (* converting to Cast as it's mostly the same *)
-  | TypeAssert (v1, _v2, v3) ->
+  | TypeAssert (v1, v2, v3) ->
       let v1 = expr v1 in
       let v3 = type_ v3 in
-      G.Cast (v3, v1)
+      G.Cast (v3, v2, v1)
   | ExprTodo (v1, v2) ->
       let v2 = list expr v2 in
       G.OtherExpr (G.OE_Todo, G.TodoK v1 :: (v2 |> List.map (fun e -> G.E e)))

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -234,11 +234,12 @@ and expr e =
       | e -> e)
   | TypedExpr (v1, v2, v3) -> (
       let v1 = expr v1 in
+      let v2 = tok v2 in
       let v3 = type_ v3 in
       match v1.G.e with
       | G.N (G.Id (id, _idinfo)) when AST_generic_.is_metavar_name (fst id) ->
           G.TypedMetavar (id, v2, v3)
-      | _ -> G.Cast (v3, v1))
+      | _ -> G.Cast (v3, v2, v1))
   | Ellipsis v1 ->
       let v1 = tok v1 in
       G.Ellipsis v1

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -366,7 +366,7 @@ and expr e : G.expr =
       G.Conditional (v1, v2, v3)
   | Cast (v1, v2) ->
       let v1 = ptype v1 and v2 = expr v2 in
-      G.Cast (v1, v2)
+      G.Cast (v1, fake ":", v2)
   | Lambda v1 -> (
       let tok = snd v1.f_name in
       match v1 with

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -377,8 +377,8 @@ and v_expr e =
       let v1 = v_expr v1 and _, v2, _ = v_bracket (v_list v_type_) v2 in
       todo_expr "InstanciatedExpr" (G.E v1 :: List.map (fun t -> G.T t) v2)
   | TypedExpr (v1, v2, v3) ->
-      let v1 = v_expr v1 and _v2 = v_tok v2 and v3 = v_ascription v3 in
-      G.Cast (v3, v1)
+      let v1 = v_expr v1 and v2 = v_tok v2 and v3 = v_ascription v3 in
+      G.Cast (v3, v2, v1)
   | DotAccess (v1, v2, v3) ->
       let v1 = v_expr v1 and v2 = v_tok v2 and v3 = v_ident v3 in
       let name = H.name_of_id v3 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1181,7 +1181,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       let v2 = token env v2 (* "as" *) in
       let v3 = type_ env v3 in
       (* TODO `as` is really a conditional cast *)
-      Cast (v3, v1)
+      Cast (v3, v2, v1)
   | `Assign_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = assignment_operator env v2 in
@@ -1200,7 +1200,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       let v2 = type_constraint env v2 in
       let v3 = token env v3 (* ")" *) in
       let v4 = expression env v4 in
-      Cast (v2, v4)
+      Cast (v2, v1, v4)
   | `Chec_exp x -> checked_expression env x
   | `Cond_access_exp (v1, v2, v3) ->
       (* map `a?.b` to `null == a ? null : a.b` *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -622,14 +622,14 @@ and arguments (env : env) ((v1, v2, v3) : CST.arguments) : G.arguments G.bracket
 
 and as_expression (env : env) ((v1, v2, v3) : CST.as_expression) =
   let v1 = expression env v1 in
-  let _v2 =
+  let v2 =
     (* MISS: Do not capture ?as vs as *)
     match v2 with
     | `As tok -> (* as *) token env tok
     | `QMARKas tok -> (* "?as" *) token env tok
   in
   let v3 = type_ env v3 in
-  G.Cast (v3, v1) |> G.e
+  G.Cast (v3, v2, v1) |> G.e
 
 and attribute_modifier (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.attribute_modifier) : G.attribute =
@@ -1438,7 +1438,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       G.Yield (v1, Some v2, true) |> G.e
       (* Q: What is this last field for? *)
   | `Cast_exp (v1, v2, v3, v4) ->
-      let _v1 = (* "(" *) token env v1 in
+      let v1 = (* "(" *) token env v1 in
       let v2 =
         match v2 with
         | `Array tok -> (* "array" *) G.TyBuiltin (str env tok)
@@ -1449,7 +1449,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       in
       let _v3 = (* ")" *) token env v3 in
       let v4 = expression env v4 in
-      G.Cast (v2, v4) |> G.e
+      G.Cast (v2, v1, v4) |> G.e
   | `Tern_exp (v1, v2, v3, v4, v5) ->
       let v1 = expression env v1 in
       let _v2 = (* "?" *) token env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -1833,9 +1833,9 @@ and unary_expression (env : env) (x : CST.unary_expression) =
           Call (IdSpecial (Op operator, tok) |> G.e, fb [ Arg v2 ]))
   | `As_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
-      let _v2 = as_operator env v2 in
+      let v2 = as_operator env v2 in
       let v3 = type_ env v3 in
-      Cast (v3, v1)
+      Cast (v3, v2, v1)
   | `Spread_exp (v1, v2) ->
       let v1 = token env v1 (* "*" *) in
       let v2 = expression env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -1168,9 +1168,9 @@ and map_expression (env : env) (x : CST.expression) =
       G.AssignOp (lhs, (op, tok), rhs)
   | `Type_cast_exp (v1, v2, v3) ->
       let expr = map_expression env v1 in
-      let _as_ = token env v2 (* "as" *) in
+      let as_ = token env v2 (* "as" *) in
       let type_ = map_type_ env v3 in
-      G.Cast (type_, expr)
+      G.Cast (type_, as_, expr)
   | `Range_exp x ->
       let x = map_range_expression env x in
       x.G.e

--- a/semgrep-core/tests/java/misc_token_cast.java
+++ b/semgrep-core/tests/java/misc_token_cast.java
@@ -1,0 +1,9 @@
+class C {
+  void g() {
+      
+    a.f(
+	//ERROR: match
+	(
+	 Object)this);
+  }
+}

--- a/semgrep-core/tests/java/misc_token_cast.sgrep
+++ b/semgrep-core/tests/java/misc_token_cast.sgrep
@@ -1,0 +1,2 @@
+(Object) this
+


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/3669
This is a bit ugly. The right fix would be to extend
the AST_generic.expr record to store the leftmost and rightmost
token in the expr, so we would not need to abuse tok in the
expr_kind itself.

test plan:
test file included




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date