### PR TITLE
Free tree-sitter tree when done

### DIFF
--- a/semgrep-core/src/parsing/parallel-invoke.yaml
+++ b/semgrep-core/src/parsing/parallel-invoke.yaml
@@ -1,0 +1,9 @@
+rules:
+- id: useless-equality
+  pattern: Parallel.invoke $X $Y ()
+  fix: $X $Y
+  message: |
+      Parallel.invoke
+  languages: [ocaml]
+  severity: WARNING
+

--- a/semgrep-core/src/parsing/parallel-invoke.yaml
+++ b/semgrep-core/src/parsing/parallel-invoke.yaml
@@ -1,9 +1,0 @@
-rules:
-- id: useless-equality
-  pattern: Parallel.invoke $X $Y ()
-  fix: $X $Y
-  message: |
-      Parallel.invoke
-  languages: [ocaml]
-  severity: WARNING
-

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -1177,7 +1177,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_bash.Parse.file file ())
+      Tree_sitter_bash.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       let bash_ast = program env cst in
@@ -1187,7 +1187,7 @@ let parse_pattern str =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_bash.Parse.string str ())
+      Tree_sitter_bash.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -1175,9 +1175,7 @@ and variable_assignment (env : env) ((v1, v2, v3) : CST.variable_assignment) :
 
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_bash.Parse.file file)
+    (fun () -> Tree_sitter_bash.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       let bash_ast = program env cst in
@@ -1185,9 +1183,7 @@ let parse file =
 
 let parse_pattern str =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_bash.Parse.string str)
+    (fun () -> Tree_sitter_bash.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
@@ -1696,7 +1696,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_c.Parse.file file ())
+      Tree_sitter_c.Parse.file file)
     (fun cst ->
       let env =
         { H.file; conv = H.line_col_to_pos file; extra = default_extra_env }

--- a/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
@@ -1694,9 +1694,7 @@ and translation_unit (env : env) (xs : CST.translation_unit) : program =
 
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_c.Parse.file file)
+    (fun () -> Tree_sitter_c.Parse.file file)
     (fun cst ->
       let env =
         { H.file; conv = H.line_col_to_pos file; extra = default_extra_env }

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -3016,9 +3016,7 @@ and map_variadic_parameter_declaration (env : env)
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_cpp.Parse.file file)
+    (fun () -> Tree_sitter_cpp.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       try map_translation_unit env cst

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -3018,7 +3018,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_cpp.Parse.file file ())
+      Tree_sitter_cpp.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       try map_translation_unit env cst

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2953,7 +2953,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_c_sharp.Parse.file file ())
+      Tree_sitter_c_sharp.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -2976,7 +2976,7 @@ let parse_pattern str =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke parse_pattern_aux str ())
+      parse_pattern_aux str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2951,9 +2951,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_c_sharp.Parse.file file)
+    (fun () -> Tree_sitter_c_sharp.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -2974,9 +2972,7 @@ let parse_pattern_aux str =
 
 let parse_pattern str =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      parse_pattern_aux str)
+    (fun () -> parse_pattern_aux str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -1253,7 +1253,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_go.Parse.file file ())
+      Tree_sitter_go.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       let x = source_file env cst in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -1251,9 +1251,7 @@ let source_file (env : env) (xs : CST.source_file) : program =
 
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_go.Parse.file file)
+    (fun () -> Tree_sitter_go.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       let x = source_file env cst in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2854,9 +2854,7 @@ let script (env : env) ((v1, v2) : CST.script) : G.program =
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_hack.Parse.file file)
+    (fun () -> Tree_sitter_hack.Parse.file file)
     (fun cst ->
       let extra = Target in
       let env = { H.file; conv = H.line_col_to_pos file; extra } in
@@ -2875,9 +2873,7 @@ let parse_expression_or_source_file str =
 
 let parse_pattern str =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      parse_expression_or_source_file str)
