### PR TITLE
Optimize pattern-inside's ending with `...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Hack: improved support for metavariables (#3716)
 
 ### Changed
+- Optimize ending `...` in `pattern-inside`s to simply match anything left
 
 ## [0.62.0](https://github.com/returntocorp/semgrep/releases/tag/v0.62.0) - 2021-08-17
 

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -887,6 +887,7 @@ let rule_of_pattern lang pattern_string pattern =
     MR.id = "-e/-f";
     pattern_string;
     pattern;
+    inside = false;
     message = "";
     severity = R.Error;
     languages = [ lang ];

--- a/semgrep-core/src/core/Mini_rule.ml
+++ b/semgrep-core/src/core/Mini_rule.ml
@@ -39,6 +39,8 @@
 type rule = {
   id : string;
   pattern : Pattern.t;
+  inside : bool;
+  (* originates from pattern-inside or pattern-not-inside *)
   message : string;
   severity : Rule.severity;
   languages : Lang.t list;

--- a/semgrep-core/src/engine/Match_patterns.ml
+++ b/semgrep-core/src/engine/Match_patterns.ml
@@ -109,7 +109,7 @@ let match_sts_sts rule a b env =
             | [] -> env
             | stmt :: _ -> MG.extend_stmts_match_span stmt env
           in
-          GG.m_stmts_deep ~less_is_ok:true a b env))
+          GG.m_stmts_deep ~inside:rule.R.inside ~less_is_ok:true a b env))
   [@@profiling]
 
 (*e: function [[Semgrep_generic.match_sts_sts]] *)

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -86,7 +86,7 @@ let formula_to_sformula formula =
 (* currently used in Match_rules.ml to extract patterns *)
 let rec visit_sformula f formula =
   match formula with
-  | Leaf (P (p, _)) -> f p
+  | Leaf (P (p, i)) -> f p i
   | Leaf (MetavarCond _) -> ()
   | Not x -> visit_sformula f x
   | Or xs | And (_, xs) -> xs |> List.iter (visit_sformula f)

--- a/semgrep-core/src/engine/Specialize_formula.mli
+++ b/semgrep-core/src/engine/Specialize_formula.mli
@@ -36,4 +36,5 @@ val formula_to_sformula : Rule.formula -> sformula
 (* Visitor *)
 (*****************************************************************************)
 
-val visit_sformula : (Rule.xpattern -> unit) -> sformula -> unit
+val visit_sformula :
+  (Rule.xpattern -> Rule.inside option -> unit) -> sformula -> unit

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1688,19 +1688,21 @@ and m_other_attribute_operator = m_other_xxx
  * todo? we could restrict ourselves to only a few forms?
  *)
 (* experimental! *)
-and m_stmts_deep ~less_is_ok (xsa : G.stmt list) (xsb : G.stmt list) tin =
+and m_stmts_deep ~inside ~less_is_ok (xsa : G.stmt list) (xsb : G.stmt list) tin
+    =
   (* shares the cache with m_list__m_stmt *)
   match (tin.cache, xsa, xsb) with
   | Some cache, a :: _, _ :: _ when a.s_use_cache ->
       let tin = { tin with mv = Env.update_min_env tin.mv a } in
       Caching.Cache.match_stmt_list ~access:cache_access ~cache
         ~function_id:CK.Match_deep ~list_kind:CK.Original ~less_is_ok
-        ~compute:(m_stmts_deep_uncached ~less_is_ok)
+        ~compute:(m_stmts_deep_uncached ~inside ~less_is_ok)
         ~pattern:xsa ~target:xsb tin
-  | _ -> m_stmts_deep_uncached ~less_is_ok xsa xsb tin
+  | _ -> m_stmts_deep_uncached ~inside ~less_is_ok xsa xsb tin
 
 (*s: function [[Generic_vs_generic.m_stmts_deep]] *)
