### PR TITLE
Fix bugs in `pattern: $X` optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Taint detection with ternary ifs (#3778)
+- Fixed corner-case crash affecting the `pattern: $X` optimization ("empty And; no positive terms in And")
 
 ## [0.64.0](https://github.com/returntocorp/semgrep/releases/tag/v0.64.0) - 09-01-2021
 

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -1,16 +1,17 @@
 module R = Rule
 module RM = Range_with_metavars
 module G = AST_generic
-module M = Metavariable
+module MV = Metavariable
 module PM = Pattern_match
 module RP = Report
 
 type selector = {
-  mvar : M.mvar;
+  mvar : MV.mvar;
   pattern : AST_generic.any;
   pid : int;
   pstr : string R.wrap;
 }
+[@@deriving show]
 
 type sformula =
   | Leaf of R.leaf
@@ -20,6 +21,7 @@ type sformula =
    * should always be inside an And to be intersected with "positive" formula.
    *)
   | Not of sformula
+[@@deriving show]
 
 (*****************************************************************************)
 (* Selecting methods *)
@@ -35,7 +37,7 @@ let selector_from_formula f =
   match f with
   | R.Leaf (R.P ({ pat = Sem (pattern, _); pid; pstr }, None)) -> (
       match pattern with
-      | G.E { e = G.N (G.Id ((mvar, _), _)); _ } ->
+      | G.E { e = G.N (G.Id ((mvar, _), _)); _ } when MV.is_metavar_name mvar ->
           Some { mvar; pattern; pid; pstr }
       | _ -> None)
   | _ -> None

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -47,9 +47,12 @@ let split_and :
   xs
   |> Common.partition_either3 (fun e ->
          match e with
+         (* positives *)
+         | R.Leaf (R.P _) | R.And _ | R.Or _ -> Left3 e
+         (* negatives *)
          | R.Not (_, f) -> Middle3 f
-         | R.Leaf (R.MetavarCond (_, c)) -> Right3 c
-         | _ -> Left3 e)
+         (* conditionals *)
+         | R.Leaf (R.MetavarCond (_, c)) -> Right3 c)
 
 let selector_from_formula f =
   match f with

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -15,12 +15,19 @@ type selector = {
 
 type sformula =
   | Leaf of R.leaf
-  | And of (selector option * sformula list)
+  | And of sformula_and
   | Or of sformula list
   (* There are restrictions on where a Not can appear in a formula. It
    * should always be inside an And to be intersected with "positive" formula.
    *)
   | Not of sformula
+
+and sformula_and = {
+  selector_opt : selector option;
+  positives : sformula list;
+  negatives : sformula list;
+  conditionals : R.metavar_cond list;
+}
 [@@deriving show]
 
 (*****************************************************************************)
@@ -33,9 +40,20 @@ let selector_equal s1 s2 = s1.mvar = s2.mvar
 (* Converter *)
 (*****************************************************************************)
 
+(* return list of "positive" x list of Not x list of Conds *)
+let split_and :
+    R.formula list -> R.formula list * R.formula list * R.metavar_cond list =
+ fun xs ->
+  xs
+  |> Common.partition_either3 (fun e ->
+         match e with
+         | R.Not (_, f) -> Middle3 f
+         | R.Leaf (R.MetavarCond (_, c)) -> Right3 c
+         | _ -> Left3 e)
+
 let selector_from_formula f =
   match f with
-  | R.Leaf (R.P ({ pat = Sem (pattern, _); pid; pstr }, None)) -> (
+  | Leaf (R.P ({ pat = Sem (pattern, _); pid; pstr }, None)) -> (
       match pattern with
       | G.E { e = G.N (G.Id ((mvar, _), _)); _ } when MV.is_metavar_name mvar ->
           Some { mvar; pattern; pid; pstr }
@@ -66,19 +84,28 @@ let formula_to_sformula formula =
         remove_selectors (selector, acc) xs
   in
   let rec formula_to_sformula formula =
-    let convert_and_formulas fs =
-      let selector, fs' = remove_selectors (None, []) fs in
-      (* We only want a selector if there is something to select from. *)
-      match fs' with
-      | [] -> (None, List.map formula_to_sformula fs)
-      | _ :: _ -> (selector, List.rev_map formula_to_sformula fs')
-    in
     (* Visit formula and convert *)
     match formula with
     | R.Leaf leaf -> Leaf leaf
     | R.And (_, fs) -> And (convert_and_formulas fs)
     | R.Or (_, fs) -> Or (List.map formula_to_sformula fs)
     | R.Not (_, f) -> Not (formula_to_sformula f)
+  and convert_and_formulas fs =
+    let pos, neg, cond = split_and fs in
+    let pos = List.map formula_to_sformula pos in
+    let neg = List.map formula_to_sformula neg in
+    let sel, pos =
+      (* We only want a selector if there is something to select from. *)
+      match remove_selectors (None, []) pos with
+      | _, [] -> (None, pos)
+      | sel, pos -> (sel, pos)
+    in
+    {
+      selector_opt = sel;
+      positives = pos;
+      negatives = neg;
+      conditionals = cond;
+    }
   in
   formula_to_sformula formula
 
@@ -91,4 +118,7 @@ let rec visit_sformula f formula =
   | Leaf (P (p, i)) -> f p i
   | Leaf (MetavarCond _) -> ()
   | Not x -> visit_sformula f x
-  | Or xs | And (_, xs) -> xs |> List.iter (visit_sformula f)
+  | Or xs -> xs |> List.iter (visit_sformula f)
+  | And fand ->
+      fand.positives |> List.iter (visit_sformula f);
+      fand.negatives |> List.iter (visit_sformula f)

--- a/semgrep-core/src/engine/Specialize_formula.mli
+++ b/semgrep-core/src/engine/Specialize_formula.mli
@@ -10,15 +10,18 @@ type selector = {
   pid : int;
   pstr : string Rule.wrap;
 }
+[@@deriving show]
 
 type sformula =
   | Leaf of Rule.leaf
   | And of (selector option * sformula list)
       (** Invariant: [And (sel_opt, fs)] satisfies
      * [not (Option.is_some sel_opt) || fs <> []], that is,
-     * we can only select from a non-empty context. *)
+     * we can only select from a non-empty context.
+     *)
   | Or of sformula list
   | Not of sformula
+[@@deriving show]
 
 (*****************************************************************************)
 (* Selecting methods *)

--- a/semgrep-core/src/engine/Specialize_formula.mli
+++ b/semgrep-core/src/engine/Specialize_formula.mli
@@ -14,13 +14,18 @@ type selector = {
 
 type sformula =
   | Leaf of Rule.leaf
-  | And of (selector option * sformula list)
-      (** Invariant: [And (sel_opt, fs)] satisfies
-     * [not (Option.is_some sel_opt) || fs <> []], that is,
-     * we can only select from a non-empty context.
-     *)
+  | And of sformula_and
   | Or of sformula list
   | Not of sformula
+
+and sformula_and = {
+  selector_opt : selector option;
+      (** Invariant: [not (Option.is_some selector_opt) || positives <> []]
+          that is, we can only select from a non-empty context. *)
+  positives : sformula list;
+  negatives : sformula list;
+  conditionals : Rule.metavar_cond list;
+}
 [@@deriving show]
 
 (*****************************************************************************)

--- a/semgrep-core/tests/OTHER/rules/pattern-x-bug.py
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-bug.py
@@ -1,0 +1,3 @@
+def test(x):
+    #ruleid:test
+    return x

--- a/semgrep-core/tests/OTHER/rules/pattern-x-bug.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-x-bug.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: test
+    languages:
+      - py
+    message: Match Found!
+    patterns:
+    - pattern: $X
+    - pattern-not: a
+    severity: WARNING


### PR DESCRIPTION
Fixes: 24e8cabfb30 ("Optimize pattern $X (#3703)")
    
test plan:
make test # test included
    
        % cat test.yaml
        rules:
        - id: test
            languages:
            - py
            message: Match Found!
            patterns:
            - pattern: $X
            - pattern-not: a
            severity: WARNING
        % cat test.py
        def test(x):
            return x
        % semgrep-core -lang py -config test.yaml test.py
        # ^ Now works, whereas previously it resulted in a crash:
        #
        #       Fatal Error: (Failure "empty And; no positive terms in And")

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