+    (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
       (* TODO: do we need a special mode to convert $FOO in the

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2856,7 +2856,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_hack.Parse.file file ())
+      Tree_sitter_hack.Parse.file file)
     (fun cst ->
       let extra = Target in
       let env = { H.file; conv = H.line_col_to_pos file; extra } in
@@ -2877,7 +2877,7 @@ let parse_pattern str =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke parse_expression_or_source_file str ())
+      parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
       (* TODO: do we need a special mode to convert $FOO in the

--- a/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
@@ -224,7 +224,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_html.Parse.file file ())
+      Tree_sitter_html.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -244,7 +244,7 @@ let parse_pattern str =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_html.Parse.string str ())
+      Tree_sitter_html.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
@@ -222,9 +222,7 @@ and map_node (env : env) (x : CST.node) : xml_body =
 
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_html.Parse.file file)
+    (fun () -> Tree_sitter_html.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -242,9 +240,7 @@ let parse file =
 
 let parse_pattern str =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_html.Parse.string str)
+    (fun () -> Tree_sitter_html.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -1729,9 +1729,7 @@ let program (env : env) (xs : CST.program) = List.map (statement env) xs
 
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_java.Parse.file file)
+    (fun () -> Tree_sitter_java.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       program env cst)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -1731,7 +1731,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_java.Parse.file file ())
+      Tree_sitter_java.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       program env cst)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -2034,9 +2034,7 @@ let source_file (env : env) (x : CST.source_file) : any =
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_kotlin.Parse.file file)
+    (fun () -> Tree_sitter_kotlin.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -2059,9 +2057,7 @@ let parse_expression_or_source_file str =
 (* todo: special mode to convert Ellipsis in the right construct! *)
 let parse_pattern str =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      parse_expression_or_source_file str)
+    (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -2036,7 +2036,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_kotlin.Parse.file file ())
+      Tree_sitter_kotlin.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -2061,7 +2061,7 @@ let parse_pattern str =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke parse_expression_or_source_file str ())
+      parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -760,9 +760,7 @@ let map_program (env : env) ((v1, v2) : CST.program) : G.program =
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_lua.Parse.file file)
+    (fun () -> Tree_sitter_lua.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -771,9 +769,7 @@ let parse file =
 (* todo: special mode to convert Ellipsis in the right construct! *)
 let parse_pattern str =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_lua.Parse.string str)
+    (fun () -> Tree_sitter_lua.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -762,7 +762,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_lua.Parse.file file ())
+      Tree_sitter_lua.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
 
@@ -773,7 +773,7 @@ let parse_pattern str =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_lua.Parse.string str ())
+      Tree_sitter_lua.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -3166,9 +3166,7 @@ let map_compilation_unit (env : env) ((v1, v2) : CST.compilation_unit) =
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_ocaml.Parse.file file)
+    (fun () -> Tree_sitter_ocaml.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       map_compilation_unit env cst)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -3168,7 +3168,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_ocaml.Parse.file file ())
+      Tree_sitter_ocaml.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       map_compilation_unit env cst)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -2061,9 +2061,7 @@ let map_program (env : env) ((v1, v2) : CST.program) =
 
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_php.Parse.file file)
+    (fun () -> Tree_sitter_php.Parse.file file)
     (fun cst ->
       let extra = () in
       let env = { H.file; conv = H.line_col_to_pos file; extra } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -2063,7 +2063,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_php.Parse.file file ())
+      Tree_sitter_php.Parse.file file)
     (fun cst ->
       let extra = () in
       let env = { H.file; conv = H.line_col_to_pos file; extra } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
@@ -501,7 +501,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_r.Parse.file file ())
+      Tree_sitter_r.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       try map_program env cst

--- a/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
@@ -499,9 +499,7 @@ and map_unary (env : env) (x : CST.unary) =
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_r.Parse.file file)
+    (fun () -> Tree_sitter_r.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       try map_program env cst

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -1520,7 +1520,7 @@ let parse file =
        *)
       | _ ->
           Parallel.backtrace_when_exn := false;
-          Parallel.invoke Tree_sitter_ruby.Parse.file file ())
+          Tree_sitter_ruby.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       (if debug then

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -1518,9 +1518,7 @@ let parse file =
        * we allocated quite a few stuff, the probability to get a segfault
        * in the child grows
        *)
