### PR TITLE
add rule message to emacs output

### DIFF
--- a/semgrep/semgrep/formatter/emacs.py
+++ b/semgrep/semgrep/formatter/emacs.py
@@ -19,6 +19,7 @@ class EmacsFormatter(BaseFormatter):
             str(rule_match.start["col"]),
             severity,
             rule_match.lines[0].rstrip(),
+            rule_match.message,
         ]
 
     def output(self) -> str:

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -10,7 +10,7 @@
       "extra": {
         "is_ignored": false,
         "lines": "console.log(x == x)",
-        "message": "Detected a useless comparison operation `x == x` or `x != x`. This\noperation is always true.\nIf testing for floating point NaN, use `math.isnan`, or\n`cmath.isnan` if the number is complex.\n",
+        "message": "Detected a useless comparison operation `x == x` or `x != x`. This operation is always true. If testing for floating point NaN, use `math.isnan`, or `cmath.isnan` if the number is complex.",
         "metadata": {
           "category": "correctness",
           "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",

--- a/semgrep/tests/e2e/snapshots/test_output/test_output_format/--emacs/results.out
+++ b/semgrep/tests/e2e/snapshots/test_output/test_output_format/--emacs/results.out
@@ -1,1 +1,1 @@
-targets/basic/stupid.py:3:12:error(eqeq-is-bad):    return a + b == a + b
+targets/basic/stupid.py:3:12:error(eqeq-is-bad):    return a + b == a + b:useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?


### PR DESCRIPTION
#### Reference issue
Fixes #3744

#### What does this implement/fix? 
This will make it so the user gets the rule's message when running semgrep with the the flag <code> --emacs </code>.

#### Any other comments?
No


PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
