### PR TITLE
adding more options to semgrep sarif formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 - OCaml: support module aliasing, so looking for `List.map` will also
   find code that renamed `List` as `L` via `module L = List`.
+- Add help text to sarif formatter output if defined in metadata field.
+- Update shortDescription in sarif formatter output if defined in metadata field. 
+- Add tags as defined in metadata field in addition to the existing tags.
 
 ### Fixed
 - core: Fix parsing of numeric literals in rule files

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -57,11 +57,11 @@ class SarifFormatter(BaseFormatter):
 
         rule_short_description = rule.metadata.get("shortDescription")
         if rule_short_description:
-            rule_json["shortDescription"]["text"] = rule_short_description
+            rule_json["shortDescription"] = {"text": rule_short_description}
 
         rule_help_text = rule.metadata.get("help")
         if rule_help_text:
-            rule_json["help"] = { "text":  rule_help_text }
+            rule_json["help"] = {"text": rule_help_text}
 
         return rule_json
 
@@ -87,9 +87,9 @@ class SarifFormatter(BaseFormatter):
             owasp = rule.metadata["owasp"]
             result.append(f"OWASP-{owasp}")
 
-        for tags in rule.metadata.get("tags"):
+        for tags in rule.metadata.get("tags", []):
             result.append(tags)
-            
+
         return result
 
     @staticmethod

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -55,6 +55,14 @@ class SarifFormatter(BaseFormatter):
         if rule_url is not None:
             rule_json["helpUri"] = rule_url
 
+        rule_short_description = rule.metadata.get("shortDescription")
+        if rule_short_description:
+            rule_json["shortDescription"]["text"] = rule_short_description
+
+        rule_help_text = rule.metadata.get("help")
+        if rule_help_text:
+            rule_json["help"] = { "text":  rule_help_text }
+
         return rule_json
 
     @staticmethod
@@ -78,6 +86,10 @@ class SarifFormatter(BaseFormatter):
         if "owasp" in rule.metadata:
             owasp = rule.metadata["owasp"]
             result.append(f"OWASP-{owasp}")
+
+        for tags in rule.metadata.get("tags"):
+            result.append(tags)
+            
         return result
 
     @staticmethod

--- a/semgrep/tests/e2e/rules/eqeq-meta.yaml
+++ b/semgrep/tests/e2e/rules/eqeq-meta.yaml
@@ -1,0 +1,66 @@
+rules:
+  - id: assert-eqeq-is-ok
+    pattern: |
+      def __eq__():
+          ...
+          $X == $X
+    message: "possibly useless comparison but in eq function"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      tags: [security, sometag]
+      shortDescription: "some short description"
+      fullDescription: "some long description"
+      help: "some help text"
+  - id: eqeq-is-bad
+    patterns:
+      - pattern-not-inside: |
+          def __eq__(...):
+              ...
+      - pattern-not-inside: assert(...)
+      - pattern-not-inside: assertTrue(...)
+      - pattern-not-inside: assertFalse(...)
+      - pattern-either:
+        - pattern: $X == $X
+        - pattern: $X != $X
+        - patterns:
+          - pattern-inside: |
+              def __init__(...):
+                  ...
+          - pattern: self.$X == self.$X
+      - pattern-not: 1 == 1
+    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: correctness
+      tags: [security, sometag]
+      shortDescription: "some short description"
+      fullDescription: "some long description"
+      help: "some help text"
+  - id: python37-compatability-os-module
+    patterns:
+      - pattern-not-inside: |
+          if hasattr(os, 'pwrite'):
+              ...
+      - pattern: os.pwrite(...)
+    message: "this function is only available on Python 3.7+"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      tags: [security, sometag]
+      shortDescription: "some short description"
+      fullDescription: "some long description"
+      help: "some help text"
+  - id: javascript-basic-eqeq-bad
+    patterns:
+      - pattern: "$X == $X"
+    message: "useless comparison"
+    languages: [js]
+    severity: ERROR
+    metadata:
+      tags: [security, sometag]
+      shortDescription: "some short description"
+      fullDescription: "some long description"
+      help: "some help text"
+      cwe: "cwe te"

