### PR TITLE
use_parsing_cache: Handle SIGXFSZ (file size limit exceeded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Fixed corner-case crash affecting the `pattern: $X` optimization ("empty And; no positive terms in And")
 - Added support for parsing labels and goto in PHP (#3592)
 - Added type inference for struct literals in Go (#3622)
+- Fix semgrep-core crash when a cache file exceeds the file size limit
 
 ## [0.64.0](https://github.com/returntocorp/semgrep/releases/tag/v0.64.0) - 09-01-2021
 


### PR DESCRIPTION
Closes PA-318

test plan:

    % semgrep-core -lang js -j 1 -e '$X == $X' -fast \
          -use_parsing_cache ./cache \
          ~/semgrep/perf/bench/juice-shop/input/juice-shop/
      #^ no longer gets killed by SIGXFSZ (Apple M1, MacOS 11)
      # and with -j 2 we no longer get a segfault



PR checklist:
- [ ] documentation is up to date
- [x] changelog is up to date