-and m_stmts_deep_uncached ~less_is_ok (xsa : G.stmt list) (xsb : G.stmt list) =
+and m_stmts_deep_uncached ~inside ~less_is_ok (xsa : G.stmt list)
+    (xsb : G.stmt list) =
   (* opti: this was the old code:
    *   if !Flag.go_deeper_stmt && (has_ellipsis_stmts xsa)
    *   then
@@ -1736,6 +1738,17 @@ and m_stmts_deep_uncached ~less_is_ok (xsa : G.stmt list) (xsb : G.stmt list) =
   | [], _ :: _ -> if less_is_ok then return () else fail ()
   (* dots: '...', can also match no statement *)
   | [ { s = G.ExprStmt ({ e = G.Ellipsis _i; _ }, _); _ } ], [] -> return ()
+  (* inside:
+   * When a pattern-inside (or pattern-not-inside) ends in ... we do not
+   * need to compute all possible endings, it's enough to return the largest
+   * one. If some other pattern P matches inside the largest match here, then
+   * that is enough to either keep P (pattern-inside) or filter it out
+   * (pattern-not-inside).
+   *)
+  | [ { s = G.ExprStmt ({ e = G.Ellipsis _i; _ }, _); _ } ], xb :: bbs
+    when inside ->
+      env_add_matched_stmt xb >>= fun () ->
+      m_stmts_deep_uncached ~inside ~less_is_ok xsa bbs
   | ( ({ s = G.ExprStmt ({ e = G.Ellipsis _i; _ }, _); _ } :: _ as xsa),
       (_ :: _ as xsb) ) ->
       (* let's first try without going deep *)
@@ -1759,7 +1772,8 @@ and m_stmts_deep_uncached ~less_is_ok (xsa : G.stmt list) (xsb : G.stmt list) =
   (* the general case *)
   | xa :: aas, xb :: bbs ->
       m_stmt xa xb >>= fun () ->
-      env_add_matched_stmt xb >>= fun () -> m_stmts_deep ~less_is_ok aas bbs
+      env_add_matched_stmt xb >>= fun () ->
+      m_stmts_deep ~inside ~less_is_ok aas bbs
   | _ :: _, _ -> fail ()
 
 (*e: function [[Generic_vs_generic.m_stmts_deep]] *)
@@ -1920,7 +1934,8 @@ and m_stmt a b =
       or_list m_stmt a bs
   (* the general case *)
   (* ... will now allow a subset of stmts (less_is_ok = false here) *)
-  | G.Block a1, B.Block b1 -> m_bracket (m_stmts_deep ~less_is_ok:false) a1 b1
+  | G.Block a1, B.Block b1 ->
+      m_bracket (m_stmts_deep ~inside:false ~less_is_ok:false) a1 b1
   (*e: [[Generic_vs_generic.m_stmt()]] deep matching cases *)
   (*s: [[Generic_vs_generic.m_stmt()]] builtin equivalences cases *)
   (* equivalence: vardef ==> assign, and go deep *)
@@ -2824,7 +2839,7 @@ and m_partial a b =
 and m_any a b =
   match (a, b) with
   | G.Str a1, B.Str b1 -> m_string_ellipsis_or_metavar_or_default a1 b1
-  | G.Ss a1, B.Ss b1 -> m_stmts_deep ~less_is_ok:true a1 b1
+  | G.Ss a1, B.Ss b1 -> m_stmts_deep ~inside:false ~less_is_ok:true a1 b1
   | G.E a1, B.E b1 -> m_expr a1 b1
   | G.S a1, B.S b1 -> m_stmt a1 b1
   (*s: [[Generic_vs_generic.m_any]] boilerplate cases *)

--- a/semgrep-core/src/matching/Generic_vs_generic.mli
+++ b/semgrep-core/src/matching/Generic_vs_generic.mli
@@ -11,7 +11,9 @@ val m_stmt : AST_generic.stmt Matching_generic.matcher
 (*e: signature [[Generic_vs_generic.m_stmt]] *)
 (*s: signature [[Generic_vs_generic.m_stmts_deep]] *)
 val m_stmts_deep :
-  less_is_ok:bool -> AST_generic.stmt list Matching_generic.matcher
+  inside:bool ->
+  less_is_ok:bool ->
+  AST_generic.stmt list Matching_generic.matcher
 
 (*e: signature [[Generic_vs_generic.m_stmts_deep]] *)
 

--- a/semgrep-core/src/parsing/Parse_mini_rule.ml
+++ b/semgrep-core/src/parsing/Parse_mini_rule.ml
@@ -106,6 +106,7 @@ let parse file =
                          {
                            R.id;
                            pattern;
+                           inside = false;
                            message;
                            languages;
                            severity;

--- a/semgrep-core/src/synthesizing/Unit_synthesizer_targets.ml
+++ b/semgrep-core/src/synthesizing/Unit_synthesizer_targets.ml
@@ -60,6 +60,7 @@ let ranges_matched lang file pattern : Range.t list =
     {
       Mini_rule.id = "unit testing";
       pattern;
+      inside = false;
       message = "";
       severity = R.Error;
       languages = [ lang ];

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -105,7 +105,7 @@ let regression_tests_for_lang ~with_caching files lang =
     Error_code.g_errors := [];
 
     let rule = { MR.
-      id = "unit testing"; pattern; message = ""; 
+      id = "unit testing"; pattern; inside=false; message = ""; 
       severity = R.Error; languages = [lang];
       pattern_string = "test: no need for pattern string";
     } in


### PR DESCRIPTION
This probably won't have a huge perf impact overall due to parsing being
the main bottle neck. However it does help perf and it's a fairly simple
optimization.

test plan:

    % make test

    % semgrep-core -lang js -config ~/semgrep-rules/typescript/react/security/audit/react-css-injection.yaml ~/semgrep/perf/bench/big-js/input/big-js
      #^ Now takes about ~19s (vs ~27s, or ~1.4x faster)
      # -profile reports matching time is ~2s (vs ~10s, or ~5x faster)

    % semgrep-core -profile -lang js \
         -config semgrep-rules/typescript/react/security/audit/react-props-injection.yaml \
         semgrep/parsing-stats/lang/javascript/tmp/mui-org-material-ui/test/bundling/fixtures/next-webpack5
      #^ Now takes about ~0.1s (vs ~1.5s, or ~12x faster)

    % semgrep -j1 --time --max-target-bytes=250000 --config semgrep-rules/typescript/react/security/audit/react-props-injection.yaml semgrep/parsing-stats/lang/javascript/tmp/*
      #^ Match time dropped from ~20s to ~10 (2x faster), but overall
      # there is not much of a speed up since parsing takes ~80% of
      # the time.



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
