### PR TITLE
cli: Improve how semgrep-core fatal errors are reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 - Add logging on failure to git ls-files (#3777)
 - Ignore files whose contents look minified (#3795)
+- Display semgrep-core errors in a better way (#3774)
 
 ### Fixed
 - Java: separate import static from regular imports during matching (#3772)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -673,7 +673,7 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
   | None ->
       error env
         (Common.spf
-           "metavariable-pattern failed because %s it not in scope, please \
+           "metavariable-pattern failed because %s is not in scope, please \
             check your rule"
            mvar);
       false

--- a/semgrep/semgrep/core_exception.py
+++ b/semgrep/semgrep/core_exception.py
@@ -120,7 +120,12 @@ class CoreException:
             )
         elif self._check_id == "FatalError":
             message = self._extra.get("message", "no message")
-            return CoreFatalError(msg=message)
+            return CoreFatalError(rule_id=self._rule_id, path=self._path, msg=message)
         else:
             message = self._extra.get("message", "no message")
-            return CoreWarning(check_id=self._check_id, msg=message)
+            return CoreWarning(
+                rule_id=self._rule_id,
+                path=self._path,
+                check_id=self._check_id,
+                msg=message,
+            )


### PR DESCRIPTION
1. The error message now specficies rule and target file.
2. Only the key info is displayed in red, the error trace will be
   white/gray, to avoid overwhelming the user with internal details.

Closes #3774

test plan:

    % cat test.yaml
    rules:
    - id: test
        languages:
        - py
        message: Match Found!
        pattern: x
        severity: WARNING
    % cat test.py
    def test():
        return x
        }
    % semgrep -c test.yaml test.py



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
