### PR TITLE
ci: simply release with `make release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,5 +95,13 @@ gitclean:
 
 .PHONY: bump
 bump:
-	$(SED) 's/__VERSION__ = ".*"/__VERSION__ = "$(SEMGREP_VERSION)"/g' semgrep/semgrep/__init__.py
-	$(SED) 's/^    install_requires=\["semgrep==.*"\],$$/    install_requires=["semgrep==$(SEMGREP_VERSION)"],/g' setup.py
+	$(SED) 's/__VERSION__ = ".*"/__VERSION__ = "$(RELEASE)"/g' semgrep/semgrep/__init__.py
+	$(SED) 's/^    install_requires=\["semgrep==.*"\],$$/    install_requires=["semgrep==$(RELEASE)"],/g' setup.py
+	$(SED) 's/## Unreleased/## Unreleased\n\n## [$(RELEASE)](https:\/\/github.com\/returntocorp\/semgrep\/releases\/tag\/v$(RELEASE)) - $(date +'%m-%d-%Y')/g' CHANGELOG.md
+
+
+.PHONY: release
+release:
+	PIPENV_PIPFILE=scripts/release/Pipfile pipenv install --dev && PIPENV_PIPFILE=scripts/release/Pipfile pipenv run python scripts/release/cut_release_branch.py
+	$(MAKE) bump
+	PIPENV_PIPFILE=scripts/release/Pipfile pipenv run python scripts/release/bump_and_push_release.py

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ gitclean:
 bump:
 	$(SED) 's/__VERSION__ = ".*"/__VERSION__ = "$(RELEASE)"/g' semgrep/semgrep/__init__.py
 	$(SED) 's/^    install_requires=\["semgrep==.*"\],$$/    install_requires=["semgrep==$(RELEASE)"],/g' setup.py
-	$(SED) 's/## Unreleased/## Unreleased\n\n## [$(RELEASE)](https:\/\/github.com\/returntocorp\/semgrep\/releases\/tag\/v$(RELEASE)) - $(date +'%m-%d-%Y')/g' CHANGELOG.md
+	$(SED) 's/## Unreleased/## Unreleased\n\n## [$(RELEASE)](https:\/\/github.com\/returntocorp\/semgrep\/releases\/tag\/v$(RELEASE)) - $(shell date +'%m-%d-%Y')/g' CHANGELOG.md
 
 
 .PHONY: release

--- a/scripts/release/bump_and_push_release.py
+++ b/scripts/release/bump_and_push_release.py
@@ -1,23 +1,26 @@
-import subprocess
-
 from util import abort
 from util import diffs
-from util import git
 from util import release_version
+
+# from util import git
 
 
 BUMP_FILES = {"semgrep/semgrep/__init__.py", "setup.py", "CHANGELOG.md"}
 
 
-def bump_and_push(version: str):
-    subprocess.run(["make", "bump"], env={"SEMGREP_VERSION": version})
+def add_commit_push(version: str):
+    """
+    Add all changes to files in BUMP_FILES, creates a release commit, and pushes said commit
+
+    Assumes all files in BUMP_FILES were modified
+    """
     changed_files = [d[1] for d in diffs()]
     if set(changed_files) != BUMP_FILES:
         abort(2, f"Expected diffs only in {BUMP_FILES}")
-    git("add", *BUMP_FILES)
-    git("commit", "-m", f"Release {version}")
-    git("push", "origin", "HEAD")
+    # git("add", *BUMP_FILES)
+    # git("commit", "-m", f"Release {version}")
+    # git("push", "origin", "HEAD")
 
 
 if __name__ == "__main__":
-    bump_and_push(release_version())
+    add_commit_push(release_version())

--- a/scripts/release/bump_and_push_release.py
+++ b/scripts/release/bump_and_push_release.py
@@ -1,8 +1,7 @@
 from util import abort
 from util import diffs
+from util import git
 from util import release_version
-
-# from util import git
 
 
 BUMP_FILES = {"semgrep/semgrep/__init__.py", "setup.py", "CHANGELOG.md"}
@@ -17,9 +16,9 @@ def add_commit_push(version: str):
     changed_files = [d[1] for d in diffs()]
     if set(changed_files) != BUMP_FILES:
         abort(2, f"Expected diffs only in {BUMP_FILES}")
-    # git("add", *BUMP_FILES)
-    # git("commit", "-m", f"Release {version}")
-    # git("push", "origin", "HEAD")
+    git("add", *BUMP_FILES)
+    git("commit", "-m", f"Release {version}")
+    git("push", "origin", "HEAD")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`make release` now handles:
- creating new release branch from latest develop
- bumping relevant version string and changelog version (new)
- adding bump changes, making a release commit, pushing the commit