--- a/semgrep/tests/e2e/snapshots/test_check/test_sarif_output_with_source_edit/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_check/test_sarif_output_with_source_edit/results.sarif
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "toolExecutionNotifications": []
+        }
+      ],
+      "results": [
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "targets/basic/stupid.py",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 26,
+                  "endLine": 3,
+                  "startColumn": 12,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?"
+          },
+          "ruleId": "rules.eqeq-is-bad"
+        },
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "targets/basic/stupid.js",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 19,
+                  "endLine": 3,
+                  "startColumn": 13,
+                  "startLine": 3
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "useless comparison"
+          },
+          "ruleId": "rules.javascript-basic-eqeq-bad"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "semgrep",
+          "rules": [
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "possibly useless comparison but in eq function"
+              },
+              "help": {
+                "text": "some help text"
+              },
+              "id": "rules.assert-eqeq-is-ok",
+              "name": "rules.assert-eqeq-is-ok",
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "security",
+                  "sometag"
+                ]
+              },
+              "shortDescription": {
+                "text": "some short description"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+              },
+              "help": {
+                "text": "some help text"
+              },
+              "id": "rules.eqeq-is-bad",
+              "name": "rules.eqeq-is-bad",
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "security",
+                  "sometag"
+                ]
+              },
+              "shortDescription": {
+                "text": "some short description"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "useless comparison"
+              },
+              "help": {
+                "text": "some help text"
+              },
+              "id": "rules.javascript-basic-eqeq-bad",
+              "name": "rules.javascript-basic-eqeq-bad",
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "cwe te",
+                  "security",
+                  "sometag"
+                ]
+              },
+              "shortDescription": {
+                "text": "some short description"
+              }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "this function is only available on Python 3.7+"
+              },
+              "help": {
+                "text": "some help text"
+              },
+              "id": "rules.python37-compatability-os-module",
+              "name": "rules.python37-compatability-os-module",
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "security",
+                  "sometag"
+                ]
+              },
+              "shortDescription": {
+                "text": "some short description"
+              }
+            }
+          ],
+          "semanticVersion": "placeholder"
+        }
+      }
+    }
+  ],
+  "version": "2.1.0"
+}

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -1,6 +1,7 @@
 import collections
 import json
 from pathlib import Path
+import pdb
 from subprocess import CalledProcessError
 from typing import Dict
 from xml.etree import cElementTree
@@ -189,6 +190,31 @@ def test_sarif_output_with_source(run_semgrep_in_tmp, snapshot):
     for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
         assert rule.get("helpUri", None) is not None
 
+def test_sarif_output_with_source_edit(run_semgrep_in_tmp, snapshot):
+    sarif_output = json.loads(
+        run_semgrep_in_tmp("rules/eqeq-meta.yaml", output_format=OutputFormat.SARIF)
+    )
+
+    # rules are logically a set so the JSON list's order doesn't matter
+    # we make the order deterministic here so that snapshots match across runs
+    # the proper solution will be https://github.com/joseph-roitman/pytest-snapshot/issues/14
+    sarif_output["runs"][0]["tool"]["driver"]["rules"] = sorted(
+        sarif_output["runs"][0]["tool"]["driver"]["rules"],
+        key=lambda rule: str(rule["id"]),
+    )
+
+    # Semgrep version is included in sarif output. Verify this independently so
+    # snapshot does not need to be updated on version bump
+    assert sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] == __VERSION__
+    sarif_output["runs"][0]["tool"]["driver"]["semanticVersion"] = "placeholder"
+
+    snapshot.assert_match(
+        json.dumps(sarif_output, indent=2, sort_keys=True), "results.sarif"
+    )
+
+    # Assert that each sarif rule object has a helpURI
+    for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
+        assert rule.get("help", None) is not None
 
 def test_url_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -1,7 +1,6 @@
 import collections
 import json
 from pathlib import Path
-import pdb
 from subprocess import CalledProcessError
 from typing import Dict
 from xml.etree import cElementTree
@@ -190,6 +189,7 @@ def test_sarif_output_with_source(run_semgrep_in_tmp, snapshot):
     for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
         assert rule.get("helpUri", None) is not None
 
+
 def test_sarif_output_with_source_edit(run_semgrep_in_tmp, snapshot):
     sarif_output = json.loads(
         run_semgrep_in_tmp("rules/eqeq-meta.yaml", output_format=OutputFormat.SARIF)
@@ -215,6 +215,7 @@ def test_sarif_output_with_source_edit(run_semgrep_in_tmp, snapshot):
     # Assert that each sarif rule object has a helpURI
     for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
         assert rule.get("help", None) is not None
+
 
 def test_url_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(


### PR DESCRIPTION
Added new options to semgrep sarif formatter:

- ability to update shortDescription through metadata field, instead of having duplicates with fullDescription
- ability to add help text through metadata field, as required by [GitHub](https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/sarif-support-for-code-scanning#reportingdescriptor-object) 
- ability to add custom tags other than `cwe` and `owasp`

```
metadata:
      tags: [security, sometag]
      shortDescription: "some short description"
      help: "some help text"
```

PR checklist:
- [ ] documentation is up to date
- [x] changelog is up to date
