### PR TITLE
Optimize pattern $X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 - Add backtrace to fatal errors reported by semgrep-core
 - Report errors during rule evaluation to the user
+- When anded with other patterns, `pattern: $X` will not be evaluated on its own, but will look at the context and find `$X` within the metavariables bound, which should be significantly faster
 
 ## [0.61.0](https://github.com/returntocorp/semgrep/releases/tag/v0.61.0) - 2021-08-04
 

--- a/semgrep-core/src/engine/Match_patterns.ml
+++ b/semgrep-core/src/engine/Match_patterns.ml
@@ -205,6 +205,14 @@ let must_analyze_statement_bloom_opti_failed pattern_strs
 (*****************************************************************************)
 
 (*s: function [[Semgrep_generic.check2]] *)
+(* [range_filter] is a predicate that defines "regions of interest" when matching
+ *   expressions, this is e.g. used for optimizing `pattern: $X`. Note that
+ *   traversing the Generic AST is generally fairly cheap, what could be more
+ *   expensive is to do the matching (due to combinatorics) and all the allocations
+ *   associatiated, especially when the pattern causaes a lot of matches. This
+ *   filter allows us to avoid all that expensive stuff when matching expressions
+ *   unless they fall in specific regions of the code.
+ *   See also docs for {!check} in Match_pattern.mli. *)
 let check2 ~hook range_filter config rules equivs (file, lang, ast) =
   logger#info "checking %s with %d mini rules" file (List.length rules);
 
@@ -311,7 +319,7 @@ let check2 ~hook range_filter config rules equivs (file, lang, ast) =
                    | Some (start_loc, end_loc) ->
                        logger#info
                          "While matching pattern %s in file %s, we skipped \
-                          expression at %d:%d-%d:%d (outside range of \
+                          expression at %d:%d-%d:%d (outside any range of \
                           interest)"
                          rule.pattern_string start_loc.file start_loc.line
                          start_loc.column end_loc.line end_loc.column;

