### PR TITLE
Remove unused .ocamlformat from semgrep-core/

### DIFF
--- a/semgrep-core/.ocamlformat
+++ b/semgrep-core/.ocamlformat
@@ -1,1 +1,0 @@
-profile=default

--- a/semgrep-core/old/lang_php/php_vs_php.ml
+++ b/semgrep-core/old/lang_php/php_vs_php.ml
@@ -96,10 +96,14 @@ let rec is_concat_of_strings e =
   | _ -> false
 
 let is_NoTransfo tok =
-  match tok.Parse_info.transfo with Parse_info.NoTransfo -> true | _ -> false
+  match tok.Parse_info.transfo with
+  | Parse_info.NoTransfo -> true
+  | _ -> false
 
 let is_Remove tok =
-  match tok.Parse_info.transfo with Parse_info.Remove -> true | _ -> false
+  match tok.Parse_info.transfo with
+  | Parse_info.Remove -> true
+  | _ -> false
 
 (*****************************************************************************)
 (* Functor parameter combinators *)
@@ -196,7 +200,9 @@ functor
       match (a, b) with
       | None, None -> return (None, None)
       | Some xa, Some xb -> f xa xb >>= fun (xa, xb) -> return (Some xa, Some xb)
-      | None, _ | Some _, _ -> fail ()
+      | None, _
+      | Some _, _ ->
+          fail ()
 
     let (m_ref : ('a, 'b) matcher -> ('a ref, 'b ref) matcher) =
      fun f a b ->
@@ -211,13 +217,17 @@ functor
       | xa :: aas, xb :: bbs ->
           f xa xb >>= fun (xa, xb) ->
           m_list f aas bbs >>= fun (aas, bbs) -> return (xa :: aas, xb :: bbs)
-      | [], _ | _ :: _, _ -> fail ()
+      | [], _
+      | _ :: _, _ ->
+          fail ()
 
     let m_either f g a b =
       match (a, b) with
       | Left a, Left b -> f a b >>= fun (a, b) -> return (Left a, Left b)
       | Right a, Right b -> g a b >>= fun (a, b) -> return (Right a, Right b)
-      | Left _, Right _ | Right _, Left _ -> fail ()
+      | Left _, Right _
+      | Right _, Left _ ->
+          fail ()
 
     let m_either3 f g h a b =
       match (a, b) with
@@ -225,7 +235,10 @@ functor
       | Right3 a, Right3 b -> h a b >>= fun (a, b) -> return (Right3 a, Right3 b)
       | Middle3 a, Middle3 b ->
           g a b >>= fun (a, b) -> return (Middle3 a, Middle3 b)
-      | Left3 _, _ | Right3 _, _ | Middle3 _, _ -> fail ()
+      | Left3 _, _
+      | Right3 _, _
+      | Middle3 _, _ ->
+          fail ()
 
     let m_unit a b = return (a, b)
 
@@ -308,7 +321,9 @@ functor
       | A.XhpName a1, B.XhpName b1 ->
           (m_wrap (m_list m_string)) a1 b1 >>= fun (a1, b1) ->
           return (A.XhpName a1, B.XhpName b1)
-      | A.Name _, _ | A.XhpName _, _ -> fail ()
+      | A.Name _, _
+      | A.XhpName _, _ ->
+          fail ()
 
     let m_name_metavar_ok a b =
       match (a, b) with
@@ -330,7 +345,9 @@ functor
       | A.XhpName a1, B.XhpName b1 ->
           (m_wrap (m_list m_string)) a1 b1 >>= fun (a1, b1) ->
           return (A.XhpName a1, B.XhpName b1)
-      | A.Name _, _ | A.XhpName _, _ -> fail ()
+      | A.Name _, _
+      | A.XhpName _, _ ->
+          fail ()
 
     (* ---------------------------------------------------------------------- *)
     (* operators *)
@@ -395,7 +412,11 @@ functor
       | A.UnMinus, B.UnMinus -> return (A.UnMinus, B.UnMinus)
       | A.UnBang, B.UnBang -> return (A.UnBang, B.UnBang)
       | A.UnTilde, B.UnTilde -> return (A.UnTilde, B.UnTilde)
-      | A.UnPlus, _ | A.UnMinus, _ | A.UnBang, _ | A.UnTilde, _ -> fail ()
+      | A.UnPlus, _
+      | A.UnMinus, _
+      | A.UnBang, _
+      | A.UnTilde, _ ->
+          fail ()
 
     let m_binaryOp a b =
       match (a, b) with
@@ -421,10 +442,14 @@ functor
           m_arithOp a1 b1 >>= fun (a1, b1) ->
           return (A.AssignOpArith a1, B.AssignOpArith b1)
       | A.AssignConcat, B.AssignConcat -> return (A.AssignConcat, B.AssignConcat)
-      | A.AssignOpArith _, _ | A.AssignConcat, _ -> fail ()
+      | A.AssignOpArith _, _
+      | A.AssignConcat, _ ->
+          fail ()
 
     let m_fixOp a b =
-      match (a, b) with _ when a =*= b -> return (a, b) | _ -> fail ()
+      match (a, b) with
+      | _ when a =*= b -> return (a, b)
+      | _ -> fail ()
 
     (* ---------------------------------------------------------------------- *)
     (* cast, cpp directives  *)
@@ -490,7 +515,10 @@ functor
       | A.LateStatic a1, B.LateStatic b1 ->
           m_tok a1 b1 >>= fun (a1, b1) ->
           return (A.LateStatic a1, B.LateStatic b1)
-      | A.XName _, _ | A.Self _, _ | A.Parent _, _ | A.LateStatic _, _ ->
+      | A.XName _, _
+      | A.Self _, _
+      | A.Parent _, _
+      | A.LateStatic _, _ ->
           fail ()
 
     and m_type_args a b =
@@ -511,7 +539,10 @@ functor
           m_name_metavar_ok a b >>= fun (a, b) ->
           m_fully_qualified_class_name xs ys >>= fun (xs, ys) ->
           return (A.QI a :: xs, B.QI b :: ys)
-      | A.QI _ :: _, _ | A.QITok _ :: _, _ | [], _ -> fail ()
+      | A.QI _ :: _, _
+      | A.QITok _ :: _, _
+      | [], _ ->
+          fail ()
 
     (*---------------------------------------------------------------------------*)
     (* argument *)
@@ -549,7 +580,10 @@ functor
           m_tok a1 b1 >>= fun (a1, b1) ->
           m_w_variable a2 b2 >>= fun (a2, b2) ->
           return (A.ArgUnpack (a1, a2), B.ArgUnpack (b1, b2))
-      | A.Arg _, _ | A.ArgRef _, _ | A.ArgUnpack _, _ -> fail ()
+      | A.Arg _, _
+      | A.ArgRef _, _
+      | A.ArgUnpack _, _ ->
+          fail ()
 
     (* ---------------------------------------------------------------------- *)
     (* expr *)
@@ -844,7 +878,9 @@ functor
     (* ---------------------------------------------------------------------- *)
     (* xhp (and a few xhp isos) *)
     (* ---------------------------------------------------------------------- *)
-    and m_xhp_tag a b = match (a, b) with a, b -> (m_list m_string) a b
+    and m_xhp_tag a b =
+      match (a, b) with
+      | a, b -> (m_list m_string) a b
 
     and m_wrap_m_xhp_tag a b =
       m_name_metavar_ok (A.XhpName a) (B.XhpName b) >>= function
@@ -860,13 +896,17 @@ functor
           >>= fun ((a1, toka), (b1, tokb)) ->
           return ((Some a1, toka), (Some b1, tokb))
       (* todo: should be ok to use </> instead of explicit tag *)
-      | None, Some _ | Some _, None -> fail ()
+      | None, Some _
+      | Some _, None ->
+          fail ()
 
     and iso_m_list_m_xhp_body a b =
       match a with
       (* iso-by-absence: it's ok to have an empty body in the pattern *)
       | [] -> return (a, b)
-      | [ A.XhpText ("\n", _) ] | [ A.XhpText ("\n\n", _) ] -> return (a, b)
+      | [ A.XhpText ("\n", _) ]
+      | [ A.XhpText ("\n\n", _) ] ->
+          return (a, b)
       | _ -> (m_list m_xhp_body) a b
 
     and sort_xhp_attributes xs =
@@ -928,7 +968,9 @@ functor
           iso_m_list_m_xhp_attribute a2 b2 >>= fun (a2, b2) ->
           m_tok a3 b3 >>= fun (a3, b3) ->
           return (A.XhpSingleton (a1, a2, a3), B.XhpSingleton (b1, b2, b3))
-      | A.Xhp _, _ | A.XhpSingleton _, _ -> fail ()
+      | A.Xhp _, _
+      | A.XhpSingleton _, _ ->
+          fail ()
 
     and m_xhp_attribute a b =
       match (a, b) with
@@ -959,8 +1001,9 @@ functor
       | A.XhpAttrExpr a1, B.XhpAttrExpr b1 ->
           (m_brace m_expr) a1 b1 >>= fun (a1, b1) ->
           return (A.XhpAttrExpr a1, B.XhpAttrExpr b1)
-      | A.XhpAttrString _, _ | A.XhpAttrExpr _, _ | A.SgrepXhpAttrValueMvar _, _
-        ->
+      | A.XhpAttrString _, _
+      | A.XhpAttrExpr _, _
+      | A.SgrepXhpAttrValueMvar _, _ ->
           fail ()
 
     and m_xhp_body a b =
@@ -974,7 +1017,10 @@ functor
       | A.XhpNested a1, B.XhpNested b1 ->
           m_xhp_html a1 b1 >>= fun (a1, b1) ->
           return (A.XhpNested a1, B.XhpNested b1)
-      | A.XhpText _, _ | A.XhpExpr _, _ | A.XhpNested _, _ -> fail ()
+      | A.XhpText _, _
+      | A.XhpExpr _, _
+      | A.XhpNested _, _ ->
+          fail ()
 
     (* ---------------------------------------------------------------------- *)
     (* scalar and other expr *)
@@ -993,7 +1039,10 @@ functor
           m_list m_encaps a2 b2 >>= fun (a2, b2) ->
           m_tok a3 b3 >>= fun (a3, b3) ->
           return (A.HereDoc (a1, a2, a3), B.HereDoc (b1, b2, b3))
-      | A.C _, _ | A.Guil _, _ | A.HereDoc _, _ -> fail ()
+      | A.C _, _
+      | A.Guil _, _
+      | A.HereDoc _, _ ->
+          fail ()
 
     and m_list_assign a b =
       match (a, b) with
@@ -1004,7 +1053,10 @@ functor
           (m_paren (m_comma_list m_list_assign)) a2 b2 >>= fun (a2, b2) ->
           return (A.ListList (a1, a2), B.ListList (b1, b2))
       | A.ListEmpty, B.ListEmpty -> return (A.ListEmpty, B.ListEmpty)
-      | A.ListVar _, _ | A.ListList _, _ | A.ListEmpty, _ -> fail ()
+      | A.ListVar _, _
+      | A.ListList _, _
+      | A.ListEmpty, _ ->
+          fail ()
 
     and m_array_pair a b =
       match (a, b) with
@@ -1219,7 +1271,9 @@ functor
           (m_either m_argument m_info) xa xb >>= fun (xa, xb) ->
           m_list__m_argument aas bbs >>= fun (aas, bbs) ->
           return (xa :: aas, xb :: bbs)
-      | [], _ | _ :: _, _ -> fail ()
+      | [], _
+      | _ :: _, _ ->
+          fail ()
 
     (* iso: new Foo(...) can match new X; *)
     and m_option__m_paren__m_list__m_argument a b =
@@ -1254,7 +1308,9 @@ functor
           (m_either m_array_pair m_info) xa xb >>= fun (xa, xb) ->
           m_list__m_array_pair aas bbs >>= fun (aas, bbs) ->
           return (xa :: aas, xb :: bbs)
-      | [], _ | _ :: _, _ -> fail ()
+      | [], _
+      | _ :: _, _ ->
+          fail ()
 
     (*---------------------------------------------------------------------------*)
     (* comma list dots iso *)
@@ -1281,7 +1337,9 @@ functor
           (m_either3 f m_info m_info) xa xb >>= fun (xa, xb) ->
           m_comma_list_dots f aas bbs >>= fun (aas, bbs) ->
           return (xa :: aas, xb :: bbs)
-      | [], _ | _ :: _, _ -> fail ()
+      | [], _
+      | _ :: _, _ ->
+          fail ()
 
     (* ---------------------------------------------------------------------- *)
     (* stmt *)
@@ -1463,7 +1521,9 @@ functor
           m_tok a3 b3 >>= fun (a3, b3) ->
           m_tok a4 b4 >>= fun (a4, b4) ->
           return (A.ColonStmt (a1, a2, a3, a4), B.ColonStmt (b1, b2, b3, b4))
-      | A.SingleStmt _, _ | A.ColonStmt _, _ -> fail ()
+      | A.SingleStmt _, _
+      | A.ColonStmt _, _ ->
+          fail ()
 
     (* ---------------------------------------------------------------------- *)
     (* stmt auxilaries *)
@@ -1651,7 +1711,8 @@ functor
 
     and m_trait_constraint_kind a b =
       match (a, b) with
-      | A.MustExtend, B.MustExtend | A.MustImplement, B.MustImplement ->
+      | A.MustExtend, B.MustExtend
+      | A.MustImplement, B.MustImplement ->
           return (a, b)
       | _ -> fail ()
 
@@ -1688,7 +1749,9 @@ functor
       | A.VModifiers a1, B.VModifiers b1 ->
           (m_list (m_wrap m_modifier)) a1 b1 >>= fun (a1, b1) ->
           return (A.VModifiers a1, B.VModifiers b1)
-      | A.NoModifiers _, _ | A.VModifiers _, _ -> fail ()
+      | A.NoModifiers _, _
+      | A.VModifiers _, _ ->
+          fail ()
 
     (* ------------------------------------------------------------------------- *)
     (* Other declarations *)

--- a/semgrep-core/old/lang_php/refactoring_code_php.ml
+++ b/semgrep-core/old/lang_php/refactoring_code_php.ml
@@ -68,7 +68,9 @@ let refactor refactorings (ast, tokens) =
                  V.kfunc_def =
                    (fun (k, _) def ->
                      match def.f_type with
-                     | FunctionRegular | MethodRegular | MethodAbstract ->
+                     | FunctionRegular
+                     | MethodRegular
+                     | MethodAbstract ->
                          let tok = Ast.info_of_ident def.f_name in
                          if tok_pos_equal_refactor_pos tok pos_opt then (
                            let tok_close_paren =

--- a/semgrep-core/old/lang_php/transforming_php.ml
+++ b/semgrep-core/old/lang_php/transforming_php.ml
@@ -195,7 +195,9 @@ module XMATCH = struct
    *)
   let adjust_transfo_with_env env transfo =
     match transfo with
-    | PI.NoTransfo | PI.Remove -> transfo
+    | PI.NoTransfo
+    | PI.Remove ->
+        transfo
     | PI.AddBefore add -> PI.AddBefore (subst_metavars env add)
     | PI.AddAfter add -> PI.AddAfter (subst_metavars env add)
     | PI.Replace add -> PI.Replace (subst_metavars env add)

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -157,7 +157,9 @@ let rec cfg_stmt : state -> F.nodei option -> stmt -> cfg_stmt_result =
       | None, None ->
           (* probably a return in both branches *)
           CfgFirstLast (newi, None)
-      | Some nodei, None | None, Some nodei -> CfgFirstLast (newi, Some nodei)
+      | Some nodei, None
+      | None, Some nodei ->
+          CfgFirstLast (newi, Some nodei)
       | Some n1, Some n2 ->
           let lasti = state.g#add_node { F.n = F.Join } in
           state.g |> add_arc (n1, lasti);

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -165,7 +165,9 @@ let var_stats prog : var_stats =
               let var = (H.str_of_ident id, sid) in
               let stat = get_stat_or_create var h in
               incr stat.lvalue;
-              (match x.e with AssignOp _ -> incr stat.rvalue | _ -> ());
+              (match x.e with
+              | AssignOp _ -> incr stat.rvalue
+              | _ -> ());
               vout (E e2)
           | N (Id (id, { id_resolved = { contents = Some (_kind, sid) }; _ }))
             ->
@@ -189,7 +191,9 @@ let literal_of_bool b =
   let tok = Parse_info.unsafe_fake_info b_str in
   Bool (b, tok)
 
-let bool_of_literal = function Bool (b, _) -> Some b | __else__ -> None
+let bool_of_literal = function
+  | Bool (b, _) -> Some b
+  | __else__ -> None
 
 let eval_bop_bool op b1 b2 =
   match op with
@@ -202,7 +206,9 @@ let literal_of_int i =
   let tok = Parse_info.unsafe_fake_info i_str in
   Int (Some i, tok)
 
-let int_of_literal = function Int (Some i, _) -> Some i | __else__ -> None
+let int_of_literal = function
+  | Int (Some i, _) -> Some i
+  | __else__ -> None
 
 let eval_bop_int op i1 i2 =
   match op with
@@ -214,10 +220,14 @@ let literal_of_string s =
   let tok = Parse_info.unsafe_fake_info s in
   String (s, tok)
 
-let string_of_literal = function String (s, _) -> Some s | __else__ -> None
+let string_of_literal = function
+  | String (s, _) -> Some s
+  | __else__ -> None
 
 let eval_bop_string op s1 s2 =
-  match op with Plus -> Some (s1 ^ s2) | __else__ -> None
+  match op with
+  | Plus -> Some (s1 ^ s2)
+  | __else__ -> None
 
 let rec eval_expr env e =
   match e.e with
@@ -366,7 +376,8 @@ let propagate_basic lang prog =
                        && kind = Global
                      then add_constant_env id (sid, literal) env);
               v (E rexp)
-          | Assign (e1, _, e2) | AssignOp (e1, _, e2) ->
+          | Assign (e1, _, e2)
+          | AssignOp (e1, _, e2) ->
               Common.save_excursion env.in_lvalue true (fun () -> v (E e1));
               v (E e2)
           | _ -> k x);

--- a/semgrep-core/src/analyzing/Dataflow_tainting.ml
+++ b/semgrep-core/src/analyzing/Dataflow_tainting.ml
@@ -126,15 +126,21 @@ let rec check_tainted_expr ~in_a_sink config fun_env env exp =
     | Mem e -> check e
   in
   let check_offset = function
-    | NoOffset | Dot _ -> false
+    | NoOffset
+    | Dot _ ->
+        false
     | Index e -> check e
   in
   let check_subexpr = function
     | Fetch { base = VarSpecial (This, _); offset = Dot fld; _ } ->
         Hashtbl.mem fun_env (str_of_name fld)
     | Fetch { base; offset; _ } -> check_base base || check_offset offset
-    | Literal _ | FixmeExp _ -> false
-    | Composite (_, (_, es, _)) | Operator (_, es) -> List.exists check es
+    | Literal _
+    | FixmeExp _ ->
+        false
+    | Composite (_, (_, es, _))
+    | Operator (_, es) ->
+        List.exists check es
     | Record fields -> List.exists (fun (_, e) -> check e) fields
     | Cast (_, e) -> check e
   in
@@ -216,8 +222,17 @@ let (transfer :
         | Some var -> Hashtbl.add fun_env (str_of_name var) ()
         | None -> ());
         None
-    | Enter | Exit | TrueNode | FalseNode | Join | NCond _ | NGoto _ | NReturn _
-    | NThrow _ | NOther _ | NTodo _ ->
+    | Enter
+    | Exit
+    | TrueNode
+    | FalseNode
+    | Join
+    | NCond _
+    | NGoto _
+    | NReturn _
+    | NThrow _
+    | NOther _
+    | NTodo _ ->
         None
   in
   let kill_ni_opt =
@@ -233,8 +248,17 @@ let (transfer :
         else
           (* all clean arguments should reset the taint *)
           IL.lvar_of_instr_opt x
-    | Enter | Exit | TrueNode | FalseNode | Join | NCond _ | NGoto _ | NReturn _
-    | NThrow _ | NOther _ | NTodo _ ->
+    | Enter
+    | Exit
+    | TrueNode
+    | FalseNode
+    | Join
+    | NCond _
+    | NGoto _
+    | NReturn _
+    | NThrow _
+    | NOther _
+    | NTodo _ ->
         None
   in
   let gen_ni = option_to_varmap gen_ni_opt in

--- a/semgrep-core/src/analyzing/Naming_AST.ml
+++ b/semgrep-core/src/analyzing/Naming_AST.ml
@@ -303,7 +303,9 @@ let with_new_context ctx env f =
 
 (*s: function [[Naming_AST.top_context]] *)
 let top_context env =
-  match !(env.ctx) with [] -> raise Impossible | x :: _xs -> x
+  match !(env.ctx) with
+  | [] -> raise Impossible
+  | x :: _xs -> x
 
 (*e: function [[Naming_AST.top_context]] *)
 
@@ -371,13 +373,16 @@ let error tok s =
 (*s: function [[Naming_AST.is_local_or_global_ctx]] *)
 let is_resolvable_name_ctx env lang =
   match top_context env with
-  | AtToplevel | InFunction -> true
+  | AtToplevel
+  | InFunction ->
+      true
   | InClass -> (
       match lang with
       (* true for Java so that we can type class fields *)
       | Lang.Java
       (* true for JS/TS so that we can resolve class methods *)
-      | Lang.Javascript | Lang.Typescript ->
+      | Lang.Javascript
+      | Lang.Typescript ->
           true
       | _ -> false)
 
@@ -395,7 +400,8 @@ let resolved_name_kind env lang =
        *)
       | Lang.Java
       (* true for JS/TS to resolve class methods. *)
-      | Lang.Javascript | Lang.Typescript ->
+      | Lang.Javascript
+      | Lang.Typescript ->
           EnclosedVar
       | _ -> raise Impossible)
 
@@ -506,7 +512,8 @@ let resolve lang prog =
                *
                *     https://github.com/returntocorp/semgrep/issues/2787.
                *)
-              | Lang.Javascript | Lang.Typescript ->
+              | Lang.Javascript
+              | Lang.Typescript ->
                   let sid = H.gensym () in
                   let resolved =
                     untyped_ent (resolved_name_kind env lang, sid)
@@ -713,7 +720,8 @@ let resolve lang prog =
           (* todo: see lrvalue.ml
            * alternative? extra id_info tag?
            *)
-          | Assign (e1, _, e2) | AssignOp (e1, _, e2) ->
+          | Assign (e1, _, e2)
+          | AssignOp (e1, _, e2) ->
               Common.save_excursion env.in_lvalue true (fun () -> vout (E e1));
               vout (E e2);
               recurse := false

--- a/semgrep-core/src/analyzing/Normalize_AST.ml
+++ b/semgrep-core/src/analyzing/Normalize_AST.ml
@@ -50,7 +50,9 @@ let normalize2 any lang =
               when lang <> Lang.Python -> (
                 (* != can be a method call in Python *)
                 let rewrite_opt =
-                  match op with NotEq -> Some (Not, Eq) | _ -> None
+                  match op with
+                  | NotEq -> Some (Not, Eq)
+                  | _ -> None
                 in
                 match rewrite_opt with
                 | None -> e

--- a/semgrep-core/src/analyzing/Typing.ml
+++ b/semgrep-core/src/analyzing/Typing.ml
@@ -15,7 +15,9 @@ let get_resolved_type lang (vinit, vtype) =
       let string_str =
         match lang with
         | Go -> "str"
-        | Javascript | Typescript -> "string"
+        | Javascript
+        | Typescript ->
+            "string"
         | _ -> "string"
       in
       (* Currently these vary between languages *)

--- a/semgrep-core/src/analyzing/controlflow.ml
+++ b/semgrep-core/src/analyzing/controlflow.ml
@@ -175,12 +175,16 @@ let simple_node_of_stmt_opt stmt =
   | G.For (_, _, _)
   | G.Switch (_, _, _)
   | G.Match (_, _, _)
-  | G.Return _ | G.Continue _ | G.Break _
+  | G.Return _
+  | G.Continue _
+  | G.Break _
   | G.Label (_, _)
-  | G.Goto _ | G.Throw _
+  | G.Goto _
+  | G.Throw _
   | G.Try (_, _, _, _)
   | G.WithUsingResource (_, _, _)
-  | G.OtherStmtWithStmt _ | G.DisjStmt _ ->
+  | G.OtherStmtWithStmt _
+  | G.DisjStmt _ ->
       None
 
 let any_of_simple_node = function

--- a/semgrep-core/src/analyzing/controlflow_build.ml
+++ b/semgrep-core/src/analyzing/controlflow_build.ml
@@ -94,7 +94,9 @@ let (lookup_some_ctx :
   aux 1 xs
 
 let info_opt any =
-  match Visitor_AST.ii_of_any any with [] -> None | x :: _xs -> Some x
+  match Visitor_AST.ii_of_any any with
+  | [] -> None
+  | x :: _xs -> Some x
 
 (*****************************************************************************)
 (* Algorithm *)
@@ -120,9 +122,12 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
   let i () = info_opt (S stmt) in
 
   match stmt.s with
-  | Label _ | Goto _ -> raise Todo
+  | Label _
+  | Goto _ ->
+      raise Todo
   | Block (_, stmts, _) -> cfg_stmt_list state previ stmts
-  | For _ | While _ ->
+  | For _
+  | While _ ->
       (* previ -> newi ---> newfakethen -> ... -> finalthen -
        *             |---|-----------------------------------|
        *                 |-> newfakelse
@@ -309,7 +314,9 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
       | None, None ->
           (* probably a return in both branches *)
           None
-      | Some nodei, None | None, Some nodei -> Some nodei
+      | Some nodei, None
+      | None, Some nodei ->
+          Some nodei
       | Some n1, Some n2 ->
           let lasti = state.g#add_node { F.n = F.Join; i = None } in
           state.g |> add_arc (n1, lasti);
@@ -322,7 +329,8 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
       (* the next statement if there is one will not be linked to
        * this new node *)
       None
-  | Continue (_, _TODOlabelid, _) | Break (_, _TODOlabelid, _) ->
+  | Continue (_, _TODOlabelid, _)
+  | Break (_, _TODOlabelid, _) ->
       let is_continue, node =
         match stmt.s with
         | Continue _ -> (true, F.Continue)
@@ -357,7 +365,9 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
                   * it has the same semantic than 'break'.
                   *)
                  Some endi
-             | TryCtx _ | NoCtx -> None)
+             | TryCtx _
+             | NoCtx ->
+                 None)
       in
       (match nodei_to_jump_to with
       | Some nodei -> state.g |> add_arc (newi, nodei)
@@ -381,7 +391,9 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
           |> List.exists (function
                | CasesAndBody (cases, _body) ->
                    cases
-                   |> List.exists (function G.Default _ -> true | _ -> false)
+                   |> List.exists (function
+                        | G.Default _ -> true
+                        | _ -> false)
                | CaseEllipsis _ -> raise Impossible))
       then state.g |> add_arc (newi, endi);
       (* let's process all cases *)
@@ -484,7 +496,10 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
         state.ctx
         |> lookup_some_ctx ~ctx_filter:(function
              | TryCtx nextcatchi -> Some nextcatchi
-             | LoopCtx _ | SwitchCtx _ | NoCtx -> None)
+             | LoopCtx _
+             | SwitchCtx _
+             | NoCtx ->
+                 None)
       in
       (match nodei_to_jump_to with
       | Some nextcatchi -> state.g |> add_arc (last_false_node, nextcatchi)
@@ -517,7 +532,10 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
         state.ctx
         |> lookup_some_ctx ~ctx_filter:(function
              | TryCtx catchi -> Some catchi
-             | LoopCtx _ | SwitchCtx _ | NoCtx -> None)
+             | LoopCtx _
+             | SwitchCtx _
+             | NoCtx ->
+                 None)
       in
       (match nodei_to_jump_to with
       | Some catchi -> state.g |> add_arc (newi, catchi)
@@ -555,8 +573,12 @@ let rec (cfg_stmt : state -> F.nodei option -> stmt -> F.nodei option) =
    * Note that DefStmt are not the only form of lambdas ... you can have
    * lambdas inside expressions too! (need a proper instr type really)
    *)
-  | DefStmt _ | ExprStmt _ | Assert _ | DirectiveStmt _ | OtherStmt _ | Match _
-    ->
+  | DefStmt _
+  | ExprStmt _
+  | Assert _
+  | DirectiveStmt _
+  | OtherStmt _
+  | Match _ ->
       cfg_simple_node state previ stmt
   | DisjStmt _ -> raise Impossible
 
@@ -593,7 +615,9 @@ and (cfg_cases :
          | CasesAndBody (cases, stmt) ->
              let node =
                (* TODO: attach expressions there!!! *)
-               match cases with [ Default _ ] -> F.Default | _ -> F.Case
+               match cases with
+               | [ Default _ ] -> F.Default
+               | _ -> F.Case
              in
 
              let i () = info_opt (S stmt) in

--- a/semgrep-core/src/analyzing/controlflow_visitor.ml
+++ b/semgrep-core/src/analyzing/controlflow_visitor.ml
@@ -43,9 +43,22 @@ let mk_visitor vin =
   fun node ->
     match node.F.n with
     (* Nothing is needed if the node has no expr information*)
-    | F.Enter | F.Exit | F.TrueNode | F.FalseNode | F.DoHeader | F.ForHeader
-    | F.SwitchEnd | F.Case | F.Default | F.TryHeader | F.CatchStart | F.Catch
-    | F.TryEnd | F.Join | F.Continue | F.Break
+    | F.Enter
+    | F.Exit
+    | F.TrueNode
+    | F.FalseNode
+    | F.DoHeader
+    | F.ForHeader
+    | F.SwitchEnd
+    | F.Case
+    | F.Default
+    | F.TryHeader
+    | F.CatchStart
+    | F.Catch
+    | F.TryEnd
+    | F.Join
+    | F.Continue
+    | F.Break
     | F.Return None
     | F.SwitchHeader None
     | F.OtherStmtWithStmtHeader (_, None) ->
@@ -70,8 +83,21 @@ let mk_visitor vin =
 
 let exprs_of_node node =
   match node.n with
-  | Enter | Exit | TrueNode | FalseNode | DoHeader | ForHeader | SwitchEnd
-  | Case | Default | TryHeader | CatchStart | Catch | TryEnd | Join | Continue
+  | Enter
+  | Exit
+  | TrueNode
+  | FalseNode
+  | DoHeader
+  | ForHeader
+  | SwitchEnd
+  | Case
+  | Default
+  | TryHeader
+  | CatchStart
+  | Catch
+  | TryEnd
+  | Join
+  | Continue
   | Break
   | Return None
   | SwitchHeader None

--- a/semgrep-core/src/analyzing/lrvalue.ml
+++ b/semgrep-core/src/analyzing/lrvalue.ml
@@ -102,9 +102,14 @@ let rec visit_expr hook lhs expr =
   | Container (typ, xs) -> (
       match typ with
       (* used on lhs? *)
-      | Array | List | Tuple -> xs |> unbracket |> List.iter recl
+      | Array
+      | List
+      | Tuple ->
+          xs |> unbracket |> List.iter recl
       (* never used on lhs *)
-      | Set | Dict -> xs |> unbracket |> List.iter recr)
+      | Set
+      | Dict ->
+          xs |> unbracket |> List.iter recr)
   | Comprehension (_, (_, (e, comps), _)) ->
       recr e;
       comps
@@ -178,7 +183,9 @@ let rec visit_expr hook lhs expr =
   (* we should not be called on a sgrep pattern *)
   | TypedMetavar (_id, _, _t) -> raise Impossible
   | DisjExpr _ -> raise Impossible
-  | DeepEllipsis _ | DotAccessEllipsis _ -> raise Impossible
+  | DeepEllipsis _
+  | DotAccessEllipsis _ ->
+      raise Impossible
   | Ellipsis _tok -> ()
   | OtherExpr (_other_xxx, anys) -> List.iter (anyhook hook Rhs) anys
 

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -410,9 +410,13 @@ and map_of_interpolated_kind = function
   (* new: *)
   | TaggedTemplateLiteral -> `InterpolatedConcat
 
-and map_of_incdec = function Incr -> `Incr | Decr -> `Decr
+and map_of_incdec = function
+  | Incr -> `Incr
+  | Decr -> `Decr
 
-and map_of_prepost = function Prefix -> `Prefix | Postfix -> `Postfix
+and map_of_prepost = function
+  | Prefix -> `Prefix
+  | Postfix -> `Postfix
 
 and map_arithmetic_operator = function
   | Plus -> `Plus

--- a/semgrep-core/src/cli/Experiments.ml
+++ b/semgrep-core/src/cli/Experiments.ml
@@ -58,7 +58,10 @@ let ebnf_to_menhir file =
              else (
                Hashtbl.replace htokens (upper s) true;
                upper s)
-         | T.Int _ | T.Float _ | T.Char _ -> raise Impossible
+         | T.Int _
+         | T.Float _
+         | T.Char _ ->
+             raise Impossible
          | T.String s ->
              Hashtbl.replace hkwd s true;
              spf "\"%s\"" s)

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -489,7 +489,9 @@ let filter_files_with_too_many_matches_and_transform_as_timeout matches =
            in
            let offending_rules = List.length sorted_offending_rules in
            let biggest_offending_rule =
-             match sorted_offending_rules with x :: _ -> x | _ -> assert false
+             match sorted_offending_rules with
+             | x :: _ -> x
+             | _ -> assert false
            in
            let (id, pat), cnt = biggest_offending_rule in
            logger#info
@@ -578,7 +580,9 @@ let parse_generic lang file =
            *)
         with Main_timeout _ as e -> Right e)
   in
-  match v with Left x -> x | Right exn -> raise exn
+  match v with
+  | Left x -> x
+  | Right exn -> raise exn
   [@@profiling]
 
 (*e: function [[Main_semgrep_core.parse_generic]] *)
@@ -700,7 +704,8 @@ let iter_files_and_get_matches_and_exn_to_errors f files =
 
 let xlang_files_of_dirs_or_files xlang files_or_dirs =
   match xlang with
-  | R.LRegex | R.LGeneric ->
+  | R.LRegex
+  | R.LGeneric ->
       (* TODO: assert is_file ? spacegrep filter files?
        * Anyway right now the Semgrep python wrapper is
        * calling -config with an explicit list of files.
@@ -842,7 +847,9 @@ let semgrep_with_rules (rules, rule_parse_time) files_or_dirs =
              |> List.filter (fun r ->
                     match (r.R.languages, xlang) with
                     | R.L (x, xs), R.L (lang, _) -> List.mem lang (x :: xs)
-                    | R.LRegex, R.LRegex | R.LGeneric, R.LGeneric -> true
+                    | R.LRegex, R.LRegex
+                    | R.LGeneric, R.LGeneric ->
+                        true
                     | _ -> false)
            in
            let hook str env matched_tokens =
@@ -854,7 +861,8 @@ let semgrep_with_rules (rules, rule_parse_time) files_or_dirs =
              lazy
                (match xlang with
                | R.L (lang, _) -> parse_generic lang file
-               | R.LRegex | R.LGeneric ->
+               | R.LRegex
+               | R.LGeneric ->
                    failwith "requesting generic AST for LRegex|LGeneric")
            in
            let file_and_more =

--- a/semgrep-core/src/core/Find_target.ml
+++ b/semgrep-core/src/core/Find_target.ml
@@ -43,7 +43,10 @@ let whitespace_stat_of_string s =
   let other = ref 0 in
   for i = 0 to String.length s - 1 do
     match s.[i] with
-    | ' ' | '\t' | '\r' -> incr whitespace
+    | ' '
+    | '\t'
+    | '\r' ->
+        incr whitespace
     | '\n' ->
         incr whitespace;
         incr lines

--- a/semgrep-core/src/core/Guess_lang.ml
+++ b/semgrep-core/src/core/Guess_lang.ml
@@ -42,7 +42,9 @@ let has_suffix suffixes =
   Test_path f
 
 let prepend_period_if_needed s =
-  match s with "" -> "." | s -> if s.[0] <> '.' then "." ^ s else s
+  match s with
+  | "" -> "."
+  | s -> if s.[0] <> '.' then "." ^ s else s
 
 (*
    Both '.d.ts' and '.ts' are considered extensions of 'hello.d.ts'.

--- a/semgrep-core/src/core/Metavariable.ml
+++ b/semgrep-core/src/core/Metavariable.ml
@@ -109,7 +109,10 @@ let program_of_mvalue : mvalue -> G.program option =
       Some [ G.exprstmt (G.N (G.Id (id, G.empty_id_info ())) |> G.e) ]
   | N x -> Some [ G.exprstmt (G.N x |> G.e) ]
   | Ss stmts -> Some stmts
-  | Args _ | T _ | P _ | Text _ ->
+  | Args _
+  | T _
+  | P _
+  | Text _ ->
       logger#debug "program_of_mvalue: not handled '%s'" (show_mvalue mval);
       None
 
@@ -167,8 +170,14 @@ let is_metavar_name s =
    * now we have this special case for PHP superglobals.
    * ref: https://www.php.net/manual/en/language.variables.superglobals.php
    *)
-  | "$_SERVER" | "$_GET" | "$_POST" | "$_FILES" | "$_COOKIE" | "$_SESSION"
-  | "$_REQUEST" | "$_ENV"
+  | "$_SERVER"
+  | "$_GET"
+  | "$_POST"
+  | "$_FILES"
+  | "$_COOKIE"
+  | "$_SESSION"
+  | "$_REQUEST"
+  | "$_ENV"
   (* todo: there's also "$GLOBALS" but this may interface with existing rules*)
     ->
       false

--- a/semgrep-core/src/core/Pattern.ml
+++ b/semgrep-core/src/core/Pattern.ml
@@ -54,7 +54,10 @@ let is_special_string_literal str =
   (* TODO: deprecate this *)
   || is_regexp_string str
 
-let is_js lang = match lang with Some x -> Lang.is_js x | None -> true
+let is_js lang =
+  match lang with
+  | Some x -> Lang.is_js x
+  | None -> true
 
 (* This is used in Analyze_pattern.ml to skip
  * semgrep special identifiers.

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -68,7 +68,9 @@ exception InternalInvalidLanguage of string (* rule id *) * string (* msg *)
 (* coupling: Parse_mini_rule.parse_languages *)
 let xlang_of_string ?id:(id_opt = None) s =
   match s with
-  | "none" | "regex" -> LRegex
+  | "none"
+  | "regex" ->
+      LRegex
   | "generic" -> LGeneric
   | _ -> (
       match Lang.lang_of_string_opt s with
@@ -126,7 +128,10 @@ let mk_xpat pat pstr =
   incr count;
   { pat; pstr; pid = !count }
 
-let is_regexp xpat = match xpat.pat with Regexp _ -> true | _ -> false
+let is_regexp xpat =
+  match xpat.pat with
+  | Regexp _ -> true
+  | _ -> false
 
 (*****************************************************************************)
 (* Formula (patterns boolean composition) *)
@@ -312,18 +317,26 @@ let rec visit_new_formula f formula =
   | Leaf (P (p, _)) -> f p
   | Leaf (MetavarCond _) -> ()
   | Not (_, x) -> visit_new_formula f x
-  | Or (_, xs) | And (_, xs) -> xs |> List.iter (visit_new_formula f)
+  | Or (_, xs)
+  | And (_, xs) ->
+      xs |> List.iter (visit_new_formula f)
 
 (* used by the metachecker for precise error location *)
 let tok_of_formula = function
-  | And (t, _) | Or (t, _) | Not (t, _) -> t
+  | And (t, _)
+  | Or (t, _)
+  | Not (t, _) ->
+      t
   | Leaf (P (p, _)) -> snd p.pstr
   | Leaf (MetavarCond (t, _)) -> t
 
 let kind_of_formula = function
   | Leaf (P _) -> "pattern"
   | Leaf (MetavarCond _) -> "condition"
-  | Or _ | And _ | Not _ -> "formula"
+  | Or _
+  | And _
+  | Not _ ->
+      "formula"
 
 (*****************************************************************************)
 (* Converters *)
@@ -366,7 +379,9 @@ let convert_extra x =
             (* if strip=true we rewrite the condition and insert Python's `int`
              * function to parse the integer value of mvar. *)
             match strip with
-            | None | Some false -> comparison
+            | None
+            | Some false ->
+                comparison
             | Some true -> rewrite_metavar_comparison_strip mvar comparison
           in
           CondEval cond)
@@ -404,6 +419,8 @@ let formula_of_pformula = function
 let partition_rules rules =
   rules
   |> Common.partition_either (fun r ->
-         match r.mode with Search f -> Left (r, f) | Taint s -> Right (r, s))
+         match r.mode with
+         | Search f -> Left (r, f)
+         | Taint s -> Right (r, s))
 
 (*e: semgrep/core/Rule.ml *)

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -233,4 +233,6 @@ let compare_actual_to_expected actual_errors expected_error_lines =
   let msg =
     spf "it should find all reported errors and no more (%d errors)" num_errors
   in
-  match num_errors with 0 -> Stdlib.Ok () | n -> Error (n, msg)
+  match num_errors with
+  | 0 -> Stdlib.Ok ()
+  | n -> Error (n, msg)

--- a/semgrep-core/src/core/Unit_guess_lang.ml
+++ b/semgrep-core/src/core/Unit_guess_lang.ml
@@ -72,7 +72,9 @@ let with_file name contents exec f =
   mkdir dir;
   let path = dir // name in
   let oc = open_out_bin path in
-  (match exec with Exec -> Unix.chmod path 0o755 | Nonexec -> ());
+  (match exec with
+  | Exec -> Unix.chmod path 0o755
+  | Nonexec -> ());
   Fun.protect
     ~finally:(fun () -> close_out oc)
     (fun () ->
@@ -82,19 +84,28 @@ let with_file name contents exec f =
 
 let test_name_only lang path expectation =
   match (expectation, Guess_lang.inspect_file lang path) with
-  | OK, Ok _ | XFAIL, Error _ -> ()
+  | OK, Ok _
+  | XFAIL, Error _ ->
+      ()
   | _ -> assert false
 
 let test_with_contents lang name contents exec expectation =
   with_file name contents exec (fun path ->
       match (expectation, Guess_lang.inspect_file lang path) with
-      | OK, Ok _ | XFAIL, Error _ -> ()
+      | OK, Ok _
+      | XFAIL, Error _ ->
+          ()
       | _ -> assert false)
 
 (* This is necessary when running the tests on Windows. *)
 let fix_path s =
   match Sys.os_type with
-  | "Win32" -> String.map (function '/' -> '\\' | c -> c) s
+  | "Win32" ->
+      String.map
+        (function
+          | '/' -> '\\'
+          | c -> c)
+        s
   | _ -> s
 
 let test_inspect_file =

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -43,7 +43,9 @@ let str_of_ident = fst
 
 let name_of_entity ent =
   match ent.name with
-  | EN (Id (i, pinfo)) | EN (IdQualified ((i, _), pinfo)) -> Some (i, pinfo)
+  | EN (Id (i, pinfo))
+  | EN (IdQualified ((i, _), pinfo)) ->
+      Some (i, pinfo)
   | EDynamic _ -> None
 
 (*s: constant [[AST_generic.gensym_counter]] *)
@@ -121,7 +123,9 @@ let rec pattern_to_expr p =
   | PatList (t1, xs, t2) ->
       Container (List, (t1, xs |> List.map pattern_to_expr, t2))
   | OtherPat (OP_Expr, [ E e ]) -> e.e
-  | PatAs _ | PatVar _ -> raise NotAnExpr
+  | PatAs _
+  | PatVar _ ->
+      raise NotAnExpr
   | _ -> raise NotAnExpr)
   |> G.e
 
@@ -148,7 +152,9 @@ let expr_to_type e =
 (*e: function [[AST_generic.opt_to_empty]] *)
 
 (*s: function [[AST_generic.opt_to_label_ident]] *)
-let opt_to_label_ident = function None -> LNone | Some id -> LId id
+let opt_to_label_ident = function
+  | None -> LNone
+  | Some id -> LId id
 
 (*e: function [[AST_generic.opt_to_label_ident]] *)
 
@@ -218,7 +224,9 @@ let funcbody_to_stmt = function
 (*s: function [[AST_generic.has_keyword_attr]] *)
 let has_keyword_attr kwd attrs =
   attrs
-  |> List.exists (function KeywordAttr (kwd2, _) -> kwd =*= kwd2 | _ -> false)
+  |> List.exists (function
+       | KeywordAttr (kwd2, _) -> kwd =*= kwd2
+       | _ -> false)
 
 (*e: function [[AST_generic.has_keyword_attr]] *)
 
@@ -251,7 +259,13 @@ let abstract_for_comparison_any x =
 
 let is_associative_operator op =
   match op with
-  | Or | And | BitOr | BitAnd | BitXor | Concat -> true
+  | Or
+  | And
+  | BitOr
+  | BitAnd
+  | BitXor
+  | Concat ->
+      true
   (* TODO: Plus, Mult, ... *)
   | __else__ -> false
 
@@ -261,7 +275,10 @@ let ac_matching_nf op args =
     args1
     |> List.map (function
          | Arg e -> e
-         | ArgKwd _ | ArgType _ | ArgOther _ -> raise_notrace Exit)
+         | ArgKwd _
+         | ArgType _
+         | ArgOther _ ->
+             raise_notrace Exit)
     |> List.map nf_one |> List.flatten
   and nf_one e =
     match e.e with

--- a/semgrep-core/src/core/ast/AST_utils.ml
+++ b/semgrep-core/src/core/ast/AST_utils.ml
@@ -88,7 +88,8 @@ let with_structural_equal equal a b =
       Fun.protect
         ~finally:(fun () -> busy_with_equal := Not_busy)
         (fun () -> equal a b)
-  | Structural_equal | Referential_equal ->
+  | Structural_equal
+  | Referential_equal ->
       failwith "an equal is already in progress"
 
 (*
@@ -102,5 +103,6 @@ let with_referential_equal equal a b =
       Fun.protect
         ~finally:(fun () -> busy_with_equal := Not_busy)
         (fun () -> equal a b)
-  | Structural_equal | Referential_equal ->
+  | Structural_equal
+  | Referential_equal ->
       failwith "an equal is already in progress"

--- a/semgrep-core/src/core/ast/Bloom_filter.ml
+++ b/semgrep-core/src/core/ast/Bloom_filter.ml
@@ -83,7 +83,11 @@ let mem elt bf =
   if is_in then Maybe else No
 
 let is_subset pattern_list bf =
-  let patterns_in_bf b x = match b with No -> No | Maybe -> mem x bf in
+  let patterns_in_bf b x =
+    match b with
+    | No -> No
+    | Maybe -> mem x bf
+  in
   List.fold_left patterns_in_bf Maybe pattern_list
 
 let make_bloom_from_set set_instead_of_bloom ids =

--- a/semgrep-core/src/core/ast/Lang.ml
+++ b/semgrep-core/src/core/ast/Lang.ml
@@ -74,9 +74,19 @@ type t =
 [@@ocamlformat "disable"]
 [@@deriving show, eq]
 
-let is_js = function Javascript | Typescript | Vue -> true | _ -> false
+let is_js = function
+  | Javascript
+  | Typescript
+  | Vue ->
+      true
+  | _ -> false
 
-let is_python = function Python | Python2 | Python3 -> true | _ -> false
+let is_python = function
+  | Python
+  | Python2
+  | Python3 ->
+      true
+  | _ -> false
 
 (*****************************************************************************)
 (* Helpers *)
@@ -240,7 +250,10 @@ let to_lowercase_alnum = function
    Manually pulled from file_type_of_file2 in file_type.ml.
 *)
 let ext_of_lang = function
-  | Python | Python2 | Python3 -> [ "py"; "pyi" ]
+  | Python
+  | Python2
+  | Python3 ->
+      [ "py"; "pyi" ]
   | Javascript -> [ "js"; "jsx" ]
   | Typescript -> [ "ts"; "tsx" ]
   | JSON -> [ "json" ]

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -377,8 +377,20 @@ let (mk_visitor : visitor_in -> visitor_out) =
   and map_container_operator x = x
   and map_special x =
     match x with
-    | ForOf | Defined | This | Super | Self | Parent | Eval | Typeof
-    | Instanceof | Sizeof | New | Spread | HashSplat | NextArrayIndex
+    | ForOf
+    | Defined
+    | This
+    | Super
+    | Self
+    | Parent
+    | Eval
+    | Typeof
+    | Instanceof
+    | Sizeof
+    | New
+    | Spread
+    | HashSplat
+    | NextArrayIndex
     | InterpolatedElement ->
         x
     | Op v1 ->

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -17,7 +17,9 @@ let vof_bracket of_a (t1, x, t2) =
   let v1 = vof_tok t1 in
   let v2 = vof_tok t2 in
   let v = of_a x in
-  match v1 with OCaml.VUnit -> v | _ -> OCaml.VTuple [ v1; v; v2 ]
+  match v1 with
+  | OCaml.VUnit -> v
+  | _ -> OCaml.VTuple [ v1; v; v2 ]
 
 let vof_ident v = vof_wrap OCaml.vof_string v
 
@@ -1007,7 +1009,8 @@ and vof_definition_kind = function
       let v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherDef", [ v1; v2 ])
 
-and vof_other_def_operator = function OD_Todo -> OCaml.VSum ("OD_Todo", [])
+and vof_other_def_operator = function
+  | OD_Todo -> OCaml.VSum ("OD_Todo", [])
 
 and vof_module_definition { mbody = v_mbody } =
   let bnds = [] in

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -371,7 +371,9 @@ let (mk_visitor : ?vardef_assign:bool -> visitor_in -> visitor_out) =
           ()
     in
     vin.kexpr (k, all_functions) x
-  and v_name_or_dynamic = function EN v1 -> v_name v1 | EDynamic e -> v_expr e
+  and v_name_or_dynamic = function
+    | EN v1 -> v_name v1
+    | EDynamic e -> v_expr e
   and v_literal = function
     | Unit v1 ->
         let v1 = v_tok v1 in
@@ -906,7 +908,8 @@ let (mk_visitor : ?vardef_assign:bool -> visitor_in -> visitor_out) =
             v_entity v1;
             v_def_kind v2);
           ()
-      | PartialIf (v1, v2) | PartialMatch (v1, v2) ->
+      | PartialIf (v1, v2)
+      | PartialMatch (v1, v2) ->
           if recurse then (
             v_tok v1;
             v_expr v2)
@@ -969,7 +972,12 @@ let (mk_visitor : ?vardef_assign:bool -> visitor_in -> visitor_out) =
         v_list v_any v2
   and v_other_def_operator _ = ()
   and v_function_kind = function
-    | Function | Method | Arrow | LambdaKind | BlockCases -> ()
+    | Function
+    | Method
+    | Arrow
+    | LambdaKind
+    | BlockCases ->
+        ()
   and v_function_definition x =
     let k { fkind; fparams = v_fparams; frettype = v_frettype; fbody = v_fbody }
         =
@@ -989,7 +997,8 @@ let (mk_visitor : ?vardef_assign:bool -> visitor_in -> visitor_out) =
       | ParamClassic v1 ->
           let v1 = v_parameter_classic v1 in
           ()
-      | ParamRest (v1, v2) | ParamHashSplat (v1, v2) ->
+      | ParamRest (v1, v2)
+      | ParamHashSplat (v1, v2) ->
           v_tok v1;
           v_parameter_classic v2
       | ParamPattern v1 ->

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -12,7 +12,9 @@ let string_of_lval x =
   | Index _ -> "[...]"
 
 let string_of_exp e =
-  match e.e with Fetch l -> string_of_lval l | _ -> "<EXP>"
+  match e.e with
+  | Fetch l -> string_of_lval l
+  | _ -> "<EXP>"
 
 let short_string_of_node_kind nkind =
   match nkind with

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -413,14 +413,20 @@ let lval_of_instr_opt x =
   | Call (Some lval, _, _)
   | CallSpecial (Some lval, _, _) ->
       Some lval
-  | Call _ | CallSpecial _ -> None
+  | Call _
+  | CallSpecial _ ->
+      None
   | FixmeInstr _ -> None
 
 (*s: function [[IL.lvar_of_instr_opt]] *)
 let lvar_of_instr_opt x =
   let open Common in
   lval_of_instr_opt x >>= fun lval ->
-  match lval.base with Var n -> Some n | VarSpecial _ | Mem _ -> None
+  match lval.base with
+  | Var n -> Some n
+  | VarSpecial _
+  | Mem _ ->
+      None
 
 (*e: function [[IL.lvar_of_instr_opt]] *)
 
@@ -448,16 +454,22 @@ let rec lvals_of_exp e =
   | Fetch lval -> lval :: lvals_in_lval lval
   | Literal _ -> []
   | Cast (_, e) -> lvals_of_exp e
-  | Composite (_, (_, xs, _)) | Operator (_, xs) -> lvals_of_exps xs
+  | Composite (_, (_, xs, _))
+  | Operator (_, xs) ->
+      lvals_of_exps xs
   | Record ys -> lvals_of_exps (ys |> List.map snd)
   | FixmeExp _ -> []
 
 and lvals_in_lval lval =
   let base_lvals =
-    match lval.base with Mem e -> lvals_of_exp e | _else_ -> []
+    match lval.base with
+    | Mem e -> lvals_of_exp e
+    | _else_ -> []
   in
   let offset_lvals =
-    match lval.offset with Index e -> lvals_of_exp e | __else_ -> []
+    match lval.offset with
+    | Index e -> lvals_of_exp e
+    | __else_ -> []
   in
   base_lvals @ offset_lvals
 
@@ -475,15 +487,35 @@ let rvars_of_instr x =
        | ___else___ -> None)
 
 let rlvals_of_node = function
-  | Enter | Exit | TrueNode | FalseNode | NGoto _ | Join -> []
+  | Enter
+  | Exit
+  | TrueNode
+  | FalseNode
+  | NGoto _
+  | Join ->
+      []
   | NInstr x -> rlvals_of_instr x
-  | NCond (_, e) | NReturn (_, e) | NThrow (_, e) -> lvals_of_exp e
-  | NOther _ | NTodo _ -> []
+  | NCond (_, e)
+  | NReturn (_, e)
+  | NThrow (_, e) ->
+      lvals_of_exp e
+  | NOther _
+  | NTodo _ ->
+      []
 
 let lval_of_node_opt = function
   | NInstr x -> lval_of_instr_opt x
-  | Enter | Exit | TrueNode | FalseNode | NGoto _ | Join | NCond _ | NReturn _
-  | NThrow _ | NOther _ | NTodo _ ->
+  | Enter
+  | Exit
+  | TrueNode
+  | FalseNode
+  | NGoto _
+  | Join
+  | NCond _
+  | NReturn _
+  | NThrow _
+  | NOther _
+  | NTodo _ ->
       None
 
 (*****************************************************************************)

--- a/semgrep-core/src/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/datalog/Datalog_experiment.ml
@@ -121,7 +121,10 @@ let instr env x =
       | _ -> todo (I x))
   | _ -> todo (I x)
 
-let stmt env x = match x.IL.s with Instr x -> instr env x | _ -> todo (S x)
+let stmt env x =
+  match x.IL.s with
+  | Instr x -> instr env x
+  | _ -> todo (S x)
 
 let facts_of_function lang def =
   let xs = AST_to_IL.stmt lang (H.funcbody_to_stmt def.G.fbody) in

--- a/semgrep-core/src/datalog/Datalog_fact.ml
+++ b/semgrep-core/src/datalog/Datalog_fact.ml
@@ -123,7 +123,11 @@ type facts = fact list
 type value = V of var | F of fld | N of func | I of callsite | Z of int
 
 let string_of_value = function
-  | V x | F x | N x | I x -> x
+  | V x
+  | F x
+  | N x
+  | I x ->
+      x
   | Z _ -> raise Impossible
 
 type _rule = string
@@ -159,6 +163,10 @@ let string_of_fact fact =
   spf "%s(%s)" str
     (xs
     |> List.map (function
-         | V x | F x | N x | I x -> spf "'%s'" x
+         | V x
+         | F x
+         | N x
+         | I x ->
+             spf "'%s'" x
          | Z i -> spf "%d" i)
     |> Common.join ", ")

--- a/semgrep-core/src/datalog/Datalog_io.ml
+++ b/semgrep-core/src/datalog/Datalog_io.ml
@@ -31,7 +31,11 @@ open Datalog_fact
 (*****************************************************************************)
 
 let string_of_value = function
-  | V x | F x | N x | I x -> spf "'%s'" x
+  | V x
+  | F x
+  | N x
+  | I x ->
+      spf "'%s'" x
   | Z i -> spf "%d" i
 
 let csv_of_tuple xs = (xs |> List.map string_of_value |> Common.join ",") ^ "\n"

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -248,7 +248,9 @@ and eval_op op values code =
   | G.NotEq, [ Float v1; Int v2 ] -> Bool (v1 <> float_of_int v2)
   | G.NotEq, [ v1; v2 ] -> Bool (v1 <> v2)
   | G.In, [ v1; v2 ] -> (
-      match v2 with List xs -> Bool (List.mem v1 xs) | _ -> Bool false)
+      match v2 with
+      | List xs -> Bool (List.mem v1 xs)
+      | _ -> Bool false)
   | _ -> raise (NotHandled code)
 
 (*****************************************************************************)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -217,7 +217,9 @@ let (mini_rule_of_pattern :
     languages =
       (match xlang with
       | R.L (x, xs) -> x :: xs
-      | R.LRegex | R.LGeneric -> raise Impossible);
+      | R.LRegex
+      | R.LGeneric ->
+          raise Impossible);
     (* useful for debugging timeout *)
     pattern_string = pstr;
   }
@@ -431,7 +433,8 @@ let matches_of_spacegrep spacegreps file =
           in
           let doc_type = Spacegrep.File_type.classify partial_doc_src in
           match doc_type with
-          | Minified | Binary ->
+          | Minified
+          | Binary ->
               logger#info "ignoring gibberish file: %s\n%!" file;
               None
           | _ ->
@@ -752,7 +755,8 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
                                   fully parse the content of %s"
                                  env.rule_id mvar);
                           (ast, errors)
-                      | R.LRegex | R.LGeneric ->
+                      | R.LRegex
+                      | R.LGeneric ->
                           failwith "requesting generic AST for LRegex|LGeneric")
                   in
                   nested_formula_has_matches { env with file; xlang } formula
@@ -785,7 +789,9 @@ and nested_formula_has_matches env formula lazy_ast_and_errors lazy_content
       formula opt_context
   in
   env.errors := res.RP.errors @ !(env.errors);
-  match final_ranges with [] -> false | _ :: _ -> true
+  match final_ranges with
+  | [] -> false
+  | _ :: _ -> true
 
 (* less: use Set instead of list? *)
 and (evaluate_formula : env -> RM.t option -> S.sformula -> RM.t list) =

--- a/semgrep-core/src/engine/Run_rules.ml
+++ b/semgrep-core/src/engine/Run_rules.ml
@@ -30,7 +30,8 @@ let check_taint hook default_config taint_rules equivs file_and_more =
       let lang =
         match xlang with
         | R.L (lang, _) -> lang
-        | R.LGeneric | R.LRegex ->
+        | R.LGeneric
+        | R.LRegex ->
             failwith "taint-mode and generic/regex matching are incompatible"
       in
       let (ast, errors), parse_time =

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -48,7 +48,10 @@ let split_and :
   |> Common.partition_either3 (fun e ->
          match e with
          (* positives *)
-         | R.Leaf (R.P _) | R.And _ | R.Or _ -> Left3 e
+         | R.Leaf (R.P _)
+         | R.And _
+         | R.Or _ ->
+             Left3 e
          (* negatives *)
          | R.Not (_, f) -> Middle3 f
          (* conditionals *)

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -42,7 +42,9 @@ let (xlangs_of_rules : Rule.t list -> Rule.xlang list) =
  fun rs -> rs |> List.map (fun r -> r.R.languages) |> List.sort_uniq compare
 
 let first_xlang_of_rules rs =
-  match rs with [] -> failwith "no rules" | { R.languages = x; _ } :: _ -> x
+  match rs with
+  | [] -> failwith "no rules"
+  | { R.languages = x; _ } :: _ -> x
 
 (*****************************************************************************)
 (* Entry point *)
@@ -141,7 +143,9 @@ let test_rules ?(unit_testing = false) xs =
                      lang target
                  in
                  (ast, errors)
-             | R.LRegex | R.LGeneric -> raise Impossible)
+             | R.LRegex
+             | R.LGeneric ->
+                 raise Impossible)
          in
          let file_and_more =
            {

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -104,17 +104,23 @@ let has_ellipsis_and_filter_ellipsis_gen f xs =
 
 let has_ellipsis_and_filter_ellipsis xs =
   has_ellipsis_and_filter_ellipsis_gen
-    (function { G.e = G.Ellipsis _; _ } -> true | _ -> false)
+    (function
+      | { G.e = G.Ellipsis _; _ } -> true
+      | _ -> false)
     xs
 
 let has_xml_ellipsis_and_filter_ellipsis xs =
   has_ellipsis_and_filter_ellipsis_gen
-    (function G.XmlEllipsis _ -> true | _ -> false)
+    (function
+      | G.XmlEllipsis _ -> true
+      | _ -> false)
     xs
 
 let has_case_ellipsis_and_filter_ellipsis xs =
   has_ellipsis_and_filter_ellipsis_gen
-    (function G.CaseEllipsis _ -> true | _ -> false)
+    (function
+      | G.CaseEllipsis _ -> true
+      | _ -> false)
     xs
 
 let has_match_case_ellipsis_and_filter_ellipsis xs =
@@ -140,7 +146,11 @@ let rec expr_of_obj_and_method_calls (obj, xs) =
       B.Call (B.DotAccess (e, tok, fld) |> G.e, args) |> G.e
 
 let rec all_suffix_of_list xs =
-  xs :: (match xs with [] -> [] | _x :: xs -> all_suffix_of_list xs)
+  xs
+  ::
+  (match xs with
+  | [] -> []
+  | _x :: xs -> all_suffix_of_list xs)
 
 let _ =
   Common2.example
@@ -172,7 +182,9 @@ let stmts_may_match pattern_stmts (stmts : AST_generic.stmt list) =
       Bloom_annotation.list_of_pattern_strings (Ss pattern_stmts)
     in
     let pat_in_stmt pat (stmt : AST_generic.stmt) =
-      match stmt.s_bf with None -> F.Maybe | Some bf -> F.mem pat bf
+      match stmt.s_bf with
+      | None -> F.Maybe
+      | Some bf -> F.mem pat bf
     in
     let rec pattern_in_any_stmt pat stmts acc =
       match stmts with
@@ -281,7 +293,9 @@ let m_module_name_prefix a b =
       (* TODO figure out what prefix support means here *)
         ~m_string_for_default:m_filepath_prefix a b
   | G.DottedName a1, B.DottedName b1 -> m_dotted_name_prefix_ok a1 b1
-  | G.FileName _, _ | G.DottedName _, _ -> fail ()
+  | G.FileName _, _
+  | G.DottedName _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_module_name_prefix]] *)
 
@@ -290,7 +304,9 @@ let m_module_name a b =
   match (a, b) with
   | G.FileName a1, B.FileName b1 -> (m_wrap m_string) a1 b1
   | G.DottedName a1, B.DottedName b1 -> m_dotted_name a1 b1
-  | G.FileName _, _ | G.DottedName _, _ -> fail ()
+  | G.FileName _, _
+  | G.DottedName _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_module_name]] *)
 
@@ -402,7 +418,9 @@ let rec m_name a b =
   (* boilerplate *)
   | G.IdQualified (a1, a2), B.IdQualified (b1, b2) ->
       m_name_ a1 b1 >>= fun () -> m_id_info a2 b2
-  | G.Id _, _ | G.IdQualified _, _ -> fail ()
+  | G.Id _, _
+  | G.IdQualified _, _ ->
+      fail ()
 
 and m_name_ a b =
   match (a, b) with
@@ -424,7 +442,10 @@ and m_qualifier a b =
   | G.QDots a, B.QDots b -> m_dotted_name a b
   | G.QTop a, B.QTop b -> m_tok a b
   | G.QExpr (a1, a2), B.QExpr (b1, b2) -> m_expr a1 b1 >>= fun () -> m_tok a2 b2
-  | G.QDots _, _ | G.QTop _, _ | G.QExpr _, _ -> fail ()
+  | G.QDots _, _
+  | G.QTop _, _
+  | G.QExpr _, _ ->
+      fail ()
 
 (* semantic! try to handle typed metavariables by querying LSP
  * to get inferred type info (only for OCaml for now) *)
@@ -537,7 +558,9 @@ and m_expr_deep a b =
         let subs = SubAST_generic.subexprs_of_expr b in
         (* less: could use a fold *)
         let rec aux xs =
-          match xs with [] -> fail () | x :: xs -> m_expr_deep a x >||> aux xs
+          match xs with
+          | [] -> fail ()
+          | x :: xs -> m_expr_deep a x >||> aux xs
         in
         aux subs )
 
@@ -739,7 +762,9 @@ and m_expr a b =
           let create_assigns expr1 expr2 = B.Assign (expr1, bt, expr2) |> G.e in
           let mult_assigns = List.map2 create_assigns vars vals in
           let rec aux xs =
-            match xs with [] -> fail () | x :: xs -> m_expr a x >||> aux xs
+            match xs with
+            | [] -> fail ()
+            | x :: xs -> m_expr a x >||> aux xs
           in
           aux mult_assigns
       | _, _ -> fail ())
@@ -851,7 +876,9 @@ and m_name_or_dynamic a b =
   (* boilerplate *)
   (*s: [[Generic_vs_generic.m_field_ident()]] boilerplate cases *)
   | G.EDynamic a, B.EDynamic b -> m_expr a b
-  | G.EN _, _ | G.EDynamic _, _ -> fail ()
+  | G.EN _, _
+  | G.EDynamic _, _ ->
+      fail ()
 
 (*e: [[Generic_vs_generic.m_field_ident()]] boilerplate cases *)
 (*e: function [[Generic_vs_generic.m_field_ident]] *)
@@ -863,7 +890,11 @@ and m_label_ident a b =
   | G.LId a, B.LId b -> m_label a b
   | G.LInt a, B.LInt b -> m_wrap m_int a b
   | G.LDynamic a, B.LDynamic b -> m_expr a b
-  | G.LNone, _ | G.LId _, _ | G.LInt _, _ | G.LDynamic _, _ -> fail ()
+  | G.LNone, _
+  | G.LId _, _
+  | G.LInt _, _
+  | G.LDynamic _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_label_ident]] *)
 and m_comprehension (a1, a2) (b1, b2) =
@@ -882,7 +913,9 @@ and m_for_or_if_comp a b =
       let* () = m_tok a1 b1 in
       let* () = m_expr a2 b2 in
       return ()
-  | G.CompFor _, _ | G.CompIf _, _ -> fail ()
+  | G.CompFor _, _
+  | G.CompIf _, _ ->
+      fail ()
 
 (*s: function [[Generic_vs_generic.m_literal]] *)
 and m_literal a b =
@@ -956,8 +989,12 @@ and m_literal_constness a b =
   match b with
   | B.Lit b1 -> m_literal a b1
   | B.Cst B.Cstr -> (
-      match a with G.String ("...", _) -> return () | ___else___ -> fail ())
-  | B.Cst _ | B.NotCst -> fail ()
+      match a with
+      | G.String ("...", _) -> return ()
+      | ___else___ -> fail ())
+  | B.Cst _
+  | B.NotCst ->
+      fail ()
 
 and m_match_cases a b =
   let has_ellipsis, a = has_match_case_ellipsis_and_filter_ellipsis a in
@@ -972,7 +1009,9 @@ and m_action (a : G.action) (b : G.action) =
 
 (*s: function [[Generic_vs_generic.m_arithmetic_operator]] *)
 and m_arithmetic_operator a b =
-  match (a, b) with _ when a =*= b -> return () | _ -> fail ()
+  match (a, b) with
+  | _ when a =*= b -> return ()
+  | _ -> fail ()
 
 (*e: function [[Generic_vs_generic.m_arithmetic_operator]] *)
 
@@ -1028,7 +1067,9 @@ and m_concat_string_kind a b =
   | G.FString, _ -> fail ()
   (* same for tagged template literals *)
   | G.TaggedTemplateLiteral, B.TaggedTemplateLiteral -> return ()
-  | G.TaggedTemplateLiteral, _ | _, B.TaggedTemplateLiteral -> fail ()
+  | G.TaggedTemplateLiteral, _
+  | _, B.TaggedTemplateLiteral ->
+      fail ()
   (* less-is-more: *)
   | _ -> return ()
 
@@ -1061,14 +1102,21 @@ and m_container_operator a b =
   | G.Set, B.Set -> return ()
   | G.Dict, B.Dict -> return ()
   | G.Tuple, B.Tuple -> return ()
-  | G.Array, _ | G.List, _ | G.Set, _ | G.Dict, _ | G.Tuple, _ -> fail ()
+  | G.Array, _
+  | G.List, _
+  | G.Set, _
+  | G.Dict, _
+  | G.Tuple, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_container_operator]] *)
 
 (*s: function [[Generic_vs_generic.m_container_ordered_elements]] *)
 and m_container_ordered_elements a b =
   m_list_with_dots m_expr
-    (function { e = G.Ellipsis _; _ } -> true | _ -> false)
+    (function
+      | { e = G.Ellipsis _; _ } -> true
+      | _ -> false)
     false (* empty list can not match non-empty list *) a b
 
 (*e: function [[Generic_vs_generic.m_container_ordered_elements]] *)
@@ -1162,7 +1210,10 @@ and m_xml_kind a b =
       let* () = m_tok a1 b1 in
       let* () = m_tok a2 b2 in
       return ()
-  | G.XmlClassic _, _ | G.XmlSingleton _, _ | G.XmlFragment _, _ -> fail ()
+  | G.XmlClassic _, _
+  | G.XmlSingleton _, _
+  | G.XmlFragment _, _ ->
+      fail ()
 
 (*s: function [[Generic_vs_generic.m_attrs]] *)
 and m_attrs a b =
@@ -1195,7 +1246,10 @@ and m_xml_attr a b =
       m_xml_attr_value a2 b2
   | G.XmlAttrExpr a1, B.XmlAttrExpr b1 -> m_bracket m_expr a1 b1
   | G.XmlEllipsis a1, B.XmlEllipsis b1 -> m_tok a1 b1
-  | G.XmlAttr _, _ | G.XmlAttrExpr _, _ | G.XmlEllipsis _, _ -> fail ()
+  | G.XmlAttr _, _
+  | G.XmlAttrExpr _, _
+  | G.XmlEllipsis _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_xml_attr]] *)
 
@@ -1218,7 +1272,10 @@ and m_body a b =
       (* less: could allow ... to match also a None *)
       m_bracket (m_option m_expr) a1 b1
   | G.XmlXml a1, B.XmlXml b1 -> m_xml a1 b1
-  | G.XmlText _, _ | G.XmlExpr _, _ | G.XmlXml _, _ -> fail ()
+  | G.XmlText _, _
+  | G.XmlExpr _, _
+  | G.XmlXml _, _ ->
+      fail ()
 
 (*e: [[Generic_vs_generic.m_body]] boilerplate cases *)
 (*e: function [[Generic_vs_generic.m_body]] *)
@@ -1229,7 +1286,8 @@ and m_body a b =
 
 (*s: function [[Generic_vs_generic.m_arguments]] *)
 and m_arguments a b =
-  match (a, b) with a, b -> m_bracket m_list__m_argument a b
+  match (a, b) with
+  | a, b -> m_bracket m_list__m_argument a b
 
 (*e: function [[Generic_vs_generic.m_arguments]] *)
 
@@ -1296,7 +1354,9 @@ and m_list__m_argument (xsa : G.argument list) (xsb : G.argument list) =
   (* the general case *)
   | xa :: aas, xb :: bbs ->
       m_argument xa xb >>= fun () -> m_list__m_argument aas bbs
-  | [], _ | _ :: _, _ -> fail ()
+  | [], _
+  | _ :: _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_list__m_argument]] *)
 
@@ -1327,7 +1387,9 @@ and m_arguments_concat a b =
       | G.Arg { e = G.Ellipsis _; _ }, G.Arg { e = G.L (G.String _); _ } ->
           fail ()
       | _ -> m_argument xa xb >>= fun () -> m_arguments_concat aas bbs)
-  | [], _ | _ :: _, _ -> fail ()
+  | [], _
+  | _ :: _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_arguments_concat]] *)
 
@@ -1344,7 +1406,11 @@ and m_argument a b =
       m_ident a1 b1 >>= fun () -> m_expr a2 b2
   | G.ArgOther (a1, a2), B.ArgOther (b1, b2) ->
       m_other_argument_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
-  | G.Arg _, _ | G.ArgKwd _, _ | G.ArgType _, _ | G.ArgOther _, _ -> fail ()
+  | G.Arg _, _
+  | G.ArgKwd _, _
+  | G.ArgType _, _
+  | G.ArgOther _, _ ->
+      fail ()
 
 (*e: [[Generic_vs_generic.m_argument()]] boilerplate cases *)
 (*e: function [[Generic_vs_generic.m_argument]] *)
@@ -1359,9 +1425,14 @@ and m_other_argument_operator = m_other_xxx
 (*---------------------------------------------------------------------------*)
 and m_call_op aop toka aargs bop tokb bargs tin =
   let is_commutative_operator = function
-    | G.BitOr | G.BitAnd | G.BitXor -> true
+    | G.BitOr
+    | G.BitAnd
+    | G.BitXor ->
+        true
     (* TODO: Plus, Mult, ... ? *)
-    | G.And | G.Or -> tin.config.commutative_boolop
+    | G.And
+    | G.Or ->
+        tin.config.commutative_boolop
     | __else__ -> false
   in
   let m_op_default =
@@ -1426,7 +1497,9 @@ and m_assoc_op tok op aargs_ac bargs_ac =
   | xa :: xsa, xb :: xsb ->
       let* () = m_expr xa xb in
       m_assoc_op tok op xsa xsb
-  | _ :: _, [] | [], _ :: _ -> fail ()
+  | _ :: _, []
+  | [], _ :: _ ->
+      fail ()
 
 (* Associative-Commutative (AC) matching of operators.
  *
@@ -1626,7 +1699,8 @@ and m_type_ a b =
 
 (*s: function [[Generic_vs_generic.m_type_arguments]] *)
 and m_type_arguments a b =
-  match (a, b) with a, b -> m_bracket (m_list m_type_argument) a b
+  match (a, b) with
+  | a, b -> m_bracket (m_list m_type_argument) a b
 
 (*e: function [[Generic_vs_generic.m_type_arguments]] *)
 
@@ -1685,7 +1759,10 @@ and m_attribute a b =
       m_name a1 b1 >>= fun () -> m_bracket m_list__m_argument a2 b2
   | G.OtherAttribute (a1, a2), B.OtherAttribute (b1, b2) ->
       m_other_attribute_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
-  | G.KeywordAttr _, _ | G.NamedAttr _, _ | G.OtherAttribute _, _ -> fail ()
+  | G.KeywordAttr _, _
+  | G.NamedAttr _, _
+  | G.OtherAttribute _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_attribute]] *)
 
@@ -2088,7 +2165,10 @@ and m_for_header a b =
       m_tok at bt >>= fun () -> m_expr a2 b2
   | G.ForIn (a1, a2), B.ForIn (b1, b2) ->
       (m_list m_for_var_or_expr) a1 b1 >>= fun () -> m_list m_expr a2 b2
-  | G.ForClassic _, _ | G.ForEach _, _ | G.ForIn _, _ -> fail ()
+  | G.ForClassic _, _
+  | G.ForEach _, _
+  | G.ForIn _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_for_header]] *)
 and m_block a b =
@@ -2104,12 +2184,16 @@ and m_for_var_or_expr a b =
   | G.ForInitVar (a1, a2), B.ForInitVar (b1, b2) ->
       m_entity a1 b1 >>= fun () -> m_variable_definition a2 b2
   | G.ForInitExpr a1, B.ForInitExpr b1 -> m_expr a1 b1
-  | G.ForInitVar _, _ | G.ForInitExpr _, _ -> fail ()
+  | G.ForInitVar _, _
+  | G.ForInitExpr _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_for_var_or_expr]] *)
 
 (*s: function [[Generic_vs_generic.m_label]] *)
-and m_label a b = match (a, b) with a, b -> m_ident a b
+and m_label a b =
+  match (a, b) with
+  | a, b -> m_ident a b
 
 (*e: function [[Generic_vs_generic.m_label]] *)
 
@@ -2124,7 +2208,8 @@ and m_catch a b =
 
 (*s: function [[Generic_vs_generic.m_finally]] *)
 and m_finally a b =
-  match (a, b) with (at, a), (bt, b) -> m_tok at bt >>= fun () -> m_stmt a b
+  match (a, b) with
+  | (at, a), (bt, b) -> m_tok at bt >>= fun () -> m_stmt a b
 
 (*e: function [[Generic_vs_generic.m_finally]] *)
 
@@ -2134,7 +2219,9 @@ and m_case_and_body a b =
   | CasesAndBody (a1, a2), CasesAndBody (b1, b2) ->
       (m_list m_case) a1 b1 >>= fun () -> m_stmt a2 b2
   | CaseEllipsis _, CasesAndBody _ -> return ()
-  | CasesAndBody _, _ | CaseEllipsis _, _ -> fail ()
+  | CasesAndBody _, _
+  | CaseEllipsis _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_case_and_body]] *)
 
@@ -2146,7 +2233,10 @@ and m_case a b =
   | G.CaseEqualExpr (a0, a1), B.CaseEqualExpr (b0, b1) ->
       m_tok a0 b0 >>= fun () -> m_expr a1 b1
   | G.Default a0, B.Default b0 -> m_tok a0 b0
-  | G.Case _, _ | G.Default _, _ | G.CaseEqualExpr _, _ -> fail ()
+  | G.Case _, _
+  | G.Default _, _
+  | G.CaseEqualExpr _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_case]] *)
 
@@ -2316,14 +2406,18 @@ and m_type_parameter_constraint a b =
   | G.HasConstructor a1, B.HasConstructor b1 -> m_tok a1 b1
   | G.OtherTypeParam (a1, a2), B.OtherTypeParam (b1, b2) ->
       m_other_type_parameter_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
-  | G.Extends _, _ | G.HasConstructor _, _ | G.OtherTypeParam _, _ -> fail ()
+  | G.Extends _, _
+  | G.HasConstructor _, _
+  | G.OtherTypeParam _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_type_parameter_constraint]] *)
 and m_other_type_parameter_operator = m_other_xxx
 
 (*s: function [[Generic_vs_generic.m_type_parameter_constraints]] *)
 and m_type_parameter_constraints a b =
-  match (a, b) with a, b -> (m_list m_type_parameter_constraint) a b
+  match (a, b) with
+  | a, b -> (m_list m_type_parameter_constraint) a b
 
 (*e: function [[Generic_vs_generic.m_type_parameter_constraints]] *)
 
@@ -2365,12 +2459,18 @@ and m_function_body a b =
    * in Visitor_AST.v_def_as_partial of the target.
    *)
   | G.FBStmt { s = G.Block (_, [], _); _ }, B.FBNothing -> return ()
-  | G.FBStmt _, _ | G.FBExpr _, _ | G.FBDecl _, _ | G.FBNothing, _ -> fail ()
+  | G.FBStmt _, _
+  | G.FBExpr _, _
+  | G.FBDecl _, _
+  | G.FBNothing, _ ->
+      fail ()
 
 (*s: function [[Generic_vs_generic.m_parameters]] *)
 and m_parameters a b =
   m_list_with_dots m_parameter
-    (function G.ParamEllipsis _ -> true | _ -> false)
+    (function
+      | G.ParamEllipsis _ -> true
+      | _ -> false)
     false (* empty list can not match non-empty list *) a b
 
 (*e: function [[Generic_vs_generic.m_parameters]] *)
@@ -2569,7 +2669,9 @@ and m_field a b =
   (*s: [[Generic_vs_generic.m_field]] boilerplate cases *)
   | G.FieldSpread (a0, a1), B.FieldSpread (b0, b1) ->
       m_tok a0 b0 >>= fun () -> m_expr a1 b1
-  | G.FieldSpread _, _ | G.FieldStmt _, _ -> fail ()
+  | G.FieldSpread _, _
+  | G.FieldStmt _, _ ->
+      fail ()
 
 (*e: [[Generic_vs_generic.m_field]] boilerplate cases *)
 (*e: function [[Generic_vs_generic.m_field]] *)
@@ -2621,7 +2723,10 @@ and m_or_type a b =
       m_ident a1 b1 >>= fun () -> m_type_ a2 b2
   | G.OtherOr (a1, a2), B.OtherOr (b1, b2) ->
       m_other_or_type_element_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
-  | G.OrConstructor _, _ | G.OrEnum _, _ | G.OrUnion _, _ | G.OtherOr _, _ ->
+  | G.OrConstructor _, _
+  | G.OrEnum _, _
+  | G.OrUnion _, _
+  | G.OtherOr _, _ ->
       fail ()
 
 (*e: function [[Generic_vs_generic.m_or_type]] *)
@@ -2734,7 +2839,10 @@ and m_module_definition_kind a b =
       (m_option m_dotted_name) a1 b1 >>= fun () -> (m_list m_item) a2 b2
   | G.OtherModule (a1, a2), B.OtherModule (b1, b2) ->
       m_other_module_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
-  | G.ModuleAlias _, _ | G.ModuleStruct _, _ | G.OtherModule _, _ -> fail ()
+  | G.ModuleAlias _, _
+  | G.ModuleStruct _, _
+  | G.OtherModule _, _ ->
+      fail ()
 
 (*e: function [[Generic_vs_generic.m_module_definition_kind]] *)
 
@@ -2769,7 +2877,8 @@ and m_directive a b =
   m_directive_basic a.d b.d >!> fun () ->
   match a.d with
   (* normalize only if very simple import pattern (no alias) *)
-  | G.ImportFrom (_, _, _, None) | G.ImportAs (_, _, None) -> (
+  | G.ImportFrom (_, _, _, None)
+  | G.ImportAs (_, _, None) -> (
       (* equivalence: *)
       let normal_a = Normalize_generic.normalize_import_opt true a.d in
       let normal_b = Normalize_generic.normalize_import_opt false b.d in
@@ -2778,9 +2887,13 @@ and m_directive a b =
           m_tok a0 b0 >>= fun () -> m_module_name_prefix a1 b1
       | _ -> fail ())
   (* more complex pattern should not be normalized *)
-  | G.ImportFrom _ | G.ImportAs _
+  | G.ImportFrom _
+  | G.ImportAs _
   (* definitely do not normalize the pattern for ImportAll *)
-  | G.ImportAll _ | G.Package _ | G.PackageEnd _ | G.Pragma _
+  | G.ImportAll _
+  | G.Package _
+  | G.PackageEnd _
+  | G.Pragma _
   | G.OtherDirective _ ->
       fail ()
 
@@ -2851,7 +2964,9 @@ and m_item a b = m_stmt a b
 (*e: function [[Generic_vs_generic.m_item]] *)
 
 (*s: function [[Generic_vs_generic.m_program]] *)
-and m_program a b = match (a, b) with a, b -> (m_list m_item) a b
+and m_program a b =
+  match (a, b) with
+  | a, b -> (m_list m_item) a b
 
 (*e: function [[Generic_vs_generic.m_program]] *)
 

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -173,7 +173,9 @@ let (( >||> ) : (tin -> tout) -> (tin -> tout) -> tin -> tout) =
 (*s: function [[Matching_generic.monadic_if_fail]] *)
 (* the if-fail combinator *)
 let ( >!> ) m1 else_cont tin =
-  match m1 tin with [] -> (else_cont ()) tin | xs -> xs
+  match m1 tin with
+  | [] -> (else_cont ()) tin
+  | xs -> xs
 
 (*e: function [[Matching_generic.monadic_if_fail]] *)
 
@@ -195,7 +197,11 @@ let (fail : tin -> tout) =
 (*e: function [[Matching_generic.fail]] *)
 
 let or_list m a bs =
-  let rec aux xs = match xs with [] -> fail | b :: bs -> m a b >||> aux bs in
+  let rec aux xs =
+    match xs with
+    | [] -> fail
+    | b :: bs -> m a b >||> aux bs
+  in
   aux bs
 
 (* Since OCaml 4.08 you can define your own let operators!
@@ -488,7 +494,9 @@ let (m_option : 'a matcher -> 'a option matcher) =
   match (a, b) with
   | None, None -> return ()
   | Some xa, Some xb -> f xa xb
-  | None, _ | Some _, _ -> fail ()
+  | None, _
+  | Some _, _ ->
+      fail ()
 
 (*e: function [[Matching_generic.m_option]] *)
 
@@ -500,7 +508,9 @@ let m_option_ellipsis_ok f a b =
   (* dots: ... can match 0 or 1 expression *)
   | Some { G.e = G.Ellipsis _; _ }, None -> return ()
   | Some xa, Some xb -> f xa xb
-  | None, _ | Some _, _ -> fail ()
+  | None, _
+  | Some _, _ ->
+      fail ()
 
 (*e: function [[Matching_generic.m_option_ellipsis_ok]] *)
 
@@ -521,7 +531,8 @@ let m_option_none_can_match_some f a b =
 (*s: function [[Matching_generic.m_ref]] *)
 let (m_ref : 'a matcher -> 'a ref matcher) =
  fun f a b ->
-  match (a, b) with { contents = xa }, { contents = xb } -> f xa xb
+  match (a, b) with
+  | { contents = xa }, { contents = xb } -> f xa xb
 
 (*e: function [[Matching_generic.m_ref]] *)
 
@@ -534,7 +545,9 @@ let rec m_list f a b =
   match (a, b) with
   | [], [] -> return ()
   | xa :: aas, xb :: bbs -> f xa xb >>= fun () -> m_list f aas bbs
-  | [], _ | _ :: _, _ -> fail ()
+  | [], _
+  | _ :: _, _ ->
+      fail ()
 
 (*e: function [[Matching_generic.m_list]] *)
 
@@ -569,7 +582,9 @@ let rec m_list_with_dots f is_dots less_is_ok xsa xsb =
   (* the general case *)
   | xa :: aas, xb :: bbs ->
       f xa xb >>= fun () -> m_list_with_dots f is_dots less_is_ok aas bbs
-  | [], _ | _ :: _, _ -> fail ()
+  | [], _
+  | _ :: _, _ ->
+      fail ()
 
 (*e: function [[Matching_generic.m_list_with_dots]] *)
 
@@ -637,7 +652,9 @@ let m_comb_1toN m_1toN a bs : _ comb_result =
  fun tin ->
   bs |> all_splits
   |> List.filter_map (fun (l, r) ->
-         match m_1toN a l tin with [] -> None | tout -> Some (r, tout))
+         match m_1toN a l tin with
+         | [] -> None
+         | tout -> Some (r, tout))
 
 (* ---------------------------------------------------------------------- *)
 (* stdlib: bool/int/string/... *)
@@ -776,7 +793,9 @@ let m_ellipsis_or_metavar_or_string a b =
 
 (*s: function [[Matching_generic.m_other_xxx]] *)
 let m_other_xxx a b =
-  match (a, b) with a, b when a =*= b -> return () | _ -> fail ()
+  match (a, b) with
+  | a, b when a =*= b -> return ()
+  | _ -> fail ()
 
 (*e: function [[Matching_generic.m_other_xxx]] *)
 (*e: semgrep/matching/Matching_generic.ml *)

--- a/semgrep-core/src/matching/Normalize_generic.ml
+++ b/semgrep-core/src/matching/Normalize_generic.ml
@@ -67,7 +67,11 @@ let normalize_import_opt is_pattern i =
       full_module_name is_pattern module_name None >>= fun x -> Some (t, x)
   | ImportAll (t, module_name, _t2) ->
       full_module_name is_pattern module_name None >>= fun x -> Some (t, x)
-  | Package _ | PackageEnd _ | Pragma _ | OtherDirective _ -> None
+  | Package _
+  | PackageEnd _
+  | Pragma _
+  | OtherDirective _ ->
+      None
 
 (*e: function [[Normalize_generic.normalize_import_opt]] *)
 
@@ -89,12 +93,16 @@ let rec eval x : constness option =
       let literals =
         args |> unbracket
         |> Common.map_filter (fun arg ->
-               match arg with Arg e -> eval e | _ -> None)
+               match arg with
+               | Arg e -> eval e
+               | _ -> None)
       in
       let strs =
         literals
         |> Common.map_filter (fun lit ->
-               match lit with Lit (String (s1, _)) -> Some s1 | _ -> None)
+               match lit with
+               | Lit (String (s1, _)) -> Some s1
+               | _ -> None)
       in
       let concated = String.concat "" strs in
       let all_args_are_string =

--- a/semgrep-core/src/metachecking/Check_pattern.ml
+++ b/semgrep-core/src/metachecking/Check_pattern.ml
@@ -5,10 +5,32 @@
 let lang_has_no_dollar_ids =
   Lang.(
     function
-    | Python | Python2 | Python3 | Java | Go | C | Cplusplus | OCaml | JSON
-    | Yaml | HCL | Csharp | Kotlin | Lua | R | HTML ->
+    | Python
+    | Python2
+    | Python3
+    | Java
+    | Go
+    | C
+    | Cplusplus
+    | OCaml
+    | JSON
+    | Yaml
+    | HCL
+    | Csharp
+    | Kotlin
+    | Lua
+    | R
+    | HTML ->
         true
-    | Javascript | Typescript | Vue | Ruby | PHP | Hack | Bash | Rust | Scala ->
+    | Javascript
+    | Typescript
+    | Vue
+    | Ruby
+    | PHP
+    | Hack
+    | Bash
+    | Rust
+    | Scala ->
         false)
 
 (*e: constant [[Check_semgrep.lang_has_no_dollar_ids]] *)

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -87,7 +87,8 @@ let check_formula env lang f =
     | Leaf (P _) -> ()
     | Leaf (MetavarCond _) -> ()
     | Not (_, f) -> find_dupe f
-    | Or (t, xs) | And (t, xs) ->
+    | Or (t, xs)
+    | And (t, xs) ->
         let rec aux xs =
           match xs with
           | [] -> ()

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -130,7 +130,9 @@ let rec (remove_not : Rule.formula -> Rule.formula option) =
   | R.Leaf x -> Some (R.Leaf x)
 
 let remove_not_final f =
-  match remove_not f with Some f -> f | None -> failwith "no formula"
+  match remove_not f with
+  | Some f -> f
+  | None -> failwith "no formula"
 
 type step0 = L of Rule.leaf
 (*old: does not work: | Not of Rule.leaf | Pos of Rule.leaf *)
@@ -226,7 +228,9 @@ and leaf_step1 f =
 *)
 
 let rec (and_step1 : cnf_step0 -> cnf_step1) =
- fun cnf -> match cnf with And xs -> And (xs |> Common.map_filter or_step1)
+ fun cnf ->
+  match cnf with
+  | And xs -> And (xs |> Common.map_filter or_step1)
 
 and or_step1 cnf =
   match cnf with
@@ -457,8 +461,9 @@ let regexp_prefilter_of_formula f =
             (* run_cnf_step2 (And [Or [Idents ["jsonwebtoken"]]]) big_str *)
           with
           (* can happen in spacegrep rules as we don't extract anything from t *)
-          | EmptyAnd | EmptyOr ->
-            true )
+          | EmptyAnd
+          | EmptyOr ->
+              true )
   with GeneralPattern -> None
 
 let regexp_prefilter_of_taint_rule rule_tok taint_spec =

--- a/semgrep-core/src/optimizing/Caching.ml
+++ b/semgrep-core/src/optimizing/Caching.ml
@@ -119,7 +119,9 @@ let add_one k name_counts =
   | Some n -> Name_counts.add k (n + 1) name_counts
 
 let get_count k name_counts =
-  match Name_counts.find_opt k name_counts with None -> 0 | Some n -> n
+  match Name_counts.find_opt k name_counts with
+  | None -> 0
+  | Some n -> n
 
 let diff_count k ~new_counts ~old_counts =
   let n = get_count k new_counts - get_count k old_counts in
@@ -134,13 +136,17 @@ let diff_backrefs bound_metavars ~new_backref_counts ~old_backref_counts =
           diff_count k ~new_counts:new_backref_counts
             ~old_counts:old_backref_counts
         in
-        match added_backref_count with 0 -> Set_.add k acc | _ -> acc)
+        match added_backref_count with
+        | 0 -> Set_.add k acc
+        | _ -> acc)
       bound_metavars Set_.empty
   in
   Set_.diff bound_metavars not_backrefs_in_rest_of_pattern
 
 let is_ellipsis_stmt (x : stmt) =
-  match x.s with ExprStmt ({ e = Ellipsis _; _ }, _) -> true | _ -> false
+  match x.s with
+  | ExprStmt ({ e = Ellipsis _; _ }, _) -> true
+  | _ -> false
 
 (*
    Decorate a pattern and target ASTs to make the suitable for memoization
@@ -324,7 +330,9 @@ module Cache_key = struct
 
   let show_compact k =
     sprintf "%s %s %s %B %i %i" (show_env k.min_env)
-      (match k.function_id with Match_deep -> "deep" | Match_list -> "list")
+      (match k.function_id with
+      | Match_deep -> "deep"
+      | Match_list -> "list")
       (match k.list_kind with
       | Original -> "orig"
       | Flattened_until last_id ->
@@ -443,13 +451,17 @@ module Cache = struct
 
   let print_cache_access k opt_res =
     printf "access %s %s\n"
-      (match opt_res with None -> "*" | Some _ -> " ")
+      (match opt_res with
+      | None -> "*"
+      | Some _ -> " ")
       (Cache_key.show_compact k)
 
   let match_stmt_list ~access ~(cache : _ list t) ~function_id ~list_kind
       ~less_is_ok ~compute ~(pattern : pattern) ~(target : target) acc =
     match (pattern, target) with
-    | [], _ | _, [] -> compute pattern target acc
+    | [], _
+    | _, [] ->
+        compute pattern target acc
     | a :: _, b :: _ -> (
         let mv : Env.t = access.get_mv_field acc in
         let key : Cache_key.t =
@@ -468,7 +480,9 @@ module Cache = struct
         | Some res -> (
             incr cache_hits;
             let backrefs =
-              match a.s_backrefs with None -> assert false | Some x -> x
+              match a.s_backrefs with
+              | None -> assert false
+              | Some x -> x
             in
             match res with
             | [] -> []

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -76,12 +76,16 @@ let parse_pattern lang ?(print_errors = false) str =
         let res = Parse_hcl_tree_sitter.parse_pattern str in
         extract_pattern_from_tree_sitter_result res print_errors
     (* use pfff *)
-    | Lang.Python | Lang.Python2 | Lang.Python3 ->
+    | Lang.Python
+    | Lang.Python2
+    | Lang.Python3 ->
         let parsing_mode = Parse_target.lang_to_python_parsing_mode lang in
         let any = Parse_python.any_of_string ~parsing_mode str in
         Python_to_generic.any any
     (* abusing JS parser so no need extend tree-sitter grammar*)
-    | Lang.Typescript | Lang.Javascript | Lang.Vue ->
+    | Lang.Typescript
+    | Lang.Javascript
+    | Lang.Vue ->
         let any = Parse_js.any_of_string str in
         Js_to_generic.any any
     | Lang.JSON ->

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -520,7 +520,9 @@ and parse_formula_old env ((key, value) : key * G.expr) : R.formula_old =
       let x = parse_string_wrap env key value in
       let xpat = R.mk_xpat (Comby (fst x)) x in
       R.Pat xpat
-  | "metavariable-regex" | "metavariable-pattern" | "metavariable-comparison"
+  | "metavariable-regex"
+  | "metavariable-pattern"
+  | "metavariable-comparison"
   | "pattern-where-python" ->
       R.PatExtra (t, parse_extra env key value)
   (* fix suggestions *)
@@ -659,7 +661,8 @@ let parse_severity ~id (s, t) =
 
 let parse_mode env mode_opt (rule_dict : dict) : R.mode =
   match mode_opt with
-  | None | Some ("search", _) ->
+  | None
+  | Some ("search", _) ->
       let formula = parse_formula env rule_dict in
       R.Search formula
   | Some ("taint", _) ->

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -165,9 +165,15 @@ let (run :
   let xs =
     match () with
     | _ when !Flag.tree_sitter_only ->
-        xs |> Common.exclude (function Pfff _ -> true | _ -> false)
+        xs
+        |> Common.exclude (function
+             | Pfff _ -> true
+             | _ -> false)
     | _ when !Flag.pfff_only ->
-        xs |> Common.exclude (function TreeSitter _ -> true | _ -> false)
+        xs
+        |> Common.exclude (function
+             | TreeSitter _ -> true
+             | _ -> false)
     | _ -> xs
   in
   match run_either file xs with
@@ -255,7 +261,9 @@ let rec just_parse_with_lang lang file =
         ]
         C_to_generic.program
   (* use pfff *)
-  | Lang.Python | Lang.Python2 | Lang.Python3 ->
+  | Lang.Python
+  | Lang.Python2
+  | Lang.Python3 ->
       let parsing_mode = lang_to_python_parsing_mode lang in
       run file
         [ Pfff (throw_tokens (Parse_python.parse ~parsing_mode)) ]

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -101,7 +101,10 @@ let as_expr : stmt_or_expr -> G.expr = function
   | Stmt (loc, st) -> expr_of_stmt loc st
   | Expr (loc, e) -> e
 
-let stmt_or_expr_loc = function Stmt (loc, _) | Expr (loc, _) -> loc
+let stmt_or_expr_loc = function
+  | Stmt (loc, _)
+  | Expr (loc, _) ->
+      loc
 
 let block : stmt_or_expr list -> stmt_or_expr = function
   | [ x ] -> x
@@ -307,7 +310,8 @@ and expansion (x : expansion) : G.expr =
   | Simple_expansion (loc, dollar_tok, var_name) ->
       let arg =
         match var_name with
-        | Simple_variable_name name | Special_variable_name name ->
+        | Simple_variable_name name
+        | Special_variable_name name ->
             G.Arg (G.N (G.Id (name, G.empty_id_info ())) |> G.e)
       in
       let func = G.N (G.Id (("$", dollar_tok), G.empty_id_info ())) |> G.e in

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -178,16 +178,41 @@ let make_scalar _anchor _tag pos value env : G.expr =
     (* TODO: emma: I will put "" back to Null and have either a warning or
      * an error when we try to parse a string and get Null in another PR.
      *)
-    | "null" | "NULL" | "Null" | "~" -> G.L (G.Null token)
-    | "y" | "Y" | "yes" | "Yes" | "YES" | "true" | "True" | "TRUE" | "on" | "On"
+    | "null"
+    | "NULL"
+    | "Null"
+    | "~" ->
+        G.L (G.Null token)
+    | "y"
+    | "Y"
+    | "yes"
+    | "Yes"
+    | "YES"
+    | "true"
+    | "True"
+    | "TRUE"
+    | "on"
+    | "On"
     | "ON" ->
         G.L (G.Bool (true, token))
-    | "n" | "N" | "no" | "No" | "NO" | "false" | "False" | "FALSE" | "off"
-    | "Off" | "OFF" ->
+    | "n"
+    | "N"
+    | "no"
+    | "No"
+    | "NO"
+    | "false"
+    | "False"
+    | "FALSE"
+    | "off"
+    | "Off"
+    | "OFF" ->
         G.L (G.Bool (false, token))
     | "-.inf" -> G.L (G.Float (Some neg_infinity, token))
     | ".inf" -> G.L (G.Float (Some neg_infinity, token))
-    | ".nan" | ".NaN" | ".NAN" -> G.L (G.Float (Some nan, token))
+    | ".nan"
+    | ".NaN"
+    | ".NAN" ->
+        G.L (G.Float (Some nan, token))
     | _ -> (
         try G.L (G.Float (Some (float_of_string value), token))
         with _ -> G.L (G.String (value, token))))
@@ -243,7 +268,11 @@ let parse (env : env) : G.expr list =
     | E.Document_end _, pos -> (node_ast, pos)
     | v, pos -> error "Expected end of document, got" v pos env
   and read_node ?node_val:(res = None) () : G.expr * E.pos =
-    let res = match res with None -> do_parse env | Some r -> r in
+    let res =
+      match res with
+      | None -> do_parse env
+      | Some r -> r
+    in
     match res with
     | E.Alias { anchor }, pos -> (G.N (make_alias anchor pos env) |> G.e, pos)
     | E.Scalar { anchor; tag; value; _ }, pos ->
@@ -315,7 +344,11 @@ let last_same_whitespace whitespace context =
 let union_whitespace e_sp w_sp =
   let esp_len = String.length e_sp in
   let check_esp i c =
-    if i < esp_len then match e_sp.[i] with ' ' -> c | c1 -> c1 else c
+    if i < esp_len then
+      match e_sp.[i] with
+      | ' ' -> c
+      | c1 -> c1
+    else c
   in
   String.mapi check_esp w_sp
 
@@ -359,7 +392,10 @@ let split_whitespace line =
     if i = line_len then (line, "")
     else
       match line.[i] with
-      | ' ' | '\t' | '-' -> read_string (i + 1)
+      | ' '
+      | '\t'
+      | '-' ->
+          read_string (i + 1)
       | _ -> (substring line 0 i, substring line i line_len)
   in
   let whitespace, line = read_string 0 in

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -392,7 +392,9 @@ and number = function
 (*e: function [[Python_to_generic.number]] *)
 
 (*s: function [[Python_to_generic.boolop]] *)
-and boolop = function And -> G.And | Or -> G.Or
+and boolop = function
+  | And -> G.And
+  | Or -> G.Or
 
 (*e: function [[Python_to_generic.boolop]] *)
 
@@ -775,7 +777,8 @@ and stmt_aux x =
         (fun (a, b) ->
           G.DirectiveStmt (G.ImportFrom (t, v1, a, b) |> G.d) |> G.s)
         v2
-  | Global (t, v1) | NonLocal (t, v1) ->
+  | Global (t, v1)
+  | NonLocal (t, v1) ->
       let v1 = list name v1 in
       v1
       |> List.map (fun x ->
@@ -858,7 +861,9 @@ and decorator (t, v1, v2) =
   let v1 = dotted_name v1 in
   let v2 = option (bracket (list argument)) v2 in
   let args =
-    match v2 with Some (t1, x, t2) -> (t1, x, t2) | None -> G.fake_bracket []
+    match v2 with
+    | Some (t1, x, t2) -> (t1, x, t2)
+    | None -> G.fake_bracket []
   in
   let name = H.name_of_ids v1 in
   G.NamedAttr (t, name, args)
@@ -887,7 +892,9 @@ let any = function
   | Stmt v1 -> (
       let v1 = stmt v1 in
       (* in Python Assign is a stmt but in the generic AST it's an expression*)
-      match v1.G.s with G.ExprStmt (x, _t) -> G.E x | _ -> G.S v1)
+      match v1.G.s with
+      | G.ExprStmt (x, _t) -> G.E x
+      | _ -> G.S v1)
   | Stmts v1 ->
       let v1 = list_stmt v1 in
       G.Ss v1

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -35,7 +35,10 @@ let option = Common.map_opt
 
 let list = Common.map
 
-let either f g x = match x with Left x -> Left (f x) | Right x -> Right (g x)
+let either f g x =
+  match x with
+  | Left x -> Left (f x)
+  | Right x -> Right (g x)
 
 let string = id
 
@@ -83,7 +86,9 @@ and assignOp = function
       let v1 = arithOp v1 in
       Right (v1, tok)
 
-and fixOp = function Dec -> G.Decr | Inc -> G.Incr
+and fixOp = function
+  | Dec -> G.Decr
+  | Inc -> G.Incr
 
 and binaryOp = function
   | Arith v1 ->
@@ -166,7 +171,9 @@ and parameter_classic { p_type; p_name } =
     pinfo = G.empty_id_info ();
   }
 
-and struct_kind = function Struct -> G.OT_StructName | Union -> G.OT_UnionName
+and struct_kind = function
+  | Struct -> G.OT_StructName
+  | Union -> G.OT_UnionName
 
 and expr e =
   (match e with
@@ -459,7 +466,9 @@ and directive = function
   | OtherDirective (v1, v2) ->
       let v1 = name v1 in
       let v2 =
-        match v2 with None -> [] | Some s -> [ G.E (G.L (G.String s) |> G.e) ]
+        match v2 with
+        | None -> []
+        | Some s -> [ G.E (G.L (G.String s) |> G.e) ]
       in
       G.DirectiveStmt (G.Pragma (v1, v2) |> G.d)
 

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -242,7 +242,9 @@ and map_base env = function
   | CLong -> CLong
   | CLongLong -> CLongLong
 
-and map_sign env = function Signed -> Signed | UnSigned -> UnSigned
+and map_sign env = function
+  | Signed -> Signed
+  | UnSigned -> UnSigned
 
 and map_floatType env = function
   | CFloat -> CFloat
@@ -396,7 +398,9 @@ and map_expr env x : G.expr =
 
 and map_ident_info env { i_scope = _v_i_scope } = todo env ()
 
-and map_special env = function This -> This | Defined -> Defined
+and map_special env = function
+  | This -> This
+  | Defined -> Defined
 
 and map_argument env x : G.argument =
   match x with
@@ -460,7 +464,9 @@ and map_constant env x : G.literal =
       let v1 = map_tok env v1 in
       todo env v1
 
-and map_isWchar env = function IsWchar -> IsWchar | IsChar -> IsChar
+and map_isWchar env = function
+  | IsWchar -> IsWchar
+  | IsChar -> IsChar
 
 and map_unaryOp env = function
   | UnPlus -> UnPlus
@@ -479,9 +485,13 @@ and map_assignOp env = function
       let v1 = map_wrap env (map_arithOp env) v1 in
       todo env v1
 
-and map_fixOp env = function Dec -> Dec | Inc -> Inc
+and map_fixOp env = function
+  | Dec -> Dec
+  | Inc -> Inc
 
-and map_dotOp env = function Dot -> Dot | Arrow -> Arrow
+and map_dotOp env = function
+  | Dot -> Dot
+  | Arrow -> Arrow
 
 and map_binaryOp env = function
   | Arith v1 ->
@@ -513,7 +523,9 @@ and map_logicalOp env = function
   | AndLog -> AndLog
   | OrLog -> OrLog
 
-and map_ptrOp env = function PtrStarOp -> PtrStarOp | PtrOp -> PtrOp
+and map_ptrOp env = function
+  | PtrStarOp -> PtrStarOp
+  | PtrOp -> PtrOp
 
 and map_allocOp env = function
   | NewOp -> NewOp
@@ -521,7 +533,9 @@ and map_allocOp env = function
   | NewArrayOp -> NewArrayOp
   | DeleteArrayOp -> DeleteArrayOp
 
-and map_accessop env = function ParenOp -> ParenOp | ArrayOp -> ArrayOp
+and map_accessop env = function
+  | ParenOp -> ParenOp
+  | ArrayOp -> ArrayOp
 
 and map_operator env = function
   | BinaryOp v1 ->

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -68,7 +68,9 @@ let ii_of_any = Lib_parsing_go.ii_of_any
 (* TODO? do results "parameters" can have names? *)
 let return_type_of_results results =
   match results with
-  | [] | [ G.ParamClassic { G.ptype = None; _ } ] -> None
+  | []
+  | [ G.ParamClassic { G.ptype = None; _ } ] ->
+      None
   | [ G.ParamClassic { G.ptype = Some t; _ } ] -> Some t
   | xs ->
       Some
@@ -490,7 +492,11 @@ let top_func () =
         let v2 = option expr v2 in
         let v3 = option simple v3 in
         (* TODO: some of v1 are really ForInitVar *)
-        let init = match v1 with None -> [] | Some e -> [ G.ForInitExpr e ] in
+        let init =
+          match v1 with
+          | None -> []
+          | Some e -> [ G.ForInitExpr e ]
+        in
         G.ForClassic (init, v2, v3)
     | ForRange (v1, v2, v3) -> (
         let opt =

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -51,7 +51,9 @@ let fb = G.fake_bracket
 
 let id_of_entname = function
   | G.EN (Id (id, idinfo)) -> (id, idinfo)
-  | G.EN _ | G.EDynamic _ -> raise Impossible
+  | G.EN _
+  | G.EDynamic _ ->
+      raise Impossible
 
 let entity_to_param { G.name; attrs; tparams = _unused } t =
   let id, info = id_of_entname name in
@@ -167,7 +169,9 @@ and modifiers v = list modifier v
 and annotation (t, v1, v2) =
   let v1 = qualified_ident v1 in
   let xs =
-    match v2 with None -> fb [] | Some x -> bracket annotation_element x
+    match v2 with
+    | None -> fb []
+    | Some x -> bracket annotation_element x
   in
   let name = H.name_of_ids v1 in
   G.NamedAttr (t, name, xs)
@@ -394,7 +398,9 @@ and expr e =
       x.G.e)
   |> G.e
 
-and expr_or_type = function Left e -> G.E (expr e) | Right t -> G.T (typ t)
+and expr_or_type = function
+  | Left e -> G.E (expr e)
+  | Right t -> G.T (typ t)
 
 and argument v =
   let v = expr v in
@@ -544,7 +550,8 @@ and init = function
 and parameters v = List.map parameter_binding v
 
 and parameter_binding = function
-  | ParamClassic v | ParamReceiver v ->
+  | ParamClassic v
+  | ParamReceiver v ->
       let ent, t = var v in
       G.ParamClassic (entity_to_param ent t)
   | ParamSpread (tk, v) ->
@@ -663,7 +670,9 @@ and import = function
 and directive = function
   | Import (static, v2) ->
       let d_attrs =
-        match static with None -> [] | Some t -> [ G.attr G.Static t ]
+        match static with
+        | None -> []
+        | Some t -> [ G.attr G.Static t ]
       in
       G.DirectiveStmt { G.d = import v2; d_attrs } |> G.s
   | Package (t, qu, _t2) ->

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -160,7 +160,9 @@ let special (x, tok) =
    TODO: see if this is an issue with other languages besides javascript.
 *)
 let as_block stmt =
-  match stmt.G.s with G.Block _ -> stmt | _ -> G.Block (fb [ stmt ]) |> G.s
+  match stmt.G.s with
+  | G.Block _ -> stmt
+  | _ -> G.Block (fb [ stmt ]) |> G.s
 
 let rec property_name = function
   | PN v1 ->
@@ -580,7 +582,11 @@ and argument x = expr x
 and attribute = function
   | KeywordAttr x -> G.KeywordAttr (keyword_attribute x)
   | NamedAttr (t, ids, opt) ->
-      let t1, args, t2 = match opt with Some x -> x | None -> fb [] in
+      let t1, args, t2 =
+        match opt with
+        | Some x -> x
+        | None -> fb []
+      in
       let args = list argument args |> List.map G.arg in
       let name = H.name_of_ids ids in
       G.NamedAttr (t, name, (t1, args, t2))

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -159,7 +159,11 @@ and stmt e : G.stmt =
   | If (t, v1, v2, v3) ->
       let v1 = expr v1
       and v2 = stmt v2
-      and v3 = match v3 with None -> None | Some x -> Some (stmt x) in
+      and v3 =
+        match v3 with
+        | None -> None
+        | Some x -> Some (stmt x)
+      in
       G.If (t, v1, v2, v3) |> G.s
   (* alt: could be a G.Seq expr *)
   | Sequence (l, v1, r) ->
@@ -212,7 +216,9 @@ and stmt e : G.stmt =
        * ExprStmt for Ellipsis otherwise Generic_vs_generic will not work.
        *)
       match e.G.e with
-      | G.Ellipsis _ | G.DeepEllipsis _ -> G.exprstmt e
+      | G.Ellipsis _
+      | G.DeepEllipsis _ ->
+          G.exprstmt e
       | _ -> G.OtherStmt (G.OS_ExprStmt2, [ G.E e ]) |> G.s)
 
 and option_expr_to_ctor_arguments v =
@@ -373,7 +379,12 @@ and expr e =
       let t = todo_category t in
       let xs = list expr xs in
       G.OtherExpr (G.OE_Todo, G.TodoK t :: List.map (fun x -> G.E x) xs)
-  | If _ | Try _ | For _ | While _ | Sequence _ | Match _ ->
+  | If _
+  | Try _
+  | For _
+  | While _
+  | Sequence _
+  | Match _ ->
       let s = stmt e in
       let x = G.stmt_to_expr s in
       x.G.e)
@@ -414,7 +425,9 @@ and argument = function
 
 and match_case (v1, (v3, _t, v2)) =
   let v1 = pattern v1 and v2 = expr v2 and v3 = option expr v3 in
-  match v3 with None -> (v1, v2) | Some x -> (G.PatWhen (v1, x), v2)
+  match v3 with
+  | None -> (v1, v2)
+  | Some x -> (G.PatWhen (v1, x), v2)
 
 and for_direction = function
   | To v1 ->
@@ -425,7 +438,9 @@ and for_direction = function
       (v1, G.Minus, G.GtE)
 
 and rec_opt v =
-  match v with None -> [] | Some t -> [ G.KeywordAttr (G.Recursive, t) ]
+  match v with
+  | None -> []
+  | Some t -> [ G.KeywordAttr (G.Recursive, t) ]
 
 and pattern = function
   | PatEllipsis v1 ->
@@ -688,7 +703,10 @@ and partial = function
        * we convert 'let x = a in b' in a sequence of VarDef and expr,
        * so those PartialLetIn are converted in a simple statement pattern
        *)
-      match defs with [] -> raise Impossible | [ x ] -> G.S x | xs -> G.Ss xs)
+      match defs with
+      | [] -> raise Impossible
+      | [ x ] -> G.S x
+      | xs -> G.Ss xs)
 
 and any = function
   | E x -> (

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -412,7 +412,9 @@ and argument e =
   let e = expr e in
   G.arg e
 
-and special = function This -> G.This | Eval -> G.Eval
+and special = function
+  | This -> G.This
+  | Eval -> G.Eval
 
 and foreach_pattern v =
   let v = expr v in

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -115,7 +115,11 @@ let rec expr e =
       let special = G.IdSpecial (G.Spread, t) |> G.e in
       G.Call (special, fb xs)
   | CodeBlock ((t1, _, t2), params_opt, xs) ->
-      let params = match params_opt with None -> [] | Some xs -> xs in
+      let params =
+        match params_opt with
+        | None -> []
+        | Some xs -> xs
+      in
       let params = list formal_param params in
       let st = G.Block (t1, list_stmts xs, t2) |> G.s in
       let def =
@@ -238,7 +242,9 @@ and method_name mn =
   | MethodIdAssign (id, teq, id_kind) ->
       let s, t = variable (id, id_kind) in
       Left (s ^ "=", PI.combine_infos t [ teq ])
-  | MethodUOperator (_, t) | MethodOperator (_, t) -> Left (PI.str_of_info t, t)
+  | MethodUOperator (_, t)
+  | MethodOperator (_, t) ->
+      Left (PI.str_of_info t, t)
   | MethodSpecialCall (l, (), _r) ->
       let special = ident ("call", l) in
       Left special
@@ -268,7 +274,9 @@ and string_contents tok = function
       |> G.e
 
 and method_name_to_any mn =
-  match method_name mn with Left id -> G.I id | Right e -> G.E e
+  match method_name mn with
+  | Left id -> G.I id
+  | Right e -> G.E e
 
 and binary_msg = function
   | Op_PLUS -> G.Plus
@@ -294,16 +302,20 @@ and binary_msg = function
   | Op_NMATCH -> G.NotMatch
   | Op_DOT2 -> G.Range
   (* never in Binop, only in DotAccess or MethodDef *)
-  | Op_AREF | Op_ASET -> raise Impossible
+  | Op_AREF
+  | Op_ASET ->
+      raise Impossible
 
 and binary (op, t) e1 e2 =
   match op with
   | B msg ->
       let op = binary_msg msg in
       G.Call (G.IdSpecial (G.Op op, t) |> G.e, fb [ G.Arg e1; G.Arg e2 ])
-  | Op_kAND | Op_AND ->
+  | Op_kAND
+  | Op_AND ->
       G.Call (G.IdSpecial (G.Op G.And, t) |> G.e, fb [ G.Arg e1; G.Arg e2 ])
-  | Op_kOR | Op_OR ->
+  | Op_kOR
+  | Op_OR ->
       G.Call (G.IdSpecial (G.Op G.Or, t) |> G.e, fb [ G.Arg e1; G.Arg e2 ])
   | Op_ASSIGN -> G.Assign (e1, t, e2)
   | Op_OP_ASGN op ->
@@ -419,7 +431,9 @@ and stmt st =
       let special = G.IdSpecial (G.Op G.Not, t) |> G.e in
       let e = G.Call (special, fb [ G.Arg e ]) |> G.e in
       let st1 =
-        match elseopt with None -> G.Block (fb []) |> G.s | Some st -> st
+        match elseopt with
+        | None -> G.Block (fb []) |> G.s
+        | Some st -> st
       in
       G.If (t, e, st1, Some st) |> G.s
   | For (t1, pat, t2, e, st) ->
@@ -491,7 +505,9 @@ and type_ e =
   H.expr_to_type e
 
 and option_tok_stmts x =
-  match x with None -> None | Some (_t, xs) -> Some (list_stmt1 xs)
+  match x with
+  | None -> None
+  | Some (_t, xs) -> Some (list_stmt1 xs)
 
 and definition def =
   match def with

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -271,7 +271,9 @@ and v_type_kind = function
   | TyRefined (v1, v2) ->
       let v1 = v_option v_type_ v1 and _lb, defs, _rb = v_refinement v2 in
       todo_type "TyRefined"
-        ((match v1 with None -> [] | Some t -> [ G.T t ])
+        ((match v1 with
+         | None -> []
+         | Some t -> [ G.T t ])
         @ (defs |> List.map (fun def -> G.Def def)))
   | TyExistential (v1, v2, v3) ->
       let v1 = v_type_ v1 in
@@ -338,7 +340,11 @@ and v_pattern = function
       let ids = v_dotted_name_of_stable_id v1 in
       let _v2TODO = v_option (v_bracket (v_list v_type_)) v2 in
       let v3 = v_option (v_bracket (v_list v_pattern)) v3 in
-      let xs = match v3 with None -> [] | Some (_, xs, _) -> xs in
+      let xs =
+        match v3 with
+        | None -> []
+        | Some (_, xs, _) -> xs
+      in
       let name = H.name_of_ids ids in
       G.PatConstructor (name, xs)
   | PatInfix (v1, v2, v3) ->
@@ -360,14 +366,18 @@ and v_expr e =
   | DeepEllipsis v1 -> G.DeepEllipsis (v_bracket v_expr v1)
   | L v1 -> (
       let v1 = v_literal v1 in
-      match v1 with Left lit -> G.L lit | Right e -> e.G.e)
+      match v1 with
+      | Left lit -> G.L lit
+      | Right e -> e.G.e)
   | Tuple v1 ->
       let v1 = v_bracket (v_list v_expr) v1 in
       G.Container (G.Tuple, v1)
   | Name v1 ->
       let sref, ids = v_path v1 in
       let start =
-        match sref with Left id -> G.N (H.name_of_id id) | Right e -> e.G.e
+        match sref with
+        | Left id -> G.N (H.name_of_id id)
+        | Right e -> e.G.e
       in
       ids
       |> List.fold_left
@@ -474,7 +484,9 @@ and v_case_clause
   let guardopt = v_option v_guard v_caseguard in
   let block = v_block v_casebody in
   let pat =
-    match guardopt with None -> pat | Some (_t, e) -> PatWhen (pat, e)
+    match guardopt with
+    | None -> pat
+    | Some (_t, e) -> PatWhen (pat, e)
   in
   (pat, expr_of_block block)
 
@@ -542,7 +554,11 @@ and v_stmt = function
       and v2 = v_expr_for_stmt v2
       and v3 = v_option v_catch_clause v3
       and v4 = v_option v_finally_clause v4 in
-      let catches = match v3 with None -> [] | Some xs -> xs in
+      let catches =
+        match v3 with
+        | None -> []
+        | Some xs -> xs
+      in
       G.Try (v1, v2, catches, v4) |> G.s
   | Throw (v1, v2) ->
       let v1 = v_tok v1 and v2 = v_expr v2 in
@@ -687,10 +703,14 @@ and v_type_parameter
   let constraints = [] in
   (id, constraints)
 
-and v_variance = function Covariant -> () | Contravariant -> ()
+and v_variance = function
+  | Covariant -> ()
+  | Contravariant -> ()
 
 and v_type_parameters v : G.type_parameter list =
-  match v with None -> [] | Some (_lb, xs, _rb) -> v_list v_type_parameter xs
+  match v with
+  | None -> []
+  | Some (_lb, xs, _rb) -> v_list v_type_parameter xs
 
 and v_definition x : G.definition list =
   match x with
@@ -712,7 +732,8 @@ and v_variable_definitions
   v_vpatterns
   |> Common.map_filter (fun pat ->
          match pat with
-         | PatVarid id | PatName (Id id, []) ->
+         | PatVarid id
+         | PatName (Id id, []) ->
              let ent = G.basic_entity id attrs in
              let vdef = { G.vinit = eopt; vtype = topt } in
              Some (ent, G.VarDef vdef)
@@ -753,10 +774,15 @@ and v_function_definition
     fparams = List.flatten params;
     (* TODO? *)
     frettype = tret;
-    fbody = (match fbody with None -> G.FBDecl G.sc | Some st -> st);
+    fbody =
+      (match fbody with
+      | None -> G.FBDecl G.sc
+      | Some st -> st);
   }
 
-and v_function_kind = function LambdaArrow -> G.Arrow | Def -> G.Method
+and v_function_kind = function
+  | LambdaArrow -> G.Arrow
+  | Def -> G.Method
 
 and v_fbody body : G.function_body =
   match body with
@@ -886,7 +912,9 @@ let v_any = function
       | st -> G.S st)
   | Ss b -> (
       let xs = v_block b in
-      match xs with [ s ] -> G.S s | xs -> G.Ss xs)
+      match xs with
+      | [ s ] -> G.S s
+      | xs -> G.Ss xs)
 
 (*****************************************************************************)
 (* Entry points *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -29,7 +29,9 @@ let str = H.str
    This is usually a sign that something wasn't done right.
 *)
 let map_last l f =
-  match List.rev l with [] -> [] | last :: other -> List.rev (f last :: other)
+  match List.rev l with
+  | [] -> []
+  | last :: other -> List.rev (f last :: other)
 
 (*
    The 'statement' rule returns one of 3 possible levels of constructs:
@@ -66,13 +68,17 @@ let unary_test_operator (env : env) (tok : ts_tok) : unary_test_operator wrap =
     | "-R" -> Is_shell_variable_a_name_ref
     | "-z" -> Is_empty_string
     | "-n" -> Is_nonempty_string
-    | "-a" | "-e " -> File_exists
+    | "-a"
+    | "-e " ->
+        File_exists
     | "-b" -> Is_block_special_file
     | "-c" -> Is_character_special_file
     | "-d" -> Is_directory
     | "-f" -> Is_regular_file
     | "-g" -> Has_SGID_bit
-    | "-h" | "-L" -> Is_symlink
+    | "-h"
+    | "-L" ->
+        Is_symlink
     | "-k" -> Has_sticky_bit
     | "-p" -> Is_named_pipe
     | "-r" -> Is_readable
@@ -381,7 +387,11 @@ and compound_statement (env : env) ((v1, v2, v3) : CST.compound_statement) :
   let open_ = token env v1 (* "{" *) in
   let close = token env v3 (* "}" *) in
   let loc = (open_, close) in
-  let blist = match v2 with Some x -> statements2 env x | None -> Empty loc in
+  let blist =
+    match v2 with
+    | Some x -> statements2 env x
+    | None -> Empty loc
+  in
   (open_, blist, close)
 
 and concatenation (env : env) ((v1, v2, v3) : CST.concatenation) :
@@ -409,7 +419,9 @@ and do_group (env : env) ((v1, v2, v3) : CST.do_group) : blist bracket =
   let do_ = token env v1 (* "do" *) in
   let done_ = token env v3 (* "done" *) in
   let blist =
-    match v2 with Some x -> statements2 env x | None -> Empty (do_, done_)
+    match v2 with
+    | Some x -> statements2 env x
+    | None -> Empty (do_, done_)
   in
   (do_, blist, done_)
 
@@ -418,7 +430,9 @@ and elif_clause (env : env) ((v1, v2, v3, v4) : CST.elif_clause) : elif =
   let cond = terminated_statement env v2 |> blist_of_pipeline in
   let then_ = token env v3 (* "then" *) in
   let body =
-    match v4 with Some x -> statements2 env x | None -> Empty (then_, then_)
+    match v4 with
+    | Some x -> statements2 env x
+    | None -> Empty (then_, then_)
   in
   let loc = (elif, snd (blist_loc body)) in
   (loc, elif, cond, then_, body)
@@ -426,7 +440,9 @@ and elif_clause (env : env) ((v1, v2, v3, v4) : CST.elif_clause) : elif =
 and else_clause (env : env) ((v1, v2) : CST.else_clause) : else_ =
   let else_ = token env v1 (* "else" *) in
   let body =
-    match v2 with Some x -> statements2 env x | None -> Empty (else_, else_)
+    match v2 with
+    | Some x -> statements2 env x
+    | None -> Empty (else_, else_)
   in
   let loc = (else_, snd (blist_loc body)) in
   (loc, else_, body)
@@ -453,7 +469,9 @@ and expansion (env : env) ((v1, v2, v3, v4) : CST.expansion) :
             let _v1 = token env v1 (* variable_name *) in
             let _v2 = token env v2 (* "=" *) in
             let _v3 =
-              match v3 with Some x -> Some (literal env x) | None -> None
+              match v3 with
+              | Some x -> Some (literal env x)
+              | None -> None
             in
             None
         | `Choice_subs_opt_SLASH_opt_regex_rep_choice_choice_conc (v1, v2, v3)
@@ -585,7 +603,11 @@ and file_redirect (env : env) ((v1, v2, v3) : CST.file_redirect) : todo =
   in
   (* TODO: dst_fd is missing e.g. the '2' in '>&2' *)
   let file = literal env v3 in
-  let start = match src_fd with None -> op_tok | Some tok -> tok in
+  let start =
+    match src_fd with
+    | None -> op_tok
+    | Some tok -> tok
+  in
   let _, end_ = expression_loc file in
   let loc = (start, end_) in
   TODO loc
@@ -701,7 +723,9 @@ and primary_expression (env : env) (x : CST.primary_expression) : expression =
       Expression_TODO loc
 
 and program (env : env) ~tok (opt : CST.program) : blist =
-  match opt with Some x -> statements env x | None -> Empty (tok, tok)
+  match opt with
+  | Some x -> statements env x
+  | None -> Empty (tok, tok)
 
 (*
    Read a statement as a list (of pipelines).
@@ -869,15 +893,21 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
       let for_ = token env v1 (* "for" *) in
       let header_open_ = token env v2 (* "((" *) in
       let _x () =
-        match v3 with Some x -> expression env x | None -> todo env ()
+        match v3 with
+        | Some x -> expression env x
+        | None -> todo env ()
       in
       let _x () = terminator env v4 in
       let _x () =
-        match v5 with Some x -> expression env x | None -> todo env ()
+        match v5 with
+        | Some x -> expression env x
+        | None -> todo env ()
       in
       let _x () = terminator env v6 in
       let _x () =
-        match v7 with Some x -> expression env x | None -> todo env ()
+        match v7 with
+        | Some x -> expression env x
+        | None -> todo env ()
       in
       let header_close = token env v8 (* "))" *) in
       let _x () =
@@ -911,7 +941,9 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
       in
       let elif_branches = List.map (elif_clause env) v5 in
       let else_branch =
-        match v6 with Some x -> Some (else_clause env x) | None -> None
+        match v6 with
+        | Some x -> Some (else_clause env x)
+        | None -> None
       in
       let fi = token env v7 (* "fi" *) in
       let loc = (if_, fi) in
@@ -923,7 +955,9 @@ and statement (env : env) (x : CST.statement) : tmp_stmt =
       let case = token env v1 (* "case" *) in
       let subject = literal env v2 in
       let _term =
-        match v3 with Some x -> Some (terminator env x) | None -> None
+        match v3 with
+        | Some x -> Some (terminator env x)
+        | None -> None
       in
       let in_ = token env v4 (* "in" *) in
       let _term = terminator env v5 in
@@ -1043,7 +1077,9 @@ and statements (env : env) ((v1, v2, v3, v4) : CST.statements) : blist =
     | None -> ()
   in
   let _trailing_newline =
-    match v4 with Some x -> Some (terminator env x) | None -> None
+    match v4 with
+    | Some x -> Some (terminator env x)
+    | None -> None
   in
   let loc = range (blist_loc blist) (blist_loc last_blist) in
   Seq (loc, blist, last_blist)
@@ -1078,7 +1114,11 @@ and string_ (env : env) ((v1, v2, v3, v4) : CST.string_) :
               [ Expansion (loc, Simple_expansion (loc, dollar, e)) ]
           | `Cmd_subs x -> [ Command_substitution (command_substitution env x) ]
         in
-        let _concat = match v2 with Some _tok -> () | None -> () in
+        let _concat =
+          match v2 with
+          | Some _tok -> ()
+          | None -> ()
+        in
         fragments)
       v2
     |> List.flatten
@@ -1096,9 +1136,17 @@ and subscript (env : env) ((v1, v2, v3, v4, v5, v6) : CST.subscript) :
   let var = str env v1 (* variable_name *) in
   let open_ = token env v2 (* "[" *) in
   let index = literal env v3 in
-  let _concat = match v4 with Some _tok -> () (* concat *) | None -> () in
+  let _concat =
+    match v4 with
+    | Some _tok -> () (* concat *)
+    | None -> ()
+  in
   let close = token env v5 (* "]" *) in
-  let _concat = match v6 with Some _tok -> () (* concat *) | None -> () in
+  let _concat =
+    match v6 with
+    | Some _tok -> () (* concat *)
+    | None -> ()
+  in
   (var, open_, index, close)
 
 and subshell (env : env) ((v1, v2, v3) : CST.subshell) : blist bracket =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
@@ -797,7 +797,9 @@ and declarator (env : env) (x : CST.declarator) : name * (type_ -> type_) =
   match x with
   | `Poin_decl (v1, v2, v3, v4, v5) ->
       let _v1 =
-        match v1 with Some x -> Some (ms_based_modifier env x) | None -> None
+        match v1 with
+        | Some x -> Some (ms_based_modifier env x)
+        | None -> None
       in
       let v2 = token env v2 (* "*" *) in
       let _v3 = List.map (ms_pointer_modifier env) v3 in
@@ -859,7 +861,9 @@ and enumerator_list (env : env) ((v1, v2, v3, v4) : CST.enumerator_list) =
     | None -> []
   in
   let _v3 =
-    match v3 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let _v4 = token env v4 (* "}" *) in
   v2
@@ -979,7 +983,9 @@ and field_declaration_list_item (env : env)
         | None -> []
       in
       let _v3 =
-        match v3 with Some x -> Some (bitfield_clause env x) | None -> None
+        match v3 with
+        | Some x -> Some (bitfield_clause env x)
+        | None -> None
       in
       let _v4 = token env v4 (* ";" *) in
       v2 |> List.map (fun (id, f) -> { fld_name = Some id; fld_type = f v1 })
@@ -1026,7 +1032,9 @@ and field_declarator (env : env) (x : CST.field_declarator) :
   match x with
   | `Poin_field_decl (v1, v2, v3, v4, v5) ->
       let _v1 =
-        match v1 with Some x -> Some (ms_based_modifier env x) | None -> None
+        match v1 with
+        | Some x -> Some (ms_based_modifier env x)
+        | None -> None
       in
       let v2 = token env v2 (* "*" *) in
       let _v3 = List.map (ms_pointer_modifier env) v3 in
@@ -1089,7 +1097,9 @@ and initializer_list (env : env) ((v1, v2, v3, v4) : CST.initializer_list) :
     | None -> []
   in
   let _v3 =
-    match v3 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let v4 = token env v4 (* "}" *) in
   (* TODO: can be RecordInit too! *)
@@ -1167,7 +1177,9 @@ and type_descriptor (env : env) ((v1, v2, v3, v4) : CST.type_descriptor) : type_
   let v2 = type_specifier env v2 in
   let _v3 = List.map (type_qualifier env) v3 in
   let v4 =
-    match v4 with Some x -> (abstract_declarator env x) v2 | None -> v2
+    match v4 with
+    | Some x -> (abstract_declarator env x) v2
+    | None -> v2
   in
   v4
 
@@ -1224,7 +1236,9 @@ and type_specifier (env : env) (x : CST.type_specifier) : type_ =
         | `Id_opt_enum_list (v1, v2) ->
             let v1 = identifier env v1 (* pattern [a-zA-Z_]\w* *) in
             let v2 =
-              match v2 with Some x -> enumerator_list env x | None -> []
+              match v2 with
+              | Some x -> enumerator_list env x
+              | None -> []
             in
             (Some v1, v2)
         | `Enum_list x -> (None, enumerator_list env x)
@@ -1299,7 +1313,9 @@ let expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
     | None -> None
   in
   let v2 = token env v2 (* ";" *) in
-  match v1 with Some e -> (e, v2) | None -> (Null v2, v2)
+  match v1 with
+  | Some e -> (e, v2)
+  | None -> (Null v2, v2)
 
 (* diff with declarator? *)
 let rec type_declarator (env : env) (x : CST.type_declarator) :
@@ -1307,7 +1323,9 @@ let rec type_declarator (env : env) (x : CST.type_declarator) :
   match x with
   | `Poin_type_decl (v1, v2, v3, v4, v5) ->
       let _v1 =
-        match v1 with Some x -> Some (ms_based_modifier env x) | None -> None
+        match v1 with
+        | Some x -> Some (ms_based_modifier env x)
+        | None -> None
       in
       let v2 = token env v2 (* "*" *) in
       let _v3 = List.map (ms_pointer_modifier env) v3 in
@@ -1441,7 +1459,9 @@ and declaration_list (env : env) ((v1, v2, v3) : CST.declaration_list) =
 and function_definition (env : env) ((v1, v2, v3, v4) : CST.function_definition)
     : func_def =
   let _v1 =
-    match v1 with Some x -> Some (ms_call_modifier env x) | None -> None
+    match v1 with
+    | Some x -> Some (ms_call_modifier env x)
+    | None -> None
   in
   let v2 = declaration_specifiers env v2 in
   let id, f = declarator env v3 in
@@ -1513,7 +1533,9 @@ and non_case_statement (env : env) (x : CST.non_case_statement) : stmt =
             Right e
       in
       let v4 =
-        match v4 with Some x -> Some (expression env x) | None -> None
+        match v4 with
+        | Some x -> Some (expression env x)
+        | None -> None
       in
       let _v5 = token env v5 (* ";" *) in
       let v6 =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -152,7 +152,9 @@ let name_scoped nameopt tcolcol id_or_op : name =
         match id_or_op1 with
         | IdIdent id -> QClassname id
         | IdTemplateId (id, args) -> QTemplateId (id, args)
-        | IdOperator _ | IdDestructor _ | IdConverter _ ->
+        | IdOperator _
+        | IdDestructor _
+        | IdConverter _ ->
             raise
               (Parse_info.Other_error
                  ( "invalid operator/destructor/converter qualifier",
@@ -170,7 +172,9 @@ let name_add_template_args name args =
   (top, qu, id_or_op)
 
 let trailing_comma env v =
-  match v with Some tok -> token env tok (* "," *) |> ignore | None -> ()
+  match v with
+  | Some tok -> token env tok (* "," *) |> ignore
+  | None -> ()
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -231,7 +235,8 @@ let map_type_qualifier (env : env) (x : CST.type_qualifier) :
 
 let map_virtual_function_specifier (env : env)
     (x : CST.virtual_function_specifier) =
-  match x with `Virt tok -> Virtual (token env tok)
+  match x with
+  | `Virt tok -> Virtual (token env tok)
 
 (* "virtual" *)
 
@@ -687,7 +692,9 @@ let map_concatenated_string (env : env) ((v1, v2) : CST.concatenated_string) =
   let v2 = List.map (map_anon_choice_raw_str_lit_28125b5 env) v2 in
   (* TODO: grab it from v1? *)
   let isWchar = IsChar in
-  match v2 with [] -> String (v1, isWchar) | _ -> MultiString (v1 :: v2)
+  match v2 with
+  | [] -> String (v1, isWchar)
+  | _ -> MultiString (v1 :: v2)
 
 let map_preproc_include (env : env) ((v1, v2, v3) : CST.preproc_include) =
   let v1 = token env v1 (* pattern #[ 	]*include *) in
@@ -733,7 +740,9 @@ let rec map_abstract_array_declarator (env : env)
     ((v1, v2, v3, v4, v5) : CST.abstract_array_declarator) : abstract_declarator
     =
   let v1 =
-    match v1 with Some x -> map_abstract_declarator env x | None -> id
+    match v1 with
+    | Some x -> map_abstract_declarator env x
+    | None -> id
   in
   let v2 = token env v2 (* "[" *) in
   let v3 = List.map (map_type_qualifier env) v3 in
@@ -757,7 +766,9 @@ and map_abstract_declarator (env : env) (x : CST.abstract_declarator) :
   | `Abst_ref_decl (v1, v2) ->
       let v1 = map_anon_choice_AMP_c92c117 env v1 in
       let v2 =
-        match v2 with Some x -> map_abstract_declarator env x | None -> id
+        match v2 with
+        | Some x -> map_abstract_declarator env x
+        | None -> id
       in
       fun x -> x |> v2 |> v1
 
@@ -765,7 +776,9 @@ and map_abstract_function_declarator (env : env)
     ((v1, v2, v3, v4) : CST.abstract_function_declarator) : abstract_declarator
     =
   let v1 =
-    match v1 with Some x -> map_abstract_declarator env x | None -> id
+    match v1 with
+    | Some x -> map_abstract_declarator env x
+    | None -> id
   in
   let v2 = map_parameter_list env v2 in
   let v3 =
@@ -797,7 +810,10 @@ and map_abstract_function_declarator (env : env)
             (* override ft_ret with trailing_return_type as x can actually
              * be a fake type sometimes (e.g., in lambdas)
              *)
-            ft_ret = (match v4 with None -> x | Some t -> t);
+            ft_ret =
+              (match v4 with
+              | None -> x
+              | Some t -> t);
             ft_params = v2;
             ft_specs;
             ft_const = None (* TODO *);
@@ -818,7 +834,9 @@ and map_abstract_pointer_declarator (env : env)
   let v2 = List.map (map_type_qualifier env) v2 in
   let f1 x = (v2, TPointer (v1, x, [])) in
   let v3 =
-    match v3 with Some x -> map_abstract_declarator env x | None -> id
+    match v3 with
+    | Some x -> map_abstract_declarator env x
+    | None -> id
   in
   (* TODO: bug? seems different order than in declarator *)
   fun x -> x |> v3 |> f1
@@ -853,7 +871,9 @@ and map_anon_choice_class_name_d6703e6 (env : env)
   | `Opt_class_name_opt_virt_spec_opt_base_class_clause_field_decl_list
       (v1, v2, v3, v4) ->
       let v1 =
-        match v1 with Some x -> Some (map_class_name env x) | None -> None
+        match v1 with
+        | Some x -> Some (map_class_name env x)
+        | None -> None
       in
       let v2 =
         match v2 with
@@ -861,7 +881,9 @@ and map_anon_choice_class_name_d6703e6 (env : env)
         | None -> None
       in
       let v3 =
-        match v3 with Some x -> map_base_class_clause env x | None -> []
+        match v3 with
+        | Some x -> map_base_class_clause env x
+        | None -> []
       in
       let v4 = map_field_declaration_list env v4 in
       fun ckey ->
@@ -1279,7 +1301,9 @@ and map_base_class_clause (env : env)
   in
   let v3 = map_class_name env v3 in
   let _v4TODO =
-    match v4 with Some tok -> Some (token env tok) (* "..." *) | None -> None
+    match v4 with
+    | Some tok -> Some (token env tok) (* "..." *)
+    | None -> None
   in
   let base1 = { i_name = v3; i_access = v2; i_virtual = None } in
   let v5 =
@@ -1561,7 +1585,9 @@ and map_conditional_expression (env : env)
 and map_constructor_or_destructor_declaration (env : env)
     ((v1, v2, v3) : CST.constructor_or_destructor_declaration) =
   let v1 =
-    match v1 with Some x -> map_constructor_specifiers env x | None -> []
+    match v1 with
+    | Some x -> map_constructor_specifiers env x
+    | None -> []
   in
   let { dn; dt } = map_function_declarator env v2 in
   let v3 = token env v3 (* ";" *) in
@@ -1573,11 +1599,15 @@ and map_constructor_or_destructor_declaration (env : env)
 and map_constructor_or_destructor_definition (env : env)
     ((v1, v2, v3, v4) : CST.constructor_or_destructor_definition) =
   let v1 =
-    match v1 with Some x -> map_constructor_specifiers env x | None -> []
+    match v1 with
+    | Some x -> map_constructor_specifiers env x
+    | None -> []
   in
   let { dn; dt } = map_function_declarator env v2 in
   let _v3TODO =
-    match v3 with Some x -> map_field_initializer_list env x | None -> []
+    match v3 with
+    | Some x -> map_field_initializer_list env x
+    | None -> []
   in
   let n = name_of_dname_for_function dn in
   let t = dt (nQ, TBase (Void (ii_of_name n))) in
@@ -1811,11 +1841,15 @@ and map_expression (env : env) (x : CST.expression) : expr =
       in
       let v2 = token env v2 (* "new" *) in
       let v3 =
-        match v3 with Some x -> Some (map_argument_list env x) | None -> None
+        match v3 with
+        | Some x -> Some (map_argument_list env x)
+        | None -> None
       in
       let t = map_type_specifier env v4 in
       let v5 =
-        match v5 with Some x -> map_new_declarator env x | None -> id
+        match v5 with
+        | Some x -> map_new_declarator env x
+        | None -> id
       in
       let t = v5 t in
       let v6 =
@@ -2135,7 +2169,9 @@ and map_field_initializer (env : env) ((v1, v2, v3) : CST.field_initializer) =
         Args x
   in
   let _v3TODO =
-    match v3 with Some tok -> Some (token env tok) (* "..." *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "..." *)
+    | None -> None
   in
   (v1, v2)
 
@@ -2169,7 +2205,10 @@ and map_function_declarator (env : env)
           ( nQ,
             TFunction
               {
-                ft_ret = (match ft_rets with [] -> x | y :: _ -> y);
+                ft_ret =
+                  (match ft_rets with
+                  | [] -> x
+                  | y :: _ -> y);
                 ft_params = v2;
                 ft_specs;
                 ft_const = None;
@@ -2211,7 +2250,10 @@ and map_function_field_declarator (env : env)
           ( nQ,
             TFunction
               {
-                ft_ret = (match ft_rets with [] -> x | y :: _ -> y);
+                ft_ret =
+                  (match ft_rets with
+                  | [] -> x
+                  | y :: _ -> y);
                 ft_params = v2;
                 ft_specs;
                 ft_const = None;
@@ -2332,7 +2374,9 @@ and map_new_declarator (env : env) (x : CST.new_declarator) :
       let v2 = map_expression env v2 in
       let v3 = token env v3 (* "]" *) in
       let v4 =
-        match v4 with Some x -> map_new_declarator env x | None -> id
+        match v4 with
+        | Some x -> map_new_declarator env x
+        | None -> id
       in
       fun t -> (nQ, TArray ((v1, Some v2, v3), v4 t))
 
@@ -2343,7 +2387,9 @@ and map_noexcept (env : env) ((v1, v2) : CST.noexcept) : exn_spec =
     | Some (v1, v2, v3) ->
         let v1 = token env v1 (* "(" *) in
         let v2 =
-          match v2 with Some x -> Some (map_expression env x) | None -> None
+          match v2 with
+          | Some x -> Some (map_expression env x)
+          | None -> None
         in
         let v3 = token env v3 (* ")" *) in
         Some (v1, v2, v3)
@@ -2412,7 +2458,9 @@ and map_non_case_statement (env : env) (x : CST.non_case_statement) : stmt =
             Left (eopt, sc)
       in
       let v4 =
-        match v4 with Some x -> Some (map_expression env x) | None -> None
+        match v4 with
+        | Some x -> Some (map_expression env x)
+        | None -> None
       in
       let _v5 = token env v5 (* ";" *) in
       let v6 =
@@ -2464,7 +2512,9 @@ and map_operator_cast (env : env) ((v1, v2, v3, v4) : CST.operator_cast) : name
 and map_operator_cast_declaration (env : env)
     ((v1, v2, v3, v4) : CST.operator_cast_declaration) : vars_decl =
   let v1 =
-    match v1 with Some x -> map_constructor_specifiers env x | None -> []
+    match v1 with
+    | Some x -> map_constructor_specifiers env x
+    | None -> []
   in
   let name = map_operator_cast env v2 in
   let v3 =
@@ -2490,7 +2540,9 @@ and map_operator_cast_declaration (env : env)
 and map_operator_cast_definition (env : env)
     ((v1, v2, v3) : CST.operator_cast_definition) =
   let v1 =
-    match v1 with Some x -> map_constructor_specifiers env x | None -> []
+    match v1 with
+    | Some x -> map_constructor_specifiers env x
+    | None -> []
   in
   let n = map_operator_cast env v2 in
   let v3 = map_anon_choice_comp_stmt_be91723 env v3 in
@@ -2612,7 +2664,9 @@ and map_parenthesized_field_declarator (env : env)
 and map_pointer_declarator (env : env)
     ((v1, v2, v3, v4, v5) : CST.pointer_declarator) : declarator =
   let v1 =
-    match v1 with Some x -> [ map_ms_based_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ map_ms_based_modifier env x ]
+    | None -> []
   in
   let v2 = token env v2 (* "*" *) in
   let v3 = List.map (map_ms_pointer_modifier env) v3 in
@@ -2635,7 +2689,9 @@ and map_pointer_expression (env : env) ((v1, v2) : CST.pointer_expression) :
 and map_pointer_field_declarator (env : env)
     ((v1, v2, v3, v4, v5) : CST.pointer_field_declarator) : declarator =
   let v1 =
-    match v1 with Some x -> [ map_ms_based_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ map_ms_based_modifier env x ]
+    | None -> []
   in
   let v2 = token env v2 (* "*" *) in
   let v3 = List.map (map_ms_pointer_modifier env) v3 in
@@ -2816,7 +2872,9 @@ and map_statement (env : env) (x : CST.statement) : stmt =
   | `Throw_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "throw" *) in
       let v2 =
-        match v2 with Some x -> Some (map_expression env x) | None -> None
+        match v2 with
+        | Some x -> Some (map_expression env x)
+        | None -> None
       in
       let v3 = token env v3 (* ";" *) in
       ExprStmt (Some (Throw (v1, v2)), v3)
@@ -3079,11 +3137,15 @@ and map_trailing_return_type (env : env)
     ((v1, v2, v3, v4) : CST.trailing_return_type) : type_ =
   let v1 = token env v1 (* "->" *) in
   let _v2TODO =
-    match v2 with Some x -> [ map_type_qualifier env x ] | None -> []
+    match v2 with
+    | Some x -> [ map_type_qualifier env x ]
+    | None -> []
   in
   let v3 = map_type_specifier env v3 in
   let v4 =
-    match v4 with Some x -> map_abstract_declarator env x | None -> id
+    match v4 with
+    | Some x -> map_abstract_declarator env x
+    | None -> id
   in
   v4 v3
 
@@ -3095,7 +3157,9 @@ and map_type_declarator (env : env) (x : CST.type_declarator) : declarator =
   match x with
   | `Poin_type_decl (v1, v2, v3, v4, v5) ->
       let v1 =
-        match v1 with Some x -> [ map_ms_based_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ map_ms_based_modifier env x ]
+        | None -> []
       in
       let v2 = token env v2 (* "*" *) in
       let v3 = List.map (map_ms_pointer_modifier env) v3 in
@@ -3178,7 +3242,9 @@ and map_type_descriptor (env : env) ((v1, v2, v3, v4) : CST.type_descriptor) :
   let v3 = List.map (map_type_qualifier env) v3 in
   let t = (v1 @ qs @ v3, tc) in
   let v4 =
-    match v4 with Some x -> map_abstract_declarator env x | None -> id
+    match v4 with
+    | Some x -> map_abstract_declarator env x
+    | None -> id
   in
   v4 t
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -41,7 +41,9 @@ let str = H.str
 let unhandled_keywordattr_to_namedattr env tok =
   G.unhandled_keywordattr (str env tok)
 
-let map_opt func env = function None -> None | Some x -> Some (func env x)
+let map_opt func env = function
+  | None -> None
+  | Some x -> Some (func env x)
 
 let ids_of_name (name : name) : dotted_ident =
   match name with
@@ -86,11 +88,16 @@ let type_parameters_with_constraints params constraints : type_parameter list =
             id = param)
           constraints
       in
-      match with_constraints with Some x -> x | None -> (param, []))
+      match with_constraints with
+      | Some x -> x
+      | None -> (param, []))
     params
 
 let arg_to_expr (a : argument) =
-  match a with Arg e -> e | ArgKwd (_, e) -> e | _ -> raise Impossible
+  match a with
+  | Arg e -> e
+  | ArgKwd (_, e) -> e
+  | _ -> raise Impossible
 
 let var_def_stmt (decls : (entity * variable_definition) list)
     (attrs : attribute list) =
@@ -1022,7 +1029,9 @@ and argument (env : env) ((v1, v2, v3) : CST.argument) : G.argument =
     | `Exp x -> expression env x
     | `Decl_exp x -> declaration_expression env x
   in
-  match v1 with None -> G.Arg v3 | Some id -> G.ArgKwd (id, v3)
+  match v1 with
+  | None -> G.Arg v3
+  | Some id -> G.ArgKwd (id, v3)
 
 and initializer_expression (env : env)
     ((v1, v2, v3, v4) : CST.initializer_expression) : expr list G.bracket =
@@ -1036,7 +1045,9 @@ and switch_expression_arm (env : env)
     ((v1, v2, v3, v4) : CST.switch_expression_arm) : action =
   let v1 = pattern env v1 in
   let v2 =
-    match v2 with Some x -> PatWhen (v1, when_clause env x) | None -> v1
+    match v2 with
+    | Some x -> PatWhen (v1, when_clause env x)
+    | None -> v1
   in
   let v3 = token env v3 (* "=>" *) in
   let v4 = expression env v4 in
@@ -1063,7 +1074,9 @@ and query_body (env : env) (x : CST.query_body) =
       let v1 = List.map (query_clause env) v1 in
       let v2 = select_or_group_clause env v2 in
       let v3 =
-        match v3 with Some x -> [ query_continuation env x ] | None -> []
+        match v3 with
+        | Some x -> [ query_continuation env x ]
+        | None -> []
       in
       v1 @ [ v2 ] @ v3
 
@@ -1133,7 +1146,11 @@ and expression (env : env) (x : CST.expression) : G.expr =
         | None -> []
       in
       let v2 = token env v2 (* "delegate" *) in
-      let v3 = match v3 with Some x -> parameter_list env x | None -> [] in
+      let v3 =
+        match v3 with
+        | Some x -> parameter_list env x
+        | None -> []
+      in
       let v4 = block env v4 in
       Lambda
         {
@@ -1352,7 +1369,9 @@ and expression (env : env) (x : CST.expression) : G.expr =
       let v1 = token env v1 (* "new" *) in
       let v2 = type_constraint env v2 in
       let v3 =
-        match v3 with Some x -> argument_list env x | None -> fake_bracket []
+        match v3 with
+        | Some x -> argument_list env x
+        | None -> fake_bracket []
       in
       let v4 =
         match v4 with
@@ -1376,7 +1395,11 @@ and expression (env : env) (x : CST.expression) : G.expr =
       x.G.e
   | `Range_exp (v1, v2, v3) ->
       let fake_zero = L (Int (Some 0, fake "0")) |> G.e in
-      let v1 = match v1 with Some x -> expression env x | None -> fake_zero in
+      let v1 =
+        match v1 with
+        | Some x -> expression env x
+        | None -> fake_zero
+      in
       let v2 = token env v2 (* ".." *) in
       let v3 =
         match v3 with
@@ -1466,7 +1489,9 @@ and expression (env : env) (x : CST.expression) : G.expr =
       let v2 = token env v2 (* "with" *) in
       let v3 = token env v3 (* "{" *) in
       let v4 =
-        match v4 with Some x -> with_initializer_expression env x | None -> []
+        match v4 with
+        | Some x -> with_initializer_expression env x
+        | None -> []
       in
       let v5 = token env v5 (* "}" *) in
       let with_fields = G.Record (v3, v4, v5) |> G.e in
@@ -1575,7 +1600,9 @@ and type_constraint (env : env) (x : CST.type_constraint) : type_ =
   type_ env x
 
 and local_variable_type (env : env) (x : CST.type_constraint) : type_ option =
-  match x with `Impl_type tok -> None (* "var" *) | x -> Some (type_ env x)
+  match x with
+  | `Impl_type tok -> None (* "var" *)
+  | x -> Some (type_ env x)
 
 and expr_statement (env : env) (x : CST.expression_statement) : stmt =
   match x with
@@ -1648,7 +1675,9 @@ and statement (env : env) (x : CST.statement) =
               | `Tuple_pat x -> tuple_pattern env x
             in
             let v1 = local_variable_type env v1 in
-            match v1 with Some t -> PatTyped (v2, t) | None -> v2)
+            match v1 with
+            | Some t -> PatTyped (v2, t)
+            | None -> v2)
         | `Exp x -> H2.expr_to_pattern (expression env x)
       in
       let v5 = token env v5 (* "in" *) in
@@ -1741,7 +1770,9 @@ and statement (env : env) (x : CST.statement) =
       let v4 = identifier env v4 (* identifier *) in
       let _, tok = v4 in
       let v5 =
-        match v5 with Some x -> type_parameter_list env x | None -> []
+        match v5 with
+        | Some x -> type_parameter_list env x
+        | None -> []
       in
       let v6 = parameter_list env v6 in
       let v7 = List.map (type_parameter_constraints_clause env) v7 in
@@ -1870,7 +1901,9 @@ and catch_declaration (env : env) ((v1, v2, v3, v4) : CST.catch_declaration) =
   let v3 = map_opt identifier env v3 (* identifier *) in
   let v4 = token env v4 (* ")" *) in
   let var =
-    match v3 with Some ident -> Some (ident, empty_id_info ()) | None -> None
+    match v3 with
+    | Some ident -> Some (ident, empty_id_info ())
+    | None -> None
   in
   PatVar (v2, var)
 
@@ -1879,7 +1912,9 @@ and case_pattern_switch_label (env : env)
   let v1 = token env v1 (* "case" *) in
   let v2 = pattern env v2 in
   let v3 =
-    match v3 with Some x -> PatWhen (v2, when_clause env x) | None -> v2
+    match v3 with
+    | Some x -> PatWhen (v2, when_clause env x)
+    | None -> v2
   in
   let v4 = token env v4 (* ":" *) in
   G.Case (v1, v3)
@@ -1938,7 +1973,9 @@ and attribute_argument (env : env) ((v1, v2) : CST.attribute_argument) =
     | None -> None
   in
   let v2 = expression env v2 in
-  match v1 with Some name -> ArgKwd (name, v2) | None -> Arg v2
+  match v1 with
+  | Some name -> ArgKwd (name, v2)
+  | None -> Arg v2
 
 and catch_filter_clause (env : env) ((v1, v2, v3, v4) : CST.catch_filter_clause)
     =
@@ -2095,7 +2132,11 @@ and subpattern (env : env) ((v1, v2) : CST.subpattern) =
 and property_pattern_clause (env : env)
     ((v1, v2, v3, v4) : CST.property_pattern_clause) =
   let v1 = token env v1 (* "{" *) in
-  let _v2 = match v2 with Some x -> [ todo_pat env v1 ] | None -> [] in
+  let _v2 =
+    match v2 with
+    | Some x -> [ todo_pat env v1 ]
+    | None -> []
+  in
   let v4 = token env v4 (* "}" *) in
   todo_pat env v1
 
@@ -2270,7 +2311,11 @@ and type_parameter_constraints_clause (env : env)
 and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
     parameter list =
   let v1 = token env v1 (* "(" *) in
-  let v2 = match v2 with Some x -> formal_parameter_list env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> formal_parameter_list env x
+    | None -> []
+  in
   let v3 = token env v3 (* ")" *) in
   v2
 
@@ -2557,8 +2602,16 @@ and class_interface_struct (env : env) class_kind
   let v2 = List.map (modifier env) v2 in
   let v3 = token env v3 (* "class" *) in
   let v4 = identifier env v4 (* identifier *) in
-  let v5 = match v5 with Some x -> type_parameter_list env x | None -> [] in
-  let v6 = match v6 with Some x -> base_list env x | None -> [] in
+  let v5 =
+    match v5 with
+    | Some x -> type_parameter_list env x
+    | None -> []
+  in
+  let v6 =
+    match v6 with
+    | Some x -> base_list env x
+    | None -> []
+  in
   let v7 = List.map (type_parameter_constraints_clause env) v7 in
   let open_bra, stmts, close_bra = declaration_list env v8 in
   let fields = List.map (fun x -> G.FieldStmt x) stmts in
@@ -2583,7 +2636,11 @@ and enum_declaration env (v1, v2, v3, v4, v5, v6, v7) =
   let v2 = List.map (modifier env) v2 in
   let v3 = token env v3 (* "enum" *) in
   let v4 = identifier env v4 (* identifier *) in
-  let v5 = match v5 with Some x -> base_list env x | None -> [] in
+  let v5 =
+    match v5 with
+    | Some x -> base_list env x
+    | None -> []
+  in
   let v6 = enum_member_declaration_list env v6 in
   let v7 = map_opt token env v7 (* ";" *) in
   let idinfo = empty_id_info () in
@@ -2596,7 +2653,11 @@ and delegate_declaration env (v1, v2, v3, v4, v5, v6, v7, v8, v9) =
   let v3 = token env v3 (* "delegate" *) in
   let v4 = return_type env v4 in
   let v5 = identifier env v5 (* identifier *) in
-  let v6 = match v6 with Some x -> type_parameter_list env x | None -> [] in
+  let v6 =
+    match v6 with
+    | Some x -> type_parameter_list env x
+    | None -> []
+  in
   let v7 = parameter_list env v7 in
   let v8 = List.map (type_parameter_constraints_clause env) v8 in
   let v9 = token env v9 (* ";" *) in
@@ -2833,7 +2894,9 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let v5 = identifier env v5 (* identifier *) in
       let _, tok = v5 in
       let v6 =
-        match v6 with Some x -> type_parameter_list env x | None -> []
+        match v6 with
+        | Some x -> type_parameter_list env x
+        | None -> []
       in
       let v7 = parameter_list env v7 in
       let v8 = List.map (type_parameter_constraints_clause env) v8 in
@@ -2982,7 +3045,9 @@ let parse_pattern_aux str =
    * is not an expression! E.g., `Foo()` as an statement will not match
    * `if (null == Foo()) ...` whereas as an expression it does. *)
   let res = Tree_sitter_c_sharp.Parse.string expr_str in
-  match res.errors with [] -> res | _ -> Tree_sitter_c_sharp.Parse.string str
+  match res.errors with
+  | [] -> res
+  | _ -> Tree_sitter_c_sharp.Parse.string str
 
 let parse_pattern str =
   H.wrap_parser

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -69,7 +69,9 @@ let identifier (env : env) (tok : CST.identifier) = str env tok
 (* identifier *)
 
 let anon_choice_new_0342769 (env : env) (x : CST.anon_choice_new_0342769) =
-  match x with `New tok -> str env tok (* "new" *) | `Make tok -> str env tok
+  match x with
+  | `New tok -> str env tok (* "new" *)
+  | `Make tok -> str env tok
 
 (* "make" *)
 
@@ -176,7 +178,11 @@ let rec type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
       v3
   in
   let v4 = token env v4 (* ":" *) in
-  let v5 = match v5 with Some x -> statement_list env x | None -> [] in
+  let v5 =
+    match v5 with
+    | Some x -> statement_list env x
+    | None -> []
+  in
   let xs = v2 :: v3 in
   (CaseExprs (v1, xs |> List.map (fun x -> Right x)), stmt1 v4 v5)
 
@@ -299,7 +305,11 @@ and anon_choice_field_id_ccb7464 (env : env)
 
 and block (env : env) ((v1, v2, v3) : CST.block) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = match v2 with Some x -> statement_list env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> statement_list env x
+    | None -> []
+  in
   let v3 = token env v3 (* "}" *) in
   Block (v1, v2, v3)
 
@@ -346,7 +356,9 @@ and field_declaration (env : env) ((v1, v2) : CST.field_declaration) :
         [ EmbeddedField (v1, v2) ]
   in
   let v2 =
-    match v2 with Some x -> Some (string_literal env x) | None -> None
+    match v2 with
+    | Some x -> Some (string_literal env x)
+    | None -> None
   in
   v1 |> List.map (fun x -> (x, v2))
 
@@ -363,7 +375,9 @@ and special_argument_list (env : env)
       v3
   in
   let _v4 =
-    match v4 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v4 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let v5 = token env v5 (* ")" *) in
   let args = ArgType v2 :: v3 in
@@ -371,13 +385,21 @@ and special_argument_list (env : env)
 
 and for_clause (env : env) ((v1, v2, v3, v4, v5) : CST.for_clause) =
   let v1 =
-    match v1 with Some x -> Some (simple_statement env x) | None -> None
+    match v1 with
+    | Some x -> Some (simple_statement env x)
+    | None -> None
   in
   let _v2 = token env v2 (* ";" *) in
-  let v3 = match v3 with Some x -> Some (expression env x) | None -> None in
+  let v3 =
+    match v3 with
+    | Some x -> Some (expression env x)
+    | None -> None
+  in
   let _v4 = token env v4 (* ";" *) in
   let v5 =
-    match v5 with Some x -> Some (simple_statement env x) | None -> None
+    match v5 with
+    | Some x -> Some (simple_statement env x)
+    | None -> None
   in
   ForClassic (v1, v3, v5)
 
@@ -489,7 +511,11 @@ and call_expression (env : env) (x : CST.call_expression) =
 and default_case (env : env) ((v1, v2, v3) : CST.default_case) =
   let v1 = token env v1 (* "default" *) in
   let v2 = token env v2 (* ":" *) in
-  let v3 = match v3 with Some x -> statement_list env x | None -> [] in
+  let v3 =
+    match v3 with
+    | Some x -> statement_list env x
+    | None -> []
+  in
   (CaseDefault v1, stmt1 v2 v3)
 
 and slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
@@ -544,16 +570,22 @@ and expression (env : env) (x : CST.expression) : expr =
       match v3 with
       | `Opt_exp_COLON_opt_exp (v1, v2, v3) ->
           let v1 =
-            match v1 with Some x -> Some (expression env x) | None -> None
+            match v1 with
+            | Some x -> Some (expression env x)
+            | None -> None
           in
           let _v2 = token env v2 (* ":" *) in
           let v3 =
-            match v3 with Some x -> Some (expression env x) | None -> None
+            match v3 with
+            | Some x -> Some (expression env x)
+            | None -> None
           in
           Slice (v1top, (t1, (v1, v3, None), t2))
       | `Opt_exp_COLON_exp_COLON_exp (v1, v2, v3, v4, v5) ->
           let v1 =
-            match v1 with Some x -> Some (expression env x) | None -> None
+            match v1 with
+            | Some x -> Some (expression env x)
+            | None -> None
           in
           let _v2 = token env v2 (* ":" *) in
           let v3 = expression env v3 in
@@ -685,7 +717,9 @@ and statement (env : env) (x : CST.statement) : stmt =
   | `Ret_stmt (v1, v2) ->
       let v1 = token env v1 (* "return" *) in
       let v2 =
-        match v2 with Some x -> Some (expression_list env x) | None -> None
+        match v2 with
+        | Some x -> Some (expression_list env x)
+        | None -> None
       in
       Return (v1, v2)
   | `Go_stmt (v1, v2) ->
@@ -864,7 +898,11 @@ and expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
   let v1 = token env v1 (* "case" *) in
   let v2 = expression_list env v2 in
   let v3 = token env v3 (* ":" *) in
-  let v4 = match v4 with Some x -> statement_list env x | None -> [] in
+  let v4 =
+    match v4 with
+    | Some x -> statement_list env x
+    | None -> []
+  in
   (CaseExprs (v1, v2 |> List.map (fun x -> Left x)), stmt1 v3 v4)
 
 and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
@@ -914,7 +952,11 @@ and const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
   let xs = v1 :: v2 in
   match v3 with
   | Some (v1, v2, v3) ->
-      let v1 = match v1 with Some x -> Some (type_ env x) | None -> None in
+      let v1 =
+        match v1 with
+        | Some x -> Some (type_ env x)
+        | None -> None
+      in
       let _v2 = token env v2 (* "=" *) in
       let v3 = expression_list env v3 in
       mk_consts ~rev xs v1 (Some v3)
@@ -1138,7 +1180,11 @@ and communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
             CaseAssign (v1, xs |> List.map (fun e -> Left e), tk, e))
   in
   let v3 = token env v3 (* ":" *) in
-  let v4 = match v4 with Some x -> statement_list env x | None -> [] in
+  let v4 =
+    match v4 with
+    | Some x -> statement_list env x
+    | None -> []
+  in
   (v2, stmt1 v3 v4)
 
 and literal_value (env : env) ((v1, v2, v3) : CST.literal_value) :
@@ -1196,7 +1242,11 @@ let top_level_declaration (env : env) (x : CST.top_level_declaration) :
         | Some x -> anon_choice_param_list_29faba4 env x
         | None -> []
       in
-      let v5 = match v5 with Some x -> block env x | None -> Empty in
+      let v5 =
+        match v5 with
+        | Some x -> block env x
+        | None -> Empty
+      in
       [ DFunc (v1, v2, ({ fparams = v3; fresults = v4 }, v5)) ]
   | `Meth_decl (v1, v2, v3, v4, v5, v6) ->
       let v1 = token env v1 (* "func" *) in
@@ -1208,7 +1258,11 @@ let top_level_declaration (env : env) (x : CST.top_level_declaration) :
         | Some x -> anon_choice_param_list_29faba4 env x
         | None -> []
       in
-      let v6 = match v6 with Some x -> block env x | None -> Empty in
+      let v6 =
+        match v6 with
+        | Some x -> block env x
+        | None -> Empty
+      in
       let receiver =
         match v2 with
         | [] -> raise Impossible

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -460,7 +460,9 @@ let xhp_enum_type (env : env) ((v1, v2, v3, v4, v5, v6) : CST.xhp_enum_type)
       v4
   in
   let _v5 =
-    match v5 with Some tok -> (* "," *) Some (token env tok) | None -> None
+    match v5 with
+    | Some tok -> (* "," *) Some (token env tok)
+    | None -> None
   in
   let _v6 = (* "}" *) token env v6 in
   (* This pass-down is really wrong. Need anon type name. *)
@@ -516,7 +518,9 @@ let _anonymous_function_use_clause (env : env)
       v4
   in
   let v5 =
-    match v5 with Some tok -> (* "," *) token env tok | None -> todo env ()
+    match v5 with
+    | Some tok -> (* "," *) token env tok
+    | None -> todo env ()
   in
   let v6 = (* ")" *) token env v6 in
   todo env (v1, v2, v3, v4, v5, v6)
@@ -524,7 +528,9 @@ let _anonymous_function_use_clause (env : env)
 let use_clause (env : env) ((v1, v2, v3) : CST.use_clause) =
   (* Q: How to represent `use` type? *)
   let _v1TODO =
-    match v1 with Some x -> Some (use_type env x) | None -> None
+    match v1 with
+    | Some x -> Some (use_type env x)
+    | None -> None
   in
   let namespace_ident = namespace_identifier env v2 in
   let v3 : G.alias option =
@@ -581,7 +587,9 @@ and anon_choice_exp_rep_COMMA_choice_exp_opt_COMMA_e4364bb (env : env)
       v2
   in
   let _v3 =
-    match v3 with Some tok -> (* "," *) Some (token env tok) | None -> None
+    match v3 with
+    | Some tok -> (* "," *) Some (token env tok)
+    | None -> None
   in
   v1 :: v2
 
@@ -687,7 +695,9 @@ and attribute_modifier (env : env)
     G.fake_bracket [ G.Arg (G.N (qualified_identifier env v2) |> G.e) ]
   in
   let v3 =
-    match v3 with Some x -> arguments env x | None -> G.fake_bracket []
+    match v3 with
+    | Some x -> arguments env x
+    | None -> G.fake_bracket []
   in
   let constr_call =
     G.Call (G.Call (G.IdSpecial (New, fk v1) |> G.e, v2) |> G.e, v3)
@@ -701,7 +711,9 @@ and attribute_modifier (env : env)
           G.fake_bracket [ G.Arg (G.N (qualified_identifier env v2) |> G.e) ]
         in
         let v3 =
-          match v3 with Some x -> arguments env x | None -> G.fake_bracket []
+          match v3 with
+          | Some x -> arguments env x
+          | None -> G.fake_bracket []
         in
         G.E
           (G.Call (G.Call (G.IdSpecial (New, fk v1) |> G.e, v2) |> G.e, v3)
@@ -709,7 +721,9 @@ and attribute_modifier (env : env)
       v4
   in
   let _v5 =
-    match v5 with Some tok -> (* "," *) Some (token env tok) | None -> None
+    match v5 with
+    | Some tok -> (* "," *) Some (token env tok)
+    | None -> None
   in
   let _v6 = (* ">>" *) token env v6 in
   G.OtherAttribute (G.OA_Expr, first_attr_mod :: v4)
@@ -1012,7 +1026,11 @@ and call_expression (env : env) ((v1, v2, v3) : CST.call_expression) =
     | `Choice_array x ->
         G.N (G.Id (collection_type env x, G.empty_id_info ())) |> G.e
   in
-  let _v2TODO = match v2 with Some x -> type_arguments env x | None -> None in
+  let _v2TODO =
+    match v2 with
+    | Some x -> type_arguments env x
+    | None -> None
+  in
   let v3 = arguments env v3 in
   G.Call (v1, v3) |> G.e
 
@@ -1032,7 +1050,11 @@ and class_const_declaration (env : env)
   let v1 = List.map (member_modifier env) v1 in
   let v2 = (* "const" *) [ G.KeywordAttr (Const, token env v2) ] in
   let attrs = v1 @ v2 in
-  let type_ = match v3 with Some x -> Some (type_ env x) | None -> None in
+  let type_ =
+    match v3 with
+    | Some x -> Some (type_ env x)
+    | None -> None
+  in
   let _v6 = (* ";" *) token env v6 in
   let v4 = G.FieldStmt (class_const_declarator env v4 attrs type_) in
   let v5 =
@@ -1079,7 +1101,9 @@ and declaration (env : env) (x : CST.declaration) =
   match x with
   | `Func_decl (v1, v2, v3) ->
       let attrs =
-        match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ attribute_modifier env x ]
+        | None -> []
       in
       let func_def, identifier, type_params =
         function_declaration_header env v2
@@ -1090,13 +1114,19 @@ and declaration (env : env) (x : CST.declaration) =
       G.DefStmt (ent, G.FuncDef def)
   | `Class_decl (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) ->
       let v1 =
-        match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ attribute_modifier env x ]
+        | None -> []
       in
       let v2 =
-        match v2 with Some x -> [ class_modifier env x ] | None -> []
+        match v2 with
+        | Some x -> [ class_modifier env x ]
+        | None -> []
       in
       let v3 =
-        match v3 with Some x -> [ class_modifier env x ] | None -> []
+        match v3 with
+        | Some x -> [ class_modifier env x ]
+        | None -> []
       in
       let v4 =
         match v4 with
@@ -1116,13 +1146,25 @@ and declaration (env : env) (x : CST.declaration) =
         | `Choice_xhp_id x -> xhp_identifier_ env x
       in
       let type_params =
-        match v7 with Some x -> type_parameters env x | None -> []
+        match v7 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
-      let v8 = match v8 with Some x -> extends_clause env x | None -> [] in
-      let v9 = match v9 with Some x -> implements_clause env x | None -> [] in
+      let v8 =
+        match v8 with
+        | Some x -> extends_clause env x
+        | None -> []
+      in
+      let v9 =
+        match v9 with
+        | Some x -> implements_clause env x
+        | None -> []
+      in
       let v10 =
         (* Q: What does this even do? *)
-        match v10 with Some x -> where_clause env x | None -> []
+        match v10 with
+        | Some x -> where_clause env x
+        | None -> []
       in
       let v11 = member_declarations env v11 in
       let def : G.class_definition =
@@ -1139,15 +1181,27 @@ and declaration (env : env) (x : CST.declaration) =
       G.DefStmt (basic_typed_entity id attrs type_params, G.ClassDef def)
   | `Inte_decl (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 =
-        match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ attribute_modifier env x ]
+        | None -> []
       in
       let v2 = (* "interface" *) token env v2 in
       let id = semgrep_extended_identifier env v3 in
       let type_params =
-        match v4 with Some x -> type_parameters env x | None -> []
+        match v4 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
-      let v5 = match v5 with Some x -> extends_clause env x | None -> [] in
-      let v6 = match v6 with Some x -> where_clause env x | None -> [] in
+      let v5 =
+        match v5 with
+        | Some x -> extends_clause env x
+        | None -> []
+      in
+      let v6 =
+        match v6 with
+        | Some x -> where_clause env x
+        | None -> []
+      in
       let v7 = member_declarations env v7 in
       let def : G.class_definition =
         {
@@ -1163,15 +1217,27 @@ and declaration (env : env) (x : CST.declaration) =
       G.DefStmt (basic_typed_entity id attrs type_params, G.ClassDef def)
   | `Trait_decl (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 =
-        match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ attribute_modifier env x ]
+        | None -> []
       in
       let v2 = (* "trait" *) token env v2 in
       let id = semgrep_extended_identifier env v3 in
       let type_params =
-        match v4 with Some x -> type_parameters env x | None -> []
+        match v4 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
-      let v5 = match v5 with Some x -> implements_clause env x | None -> [] in
-      let v6 = match v6 with Some x -> where_clause env x | None -> [] in
+      let v5 =
+        match v5 with
+        | Some x -> implements_clause env x
+        | None -> []
+      in
+      let v6 =
+        match v6 with
+        | Some x -> where_clause env x
+        | None -> []
+      in
       let v7 = member_declarations env v7 in
       let def : G.class_definition =
         {
@@ -1187,7 +1253,9 @@ and declaration (env : env) (x : CST.declaration) =
       G.DefStmt (basic_typed_entity id attrs type_params, G.ClassDef def)
   | `Alias_decl (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 =
-        match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ attribute_modifier env x ]
+        | None -> []
       in
       let _v2 =
         match v2 with
@@ -1195,7 +1263,9 @@ and declaration (env : env) (x : CST.declaration) =
         | `Newt tok -> (* "newtype" *) token env tok
       in
       let type_params =
-        match v4 with Some x -> type_parameters env x | None -> []
+        match v4 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
       (* Q: Type params vs type attributes in generic? Which to use here?
          Put within Name or pass to Apply?*)
@@ -1218,7 +1288,9 @@ and declaration (env : env) (x : CST.declaration) =
           G.TypeDef { tbody = AliasType v7 } )
   | `Enum_decl (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
       let v1 =
-        match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ attribute_modifier env x ]
+        | None -> []
       in
       let _v2 = (* "enum" *) token env v2 in
       let v3 = semgrep_extended_identifier env v3 in
@@ -1267,7 +1339,11 @@ and declaration (env : env) (x : CST.declaration) =
       | None -> G.DirectiveStmt (G.PackageEnd v1 |> G.d))
   | `Const_decl (v1, v2, v3, v4, v5) ->
       let attr = (* "const" *) [ G.KeywordAttr (Const, token env v1) ] in
-      let type_ = match v2 with Some x -> Some (type_ env x) | None -> None in
+      let type_ =
+        match v2 with
+        | Some x -> Some (type_ env x)
+        | None -> None
+      in
       let v3 = const_declarator env v3 attr type_ |> G.s in
       let v4 =
         List.map
@@ -1368,7 +1444,9 @@ and expression (env : env) (x : CST.expression) : G.expr =
       | `Array (v1, v2, v3, v4, v5) ->
           let _collectionTODO = collection_type env v1 in
           let _v2TODO =
-            match v2 with Some x -> type_arguments env x | None -> None
+            match v2 with
+            | Some x -> type_arguments env x
+            | None -> None
           in
           let v3 = (* "[" *) token env v3 in
           let v4 =
@@ -1530,7 +1608,9 @@ and expression (env : env) (x : CST.expression) : G.expr =
           G.Conditional (v1, v3, v5) |> G.e
       | `Lambda_exp (v1, v2, v3, v4, v5) ->
           let _v1TODO =
-            match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+            match v1 with
+            | Some x -> [ attribute_modifier env x ]
+            | None -> []
           in
           let _v2TODO =
             match v2 with
@@ -1577,7 +1657,9 @@ and expression (env : env) (x : CST.expression) : G.expr =
           let v1 = (* "new" *) token env v1 in
           let v2 = G.fake_bracket [ G.Arg (variablish env v2) ] in
           let _v3TODO =
-            match v3 with Some x -> type_arguments env x | None -> None
+            match v3 with
+            | Some x -> type_arguments env x
+            | None -> None
           in
           let v4 = arguments env v4 in
           G.Call (G.Call (G.IdSpecial (New, v1) |> G.e, v2) |> G.e, v4) |> G.e
@@ -1693,7 +1775,9 @@ and function_declaration_header (env : env)
   let function_keyword = (* "function" *) token env v2 in
   let identifier = semgrep_extended_identifier env v3 in
   let type_params =
-    match v4 with Some x -> type_parameters env x | None -> []
+    match v4 with
+    | Some x -> type_parameters env x
+    | None -> []
   in
   let parameters = parameters env v5 in
   let attribute_modifier_and_return_type =
@@ -1710,7 +1794,9 @@ and function_declaration_header (env : env)
     | None -> None
   in
   let _where_clauseTODO =
-    match v7 with Some x -> where_clause env x | None -> []
+    match v7 with
+    | Some x -> where_clause env x
+    | None -> []
   in
   ( {
       fkind = (G.Function, function_keyword);
@@ -1771,7 +1857,9 @@ and member_declarations (env : env) ((v1, v2, v3) : CST.member_declarations) =
 
 and method_declaration (env : env) ((v1, v2, v3, v4) : CST.method_declaration) =
   let v1 =
-    match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ attribute_modifier env x ]
+    | None -> []
   in
   let v2 = List.map (member_modifier env) v2 in
   let func_def, identifier, type_args = function_declaration_header env v3 in
@@ -1785,10 +1873,14 @@ and parameter (env : env) (x : CST.parameter) : G.parameter =
   | `Opt_attr_modi_opt_visi_modi_opt_inout_modi_opt_choice_type_spec_opt_vari_modi_var_opt_EQ_exp
       (v1, v2, v3, v4, v5, v6, v7) -> (
       let v1 =
-        match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ attribute_modifier env x ]
+        | None -> []
       in
       let v2 =
-        match v2 with Some x -> [ visibility_modifier env x ] | None -> []
+        match v2 with
+        | Some x -> [ visibility_modifier env x ]
+        | None -> []
       in
       let v3 =
         (* Q: Mutable? This is the best keyword I could think of. *)
@@ -1796,7 +1888,11 @@ and parameter (env : env) (x : CST.parameter) : G.parameter =
         | Some tok -> (* "inout" *) [ G.KeywordAttr (Mutable, token env tok) ]
         | None -> []
       in
-      let v4 = match v4 with Some x -> Some (type_ env x) | None -> None in
+      let v4 =
+        match v4 with
+        | Some x -> Some (type_ env x)
+        | None -> None
+      in
       let v5 =
         match v5 with
         | Some tok -> (* "..." *) Some (token env tok)
@@ -1937,11 +2033,17 @@ and prefix_unary_expression (env : env) (x : CST.prefix_unary_expression) =
 and property_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.property_declaration) =
   let v1 =
-    match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ attribute_modifier env x ]
+    | None -> []
   in
   let v2 = List.map (member_modifier env) v2 in
   let attrs = v1 @ v2 in
-  let type_ = match v3 with Some x -> Some (type_ env x) | None -> None in
+  let type_ =
+    match v3 with
+    | Some x -> Some (type_ env x)
+    | None -> None
+  in
   let v4 = G.FieldStmt (property_declarator env v4 attrs type_) in
   let v5 =
     List.map
@@ -2104,7 +2206,9 @@ and statement (env : env) (x : CST.statement) =
       let create_directive use_clause prefix_idents =
         let idents, alias = use_clause in
         let idents =
-          match idents with Some x -> x | None -> raise Impossible
+          match idents with
+          | Some x -> x
+          | None -> raise Impossible
         in
         G.s
           (G.DirectiveStmt
@@ -2136,7 +2240,9 @@ and statement (env : env) (x : CST.statement) =
             (v1, v2, v3, v4, v5, v6, v7) ->
             (* Q: How to represent `use` type? We are also possibly passed it up from use_clause. *)
             let _v1TODO =
-              match v1 with Some x -> Some (use_type env x) | None -> None
+              match v1 with
+              | Some x -> Some (use_type env x)
+              | None -> None
             in
             let v2 = namespace_identifier env v2 in
             let ident_prefix =
@@ -2388,7 +2494,11 @@ and type_kind (env : env) (x : CST.type_) : G.type_kind =
   match x with
   | `Type_spec (v1, v2, v3) ->
       let _v1TODO = List.map (type_modifier env) v1 in
-      let v3 = match v3 with Some x -> type_arguments env x | None -> None in
+      let v3 =
+        match v3 with
+        | Some x -> type_arguments env x
+        | None -> None
+      in
       let v2 =
         match v2 with
         | `Choice_bool x -> G.TyBuiltin (primitive_type env x)
@@ -2531,19 +2641,25 @@ and type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) :
     | None -> None
   in
   let v3 = (* ">" *) token env v3 in
-  match v2 with Some v2 -> Some (v1, v2, v3) | None -> None
+  match v2 with
+  | Some v2 -> Some (v1, v2, v3)
+  | None -> None
 
 and type_const_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6, v7, v8, v9) : CST.type_const_declaration) =
   let v1 =
-    match v1 with Some x -> [ attribute_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ attribute_modifier env x ]
+    | None -> []
   in
   let v2 = List.map (member_modifier env) v2 in
   let v3 = (* "const" *) [ G.KeywordAttr (Const, token env v3) ] in
   let _v4 = (* "type" *) token env v4 in
   let id = semgrep_extended_identifier env v5 in
   let type_params =
-    match v6 with Some x -> type_parameters env x | None -> []
+    match v6 with
+    | Some x -> type_parameters env x
+    | None -> []
   in
   (* Q: How to represent this `as __type__`? It is a constraint? Make an attribute?
      OTP_Constrained on type param? But then can't be builtin *)
@@ -2581,7 +2697,9 @@ and type_const_declaration (env : env)
 and type_parameter (env : env) ((v1, v2, v3, v4) : CST.type_parameter) :
     G.type_parameter =
   let _v1TODO =
-    match v1 with Some x -> Some (attribute_modifier env x) | None -> None
+    match v1 with
+    | Some x -> Some (attribute_modifier env x)
+    | None -> None
   in
   let _v2TODO =
     match v2 with
@@ -2621,7 +2739,9 @@ and type_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.type_parameters) =
       v3
   in
   let _v4 =
-    match v4 with Some tok -> (* "," *) Some (token env tok) | None -> None
+    match v4 with
+    | Some tok -> (* "," *) Some (token env tok)
+    | None -> None
   in
   let _v5 = (* ">" *) token env v5 in
   v2 :: v3
@@ -2635,13 +2755,19 @@ and variablish (env : env) (x : CST.variablish) : G.expr =
   | `List_exp (v1, v2, v3, v4, v5, v6) ->
       let _v1TODO = (* "list" *) token env v1 in
       let v2 = (* "(" *) token env v2 in
-      let v3 = match v3 with Some x -> [ expression env x ] | None -> [] in
+      let v3 =
+        match v3 with
+        | Some x -> [ expression env x ]
+        | None -> []
+      in
       let v4 =
         List.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 =
-              match v2 with Some x -> [ expression env x ] | None -> []
+              match v2 with
+              | Some x -> [ expression env x ]
+              | None -> []
             in
             v2)
           v4

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -128,7 +128,9 @@ let map_literal_value (env : env) (x : CST.literal_value) : literal =
 
 let rec map_anon_choice_get_attr_7bbf24f (env : env)
     (x : CST.anon_choice_get_attr_7bbf24f) =
-  match x with `Get_attr x -> map_get_attr env x | `Index x -> map_index env x
+  match x with
+  | `Get_attr x -> map_get_attr env x
+  | `Index x -> map_index env x
 
 and map_anon_choice_temp_lit_c764a73 (env : env)
     (x : CST.anon_choice_temp_lit_0082c06) =
@@ -145,7 +147,9 @@ and map_anon_choice_temp_lit_c764a73 (env : env)
         | None -> None
       in
       let v3 =
-        match v3 with Some x -> Some (map_expression env x) | None -> None
+        match v3 with
+        | Some x -> Some (map_expression env x)
+        | None -> None
       in
       let _v4TODO =
         match v4 with
@@ -198,12 +202,18 @@ and map_binary_operation (env : env) (x : CST.binary_operation) =
       (v1, v2, v3)
   | `Expr_term_choice_AMPAMP_expr_term (v1, v2, v3) ->
       let v1 = map_expr_term env v1 in
-      let v2 = match v2 with `AMPAMP tok -> (* "&&" *) (And, token env tok) in
+      let v2 =
+        match v2 with
+        | `AMPAMP tok -> (* "&&" *) (And, token env tok)
+      in
       let v3 = map_expr_term env v3 in
       (v1, v2, v3)
   | `Expr_term_choice_BARBAR_expr_term (v1, v2, v3) ->
       let v1 = map_expr_term env v1 in
-      let v2 = match v2 with `BARBAR tok -> (* "||" *) (Or, token env tok) in
+      let v2 =
+        match v2 with
+        | `BARBAR tok -> (* "||" *) (Or, token env tok)
+      in
       let v3 = map_expr_term env v3 in
       (v1, v2, v3)
 
@@ -211,7 +221,11 @@ and map_collection_value (env : env) (x : CST.collection_value) : expr =
   match x with
   | `Tuple (v1, v2, v3) ->
       let v1 = (* "[" *) token env v1 in
-      let v2 = match v2 with Some x -> map_tuple_elems env x | None -> [] in
+      let v2 =
+        match v2 with
+        | Some x -> map_tuple_elems env x
+        | None -> []
+      in
       let v3 = (* "]" *) token env v3 in
       G.Container (G.Tuple, (v1, v2, v3)) |> G.e
   | `Obj x -> map_object_ env x
@@ -231,7 +245,9 @@ and map_expr_term (env : env) (x : CST.expr_term) : expr =
           let v1 = (* identifier *) map_identifier env v1 in
           let v2 = (* "(" *) token env v2 in
           let v3 =
-            match v3 with Some x -> map_function_arguments env x | None -> []
+            match v3 with
+            | Some x -> map_function_arguments env x
+            | None -> []
           in
           let v4 = (* ")" *) token env v4 in
           let n = N (H2.name_of_id v1) |> G.e in
@@ -284,7 +300,11 @@ and map_for_expr (env : env) (x : CST.for_expr) =
       let v1 = (* "[" *) token env v1 in
       let tfor, ids, tin, e, _tcolon = map_for_intro env v2 in
       let v3 = map_expression env v3 in
-      let v4 = match v4 with Some x -> [ map_for_cond env x ] | None -> [] in
+      let v4 =
+        match v4 with
+        | Some x -> [ map_for_cond env x ]
+        | None -> []
+      in
       let v5 = (* "]" *) token env v5 in
       let pat = pattern_of_ids ids in
       let compfor = CompFor (tfor, pat, tin, e) in
@@ -302,7 +322,11 @@ and map_for_expr (env : env) (x : CST.for_expr) =
         | Some tok -> (* ellipsis *) Some (token env tok)
         | None -> None
       in
-      let v7 = match v7 with Some x -> [ map_for_cond env x ] | None -> [] in
+      let v7 =
+        match v7 with
+        | Some x -> [ map_for_cond env x ]
+        | None -> []
+      in
       let v8 = (* "}" *) token env v8 in
       let pat = pattern_of_ids ids in
       let compfor = CompFor (tfor, pat, tin, e) in
@@ -368,7 +392,11 @@ and map_index (env : env) (x : CST.index) =
 
 and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
   let v1 = (* "{" *) token env v1 in
-  let v2 = match v2 with Some x -> map_object_elems env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> map_object_elems env x
+    | None -> []
+  in
   let v3 = (* "}" *) token env v3 in
   Record (v1, v2, v3) |> G.e
 
@@ -382,7 +410,11 @@ and map_object_elem (env : env) (x : CST.object_elem) : field =
         | `COLON tok -> (* ":" *) Right (token env tok)
       in
       let v3 = map_expression env v3 in
-      let n_or_dyn = match v1.e with N n -> EN n | _ -> EDynamic v1 in
+      let n_or_dyn =
+        match v1.e with
+        | N n -> EN n
+        | _ -> EDynamic v1
+      in
       let ent = { name = n_or_dyn; attrs = []; tparams = [] } in
       let vdef = { vinit = Some v3; vtype = None } in
       let def =
@@ -407,7 +439,9 @@ and map_object_elems (env : env) ((v1, v2, v3) : CST.object_elems) =
       v2
   in
   let _v3 =
-    match v3 with Some tok -> (* "," *) Some (token env tok) | None -> None
+    match v3 with
+    | Some tok -> (* "," *) Some (token env tok)
+    | None -> None
   in
   v1 :: v2
 
@@ -480,7 +514,9 @@ and map_tuple_elems (env : env) ((v1, v2, v3) : CST.tuple_elems) : expr list =
       v2
   in
   let _v3 =
-    match v3 with Some tok -> (* "," *) Some (token env tok) | None -> None
+    match v3 with
+    | Some tok -> (* "," *) Some (token env tok)
+    | None -> None
   in
   v1 :: v2
 
@@ -510,7 +546,11 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
       v2
   in
   let v3 = (* "{" *) token env v3 in
-  let v4 = match v4 with Some x -> map_body env x | None -> [] in
+  let v4 =
+    match v4 with
+    | Some x -> map_body env x
+    | None -> []
+  in
   let v5 = (* "}" *) token env v5 in
 
   let n = H2.name_of_id v1 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -174,7 +174,9 @@ let module_directive (env : env) ((v1, v2) : CST.module_directive) =
           | None -> None
         in
         let _v4 =
-          match v4 with Some x -> Some (qualifier_extra env x) | None -> None
+          match v4 with
+          | Some x -> Some (qualifier_extra env x)
+          | None -> None
         in
         let _v5 =
           List.map
@@ -195,7 +197,9 @@ let module_directive (env : env) ((v1, v2) : CST.module_directive) =
           | None -> None
         in
         let _v4 =
-          match v4 with Some x -> Some (qualifier_extra env x) | None -> None
+          match v4 with
+          | Some x -> Some (qualifier_extra env x)
+          | None -> None
         in
         let _v5 =
           List.map
@@ -559,7 +563,11 @@ and primary_expression (env : env) (x : CST.primary_expression) =
         match v3 with
         | `Rep1_dimens_expr_opt_dimens (v1, v2) ->
             let v1 = List.map (dimensions_expr env) v1 in
-            let v2 = match v2 with Some x -> dimensions env x | None -> [] in
+            let v2 =
+              match v2 with
+              | Some x -> dimensions env x
+              | None -> []
+            in
             (v1, v2, None)
         | `Dimens_array_init (v1, v2) ->
             let v1 = dimensions env v1 in
@@ -612,7 +620,11 @@ and unqualified_object_creation_expression (env : env)
   let v2 = option (type_arguments env) v2 in
   let v3 = basic_type_extra env v3 in
   let v4 = argument_list env v4 in
-  let v5 = match v5 with Some x -> Some (class_body env x) | None -> None in
+  let v5 =
+    match v5 with
+    | Some x -> Some (class_body env x)
+    | None -> None
+  in
   (v1, v2, v3, v4, v5)
 
 and field_access (env : env) ((v1, v2, v3, v4) : CST.field_access) =
@@ -703,7 +715,9 @@ and wildcard (env : env) ((v1, v2, v3) : CST.wildcard) =
   let _v1 = List.map (annotation env) v1 in
   let v2 = token env v2 (* "?" *) in
   let v3 =
-    match v3 with Some x -> Some (wildcard_bounds env x) | None -> None
+    match v3 with
+    | Some x -> Some (wildcard_bounds env x)
+    | None -> None
   in
   TWildCard (v2, v3)
 
@@ -783,7 +797,11 @@ and statement_aux env x : Ast_java.stmt list =
             let _v2 = token env v2 (* ";" *) in
             ForInitExprs v1
       in
-      let v4 = match v4 with Some x -> [ expression env x ] | None -> [] in
+      let v4 =
+        match v4 with
+        | Some x -> [ expression env x ]
+        | None -> []
+      in
       let _v5 = token env v5 (* ";" *) in
       let v6 =
         match v6 with
@@ -806,7 +824,11 @@ and statement_aux env x : Ast_java.stmt list =
   | `Enha_for_stmt (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
       let v1 = token env v1 (* "for" *) in
       let _v2 = token env v2 (* "(" *) in
-      let v3 = match v3 with Some x -> modifiers env x | None -> [] in
+      let v3 =
+        match v3 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let v4 = unannotated_type env v4 in
       let v5 = variable_declarator_id env v5 in
       let _v6 = token env v6 (* ":" *) in
@@ -853,7 +875,9 @@ and statement_aux env x : Ast_java.stmt list =
   | `Ret_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "return" *) in
       let v2 =
-        match v2 with Some x -> Some (expression env x) | None -> None
+        match v2 with
+        | Some x -> Some (expression env x)
+        | None -> None
       in
       let _v3 = token env v3 (* ";" *) in
       [ Return (v1, v2) ]
@@ -894,7 +918,9 @@ and statement_aux env x : Ast_java.stmt list =
       let v3 = block env v3 in
       let v4 = List.map (catch_clause env) v4 in
       let v5 =
-        match v5 with Some x -> Some (finally_clause env x) | None -> None
+        match v5 with
+        | Some x -> Some (finally_clause env x)
+        | None -> None
       in
       [ Try (v1, Some v2, v3, v4, v5) ]
 
@@ -970,7 +996,11 @@ and catch_clause (env : env) ((v1, v2, v3, v4, v5) : CST.catch_clause) =
 
 and catch_formal_parameter (env : env)
     ((v1, v2, v3) : CST.catch_formal_parameter) =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let vtyp, vothertyps = catch_type env v2 in
   let v3 = variable_declarator_id env v3 in
   let vdef = canon_var v1 (Some vtyp) v3 in
@@ -1006,7 +1036,9 @@ and resource_specification (env : env)
       v3
   in
   let _v4 =
-    match v4 with Some tok -> Some (token env tok) (* ";" *) | None -> None
+    match v4 with
+    | Some tok -> Some (token env tok) (* ";" *)
+    | None -> None
   in
   let v5 = token env v5 (* ")" *) in
   (v1, v2 :: v3, v5)
@@ -1014,7 +1046,11 @@ and resource_specification (env : env)
 and resource (env : env) (x : CST.resource) =
   match x with
   | `Opt_modifs_unan_type_var_decl_id_EQ_exp (v1, v2, v3, v4, v5) ->
-      let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+      let v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let v2 = unannotated_type env v2 in
       let v3 = variable_declarator_id env v3 in
       let _v4 = token env v4 (* "=" *) in
@@ -1146,10 +1182,18 @@ and declaration (env : env) (x : CST.declaration) : AST.stmt =
 
 and enum_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.enum_declaration) :
     enum_decl =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let _v2 = token env v2 (* "enum" *) in
   let v3 = identifier env v3 (* pattern [a-zA-Z_]\w* *) in
-  let v4 = match v4 with Some x -> super_interfaces env x | None -> [] in
+  let v4 =
+    match v4 with
+    | Some x -> super_interfaces env x
+    | None -> []
+  in
   let v5 = enum_body env v5 in
   { en_name = v3; en_mods = v1; en_impls = v4; en_body = v5 }
 
@@ -1171,17 +1215,25 @@ and enum_body (env : env) ((v1, v2, v3, v4, v5) : CST.enum_body) =
     | None -> []
   in
   let _v3 =
-    match v3 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let v4 =
-    match v4 with Some x -> enum_body_declarations env x | None -> []
+    match v4 with
+    | Some x -> enum_body_declarations env x
+    | None -> []
   in
   let _v5 = token env v5 (* "}" *) in
   (v2, v4)
 
 and record_declaration (env : env)
     ((v1, v2, v3, v4, v5) : CST.record_declaration) : class_decl =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = token env v2 (* "record" *) in
   let v3 = identifier env v3 (* pattern [a-zA-Z_]\w* *) in
   let v4 = formal_parameters env v4 in
@@ -1218,22 +1270,48 @@ and enum_body_declarations (env : env) ((v1, v2) : CST.enum_body_declarations) =
   List.flatten v2
 
 and enum_constant (env : env) ((v1, v2, v3, v4) : CST.enum_constant) =
-  let _v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let _v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = identifier env v2 (* pattern [a-zA-Z_]\w* *) in
   let v3 =
-    match v3 with Some x -> Some (argument_list env x) | None -> None
+    match v3 with
+    | Some x -> Some (argument_list env x)
+    | None -> None
   in
-  let v4 = match v4 with Some x -> Some (class_body env x) | None -> None in
+  let v4 =
+    match v4 with
+    | Some x -> Some (class_body env x)
+    | None -> None
+  in
   (v2, v3, v4)
 
 and class_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6, v7) : CST.class_declaration) : class_decl =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = token env v2 (* "class" *) in
   let v3 = identifier env v3 (* pattern [a-zA-Z_]\w* *) in
-  let v4 = match v4 with Some x -> type_parameters env x | None -> [] in
-  let v5 = match v5 with Some x -> Some (superclass env x) | None -> None in
-  let v6 = match v6 with Some x -> super_interfaces env x | None -> [] in
+  let v4 =
+    match v4 with
+    | Some x -> type_parameters env x
+    | None -> []
+  in
+  let v5 =
+    match v5 with
+    | Some x -> Some (superclass env x)
+    | None -> None
+  in
+  let v6 =
+    match v6 with
+    | Some x -> super_interfaces env x
+    | None -> []
+  in
   let v7 = class_body env v7 in
   {
     cl_name = v3;
@@ -1286,7 +1364,11 @@ and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) :
     type_parameter =
   let _v1 = List.map (annotation env) v1 in
   let v2 = identifier env v2 (* pattern [a-zA-Z_]\w* *) in
-  let v3 = match v3 with Some x -> type_bound env x | None -> [] in
+  let v3 =
+    match v3 with
+    | Some x -> type_bound env x
+    | None -> []
+  in
   TParam (v2, v3)
 
 and type_bound (env : env) ((v1, v2, v3) : CST.type_bound) =
@@ -1337,9 +1419,17 @@ and static_initializer (env : env) ((v1, v2) : CST.static_initializer) =
 
 and constructor_declaration (env : env)
     ((v1, v2, v3, v4) : CST.constructor_declaration) : constructor_decl =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = constructor_declarator env v2 in
-  let v3 = match v3 with Some x -> throws env x | None -> [] in
+  let v3 =
+    match v3 with
+    | Some x -> throws env x
+    | None -> []
+  in
   let _tparams, id, params = v2 in
   let vdef = { name = id; mods = v1; type_ = None } in
   let v4 = constructor_body env v4 in
@@ -1347,7 +1437,11 @@ and constructor_declaration (env : env)
 
 and constructor_declarator (env : env)
     ((v1, v2, v3) : CST.constructor_declarator) =
-  let v1 = match v1 with Some x -> type_parameters env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> type_parameters env x
+    | None -> []
+  in
   let v2 = identifier env v2 (* pattern [a-zA-Z_]\w* *) in
   let v3 = formal_parameters env v3 in
   (v1, v2, v3)
@@ -1377,7 +1471,10 @@ and explicit_constructor_invocation (env : env)
         in
         v2
     | `Choice_prim_exp_DOT_opt_type_args_super (v1, v2, v3, v4) ->
-        let v1 = match v1 with `Prim_exp x -> primary_expression env x in
+        let v1 =
+          match v1 with
+          | `Prim_exp x -> primary_expression env x
+        in
         let v2 = token env v2 (* "." *) in
         let _v3 = option (type_arguments env) v3 in
         let v4 = super_id_field env v4 (* "super" *) in
@@ -1388,7 +1485,11 @@ and explicit_constructor_invocation (env : env)
   Expr (Call (v1, v2), v3)
 
 and field_declaration (env : env) ((v1, v2, v3, v4) : CST.field_declaration) =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = unannotated_type env v2 in
   let v3 = variable_declarator_list env v3 in
   let _v4 = token env v4 (* ";" *) in
@@ -1396,7 +1497,11 @@ and field_declaration (env : env) ((v1, v2, v3, v4) : CST.field_declaration) =
 
 and annotation_type_declaration (env : env)
     ((v1, v2, v3, v4) : CST.annotation_type_declaration) : class_decl =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = token env v2 (* "@interface" *) in
   let v3 = identifier env v3 (* pattern [a-zA-Z_]\w* *) in
   let v4 = annotation_type_body env v4 in
@@ -1431,14 +1536,24 @@ and annotation_type_body (env : env) ((v1, v2, v3) : CST.annotation_type_body) =
 and annotation_type_element_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.annotation_type_element_declaration)
     =
-  let _v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let _v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let _v2 = unannotated_type env v2 in
   let v3 = token env v3 (* pattern [a-zA-Z_]\w* *) in
   let _v4 = token env v4 (* "(" *) in
   let _v5 = token env v5 (* ")" *) in
-  let _v6 = match v6 with Some x -> dimensions env x | None -> [] in
+  let _v6 =
+    match v6 with
+    | Some x -> dimensions env x
+    | None -> []
+  in
   let _v7 =
-    match v7 with Some x -> Some (default_value env x) | None -> None
+    match v7 with
+    | Some x -> Some (default_value env x)
+    | None -> None
   in
   let _v8 = token env v8 (* ";" *) in
   AnnotationTypeElementTodo v3
@@ -1450,11 +1565,23 @@ and default_value (env : env) ((v1, v2) : CST.default_value) =
 
 and interface_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.interface_declaration) : class_decl =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = token env v2 (* "interface" *) in
   let v3 = identifier env v3 (* pattern [a-zA-Z_]\w* *) in
-  let v4 = match v4 with Some x -> type_parameters env x | None -> [] in
-  let v5 = match v5 with Some x -> extends_interfaces env x | None -> [] in
+  let v4 =
+    match v4 with
+    | Some x -> type_parameters env x
+    | None -> []
+  in
+  let v5 =
+    match v5 with
+    | Some x -> extends_interfaces env x
+    | None -> []
+  in
   let v6 = interface_body env v6 in
   {
     cl_name = v3;
@@ -1492,7 +1619,11 @@ and interface_body (env : env) ((v1, v2, v3) : CST.interface_body) =
 
 and constant_declaration (env : env)
     ((v1, v2, v3, v4) : CST.constant_declaration) =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = unannotated_type env v2 in
   let v3 = variable_declarator_list env v3 in
   let _v4 = token env v4 (* ";" *) in
@@ -1531,7 +1662,11 @@ and variable_declarator (env : env) ((v1, v2) : CST.variable_declarator) :
 and variable_declarator_id (env : env) ((v1, v2) : CST.variable_declarator_id) :
     var_decl_id =
   let v1 = id_extra env v1 in
-  let v2 = match v2 with Some x -> dimensions env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> dimensions env x
+    | None -> []
+  in
   List.fold_left (fun acc _e -> ArrayDecl acc) (IdentDecl v1) v2
 
 and array_initializer (env : env) ((v1, v2, v3, v4) : CST.array_initializer) =
@@ -1552,7 +1687,9 @@ and array_initializer (env : env) ((v1, v2, v3, v4) : CST.array_initializer) =
     | None -> []
   in
   let _v3_trailing =
-    match v3 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let v4 = token env v4 (* "}" *) in
   (v1, v2, v4)
@@ -1614,7 +1751,11 @@ and method_header (env : env) ((v1, v2, v3, v4) : CST.method_header) =
   in
   let v2 = unannotated_type env v2 in
   let v3 = method_declarator env v3 in
-  let v4 = match v4 with Some x -> throws env x | None -> [] in
+  let v4 =
+    match v4 with
+    | Some x -> throws env x
+    | None -> []
+  in
   let id, params, dims = v3 in
   let t =
     List.fold_left (fun acc (t1, (), t2) -> TArray (t1, acc, t2)) v2 dims
@@ -1624,13 +1765,19 @@ and method_header (env : env) ((v1, v2, v3, v4) : CST.method_header) =
 and method_declarator (env : env) ((v1, v2, v3) : CST.method_declarator) =
   let v1 = id_extra env v1 in
   let v2 = formal_parameters env v2 in
-  let v3 = match v3 with Some x -> dimensions env x | None -> [] in
+  let v3 =
+    match v3 with
+    | Some x -> dimensions env x
+    | None -> []
+  in
   (v1, v2, v3)
 
 and formal_parameters (env : env) ((v1, v2, v3, v4) : CST.formal_parameters) =
   let _v1 = token env v1 (* "(" *) in
   let v2 =
-    match v2 with Some x -> [ receiver_parameter env x ] | None -> []
+    match v2 with
+    | Some x -> [ receiver_parameter env x ]
+    | None -> []
   in
   let v3 =
     match v3 with
@@ -1659,7 +1806,11 @@ and formal_parameters (env : env) ((v1, v2, v3, v4) : CST.formal_parameters) =
   v2 @ v3
 
 and formal_parameter (env : env) ((v1, v2, v3) : CST.formal_parameter) =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = unannotated_type env v2 in
   let v3 = variable_declarator_id env v3 in
   ParamClassic (AST.canon_var v1 (Some v2) v3)
@@ -1681,7 +1832,11 @@ and receiver_parameter (env : env) ((v1, v2, v3, v4) : CST.receiver_parameter) =
   ParamReceiver (AST.canon_var [] (Some v2) (IdentDecl v4))
 
 and spread_parameter (env : env) ((v1, v2, v3, v4) : CST.spread_parameter) =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = unannotated_type env v2 in
   let v3 = token env v3 (* "..." *) in
   let v4 = variable_declarator env v4 in
@@ -1703,14 +1858,22 @@ and throws (env : env) ((v1, v2, v3) : CST.throws) : typ list =
 
 and local_variable_declaration (env : env)
     ((v1, v2, v3, v4) : CST.local_variable_declaration) : var_with_init list =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = unannotated_type env v2 in
   let v3 = variable_declarator_list env v3 in
   let _v4 = token env v4 (* ";" *) in
   decls (fun x -> x) v1 v2 v3
 
 and method_declaration (env : env) ((v1, v2, v3) : CST.method_declaration) =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = method_header env v2 in
   let v3 =
     match v3 with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -160,7 +160,9 @@ let postfix_unary_operator (env : env) (x : CST.postfix_unary_operator) =
 (* "!!" *)
 
 let variance_modifier (env : env) (x : CST.variance_modifier) =
-  match x with `In tok -> token env tok (* "in" *) | `Out tok -> token env tok
+  match x with
+  | `In tok -> token env tok (* "in" *)
+  | `Out tok -> token env tok
 
 (* "out" *)
 
@@ -430,7 +432,9 @@ let literal_constant (env : env) (x : CST.literal_constant) =
       let iopt, v1 = anon_choice_int_lit_9015f32 env v1 in
       let v2 = str env v2 (* pattern [uU] *) in
       let _v3 =
-        match v3 with Some tok -> Some (str env tok) (* "L" *) | None -> None
+        match v3 with
+        | Some tok -> Some (str env tok) (* "L" *)
+        | None -> None
       in
       let _str = PI.str_of_info v1 ^ fst v2 in
       Int (iopt, PI.combine_infos v1 [ snd v2 ])
@@ -578,7 +582,11 @@ and binary_expression (env : env) (x : CST.binary_expression) =
 
 and block (env : env) ((v1, v2, v3) : CST.block) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = match v2 with Some x -> statements env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> statements env x
+    | None -> []
+  in
   let v3 = token env v3 (* "}" *) in
   Block (v1, v2, v3) |> G.s
 
@@ -612,7 +620,9 @@ and catch_block (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.catch_block)
 and class_body (env : env) ((v1, v2, v3) : CST.class_body) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
-    match v2 with Some x -> class_member_declarations env x | None -> []
+    match v2 with
+    | Some x -> class_member_declarations env x
+    | None -> []
   in
   let v3 = token env v3 (* "}" *) in
   (v1, v2, v3)
@@ -622,7 +632,11 @@ and class_declaration (env : env) (x : CST.class_declaration) :
   match x with
   | `Opt_modifs_choice_class_simple_id_opt_type_params_opt_prim_cons_opt_COLON_dele_specis_opt_type_consts_opt_class_body
       (v1, v2, v3, v4, v5, v6, v7, v8) ->
-      let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+      let v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let v2 =
         match v2 with
         | `Class tok -> (Class, token env tok) (* "class" *)
@@ -630,7 +644,11 @@ and class_declaration (env : env) (x : CST.class_declaration) :
         (* "interface" *)
       in
       let v3 = simple_identifier env v3 in
-      let _v4 = match v4 with Some x -> type_parameters env x | None -> [] in
+      let _v4 =
+        match v4 with
+        | Some x -> type_parameters env x
+        | None -> []
+      in
       let _v5 =
         match v5 with
         | Some x -> Some (primary_constructor env x)
@@ -644,8 +662,16 @@ and class_declaration (env : env) (x : CST.class_declaration) :
             Some (v1, v2)
         | None -> None
       in
-      let _v7 = match v7 with Some x -> type_constraints env x | None -> [] in
-      let v8 = match v8 with Some x -> class_body env x | None -> fb [] in
+      let _v7 =
+        match v7 with
+        | Some x -> type_constraints env x
+        | None -> []
+      in
+      let v8 =
+        match v8 with
+        | Some x -> class_body env x
+        | None -> fb []
+      in
       let ent = G.basic_entity v3 v1 in
       let cdef =
         {
@@ -660,11 +686,19 @@ and class_declaration (env : env) (x : CST.class_declaration) :
       (ent, cdef)
   | `Opt_modifs_enum_class_simple_id_opt_type_params_opt_prim_cons_opt_COLON_dele_specis_opt_type_consts_opt_enum_class_body
       (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
-      let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+      let v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let _v2 = token env v2 (* "enum" *) in
       let v3 = (Class, token env v3) (* "class" *) in
       let v4 = simple_identifier env v4 in
-      let _v5 = match v5 with Some x -> type_parameters env x | None -> [] in
+      let _v5 =
+        match v5 with
+        | Some x -> type_parameters env x
+        | None -> []
+      in
       let _v6 =
         match v6 with
         | Some x -> Some (primary_constructor env x)
@@ -678,9 +712,15 @@ and class_declaration (env : env) (x : CST.class_declaration) :
             Some (v1, v2)
         | None -> None
       in
-      let _v8 = match v8 with Some x -> type_constraints env x | None -> [] in
+      let _v8 =
+        match v8 with
+        | Some x -> type_constraints env x
+        | None -> []
+      in
       let v9 =
-        match v9 with Some x -> enum_class_body env x | None -> fb []
+        match v9 with
+        | Some x -> enum_class_body env x
+        | None -> fb []
       in
       let ent = G.basic_entity v4 v1 in
       let cdef =
@@ -702,7 +742,11 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
       let d = declaration env x in
       FieldStmt (s (DefStmt d))
   | `Comp_obj (v1, v2, v3, v4, v5, v6) ->
-      let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+      let v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let v2 = token env v2 (* "companion" *) in
       let v3 = token env v3 (* "object" *) in
       let v4 =
@@ -718,7 +762,11 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
             Some (v1, v2)
         | None -> None
       in
-      let v6 = match v6 with Some x -> class_body env x | None -> fb [] in
+      let v6 =
+        match v6 with
+        | Some x -> class_body env x
+        | None -> fb []
+      in
       let ent = G.basic_entity v4 v1 in
       let cdef =
         {
@@ -736,7 +784,11 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
       let v2 = block env v2 in
       FieldStmt v2
   | `Seco_cons (v1, v2, v3, v4, v5) ->
-      let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+      let v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let v2 = token env v2 (* "constructor" *) in
       let v3 = function_value_parameters env v3 in
       let v4 =
@@ -748,7 +800,9 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
         | None -> None
       in
       let v5 =
-        match v5 with Some x -> G.FBStmt (block env x) | None -> G.FBDecl G.sc
+        match v5 with
+        | Some x -> G.FBStmt (block env x)
+        | None -> G.FBDecl G.sc
       in
       todo env (v1, v2, v3, v4, v5)
 
@@ -763,7 +817,11 @@ and class_member_declarations (env : env) (xs : CST.class_member_declarations) :
 
 and class_parameter (env : env) ((v1, v2, v3, v4, v5, v6) : CST.class_parameter)
     =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 =
     match v2 with
     | Some x -> Some (anon_choice_val_2833752 env x)
@@ -821,7 +879,9 @@ and constructor_invocation (env : env) ((v1, v2) : CST.constructor_invocation) =
   v1
 
 and control_structure_body (env : env) (x : CST.control_structure_body) : stmt =
-  match x with `Blk x -> block env x | `Stmt x -> statement env x
+  match x with
+  | `Blk x -> block env x
+  | `Stmt x -> statement env x
 
 and declaration (env : env) (x : CST.declaration) : definition =
   match x with
@@ -829,7 +889,11 @@ and declaration (env : env) (x : CST.declaration) : definition =
       let ent, cdef = class_declaration env x in
       (ent, ClassDef cdef)
   | `Obj_decl (v1, v2, v3, v4, v5) ->
-      let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+      let v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let v2 = token env v2 (* "object" *) in
       let v3 = simple_identifier env v3 in
       let _v4 =
@@ -840,7 +904,11 @@ and declaration (env : env) (x : CST.declaration) : definition =
             Some (v1, v2)
         | None -> None
       in
-      let v5 = match v5 with Some x -> class_body env x | None -> fb [] in
+      let v5 =
+        match v5 with
+        | Some x -> class_body env x
+        | None -> fb []
+      in
       let ent = G.basic_entity v3 v1 in
       let cdef =
         {
@@ -854,8 +922,16 @@ and declaration (env : env) (x : CST.declaration) : definition =
       in
       (ent, ClassDef cdef)
   | `Func_decl (v1, v2, v3, v4, v5, v6, v7, v8) ->
-      let _v1 = match v1 with Some x -> modifiers env x | None -> [] in
-      let _v2 = match v2 with Some x -> type_parameters env x | None -> [] in
+      let _v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
+      let _v2 =
+        match v2 with
+        | Some x -> type_parameters env x
+        | None -> []
+      in
       let v3 = token env v3 (* "fun" *) in
       let v4 = simple_identifier env v4 in
       let v5 = function_value_parameters env v5 in
@@ -867,9 +943,15 @@ and declaration (env : env) (x : CST.declaration) : definition =
             Some v2
         | None -> None
       in
-      let _v7 = match v7 with Some x -> type_constraints env x | None -> [] in
+      let _v7 =
+        match v7 with
+        | Some x -> type_constraints env x
+        | None -> []
+      in
       let v8 =
-        match v8 with Some x -> function_body env x | None -> G.FBDecl G.sc
+        match v8 with
+        | Some x -> function_body env x
+        | None -> G.FBDecl G.sc
       in
       let entity = basic_entity v4 [] in
       let func_def =
@@ -878,12 +960,24 @@ and declaration (env : env) (x : CST.declaration) : definition =
       let def_kind = FuncDef func_def in
       (entity, def_kind)
   | `Prop_decl (v1, v2, v3, v4, v5, v6, v7) ->
-      let _v1 = match v1 with Some x -> modifiers env x | None -> [] in
+      let _v1 =
+        match v1 with
+        | Some x -> modifiers env x
+        | None -> []
+      in
       let _v2 = anon_choice_val_2833752 env v2 in
-      let _v3 = match v3 with Some x -> type_parameters env x | None -> [] in
+      let _v3 =
+        match v3 with
+        | Some x -> type_parameters env x
+        | None -> []
+      in
       let v4 = variable_declaration env v4 in
       let tok, type_info = v4 in
-      let _v5 = match v5 with Some x -> type_constraints env x | None -> [] in
+      let _v5 =
+        match v5 with
+        | Some x -> type_constraints env x
+        | None -> []
+      in
       let v6 =
         match v6 with
         | Some x -> (
@@ -951,13 +1045,19 @@ and delegation_specifiers (env : env) ((v1, v2) : CST.delegation_specifiers) =
 
 and enum_class_body (env : env) ((v1, v2, v3, v4) : CST.enum_class_body) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = match v2 with Some x -> enum_entries env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> enum_entries env x
+    | None -> []
+  in
   let v3 =
     match v3 with
     | Some (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 =
-          match v2 with Some x -> class_member_declarations env x | None -> []
+          match v2 with
+          | Some x -> class_member_declarations env x
+          | None -> []
         in
         v2
     | None -> []
@@ -976,17 +1076,29 @@ and enum_entries (env : env) ((v1, v2, v3) : CST.enum_entries) =
       v2
   in
   let _v3 =
-    match v3 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   v1 :: v2
 
 and enum_entry (env : env) ((v1, v2, v3, v4) : CST.enum_entry) =
-  let v1 = match v1 with Some x -> modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> modifiers env x
+    | None -> []
+  in
   let v2 = simple_identifier env v2 in
   let v3 =
-    match v3 with Some x -> Some (value_arguments env x) | None -> None
+    match v3 with
+    | Some x -> Some (value_arguments env x)
+    | None -> None
   in
-  let v4 = match v4 with Some x -> Some (class_body env x) | None -> None in
+  let v4 =
+    match v4 with
+    | Some x -> Some (class_body env x)
+    | None -> None
+  in
   todo env (v1, v2, v3, v4)
 
 and expression (env : env) (x : CST.expression) : expr =
@@ -1041,7 +1153,9 @@ and function_literal (env : env) (x : CST.function_literal) =
       let _v3 = token env v3 (* "(" *) in
       let _v4 = token env v4 (* ")" *) in
       let v5 =
-        match v5 with Some x -> function_body env x | None -> G.FBDecl G.sc
+        match v5 with
+        | Some x -> function_body env x
+        | None -> G.FBDecl G.sc
       in
       let kind = (Function, v1) in
       let func_def =
@@ -1086,7 +1200,11 @@ and function_type_parameters (env : env)
 
 and function_value_parameter (env : env)
     ((v1, v2, v3) : CST.function_value_parameter) =
-  let v1 = match v1 with Some x -> parameter_modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> parameter_modifiers env x
+    | None -> []
+  in
   let param1, param2 = parameter env v2 in
   let v3 =
     match v3 with
@@ -1238,14 +1356,20 @@ and lambda_literal (env : env) ((v1, v2, v3, v4) : CST.lambda_literal) =
     match v2 with
     | Some (v1, v2) ->
         let v1 =
-          match v1 with Some x -> lambda_parameters env x | None -> []
+          match v1 with
+          | Some x -> lambda_parameters env x
+          | None -> []
         in
         (* use this to delimit the Block below. *)
         let v2 = token env v2 (* "->" *) in
         (v1, v2)
     | None -> ([], v1)
   in
-  let v3 = match v3 with Some x -> statements env x | None -> [] in
+  let v3 =
+    match v3 with
+    | Some x -> statements env x
+    | None -> []
+  in
   let v4 = token env v4 (* "}" *) in
   let fbody = G.FBStmt (Block (lbracket, v3, v4) |> G.s) in
   let kind = (LambdaKind, v1) in
@@ -1373,7 +1497,11 @@ and parameter_modifiers (env : env) (x : CST.parameter_modifiers) =
 
 and parameter_with_optional_type (env : env)
     ((v1, v2, v3) : CST.parameter_with_optional_type) : ident * type_ option =
-  let _v1 = match v1 with Some x -> parameter_modifiers env x | None -> [] in
+  let _v1 =
+    match v1 with
+    | Some x -> parameter_modifiers env x
+    | None -> []
+  in
   let v2 = simple_identifier env v2 in
   let v3 =
     match v3 with
@@ -1402,7 +1530,11 @@ and primary_constructor (env : env) ((v1, v2) : CST.primary_constructor) =
   let v1 =
     match v1 with
     | Some (v1, v2) ->
-        let _v1 = match v1 with Some x -> modifiers env x | None -> [] in
+        let _v1 =
+          match v1 with
+          | Some x -> modifiers env x
+          | None -> []
+        in
         let v2 = token env v2 (* "constructor" *) in
         Some v2
     | None -> None
@@ -1520,7 +1652,11 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr_kind =
       x.G.e
   | `When_exp (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "when" *) in
-      let v2 = match v2 with Some x -> when_subject env x | None -> None in
+      let v2 =
+        match v2 with
+        | Some x -> when_subject env x
+        | None -> None
+      in
       let _v3 = token env v3 (* "{" *) in
       let v4 = List.map (when_entry env) v4 in
       let _v5 = token env v5 (* "}" *) in
@@ -1677,7 +1813,11 @@ and string_literal (env : env) (x : CST.string_literal) =
       todo env (v1, v2, v3)
 
 and type_ (env : env) ((v1, v2) : CST.type_) : type_ =
-  let v1 = match v1 with Some x -> type_modifiers env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> type_modifiers env x
+    | None -> []
+  in
   let v2 =
     match v2 with
     | `Paren_type x -> parenthesized_type env x
@@ -1734,7 +1874,9 @@ and type_modifiers (env : env) (xs : CST.type_modifiers) : attribute list =
 
 and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
   let _v1 =
-    match v1 with Some x -> type_parameter_modifiers env x | None -> []
+    match v1 with
+    | Some x -> type_parameter_modifiers env x
+    | None -> []
   in
   let origv2 = simple_identifier env v2 in
   let v3 =
@@ -1778,7 +1920,9 @@ and type_projection (env : env) ~tok (x : CST.type_projection) =
   match x with
   | `Opt_type_proj_modifs_type (v1, v2) ->
       let _v1 =
-        match v1 with Some x -> type_projection_modifiers env x | None -> []
+        match v1 with
+        | Some x -> type_projection_modifiers env x
+        | None -> []
       in
       let v2 = type_ env v2 in
       let fake_token = Parse_info.fake_info tok "type projection" in
@@ -1878,7 +2022,11 @@ and user_type (env : env) ((v1, v2) : CST.user_type) =
 
 and value_argument (env : env) ((v1, v2, v3, v4) : CST.value_argument) :
     argument =
-  let _v1 = match v1 with Some x -> annotation env x | None -> [] in
+  let _v1 =
+    match v1 with
+    | Some x -> annotation env x
+    | None -> []
+  in
   let v2 =
     match v2 with
     | Some (v1, v2) ->
@@ -1888,7 +2036,9 @@ and value_argument (env : env) ((v1, v2, v3, v4) : CST.value_argument) :
     | None -> None
   in
   let v3 =
-    match v3 with Some tok -> Some (token env tok) (* "*" *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "*" *)
+    | None -> None
   in
   let v4 = expression env v4 in
   let e =
@@ -1896,7 +2046,9 @@ and value_argument (env : env) ((v1, v2, v3, v4) : CST.value_argument) :
     | None -> v4
     | Some t -> Call (IdSpecial (Spread, t) |> G.e, fb [ Arg v4 ]) |> G.e
   in
-  match v2 with None -> Arg e | Some (id, _t) -> ArgKwd (id, e)
+  match v2 with
+  | None -> Arg e
+  | Some (id, _t) -> ArgKwd (id, e)
 
 and value_arguments (env : env) ((v1, v2, v3) : CST.value_arguments) :
     arguments bracket =
@@ -2015,7 +2167,11 @@ let source_file (env : env) (x : CST.source_file) : any =
   match x with
   | `Opt_sheb_line_opt_rep1_file_anno_semi_opt_pack_header_rep_import_header_rep_stmt_semi
       (v1, v2, v3, v4, v5) ->
-      let _v1 = match v1 with Some x -> shebang_line env x | None -> () in
+      let _v1 =
+        match v1 with
+        | Some x -> shebang_line env x
+        | None -> ()
+      in
       let _v2 =
         match v2 with
         | Some (v1, v2) ->
@@ -2025,7 +2181,9 @@ let source_file (env : env) (x : CST.source_file) : any =
         | None -> ()
       in
       let v3 =
-        match v3 with Some x -> [ package_header env x ] | None -> []
+        match v3 with
+        | Some x -> [ package_header env x ]
+        | None -> []
       in
       let v4 = List.map (import_header env) v4 in
       let v5 =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -233,7 +233,9 @@ and map_arguments (env : env) (x : CST.arguments) : G.arguments G.bracket =
   | `LPAR_opt_exp_rep_COMMA_exp_RPAR (v1, v2, v3) ->
       let v1 = token env v1 (* "(" *) in
       let v2 =
-        match v2 with Some x -> map_anon_arguments env x | None -> []
+        match v2 with
+        | Some x -> map_anon_arguments env x
+        | None -> []
       in
       let v3 = token env v3 (* ")" *) in
       (v1, v2, v3)
@@ -462,7 +464,11 @@ and map_field_sequence (env : env) ((v1, v2, v3) : CST.field_sequence) :
         v2)
       v2
   in
-  let _v3 = match v3 with Some x -> [ map_field_sep env x ] | None -> [] in
+  let _v3 =
+    match v3 with
+    | Some x -> [ map_field_sep env x ]
+    | None -> []
+  in
   v1 :: v2
 
 and map_function_body (env : env) ((v1, v2, v3, v4) : CST.function_body)
@@ -571,9 +577,15 @@ and map_prefix (env : env) (x : CST.prefix) : G.expr =
 and map_return_statement (env : env) ((v1, v2, v3) : CST.return_statement) =
   let v1 = token env v1 (* "return" *) in
   let v2 =
-    match v2 with Some x -> Some (map_expression_tuple env x) | None -> None
+    match v2 with
+    | Some x -> Some (map_expression_tuple env x)
+    | None -> None
   in
-  let v3 = match v3 with Some tok -> token env tok (* ";" *) | None -> G.sc in
+  let v3 =
+    match v3 with
+    | Some tok -> token env tok (* ";" *)
+    | None -> G.sc
+  in
   G.Return (v1, v2, v3) |> G.s
 
 and map_statement (env : env) (x : CST.statement) : G.stmt list =
@@ -646,7 +658,9 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
           None v6
       in
       let v7 =
-        match v7 with Some x -> Some (map_else_ env x) | None -> None
+        match v7 with
+        | Some x -> Some (map_else_ env x)
+        | None -> None
       in
       let _v8 = token env v8 (* "end" *) in
       let ifstmt =
@@ -707,7 +721,11 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
 
 and map_table (env : env) ((v1, v2, v3) : CST.table) : G.expr =
   let v1 = token env v1 (* "{" *) in
-  let v2 = match v2 with Some x -> map_field_sequence env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> map_field_sequence env x
+    | None -> []
+  in
   let v3 = token env v3 (* "}" *) in
   G.Container (G.Dict, (v1, v2, v3)) |> G.e
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -41,7 +41,9 @@ let token = H.token
 let str = H.str
 
 (* like in parser_ml.mly *)
-let seq1 = function [ x ] -> x | xs -> Sequence (PI.unsafe_fake_bracket xs)
+let seq1 = function
+  | [ x ] -> x
+  | xs -> Sequence (PI.unsafe_fake_bracket xs)
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -74,12 +76,16 @@ let map_boolean (env : env) (x : CST.boolean) : literal =
 (* "false" *)
 
 let map_or_operator (env : env) (x : CST.or_operator) : string wrap =
-  match x with `Or tok -> str env tok (* "or" *) | `BARBAR tok -> str env tok
+  match x with
+  | `Or tok -> str env tok (* "or" *)
+  | `BARBAR tok -> str env tok
 
 (* "||" *)
 
 let map_and_operator_ (env : env) (x : CST.and_operator_) : string wrap =
-  match x with `AMP tok -> str env tok (* "&" *) | `AMPAMP tok -> str env tok
+  match x with
+  | `AMP tok -> str env tok (* "&" *)
+  | `AMPAMP tok -> str env tok
 
 (* "&&" *)
 
@@ -132,7 +138,8 @@ let map_anon_choice_muta_d43fe41 (env : env) (x : CST.anon_choice_muta_d43fe41)
 (* "virtual" *)
 
 let map_assign_operator (env : env) (x : CST.assign_operator) =
-  match x with `COLONEQ tok -> str env tok
+  match x with
+  | `COLONEQ tok -> str env tok
 
 (* ":=" *)
 
@@ -379,7 +386,11 @@ let map_class_type_path (env : env) (x : CST.class_type_path) : name =
 
 let map_string_ (env : env) ((v1, v2, v3) : CST.string_) : string wrap =
   let v1 = token env v1 (* "\"" *) in
-  let v2 = match v2 with Some x -> map_string_content env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> map_string_content env x
+    | None -> []
+  in
   let v3 = token env v3 (* "\"" *) in
   let s = v2 |> List.map fst |> String.concat "" in
   let ts = v2 |> List.map snd in
@@ -530,7 +541,9 @@ let map_constant (env : env) (x : CST.constant) : literal =
       let v1 = token env v1 (* "{" *) in
       let v2 = token env v2 (* left_quoted_string_delimiter *) in
       let v3 =
-        match v3 with Some x -> map_quoted_string_content env x | None -> []
+        match v3 with
+        | Some x -> map_quoted_string_content env x
+        | None -> []
       in
       let v4 = token env v4 (* right_quoted_string_delimiter *) in
       let v5 = token env v5 (* "}" *) in
@@ -556,7 +569,9 @@ let map_attribute (env : env) ((v1, v2) : CST.attribute) : dotted_ident =
   v2
 
 let map_attribute_opt env v =
-  match v with Some x -> Some (map_attribute env x) | None -> None
+  match v with
+  | Some x -> Some (map_attribute env x)
+  | None -> None
 
 let map_type_param (env : env) ((v1, v2) : CST.type_param) : type_parameter =
   let _v1TODO =
@@ -697,7 +712,9 @@ let rec map_anon_bind_pat_ext_rep_SEMI_bind_pat_ext_opt_SEMI_38caf30 (env : env)
       v2
   in
   let _v3 =
-    match v3 with Some tok -> [ token env tok (* ";" *) ] | None -> []
+    match v3 with
+    | Some tok -> [ token env tok (* ";" *) ]
+    | None -> []
   in
   v1 :: v2
 
@@ -706,7 +723,11 @@ and map_anon_choice_cons_type_771aabb (env : env)
   match x with
   | `Cons_type (v1, v2, v3, v4, v5) ->
       let _v1 = token env v1 (* "type" *) in
-      let _v2 = match v2 with Some x -> map_type_params env x | None -> [] in
+      let _v2 =
+        match v2 with
+        | Some x -> map_type_params env x
+        | None -> []
+      in
       let _v3 = map_type_constructor_path env v3 in
       let _v4 = map_type_equation env v4 in
       let _v5 = List.map (map_type_constraint env) v5 in
@@ -780,7 +801,9 @@ and map_anon_exp_ext_rep_SEMI_exp_ext_opt_SEMI_f0de170 (env : env)
       v2
   in
   let _v3 =
-    match v3 with Some tok -> [ token env tok (* ";" *) ] | None -> []
+    match v3 with
+    | Some tok -> [ token env tok (* ";" *) ]
+    | None -> []
   in
   v1 :: v2
 
@@ -797,7 +820,9 @@ and map_anon_pat_ext_rep_SEMI_pat_ext_opt_SEMI_3830e8c (env : env)
       v2
   in
   let _v3 =
-    match v3 with Some tok -> [ token env tok (* ";" *) ] | None -> []
+    match v3 with
+    | Some tok -> [ token env tok (* ";" *) ]
+    | None -> []
   in
   v1 :: v2
 
@@ -875,12 +900,16 @@ and map_attribute_payload (env : env) (x : CST.attribute_payload) : item list =
       let v1 = token env v1 (* "?" *) in
       let _v2 = map_pattern_ext env v2 in
       let _v3 =
-        match v3 with Some x -> Some (map_guard env x) | None -> None
+        match v3 with
+        | Some x -> Some (map_guard env x)
+        | None -> None
       in
       [ ItemTodo (("AttrQuestion", v1), []) |> mki ]
 
 and map_attribute_payload_opt env v =
-  match v with Some x -> map_attribute_payload env x | None -> []
+  match v with
+  | Some x -> map_attribute_payload env x
+  | None -> []
 
 and map_bigarray_get_expression (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.bigarray_get_expression) =
@@ -1006,7 +1035,9 @@ and map_class_binding (env : env)
   let _v3 = token env v3 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
   let _v4 = List.map (map_parameter env) v4 in
   let _v5 =
-    match v5 with Some x -> Some (map_class_typed env x) | None -> None
+    match v5 with
+    | Some x -> Some (map_class_typed env x)
+    | None -> None
   in
   let _v6 =
     match v6 with
@@ -1401,7 +1432,9 @@ and map_expression (env : env) (x : CST.expression) : expr =
       let v3 = map_sequence_expression_ext env v3 |> seq1 in
       let v4 = map_then_clause env v4 in
       let v5 =
-        match v5 with Some x -> Some (map_else_clause env x) | None -> None
+        match v5 with
+        | Some x -> Some (map_else_clause env x)
+        | None -> None
       in
       If (v1, v3, v4, v5)
   | `While_exp (v1, v2, v3, v4) ->
@@ -1449,7 +1482,9 @@ and map_expression (env : env) (x : CST.expression) : expr =
       let _v2 = map_attribute_opt env v2 in
       let v3 = List.map (map_parameter env) v3 in
       let _v4TODO =
-        match v4 with Some x -> Some (map_simple_typed env x) | None -> None
+        match v4 with
+        | Some x -> Some (map_simple_typed env x)
+        | None -> None
       in
       let _v5 = token env v5 (* "->" *) in
       let v6 = map_sequence_expression_ext env v6 |> seq1 in
@@ -1699,7 +1734,9 @@ and map_item_extension (env : env) (x : CST.item_extension) =
       in
       let _v4 = token env v4 (* left_quoted_string_delimiter *) in
       let _v5 =
-        match v5 with Some x -> map_quoted_string_content env x | None -> []
+        match v5 with
+        | Some x -> map_quoted_string_content env x
+        | None -> []
       in
       let _v6 = token env v6 (* right_quoted_string_delimiter *) in
       let _v7 = token env v7 (* "}" *) in
@@ -1789,7 +1826,11 @@ and map_list_pattern (env : env) ((v1, v2, v3) : CST.list_pattern) =
 and map_match_case (env : env) ((v1, v2, v3, v4) : CST.match_case) : match_case
     =
   let v1 = map_pattern_ext env v1 in
-  let v2 = match v2 with Some x -> Some (map_guard env x) | None -> None in
+  let v2 =
+    match v2 with
+    | Some x -> Some (map_guard env x)
+    | None -> None
+  in
   let v3 = token env v3 (* "->" *) in
   let v4 =
     match v4 with
@@ -1803,7 +1844,9 @@ and map_match_case (env : env) ((v1, v2, v3, v4) : CST.match_case) : match_case
 
 and map_match_cases (env : env) ((v1, v2, v3) : CST.match_cases) =
   let _v1 =
-    match v1 with Some tok -> Some (token env tok) (* "|" *) | None -> None
+    match v1 with
+    | Some tok -> Some (token env tok) (* "|" *)
+    | None -> None
   in
   let v2 = map_match_case env v2 in
   let v3 =
@@ -1820,7 +1863,9 @@ and map_module_binding (env : env) ((v1, v2, v3, v4, v5) : CST.module_binding) =
   let v1 = map_anon_choice_module_name_7ad5569 env v1 in
   let _v2TODO = List.map (map_module_parameter env) v2 in
   let _v3TODO =
-    match v3 with Some x -> Some (map_module_typed env x) | None -> None
+    match v3 with
+    | Some x -> Some (map_module_typed env x)
+    | None -> None
   in
   let v4 =
     match v4 with
@@ -1859,7 +1904,11 @@ and map_module_expression (env : env) (x : CST.module_expression) =
       ModuleName (qualifier_to_name x)
   | `Stru_ (v1, v2, v3) ->
       let _v1 = token env v1 (* "struct" *) in
-      let v2 = match v2 with Some x -> map_structure env x | None -> [] in
+      let v2 =
+        match v2 with
+        | Some x -> map_structure env x
+        | None -> []
+      in
       let _v3 = token env v3 (* "end" *) in
       ModuleStruct v2
   | `Func (v1, v2, v3, v4) ->
@@ -1907,7 +1956,11 @@ and map_module_type (env : env) (x : CST.module_type) =
       ()
   | `Sign_ (v1, v2, v3) ->
       let _v1 = token env v1 (* "sig" *) in
-      let _v2 = match v2 with Some x -> map_signature env x | None -> [] in
+      let _v2 =
+        match v2 with
+        | Some x -> map_signature env x
+        | None -> []
+      in
       let _v3 = token env v3 (* "end" *) in
       ()
   | `Module_type_cons (v1, v2, v3, v4) ->
@@ -1997,7 +2050,9 @@ and map_object_copy_expression (env : env)
     | None -> []
   in
   let _v3 =
-    match v3 with Some tok -> Some (token env tok) (* ";" *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* ";" *)
+    | None -> None
   in
   let _v4 = token env v4 (* ">}" *) in
   ExprTodo (("ObjCopy", v1), v2 |> List.map snd)
@@ -2034,7 +2089,9 @@ and map_object_expression (env : env)
 and map_open_module (env : env) ((v1, v2, v3, v4, v5) : CST.open_module) =
   let v1 = token env v1 (* "open" *) in
   let _v2 =
-    match v2 with Some tok -> Some (token env tok) (* "!" *) | None -> None
+    match v2 with
+    | Some tok -> Some (token env tok) (* "!" *)
+    | None -> None
   in
   let _v3 = map_attribute_opt env v3 in
   let v4 = map_module_expression_ext env v4 in
@@ -2050,7 +2107,9 @@ and map_package_expression (env : env)
   let _v3 = map_attribute_opt env v3 in
   let _v4 = map_module_expression_ext env v4 in
   let _v5 =
-    match v5 with Some x -> Some (map_module_typed env x) | None -> None
+    match v5 with
+    | Some x -> Some (map_module_typed env x)
+    | None -> None
   in
   let _v6 = token env v6 (* ")" *) in
   ExprTodo (("Package", v1), [])
@@ -2062,7 +2121,9 @@ and map_package_pattern (env : env)
   let _v3 = map_attribute_opt env v3 in
   let _v4 = map_anon_choice_module_name_7ad5569 env v4 in
   let _v5 =
-    match v5 with Some x -> Some (map_module_typed env x) | None -> None
+    match v5 with
+    | Some x -> Some (map_module_typed env x)
+    | None -> None
   in
   let _v6 = token env v6 (* ")" *) in
   PatTodo (("Package", v1), [])
@@ -2246,7 +2307,9 @@ and map_record_binding_pattern (env : env)
     | None -> None
   in
   let _v5 =
-    match v5 with Some tok -> Some (token env tok) (* ";" *) | None -> None
+    match v5 with
+    | Some tok -> Some (token env tok) (* ";" *)
+    | None -> None
   in
   let v6 = token env v6 (* "}" *) in
   PatRecord (v1, v3, v6)
@@ -2264,7 +2327,9 @@ and map_record_declaration (env : env)
       v3
   in
   let _v4 =
-    match v4 with Some tok -> Some (token env tok) (* ";" *) | None -> None
+    match v4 with
+    | Some tok -> Some (token env tok) (* ";" *)
+    | None -> None
   in
   let v5 = token env v5 (* "}" *) in
   (v1, v2 :: v3, v5)
@@ -2290,7 +2355,9 @@ and map_record_expression (env : env)
       v4
   in
   let _v5 =
-    match v5 with Some tok -> Some (token env tok) (* ";" *) | None -> None
+    match v5 with
+    | Some tok -> Some (token env tok) (* ";" *)
+    | None -> None
   in
   let v6 = token env v6 (* "}" *) in
   Record (v2, (v1, v3 :: v4, v6))
@@ -2316,7 +2383,9 @@ and map_record_pattern (env : env)
     | None -> None
   in
   let _v5 =
-    match v5 with Some tok -> Some (token env tok) (* ";" *) | None -> None
+    match v5 with
+    | Some tok -> Some (token env tok) (* ";" *)
+    | None -> None
   in
   let v6 = token env v6 (* "}" *) in
   PatRecord (v1, v2 :: v3, v6)
@@ -2597,7 +2666,9 @@ and map_simple_module_expression (env : env) (x : CST.simple_module_expression)
       let _v2 = token env v2 (* "val" *) in
       let _v3 = map_expression_ext env v3 in
       let _v4 =
-        match v4 with Some x -> Some (map_module_typed env x) | None -> None
+        match v4 with
+        | Some x -> Some (map_module_typed env x)
+        | None -> None
       in
       let _v5 =
         match v5 with
@@ -2668,7 +2739,9 @@ and map_simple_pattern (env : env) (x : CST.simple_pattern) : pattern =
       let v2 = map_pattern_ext env v2 in
       let v3 = token env v3 (* ")" *) in
       (* putting real tokens on Tuples *)
-      match v2 with PatTuple (_, xs, _) -> PatTuple (v1, xs, v3) | p -> p)
+      match v2 with
+      | PatTuple (_, xs, _) -> PatTuple (v1, xs, v3)
+      | p -> p)
 
 and map_simple_pattern_ext (env : env) (x : CST.simple_pattern_ext) : pattern =
   match x with
@@ -2703,7 +2776,9 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
           (v1, v2, v3, v4, v5, v6) ->
           let v1 = token env v1 (* "[" *) in
           let _v2 =
-            match v2 with Some x -> Some (map_tag_spec env x) | None -> None
+            match v2 with
+            | Some x -> Some (map_tag_spec env x)
+            | None -> None
           in
           let _v3 = token env v3 (* "|" *) in
           let _v4 = map_tag_spec env v4 in
@@ -2990,11 +3065,17 @@ and map_type_ (env : env) (x : CST.type_) : type_ =
       TyTodo (("Alias", v2), [ v1 ])
 
 and private_opt env v =
-  match v with None -> None | Some tok -> Some (token env tok)
+  match v with
+  | None -> None
+  | Some tok -> Some (token env tok)
 
 and map_type_binding (env : env) ((v1, v2, v3) : CST.type_binding) :
     type_declaration =
-  let tparams = match v1 with Some x -> map_type_params env x | None -> [] in
+  let tparams =
+    match v1 with
+    | Some x -> map_type_params env x
+    | None -> []
+  in
   let v2 =
     match v2 with
     | `Id_opt_type_equa_opt_EQ_opt_priv_choice_vari_decl_rep_type_cons
@@ -3094,11 +3175,15 @@ and map_typed (env : env) ((v1, v2) : CST.typed) : tok * type_ =
   (v1, v2)
 
 and map_typed_opt env v : type_ option =
-  match v with Some x -> Some (snd (map_typed env x)) | None -> None
+  match v with
+  | Some x -> Some (snd (map_typed env x))
+  | None -> None
 
 and map_typed_label (env : env) ((v1, v2, v3, v4) : CST.typed_label) =
   let _v1 =
-    match v1 with Some tok -> Some (token env tok) (* "?" *) | None -> None
+    match v1 with
+    | Some tok -> Some (token env tok) (* "?" *)
+    | None -> None
   in
   let _v2 = str env v2 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
   let v3 = token env v3 (* ":" *) in
@@ -3106,7 +3191,9 @@ and map_typed_label (env : env) ((v1, v2, v3, v4) : CST.typed_label) =
   TyTodo (("Label", v3), [ v4 ])
 
 and rec_opt env x =
-  match x with None -> None | Some tok -> Some (token env tok)
+  match x with
+  | None -> None
+  | Some tok -> Some (token env tok)
 
 and map_value_definition (env : env) ((v1, v2, v3) : CST.value_definition) :
     tok * rec_opt * let_binding list =
@@ -3158,7 +3245,11 @@ let map_compilation_unit (env : env) ((v1, v2) : CST.compilation_unit) =
     | Some tok -> Some (token env tok) (* pattern #!.* *)
     | None -> None
   in
-  let v2 = match v2 with Some x -> map_structure env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> map_structure env x
+    | None -> []
+  in
   v2
 
 (*****************************************************************************)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -205,7 +205,9 @@ let map_anonymous_function_use_clause (env : env)
   let v1 = (* pattern [uU][sS][eE] *) token env v1 in
   let v2 = (* "(" *) token env v2 in
   let v3 =
-    match v3 with Some tok -> (* "&" *) token env tok | None -> todo env ()
+    match v3 with
+    | Some tok -> (* "&" *) token env tok
+    | None -> todo env ()
   in
   let v4 = map_variable_name env v4 in
   let v5 =
@@ -222,7 +224,9 @@ let map_anonymous_function_use_clause (env : env)
       v5
   in
   let v6 =
-    match v6 with Some tok -> (* "," *) token env tok | None -> todo env ()
+    match v6 with
+    | Some tok -> (* "," *) token env tok
+    | None -> todo env ()
   in
   let v7 = (* ")" *) token env v7 in
   todo env (v1, v2, v3, v4, v5, v6, v7)
@@ -504,10 +508,14 @@ and map_anon_choice_simple_param_5af5eb3 (env : env)
   match x with
   | `Simple_param (v1, v2, v3, v4, v5) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 =
-        match v2 with Some x -> map_type_ env x | None -> todo env ()
+        match v2 with
+        | Some x -> map_type_ env x
+        | None -> todo env ()
       in
       let v3 =
         match v3 with
@@ -523,10 +531,14 @@ and map_anon_choice_simple_param_5af5eb3 (env : env)
       todo env (v1, v2, v3, v4, v5)
   | `Vari_param (v1, v2, v3, v4, v5) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 =
-        match v2 with Some x -> map_type_ env x | None -> todo env ()
+        match v2 with
+        | Some x -> map_type_ env x
+        | None -> todo env ()
       in
       let v3 =
         match v3 with
@@ -539,7 +551,9 @@ and map_anon_choice_simple_param_5af5eb3 (env : env)
   | `Prop_prom_param (v1, v2, v3, v4) ->
       let v1 = map_visibility_modifier env v1 in
       let v2 =
-        match v2 with Some x -> map_type_ env x | None -> todo env ()
+        match v2 with
+        | Some x -> map_type_ env x
+        | None -> todo env ()
       in
       let v3 = map_variable_name env v3 in
       let v4 =
@@ -580,7 +594,9 @@ and map_arguments (env : env) ((v1, v2, v3, v4) : CST.arguments) =
     | None -> todo env ()
   in
   let v3 =
-    match v3 with Some tok -> (* "," *) token env tok | None -> todo env ()
+    match v3 with
+    | Some tok -> (* "," *) token env tok
+    | None -> todo env ()
   in
   let v4 = (* ")" *) token env v4 in
   todo env (v1, v2, v3, v4)
@@ -671,7 +687,9 @@ and map_array_element_initializer (env : env)
 and map_attribute (env : env) ((v1, v2) : CST.attribute) =
   let v1 = map_anon_choice_name_062e4f2 env v1 in
   let v2 =
-    match v2 with Some x -> map_arguments env x | None -> todo env ()
+    match v2 with
+    | Some x -> map_arguments env x
+    | None -> todo env ()
   in
   todo env (v1, v2)
 
@@ -884,7 +902,9 @@ and map_catch_clause (env : env) ((v1, v2, v3, v4, v5, v6) : CST.catch_clause) =
   let v2 = (* "(" *) token env v2 in
   let v3 = map_type_list env v3 in
   let v4 =
-    match v4 with Some x -> map_variable_name env x | None -> todo env ()
+    match v4 with
+    | Some x -> map_variable_name env x
+    | None -> todo env ()
   in
   let v5 = (* ")" *) token env v5 in
   let v6 = map_compound_statement env v6 in
@@ -1021,7 +1041,9 @@ and map_enum_member_declaration (env : env) (x : CST.enum_member_declaration) =
   match x with
   | `Enum_case (v1, v2, v3, v4, v5) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 = (* "case" *) token env v2 in
       let v3 =
@@ -1067,7 +1089,9 @@ and map_expression (env : env) (x : CST.expression) =
       let v1 = map_expression env v1 in
       let v2 = (* "?" *) token env v2 in
       let v3 =
-        match v3 with Some x -> map_expression env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_expression env x
+        | None -> todo env ()
       in
       let v4 = (* ":" *) token env v4 in
       let v5 = map_expression env v5 in
@@ -1197,7 +1221,9 @@ and map_formal_parameters (env : env) ((v1, v2, v3, v4) : CST.formal_parameters)
     | None -> todo env ()
   in
   let v3 =
-    match v3 with Some tok -> (* "," *) token env tok | None -> todo env ()
+    match v3 with
+    | Some tok -> (* "," *) token env tok
+    | None -> todo env ()
   in
   let v4 = (* ")" *) token env v4 in
   todo env (v1, v2, v3, v4)
@@ -1206,12 +1232,16 @@ and map_function_definition_header (env : env)
     ((v1, v2, v3, v4, v5) : CST.function_definition_header) =
   let v1 = (* pattern [fF][uU][nN][cC][tT][iI][oO][nN] *) token env v1 in
   let v2 =
-    match v2 with Some tok -> (* "&" *) token env tok | None -> todo env ()
+    match v2 with
+    | Some tok -> (* "&" *) token env tok
+    | None -> todo env ()
   in
   let v3 = map_anon_choice_name_9dd129a env v3 in
   let v4 = map_formal_parameters env v4 in
   let v5 =
-    match v5 with Some x -> map_return_type env x | None -> todo env ()
+    match v5 with
+    | Some x -> map_return_type env x
+    | None -> todo env ()
   in
   todo env (v1, v2, v3, v4, v5)
 
@@ -1256,7 +1286,9 @@ and map_match_block (env : env) ((v1, v2, v3, v4, v5) : CST.match_block) =
       v3
   in
   let v4 =
-    match v4 with Some tok -> (* "," *) token env tok | None -> todo env ()
+    match v4 with
+    | Some tok -> (* "," *) token env tok
+    | None -> todo env ()
   in
   let v5 = (* "}" *) token env v5 in
   todo env (v1, v2, v3, v4, v5)
@@ -1284,7 +1316,9 @@ and map_member_declaration (env : env) (x : CST.member_declaration) =
   match x with
   | `Class_const_decl (v1, v2, v3) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 =
         match v2 with
@@ -1295,11 +1329,15 @@ and map_member_declaration (env : env) (x : CST.member_declaration) =
       todo env (v1, v2, v3)
   | `Prop_decl (v1, v2, v3, v4, v5, v6) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 = List.map (map_modifier env) v2 in
       let v3 =
-        match v3 with Some x -> map_type_ env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_type_ env x
+        | None -> todo env ()
       in
       let v4 = map_property_element env v4 in
       let v5 =
@@ -1333,7 +1371,9 @@ and map_member_name (env : env) (x : CST.member_name) =
 and map_method_declaration (env : env)
     ((v1, v2, v3, v4) : CST.method_declaration) =
   let v1 =
-    match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+    match v1 with
+    | Some x -> map_attribute_list env x
+    | None -> todo env ()
   in
   let v2 = List.map (map_modifier env) v2 in
   let v3 = map_function_definition_header env v3 in
@@ -1358,7 +1398,9 @@ and map_object_creation_expression (env : env)
       let v1 = (* "new" *) token env v1 in
       let v2 = map_class_type_designator env v2 in
       let v3 =
-        match v3 with Some x -> map_arguments env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ()
       in
       todo env (v1, v2, v3)
   | `New_pat_a7a1629_opt_args_opt_base_clause_opt_class_inte_clause_decl_list
@@ -1366,10 +1408,14 @@ and map_object_creation_expression (env : env)
       let v1 = (* "new" *) token env v1 in
       let v2 = (* pattern [cC][lL][aA][sS][sS] *) token env v2 in
       let v3 =
-        match v3 with Some x -> map_arguments env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ()
       in
       let v4 =
-        match v4 with Some x -> map_base_clause env x | None -> todo env ()
+        match v4 with
+        | Some x -> map_base_clause env x
+        | None -> todo env ()
       in
       let v5 =
         match v5 with
@@ -1419,7 +1465,9 @@ and map_primary_expression (env : env) (x : CST.primary_expression) =
         | None -> todo env ()
       in
       let v6 =
-        match v6 with Some x -> map_return_type env x | None -> todo env ()
+        match v6 with
+        | Some x -> map_return_type env x
+        | None -> todo env ()
       in
       let v7 = map_compound_statement env v7 in
       todo env (v1, v2, v3, v4, v5, v6, v7)
@@ -1437,7 +1485,9 @@ and map_primary_expression (env : env) (x : CST.primary_expression) =
       in
       let v4 = map_formal_parameters env v4 in
       let v5 =
-        match v5 with Some x -> map_return_type env x | None -> todo env ()
+        match v5 with
+        | Some x -> map_return_type env x
+        | None -> todo env ()
       in
       let v6 = (* "=>" *) token env v6 in
       let v7 = map_expression env v7 in
@@ -1562,15 +1612,21 @@ and map_statement (env : env) (x : CST.statement) =
       let v1 = (* pattern [fF][oO][rR] *) token env v1 in
       let v2 = (* "(" *) token env v2 in
       let v3 =
-        match v3 with Some x -> map_expressions env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_expressions env x
+        | None -> todo env ()
       in
       let v4 = (* ";" *) token env v4 in
       let v5 =
-        match v5 with Some x -> map_expressions env x | None -> todo env ()
+        match v5 with
+        | Some x -> map_expressions env x
+        | None -> todo env ()
       in
       let v6 = (* ";" *) token env v6 in
       let v7 =
-        match v7 with Some x -> map_expressions env x | None -> todo env ()
+        match v7 with
+        | Some x -> map_expressions env x
+        | None -> todo env ()
       in
       let v8 = (* ")" *) token env v8 in
       let v9 =
@@ -1622,21 +1678,27 @@ and map_statement (env : env) (x : CST.statement) =
   | `Cont_stmt (v1, v2, v3) ->
       let v1 = (* pattern [cC][oO][nN][tT][iI][nN][uU][eE] *) token env v1 in
       let v2 =
-        match v2 with Some x -> map_expression env x | None -> todo env ()
+        match v2 with
+        | Some x -> map_expression env x
+        | None -> todo env ()
       in
       let v3 = map_semicolon env v3 in
       todo env (v1, v2, v3)
   | `Brk_stmt (v1, v2, v3) ->
       let v1 = (* pattern [bB][rR][eE][aA][kK] *) token env v1 in
       let v2 =
-        match v2 with Some x -> map_expression env x | None -> todo env ()
+        match v2 with
+        | Some x -> map_expression env x
+        | None -> todo env ()
       in
       let v3 = map_semicolon env v3 in
       todo env (v1, v2, v3)
   | `Ret_stmt (v1, v2, v3) ->
       let v1 = (* pattern [rR][eE][tT][uU][rR][nN] *) token env v1 in
       let v2 =
-        match v2 with Some x -> map_expression env x | None -> todo env ()
+        match v2 with
+        | Some x -> map_expression env x
+        | None -> todo env ()
       in
       let v3 = map_semicolon env v3 in
       todo env (v1, v2, v3)
@@ -1696,14 +1758,18 @@ and map_statement (env : env) (x : CST.statement) =
   | `Const_decl x -> map_const_declaration env x
   | `Func_defi (v1, v2, v3) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 = map_function_definition_header env v2 in
       let v3 = map_compound_statement env v3 in
       todo env (v1, v2, v3)
   | `Class_decl (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 =
         match v2 with
@@ -1721,7 +1787,9 @@ and map_statement (env : env) (x : CST.statement) =
         token env v4
       in
       let v5 =
-        match v5 with Some x -> map_base_clause env x | None -> todo env ()
+        match v5 with
+        | Some x -> map_base_clause env x
+        | None -> todo env ()
       in
       let v6 =
         match v6 with
@@ -1730,7 +1798,9 @@ and map_statement (env : env) (x : CST.statement) =
       in
       let v7 = map_declaration_list env v7 in
       let v8 =
-        match v8 with Some x -> map_semicolon env x | None -> todo env ()
+        match v8 with
+        | Some x -> map_semicolon env x
+        | None -> todo env ()
       in
       todo env (v1, v2, v3, v4, v5, v6, v7, v8)
   | `Inte_decl (v1, v2, v3, v4) ->
@@ -1742,7 +1812,9 @@ and map_statement (env : env) (x : CST.statement) =
         token env v2
       in
       let v3 =
-        match v3 with Some x -> map_base_clause env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_base_clause env x
+        | None -> todo env ()
       in
       let v4 = map_declaration_list env v4 in
       todo env (v1, v2, v3, v4)
@@ -1756,7 +1828,9 @@ and map_statement (env : env) (x : CST.statement) =
       todo env (v1, v2, v3)
   | `Enum_decl (v1, v2, v3, v4, v5, v6) ->
       let v1 =
-        match v1 with Some x -> map_attribute_list env x | None -> todo env ()
+        match v1 with
+        | Some x -> map_attribute_list env x
+        | None -> todo env ()
       in
       let v2 = (* pattern [eE][nN][uU][mM] *) token env v2 in
       let v3 =
@@ -1764,7 +1838,9 @@ and map_statement (env : env) (x : CST.statement) =
         token env v3
       in
       let v4 =
-        match v4 with Some x -> map_return_type env x | None -> todo env ()
+        match v4 with
+        | Some x -> map_return_type env x
+        | None -> todo env ()
       in
       let v5 =
         match v5 with
@@ -1870,7 +1946,9 @@ and map_subscript_expression (env : env) ((v1, v2) : CST.subscript_expression) =
     | `LBRACK_opt_exp_RBRACK (v1, v2, v3) ->
         let v1 = (* "[" *) token env v1 in
         let v2 =
-          match v2 with Some x -> map_expression env x | None -> todo env ()
+          match v2 with
+          | Some x -> map_expression env x
+          | None -> todo env ()
         in
         let v3 = (* "]" *) token env v3 in
         todo env (v1, v2, v3)
@@ -2044,7 +2122,11 @@ and map_variadic_unpacking (env : env) ((v1, v2) : CST.variadic_unpacking) =
   todo env (v1, v2)
 
 let map_program (env : env) ((v1, v2) : CST.program) =
-  let v1 = match v1 with Some x -> map_text env x | None -> todo env () in
+  let v1 =
+    match v1 with
+    | Some x -> map_text env x
+    | None -> todo env ()
+  in
   let v2 =
     match v2 with
     | Some (v1, v2) ->

--- a/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
@@ -158,14 +158,18 @@ let rec map_argument (env : env) (x : CST.argument) =
       let v1 = map_anon_choice_id_c711a0e env v1 in
       let v2 = token env v2 (* "=" *) in
       let v3 =
-        match v3 with Some x -> map_expression env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_expression env x
+        | None -> todo env ()
       in
       todo env (v1, v2, v3)
 
 and map_arguments (env : env) (xs : CST.arguments) =
   List.map
     (fun x ->
-      match x with `Arg x -> map_argument env x | `COMMA tok -> token env tok
+      match x with
+      | `Arg x -> map_argument env x
+      | `COMMA tok -> token env tok
       (* "," *))
     xs
 
@@ -304,7 +308,9 @@ and map_expression (env : env) (x : CST.expression) =
       let v1 = map_expression env v1 in
       let v2 = token env v2 (* "(" *) in
       let v3 =
-        match v3 with Some x -> map_arguments env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ()
       in
       let v4 = token env v4 (* ")" *) in
       todo env (v1, v2, v3, v4)
@@ -326,7 +332,9 @@ and map_expression (env : env) (x : CST.expression) =
       let v1 = map_expression env v1 in
       let v2 = token env v2 (* "[" *) in
       let v3 =
-        match v3 with Some x -> map_arguments env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ()
       in
       let v4 = token env v4 (* "]" *) in
       todo env (v1, v2, v3, v4)
@@ -334,7 +342,9 @@ and map_expression (env : env) (x : CST.expression) =
       let v1 = map_expression env v1 in
       let v2 = token env v2 (* "[[" *) in
       let v3 =
-        match v3 with Some x -> map_arguments env x | None -> todo env ()
+        match v3 with
+        | Some x -> map_arguments env x
+        | None -> todo env ()
       in
       let v4 = token env v4 (* "]]" *) in
       todo env (v1, v2, v3, v4)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -113,10 +113,14 @@ let anon_choice_int_e7b97da (env : env) (x : CST.anon_choice_int_e7b97da) =
    )? *)
 
 let anon_choice_DOT_5431c66 (env : env) (x : CST.anon_choice_DOT_5431c66) =
-  match x with `DOT tok -> token2 env tok | `AMPDOT tok -> token2 env tok
+  match x with
+  | `DOT tok -> token2 env tok
+  | `AMPDOT tok -> token2 env tok
 
 let terminator (_env : env) (x : CST.terminator) : unit =
-  match x with `Line_brk _tok -> () | `SEMI _tok -> ()
+  match x with
+  | `Line_brk _tok -> ()
+  | `SEMI _tok -> ()
 
 let variable (env : env) (x : CST.variable) : AST.variable =
   match x with
@@ -144,7 +148,11 @@ let rec statements (env : env) (x : CST.statements) : AST.stmts =
                | `Empty_stmt _tok -> [])
         |> List.flatten
       in
-      let v2 = match v2 with Some x -> [ statement env x ] | None -> [] in
+      let v2 =
+        match v2 with
+        | Some x -> [ statement env x ]
+        | None -> []
+      in
       v1 @ v2
   | `Stmt x -> [ statement env x ]
 
@@ -204,13 +212,21 @@ and statement (env : env) (x : CST.statement) :
   | `Begin_blk (v1, v2, v3, v4) ->
       let v1 = token2 env v1 in
       let v2 = token2 env v2 in
-      let v3 = match v3 with Some x -> statements env x | None -> [] in
+      let v3 =
+        match v3 with
+        | Some x -> statements env x
+        | None -> []
+      in
       let v4 = token2 env v4 in
       D (BeginBlock (v1, (v2, v3, v4)))
   | `End_blk (v1, v2, v3, v4) ->
       let v1 = token2 env v1 in
       let v2 = token2 env v2 in
-      let v3 = match v3 with Some x -> statements env x | None -> [] in
+      let v3 =
+        match v3 with
+        | Some x -> statements env x
+        | None -> []
+      in
       let v4 = token2 env v4 in
       D (EndBlock (v1, (v2, v3, v4)))
   | `Exp x -> expression env x
@@ -221,10 +237,18 @@ and method_rest (env : env) ((v1, v2, v3) : CST.method_rest) =
     match v2 with
     | `Params_opt_term (v1, v2) ->
         let v1 = parameters env v1 |> G.unbracket in
-        let _v2 = match v2 with Some x -> terminator env x | None -> () in
+        let _v2 =
+          match v2 with
+          | Some x -> terminator env x
+          | None -> ()
+        in
         v1
     | `Opt_bare_params_term (v1, v2) ->
-        let v1 = match v1 with Some x -> bare_parameters env x | None -> [] in
+        let v1 =
+          match v1 with
+          | Some x -> bare_parameters env x
+          | None -> []
+        in
         let _v2 = terminator env v2 in
         v1
   in
@@ -283,7 +307,11 @@ and block_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.block_parameters) :
         v1 :: v2
     | None -> []
   in
-  let _v3 = match v3 with Some _tok -> () | None -> () in
+  let _v3 =
+    match v3 with
+    | Some _tok -> ()
+    | None -> ()
+  in
   let _v4SEMICOLONPARAMS =
     match v4 with
     | Some (v1, v2, v3) ->
@@ -325,7 +353,11 @@ and simple_formal_parameter (env : env) (x : CST.simple_formal_parameter) :
       | None -> Formal_rest v1)
   | `Hash_splat_param (v1, v2) ->
       let v1 = token2 env v1 in
-      let v2 = match v2 with Some tok -> Some (str env tok) | None -> None in
+      let v2 =
+        match v2 with
+        | Some tok -> Some (str env tok)
+        | None -> None
+      in
       Formal_hash_splat (v1, v2)
   | `Blk_param (v1, v2) ->
       let v1 = token2 env v1 in
@@ -334,7 +366,11 @@ and simple_formal_parameter (env : env) (x : CST.simple_formal_parameter) :
   | `Kw_param (v1, v2, v3) ->
       let v1 = str env v1 in
       let v2 = token2 env v2 in
-      let v3 = match v3 with Some x -> Some (arg env x) | None -> None in
+      let v3 =
+        match v3 with
+        | Some x -> Some (arg env x)
+        | None -> None
+      in
       Formal_kwd (v1, v2, v3)
   | `Opt_param (v1, v2, v3) ->
       let v1 = str env v1 in
@@ -373,7 +409,9 @@ and when_ (env : env) ((v1, v2, v3, v4) : CST.when_) =
   (twhen, v2 :: v3, v4)
 
 and pattern (env : env) (x : CST.pattern) : AST.pattern =
-  match x with `Arg x -> arg env x | `Splat_arg x -> splat_argument env x
+  match x with
+  | `Arg x -> arg env x
+  | `Splat_arg x -> splat_argument env x
 
 and elsif (env : env) ((v1, v2, v3, v4) : CST.elsif) : AST.tok * AST.stmt =
   let v1 = token2 env v1 in
@@ -400,8 +438,16 @@ and elsif (env : env) ((v1, v2, v3, v4) : CST.elsif) : AST.tok * AST.stmt =
 
 and else_ (env : env) ((v1, v2, v3) : CST.else_) : AST.tok * AST.stmts =
   let v1 = token2 env v1 in
-  let _v2 = match v2 with Some x -> terminator env x | None -> () in
-  let v3 = match v3 with Some x -> statements env x | None -> [] in
+  let _v2 =
+    match v2 with
+    | Some x -> terminator env x
+    | None -> ()
+  in
+  let v3 =
+    match v3 with
+    | Some x -> statements env x
+    | None -> []
+  in
   (v1, v3)
 
 and then_ (env : env) (x : CST.then_) : AST.stmts =
@@ -411,21 +457,39 @@ and then_ (env : env) (x : CST.then_) : AST.stmts =
       let v2 = statements env v2 in
       v2
   | `Opt_term_then_opt_stmts (v1, v2, v3) ->
-      let _v1 = match v1 with Some x -> terminator env x | None -> () in
+      let _v1 =
+        match v1 with
+        | Some x -> terminator env x
+        | None -> ()
+      in
       let _v2 = token2 env v2 in
-      let v3 = match v3 with Some x -> statements env x | None -> [] in
+      let v3 =
+        match v3 with
+        | Some x -> statements env x
+        | None -> []
+      in
       v3
 
 and ensure (env : env) ((v1, v2) : CST.ensure) =
   let v1 = token2 env v1 in
-  let v2 = match v2 with Some x -> statements env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> statements env x
+    | None -> []
+  in
   (v1, v2)
 
 and rescue (env : env) ((v1, v2, v3, v4) : CST.rescue) =
   let v1 = token2 env v1 in
-  let v2 = match v2 with Some x -> exceptions env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> exceptions env x
+    | None -> []
+  in
   let v3 =
-    match v3 with Some x -> Some (exception_variable env x) | None -> None
+    match v3 with
+    | Some x -> Some (exception_variable env x)
+    | None -> None
   in
   let v4 =
     match v4 with
@@ -438,7 +502,9 @@ and rescue (env : env) ((v1, v2, v3, v4) : CST.rescue) =
 
 and exceptions (env : env) ((v1, v2) : CST.exceptions) : AST.expr list =
   let v1 =
-    match v1 with `Arg x -> arg env x | `Splat_arg x -> splat_argument env x
+    match v1 with
+    | `Arg x -> arg env x
+    | `Splat_arg x -> splat_argument env x
   in
   let v2 =
     List.map
@@ -461,7 +527,11 @@ and exception_variable (env : env) ((v1, v2) : CST.exception_variable) =
 
 and body_statement (env : env) ((v1, v2, v3) : CST.body_statement) :
     AST.body_exn * AST.tok =
-  let v1 = match v1 with Some x -> statements env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> statements env x
+    | None -> []
+  in
   let rescue_exprs, else_expr, ensure_expr =
     Common2.partition_either3
       (fun x ->
@@ -475,11 +545,17 @@ and body_statement (env : env) ((v1, v2, v3) : CST.body_statement) :
   in
   let tend = token2 env v3 in
   let ensure_expr =
-    match ensure_expr with [] -> None | [ x ] -> Some x | x :: _ -> Some x
+    match ensure_expr with
+    | [] -> None
+    | [ x ] -> Some x
+    | x :: _ -> Some x
     (* TODO: weird, should have only one no? *)
   in
   let else_expr =
-    match else_expr with [] -> None | [ x ] -> Some x | x :: _ -> Some x
+    match else_expr with
+    | [] -> None
+    | [ x ] -> Some x
+    | x :: _ -> Some x
     (* TODO: weird, should have only one no? *)
   in
   ({ body_exprs = v1; rescue_exprs; else_expr; ensure_expr }, tend)
@@ -626,14 +702,18 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         | None -> []
       in
       let _v4 =
-        match v4 with Some tok -> Some (token2 env tok) | None -> None
+        match v4 with
+        | Some tok -> Some (token2 env tok)
+        | None -> None
       in
       let v5 = token2 env v5 (* string_end *) in
       Literal (String (Double (v1, v3 |> List.flatten, v5)))
   | `Symb_array (v1, v2, v3, v4, v5) ->
       let v1 = token2 env v1 (* %i( *) in
       let _v2 =
-        match v2 with Some tok -> Some (token2 env tok) | None -> None
+        match v2 with
+        | Some tok -> Some (token2 env tok)
+        | None -> None
       in
       let v3 =
         match v3 with
@@ -641,7 +721,9 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         | None -> []
       in
       let _v4 =
-        match v4 with Some tok -> Some (token2 env tok) | None -> None
+        match v4 with
+        | Some tok -> Some (token2 env tok)
+        | None -> None
       in
       let v5 = token2 env v5 (* ) *) in
       Atom (v1, AtomFromString (v1, v3 |> List.flatten, v5))
@@ -667,7 +749,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
                   v2)
                 v2
             in
-            let _v3 = match v3 with Some _tok -> () | None -> () in
+            let _v3 =
+              match v3 with
+              | Some _tok -> ()
+              | None -> ()
+            in
             v1 :: v2
         | None -> []
       in
@@ -675,7 +761,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
       Hash (true, (v1, v2, v3))
   | `Subs (v1, v2, v3) ->
       let v1 = token2 env v1 in
-      let v2 = match v2 with Some x -> literal_contents env x | None -> [] in
+      let v2 =
+        match v2 with
+        | Some x -> literal_contents env x
+        | None -> []
+      in
       let v3 = token2 env v3 in
       Literal (String (Tick (v1, v2, v3)))
   | `Simple_symb tok -> Atom (simple_symbol env tok)
@@ -703,7 +793,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
       Literal (String (Double (l, v1 @ v2, r)))
   | `Regex (v1, v2, v3) ->
       let v1 = token2 env v1 in
-      let v2 = match v2 with Some x -> literal_contents env x | None -> [] in
+      let v2 =
+        match v2 with
+        | Some x -> literal_contents env x
+        | None -> []
+      in
       let v3 = token2 env v3 in
       (* TODO: no modifier in Ruby grammar.js? *)
       Literal (Regexp ((v1, v2, v3), None))
@@ -719,7 +813,9 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         | None -> None
       in
       let v3 =
-        match v3 with `Blk x -> block env x | `Do_blk x -> do_block env x
+        match v3 with
+        | `Blk x -> block env x
+        | `Do_blk x -> do_block env x
       in
       let b = false in
       (* should have a third option for lambdas *)
@@ -756,7 +852,9 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         | `Scope_resol x -> NameScope (scope_resolution env x)
       in
       let v3 =
-        match v3 with Some x -> Some (superclass env x) | None -> None
+        match v3 with
+        | Some x -> Some (superclass env x)
+        | None -> None
       in
       let _v4 = terminator env v4 in
       let v5, _tend = body_statement env v5 in
@@ -786,7 +884,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
       D (ModuleDef (v1, v2, v3))
   | `Begin (v1, v2, v3) ->
       let tbegin = token2 env v1 in
-      let _v2 = match v2 with Some x -> terminator env x | None -> () in
+      let _v2 =
+        match v2 with
+        | Some x -> terminator env x
+        | None -> ()
+      in
       let v3, tend = body_statement env v3 in
       S (Block (tbegin, [ S (ExnBlock v3) ], tend))
   | `While (v1, v2, v3) ->
@@ -858,13 +960,21 @@ and primary (env : env) (x : CST.primary) : AST.expr =
   | `Case (v1, v2, v3, v5, v6, v7) ->
       let v1 = token2 env v1 in
       let v2 =
-        match v2 with Some x -> Some (statement env x) | None -> None
+        match v2 with
+        | Some x -> Some (statement env x)
+        | None -> None
       in
       let _v3 =
-        match v3 with Some x -> Some (terminator env x) | None -> None
+        match v3 with
+        | Some x -> Some (terminator env x)
+        | None -> None
       in
       let v5 = List.map (when_ env) v5 in
-      let v6 = match v6 with Some x -> Some (else_ env x) | None -> None in
+      let v6 =
+        match v6 with
+        | Some x -> Some (else_ env x)
+        | None -> None
+      in
       let _v7 = token2 env v7 in
       S (Case (v1, { case_guard = v2; case_whens = v5; case_else = v6 }))
   | `Ret (v1, v2) ->
@@ -943,7 +1053,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
 and parenthesized_statements (env : env)
     ((v1, v2, v3) : CST.parenthesized_statements) =
   let v1 = token2 env v1 in
-  let v2 = match v2 with Some x -> statements env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> statements env x
+    | None -> []
+  in
   let v3 = token2 env v3 in
   (v1, v2, v3)
 
@@ -1079,7 +1193,11 @@ and argument_list_with_trailing_comma (env : env)
         v2)
       v2
   in
-  let _v3 = match v3 with Some _tok -> () | None -> () in
+  let _v3 =
+    match v3 with
+    | Some _tok -> ()
+    | None -> ()
+  in
   v1 :: v2
 
 and argument (env : env) (x : CST.argument) : AST.expr =
@@ -1104,19 +1222,33 @@ and hash_splat_argument (env : env) ((v1, v2) : CST.hash_splat_argument) =
   Unary ((Op_UStarStar, v1), v2)
 
 and do_ (env : env) ((v1, v2, v3) : CST.do_) : AST.expr list =
-  (match v1 with `Do _tok (* "do" *) -> () | `Term x -> terminator env x);
-  let v2 = match v2 with Some x -> statements env x | None -> [] in
+  (match v1 with
+  | `Do _tok (* "do" *) -> ()
+  | `Term x -> terminator env x);
+  let v2 =
+    match v2 with
+    | Some x -> statements env x
+    | None -> []
+  in
   let _v3 = token2 env v3 (* "end" *) in
   v2
 
 and do_block (env : env) ((v1, v2, v3, v4) : CST.do_block) : AST.expr =
   let tdo = token2 env v1 in
-  let _v2 = match v2 with Some x -> terminator env x | None -> () in
+  let _v2 =
+    match v2 with
+    | Some x -> terminator env x
+    | None -> ()
+  in
   let params_opt =
     match v3 with
     | Some (v1, v2) ->
         let v1 = block_parameters env v1 |> G.unbracket in
-        let _v2 = match v2 with Some x -> terminator env x | None -> () in
+        let _v2 =
+          match v2 with
+          | Some x -> terminator env x
+          | None -> ()
+        in
         Some v1
     | None -> None
   in
@@ -1131,7 +1263,11 @@ and block (env : env) ((v1, v2, v3, v4) : CST.block) =
     | Some x -> Some (block_parameters env x |> G.unbracket)
     | None -> None
   in
-  let v3 = match v3 with Some x -> statements env x | None -> [] in
+  let v3 =
+    match v3 with
+    | Some x -> statements env x
+    | None -> []
+  in
   let rb = token2 env v4 in
   CodeBlock ((lb, true, rb), params_opt, v3)
 
@@ -1340,7 +1476,9 @@ and range (env : env) (x : CST.range) : AST.expr =
 and right_assignment_list (env : env) ((v1, v2) : CST.right_assignment_list) :
     AST.expr list =
   let v1 =
-    match v1 with `Arg x -> arg env x | `Splat_arg x -> splat_argument env x
+    match v1 with
+    | `Arg x -> arg env x
+    | `Splat_arg x -> splat_argument env x
   in
   let v2 =
     List.map
@@ -1374,7 +1512,11 @@ and destructured_left_assignment (env : env)
 
 and rest_assignment (env : env) ((v1, v2) : CST.rest_assignment) =
   let v1 = token2 env v1 (* "*" *) in
-  let v2 = match v2 with Some x -> Some (lhs env x) | None -> None in
+  let v2 =
+    match v2 with
+    | Some x -> Some (lhs env x)
+    | None -> None
+  in
   Splat (v1, v2)
 
 and lhs (env : env) (x : CST.lhs) : AST.expr =
@@ -1421,12 +1563,18 @@ and interpolation (env : env) ((v1, v2, v3) : CST.interpolation) :
     AST.expr AST.bracket option =
   let lb = token2 env v1 (* "#{" *) in
   let rb = token2 env v3 (* "}" *) in
-  match v2 with Some x -> Some (lb, statement env x, rb) | None -> None
+  match v2 with
+  | Some x -> Some (lb, statement env x, rb)
+  | None -> None
 
 and string_ (env : env) ((v1, v2, v3) : CST.string_) : AST.interp list bracket =
   let v1 = token2 env v1 in
   (* single or double quote *)
-  let v2 = match v2 with Some x -> literal_contents env x | None -> [] in
+  let v2 =
+    match v2 with
+    | Some x -> literal_contents env x
+    | None -> []
+  in
   let v3 = token2 env v3 in
   (* single or double quote *)
   (v1, v2, v3)
@@ -1441,7 +1589,11 @@ and simple_symbol (env : env) (tok : CST.simple_symbol) : atom =
 and delimited_symbol (env : env) ((v1, v2, v3) : CST.delimited_symbol) : atom =
   (* TODO: split v1 *)
   let v1 = token2 env v1 (* symbol_start :" "*) in
-  let res = match v2 with Some x -> literal_contents env x | None -> [] in
+  let res =
+    match v2 with
+    | Some x -> literal_contents env x
+    | None -> []
+  in
   let v3 = token2 env v3 (* string_end " "*) in
   (Parse_info.fake_info v1 ":", AtomFromString (v1, res, v3))
 
@@ -1471,7 +1623,11 @@ and mlhs (env : env) ((v1, v2, v3) : CST.mlhs) : AST.expr list =
         v2)
       v2
   in
-  let _v3 = match v3 with Some _tok -> () | None -> () in
+  let _v3 =
+    match v3 with
+    | Some _tok -> ()
+    | None -> ()
+  in
   v1 :: v2
 
 and pair (env : env) (x : CST.pair) =
@@ -1498,7 +1654,9 @@ and pair (env : env) (x : CST.pair) =
       | _ -> Binop (v1, (Op_ASSOC, v2), v3))
 
 let program (env : env) ((v1, _v2interpreted) : CST.program) : AST.stmts =
-  match v1 with Some x -> statements env x | None -> []
+  match v1 with
+  | Some x -> statements env x
+  | None -> []
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -102,7 +102,9 @@ and macro_item_to_any = function
   | MacTreeBis ((l, xs, r), idopt, t) ->
       G.Anys
         ([ G.Tk l ] @ macro_items_to_anys xs @ [ G.Tk r ]
-        @ (match idopt with None -> [] | Some id -> [ G.I id ])
+        @ (match idopt with
+          | None -> []
+          | Some id -> [ G.I id ])
         @ [ G.Tk t ])
 
 (* TODO: factorize with macro_items_to_anys above *)
@@ -112,7 +114,11 @@ let rec convert_macro_item (item : rust_macro_item) : G.any list =
   | MacTree (_, items, _) -> List.flatten (List.map convert_macro_item items)
   | MacTreeBis ((_, items, _), ident, tok) ->
       let items = List.flatten (List.map convert_macro_item items) in
-      let ident = match ident with Some i -> [ G.I i ] | None -> [] in
+      let ident =
+        match ident with
+        | Some i -> [ G.I i ]
+        | None -> []
+      in
       items @ ident @ [ G.Tk tok ]
 
 type rust_macro_pattern =
@@ -134,7 +140,11 @@ let rec convert_macro_pattern (pattern : rust_macro_pattern) : G.any list =
   | RustMacPatTree _patsTODO -> []
   | RustMacPatRepetition ((_, pats, _), ident, tok) ->
       let pats = List.flatten (List.map convert_macro_pattern pats) in
-      let ident = match ident with Some i -> [ G.I i ] | None -> [] in
+      let ident =
+        match ident with
+        | Some i -> [ G.I i ]
+        | None -> []
+      in
       pats @ ident @ [ G.Tk tok ]
   | RustMacPatBinding (ident, tok) -> [ G.I ident; G.Tk tok ]
   | RustMacPatToken any -> [ any ]
@@ -300,12 +310,20 @@ let map_literal_pattern (env : env) (x : CST.literal_pattern) : G.pattern =
       | `Int_lit tok ->
           let iopt, t = integer_literal env tok in
           (* integer_literal *)
-          let iopt = match iopt with Some i -> Some (-i) | None -> None in
+          let iopt =
+            match iopt with
+            | Some i -> Some (-i)
+            | None -> None
+          in
           G.PatLiteral (G.Int (iopt, PI.combine_infos (snd neg) [ t ]))
       | `Float_lit tok ->
           let fopt, t = float_literal env tok in
           (* float_literal *)
-          let fopt = match fopt with Some f -> Some (-.f) | None -> None in
+          let fopt =
+            match fopt with
+            | Some f -> Some (-.f)
+            | None -> None
+          in
           G.PatLiteral (G.Float (fopt, PI.combine_infos (snd neg) [ t ])))
 
 let map_extern_modifier (env : env) ((v1, v2) : CST.extern_modifier) :
@@ -813,10 +831,14 @@ and map_associated_type (env : env)
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   let type_params =
-    match v3 with Some x -> map_type_parameters env x | None -> []
+    match v3 with
+    | Some x -> map_type_parameters env x
+    | None -> []
   in
   let _trait_bounds =
-    match v4 with Some x -> map_trait_bounds env x | None -> []
+    match v4 with
+    | Some x -> map_trait_bounds env x
+    | None -> []
   in
   let ty =
     Option.map
@@ -1037,7 +1059,9 @@ and map_const_item (env : env) ((v1, v2, v3, v4, v5, v6) : CST.const_item) :
 and map_constrained_type_parameter (env : env)
     ((v1, v2) : CST.constrained_type_parameter) : G.type_parameter =
   let ident =
-    match v1 with `Life x -> map_lifetime env x | `Id tok -> ident env tok
+    match v1 with
+    | `Life x -> map_lifetime env x
+    | `Id tok -> ident env tok
     (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   in
   let _boundsTODO = map_trait_bounds env v2 in
@@ -1061,7 +1085,9 @@ and map_else_clause (env : env) ((v1, v2) : CST.else_clause) : G.stmt =
 and map_enum_variant (env : env) ((v1, v2, v3, v4) : CST.enum_variant) :
     G.or_type_element =
   let _visibilityTODO =
-    match v1 with Some x -> map_visibility_modifier env x | None -> []
+    match v1 with
+    | Some x -> map_visibility_modifier env x
+    | None -> []
   in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
@@ -1281,7 +1307,9 @@ and map_expression (env : env) (x : CST.expression) =
           v5
       in
       let expr_last =
-        match v6 with Some x -> [ map_expression env x ] | None -> []
+        match v6 with
+        | Some x -> [ map_expression env x ]
+        | None -> []
       in
       let rparen = token env v7 (* ")" *) in
       let exprs = List.concat [ [ expr_first ]; expr_rest; expr_last ] in
@@ -1299,7 +1327,9 @@ and map_expression (env : env) (x : CST.expression) =
   | `Brk_exp (v1, v2, v3) ->
       let break = token env v1 (* "break" *) in
       let label =
-        match v2 with Some x -> map_loop_label env x | None -> G.LNone
+        match v2 with
+        | Some x -> map_loop_label env x
+        | None -> G.LNone
       in
       let _exprTODO = Option.map (fun x -> map_expression env x) v3 in
       let break_stmt = G.Break (break, label, sc) |> G.s in
@@ -1309,7 +1339,9 @@ and map_expression (env : env) (x : CST.expression) =
   | `Cont_exp (v1, v2) ->
       let continue = token env v1 (* "continue" *) in
       let label =
-        match v2 with Some x -> map_loop_label env x | None -> G.LNone
+        match v2 with
+        | Some x -> map_loop_label env x
+        | None -> G.LNone
       in
       let continue_stmt = G.Continue (continue, label, sc) |> G.s in
       let x = G.stmt_to_expr continue_stmt in
@@ -1481,7 +1513,9 @@ and map_expression_statement (env : env) (x : CST.expression_statement) : G.stmt
 and map_field_declaration (env : env) ((v1, v2, v3, v4) : CST.field_declaration)
     : G.field =
   let attrs =
-    match v1 with Some x -> map_visibility_modifier env x | None -> []
+    match v1 with
+    | Some x -> map_visibility_modifier env x
+    | None -> []
   in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
@@ -1525,7 +1559,9 @@ and map_field_declaration_list (env : env)
 and map_field_declaration_type (env : env)
     ((v1, v2, v3, v4) : CST.field_declaration) : G.type_ =
   let _attrsTODO =
-    match v1 with Some x -> map_visibility_modifier env x | None -> []
+    match v1 with
+    | Some x -> map_visibility_modifier env x
+    | None -> []
   in
   let _identTODO = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
@@ -1561,7 +1597,9 @@ and map_field_declaration_list_types (env : env)
 and map_field_declaration_union (env : env)
     ((v1, v2, v3, v4) : CST.field_declaration) : G.or_type_element =
   let _attrsTODO =
-    match v1 with Some x -> map_visibility_modifier env x | None -> []
+    match v1 with
+    | Some x -> map_visibility_modifier env x
+    | None -> []
   in
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
@@ -1645,7 +1683,9 @@ and map_foreign_block_item (env : env) ((v1, v2, v3) : CST.foreign_block_item) :
     G.stmt =
   let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
   let _visibilityTODO =
-    match v2 with Some x -> map_visibility_modifier env x | None -> []
+    match v2 with
+    | Some x -> map_visibility_modifier env x
+    | None -> []
   in
   match v3 with
   | `Fore_item_static x -> map_foreign_item_static env x
@@ -1707,7 +1747,9 @@ and map_function_declaration (env : env)
         G.EDynamic (G.N (G.Id (metavar, G.empty_id_info ())) |> G.e)
   in
   let type_params =
-    match v2 with Some x -> map_type_parameters env x | None -> []
+    match v2 with
+    | Some x -> map_type_parameters env x
+    | None -> []
   in
   let params = map_parameters env v3 in
   let retval =
@@ -1723,7 +1765,9 @@ and map_function_declaration (env : env)
 and map_function_item (env : env) ((v1, v2, v3, v4) : CST.function_item) :
     G.stmt =
   let attrs =
-    match v1 with Some x -> map_function_modifiers env x | None -> []
+    match v1 with
+    | Some x -> map_function_modifiers env x
+    | None -> []
   in
   let id = token env v2 (* "fn" *) in
   let fn_decl = map_function_declaration env v3 in
@@ -1772,7 +1816,9 @@ and map_function_signature_with_default_item (env : env)
 and map_function_type (env : env) ((v1, v2, v3, v4) : CST.function_type) :
     G.type_ =
   let _lifetimesTODO =
-    match v1 with Some x -> map_for_lifetimes env x | None -> []
+    match v1 with
+    | Some x -> map_for_lifetimes env x
+    | None -> []
   in
   let _traitTODO, _modifiersTODO =
     match v2 with
@@ -1852,7 +1898,9 @@ and map_impl_block_item (env : env) ((v1, v2, v3) : CST.impl_block_item) :
     G.stmt =
   let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
   let _visibility =
-    match v2 with Some x -> map_visibility_modifier env x | None -> []
+    match v2 with
+    | Some x -> map_visibility_modifier env x
+    | None -> []
   in
   match v3 with
   | `Impl_blk_item_const x -> map_impl_block_item_const env x
@@ -1889,7 +1937,9 @@ and map_impl_block_item_type (env : env)
   let ident = ident env v2 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   let type_params =
-    match v3 with Some x -> map_type_parameters env x | None -> []
+    match v3 with
+    | Some x -> map_type_parameters env x
+    | None -> []
   in
   let _equals = token env v4 (* "=" *) in
   let ty_ = map_type_ env v5 in
@@ -2058,7 +2108,9 @@ and map_ordered_field_declaration_list (env : env)
     | Some (v1, v2, v3, v4) ->
         let outer_attrs = List.map (map_outer_attribute_item env) v1 in
         let visibility =
-          match v2 with Some x -> map_visibility_modifier env x | None -> []
+          match v2 with
+          | Some x -> map_visibility_modifier env x
+          | None -> []
         in
         let type_first = map_type_ env v3 in
         let field_first =
@@ -2098,7 +2150,9 @@ and map_ordered_field_declaration_list_types (env : env)
     | Some (v1, v2, v3, v4) ->
         let _outer_attrs = List.map (map_outer_attribute_item env) v1 in
         let _visibility =
-          match v2 with Some x -> map_visibility_modifier env x | None -> []
+          match v2 with
+          | Some x -> map_visibility_modifier env x
+          | None -> []
         in
         let type_first = map_type_ env v3 in
         let type_rest =
@@ -2267,7 +2321,9 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
   | `Tuple_pat (v1, v2, v3, v4) ->
       let lparen = token env v1 (* "(" *) in
       let items =
-        match v2 with Some x -> map_tuple_pattern_list env x | None -> []
+        match v2 with
+        | Some x -> map_tuple_pattern_list env x
+        | None -> []
       in
       let _comma = Option.map (fun tok -> token env tok) v3 in
       (* "," *)
@@ -2277,7 +2333,9 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
       let _nameTODO = map_tuple_struct_name env v1 in
       let lparen = token env v2 (* "(" *) in
       let items =
-        match v3 with Some x -> map_tuple_pattern_list env x | None -> []
+        match v3 with
+        | Some x -> map_tuple_pattern_list env x
+        | None -> []
       in
       let _comma = Option.map (fun tok -> token env tok) v4 in
       (* "," *)
@@ -2312,7 +2370,9 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
   | `Slice_pat (v1, v2, v3, v4) ->
       let lbracket = token env v1 (* "[" *) in
       let patterns =
-        match v2 with Some x -> map_tuple_pattern_list env x | None -> []
+        match v2 with
+        | Some x -> map_tuple_pattern_list env x
+        | None -> []
       in
       let _comma = Option.map (fun tok -> token env tok) v3 in
       (* "," *)
@@ -2799,14 +2859,16 @@ and map_use_list (env : env) ((v1, v2, v3, v4) : CST.use_list)
     match v2 with
     | Some (v1, v2) ->
         let use_clause_first =
-          match v1 with `Use_clause x -> map_use_clause env x use
+          match v1 with
+          | `Use_clause x -> map_use_clause env x use
         in
         let use_clause_rest =
           List.map
             (fun (v1, v2) ->
               let _comma = token env v1 (* "," *) in
               let use_clause =
-                match v2 with `Use_clause x -> map_use_clause env x use
+                match v2 with
+                | `Use_clause x -> map_use_clause env x use
               in
               use_clause)
             v2
@@ -2912,7 +2974,9 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
                 v2
             in
             let rule_last =
-              match v3 with Some x -> [ map_macro_rule env x ] | None -> []
+              match v3 with
+              | Some x -> [ map_macro_rule env x ]
+              | None -> []
             in
             let rparen = token env v4 (* ")" *) in
             let _semicolon = token env v5 (* ";" *) in
@@ -2928,7 +2992,9 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
                 v2
             in
             let rule_last =
-              match v3 with Some x -> [ map_macro_rule env x ] | None -> []
+              match v3 with
+              | Some x -> [ map_macro_rule env x ]
+              | None -> []
             in
             let rbrace = token env v4 (* "}" *) in
             (lbrace, List.concat [ rules; rule_last ], rbrace)
@@ -2985,7 +3051,9 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
-        match v3 with Some x -> map_type_parameters env x | None -> []
+        match v3 with
+        | Some x -> map_type_parameters env x
+        | None -> []
       in
       let fields, _where_clauseTODO =
         match v4 with
@@ -3032,10 +3100,14 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
-        match v3 with Some x -> map_type_parameters env x | None -> []
+        match v3 with
+        | Some x -> map_type_parameters env x
+        | None -> []
       in
       let _where_clauseTODO =
-        match v4 with Some x -> map_where_clause env x | None -> []
+        match v4 with
+        | Some x -> map_where_clause env x
+        | None -> []
       in
       let variants = map_field_declaration_list_union env v5 in
       let type_def = { G.tbody = G.OrType variants } in
@@ -3052,7 +3124,9 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
-        match v3 with Some x -> map_type_parameters env x | None -> []
+        match v3 with
+        | Some x -> map_type_parameters env x
+        | None -> []
       in
       let _where_clause = Option.map (fun x -> map_where_clause env x) v4 in
       let body = map_enum_variant_list env v5 in
@@ -3070,7 +3144,9 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
       let ident = ident env v2 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let type_params =
-        match v3 with Some x -> map_type_parameters env x | None -> []
+        match v3 with
+        | Some x -> map_type_parameters env x
+        | None -> []
       in
       let _equals = token env v4 (* "=" *) in
       let _tyTODO = map_type_ env v5 in
@@ -3091,7 +3167,9 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
   | `Func_item x -> [ map_function_item env x ]
   | `Func_sign_item (v1, v2, v3, v4) ->
       let attrs =
-        match v1 with Some x -> map_function_modifiers env x | None -> []
+        match v1 with
+        | Some x -> map_function_modifiers env x
+        | None -> []
       in
       let fn = token env v2 (* "fn" *) in
       let fn_decl = map_function_declaration env v3 in
@@ -3121,7 +3199,9 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
       let _attrs = deoptionalize [ unsafe_attr ] in
       let _impl = token env v2 (* "impl" *) in
       let _type_paramsTODO =
-        match v3 with Some x -> map_type_parameters env x | None -> []
+        match v3 with
+        | Some x -> map_type_parameters env x
+        | None -> []
       in
       let _trait_typeTODO =
         Option.map
@@ -3156,10 +3236,14 @@ and map_item_kind (env : env) _outer_attrs _visibility (x : CST.item_kind) :
       let ident = ident env v3 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       let _type_paramsTODO =
-        match v4 with Some x -> map_type_parameters env x | None -> []
+        match v4 with
+        | Some x -> map_type_parameters env x
+        | None -> []
       in
       let _trait_boundsTODO =
-        match v5 with Some x -> map_trait_bounds env x | None -> []
+        match v5 with
+        | Some x -> map_trait_bounds env x
+        | None -> []
       in
       let _where_clauseTODO = Option.map (fun x -> map_where_clause env x) v6 in
       let fields = map_trait_block env v7 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
@@ -153,7 +153,9 @@ let wrap_parser tree_sitter_parser ast_mapper =
    *)
   let res : 'a Tree_sitter_run.Parsing_result.t = tree_sitter_parser () in
   let program =
-    match res.program with Some cst -> Some (ast_mapper cst) | None -> None
+    match res.program with
+    | Some cst -> Some (ast_mapper cst)
+    | None -> None
   in
   { res with program }
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -50,12 +50,16 @@ let todo_any str t any =
    This conversion is intended to create a sub-pattern.
 *)
 let sub_pattern (id_or_pat : (a_ident, a_pattern) either) : a_pattern =
-  match id_or_pat with Left id -> Id id | Right pat -> pat
+  match id_or_pat with
+  | Left id -> Id id
+  | Right pat -> pat
 
 let fb = PI.unsafe_fake_bracket
 
 let optional env opt f =
-  match opt with None -> None | Some x -> Some (f env x)
+  match opt with
+  | None -> None
+  | Some x -> Some (f env x)
 
 (*
    Map the comma-separated representation of a list to an ocaml list.
@@ -117,7 +121,11 @@ let empty_stmt env tok =
 let number_as_string (env : env) (tok : CST.number) =
   let _, s = tok in
   let opt_num, t = number env tok in
-  let num_str = match opt_num with None -> s | Some n -> string_of_float n in
+  let num_str =
+    match opt_num with
+    | None -> s
+    | Some n -> string_of_float n
+  in
   (num_str, t)
 
 let string_ (env : env) (x : CST.string_) : string wrap =
@@ -198,7 +206,9 @@ let jsx_element_name (env : env) (x : CST.jsx_element_name) : a_ident =
       let xs = nested_identifier env x in
       let str = xs |> List.map fst |> String.concat "." in
       let hd, tl =
-        match xs with [] -> raise Impossible | x :: xs -> (x, xs)
+        match xs with
+        | [] -> raise Impossible
+        | x :: xs -> (x, xs)
       in
       (str, PI.combine_infos (snd hd) (tl |> List.map snd))
   | `Jsx_name_name x ->
@@ -288,7 +298,9 @@ let import_export_specifier (env : env)
     ((v1, v2, v3) : CST.import_export_specifier) :
     (a_ident * a_ident option) option =
   let type_or_typeof =
-    match v1 with Some x -> Some (type_or_typeof env x) | None -> None
+    match v1 with
+    | Some x -> Some (type_or_typeof env x)
+    | None -> None
   in
   let opt_as_id =
     match v3 with
@@ -304,7 +316,11 @@ let import_export_specifier (env : env)
 let concat_nested_identifier (idents : a_ident list) : a_ident =
   let str = idents |> List.map fst |> String.concat "." in
   let tokens = List.map snd idents in
-  let x, xs = match tokens with [] -> assert false | x :: xs -> (x, xs) in
+  let x, xs =
+    match tokens with
+    | [] -> assert false
+    | x :: xs -> (x, xs)
+  in
   (str, PI.combine_infos x xs)
 
 (* 'import id = require(...)' are Commonjs-style import.
@@ -373,10 +389,14 @@ let import_export_specifiers (env : env)
 let export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
   let _open = token env v1 (* "{" *) in
   let xs =
-    match v2 with Some x -> import_export_specifiers env x | None -> []
+    match v2 with
+    | Some x -> import_export_specifiers env x
+    | None -> []
   in
   let _trailing_comma =
-    match v3 with Some _tok -> (* "," *) () | None -> ()
+    match v3 with
+    | Some _tok -> (* "," *) ()
+    | None -> ()
   in
   let _close = token env v4 (* "}" *) in
   xs
@@ -384,10 +404,14 @@ let export_clause (env : env) ((v1, v2, v3, v4) : CST.export_clause) =
 let named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   let _open = token env v1 (* "{" *) in
   let imports =
-    match v2 with Some x -> import_export_specifiers env x | None -> []
+    match v2 with
+    | Some x -> import_export_specifiers env x
+    | None -> []
   in
   let _trailing_comma =
-    match v3 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v3 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let _close = token env v4 (* "}" *) in
   fun (import_tok : tok) (from_path : a_filename) ->
@@ -626,7 +650,11 @@ and object_property_pattern (env : env) (x : CST.anon_choice_pair_pat_3ff9cbe) :
         { fld_name = v1; fld_attrs = []; fld_type = ty; fld_body = Some body }
   | `Rest_pat x ->
       let t, p = rest_pattern env x in
-      let pat = match p with Left id -> idexp id | Right pat -> pat in
+      let pat =
+        match p with
+        | Left id -> idexp id
+        | Right pat -> pat
+      in
       FieldSpread (t, pat)
   | `Obj_assign_pat (v1, v2, v3) ->
       let pat =
@@ -908,7 +936,9 @@ and variable_declarator (env : env) (x : CST.variable_declarator) =
         | None -> None
       in
       let default =
-        match v3 with Some x -> Some (initializer_ env x) | None -> None
+        match v3 with
+        | Some x -> Some (initializer_ env x)
+        | None -> None
       in
       (id_or_pat, type_, default)
   | `Id_BANG_type_anno (v1, v2, v3) ->
@@ -934,7 +964,9 @@ and type_arguments (env : env) ((v1, v2, v3, v4, v5) : CST.type_arguments) :
   let v1 = token env v1 (* "<" *) in
   let types = map_sep_list env v2 v3 type_ in
   let _v4 =
-    match v4 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v4 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let v5 = token env v5 (* ">" *) in
   (v1, types, v5)
@@ -944,7 +976,10 @@ and add_decorators xs property =
   | Field fld -> Field { fld with fld_attrs = xs @ fld.fld_attrs }
   | FieldColon fld -> FieldColon { fld with fld_attrs = xs @ fld.fld_attrs }
   (* less: modify ast_js to allow decorator on those constructs? *)
-  | FieldSpread _ | FieldPatDefault _ | FieldEllipsis _ | FieldTodo _ ->
+  | FieldSpread _
+  | FieldPatDefault _
+  | FieldEllipsis _
+  | FieldTodo _ ->
       property
 
 (* TODO: types - class body can be just a signature. *)
@@ -962,7 +997,9 @@ and class_body (env : env) ((v1, v2, v3) : CST.class_body) :
         | `Meth_defi_opt_choice_auto_semi (v1, v2) ->
             let v1 = method_definition env v1 in
             let _v2 =
-              match v2 with Some x -> Some (semicolon env x) | None -> None
+              match v2 with
+              | Some x -> Some (semicolon env x)
+              | None -> None
             in
             add_decorators (List.rev acc_decorators) v1 :: aux [] xs
         | `Choice_abst_meth_sign_choice_choice_auto_semi (v1, v2) -> (
@@ -998,9 +1035,15 @@ and class_body (env : env) ((v1, v2, v3) : CST.class_body) :
 and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) :
     a_type_parameter =
   let v1 = str env v1 (* identifier *) in
-  let _v2 = match v2 with Some x -> Some (constraint_ env x) | None -> None in
+  let _v2 =
+    match v2 with
+    | Some x -> Some (constraint_ env x)
+    | None -> None
+  in
   let _v3 =
-    match v3 with Some x -> Some (default_type env x) | None -> None
+    match v3 with
+    | Some x -> Some (default_type env x)
+    | None -> None
   in
   v1
 
@@ -1010,7 +1053,9 @@ and member_expression (env : env) ((v1, v2, v3) : CST.member_expression) : expr
   (* TODO: distinguish optional chaining "?." from a simple access "." *)
   let dot_tok =
     match v2 with
-    | `DOT tok (* "." *) | `QMARKDOT (* "?." *) tok -> token env tok
+    | `DOT tok (* "." *)
+    | `QMARKDOT (* "?." *) tok ->
+        token env tok
   in
   let id_tok =
     match v3 with
@@ -1051,7 +1096,9 @@ and subscript_expression (env : env)
     ((v1, v2, v3, v4, v5) : CST.subscript_expression) : expr =
   let expr = expr_or_prim_expr env v1 in
   let _v2 =
-    match v2 with None -> None | Some tok -> (* "?." *) Some (token env tok)
+    match v2 with
+    | None -> None
+    | Some tok -> (* "?." *) Some (token env tok)
   in
   let v3 = token env v3 (* "[" *) in
   let v4 = expressions env v4 in
@@ -1176,10 +1223,14 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           in
           (* TODO types *)
           let _v4 =
-            match v4 with Some x -> type_parameters env x | None -> []
+            match v4 with
+            | Some x -> type_parameters env x
+            | None -> []
           in
           let c_extends, c_implements =
-            match v5 with Some x -> class_heritage env x | None -> ([], [])
+            match v5 with
+            | Some x -> class_heritage env x
+            | None -> ([], [])
           in
           let v6 = class_body env v6 in
           let class_ =
@@ -1253,7 +1304,9 @@ and module__ (env : env) ((v1, v2) : CST.module__) =
   in
   let v2 =
     (* optional module body *)
-    match v2 with Some x -> Some (statement_block env x) | None -> None
+    match v2 with
+    | Some x -> Some (statement_block env x)
+    | None -> None
   in
   (v1, v2)
 
@@ -1277,11 +1330,15 @@ and catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) : catch =
         let _open = token env v1 (* "(" *) in
         let id_or_pat = id_or_destructuring_pattern env v2 in
         let type_ =
-          match v3 with Some x -> Some (type_annotation env x) | None -> None
+          match v3 with
+          | Some x -> Some (type_annotation env x)
+          | None -> None
         in
         let _close = token env v4 (* ")" *) in
         let pat =
-          match id_or_pat with Left id -> idexp id | Right pat -> pat
+          match id_or_pat with
+          | Left id -> idexp id
+          | Right pat -> pat
         in
         let pat =
           match type_ with
@@ -1378,7 +1435,9 @@ and anon_opt_opt_choice_exp_rep_COMMA_opt_choice_exp_208ebb4 (env : env)
   match opt with
   | Some (v1, v2) ->
       let v1 =
-        match v1 with Some x -> [ anon_choice_exp_9818c1b env x ] | None -> []
+        match v1 with
+        | Some x -> [ anon_choice_exp_9818c1b env x ]
+        | None -> []
       in
       let v2 = anon_rep_COMMA_opt_choice_exp_ca698a5 env v2 in
       v1 @ v2
@@ -1402,7 +1461,9 @@ and for_header (env : env) ((v1, v2, v3, v4, v5) : CST.for_header) : for_header
         in
         let id_or_pat = id_or_destructuring_pattern env v2 in
         let pat =
-          match id_or_pat with Left id -> idexp id | Right pat -> pat
+          match id_or_pat with
+          | Left id -> idexp id
+          | Right pat -> pat
         in
         let var = Ast_js.var_pattern_to_var var_kind pat (snd var_kind) None in
         Left var
@@ -1536,7 +1597,9 @@ and expression (env : env) (x : CST.expression) : expr =
         | None -> []
       in
       let t1, xs, t2 =
-        match v4 with Some x -> arguments env x | None -> fb []
+        match v4 with
+        | Some x -> arguments env x
+        | None -> fb []
       in
       (* less: we should remove the extra Apply but that's what we do in pfff*)
       let newcall = Apply (IdSpecial (New, v1), fb [ v2 ]) in
@@ -1746,7 +1809,9 @@ and formal_parameter (env : env) (x : CST.formal_parameter) : parameter =
           | None -> None
         in
         let default =
-          match v3 with Some x -> Some (initializer_ env x) | None -> None
+          match v3 with
+          | Some x -> Some (initializer_ env x)
+          | None -> None
         in
         (id_or_pat, type_, default)
     | `Opt_param (v1, v2, v3, v4) ->
@@ -1759,7 +1824,9 @@ and formal_parameter (env : env) (x : CST.formal_parameter) : parameter =
           | None -> None
         in
         let opt_default =
-          match v4 with Some x -> Some (initializer_ env x) | None -> None
+          match v4 with
+          | Some x -> Some (initializer_ env x)
+          | None -> None
         in
         (id_or_pat, opt_type, opt_default)
   in
@@ -1837,7 +1904,9 @@ and statement (env : env) (x : CST.statement) : stmt list =
       let v1 = token env v1 (* "import" *) in
       let import_tok = v1 in
       let _v2 =
-        match v2 with Some x -> Some (type_or_typeof env x) | None -> None
+        match v2 with
+        | Some x -> Some (type_or_typeof env x)
+        | None -> None
       in
       let v3 =
         match v3 with
@@ -1909,7 +1978,9 @@ and statement (env : env) (x : CST.statement) : stmt list =
             None
       in
       let v5 =
-        match v5 with Some x -> Some (expressions env x) | None -> None
+        match v5 with
+        | Some x -> Some (expressions env x)
+        | None -> None
       in
       let _v6 = token env v6 (* ")" *) in
       let v7 = statement1 env v7 in
@@ -1940,10 +2011,14 @@ and statement (env : env) (x : CST.statement) : stmt list =
       let v1 = token env v1 (* "try" *) in
       let v2 = statement_block env v2 in
       let v3 =
-        match v3 with Some x -> Some (catch_clause env x) | None -> None
+        match v3 with
+        | Some x -> Some (catch_clause env x)
+        | None -> None
       in
       let v4 =
-        match v4 with Some x -> Some (finally_clause env x) | None -> None
+        match v4 with
+        | Some x -> Some (finally_clause env x)
+        | None -> None
       in
       [ Try (v1, v2, v3, v4) ]
   | `With_stmt (v1, v2, v3) ->
@@ -1972,7 +2047,9 @@ and statement (env : env) (x : CST.statement) : stmt list =
   | `Ret_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "return" *) in
       let v2 =
-        match v2 with Some x -> Some (expressions env x) | None -> None
+        match v2 with
+        | Some x -> Some (expressions env x)
+        | None -> None
       in
       let v3 = semicolon env v3 in
       [ Return (v1, v2, v3) ]
@@ -1991,7 +2068,9 @@ and statement (env : env) (x : CST.statement) : stmt list =
 and method_definition (env : env)
     ((v1, v2, v3, v4, v5, v6, v7, v8, v9) : CST.method_definition) : property =
   let v1 =
-    match v1 with Some x -> [ accessibility_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ accessibility_modifier env x ]
+    | None -> []
   in
   let v2 =
     match v2 with
@@ -2009,7 +2088,9 @@ and method_definition (env : env)
     | None -> []
   in
   let v5 =
-    match v5 with Some x -> [ anon_choice_get_8fb02de env x ] | None -> []
+    match v5 with
+    | Some x -> [ anon_choice_get_8fb02de env x ]
+    | None -> []
   in
   let v6 = property_name env v6 in
   let v7 =
@@ -2035,9 +2116,15 @@ and class_declaration (env : env)
   let v2 = token env v2 (* "class" *) in
   let v3 = identifier env v3 (* identifier *) in
   (* TODO types: type_parameters *)
-  let _v4 = match v4 with Some x -> type_parameters env x | None -> [] in
+  let _v4 =
+    match v4 with
+    | Some x -> type_parameters env x
+    | None -> []
+  in
   let c_extends, c_implements =
-    match v5 with Some x -> class_heritage env x | None -> ([], [])
+    match v5 with
+    | Some x -> class_heritage env x
+    | None -> ([], [])
   in
   let v6 = class_body env v6 in
   let _v7 =
@@ -2238,7 +2325,9 @@ and anon_choice_export_stmt_f90d83f (env : env)
       Right xs
   | `Prop_sign (v1, v2, v3, v4, v5, v6) ->
       let v1 =
-        match v1 with Some x -> [ accessibility_modifier env x ] | None -> []
+        match v1 with
+        | Some x -> [ accessibility_modifier env x ]
+        | None -> []
       in
       let v2 =
         match v2 with
@@ -2277,7 +2366,9 @@ and anon_choice_export_stmt_f90d83f (env : env)
   | `Cons_sign (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "new" *) in
       let _tparams =
-        match v2 with Some x -> type_parameters env x | None -> []
+        match v2 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
       let v3 = formal_parameters env v3 in
       let v4 =
@@ -2306,7 +2397,9 @@ and public_field_definition (env : env)
     ((v1, v2, v3, v4, v5, v6, v7) : CST.public_field_definition) =
   let _tok_declare = optional env v1 token in
   let _access_modif =
-    match v2 with Some x -> [ accessibility_modifier env x ] | None -> []
+    match v2 with
+    | Some x -> [ accessibility_modifier env x ]
+    | None -> []
   in
   let attributes =
     match v3 with
@@ -2322,7 +2415,8 @@ and public_field_definition (env : env)
           | None -> []
         in
         v1 @ v2
-    | `Opt_abst_opt_read (v1, v2) | `Opt_read_opt_abst (v2, v1) ->
+    | `Opt_abst_opt_read (v1, v2)
+    | `Opt_read_opt_abst (v2, v1) ->
         let v1 =
           match v1 with
           | Some tok -> [ (Abstract, token env tok) ] (* "abstract" *)
@@ -2345,10 +2439,14 @@ and public_field_definition (env : env)
     | None -> []
   in
   let opt_type =
-    match v6 with Some x -> Some (type_annotation env x |> snd) | None -> None
+    match v6 with
+    | Some x -> Some (type_annotation env x |> snd)
+    | None -> None
   in
   let opt_init =
-    match v7 with Some x -> Some (initializer_ env x) | None -> None
+    match v7 with
+    | Some x -> Some (initializer_ env x)
+    | None -> None
   in
   let attrs = attributes |> List.map attr in
   Field
@@ -2408,7 +2506,11 @@ and class_heritage (env : env) (x : CST.class_heritage) :
   match x with
   | `Extends_clause_opt_imples_clause (v1, v2) ->
       let v1 = extends_clause env v1 in
-      let v2 = match v2 with Some x -> implements_clause env x | None -> [] in
+      let v2 =
+        match v2 with
+        | Some x -> implements_clause env x
+        | None -> []
+      in
       (v1, v2)
   | `Imples_clause x ->
       let x = implements_clause env x in
@@ -2454,11 +2556,15 @@ and expressions (env : env) (x : CST.expressions) : expr =
 and abstract_method_signature (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.abstract_method_signature) =
   let v1 =
-    match v1 with Some x -> [ accessibility_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ accessibility_modifier env x ]
+    | None -> []
   in
   let v2 = [ (Abstract, token env v2) ] (* "abstract" *) in
   let v3 =
-    match v3 with Some x -> [ anon_choice_get_8fb02de env x ] | None -> []
+    match v3 with
+    | Some x -> [ anon_choice_get_8fb02de env x ]
+    | None -> []
   in
   let v4 = property_name env v4 in
   let v5 =
@@ -2501,7 +2607,11 @@ and todo_asserts (env : env) ((v1, v2, v3) : CST.asserts) =
 
 and call_signature (env : env) ((v1, v2, v3) : CST.call_signature) :
     a_type_parameter list * (parameter list * type_ option) =
-  let v1 = match v1 with Some x -> type_parameters env x | None -> [] in
+  let v1 =
+    match v1 with
+    | Some x -> type_parameters env x
+    | None -> []
+  in
   let v2 = formal_parameters env v2 in
   let v3 =
     match v3 with
@@ -2539,7 +2649,9 @@ and object_ (env : env) ((v1, v2, v3) : CST.object_) : a_obj =
     match v2 with
     | Some (v1, v2) ->
         map_sep_list env v1 v2 (fun env x ->
-            match x with Some x -> [ object_property env x ] | None -> [])
+            match x with
+            | Some x -> [ object_property env x ]
+            | None -> [])
         |> List.flatten
     | None -> []
   in
@@ -2579,7 +2691,9 @@ and type_ (env : env) (x : CST.type_) : type_ =
       (* ?? *))
   | `Func_type (v1, v2, v3, v4) ->
       let _tparams =
-        match v1 with Some x -> type_parameters env x | None -> []
+        match v1 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
       let params = formal_parameters env v2 in
       let _arrow = token env v3 (* "=>" *) in
@@ -2598,7 +2712,9 @@ and type_ (env : env) (x : CST.type_) : type_ =
   | `Cons_type (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "new" *) in
       let _tparams =
-        match v2 with Some x -> type_parameters env x | None -> []
+        match v2 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
       let v3 = formal_parameters env v3 in
       let _v4 = token env v4 (* "=>" *) in
@@ -2615,7 +2731,9 @@ and type_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.type_parameters) :
   let _v1 = token env v1 (* "<" *) in
   let type_params = map_sep_list env v2 v3 type_parameter in
   let _v4 =
-    match v4 with Some tok -> Some (token env tok) (* "," *) | None -> None
+    match v4 with
+    | Some tok -> Some (token env tok) (* "," *)
+    | None -> None
   in
   let _v5 = token env v5 (* ">" *) in
   type_params
@@ -2635,10 +2753,14 @@ and parameter_name (env : env) ((v1, v2, v3, v4) : CST.parameter_name) :
     (a_ident, a_pattern) Common.either =
   let _decorators = List.map (decorator env) v1 in
   let _accessibility =
-    match v2 with Some x -> [ accessibility_modifier env x ] | None -> []
+    match v2 with
+    | Some x -> [ accessibility_modifier env x ]
+    | None -> []
   in
   let _readonly =
-    match v3 with Some tok -> [ token env tok ] (* "readonly" *) | None -> []
+    match v3 with
+    | Some tok -> [ token env tok ] (* "readonly" *)
+    | None -> []
   in
   let id_or_pat =
     match v4 with
@@ -2756,7 +2878,9 @@ and tuple_type_member (env : env) (x : CST.tuple_type_member) :
 and method_signature (env : env)
     ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.method_signature) =
   let v1 =
-    match v1 with Some x -> [ accessibility_modifier env x ] | None -> []
+    match v1 with
+    | Some x -> [ accessibility_modifier env x ]
+    | None -> []
   in
   let v2 =
     match v2 with
@@ -2774,7 +2898,9 @@ and method_signature (env : env)
     | None -> []
   in
   let v5 =
-    match v5 with Some x -> [ anon_choice_get_8fb02de env x ] | None -> []
+    match v5 with
+    | Some x -> [ anon_choice_get_8fb02de env x ]
+    | None -> []
   in
   let v6 = property_name env v6 in
   let v7 =
@@ -2825,10 +2951,14 @@ and declaration (env : env) (x : CST.declaration) : definition list =
       let v3 = token env v3 (* "class" *) in
       let v4 = identifier env v4 (* identifier *) in
       let _tparams =
-        match v5 with Some x -> type_parameters env x | None -> []
+        match v5 with
+        | Some x -> type_parameters env x
+        | None -> []
       in
       let c_extends, c_implements =
-        match v6 with Some x -> class_heritage env x | None -> ([], [])
+        match v6 with
+        | Some x -> class_heritage env x
+        | None -> ([], [])
       in
       let v7 = class_body env v7 in
       let attrs = [ v2 ] in
@@ -2856,7 +2986,11 @@ and declaration (env : env) (x : CST.declaration) : definition list =
   | `Type_alias_decl (v1, v2, v3, v4, v5, v6) ->
       let _v1 = token env v1 (* "type" *) in
       let _v2 = token env v2 (* identifier *) in
-      let _v3 = match v3 with Some x -> type_parameters env x | None -> [] in
+      let _v3 =
+        match v3 with
+        | Some x -> type_parameters env x
+        | None -> []
+      in
       let _v4 = token env v4 (* "=" *) in
       let _v5 = type_ env v5 in
       let _v6 = semicolon env v6 in
@@ -2864,7 +2998,9 @@ and declaration (env : env) (x : CST.declaration) : definition list =
       (* TODO *)
   | `Enum_decl (v1, v2, v3, v4) ->
       let _v1 =
-        match v1 with Some tok -> [ token env tok ] (* "const" *) | None -> []
+        match v1 with
+        | Some tok -> [ token env tok ] (* "const" *)
+        | None -> []
       in
       let _v2 = token env v2 (* "enum" *) in
       let _v3 = identifier env v3 (* identifier *) in
@@ -2874,8 +3010,16 @@ and declaration (env : env) (x : CST.declaration) : definition list =
   | `Inte_decl (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "interface" *) in
       let v2 = identifier env v2 (* identifier *) in
-      let _v3 = match v3 with Some x -> type_parameters env x | None -> [] in
-      let v4 = match v4 with Some x -> extends_clause env x | None -> [] in
+      let _v3 =
+        match v3 with
+        | Some x -> type_parameters env x
+        | None -> []
+      in
+      let v4 =
+        match v4 with
+        | Some x -> extends_clause env x
+        | None -> []
+      in
       let t1, xs, t2 = object_type env v5 in
       let xs =
         xs

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -167,7 +167,9 @@ let map_anon_choice_attr_a1991da (env : env) (x : CST.anon_choice_attr_a1991da)
             v1
       in
       let _v2TODO =
-        match v2 with Some x -> map_directive_modifiers env x | None -> []
+        match v2 with
+        | Some x -> map_directive_modifiers env x
+        | None -> []
       in
       let teq, v3 =
         match v3 with

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -94,7 +94,9 @@ let range_of_any_opt startp_of_match_range any =
   (* those are ok and we don't want to generate a NoTokenLocation for those.
    * alt: change Semgrep.atd to make optional startp/endp for metavar_value.
    *)
-  | Ss [] | Args [] -> Some empty_range
+  | Ss []
+  | Args [] ->
+      Some empty_range
   | _ ->
       let ( let* ) = Common.( >>= ) in
       let* min_loc, max_loc = V.range_of_any_opt any in

--- a/semgrep-core/src/spacegrep/src/bin/Space_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Space_main.ml
@@ -13,7 +13,9 @@
 let dispatch () =
   Printexc.record_backtrace true;
   match Filename.basename Sys.argv.(0) with
-  | "spacecat" | "space-cat" -> Spacecat_main.main ()
+  | "spacecat"
+  | "space-cat" ->
+      Spacecat_main.main ()
   | _ -> Spacegrep_main.main ()
 
 let () = dispatch ()

--- a/semgrep-core/src/spacegrep/src/bin/Spacecat_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacecat_main.ml
@@ -60,7 +60,9 @@ let info name = Term.info ~doc ~man name
 let parse_command_line name =
   match Term.eval (cmdline_term, info name) with
   | `Error _ -> exit 1
-  | `Version | `Help -> exit 0
+  | `Version
+  | `Help ->
+      exit 0
   | `Ok config -> config
 
 let run_one config input =
@@ -77,7 +79,10 @@ let run_one config input =
         let src_prefix =
           match Src_file.source src with
           | File path -> Printf.sprintf "%s: " path
-          | Stdin | String | Channel -> ""
+          | Stdin
+          | String
+          | Channel ->
+              ""
         in
         Printf.printf "%s%s\n" src_prefix err.msg
   else src |> Parse_doc.of_src |> Doc_AST.to_pattern |> print

--- a/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
@@ -236,7 +236,11 @@ let output_format_conv =
     | s -> Error (`Msg ("Invalid output format: " ^ s))
   in
   let printer fmt output_format =
-    let s = match output_format with Text -> "text" | Semgrep -> "semgrep" in
+    let s =
+      match output_format with
+      | Text -> "text"
+      | Semgrep -> "semgrep"
+    in
     Format.pp_print_string fmt s
   in
   Cmdliner.Arg.conv (parser, printer)
@@ -378,7 +382,9 @@ let cmdline_term =
   let combine case_insensitive color output_format debug force pattern
       pattern_files anon_doc_file doc_files time timeout warn no_skip_search =
     let doc_files =
-      match anon_doc_file with None -> doc_files | Some x -> x :: doc_files
+      match anon_doc_file with
+      | None -> doc_files
+      | Some x -> x :: doc_files
     in
     {
       case_insensitive;
@@ -421,7 +427,9 @@ let info name = Term.info ~doc ~man name
 let parse_command_line name =
   match Term.eval (cmdline_term, info name) with
   | `Error _ -> exit 1
-  | `Version | `Help -> exit 0
+  | `Version
+  | `Help ->
+      exit 0
   | `Ok config -> config
 
 (*

--- a/semgrep-core/src/spacegrep/src/lib/Doc_AST.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Doc_AST.ml
@@ -78,7 +78,10 @@ and to_pat_node (node : node) : Pattern_AST.node =
   | List nodes -> List (to_pattern nodes)
 
 and to_pat_atom (atom : atom) : Pattern_AST.atom =
-  match atom with Word s -> Word s | Punct c -> Punct c | Byte c -> Byte c
+  match atom with
+  | Word s -> Word s
+  | Punct c -> Punct c
+  | Byte c -> Byte c
 
 (* Equality function that disregards location. Meant for unit tests. *)
 let eq a b = Pattern_AST.eq (to_pattern a) (to_pattern b)

--- a/semgrep-core/src/spacegrep/src/lib/File_type.ml
+++ b/semgrep-core/src/spacegrep/src/lib/File_type.ml
@@ -28,11 +28,17 @@ let classify src =
             incr newlines;
             incr ascii_printable
         (* ascii and printable, other than LF *)
-        | '\t' | '\r' | ' ' .. '~' -> incr ascii_printable
+        | '\t'
+        | '\r'
+        | ' ' .. '~' ->
+            incr ascii_printable
         (* non-ascii *)
         | '\x80' .. '\xff' -> ()
         (* ascii and not printable *)
-        | '\x00' .. '\x08' | '\x0b' .. '\x0c' | '\x0e' .. '\x1f' | '\x7f' ->
+        | '\x00' .. '\x08'
+        | '\x0b' .. '\x0c'
+        | '\x0e' .. '\x1f'
+        | '\x7f' ->
             incr ascii_not_printable)
       contents;
     let num_lines = !newlines + 1 in

--- a/semgrep-core/src/spacegrep/src/lib/Find_files.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Find_files.ml
@@ -39,10 +39,14 @@ let create_visit_tracker () =
   let tbl = Hashtbl.create 100 in
   let get_id path = try Some (stat path).st_ino with _ -> None in
   let was_visited path =
-    match get_id path with None -> true | Some id -> Hashtbl.mem tbl id
+    match get_id path with
+    | None -> true
+    | Some id -> Hashtbl.mem tbl id
   in
   let mark_visited path =
-    match get_id path with None -> () | Some id -> Hashtbl.replace tbl id ()
+    match get_id path with
+    | None -> ()
+    | Some id -> Hashtbl.replace tbl id ()
   in
   { was_visited; mark_visited }
 
@@ -71,7 +75,8 @@ let fold_one ~accept_file_name ~accept_dir_name visit_tracker f acc root =
             in
             List.fold_left fold acc children
       | Some Unix.S_REG -> if accept_file_name name then f acc path else acc
-      | None | Some _ ->
+      | None
+      | Some _ ->
           (* leave broken symlinks and special files alone *)
           acc)
   in

--- a/semgrep-core/src/spacegrep/src/lib/Match.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Match.ml
@@ -142,7 +142,9 @@ let extend_dots_matched ~dots:opt_dots (end_ : Loc.Pos.t) =
 
 let close_dots conf ~dots:opt_dots env =
   match opt_dots with
-  | None | Some { opt_mvar = None; _ } -> Some env
+  | None
+  | Some { opt_mvar = None; _ } ->
+      Some env
   | Some { matched; opt_mvar = Some name; _ } -> (
       let name = "..." ^ name in
       let start_pos, end_pos = matched in
@@ -154,7 +156,9 @@ let close_dots conf ~dots:opt_dots env =
           if String.equal value value0 then Some env else None)
 
 let close_dots_or_fail conf ~dots env f =
-  match close_dots conf ~dots env with None -> Fail | Some env' -> f env'
+  match close_dots conf ~dots env with
+  | None -> Fail
+  | Some env' -> f env'
 
 let complete_dots conf ~dots env last_loc =
   let _, last_end = last_loc in
@@ -190,7 +194,9 @@ let doc_matches_dots ~dots:opt_dots last_loc doc =
 
 let rec pat_matches_empty_doc pat =
   match pat with
-  | [] | End :: _ -> true
+  | []
+  | End :: _ ->
+      true
   | Atom _ :: _ -> false
   | Dots _ :: pat -> pat_matches_empty_doc pat
   | List pat1 :: pat2 ->
@@ -383,7 +389,9 @@ let fold_block_starts acc (doc : Doc_AST.node list) f =
   fold ~is_block_start:true acc doc
 
 let starts_with_dots (pat : Pattern_AST.node list) =
-  match pat with Dots _ :: _ -> true | _ -> false
+  match pat with
+  | Dots _ :: _ -> true
+  | _ -> false
 
 let convert_named_captures env =
   Env.bindings env
@@ -490,7 +498,9 @@ let timed_search ~no_skip_search ~case_sensitive src pat doc =
   timef (fun () -> search ~no_skip_search ~case_sensitive src pat doc)
 
 let ansi_highlight s =
-  match s with "" -> s | s -> ANSITerminal.(sprintf [ Bold; green ] "%s" s)
+  match s with
+  | "" -> s
+  | s -> ANSITerminal.(sprintf [ Bold; green ] "%s" s)
 
 let make_separator_printer () =
   let is_first = ref true in
@@ -502,7 +512,10 @@ let print ?(highlight = false)
   let line_prefix =
     match Src_file.source src with
     | File path -> sprintf "%s:" path
-    | Stdin | String | Channel -> ""
+    | Stdin
+    | String
+    | Channel ->
+        ""
   in
   List.iter
     (fun match_ ->
@@ -525,7 +538,10 @@ let print_errors ?(highlight = false) errors =
       let src_prefix =
         match Src_file.source src with
         | File path -> sprintf "%s: " path
-        | Stdin | String | Channel -> ""
+        | Stdin
+        | String
+        | Channel ->
+            ""
       in
       eprintf "%s %s%s\n" error_prefix src_prefix error.Parse_pattern.msg)
     errors

--- a/semgrep-core/src/spacegrep/src/lib/Parse_pattern.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Parse_pattern.ml
@@ -173,7 +173,9 @@ let check_pattern pat0 =
   let rec check = function
     | [] -> None
     | List pat1 :: pat2 -> (
-        match check pat1 with Some err -> Some err | None -> check pat2)
+        match check pat1 with
+        | Some err -> Some err
+        | None -> check pat2)
     | Dots (_, opt_mvar1) :: Dots (loc, Some mvar2) :: _ ->
         let msg =
           Printf.sprintf "Invalid pattern sequence: %s $...%s"
@@ -191,6 +193,9 @@ let of_lexbuf ?(is_doc = false) lexbuf =
   let lines = Lexer.lines lexbuf in
   let pat = parse_root ~is_doc lines in
   if is_doc then Ok pat
-  else match check_pattern pat with None -> Ok pat | Some err -> Error err
+  else
+    match check_pattern pat with
+    | None -> Ok pat
+    | Some err -> Error err
 
 let of_src ?is_doc src = Src_file.to_lexbuf src |> of_lexbuf ?is_doc

--- a/semgrep-core/src/spacegrep/src/lib/Pattern_AST.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Pattern_AST.ml
@@ -81,7 +81,8 @@ let rec eq a b =
       | List a, List b -> eq a b
       | Dots (_, None), Dots (_, None) -> true
       | Dots (_, Some mva), Dots (_, Some mvb) -> mva = mvb
-      | Dots (_, None), Dots (_, Some _) | Dots (_, Some _), Dots (_, None) ->
+      | Dots (_, None), Dots (_, Some _)
+      | Dots (_, Some _), Dots (_, None) ->
           false
       | End, End -> true
       | _ -> false)

--- a/semgrep-core/src/spacegrep/src/lib/Pre_match.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Pre_match.ml
@@ -18,9 +18,16 @@ let pattern_has_bytes (pat : Pattern_AST.t) =
   let open Pattern_AST in
   let rec has_bytes = function
     | Atom (_, atom) -> (
-        match atom with Byte _ -> true | Word _ | Punct _ | Metavar _ -> false)
+        match atom with
+        | Byte _ -> true
+        | Word _
+        | Punct _
+        | Metavar _ ->
+            false)
     | List nodes -> List.exists has_bytes nodes
-    | Dots _ | End -> false
+    | Dots _
+    | End ->
+        false
   in
   List.exists has_bytes pat
 
@@ -40,12 +47,16 @@ let build_atom_table ~case_sensitive (pat : Pattern_AST.t) =
   and index_node = function
     | Atom (_, atom) -> index_atom atom
     | List nodes -> index nodes
-    | Dots _ | End -> ()
+    | Dots _
+    | End ->
+        ()
   and index_atom = function
     | Word word ->
         let k = if case_sensitive then word else lowercase word in
         Hashtbl.replace words k ()
-    | Punct k | Byte k -> Hashtbl.replace chars k ()
+    | Punct k
+    | Byte k ->
+        Hashtbl.replace chars k ()
     | Metavar _ -> ()
   in
   index pat;

--- a/semgrep-core/src/spacegrep/src/lib/Print_match.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Print_match.ml
@@ -25,9 +25,15 @@ let show_doc_node (doc_node : Doc_AST.node) =
   | Atom (_loc, Byte c) -> sprintf "Byte 0x%02x" (Char.code c)
   | List _ -> "List"
 
-let show_pat pat = match pat with [] -> "[]" | node :: _ -> show_pat_node node
+let show_pat pat =
+  match pat with
+  | [] -> "[]"
+  | node :: _ -> show_pat_node node
 
-let show_doc doc = match doc with [] -> "[]" | node :: _ -> show_doc_node node
+let show_doc doc =
+  match doc with
+  | [] -> "[]"
+  | node :: _ -> show_doc_node node
 
 let print (pat : Pattern_AST.t) (doc : Doc_AST.t) =
   printf "pat %s : doc %s\n" (show_pat pat) (show_doc doc)

--- a/semgrep-core/src/spacegrep/src/lib/Src_file.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Src_file.ml
@@ -62,7 +62,11 @@ let of_channel ?(source = Channel) ?max_len ic =
 let of_stdin ?(source = Stdin) () = of_channel ~source stdin
 
 let of_file ?source ?max_len file =
-  let source = match source with None -> File file | Some x -> x in
+  let source =
+    match source with
+    | None -> File file
+    | Some x -> x
+  in
   let ic = open_in_bin file in
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)
@@ -74,7 +78,10 @@ let to_lexbuf x = Lexing.from_string x.contents
    right after the end of the current line. *)
 let rec find_end_of_line s i =
   if i >= String.length s then i
-  else match s.[i] with '\n' -> i + 1 | _ -> find_end_of_line s (i + 1)
+  else
+    match s.[i] with
+    | '\n' -> i + 1
+    | _ -> find_end_of_line s (i + 1)
 
 (* Remove the trailing newline character if there is one. *)
 let remove_trailing_newline s =

--- a/semgrep-core/src/spacegrep/src/test/Src_file.ml
+++ b/semgrep-core/src/spacegrep/src/test/Src_file.ml
@@ -33,7 +33,9 @@ and find_word_locations_in_node word node =
 let loc_of_word word input =
   let lexbuf = Lexing.from_string input in
   let ast = Parse_doc.of_lexbuf lexbuf in
-  match find_word_locations word ast with [ loc ] -> loc | _ -> assert false
+  match find_word_locations word ast with
+  | [ loc ] -> loc
+  | _ -> assert false
 
 (*
    Obtain correct token locations by parsing a document and searching

--- a/semgrep-core/src/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Code.ml
@@ -122,7 +122,9 @@ let get_id ?(with_type = false) env e =
 
 let has_nested_call =
   List.find_opt (fun x ->
-      match x with Arg { e = Call _; _ } -> true | _ -> false)
+      match x with
+      | Arg { e = Call _; _ } -> true
+      | _ -> false)
 
 (*****************************************************************************)
 (* Algorithm *)
@@ -284,7 +286,11 @@ and generalize_exprstmt (e, tok) env =
   add_expr e (fun (str, e') -> (str, S (ExprStmt (e', tok) |> G.s))) env
 
 and generalize_if s_in =
-  let opt f so = match so with None -> None | Some x -> Some (f x) in
+  let opt f so =
+    match so with
+    | None -> None
+    | Some x -> Some (f x)
+  in
   let rec dots_in_body s =
     match s.s with
     | If (tok, e, s, sopt) ->
@@ -309,7 +315,9 @@ and generalize_if s_in =
 
 and generalize_while (tok, e, s) env =
   let body_dots =
-    match s.s with Block (t1, _, t2) -> body_ellipsis t1 t2 | _ -> fk_stmt
+    match s.s with
+    | Block (t1, _, t2) -> body_ellipsis t1 t2
+    | _ -> fk_stmt
   in
   let dots_in_cond =
     ("dots in condition", S (While (tok, Ellipsis fk |> G.e, s) |> G.s))
@@ -325,7 +333,9 @@ and generalize_while (tok, e, s) env =
 
 and generalize_for (tok, hdr, s) =
   let body_dots =
-    match s.s with Block (t1, _, t2) -> body_ellipsis t1 t2 | _ -> fk_stmt
+    match s.s with
+    | Block (t1, _, t2) -> body_ellipsis t1 t2
+    | _ -> fk_stmt
   in
   let dots_in_body = ("dots in body", S (For (tok, hdr, body_dots) |> G.s)) in
   let dots_in_cond =

--- a/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
@@ -337,7 +337,9 @@ let pattern_from_expr env e : pattern_instrs =
   | Call (e', (lp, args, rp)) -> pattern_from_call env (e', (lp, args, rp))
   | L l -> pattern_from_literal env l
   | Assign (e1, tok, e2) -> pattern_from_assign env (e1, tok, e2)
-  | N _ | DotAccess _ -> [ (env, E e, [ (DONE, fun f any -> f any) ]) ]
+  | N _
+  | DotAccess _ ->
+      [ (env, E e, [ (DONE, fun f any -> f any) ]) ]
   | _expr ->
       [
         (let env', id = metavar_pattern env e in

--- a/semgrep-core/src/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/src/synthesizing/Pretty_print_generic.ml
@@ -47,9 +47,13 @@ let ident (s, _) = s
 
 let ident_or_dynamic = function
   | EN (Id (x, _idinfo)) -> ident x
-  | EN _ | EDynamic _ -> raise Todo
+  | EN _
+  | EDynamic _ ->
+      raise Todo
 
-let opt f = function None -> "" | Some x -> f x
+let opt f = function
+  | None -> ""
+  | Some x -> f x
 
 (* pad: note that Parse_info.str_of_info does not raise an exn anymore
  * on fake tokens. It instead returns the fake token string
@@ -66,20 +70,60 @@ let print_type t =
 let print_bool env = function
   | true -> (
       match env.lang with
-      | Lang.Python | Lang.Python2 | Lang.Python3 -> "True"
-      | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.Javascript
-      | Lang.JSON | Lang.Yaml | Lang.OCaml | Lang.Ruby | Lang.Typescript
-      | Lang.Vue | Lang.Csharp | Lang.PHP | Lang.Hack | Lang.Kotlin | Lang.Lua
-      | Lang.Bash | Lang.Rust | Lang.Scala | Lang.HTML | Lang.HCL ->
+      | Lang.Python
+      | Lang.Python2
+      | Lang.Python3 ->
+          "True"
+      | Lang.Java
+      | Lang.Go
+      | Lang.C
+      | Lang.Cplusplus
+      | Lang.Javascript
+      | Lang.JSON
+      | Lang.Yaml
+      | Lang.OCaml
+      | Lang.Ruby
+      | Lang.Typescript
+      | Lang.Vue
+      | Lang.Csharp
+      | Lang.PHP
+      | Lang.Hack
+      | Lang.Kotlin
+      | Lang.Lua
+      | Lang.Bash
+      | Lang.Rust
+      | Lang.Scala
+      | Lang.HTML
+      | Lang.HCL ->
           "true"
       | Lang.R -> "TRUE")
   | false -> (
       match env.lang with
-      | Lang.Python | Lang.Python2 | Lang.Python3 -> "False"
-      | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.JSON | Lang.Yaml
-      | Lang.Javascript | Lang.OCaml | Lang.Ruby | Lang.Typescript | Lang.Csharp
-      | Lang.Vue | Lang.PHP | Lang.Hack | Lang.Kotlin | Lang.Lua | Lang.Bash
-      | Lang.Rust | Lang.Scala | Lang.HTML | Lang.HCL ->
+      | Lang.Python
+      | Lang.Python2
+      | Lang.Python3 ->
+          "False"
+      | Lang.Java
+      | Lang.Go
+      | Lang.C
+      | Lang.Cplusplus
+      | Lang.JSON
+      | Lang.Yaml
+      | Lang.Javascript
+      | Lang.OCaml
+      | Lang.Ruby
+      | Lang.Typescript
+      | Lang.Csharp
+      | Lang.Vue
+      | Lang.PHP
+      | Lang.Hack
+      | Lang.Kotlin
+      | Lang.Lua
+      | Lang.Bash
+      | Lang.Rust
+      | Lang.Scala
+      | Lang.HTML
+      | Lang.HCL ->
           "false"
       | Lang.R -> "FALSE")
 
@@ -91,7 +135,10 @@ let arithop env (op, tok) =
   | Div -> "/"
   | Mod -> "%"
   | Pow -> "**"
-  | Eq -> ( match env.lang with Lang.OCaml -> "=" | _ -> "==")
+  | Eq -> (
+      match env.lang with
+      | Lang.OCaml -> "="
+      | _ -> "==")
   | Lt -> "<"
   | LtE -> "<="
   | Gt -> ">"
@@ -134,7 +181,10 @@ let rec stmt env level st =
   | _ -> todo (S st)
 
 and block env (t1, ss, t2) level =
-  let rec indent = function 0 -> "" | n -> "    " ^ indent (n - 1) in
+  let rec indent = function
+    | 0 -> ""
+    | n -> "    " ^ indent (n - 1)
+  in
   let rec show_statements env = function
     | [] -> ""
     | [ x ] -> F.sprintf "%s%s" (indent level) (stmt env level x)
@@ -156,7 +206,10 @@ and block env (t1, ss, t2) level =
   else show_statements env ss
 
 and if_stmt env level (tok, e, s, sopt) =
-  let rec indent = function 0 -> "" | n -> "    " ^ indent (n - 1) in
+  let rec indent = function
+    | 0 -> ""
+    | n -> "    " ^ indent (n - 1)
+  in
   let no_paren_cond = F.sprintf "%s %s" in
   (* if cond *)
   let paren_cond = F.sprintf "%s (%s)" in
@@ -166,13 +219,31 @@ and if_stmt env level (tok, e, s, sopt) =
   let bracket_body = F.sprintf "%s %s" (* (if cond) body *) in
   let format_cond, elseif_str, format_block =
     match env.lang with
-    | Lang.Bash | Lang.Ruby | Lang.OCaml | Lang.Scala | Lang.PHP | Lang.Hack
-    | Lang.Yaml | Lang.HTML | Lang.HCL ->
+    | Lang.Bash
+    | Lang.Ruby
+    | Lang.OCaml
+    | Lang.Scala
+    | Lang.PHP
+    | Lang.Hack
+    | Lang.Yaml
+    | Lang.HTML
+    | Lang.HCL ->
         raise Todo
-    | Lang.Python | Lang.Python2 | Lang.Python3 ->
+    | Lang.Python
+    | Lang.Python2
+    | Lang.Python3 ->
         (no_paren_cond, "elif", colon_body)
-    | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.JSON
-    | Lang.Javascript | Lang.Typescript | Lang.Vue | Lang.Kotlin | Lang.Rust
+    | Lang.Java
+    | Lang.Go
+    | Lang.C
+    | Lang.Cplusplus
+    | Lang.Csharp
+    | Lang.JSON
+    | Lang.Javascript
+    | Lang.Typescript
+    | Lang.Vue
+    | Lang.Kotlin
+    | Lang.Rust
     | Lang.R ->
         (paren_cond, "else if", bracket_body)
     | Lang.Lua -> (paren_cond, "elseif", bracket_body)
@@ -200,12 +271,29 @@ and while_stmt env level (tok, e, s) =
   let ruby_while = F.sprintf "%s %s\n %s\nend" in
   let while_format =
     match env.lang with
-    | Lang.Bash | Lang.PHP | Lang.Hack | Lang.Lua | Lang.Yaml | Lang.Scala
-    | Lang.HTML | Lang.HCL ->
+    | Lang.Bash
+    | Lang.PHP
+    | Lang.Hack
+    | Lang.Lua
+    | Lang.Yaml
+    | Lang.Scala
+    | Lang.HTML
+    | Lang.HCL ->
         raise Todo
-    | Lang.Python | Lang.Python2 | Lang.Python3 -> python_while
-    | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
-    | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.Vue | Lang.Rust
+    | Lang.Python
+    | Lang.Python2
+    | Lang.Python3 ->
+        python_while
+    | Lang.Java
+    | Lang.C
+    | Lang.Cplusplus
+    | Lang.Csharp
+    | Lang.Kotlin
+    | Lang.JSON
+    | Lang.Javascript
+    | Lang.Typescript
+    | Lang.Vue
+    | Lang.Rust
     | Lang.R ->
         c_while
     | Lang.Go -> go_while
@@ -218,14 +306,32 @@ and do_while stmt env level (s, e) =
   let c_do_while = F.sprintf "do %s\nwhile(%s)" in
   let do_while_format =
     match env.lang with
-    | Lang.Bash | Lang.PHP | Lang.Hack | Lang.Lua | Lang.Yaml | Lang.Scala
-    | Lang.HTML | Lang.HCL ->
+    | Lang.Bash
+    | Lang.PHP
+    | Lang.Hack
+    | Lang.Lua
+    | Lang.Yaml
+    | Lang.Scala
+    | Lang.HTML
+    | Lang.HCL ->
         raise Todo
-    | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
-    | Lang.Javascript | Lang.Typescript | Lang.Vue ->
+    | Lang.Java
+    | Lang.C
+    | Lang.Cplusplus
+    | Lang.Csharp
+    | Lang.Kotlin
+    | Lang.Javascript
+    | Lang.Typescript
+    | Lang.Vue ->
         c_do_while
-    | Lang.Python | Lang.Python2 | Lang.Python3 | Lang.Go | Lang.JSON
-    | Lang.OCaml | Lang.Rust | Lang.R ->
+    | Lang.Python
+    | Lang.Python2
+    | Lang.Python3
+    | Lang.Go
+    | Lang.JSON
+    | Lang.OCaml
+    | Lang.Rust
+    | Lang.R ->
         failwith "impossible; no do while"
     | Lang.Ruby -> failwith "ruby is so weird (here, do while loop)"
   in
@@ -234,16 +340,35 @@ and do_while stmt env level (s, e) =
 and for_stmt env level (for_tok, hdr, s) =
   let for_format =
     match env.lang with
-    | Lang.Bash | Lang.PHP | Lang.HTML | Lang.Hack | Lang.Lua | Lang.Yaml
-    | Lang.Scala | Lang.HCL ->
+    | Lang.Bash
+    | Lang.PHP
+    | Lang.HTML
+    | Lang.Hack
+    | Lang.Lua
+    | Lang.Yaml
+    | Lang.Scala
+    | Lang.HCL ->
         raise Todo
-    | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin
-    | Lang.Javascript | Lang.Typescript | Lang.Vue | Lang.Rust | Lang.R ->
+    | Lang.Java
+    | Lang.C
+    | Lang.Cplusplus
+    | Lang.Csharp
+    | Lang.Kotlin
+    | Lang.Javascript
+    | Lang.Typescript
+    | Lang.Vue
+    | Lang.Rust
+    | Lang.R ->
         F.sprintf "%s (%s) %s"
     | Lang.Go -> F.sprintf "%s %s %s"
-    | Lang.Python | Lang.Python2 | Lang.Python3 -> F.sprintf "%s %s:\n%s"
+    | Lang.Python
+    | Lang.Python2
+    | Lang.Python3 ->
+        F.sprintf "%s %s:\n%s"
     | Lang.Ruby -> F.sprintf "%s %s\ndo %s\nend"
-    | Lang.JSON | Lang.OCaml -> failwith "JSON/OCaml has for loops????"
+    | Lang.JSON
+    | Lang.OCaml ->
+        failwith "JSON/OCaml has for loops????"
   in
   let show_init = function
     | ForInitVar (ent, var_def) ->
@@ -278,20 +403,35 @@ and def_stmt env (entity, def_kind) =
   let var_def (ent, def) =
     let no_val, with_val =
       match env.lang with
-      | Lang.Bash | Lang.PHP | Lang.Hack | Lang.Lua | Lang.Yaml | Lang.Scala
-      | Lang.HTML | Lang.HCL ->
+      | Lang.Bash
+      | Lang.PHP
+      | Lang.Hack
+      | Lang.Lua
+      | Lang.Yaml
+      | Lang.Scala
+      | Lang.HTML
+      | Lang.HCL ->
           raise Todo
-      | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin ->
+      | Lang.Java
+      | Lang.C
+      | Lang.Cplusplus
+      | Lang.Csharp
+      | Lang.Kotlin ->
           ( (fun typ id _e -> F.sprintf "%s %s;" typ id),
             fun typ id e -> F.sprintf "%s %s = %s;" typ id e )
-      | Lang.Javascript | Lang.Typescript | Lang.Vue ->
+      | Lang.Javascript
+      | Lang.Typescript
+      | Lang.Vue ->
           ( (fun _typ id _e -> F.sprintf "var %s;" id),
             fun _typ id e -> F.sprintf "var %s = %s;" id e )
       | Lang.Go ->
           ( (fun typ id _e -> F.sprintf "var %s %s" id typ),
             fun typ id e -> F.sprintf "var %s %s = %s" id typ e )
           (* will have extra space if no type *)
-      | Lang.Python | Lang.Python2 | Lang.Python3 | Lang.Ruby ->
+      | Lang.Python
+      | Lang.Python2
+      | Lang.Python3
+      | Lang.Ruby ->
           ( (fun _typ id _e -> F.sprintf "%s" id),
             fun _typ id e -> F.sprintf "%s = %s" id e )
       | Lang.Rust ->
@@ -301,7 +441,8 @@ and def_stmt env (entity, def_kind) =
       | Lang.R ->
           ( (fun _typ id _e -> F.sprintf "%s" id),
             fun _typ id e -> F.sprintf "%s <- %s" id e )
-      | Lang.JSON | Lang.OCaml ->
+      | Lang.JSON
+      | Lang.OCaml ->
           failwith "I think JSON/OCaml have no variable definitions"
     in
     let typ, id =
@@ -319,16 +460,38 @@ and def_stmt env (entity, def_kind) =
   | _ -> todo (S (DefStmt (entity, def_kind) |> G.s))
 
 and return env (tok, eopt) _sc =
-  let to_return = match eopt with None -> "" | Some e -> expr env e in
+  let to_return =
+    match eopt with
+    | None -> ""
+    | Some e -> expr env e
+  in
   match env.lang with
-  | Lang.Bash | Lang.PHP | Lang.Hack | Lang.Yaml | Lang.Scala | Lang.HTML
+  | Lang.Bash
+  | Lang.PHP
+  | Lang.Hack
+  | Lang.Yaml
+  | Lang.Scala
+  | Lang.HTML
   | Lang.HCL ->
       raise Todo
-  | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin | Lang.Rust
-    ->
+  | Lang.Java
+  | Lang.C
+  | Lang.Cplusplus
+  | Lang.Csharp
+  | Lang.Kotlin
+  | Lang.Rust ->
       F.sprintf "%s %s;" (token "return" tok) to_return
-  | Lang.Python | Lang.Python2 | Lang.Python3 | Lang.Go | Lang.Ruby | Lang.OCaml
-  | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.Vue | Lang.Lua ->
+  | Lang.Python
+  | Lang.Python2
+  | Lang.Python3
+  | Lang.Go
+  | Lang.Ruby
+  | Lang.OCaml
+  | Lang.JSON
+  | Lang.Javascript
+  | Lang.Typescript
+  | Lang.Vue
+  | Lang.Lua ->
       F.sprintf "%s %s" (token "return" tok) to_return
   | Lang.R -> F.sprintf "%s(%s)" (token "return" tok) to_return
 
@@ -341,15 +504,33 @@ and break env (tok, lbl) _sc =
     | LDynamic e -> F.sprintf " %s" (expr env e)
   in
   match env.lang with
-  | Lang.Bash | Lang.PHP | Lang.Hack | Lang.Yaml | Lang.Scala | Lang.HTML
+  | Lang.Bash
+  | Lang.PHP
+  | Lang.Hack
+  | Lang.Yaml
+  | Lang.Scala
+  | Lang.HTML
   | Lang.HCL ->
       raise Todo
-  | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin | Lang.Rust
-    ->
+  | Lang.Java
+  | Lang.C
+  | Lang.Cplusplus
+  | Lang.Csharp
+  | Lang.Kotlin
+  | Lang.Rust ->
       F.sprintf "%s%s;" (token "break" tok) lbl_str
-  | Lang.Python | Lang.Python2 | Lang.Python3 | Lang.Go | Lang.Ruby | Lang.OCaml
-  | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.Vue | Lang.Lua | Lang.R
-    ->
+  | Lang.Python
+  | Lang.Python2
+  | Lang.Python3
+  | Lang.Go
+  | Lang.Ruby
+  | Lang.OCaml
+  | Lang.JSON
+  | Lang.Javascript
+  | Lang.Typescript
+  | Lang.Vue
+  | Lang.Lua
+  | Lang.R ->
       F.sprintf "%s%s" (token "break" tok) lbl_str
 
 and continue env (tok, lbl) _sc =
@@ -361,14 +542,32 @@ and continue env (tok, lbl) _sc =
     | LDynamic e -> F.sprintf " %s" (expr env e)
   in
   match env.lang with
-  | Lang.Bash | Lang.PHP | Lang.Hack | Lang.Yaml | Lang.Scala | Lang.HTML
+  | Lang.Bash
+  | Lang.PHP
+  | Lang.Hack
+  | Lang.Yaml
+  | Lang.Scala
+  | Lang.HTML
   | Lang.HCL ->
       raise Todo
-  | Lang.Java | Lang.C | Lang.Cplusplus | Lang.Csharp | Lang.Kotlin | Lang.Lua
+  | Lang.Java
+  | Lang.C
+  | Lang.Cplusplus
+  | Lang.Csharp
+  | Lang.Kotlin
+  | Lang.Lua
   | Lang.Rust ->
       F.sprintf "%s%s;" (token "continue" tok) lbl_str
-  | Lang.Python | Lang.Python2 | Lang.Python3 | Lang.Go | Lang.Ruby | Lang.OCaml
-  | Lang.JSON | Lang.Javascript | Lang.Typescript | Lang.Vue ->
+  | Lang.Python
+  | Lang.Python2
+  | Lang.Python3
+  | Lang.Go
+  | Lang.Ruby
+  | Lang.OCaml
+  | Lang.JSON
+  | Lang.Javascript
+  | Lang.Typescript
+  | Lang.Vue ->
       F.sprintf "%s%s" (token "continue" tok) lbl_str
   | Lang.R -> F.sprintf "%s%s" (token "next" tok) lbl_str
 
@@ -428,7 +627,11 @@ and call env (e, (_, es, _)) =
   | IdSpecial (New, _), x :: ys ->
       F.sprintf "%s %s(%s)" s1 (argument env x) (arguments env ys)
   | IdSpecial (IncrDecr (i_d, pre_post), _), [ x ] -> (
-      let op_str = match i_d with Incr -> "++" | Decr -> "--" in
+      let op_str =
+        match i_d with
+        | Incr -> "++"
+        | Decr -> "--"
+      in
       match pre_post with
       | Prefix -> F.sprintf "%s%s" op_str (argument env x)
       | Postfix -> F.sprintf "%s%s" (argument env x) op_str)
@@ -442,16 +645,40 @@ and literal env l =
   | Char (s, _) -> F.sprintf "'%s'" s
   | String (s, _) -> (
       match env.lang with
-      | Lang.Bash | Lang.PHP | Lang.Hack | Lang.Yaml | Lang.Scala | Lang.HTML
+      | Lang.Bash
+      | Lang.PHP
+      | Lang.Hack
+      | Lang.Yaml
+      | Lang.Scala
+      | Lang.HTML
       | Lang.HCL ->
           raise Todo
-      | Lang.Python | Lang.Python2 | Lang.Python3 -> "'" ^ s ^ "'"
-      | Lang.Java | Lang.Go | Lang.C | Lang.Cplusplus | Lang.Csharp
-      | Lang.Kotlin | Lang.JSON | Lang.Javascript | Lang.Vue | Lang.OCaml
-      | Lang.Ruby | Lang.Typescript | Lang.Lua | Lang.Rust | Lang.R ->
+      | Lang.Python
+      | Lang.Python2
+      | Lang.Python3 ->
+          "'" ^ s ^ "'"
+      | Lang.Java
+      | Lang.Go
+      | Lang.C
+      | Lang.Cplusplus
+      | Lang.Csharp
+      | Lang.Kotlin
+      | Lang.JSON
+      | Lang.Javascript
+      | Lang.Vue
+      | Lang.OCaml
+      | Lang.Ruby
+      | Lang.Typescript
+      | Lang.Lua
+      | Lang.Rust
+      | Lang.R ->
           "\"" ^ s ^ "\"")
   | Regexp ((_, (s, _), _), rmod) -> (
-      "/" ^ s ^ "/" ^ match rmod with None -> "" | Some (s, _) -> s)
+      "/" ^ s ^ "/"
+      ^
+      match rmod with
+      | None -> ""
+      | Some (s, _) -> s)
   | x -> todo (E (L x |> G.e))
 
 and arguments env xs =
@@ -482,10 +709,13 @@ and slice_access env e (o1, o2) = function
       F.sprintf "%s[%s:%s:%s]" (expr env e) (option env o1) (option env o2)
         (expr env e1)
 
-and option env = function None -> "" | Some e -> expr env e
+and option env = function
+  | None -> ""
+  | Some e -> expr env e
 
 and other _env (op, anys) =
-  match (op, anys) with _ -> todo (E (OtherExpr (op, anys) |> G.e))
+  match (op, anys) with
+  | _ -> todo (E (OtherExpr (op, anys) |> G.e))
 
 and dot_access env (e, _tok, fi) =
   F.sprintf "%s.%s" (expr env e) (field_ident env fi)

--- a/semgrep-core/src/synthesizing/Range_to_AST.ml
+++ b/semgrep-core/src/synthesizing/Range_to_AST.ml
@@ -94,7 +94,9 @@ let any_at_range_first r1 ast =
 
   try
     visitor (G.Pr ast);
-    match expr_at_range r1 ast with None -> None | Some e -> Some (G.E e)
+    match expr_at_range r1 ast with
+    | None -> None
+    | Some e -> Some (G.E e)
   with Found a -> Some a
 
 let any_to_stmt (any : G.any) : G.stmt =
@@ -116,7 +118,9 @@ let join_anys (anys : AST_generic.any list) : AST_generic.any option =
          contain a single expression or one-or-more statements."
 
 let split_any (any : G.any) : G.any list =
-  match any with G.Ss stmts -> List.map (fun s -> G.S s) stmts | x -> [ x ]
+  match any with
+  | G.Ss stmts -> List.map (fun s -> G.S s) stmts
+  | x -> [ x ]
 
 let any_at_range_all r1 ast : AST_generic.any option =
   let rec any_at_range_list r1 ast : AST_generic.any list =


### PR DESCRIPTION

PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date
