### PR TITLE
Ensure we don't accidentally return folders as targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 - core: Fix parsing of numeric literals in rule files
 - Java: fix the range and autofix of Cast expressions (#3669)
-- Generic mode scanner no longer tries to open submodule folders as files (#3690)
+- Generic mode scanner no longer tries to open submodule folders as files (#3701)
 
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - core: Fix parsing of numeric literals in rule files
+- Generic parser no longer tries to open submodule folders as files
 
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 - core: Fix parsing of numeric literals in rule files
 - Java: fix the range and autofix of Cast expressions (#3669)
-- Generic parser no longer tries to open submodule folders as files (#3690)
+- Generic mode scanner no longer tries to open submodule folders as files (#3690)
 
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -284,7 +284,7 @@ class CoreRunner:
                         targets = [
                             target
                             for target in targets
-                            if target not in max_timeout_files and not target.is_dir()
+                            if target not in max_timeout_files
                         ]
 
                         # opti: no need to call semgrep-core if no target files

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -284,8 +284,7 @@ class CoreRunner:
                         targets = [
                             target
                             for target in targets
-                            if target not in max_timeout_files
-                            and not target.is_dir()
+                            if target not in max_timeout_files and not target.is_dir()
                         ]
 
                         # opti: no need to call semgrep-core if no target files

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -285,6 +285,7 @@ class CoreRunner:
                             target
                             for target in targets
                             if target not in max_timeout_files
+                            and not target.is_dir()
                         ]
 
                         # opti: no need to call semgrep-core if no target files

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -95,8 +95,11 @@ def _run_semgrep(
     elif output_format == OutputFormat.SARIF:
         options.append("--sarif")
 
+    cmd = [sys.executable, "-m", "semgrep", *options, Path("targets") / target_name]
+    print(f"current directory: {os.getcwd()}")
+    print(f"semgrep command: {cmd}")
     output = subprocess.check_output(
-        [sys.executable, "-m", "semgrep", *options, Path("targets") / target_name],
+        cmd,
         encoding="utf-8",
         stderr=subprocess.STDOUT if stderr else subprocess.PIPE,
         env=env,

--- a/semgrep/tests/qa/test_public_repos.py
+++ b/semgrep/tests/qa/test_public_repos.py
@@ -211,11 +211,27 @@ def test_semgrep_on_repo(monkeypatch, tmp_path, repo_object):
         for exclude in excludes:
             cmd.extend(["--exclude", exclude])
 
-    sub_output = subprocess.check_output(
+    print(f"semgrep command: {cmd}")
+
+    res = subprocess.run(
         cmd,
         encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    output = json.loads(sub_output)
+    returncode = res.returncode
+    print("--- semgrep error output ---")
+    print(res.stderr)
+    print("----------------------------")
+    print("--- semgrep standard output ---")
+    print(res.stdout)
+    print("-------------------------------")
+    if returncode != 0:
+        # Fail regardless of the expected status "ok" or "xfail".
+        raise subprocess.SubprocessError(
+            f"Semgrep exited with non-zero status: {returncode}"
+        )
+    output = json.loads(res.stdout)
 
     expected_results_count = len(repo_languages)
     if len(output["results"]) != expected_results_count or len(output["errors"]) != 0:


### PR DESCRIPTION
This is a take-over of @malexmave's PR https://github.com/returntocorp/semgrep/pull/3690

Fixes #3660

I also added some logging for the tests so we can see what's going on with `pytest -s` (prints captured stdout and stderr even when the test passes).

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
