### PR TITLE
Fix adjust_for_docker

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -258,8 +258,8 @@ def adjust_for_docker() -> None:
             raise SemgrepError(
                 f"Detected Docker environment without a code volume, please include '-v \"${{PWD}}:{SRC_DIRECTORY}\"'"
             )
-    if SRC_DIRECTORY.exists():
-        os.chdir(SRC_DIRECTORY)
+        if SRC_DIRECTORY.exists():
+            os.chdir(SRC_DIRECTORY)
 
 
 def get_base_path() -> Path:


### PR DESCRIPTION
It appears to me that the `chdir` is missing one level of indentation because it basically gets executed every single time. So even locally, if the `src` directory exists it would `chdir` even though we're not in docker.

This caused us a couple of hours of debugging at Shopify.

I know there were several attempts to fix the whole docker chdir issue  https://github.com/returntocorp/semgrep/pull/3125 and https://github.com/returntocorp/semgrep/pull/3134 but this seems unrelated and I just wanted to bring it up.

Also fine if you decide to not fix it as we can work around with setting the path in an env variable.

PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
