### PR TITLE
Use enum for rule severity instead of arbitrary string

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -19,6 +19,7 @@ from semgrep.constants import DEFAULT_SEMGREP_CONFIG_NAME
 from semgrep.constants import ID_KEY
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.constants import RULES_KEY
+from semgrep.constants import RuleSeverity
 from semgrep.constants import SEMGREP_URL
 from semgrep.constants import SEMGREP_USER_AGENT
 from semgrep.error import InvalidRuleSchemaError
@@ -29,6 +30,7 @@ from semgrep.rule_lang import parse_yaml_preserve_spans
 from semgrep.rule_lang import Span
 from semgrep.rule_lang import YamlMap
 from semgrep.rule_lang import YamlTree
+from semgrep.semgrep_types import Language
 from semgrep.util import is_config_suffix
 from semgrep.util import is_url
 from semgrep.verbose_logging import getLogger
@@ -51,8 +53,8 @@ DEFAULT_CONFIG = {
             "id": "eqeq-is-bad",
             "pattern": "$X == $X",
             "message": "$X == $X is a useless equality check",
-            "languages": ["python"],
-            "severity": "ERROR",
+            "languages": [Language.PYTHON.value],
+            "severity": RuleSeverity.ERROR.value,
         },
     ],
 }
@@ -230,7 +232,7 @@ def manual_config(pattern: str, lang: str) -> Dict[str, YamlTree]:
                         "pattern": pattern_tree,
                         "message": pattern,
                         "languages": [lang],
-                        "severity": "ERROR",
+                        "severity": RuleSeverity.ERROR.value,
                     }
                 ]
             },

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -2,6 +2,7 @@ import os
 import re
 from enum import auto
 from enum import Enum
+from typing import Type
 
 from semgrep import __VERSION__
 
@@ -38,6 +39,22 @@ class OutputFormat(Enum):
 
     def is_json(self) -> bool:
         return self in [OutputFormat.JSON, OutputFormat.SARIF]
+
+
+# Ensure consistency with 'severity' in 'rule_schema.yaml'
+class RuleSeverity(Enum):
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+    @classmethod
+    def _missing_(cls: Type[Enum], value: object) -> Enum:
+        if not isinstance(value, str):
+            raise TypeError(f"invalid rule severity type: {type(value)}")
+        for member in cls:
+            if member.value.lower() == value:
+                return member
+        raise ValueError(f"invalid rule severity value: {value}")
 
 
 # Inline 'noqa' implementation modified from flake8:

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -394,7 +394,7 @@ class CoreRunner:
         )
         by_severity = collections.defaultdict(list)
         for rule, findings in findings_by_rule.items():
