### PR TITLE
Fix AST to IL translation for ternary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+
+### Changed
+
+### Fixed
+- Taint detection with ternary ifs (#3778)
+
 ## [0.64.0](https://github.com/returntocorp/semgrep/releases/tag/v0.64.0) - 09-01-2021
 
 ### Added

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -493,7 +493,7 @@ and expr_aux env eorig =
   | G.Conditional (e1orig, e2orig, e3orig) ->
       let tok = G.fake "conditional" in
       let lval = fresh_lval env tok in
-      let lvalexp = mk_e (Fetch lval) e1orig in
+      let lvalexp = mk_e (Fetch lval) eorig in
 
       (* not sure this is correct *)
       let before = List.rev !(env.stmts) in

--- a/semgrep-core/tests/tainting_rules/php/ternary.php
+++ b/semgrep-core/tests/tainting_rules/php/ternary.php
@@ -1,0 +1,6 @@
+<?php
+function wrap() {
+   $tainted = (sanitizer($source) ? $source : 'ok');
+   // ERROR: match 
+   sink($tainted);
+}

--- a/semgrep-core/tests/tainting_rules/php/ternary.yaml
+++ b/semgrep-core/tests/tainting_rules/php/ternary.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: taint-not-detected
+    languages:
+      - php
+    message: Match Found!
+    mode: taint
+    pattern-sanitizers:
+      - pattern: sanitizer(...)
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: $source
+    severity: WARNING
+


### PR DESCRIPTION
The originating expression for the value of a ternary expression should be that ternary expression, not the condition.

Closes #3778 

Test plan: make test



PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