-      | _ ->
-          Parallel.backtrace_when_exn := false;
-          Tree_sitter_ruby.Parse.file file)
+      | _ -> Tree_sitter_ruby.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       (if debug then

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -3269,7 +3269,7 @@ let parse file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_rust.Parse.file file ())
+      Tree_sitter_rust.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = Target } in
       match map_source_file env cst with
@@ -3294,7 +3294,7 @@ let parse_pattern str =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke parse_expression_or_source_file str ())
+      parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -3267,9 +3267,7 @@ let map_source_file (env : env) (x : CST.source_file) : G.any =
 (*****************************************************************************)
 let parse file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_rust.Parse.file file)
+    (fun () -> Tree_sitter_rust.Parse.file file)
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = Target } in
       match map_source_file env cst with
@@ -3292,9 +3290,7 @@ let parse_expression_or_source_file str =
 (* todo: special mode to convert Ellipsis in the right construct! *)
 let parse_pattern str =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      parse_expression_or_source_file str)
+    (fun () -> parse_expression_or_source_file str)
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = Pattern } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -2982,7 +2982,6 @@ let parse ?dialect file =
   H.wrap_parser
     (fun () ->
       let dialect = guess_dialect dialect file in
-      Parallel.backtrace_when_exn := false;
       match dialect with
       | `Typescript ->
           let cst = Tree_sitter_typescript.Parse.file file in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -2985,10 +2985,10 @@ let parse ?dialect file =
       Parallel.backtrace_when_exn := false;
       match dialect with
       | `Typescript ->
-          let cst = Parallel.invoke Tree_sitter_typescript.Parse.file file () in
+          let cst = Tree_sitter_typescript.Parse.file file in
           (cst :> cst_result)
       | `TSX ->
-          let cst = Parallel.invoke Tree_sitter_tsx.Parse.file file () in
+          let cst = Tree_sitter_tsx.Parse.file file in
           (cst :> cst_result))
     (fun cst ->
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -373,9 +373,7 @@ let parse_string_and_adjust_wrt_base content tbase fparse =
 
 let parse parse_js file =
   H.wrap_parser
-    (fun () ->
-      Parallel.backtrace_when_exn := false;
-      Tree_sitter_vue.Parse.file file)
+    (fun () -> Tree_sitter_vue.Parse.file file)
     (fun cst ->
       let extra =
         {

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -375,7 +375,7 @@ let parse parse_js file =
   H.wrap_parser
     (fun () ->
       Parallel.backtrace_when_exn := false;
-      Parallel.invoke Tree_sitter_vue.Parse.file file ())
+      Tree_sitter_vue.Parse.file file)
     (fun cst ->
       let extra =
         {


### PR DESCRIPTION
Integrates changes from https://github.com/returntocorp/ocaml-tree-sitter-core/pull/11

For convenience, all the information in that commit message is here too.

Expose ts_tree_delete and call it when done parsing (at the end of of_ts_tree). Also, remove the fork when calling tree-sitter in tsx (just to check). This should affect all javascript and tsx repos.

Test plan:

Create a yaml file with pattern $X == $Y. Uncomment ts_tree_delete in finalize_tree in semgrep-core/src/ocaml-tree-sitter-core/src/bindings/lib/bindings.c.

Now go to perf/bench/njs-juice (or really any bench)

Run

sc -config /Users/emma/workspace/segfault/metavar.yaml .  -lang js
You should get a segfault.

Checkout this branch

There should be no segfault! You can confirm that the tree is being deleted by printing in octs_tree_delete.

To verify memory leak:

Go to Parse_typescript_tree_sitter (or your language of choice).

Before where it says `let cst = Tree_sitter_tsx.Parse ...`, add

```
          let rec loop () =
          let _cst = Tree_sitter_tsx.Parse.file file in
          loop (); ()
          in
          loop ()
```

Run `sc -config /Users/emma/workspace/segfault/metavar.yaml .  -lang js`. I used the `l50000.js` test in `semgrep-core/perf`, but it shouldn't matter. In another terminal, run top. Verify that memory usage loops. (Important: program should hang)

To be extra sure, checkout develop, put these lines in, look at top. It will not go down (I let it go to 12G+).

PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