-            by_severity[rule.severity.lower()].extend(findings)
+            by_severity[rule.severity.value.lower()].extend(findings)
 
         by_sev_strings = [
             f"{len(findings)} {sev}" for sev, findings in by_severity.items()

--- a/semgrep/semgrep/formatter/emacs.py
+++ b/semgrep/semgrep/formatter/emacs.py
@@ -11,11 +11,8 @@ class EmacsFormatter(BaseFormatter):
         check_id = (
             rule_match.id.split(".")[-1] if rule_match.id != CLI_RULE_ID else None
         )
-        severity = (
-            rule_match.severity.lower() + f"({check_id})"
-            if check_id
-            else rule_match.severity.lower()
-        )
+        match_severity = rule_match.severity.value.lower()
+        severity = match_severity + f"({check_id})" if check_id else match_severity
         return [
             str(rule_match.path),
             str(rule_match.start["line"]),

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -16,7 +16,7 @@ class JsonFormatter(BaseFormatter):
         json_obj["extra"] = json_obj.get("extra", {})
         json_obj["extra"]["message"] = rule_match.message
         json_obj["extra"]["metadata"] = rule_match.metadata
-        json_obj["extra"]["severity"] = rule_match.severity
+        json_obj["extra"]["severity"] = rule_match.severity.value
         json_obj["path"] = json_obj.get("path", str(rule_match.path))
         json_obj["start"] = rule_match.start
         json_obj["end"] = rule_match.end

--- a/semgrep/semgrep/formatter/junit_xml.py
+++ b/semgrep/semgrep/formatter/junit_xml.py
@@ -19,7 +19,7 @@ class JunitXmlFormatter(BaseFormatter):
         test_case.add_failure_info(
             message=rule_match.message,
             output=rule_match.lines,
-            failure_type=rule_match.severity,
+            failure_type=rule_match.severity.value,
         )
         return test_case
 

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import List
 
 from semgrep import __VERSION__
+from semgrep.constants import RuleSeverity
 from semgrep.error import Level
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
@@ -72,7 +73,11 @@ class SarifFormatter(BaseFormatter):
 
         See https://github.com/oasis-tcs/sarif-spec/blob/a6473580/Schemata/sarif-schema-2.1.0.json#L1566
         """
-        mapping = {"INFO": "note", "ERROR": "error", "WARNING": "warning"}
+        mapping = {
+            RuleSeverity.INFO: "note",
+            RuleSeverity.WARNING: "warning",
+            RuleSeverity.ERROR: "error",
+        }
         return mapping[rule.severity]
 
     @staticmethod

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -16,6 +16,7 @@ from semgrep.constants import CLI_RULE_ID
 from semgrep.constants import ELLIPSIS_STRING
 from semgrep.constants import MAX_CHARS_FLAG_NAME
 from semgrep.constants import MAX_LINES_FLAG_NAME
+from semgrep.constants import RuleSeverity
 from semgrep.formatter.base import BaseFormatter
 from semgrep.rule_match import RuleMatch
 from semgrep.util import format_bytes
@@ -190,7 +191,6 @@ class TextFormatter(BaseFormatter):
             current_file = rule_match.path
             check_id = rule_match.id
             message = rule_match.message
-            severity = rule_match.severity.lower()
             fix = rule_match.fix
             if last_file is None or last_file != current_file:
                 if last_file is not None:
@@ -203,14 +203,14 @@ class TextFormatter(BaseFormatter):
                 and check_id != CLI_RULE_ID
                 and (last_message is None or last_message != message)
             ):
-                severity_prepend = ""
-                if severity:
-                    if severity == "error":
-                        severity_prepend = f"{RED_COLOR}severity:{severity} "
-                    elif severity == "warning":
-                        severity_prepend = f"{YELLOW_COLOR}severity:{severity} "
-                    else:
-                        severity_prepend = f"severity:{severity} "
+                severity_colors = {
+                    RuleSeverity.INFO: "",
+                    RuleSeverity.WARNING: YELLOW_COLOR,
+                    RuleSeverity.ERROR: RED_COLOR,
+                }
+                severity_color = severity_colors[rule_match.severity]
+                severity_string = rule_match.severity.value.lower()
+                severity_prepend = f"{severity_color}severity:{severity_string}"
                 yield f"{severity_prepend}{YELLOW_COLOR}rule:{check_id}: {message}{RESET_COLOR}"
 
             last_file = current_file

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -210,7 +210,7 @@ class TextFormatter(BaseFormatter):
                 }
                 severity_color = severity_colors[rule_match.severity]
                 severity_string = rule_match.severity.value.lower()
-                severity_prepend = f"{severity_color}severity:{severity_string}"
+                severity_prepend = f"{severity_color}severity:{severity_string} "
                 yield f"{severity_prepend}{YELLOW_COLOR}rule:{check_id}: {message}{RESET_COLOR}"
 
             last_file = current_file

--- a/semgrep/semgrep/formatter/vim.py
+++ b/semgrep/semgrep/formatter/vim.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from semgrep.constants import RuleSeverity
 from semgrep.formatter.base import BaseFormatter
 from semgrep.rule_match import RuleMatch
 
@@ -8,9 +9,9 @@ class VimFormatter(BaseFormatter):
     @staticmethod
     def _get_parts(rule_match: RuleMatch) -> List[str]:
         severity = {
-            "INFO": "I",
-            "WARNING": "W",
-            "ERROR": "E",
+            RuleSeverity.INFO: "I",
+            RuleSeverity.WARNING: "W",
+            RuleSeverity.ERROR: "E",
         }
         return [
             str(rule_match.path),

--- a/semgrep/semgrep/join_rule.py
+++ b/semgrep/semgrep/join_rule.py
@@ -22,6 +22,7 @@ from ruamel.yaml import YAML
 import semgrep.semgrep_main
 from semgrep.config_resolver import Config
 from semgrep.config_resolver import resolve_config
+from semgrep.constants import RuleSeverity
 from semgrep.error import ERROR_MAP
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import Level
@@ -452,7 +453,9 @@ def run_join_rule(
             metadata=join_rule.get(
                 "metadata", match.get("extra", {}).get("metadata", {})
             ),
-            severity=join_rule.get("severity", match.get("severity", "INFO")),
+            severity=join_rule.get(
+                "severity", match.get("severity", RuleSeverity.INFO.value)
+            ),
             path=Path(match.get("path", "[empty]")),
             start=match.get("start", {}),
             end=match.get("end", {}),

--- a/semgrep/semgrep/join_rule.py
+++ b/semgrep/semgrep/join_rule.py
@@ -453,8 +453,10 @@ def run_join_rule(
             metadata=join_rule.get(
                 "metadata", match.get("extra", {}).get("metadata", {})
             ),
-            severity=join_rule.get(
-                "severity", match.get("severity", RuleSeverity.INFO.value)
+            severity=RuleSeverity(
+                join_rule.get(
+                    "severity", match.get("severity", RuleSeverity.INFO.value)
+                )
             ),
             path=Path(match.get("path", "[empty]")),
             start=match.get("start", {}),

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import Optional
 from typing import Union
 
+from semgrep.constants import RuleSeverity
 from semgrep.error import InvalidRuleSchemaError
 from semgrep.rule_lang import EmptySpan
 from semgrep.rule_lang import Span
@@ -129,8 +130,8 @@ class Rule:
         return self._raw.get("metadata", {})
 
     @property
-    def severity(self) -> str:
-        return str(self._raw["severity"])
+    def severity(self) -> RuleSeverity:
+        return RuleSeverity(self._raw["severity"])
 
     @property
     def mode(self) -> str:

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -8,6 +8,7 @@ from typing import Tuple
 
 import attr
 
+from semgrep.constants import RuleSeverity
 from semgrep.pattern_match import PatternMatch
 
 
@@ -21,7 +22,7 @@ class RuleMatch:
     _pattern_match: PatternMatch = attr.ib(repr=False)
     _message: str = attr.ib(repr=False)
     _metadata: Dict[str, Any] = attr.ib(repr=False)
-    _severity: str = attr.ib(repr=False)
+    _severity: RuleSeverity = attr.ib(repr=False)
     _fix: Optional[str] = attr.ib(repr=False)
     _fix_regex: Optional[Dict[str, Any]] = attr.ib(repr=False)
 
@@ -42,7 +43,7 @@ class RuleMatch:
         pattern_match: PatternMatch,
         message: str,
         metadata: Dict[str, Any],
-        severity: str,
+        severity: RuleSeverity,
         fix: Optional[str],
         fix_regex: Optional[Dict[str, Any]],
     ) -> "RuleMatch":
@@ -98,7 +99,7 @@ class RuleMatch:
         return self._metadata
 
     @property
-    def severity(self) -> str:
+    def severity(self) -> RuleSeverity:
         return self._severity
 
     @property

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -187,7 +187,7 @@ def main(
     if severity is None or severity == []:
         filtered_rules = all_rules
     else:
-        filtered_rules = [rule for rule in all_rules if rule.severity in severity]
+        filtered_rules = [rule for rule in all_rules if rule.severity.value in severity]
 
     output_handler.handle_semgrep_errors(errors)
 


### PR DESCRIPTION
Using an `enum` allows for better typing support, and will allow us to more easily change the severity values (e.g. info -> low) in the future should we decide to do so.

PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