--- a/semgrep-core/src/engine/Match_patterns.mli
+++ b/semgrep-core/src/engine/Match_patterns.mli
@@ -3,11 +3,20 @@
 (*s: signature [[Semgrep_generic.check]] *)
 val check :
   hook:(Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
+  ?range_filter:(Parse_info.token_location * Parse_info.token_location -> bool) ->
   Config_semgrep.t ->
   Mini_rule.rules ->
   Equivalence.equivalences ->
   Common.filename * Lang.t * Target.t ->
   Pattern_match.t list
+(** Match mini-rules (patterns) against a target file.
+  *
+  * @param range_filter A predicate that defines a range of interest when matching
+  *    expressions. This is e.g. used for optimizing `pattern: $X` by filtering out
+  *    any matches that are not within the ranges of preceding `pattern-inside`s.
+  *    Typically you will check that the range of the expression is strictly inside
+  *    your area(s) of interest, no need to worry about sub-expressions, they will
+  *    visited regardless. *)
 
 (*e: signature [[Semgrep_generic.check]] *)
 

--- a/semgrep-core/src/engine/Match_patterns.mli
+++ b/semgrep-core/src/engine/Match_patterns.mli
@@ -11,11 +11,11 @@ val check :
   Pattern_match.t list
 (** Match mini-rules (patterns) against a target file.
   *
-  * @param range_filter A predicate that defines a range of interest when matching
+  * @param range_filter A predicate that defines "regions of interest" when matching
   *    expressions. This is e.g. used for optimizing `pattern: $X` by filtering out
   *    any matches that are not within the ranges of preceding `pattern-inside`s.
   *    Typically you will check that the range of the expression is strictly inside
-  *    your area(s) of interest, no need to worry about sub-expressions, they will
+  *    your area(s) of interest, no need to worry about sub-expressions, they will be
   *    visited regardless. *)
 
 (*e: signature [[Semgrep_generic.check]] *)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -895,7 +895,9 @@ and run_selector_on_ranges env selector_opt ranges =
       (* Nothing to select. *)
       ranges
   | Some { S.pattern; pid; pstr; _ }, ranges ->
-      (* Find matches of `pattern` inside `ranges`. *)
+      (* Find matches of `pattern` *but* only inside `ranges`, this prevents
+       * matching and allocations that are wasteful because they are going to
+       * be thrown away later when interesecting the results. *)
       let range_filter (tok1, tok2) =
         let r = Range.range_of_token_locations tok1 tok2 in
         List.exists (fun rwm -> Range.( $<=$ ) r rwm.RM.r) ranges

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -10,7 +10,6 @@ type selector = {
   pattern : AST_generic.any;
   pid : int;
   pstr : string R.wrap;
-  lazy_matches : RP.times RP.match_result Lazy.t;
 }
 
 type sformula =
@@ -26,61 +25,51 @@ type sformula =
 (* Selecting methods *)
 (*****************************************************************************)
 
-(* this will be adjusted later in range_to_pattern_match_adjusted *)
-let fake_rule_id (id, str) =
-  { PM.id = string_of_int id; pattern_string = str; message = "" }
-
-let match_selector ?err:(msg = "no match") (sel_opt : selector option) :
-    RM.ranges =
-  let get_match (x : RP.times RP.match_result) = x.matches in
-  match sel_opt with
-  | None -> failwith msg
-  | Some selector ->
-      List.map RM.match_result_to_range
-        (get_match (Lazy.force selector.lazy_matches))
-
 let selector_equal s1 s2 = s1.mvar = s2.mvar
 
 (*****************************************************************************)
 (* Converter *)
 (*****************************************************************************)
 
-let selector_from_formula match_func f =
+let selector_from_formula f =
   match f with
   | R.Leaf (R.P ({ pat = Sem (pattern, _); pid; pstr }, None)) -> (
       match pattern with
       | G.E { e = G.N (G.Id ((mvar, _), _)); _ } ->
-          Some
-            {
-              mvar;
-              pattern;
-              pid;
-              pstr;
-              lazy_matches = lazy (match_func [ (pattern, pid, fst pstr) ]);
-            }
+          Some { mvar; pattern; pid; pstr }
       | _ -> None)
   | _ -> None
 
-let formula_to_sformula match_func formula =
+let formula_to_sformula formula =
+  let rec remove_selectors (selector, acc) formulas =
+    match formulas with
+    | [] -> (selector, acc)
+    | x :: xs ->
+        let selector, acc =
+          match (selector, selector_from_formula x) with
+          | None, None -> (None, x :: acc)
+          | Some s, None -> (Some s, x :: acc)
+          | None, Some s -> (Some s, acc)
+          | Some s1, Some s2 when selector_equal s1 s2 -> (Some s1, acc)
+          | Some s1, Some _s2 ->
+              (* patterns:
+               * ...
+               * - pattern: $X
+               * - pattern: $Y
+               *)
+              (* TODO: Should we fail here or just reported as a warning? This
+               * is something to catch with the meta-checker. *)
+              (Some s1, x :: acc)
+        in
+        remove_selectors (selector, acc) xs
+  in
   let rec formula_to_sformula formula =
-    let rec remove_selectors (selector, acc) formulas =
-      match formulas with
-      | [] -> (selector, acc)
-      | x :: xs ->
-          let selector, acc =
-            match (selector, selector_from_formula match_func x) with
-            | None, None -> (None, x :: acc)
-            | Some s, None -> (Some s, x :: acc)
-            | None, Some s -> (Some s, acc)
-            | Some s1, Some s2 ->
-                if selector_equal s1 s2 then (Some s1, acc) else (None, [])
-            (* This will never be valid *)
-          in
-          remove_selectors (selector, acc) xs
-    in
     let convert_and_formulas fs =
-      let selector, fs = remove_selectors (None, []) fs in
-      (selector, List.map formula_to_sformula fs)
+      let selector, fs' = remove_selectors (None, []) fs in
+      (* We only want a selector if there is something to select from. *)
+      match fs' with
+      | [] -> (None, List.map formula_to_sformula fs)
+      | _ :: _ -> (selector, List.rev_map formula_to_sformula fs')
     in
     (* Visit formula and convert *)
     match formula with

--- a/semgrep-core/src/engine/Specialize_formula.mli
+++ b/semgrep-core/src/engine/Specialize_formula.mli
@@ -9,13 +9,14 @@ type selector = {
   pattern : AST_generic.any;
   pid : int;
   pstr : string Rule.wrap;
-  (* lazy_matches necessary in case `$X` is the only pattern *)
-  lazy_matches : Report.times Report.match_result Lazy.t;
 }
 
 type sformula =
   | Leaf of Rule.leaf
   | And of (selector option * sformula list)
+      (** Invariant: [And (sel_opt, fs)] satisfies
+     * [not (Option.is_some sel_opt) || fs <> []], that is,
+     * we can only select from a non-empty context. *)
   | Or of sformula list
   | Not of sformula
 
@@ -23,22 +24,13 @@ type sformula =
 (* Selecting methods *)
 (*****************************************************************************)
 
-val fake_rule_id : int * string -> Pattern_match.rule_id
-
-val match_selector :
-  ?err:string -> selector option -> Range_with_metavars.ranges
-
 val selector_equal : selector -> selector -> bool
 
 (*****************************************************************************)
 (* Converter *)
 (*****************************************************************************)
 
-val formula_to_sformula :
-  ((AST_generic.any * Rule.pattern_id * string) list ->
-  Report.times Report.match_result) ->
-  Rule.formula ->
-  sformula
+val formula_to_sformula : Rule.formula -> sformula
 
 (*****************************************************************************)
 (* Visitor *)

--- a/semgrep-core/src/engine/Specialize_formula.mli
+++ b/semgrep-core/src/engine/Specialize_formula.mli
@@ -6,6 +6,7 @@
 
 type selector = {
   mvar : Metavariable.mvar;
+  pattern : AST_generic.any;
   pid : int;
   pstr : string Rule.wrap;
   (* lazy_matches necessary in case `$X` is the only pattern *)
@@ -26,12 +27,6 @@ val fake_rule_id : int * string -> Pattern_match.rule_id
 
 val match_selector :
   ?err:string -> selector option -> Range_with_metavars.ranges
-
-val select_from_ranges :
-  string ->
-  selector option ->
-  Range_with_metavars.ranges ->
-  Range_with_metavars.ranges
 
 val selector_equal : selector -> selector -> bool
 

--- a/semgrep-core/src/engine/Tainting_generic.ml
+++ b/semgrep-core/src/engine/Tainting_generic.ml
@@ -56,7 +56,7 @@ let any_in_ranges any ranges =
         (G.show_any any);
       false
   | Some (tok1, tok2) ->
-      let r = { Range.start = tok1.charpos; end_ = tok2.charpos } in
+      let r = Range.range_of_token_locations tok1 tok2 in
       List.exists (Range.( $<=$ ) r) ranges
 
 let ranges_of_pformula config equivs file_and_more rule_id pformula =

--- a/semgrep-core/tests/OTHER/rules/pattern-x-1.py
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-1.py
@@ -1,0 +1,7 @@
+def foo(x):
+  #ok:test
+  a = x + b
+  #ok:test
+  c = a + x
+  #ruleid:test
+  return (c + x)

--- a/semgrep-core/tests/OTHER/rules/pattern-x-1.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-1.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test
+  languages: [python]
+  patterns:
+  - pattern-inside: |
+      def $F($X, ...):
+          ...
+  - pattern-inside: |
+      return ...
+  - pattern: $X
+  message: Test
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/pattern-x-2.py
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-2.py
@@ -1,0 +1,7 @@
+def foo(x):
+  #ruleid:test
+  a = x + b
+  #ruleid:test
+  c = a + x
+  #ruleid:test
+  return (c + x)

--- a/semgrep-core/tests/OTHER/rules/pattern-x-2.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-2.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: test
+  languages: [python]
+  patterns:
+  - pattern-inside: |
+      def $F($X, ...):
+          ...
+  - pattern: $X
+  message: Test
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/pattern-x-3.py
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-3.py
@@ -1,6 +1,3 @@
-#ok:test
-bar = x
-
 def foo(x):
   #ruleid:test
   a = x + b
@@ -8,3 +5,9 @@ def foo(x):
   c = a + x
   #ruleid:test
   return (c + x)
+
+#ruleid:test
+bar = x
+
+#ruleid:test
+baz = 2*bar

--- a/semgrep-core/tests/OTHER/rules/pattern-x-3.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-3.yaml
@@ -1,0 +1,7 @@
+rules:
+- id: test
+  languages: [python]
+  patterns:
+  - pattern: $X
+  message: Test
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/pattern-x-4.py
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-4.py
@@ -1,10 +1,10 @@
 #ok:test
 bar = x
 
-def foo(x):
-  #ruleid:test
+def bar(x):
+  #ok:test
   a = x + b
-  #ruleid:test
+  #ok:test
   c = a + x
-  #ruleid:test
+  #ok:test
   return (c + x)

--- a/semgrep-core/tests/OTHER/rules/pattern-x-4.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-4.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: test
+  languages: [python]
+  patterns:
+  - pattern-inside: |
+      def foo($X, ...):
+          ...
+  - pattern: $X
+  message: Test
+  severity: ERROR


### PR DESCRIPTION
Fixes: bfc4f3da447 ("Revert `pattern: $X` optimization (#3478)")
Fixes: 32e8897523c ("Separate pattern: $X in anded patterns to a special field (#3435)")

test plan:

    % make test # tests included

    % semgrep-core -lang py -config \
            ~/semgrep/semgrep-core/tests/OTHER/rules/pattern-x-1.yaml \
            bench/django/input/django
        #^ now takes ~6 seconds (i.e., almost 10x faster)

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
