### PR TITLE
Hide dangerously flag and remove kwargs

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -433,6 +433,11 @@ def cli() -> None:
     if args.dump_ast and not args.lang:
         parser.error("--dump-ast and -l/--lang must both be specified")
 
+    if args.dangerously_allow_arbitrary_code_execution_from_rules:
+        logger.warning(
+            "The '--dangerously-allow-arbitrary-code-execution-from-rules' flag is now deprecated and does nothing. It will be removed in the future."
+        )
+
     output_time = args.time or args.json_time
 
     # set the flags

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -16,7 +16,6 @@ from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import MAX_CHARS_FLAG_NAME
 from semgrep.constants import MAX_LINES_FLAG_NAME
 from semgrep.constants import OutputFormat
-from semgrep.constants import RCE_RULE_FLAG
 from semgrep.constants import SEMGREP_URL
 from semgrep.dump_ast import dump_parsed_ast
 from semgrep.error import SemgrepError
@@ -149,15 +148,6 @@ def cli() -> None:
         "--skip-unknown-extensions",
         action="store_true",
         help="Scan only known file extensions, even if unrecognized ones are explicitly targeted.",
-    )
-
-    config.add_argument(
-        RCE_RULE_FLAG,
-        action="store_true",
-        help=(
-            "WARNING: allow rules to run arbitrary code. ONLY ENABLE IF YOU "
-            "TRUST THE SOURCE OF ALL RULES IN YOUR CONFIGURATION."
-        ),
     )
 
     config.add_argument(
@@ -418,6 +408,12 @@ def cli() -> None:
         help=argparse.SUPPRESS,
         # help="Legacy pattern recommendation functionality for use in semgrep-app playground",
     )
+    config.add_argument(
+        "--dangerously-allow-arbitrary-code-execution-from-rules",
+        action="store_true",
+        help=argparse.SUPPRESS,
+        # help="WARNING: allow rules to run arbitrary code (pattern-where-python)",
+    )
 
     ### Parse and validate
     args = parser.parse_args()
@@ -523,7 +519,6 @@ def cli() -> None:
                 autofix=args.autofix,
                 dryrun=args.dryrun,
                 disable_nosem=args.disable_nosem,
-                dangerously_allow_arbitrary_code_execution_from_rules=args.dangerously_allow_arbitrary_code_execution_from_rules,
                 no_git_ignore=args.no_git_ignore,
                 timeout=args.timeout,
                 max_memory=args.max_memory,

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -5,7 +5,6 @@ from enum import Enum
 
 from semgrep import __VERSION__
 
-RCE_RULE_FLAG = "--dangerously-allow-arbitrary-code-execution-from-rules"
 RULES_KEY = "rules"
 ID_KEY = "id"
 CLI_RULE_ID = "-"

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -273,11 +273,7 @@ class CoreRunner:
                     debug_tqdm_write(f"Running rule {rule.id}...")
                     with tempfile.NamedTemporaryFile(
                         "w", suffix=".yaml"
-                    ) as rule_file, tempfile.NamedTemporaryFile(
-                        "w"
-                    ) as target_file, tempfile.NamedTemporaryFile(
-                        "w"
-                    ) as equiv_file:
+                    ) as rule_file, tempfile.NamedTemporaryFile("w") as target_file:
                         targets = self.get_files_for_language(
                             language, rule, target_manager
                         )

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -165,7 +165,6 @@ def main(
     autofix: bool = False,
     dryrun: bool = False,
     disable_nosem: bool = False,
-    dangerously_allow_arbitrary_code_execution_from_rules: bool = False,
     no_git_ignore: bool = False,
     timeout: int = DEFAULT_TIMEOUT,
     max_memory: int = 0,

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -334,7 +334,6 @@ def generate_file_pairs(
     config: Path,
     ignore_todo: bool,
     strict: bool,
-    unsafe: bool,
     json_output: bool,
     save_test_output_tar: bool = True,
     optimizations: str = "none",
@@ -351,7 +350,6 @@ def generate_file_pairs(
         no_git_ignore=True,
         no_rewrite_rule_ids=True,
         strict=strict,
-        dangerously_allow_arbitrary_code_execution_from_rules=unsafe,
         optimizations=optimizations,
     )
     with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
@@ -482,7 +480,6 @@ def test_main(args: argparse.Namespace) -> None:
         config,
         args.test_ignore_todo,
         args.strict,
-        args.dangerously_allow_arbitrary_code_execution_from_rules,
         args.json,
         args.save_test_output_tar,
         args.optimizations,


### PR DESCRIPTION
Since `pattern-where-python` has been removed we no longer need this flag. To maintain backwards compatibility, I've only suppressed it, not fully removed it. This means you can still run with the flag, but it's not visible in `-h` and won't actually do anything. I figured the less we have `dangerously_allow_arbitrary_code_execution` floating around in the codebase the better.

PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
