### PR TITLE
core: Fix fatal error "an equal is already in progress"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Generic mode scanner no longer tries to open submodule folders as files (#3701)
 - `pattern-regex` with completely empty files (#3705)
 - `--sarif` exit code with suppressed findings (#3680)
+- Fixed fatal errors when a pattern results in a large number of matches
 
 ### Changed
 - Add backtrace to fatal errors reported by semgrep-core

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -424,6 +424,7 @@ let cache_file_of_file filename =
 exception Main_timeout of string
 
 let timeout_function file f =
+  let saved_busy_with_equal = !AST_utils.busy_with_equal in
   let timeout = if !timeout <= 0. then None else Some !timeout in
   match
     Common.set_timeout_opt ~verbose:false ~name:"Main.timeout_function" timeout
@@ -431,6 +432,9 @@ let timeout_function file f =
   with
   | Some res -> res
   | None ->
+      (* Note that we could timeout while testing the equality of two ASTs and
+       * `busy_with_equal` will then erroneously have a `<> Not_busy` value. *)
+      AST_utils.busy_with_equal := saved_busy_with_equal;
       logger#info "Main: timeout for file %s" file;
       raise (Main_timeout file)
 

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -80,4 +80,17 @@ and rule_id = {
 
 (*e: type [[Match_result.t]] *)
 
+let uniq pms =
+  let eq = AST_utils.with_structural_equal equal in
+  let tbl = Hashtbl.create 1_024 in
+  pms
+  |> List.iter (fun pm ->
+         let r = pm.range_loc in
+         let ys = Hashtbl.find_all tbl r in
+         match List.find_opt (fun y -> eq pm y) ys with
+         | Some _ -> ()
+         | None -> Hashtbl.add tbl r pm);
+  tbl |> Hashtbl.to_seq_values |> List.of_seq
+  [@@profiling]
+
 (*e: semgrep/core/Pattern_match.ml *)

--- a/semgrep-core/src/engine/Match_patterns.ml
+++ b/semgrep-core/src/engine/Match_patterns.ml
@@ -482,7 +482,7 @@ let check2 ~hook range_filter config rules equivs (file, lang, ast) =
      * old: this uniq_by was introducing regressions in semgrep!
      * See tests/OTHER/rules/regression_uniq_or_ellipsis.go but it's fixed now.
      *)
-    |> Common.uniq_by (AST_utils.with_structural_equal Pattern_match.equal)
+    |> PM.uniq
 
 (*e: function [[Semgrep_generic.check2]] *)
 

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -992,7 +992,7 @@ let check hook default_config rules equivs file_and_more =
                    (* dedup similar findings (we do that also in Match_patterns.ml,
                     * but different mini-rules matches can now become the same match)
                     *)
-                   |> uniq_by (AST_utils.with_structural_equal PM.equal)
+                   |> PM.uniq
                    |> before_return (fun v ->
                           v
                           |> List.iter (fun (m : Pattern_match.t) ->

--- a/semgrep-core/src/engine/Tainting_generic.ml
+++ b/semgrep-core/src/engine/Tainting_generic.ml
@@ -180,7 +180,7 @@ let check hook default_config (taint_rules : (Rule.rule * Rule.taint_spec) list)
 
   !matches
   (* same post-processing as for search-mode in Match_rules.ml *)
-  |> Common.uniq_by (AST_utils.with_structural_equal PM.equal)
+  |> PM.uniq
   |> Common.before_return (fun v ->
          v
          |> List.iter (fun (m : Pattern_match.t) ->

--- a/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
@@ -12,7 +12,25 @@
         "lines": "    nested_patterns_func('foo', 1)",
         "message": "test",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "'foo'",
+            "end": {
+              "col": 31,
+              "line": 2,
+              "offset": 48
+            },
+            "start": {
+              "col": 26,
+              "line": 2,
+              "offset": 43
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "WARNING"
       },
       "path": "targets/basic/nested-patterns.js",
@@ -32,7 +50,25 @@
         "lines": "    nested_patterns_func('bar', 2)",
         "message": "test",
         "metadata": {},
-        "metavars": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "'bar'",
+            "end": {
+              "col": 31,
+              "line": 3,
+              "offset": 83
+            },
+            "start": {
+              "col": 26,
+              "line": 3,
+              "offset": 78
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "WARNING"
       },
       "path": "targets/basic/nested-patterns.js",

--- a/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_message_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
@@ -10,7 +10,7 @@
       "extra": {
         "is_ignored": false,
         "lines": "            print(\"blah\")",
-        "message": "'print(\"blah\")' detected in method 'C' in class 'A'",
+        "message": "'print(\"blah\")' detected in method 'B' in class 'A'",
         "metadata": {},
         "metavars": {
           "$CLASS": {
@@ -31,16 +31,16 @@
             }
           },
           "$FUNC": {
-            "abstract_content": "C",
+            "abstract_content": "B",
             "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 37
+              "col": 10,
+              "line": 2,
+              "offset": 20
             },
             "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 36
+              "col": 9,
+              "line": 2,
+              "offset": 19
             },
             "unique_id": {
               "md5sum": "<masked in tests>",
@@ -82,7 +82,7 @@
       "extra": {
         "is_ignored": false,
         "lines": "            print(\"blah\")",
-        "message": "'print(\"blah\")' detected in method 'B' in class 'A'",
+        "message": "'print(\"blah\")' detected in method 'C' in class 'A'",
         "metadata": {},
         "metavars": {
           "$CLASS": {
@@ -103,16 +103,16 @@
             }
           },
           "$FUNC": {
-            "abstract_content": "B",
+            "abstract_content": "C",
             "end": {
-              "col": 10,
-              "line": 2,
-              "offset": 20
+              "col": 14,
+              "line": 3,
+              "offset": 37
             },
             "start": {
-              "col": 9,
-              "line": 2,
-              "offset": 19
+              "col": 13,
+              "line": 3,
+              "offset": 36
             },
             "unique_id": {
               "md5sum": "<masked in tests>",
@@ -226,7 +226,7 @@
       "extra": {
         "is_ignored": false,
         "lines": "            print(\"asdf\")",
-        "message": "'print(\"asdf\")' detected in method 'E' in class 'A'",
+        "message": "'print(\"asdf\")' detected in method 'D' in class 'A'",
         "metadata": {},
         "metavars": {
           "$CLASS": {
@@ -247,16 +247,16 @@
             }
           },
           "$FUNC": {
-            "abstract_content": "E",
+            "abstract_content": "D",
             "end": {
-              "col": 14,
-              "line": 8,
-              "offset": 115
+              "col": 10,
+              "line": 6,
+              "offset": 77
             },
             "start": {
-              "col": 13,
-              "line": 8,
-              "offset": 114
+              "col": 9,
+              "line": 6,
+              "offset": 76
             },
             "unique_id": {
               "md5sum": "<masked in tests>",
@@ -298,7 +298,7 @@
       "extra": {
         "is_ignored": false,
         "lines": "            print(\"asdf\")",
-        "message": "'print(\"asdf\")' detected in method 'D' in class 'A'",
+        "message": "'print(\"asdf\")' detected in method 'E' in class 'A'",
         "metadata": {},
         "metavars": {
           "$CLASS": {
@@ -319,16 +319,16 @@
             }
           },
           "$FUNC": {
-            "abstract_content": "D",
+            "abstract_content": "E",
             "end": {
-              "col": 10,
-              "line": 6,
-              "offset": 77
+              "col": 14,
+              "line": 8,
+              "offset": 115
             },
             "start": {
-              "col": 9,
-              "line": 6,
-              "offset": 76
+              "col": 13,
+              "line": 8,
+              "offset": 114
             },
             "unique_id": {
               "md5sum": "<masked in tests>",


### PR DESCRIPTION
And added an optimized `Pattern_match.uniq` function to replace
`Common.uniq_by`.

Note that Semgrep returns the same matches as before, but sometimes in
a different order.

This issue was reported by a customer weeks ago but we could not figure
it out without an example. I just happened to hit the same bug when
benchmarking some taint rules.

test plan:

    % make test

    % semgrep-core -timeout 5 -j 1 -profile -lang js \
         -config semgrep-rules/typescript/react/security/audit/react-props-injection.yaml \
         semgrep/parsing-stats/lang/javascript/tmp/mui-org-material-ui/test/bundling/fixtures/next-webpack5

      #^ Try it several times, it no longer triggers a fatal error

Rule react-props-injection contains the following pattern:

    import $PROPS from "...";
    ...

This pattern leads to more than 90k matches in
lang/javascript/tmp/mui-org-material-ui/test/bundling/fixtures/next-webpack5/pages/next-webpack.fixture.js
which causes Common.uniq_by to "explode". If we are unlucky and the
analysis timesout while we are testing the equality of two ASTs, then
`AST_utils.busy_with_equal` is left in the wrong state and all the
subsequent equality tests will lead to a fatal error.



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
