### PR TITLE
tainting: Enable -filter_irrelevant_rules for taint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 - Hack: improved support for metavariables (#3716)
 - Dataflow: Disregard type arguments but not the entire instruction
+- Taint mode will now benefit from semgrep-core's -filter_irrelevant_rules
 
 ### Changed
 - Optimize ending `...` in `pattern-inside`s to simply match anything left

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -824,10 +824,17 @@ let semgrep_with_rules (rules, rule_parse_time) files_or_dirs =
                | R.LRegex | R.LGeneric ->
                    failwith "requesting generic AST for LRegex|LGeneric")
            in
+           let file_and_more =
+             {
+               File_and_more.file;
+               xlang;
+               lazy_content = lazy (Common.read_file file);
+               lazy_ast_and_errors;
+             }
+           in
            let res =
              Run_rules.check hook Config_semgrep.default_config rules
-               (parse_equivalences ())
-               (file, xlang, lazy_ast_and_errors)
+               (parse_equivalences ()) file_and_more
            in
            RP.add_file file res)
   in

--- a/semgrep-core/src/engine/File_and_more.ml
+++ b/semgrep-core/src/engine/File_and_more.ml
@@ -1,0 +1,20 @@
+(*
+ * Copyright (C) 2021 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+type t = {
+  file : Common.filename;
+  xlang : Rule.xlang;
+  lazy_content : string lazy_t;
+  lazy_ast_and_errors : (AST_generic.program * Error_code.error list) lazy_t;
+}

--- a/semgrep-core/src/engine/Match_rules.mli
+++ b/semgrep-core/src/engine/Match_rules.mli
@@ -3,23 +3,24 @@
 (*
    Check search-mode rules.
    Return matches, errors, match time.
+
+   NOTE: We used to filter irrelevant rules here, but now this is done in
+        Run_rules.check! If you call this function directly, there is no
+        filtering of irrelevant rules.
 *)
 val check :
   (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
   Config_semgrep.t ->
   (Rule.rule * Rule.pformula) list ->
   Equivalence.equivalences ->
-  Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t ->
+  File_and_more.t ->
   Report.times Report.match_result
 
 val matches_of_formula :
   Config_semgrep_t.t ->
   Equivalence.equivalences ->
   Rule.rule_id ->
-  Common.filename
-  * Rule.xlang
-  * (AST_generic.program * Error_code.error list) lazy_t ->
-  string lazy_t ->
+  File_and_more.t ->
   Rule.formula ->
   Range_with_metavars.t option ->
   Report.times Report.match_result * Range_with_metavars.ranges

--- a/semgrep-core/src/engine/Run_rules.ml
+++ b/semgrep-core/src/engine/Run_rules.ml
@@ -15,6 +15,9 @@
 
 module R = Rule
 module RP = Report
+module FM = File_and_more
+
+let logger = Logging.get_logger [ __MODULE__ ]
 
 let lazy_force x = Lazy.force x [@@profiling]
 
@@ -22,7 +25,7 @@ let check_taint hook default_config taint_rules equivs file_and_more =
   match taint_rules with
   | [] -> RP.empty_semgrep_result
   | __else__ ->
-      let file, _xlang, lazy_ast_and_errors = file_and_more in
+      let { FM.file; lazy_ast_and_errors; _ } = file_and_more in
       let (ast, errors), parse_time =
         Common.with_time (fun () -> lazy_force lazy_ast_and_errors)
       in
@@ -33,8 +36,29 @@ let check_taint hook default_config taint_rules equivs file_and_more =
       in
       { RP.matches; errors; profiling = { RP.parse_time; match_time } }
 
+let filter_and_partition_rules rules file_and_more =
+  let { FM.file; lazy_content; _ } = file_and_more in
+  rules
+  |> List.filter (fun r ->
+         let relevant_rule =
+           if !Flag_semgrep.filter_irrelevant_rules then (
+             match Analyze_rule.regexp_prefilter_of_rule r with
+             | None -> true
+             | Some (re, f) ->
+                 let content = Lazy.force lazy_content in
+                 logger#info "looking for %s in %s" re file;
+                 f content)
+           else true
+         in
+         if not relevant_rule then
+           logger#info "skipping rule %s for %s" (fst r.R.id) file;
+         relevant_rule)
+  |> R.partition_rules
+
 let check hook default_config rules equivs file_and_more =
-  let search_rules, taint_rules = R.partition_rules rules in
+  let search_rules, taint_rules =
+    filter_and_partition_rules rules file_and_more
+  in
   let res_search =
     Match_rules.check hook default_config search_rules equivs file_and_more
   in

--- a/semgrep-core/src/engine/Run_rules.mli
+++ b/semgrep-core/src/engine/Run_rules.mli
@@ -6,5 +6,5 @@ val check :
   Config_semgrep.t ->
   Rule.rules ->
   Equivalence.equivalences ->
-  Common.filename * Rule.xlang * (Target.t * Error_code.error list) Lazy.t ->
+  File_and_more.t ->
   Report.times Report.match_result

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -12,6 +12,7 @@
  * file license.txt for more details.
  *)
 open Common
+module FM = File_and_more
 module FT = File_type
 module R = Rule
 module E = Error_code
@@ -142,15 +143,19 @@ let test_rules ?(ounit_context = false) xs =
                  (ast, errors)
              | R.LRegex | R.LGeneric -> raise Impossible)
          in
+         let file_and_more =
+           {
+             FM.file = target;
+             xlang;
+             lazy_content = lazy (Common.read_file target);
+             lazy_ast_and_errors;
+           }
+         in
          E.g_errors := [];
          Flag_semgrep.with_opt_cache := false;
          let config = Config_semgrep.default_config in
          let res =
-           try
-             Run_rules.check
-               (fun _ _ _ -> ())
-               config rules []
-               (target, xlang, lazy_ast_and_errors)
+           try Run_rules.check (fun _ _ _ -> ()) config rules [] file_and_more
            with exn ->
              failwith (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))
          in

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -461,6 +461,18 @@ let regexp_prefilter_of_formula f =
             true )
   with GeneralPattern -> None
 
+let regexp_prefilter_of_taint_rule rule_tok taint_spec =
+  (* We must be able to match some source _and_ some sink. *)
+  let sources = taint_spec.R.sources |> Common.map R.formula_of_pformula in
+  let sinks = taint_spec.R.sinks |> Common.map R.formula_of_pformula in
+  let f =
+    (* Note that this formula would likely not yield any meaningful result
+     * if executed by search-mode, but it works for the purpose of this
+     * analysis! *)
+    R.And (rule_tok, [ R.Or (rule_tok, sources); R.Or (rule_tok, sinks) ])
+  in
+  regexp_prefilter_of_formula f
+
 let hmemo = Hashtbl.create 101
 
 let regexp_prefilter_of_rule r =
@@ -471,4 +483,4 @@ let regexp_prefilter_of_rule r =
       | R.Search pf ->
           let f = R.formula_of_pformula pf in
           regexp_prefilter_of_formula f
-      | R.Taint _ -> (* TODO *) None)
+      | R.Taint spec -> regexp_prefilter_of_taint_rule t spec)


### PR DESCRIPTION
test plan:

    % make test

    % semgrep --time -c semgrep-rules/javascript/angular/security \
          semgrep/parsing-stats/lang/javascript/tmp/*
    # ^ using https://github.com/returntocorp/semgrep-rules/pull/1403
    # the taint-mode rules are now basically as fast as the previous
    # fake-taint rules but yield ~5x more findings



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
