### PR TITLE
Reduce usage of pattern_match object

### DIFF
--- a/semgrep/semgrep/evaluation.py
+++ b/semgrep/semgrep/evaluation.py
@@ -20,18 +20,22 @@ def create_output(
             if rule.fix
             else None
         )
-        rule_match = RuleMatch.from_pattern_match(
+        rule_match = RuleMatch(
             rule.id,
-            pattern_match,
             message=message,
             metadata=rule.metadata,
             severity=rule.severity,
             fix=fix,
             fix_regex=rule.fix_regex,
+            path=pattern_match.path,
+            start=pattern_match.start,
+            end=pattern_match.end,
+            extra=pattern_match.extra,
+            lines_cache={},
         )
         output.append(rule_match)
 
-    return sorted(output, key=lambda rule_match: rule_match._pattern_match.range.start)
+    return sorted(output, key=lambda rule_match: rule_match.start.get("offset", 0))
 
 
 def interpolate_string_with_metavariables(

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -1,4 +1,3 @@
-import copy
 import json
 from typing import Any
 from typing import Dict
@@ -10,16 +9,22 @@ from semgrep.rule_match import RuleMatch
 class JsonFormatter(BaseFormatter):
     @staticmethod
     def _rule_match_to_json(rule_match: RuleMatch) -> Dict[str, Any]:
-        json_obj = copy.deepcopy(rule_match._pattern_match._raw_json)
-
+        json_obj: Dict[str, Any] = {}
         json_obj["check_id"] = rule_match.id
-        json_obj["extra"] = json_obj.get("extra", {})
+        json_obj["extra"] = rule_match.extra
         json_obj["extra"]["message"] = rule_match.message
         json_obj["extra"]["metadata"] = rule_match.metadata
         json_obj["extra"]["severity"] = rule_match.severity.value
-        json_obj["path"] = json_obj.get("path", str(rule_match.path))
-        json_obj["start"] = rule_match.start
-        json_obj["end"] = rule_match.end
+        json_obj["path"] = str(rule_match.path)
+
+        start = rule_match.start
+        if "offset" in start:
+            del start["offset"]
+        json_obj["start"] = start
+        end = rule_match.end
+        if "offset" in end:
+            del end["offset"]
+        json_obj["end"] = end
 
         # 'lines' already contains '\n' at the end of each line
         json_obj["extra"]["lines"] = "".join(rule_match.lines).rstrip()

--- a/semgrep/semgrep/join_rule.py
+++ b/semgrep/semgrep/join_rule.py
@@ -27,7 +27,6 @@ from semgrep.error import ERROR_MAP
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import Level
 from semgrep.error import SemgrepError
-from semgrep.pattern_match import PatternMatch
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.verbose_logging import getLogger
@@ -446,7 +445,6 @@ def run_join_rule(
     rule_matches = [
         RuleMatch(
             id=join_rule.get("id", match.get("check_id", "[empty]")),
-            pattern_match=PatternMatch({}),
             message=join_rule.get(
                 "message", match.get("extra", {}).get("message", "[empty]")
             ),

--- a/semgrep/semgrep/pattern_match.py
+++ b/semgrep/semgrep/pattern_match.py
@@ -64,16 +64,12 @@ class PatternMatch:
     def start(self) -> Dict[str, Any]:
         # https://docs.r2c.dev/en/latest/api/output.html does not support offset at the moment
         start = dict(self._raw_json["start"])
-        if "offset" in start:
-            del start["offset"]
         return start
 
     @property
     def end(self) -> Dict[str, Any]:
         # https://docs.r2c.dev/en/latest/api/output.html does not support offset at the moment
         end = dict(self._raw_json["end"])
-        if "offset" in end:
-            del end["offset"]
         return end
 
     def _read_metavariable_values(self) -> Dict[str, str]:

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -9,7 +9,6 @@ from typing import Tuple
 import attr
 
 from semgrep.constants import RuleSeverity
-from semgrep.pattern_match import PatternMatch
 
 
 @attr.s(frozen=True)
@@ -19,7 +18,6 @@ class RuleMatch:
     """
 
     _id: str = attr.ib()
-    _pattern_match: PatternMatch = attr.ib(repr=False)
     _message: str = attr.ib(repr=False)
     _metadata: Dict[str, Any] = attr.ib(repr=False)
     _severity: RuleSeverity = attr.ib(repr=False)
@@ -35,38 +33,6 @@ class RuleMatch:
 
     # optional attributes
     _is_ignored: Optional[bool] = attr.ib(default=None)
-
-    @classmethod
-    def from_pattern_match(
-        cls,
-        rule_id: str,
-        pattern_match: PatternMatch,
-        message: str,
-        metadata: Dict[str, Any],
-        severity: RuleSeverity,
-        fix: Optional[str],
-        fix_regex: Optional[Dict[str, Any]],
-    ) -> "RuleMatch":
-        path = pattern_match.path
-        start = pattern_match.start
-        end = pattern_match.end
-
-        # note that message in extra is still the old value defined before metavar interpolation
-        extra = pattern_match.extra
-        return cls(
-            rule_id,
-            pattern_match,
-            message,
-            metadata,
-            severity,
-            fix,
-            fix_regex,
-            path,
-            start,
-            end,
-            extra,
-            {},
-        )
 
     @property
     def id(self) -> str:

--- a/semgrep/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesmultiple-rules.yaml-join_rulesuser-input-with-unescaped-extension/results.json
+++ b/semgrep/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesmultiple-rules.yaml-join_rulesuser-input-with-unescaped-extension/results.json
@@ -32,6 +32,25 @@
         "lines": "        <li>person_name_full is <b>{{ person_name_full }}</b></li>",
         "message": "The variable '$VAR' is most likely an XSS. This variable originates from user input and is rendered in an unescaped manner. An attacker could control this variable and input scripts onto rendered pages, resulting in all manner of bad juju. The best fix is to make sure your template extensions end in '.html', which automatically escapes rendered variables.",
         "metadata": {},
+        "metavars": {
+          "$VAR": {
+            "abstract_content": " person_name_full",
+            "end": {
+              "col": 55,
+              "line": 9,
+              "offset": 159
+            },
+            "start": {
+              "col": 38,
+              "line": 9,
+              "offset": 142
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "ERROR"
       },
       "path": "targets/join_rules/user-input-with-unescaped-extension/launch.htm.j2",

--- a/semgrep/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-escaped-with-safe.yaml-join_rulesuser-input-escaped-with-safe/results.json
+++ b/semgrep/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-escaped-with-safe.yaml-join_rulesuser-input-escaped-with-safe/results.json
@@ -14,6 +14,25 @@
         "metadata": {
           "hi": "hi"
         },
+        "metavars": {
+          "$VAR": {
+            "abstract_content": "query",
+            "end": {
+              "col": 33,
+              "line": 19,
+              "offset": 442
+            },
+            "start": {
+              "col": 28,
+              "line": 19,
+              "offset": 437
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "ERROR"
       },
       "path": "targets/join_rules/user-input-escaped-with-safe/search.html",

--- a/semgrep/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-with-unescaped-extension.yaml-join_rulesuser-input-with-unescaped-extension/results.json
+++ b/semgrep/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-with-unescaped-extension.yaml-join_rulesuser-input-with-unescaped-extension/results.json
@@ -12,6 +12,25 @@
         "lines": "        <li>person_name_full is <b>{{ person_name_full }}</b></li>",
         "message": "The variable '$VAR' is most likely an XSS. This variable originates from user input and is rendered in an unescaped manner. An attacker could control this variable and input scripts onto rendered pages, resulting in all manner of bad juju. The best fix is to make sure your template extensions end in '.html', which automatically escapes rendered variables.",
         "metadata": {},
+        "metavars": {
+          "$VAR": {
+            "abstract_content": " person_name_full",
+            "end": {
+              "col": 55,
+              "line": 9,
+              "offset": 159
+            },
+            "start": {
+              "col": 38,
+              "line": 9,
+              "offset": 142
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
         "severity": "ERROR"
       },
       "path": "targets/join_rules/user-input-with-unescaped-extension/launch.htm.j2",


### PR DESCRIPTION
Now that we run whole rules in semgrep-core this class is unnecessary. After this PR the only remaining
usage is in converting semgrep-core output to RuleMatch objects. It's a little involved for now to break
that part out so will do that in a separate PR.
