### PR TITLE
Add attributes to directives to support Java import static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 - Enable associative matching for string concatenation (#3741)
 
+### Fixed
+- Java: separate import static from regular imports during matching (#3772)
+
 ## [0.63.0](https://github.com/returntocorp/semgrep/releases/tag/v0.63.0) - 08-25-2021
 
 ### Added

--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -45,8 +45,7 @@ dump:
 
 pr:
 	git push origin `git rev-parse --abbrev-ref HEAD`
-	hub pull-request -b develop -r mjambon -r IagoAbal
-#not this month: -r emjin
+	hub pull-request -b develop -r mjambon -r IagoAbal -r emjin
 
 push:
 	git push origin `git rev-parse --abbrev-ref HEAD`

--- a/semgrep-core/src/analyzing/Naming_AST.ml
+++ b/semgrep-core/src/analyzing/Naming_AST.ml
@@ -566,7 +566,7 @@ let resolve lang prog =
       (* sgrep: the import aliases *)
       V.kdir =
         (fun (k, _v) x ->
-          (match x with
+          (match x.d with
           | ImportFrom (_, DottedName xs, id, Some (alias, id_info)) ->
               (* for python *)
               let sid = H.gensym () in

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -1119,7 +1119,12 @@ and map_class_kind = function
   | AtInterface -> `AtInterface
   | RecordClass -> `RecordClass
 
-and map_directive = function
+and map_directive { d; dattrs } =
+  let d = map_directive_kind d in
+  let _dattrsTODO = map_of_list map_attribute dattrs in
+  d
+
+and map_directive_kind = function
   | ImportFrom (t, v1, v2, v3) ->
       let t = map_tok t in
       let v1 = map_module_name v1 and v2, v3 = map_alias (v2, v3) in

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -38,7 +38,7 @@
  * per-language basis, many useful analysis are trivial and require just an
  * AST and a visitor. One could duplicate those analysis for each language
  * or design an AST (this file) generic enough to factorize all those
- * analysis (e.g., unused entity). We want to remain
+ * analysis (e.g., unused entity). However, we want to remain
  * as precise as possible and not lose too much information while going
  * from the specific language AST to the generic AST. We also do not want
  * to be too generic as in ast_fuzzy.ml, where we have a very general
@@ -379,10 +379,8 @@ and id_info = {
 (*****************************************************************************)
 
 (*s: type [[AST_generic.expr]] *)
-(* todo? we could do like for stmt and have 'expr' and 'expr_kind', which
- * would allow us to store more semantic information at each expr node,
- * e.g., type information, or constant evaluation, or range, but it
- * would be a bigger refactoring than for stmt.
+(* todo? we could store more semantic information at each expr node,
+ * e.g., type information, constant evaluation, range.
  *)
 and expr = {
   e : expr_kind;
@@ -1749,7 +1747,15 @@ and macro_definition = { macroparams : ident list; macrobody : any list }
  * entity (in this module/namespace) even though some languages such as Python
  * blur the difference.
  *)
-and directive =
+and directive = {
+  d : directive_kind;
+  (* Right now dattrs is used just for Static import in Java, and for
+   * OCaml attributes of directives (e.g., open).
+   *)
+  dattrs : attribute list;
+}
+
+and directive_kind =
   (* newvar: *)
   | ImportFrom of
       tok (* 'import'/'from' for Python, 'include' for C *)
@@ -1988,6 +1994,8 @@ let s skind =
   }
 
 let e ekind = { e = ekind; e_id = 0; e_range = None }
+
+let d dkind = { d = dkind; dattrs = [] }
 
 (*s: function [[AST_generic.basic_field]] *)
 let basic_field id vopt typeopt =

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -957,7 +957,11 @@ let (mk_visitor : visitor_in -> visitor_out) =
       cparams;
     }
   and map_class_kind (x, t) = (x, map_tok t)
-  and map_directive = function
+  and map_directive { d; dattrs } =
+    let d = map_directive_kind d in
+    let dattrs = map_of_list map_attribute dattrs in
+    { d; dattrs }
+  and map_directive_kind = function
     | ImportFrom (t, v1, v2, v3) ->
         let t = map_tok t in
         let v1 = map_module_name v1 and v2, v3 = map_alias (v2, v3) in

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -1241,7 +1241,17 @@ and vof_ident_and_id_info (v1, v2) =
   let v2 = vof_id_info v2 in
   OCaml.VTuple [ v1; v2 ]
 
-and vof_directive = function
+and vof_directive { d; dattrs } =
+  let bnds = [] in
+  let arg = vof_directive_kind d in
+  let bnd = ("d", arg) in
+  let bnds = bnd :: bnds in
+  let arg = OCaml.vof_list vof_attribute dattrs in
+  let bnd = ("dattrs", arg) in
+  let bnds = bnd :: bnds in
+  OCaml.VDict bnds
+
+and vof_directive_kind = function
   | ImportFrom (t, v1, v2, v3) ->
       let t = vof_tok t in
       let v1 = vof_module_name v1 and v2, v3 = vof_alias (v2, v3) in

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1111,7 +1111,8 @@ let (mk_visitor : visitor_in -> visitor_out) =
     ()
   and v_directive x =
     let k x =
-      match x with
+      v_list v_attribute x.dattrs;
+      match x.d with
       | ImportFrom (t, v1, v2, v3) ->
           let t = v_tok t in
           let v1 = v_module_name v1 and _ = v_alias (v2, v3) in

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -2711,13 +2711,17 @@ and m_macro_definition a b =
 
 (*s: function [[Generic_vs_generic.m_directive]] *)
 and m_directive a b =
-  m_directive_basic a b >!> fun () ->
-  match a with
+  let* () =
+    m_list_in_any_order ~less_is_ok:true m_attribute a.dattrs b.dattrs
+  in
+
+  m_directive_basic a.d b.d >!> fun () ->
+  match a.d with
   (* normalize only if very simple import pattern (no alias) *)
   | G.ImportFrom (_, _, _, None) | G.ImportAs (_, _, None) -> (
       (* equivalence: *)
-      let normal_a = Normalize_generic.normalize_import_opt true a in
-      let normal_b = Normalize_generic.normalize_import_opt false b in
+      let normal_a = Normalize_generic.normalize_import_opt true a.d in
+      let normal_b = Normalize_generic.normalize_import_opt false b.d in
       match (normal_a, normal_b) with
       | Some (a0, a1), Some (b0, b1) ->
           m_tok a0 b0 >>= fun () -> m_module_name_prefix a1 b1

--- a/semgrep-core/src/matching/Normalize_generic.mli
+++ b/semgrep-core/src/matching/Normalize_generic.mli
@@ -3,7 +3,7 @@
 (*s: signature [[Normalize_generic.normalize_import_opt]] *)
 val normalize_import_opt :
   bool ->
-  AST_generic.directive ->
+  AST_generic.directive_kind ->
   (AST_generic.tok * AST_generic.module_name) option
 
 (*e: signature [[Normalize_generic.normalize_import_opt]] *)

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -753,14 +753,15 @@ and stmt_aux x =
       [ G.Assert (t, v1, v2, G.sc) |> G.s ]
   | ImportAs (t, v1, v2) ->
       let mname = module_name v1 and nopt = option ident_and_id_info v2 in
-      [ G.DirectiveStmt (G.ImportAs (t, mname, nopt)) |> G.s ]
+      [ G.DirectiveStmt (G.ImportAs (t, mname, nopt) |> G.d) |> G.s ]
   | ImportAll (t, v1, v2) ->
       let mname = module_name v1 and v2 = info v2 in
-      [ G.DirectiveStmt (G.ImportAll (t, mname, v2)) |> G.s ]
+      [ G.DirectiveStmt (G.ImportAll (t, mname, v2) |> G.d) |> G.s ]
   | ImportFrom (t, v1, v2) ->
       let v1 = module_name v1 and v2 = list alias v2 in
       List.map
-        (fun (a, b) -> G.DirectiveStmt (G.ImportFrom (t, v1, a, b)) |> G.s)
+        (fun (a, b) ->
+          G.DirectiveStmt (G.ImportFrom (t, v1, a, b) |> G.d) |> G.s)
         v2
   | Global (t, v1) | NonLocal (t, v1) ->
       let v1 = list name v1 in

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -439,7 +439,7 @@ and define_body = function
 and directive = function
   | Include (t, v1) ->
       let v1 = wrap string v1 in
-      G.DirectiveStmt (G.ImportAs (t, G.FileName v1, None))
+      G.DirectiveStmt (G.ImportAs (t, G.FileName v1, None) |> G.d)
   | Define (_t, v1, v2) ->
       let v1 = name v1 and v2 = define_body v2 in
       let ent = G.basic_entity v1 [] in
@@ -453,7 +453,7 @@ and directive = function
       let v2 =
         match v2 with None -> [] | Some s -> [ G.E (G.L (G.String s) |> G.e) ]
       in
-      G.DirectiveStmt (G.Pragma (v1, v2))
+      G.DirectiveStmt (G.Pragma (v1, v2) |> G.d)
 
 and definition = function
   | StructDef v1 ->

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -573,10 +573,10 @@ let top_func () =
     | STop v1 -> stmt v1
     | Package (t1, id) ->
         let id = ident id in
-        G.DirectiveStmt (G.Package (t1, [ id ])) |> G.s
+        G.DirectiveStmt (G.Package (t1, [ id ]) |> G.d) |> G.s
     | Import x ->
         let x = import x in
-        G.DirectiveStmt x |> G.s
+        G.DirectiveStmt (x |> G.d) |> G.s
   and import { i_path; i_kind; i_tok } =
     let module_name = G.FileName (wrap string i_path) in
     let s, tok = i_path in
@@ -601,7 +601,7 @@ let top_func () =
     | ITop x -> [ top_decl x ]
     | IImport x ->
         let x = import x in
-        [ G.DirectiveStmt x |> G.s ]
+        [ G.DirectiveStmt (x |> G.d) |> G.s ]
     | IStmt x -> stmt_aux x
   and item x = G.stmt1 (item_aux x)
   and partial = function
@@ -638,7 +638,7 @@ let top_func () =
           G.S v1
       | I v1 ->
           let v1 = import v1 in
-          G.S (G.DirectiveStmt v1 |> G.s)
+          G.S (G.DirectiveStmt (v1 |> G.d) |> G.s)
       | P v1 ->
           let v1 = program v1 in
           G.Pr v1

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -647,10 +647,14 @@ and import = function
       G.ImportFrom (t, G.DottedName xs, id, None)
 
 and directive = function
-  | Import (_vstatic, v2) -> G.DirectiveStmt (import v2) |> G.s
+  | Import (static, v2) ->
+      let dattrs =
+        match static with None -> [] | Some t -> [ G.attr G.Static t ]
+      in
+      G.DirectiveStmt { G.d = import v2; dattrs } |> G.s
   | Package (t, qu, _t2) ->
       let qu = qualified_ident qu in
-      G.DirectiveStmt (G.Package (t, qu)) |> G.s
+      G.DirectiveStmt (G.Package (t, qu) |> G.d) |> G.s
   | ModuleTodo t -> G.OtherStmt (G.OS_Todo, [ G.Tk t ]) |> G.s
 
 let program v = stmts v

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -321,7 +321,7 @@ and stmt x =
       G.OtherStmt (G.OS_Todo, G.TodoK v1 :: v2) |> G.s
   | M v1 ->
       let v1 = module_directive v1 in
-      G.DirectiveStmt v1 |> G.s
+      G.DirectiveStmt (v1 |> G.d) |> G.s
   | DefStmt v1 ->
       let v1 = definition v1 in
       G.DefStmt v1 |> G.s
@@ -734,7 +734,8 @@ and require_to_import_in_stmt_opt st =
                          | _ -> Some (id2, G.empty_id_info ())
                        in
                        G.DirectiveStmt
-                         (G.ImportFrom (treq, G.FileName file, id1, alias_opt))
+                         (G.ImportFrom (treq, G.FileName file, id1, alias_opt)
+                         |> G.d)
                        |> G.s
                    | _ -> raise ComplicatedCase)
             in

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -629,8 +629,9 @@ and item { i; iattrs } =
       [ G.DefStmt (ent, def) |> G.s ]
   | Open (t, v1) ->
       let v1 = module_name v1 in
-      (* no attrs here *)
-      let dir = G.ImportAll (t, G.DottedName v1, fake "*") in
+      let dir =
+        { G.d = G.ImportAll (t, G.DottedName v1, fake "*"); dattrs = attrs }
+      in
       [ G.DirectiveStmt dir |> G.s ]
   | Val (_t, v1, v2) ->
       let v1 = ident v1 and v2 = type_ v2 in

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -176,12 +176,12 @@ let rec stmt_aux = function
       [ G.DefStmt (ent, G.TypeDef def) |> G.s ]
   | NamespaceDef (t, v1, (_t1, v2, t2)) ->
       let v1 = qualified_ident v1 and v2 = list stmt v2 in
-      [ G.DirectiveStmt (G.Package (t, v1)) |> G.s ]
+      [ G.DirectiveStmt (G.Package (t, v1) |> G.d) |> G.s ]
       @ v2
-      @ [ G.DirectiveStmt (G.PackageEnd t2) |> G.s ]
+      @ [ G.DirectiveStmt (G.PackageEnd t2 |> G.d) |> G.s ]
   | NamespaceUse (t, v1, v2) ->
       let v1 = qualified_ident v1 and v2 = option alias v2 in
-      [ G.DirectiveStmt (G.ImportAs (t, G.DottedName v1, v2)) |> G.s ]
+      [ G.DirectiveStmt (G.ImportAs (t, G.DottedName v1, v2) |> G.d) |> G.s ]
   | StaticVars (t, v1) ->
       v1
       |> list (fun (v1, v2) ->

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -577,11 +577,13 @@ and definition def =
   | Alias (t, mn1, mn2) ->
       let mn1 = method_name_to_any mn1 in
       let mn2 = method_name_to_any mn2 in
-      G.DirectiveStmt (G.OtherDirective (G.OI_Alias, [ G.Tk t; mn1; mn2 ]))
+      G.DirectiveStmt
+        (G.OtherDirective (G.OI_Alias, [ G.Tk t; mn1; mn2 ]) |> G.d)
       |> G.s
   | Undef (t, mns) ->
       let mns = list method_name_to_any mns in
-      G.DirectiveStmt (G.OtherDirective (G.OI_Undef, G.Tk t :: mns)) |> G.s
+      G.DirectiveStmt (G.OtherDirective (G.OI_Undef, G.Tk t :: mns) |> G.d)
+      |> G.s
 
 and body_exn x =
   match x with

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -143,10 +143,10 @@ let rec v_import_expr tk (v1, v2) =
 and v_import_spec = function
   | ImportId v1 ->
       let v1 = v_ident v1 in
-      fun tk path -> [ G.ImportFrom (tk, path, v1, None) ]
+      fun tk path -> [ G.ImportFrom (tk, path, v1, None) |> G.d ]
   | ImportWildcard v1 ->
       let v1 = v_tok v1 in
-      fun tk path -> [ G.ImportAll (tk, path, v1) ]
+      fun tk path -> [ G.ImportAll (tk, path, v1) |> G.d ]
   | ImportSelectors (_, v1, _) ->
       let v1 = (v_list v_import_selector) v1 in
       fun tk path ->
@@ -157,7 +157,7 @@ and v_import_spec = function
                  | None -> None
                  | Some (_, id) -> Some (id, G.empty_id_info ())
                in
-               G.ImportFrom (tk, path, id, alias))
+               G.ImportFrom (tk, path, id, alias) |> G.d)
 
 let v_import (v1, v2) : G.directive list =
   let v1 = v_tok v1 in
@@ -611,13 +611,13 @@ and v_block_stat x : G.item list =
       [ v1 ]
   | Package v1 ->
       let ipak, ids = v_package v1 in
-      [ G.DirectiveStmt (G.Package (ipak, ids)) |> G.s ]
+      [ G.DirectiveStmt (G.Package (ipak, ids) |> G.d) |> G.s ]
   | Packaging (v1, (_lb, v2, rb)) ->
       let ipak, ids = v_package v1 in
       let xxs = v_list v_top_stat v2 in
-      [ G.DirectiveStmt (G.Package (ipak, ids)) |> G.s ]
+      [ G.DirectiveStmt (G.Package (ipak, ids) |> G.d) |> G.s ]
       @ List.flatten xxs
-      @ [ G.DirectiveStmt (G.PackageEnd rb) |> G.s ]
+      @ [ G.DirectiveStmt (G.PackageEnd rb |> G.d) |> G.s ]
 
 and v_top_stat v = v_block_stat v
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2432,7 +2432,7 @@ and extern_alias_directive (env : env)
   let v3 = identifier env v3 (* identifier *) in
   let v4 = token env v4 (* ";" *) in
   let extern =
-    G.OtherDirective (G.OI_Extern, [ G.Tk v1; G.Tk v2; G.I v3; G.Tk v4 ])
+    G.OtherDirective (G.OI_Extern, [ G.Tk v1; G.Tk v2; G.I v3; G.Tk v4 ]) |> G.d
   in
   G.DirectiveStmt extern |> G.s
 
@@ -2459,7 +2459,7 @@ and using_directive (env : env) ((v1, v2, v3, v4) : CST.using_directive) =
         (* using System.IO; *)
         G.ImportAll (v1, G.DottedName (ids_of_name v3), v4)
   in
-  G.DirectiveStmt import |> G.s
+  G.DirectiveStmt (import |> G.d) |> G.s
 
 and global_attribute_list (env : env)
     ((v1, v2, v3, v4, v5) : CST.global_attribute_list) =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -1259,9 +1259,9 @@ and declaration (env : env) (x : CST.declaration) =
         | None -> None
       in
       match v2 with
-      | Some v2 -> G.DirectiveStmt (G.Package (v1, v2))
+      | Some v2 -> G.DirectiveStmt (G.Package (v1, v2) |> G.d)
       (* TODO: I think this is wrong and PackageEnd should instead be used to handle namespaces with block inside? But how? *)
-      | None -> G.DirectiveStmt (G.PackageEnd v1))
+      | None -> G.DirectiveStmt (G.PackageEnd v1 |> G.d))
   | `Const_decl (v1, v2, v3, v4, v5) ->
       let attr = (* "const" *) [ G.KeywordAttr (Const, token env v1) ] in
       let type_ = match v2 with Some x -> Some (type_ env x) | None -> None in
@@ -2106,7 +2106,8 @@ and statement (env : env) (x : CST.statement) =
         in
         G.s
           (G.DirectiveStmt
-             (G.ImportAs (v1, G.DottedName (prefix_idents @ idents), alias)))
+             (G.ImportAs (v1, G.DottedName (prefix_idents @ idents), alias)
+             |> G.d))
       in
       let v2 =
         match v2 with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -440,7 +440,7 @@ let package_header (env : env) ((v1, v2, v3) : CST.package_header) : directive =
   let v1 = token env v1 (* "package" *) in
   let v2 = identifier env v2 in
   let _v3 = token env v3 (* pattern [\r\n]+ *) in
-  Package (v1, v2)
+  Package (v1, v2) |> G.d
 
 let import_header (env : env) ((v1, v2, v3, v4) : CST.import_header) : directive
     =
@@ -459,7 +459,7 @@ let import_header (env : env) ((v1, v2, v3, v4) : CST.import_header) : directive
     | None -> ImportAs (v1, DottedName v2, None)
   in
   let _v4 = token env v4 (* pattern [\r\n]+ *) in
-  v3
+  v3 |> G.d
 
 let rec _annotated_lambda (env : env) (v1 : CST.annotated_lambda) =
   lambda_literal env v1

--- a/semgrep-core/tests/java/misc_import_static.java
+++ b/semgrep-core/tests/java/misc_import_static.java
@@ -1,0 +1,4 @@
+//ERROR: match
+import static foo.bar.ThisIsWrong;
+// not this one
+import foo.bar.ThisIsOkay;

--- a/semgrep-core/tests/java/misc_import_static.sgrep
+++ b/semgrep-core/tests/java/misc_import_static.sgrep
@@ -1,0 +1,1 @@
+import static $CLASS;


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/3772

An alternative would be to add an argument to the
Import and ImportAll constructs, but this seems more general.
This also handles attributes on OCaml directives.

test plan:
test file included




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date