### PR TITLE
Make safe fake tokens the default

### DIFF
--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -191,7 +191,7 @@ let var_stats prog : var_stats =
 
 let literal_of_bool b =
   let b_str = string_of_bool b in
-  let tok = Parse_info.fake_info b_str in
+  let tok = Parse_info.unsafe_fake_info b_str in
   Bool (b, tok)
 
 let bool_of_literal = function Bool (b, _) -> Some b | __else__ -> None
@@ -204,7 +204,7 @@ let eval_bop_bool op b1 b2 =
 
 let literal_of_int i =
   let i_str = string_of_int i in
-  let tok = Parse_info.fake_info i_str in
+  let tok = Parse_info.unsafe_fake_info i_str in
   Int (Some i, tok)
 
 let int_of_literal = function Int (Some i, _) -> Some i | __else__ -> None
@@ -216,7 +216,7 @@ let eval_bop_int op i1 i2 =
   | __else__ -> None
 
 let literal_of_string s =
-  let tok = Parse_info.fake_info s in
+  let tok = Parse_info.unsafe_fake_info s in
   String (s, tok)
 
 let string_of_literal = function String (s, _) -> Some s | __else__ -> None

--- a/semgrep-core/src/analyzing/Dataflow_constness.ml
+++ b/semgrep-core/src/analyzing/Dataflow_constness.ml
@@ -122,20 +122,20 @@ let refine_constness_ref c_ref c' =
 let literal_of_bool b =
   let b_str = string_of_bool b in
   (* TODO: use proper token when possible? *)
-  let tok = Parse_info.fake_info b_str in
+  let tok = Parse_info.unsafe_fake_info b_str in
   G.Bool (b, tok)
 
 let literal_of_int i =
   let i_str = string_of_int i in
   (* TODO: use proper token when possible? *)
-  let tok = Parse_info.fake_info i_str in
+  let tok = Parse_info.unsafe_fake_info i_str in
   G.Int (Some i, tok)
 
 let int_of_literal = function G.Int (x, _) -> x | ___else___ -> None
 
 let literal_of_string s =
   (* TODO: use proper token when possible? *)
-  let tok = Parse_info.fake_info s in
+  let tok = Parse_info.unsafe_fake_info s in
   G.String (s, tok)
 
 let eval_unop_bool op b =

--- a/semgrep-core/src/analyzing/controlflow_build.ml
+++ b/semgrep-core/src/analyzing/controlflow_build.ml
@@ -727,7 +727,7 @@ let string_of_error (error_kind, info) =
   match info with
   | None -> spf "NOLOC: FLOW %s" (string_of_error_kind error_kind)
   | Some info ->
-      let info = Parse_info.token_location_of_info info in
+      let info = Parse_info.unsafe_token_location_of_info info in
       spf "%s:%d:%d: FLOW %s" info.Parse_info.file info.Parse_info.line
         info.Parse_info.column
         (string_of_error_kind error_kind)

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -361,7 +361,7 @@ let save_rules_file_in_tmp () =
 let exn_to_error file exn =
   match exn with
   | AST_generic.Error (s, tok) ->
-      let loc = PI.token_location_of_info tok in
+      let loc = PI.unsafe_token_location_of_info tok in
       E.mk_error_loc loc (AstBuilderError s)
   | _ -> E.exn_to_error file exn
 
@@ -618,7 +618,7 @@ let parse_pattern lang_pattern str =
            str,
            Rule.L (lang_pattern, []),
            Common.exn_to_s exn,
-           Parse_info.fake_info "no loc",
+           Parse_info.unsafe_fake_info "no loc",
            [] ))
   [@@profiling]
 

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -2027,7 +2027,7 @@ let arg e = Arg e
 (* Try avoid using them! if you build new constructs, you should try
  * to derive the tokens in those new constructs from existing constructs.
  *)
-let fake s = Parse_info.fake_info s
+let fake s = Parse_info.unsafe_fake_info s
 
 (*e: function [[AST_generic.fake]] *)
 (*s: function [[AST_generic.fake_bracket]] *)
@@ -2041,7 +2041,7 @@ let unbracket (_, x, _) = x
 (* bugfix: I used to put ";" but now Parse_info.str_of_info prints
  * the string of a fake info
  *)
-let sc = Parse_info.fake_info ""
+let sc = Parse_info.unsafe_fake_info ""
 
 let unhandled_keywordattr (s, t) =
   NamedAttr (t, Id ((s, t), empty_id_info ()), fake_bracket [])

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -190,9 +190,9 @@ let vardef_to_assign (ent, def) =
   let v =
     match def.vinit with
     | Some v -> v
-    | None -> L (Null (Parse_info.fake_info "null")) |> G.e
+    | None -> L (Null (Parse_info.unsafe_fake_info "null")) |> G.e
   in
-  Assign (name, Parse_info.fake_info "=", v) |> G.e
+  Assign (name, Parse_info.unsafe_fake_info "=", v) |> G.e
 
 (*e: function [[AST_generic.vardef_to_assign]] *)
 
@@ -202,7 +202,7 @@ let funcdef_to_lambda (ent, def) resolved =
   let idinfo = { (empty_id_info ()) with id_resolved = ref resolved } in
   let name = name_or_dynamic_to_expr ent.name (Some idinfo) in
   let v = Lambda def |> G.e in
-  Assign (name, Parse_info.fake_info "=", v) |> G.e
+  Assign (name, Parse_info.unsafe_fake_info "=", v) |> G.e
 
 (*e: function [[AST_generic.funcdef_to_lambda]] *)
 

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -258,8 +258,8 @@ let (mk_visitor : visitor_in -> visitor_out) =
               v2 |> unbracket
               |> List.iter (fun e ->
                      match e.e with
-                     | Tuple (_, [ { e = L (String id); _ }; e ], _) ->
-                         let t = PI.fake_info ":" in
+                     | Tuple (tok, [ { e = L (String id); _ }; e ], _) ->
+                         let t = PI.fake_info tok ":" in
                          v_partial ~recurse:false
                            (PartialSingleField (id, t, e))
                      | _ -> ())
@@ -268,8 +268,8 @@ let (mk_visitor : visitor_in -> visitor_out) =
               v2 |> unbracket
               |> List.iter (fun e ->
                      match e.e with
-                     | Tuple (_, [ { e = N (Id (id, _)); _ }; e ], _) ->
-                         let t = PI.fake_info ":" in
+                     | Tuple (tok, [ { e = N (Id (id, _)); _ }; e ], _) ->
+                         let t = PI.fake_info tok ":" in
                          v_partial ~recurse:false
                            (PartialSingleField (id, t, e))
                      | _ -> ())
@@ -1027,7 +1027,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
           | DefStmt
               ( { name = EN (Id (id, _)); _ },
                 FieldDefColon { vinit = Some e; _ } ) ->
-              let t = PI.fake_info ":" in
+              let t = PI.fake_info (snd id) ":" in
               v_partial ~recurse:false (PartialSingleField (id, t, e))
           | _ -> ());
           let v1 = v_stmt v1 in
@@ -1270,7 +1270,7 @@ let extract_ranges recursor =
   in
   let incorporate_token tok =
     if PI.is_origintok tok then
-      let tok_loc = PI.token_location_of_info tok in
+      let tok_loc = PI.unsafe_token_location_of_info tok in
       incorporate_tokens (tok_loc, tok_loc)
   in
   let hooks =

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -627,7 +627,7 @@ let rec filter_ranges env xs cond =
           * the text representation of the metavar content.
           *)
          | R.CondRegexp (mvar, (re_str, _re)) ->
-             let fk = PI.fake_info "" in
+             let fk = PI.unsafe_fake_info "" in
              let fki = AST_generic.empty_id_info () in
              let e =
                (* old: spf "semgrep_re_match(%s, \"%s\")" mvar re_str
@@ -707,7 +707,7 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
                        * need to fix the token locations in `mast`. *)
                       let mast_start_loc =
                         mval |> MV.ii_of_mval |> Visitor_AST.range_of_tokens
-                        |> fst |> PI.token_location_of_info
+                        |> fst |> PI.unsafe_token_location_of_info
                       in
                       let fix_loc loc =
                         {

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -238,7 +238,7 @@ let make_dotted xs =
       let base = B.N (B.Id (x, B.empty_id_info ())) |> G.e in
       List.fold_left
         (fun acc e ->
-          let tok = Parse_info.fake_info "." in
+          let tok = Parse_info.fake_info (snd x) "." in
           B.DotAccess (acc, tok, B.EN (B.Id (e, B.empty_id_info ()))) |> G.e)
         base xs
 

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -728,7 +728,7 @@ let m_tuple3 m_a m_b m_c (a1, b1, c1) (a2, b2, c2) =
  * split strings in different tokens).
  *)
 let adjust_info_remove_enclosing_quotes (s, info) =
-  let loc = PI.token_location_of_info info in
+  let loc = PI.unsafe_token_location_of_info info in
   let raw_str = loc.PI.str in
   let re = Str.regexp_string s in
   try

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -59,7 +59,7 @@ type env = { r : Rule.t; errors : E.error list ref }
 (*****************************************************************************)
 
 let error env t s =
-  let loc = Parse_info.token_location_of_info t in
+  let loc = Parse_info.unsafe_token_location_of_info t in
   let check_id = "semgrep-metacheck-builtin" in
   let err = E.mk_error_loc loc (E.SemgrepMatchFound (check_id, s)) in
   Common.push err env.errors

--- a/semgrep-core/src/parsing/Parse_mini_rule.ml
+++ b/semgrep-core/src/parsing/Parse_mini_rule.ml
@@ -95,13 +95,13 @@ let parse file =
                            PR.parse_pattern ~id ~lang
                              {
                                pattern = pattern_string;
-                               t = Parse_info.fake_info pattern_string;
+                               t = Parse_info.fake_info t pattern_string;
                                path = [];
                              }
                          in
                          let severity =
                            PR.parse_severity ~id
-                             (sev, Parse_info.fake_info "sev")
+                             (sev, Parse_info.fake_info t "sev")
                          in
                          {
                            R.id;

--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -371,9 +371,9 @@ let extend_left new_start_tok (_, end_) : loc = (new_start_tok, end_)
 
 let extend_right (start, _) new_end_tok : loc = (start, new_end_tok)
 
-let fake_tok = Parse_info.fake_info "fake"
+let unsafe_fake_tok = Parse_info.unsafe_fake_info "fake"
 
-let fake_loc = (fake_tok, fake_tok)
+let unsafe_fake_loc = (unsafe_fake_tok, unsafe_fake_tok)
 
 (*
    Convert a pair (loc, x) to a wrap, which uses a single token to indicate
@@ -423,7 +423,7 @@ let union_loc a b = (min_loc_tok a b, max_loc_tok a b)
 *)
 let list_loc get_loc l =
   match l with
-  | [] -> fake_loc
+  | [] -> unsafe_fake_loc
   | first :: other ->
       List.fold_left
         (fun loc x -> union_loc loc (get_loc x))
@@ -568,7 +568,7 @@ let concat_blists (x : blist list) : blist =
   | [] ->
       (* TODO: use actual location in the program rather than completely
          fake location *)
-      Empty fake_loc
+      Empty unsafe_fake_loc
   | last_blist :: blists ->
       let end_ = blist_loc last_blist in
       List.fold_left

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -174,7 +174,7 @@ let make_scalar _anchor _tag pos value env : G.expr =
   else
     let token = mk_tok pos value env in
     (match value with
-    | "__sgrep_ellipses__" -> G.Ellipsis (Parse_info.fake_info "...")
+    | "__sgrep_ellipses__" -> G.Ellipsis (Parse_info.fake_info token "...")
     (* TODO: emma: I will put "" back to Null and have either a warning or
      * an error when we try to parse a string and get Null in another PR.
      *)
@@ -208,7 +208,8 @@ let make_mappings _anchor _tag start_pos (es, end_pos) env =
 let make_mapping (pos1, pos2) ((key, value) : G.expr * G.expr) env =
   match (key.G.e, value.G.e) with
   | G.Ellipsis _, G.Ellipsis _ ->
-      (G.Ellipsis (Parse_info.fake_info "...") |> G.e, pos2)
+      let tok = mk_tok pos1 "..." env in
+      (G.Ellipsis (Parse_info.fake_info tok "...") |> G.e, pos2)
   | _ -> (G.Tuple (mk_bracket (pos1, pos2) [ key; value ] env) |> G.e, pos2)
 
 let make_doc start_pos (doc, end_pos) env : G.expr list =

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -51,9 +51,13 @@ let name_of_qualified_ident = function
   | Right (xs, id) ->
       (id, { G.name_qualifier = Some (G.QDots xs); name_typeargs = None })
 
-let fake s = Parse_info.fake_info s
+let fake tok s = Parse_info.fake_info tok s
 
-let fake_id s = (s, fake s)
+let unsafe_fake s = Parse_info.unsafe_fake_info s
+
+let _fake_id tok s = (s, fake tok s)
+
+let unsafe_fake_id s = (s, unsafe_fake s)
 
 let fb = G.fake_bracket
 
@@ -134,7 +138,7 @@ let top_func () =
         let params, ret = func_type v1 in
         let ret =
           match ret with
-          | None -> G.TyBuiltin (fake_id "void") |> G.t
+          | None -> G.TyBuiltin (unsafe_fake_id "void") |> G.t
           | Some t -> t
         in
         G.TyFun (params, ret)
@@ -154,10 +158,10 @@ let top_func () =
         let v1 = bracket (list interface_field) v1 in
         G.TyInterfaceAnon (t, v1)
   and chan_dir = function
-    | TSend -> G.TyN (G.Id (fake_id "send", G.empty_id_info ())) |> G.t
-    | TRecv -> G.TyN (G.Id (fake_id "recv", G.empty_id_info ())) |> G.t
+    | TSend -> G.TyN (G.Id (unsafe_fake_id "send", G.empty_id_info ())) |> G.t
+    | TRecv -> G.TyN (G.Id (unsafe_fake_id "recv", G.empty_id_info ())) |> G.t
     | TBidirectional ->
-        G.TyN (G.Id (fake_id "bidirectional", G.empty_id_info ())) |> G.t
+        G.TyN (G.Id (unsafe_fake_id "bidirectional", G.empty_id_info ())) |> G.t
   and func_type { fparams; fresults } =
     let fparams = list parameter_binding fparams in
     let fresults = list parameter_binding fresults in
@@ -194,8 +198,9 @@ let top_func () =
     | EmbeddedField (v1, v2) ->
         let _v1TODO = option tok v1 and v2 = qualified_ident v2 in
         let name = name_of_qualified_ident v2 in
+        let (_, tok), _ = name in
         G.FieldSpread
-          (fake "...", G.N (G.IdQualified (name, G.empty_id_info ())) |> G.e)
+          (fake tok "...", G.N (G.IdQualified (name, G.empty_id_info ())) |> G.e)
     | FieldEllipsis t -> G.fieldEllipsis t
   and tag v = wrap string v
   and interface_field = function
@@ -213,8 +218,9 @@ let top_func () =
     | EmbeddedInterface v1 ->
         let v1 = qualified_ident v1 in
         let name = name_of_qualified_ident v1 in
+        let (_, tok), _ = name in
         G.FieldSpread
-          (fake "...", G.N (G.IdQualified (name, G.empty_id_info ())) |> G.e)
+          (fake tok "...", G.N (G.IdQualified (name, G.empty_id_info ())) |> G.e)
     | FieldEllipsis2 t -> G.fieldEllipsis t
   and expr_or_type v = either expr type_ v
   and expr e =
@@ -236,7 +242,7 @@ let top_func () =
         G.Call (e, args)
     | Cast (v1, v2) ->
         let v1 = type_ v1 and v2 = expr v2 in
-        G.Cast (v1, fake "(", v2)
+        G.Cast (v1, unsafe_fake "(", v2)
     | Deref (v1, v2) ->
         let v1 = tok v1 and v2 = expr v2 in
         G.DeRef (v1, v2)
@@ -255,8 +261,9 @@ let top_func () =
             fb ([ v1; v3 ] |> List.map G.arg) )
     | CompositeLit (v1, v2) ->
         let v1 = type_ v1
-        and _t1, v2, _t2 = bracket (list init_for_composite_lit) v2 in
-        G.Call (G.IdSpecial (G.New, fake "new") |> G.e, fb (G.ArgType v1 :: v2))
+        and t1, v2, _t2 = bracket (list init_for_composite_lit) v2 in
+        G.Call
+          (G.IdSpecial (G.New, fake t1 "new") |> G.e, fb (G.ArgType v1 :: v2))
     | Slice (v1, (t1, v2, t2)) ->
         let e = expr v1 in
         let v1, v2, v3 = v2 in
@@ -267,7 +274,7 @@ let top_func () =
     | TypeAssert (v1, (lp, v2, rp)) ->
         let v1 = expr v1 and v2 = type_ v2 in
         G.Call
-          ( G.IdSpecial (G.Instanceof, fake "instanceof") |> G.e,
+          ( G.IdSpecial (G.Instanceof, fake lp "instanceof") |> G.e,
             (lp, [ G.Arg v1; G.ArgType v2 ], rp) )
     | Ellipsis v1 ->
         let v1 = tok v1 in
@@ -494,7 +501,7 @@ let top_func () =
         and v3 = expr v3 in
         match opt with
         | None ->
-            let pattern = G.PatUnderscore (fake "_") in
+            let pattern = G.PatUnderscore (fake v2 "_") in
             G.ForEach (pattern, v2, v3)
         | Some (xs, _tokEqOrColonEqTODO) ->
             let pattern =
@@ -542,11 +549,13 @@ let top_func () =
         let v1 = ident v1
         and v2 = option type_ v2
         and v3 = option constant_expr v3 in
-        let ent = G.basic_entity v1 [ G.attr G.Const (fake "const") ] in
+        let ent =
+          G.basic_entity v1 [ G.attr G.Const (fake (snd v1) "const") ]
+        in
         G.DefStmt (ent, G.VarDef { G.vinit = v3; vtype = v2 }) |> G.s
     | DVar (v1, v2, v3) ->
         let v1 = ident v1 and v2 = option type_ v2 and v3 = option expr v3 in
-        let ent = G.basic_entity v1 [ G.attr G.Var (fake "var") ] in
+        let ent = G.basic_entity v1 [ G.attr G.Var (fake (snd v1) "var") ] in
         G.DefStmt (ent, G.VarDef { G.vinit = v3; vtype = v2 }) |> G.s
     | DTypeAlias (v1, v2, v3) ->
         let v1 = ident v1 and _v2 = tok v2 and v3 = type_ v3 in

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -103,7 +103,7 @@ let special (x, tok) =
           match args with
           | [ e ] ->
               let tvoid = G.TyBuiltin ("void", tok) |> G.t in
-              G.Cast (tvoid, PI.fake_info ":", e)
+              G.Cast (tvoid, PI.fake_info tok ":", e)
           | _ -> error tok "Impossible: Too many arguments to Void")
   | Spread -> SR_Special (G.Spread, tok)
   | Yield ->
@@ -454,7 +454,8 @@ and type_kind x =
   | TyLiteral l ->
       let l = literal l in
       G.OtherType
-        (G.OT_Todo, [ G.TodoK ("LitType", PI.fake_info ""); G.E (G.L l |> G.e) ])
+        ( G.OT_Todo,
+          [ G.TodoK ("LitType", PI.unsafe_fake_info ""); G.E (G.L l |> G.e) ] )
   | TyQuestion (tok, t) ->
       let t = type_ t in
       G.TyQuestion (t, tok)
@@ -468,11 +469,12 @@ and type_kind x =
       let params = List.map parameter_binding params in
       let rett =
         match typ_opt with
-        | None -> G.TyBuiltin ("void", PI.fake_info "void") |> G.t
+        | None -> G.TyBuiltin ("void", PI.unsafe_fake_info "void") |> G.t
         | Some t -> type_ t
       in
       G.TyFun (params, rett)
-  | TyRecordAnon (lt, (), rt) -> G.TyRecordAnon (PI.fake_info "", (lt, [], rt))
+  | TyRecordAnon (lt, (), rt) ->
+      G.TyRecordAnon (PI.fake_info lt "", (lt, [], rt))
   | TyOr (t1, tk, t2) ->
       let t1 = type_ t1 in
       let t2 = type_ t2 in

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -45,7 +45,9 @@ let bool = id
 
 let string = id
 
-let fake s = Parse_info.fake_info s
+let fake tok s = Parse_info.fake_info tok s
+
+let unsafe_fake s = Parse_info.unsafe_fake_info s
 
 let fb = G.fake_bracket
 
@@ -388,7 +390,7 @@ and expr_as_stmt = function
   | D x -> definition x
   | e ->
       let e = expr e in
-      G.ExprStmt (e, fake ";") |> G.s
+      G.ExprStmt (e, unsafe_fake ";") |> G.s
 
 and stmt st =
   match st with
@@ -511,12 +513,12 @@ and definition def =
               let ent = G.basic_entity id [] in
               G.DefStmt (ent, G.FuncDef funcdef) |> G.s
           | Right e ->
-              let ent = G.basic_entity ("", fake "") [] in
+              let ent = G.basic_entity ("", fake t "") [] in
               G.OtherStmt (G.OS_Todo, [ G.E e; G.Def (ent, G.FuncDef funcdef) ])
               |> G.s)
       | SingletonM e ->
           let e = expr e in
-          let ent = G.basic_entity ("", fake "") [] in
+          let ent = G.basic_entity ("", fake t "") [] in
           G.OtherStmt (G.OS_Todo, [ G.E e; G.Def (ent, G.FuncDef funcdef) ])
           |> G.s)
   | ClassDef (t, kind, body) -> (
@@ -607,11 +609,13 @@ and body_exn x =
       in
       match elseopt with
       | None ->
-          let try_ = G.Try (fake "try", body, catches, finally_opt) |> G.s in
+          let try_ =
+            G.Try (unsafe_fake "try", body, catches, finally_opt) |> G.s
+          in
           G.Block (fb [ try_ ]) |> G.s
-      | Some (_t, sts) ->
+      | Some (t, sts) ->
           let st = list_stmt1 sts in
-          let try_ = G.Try (fake "try", body, catches, finally_opt) |> G.s in
+          let try_ = G.Try (fake t "try", body, catches, finally_opt) |> G.s in
           let st = G.Block (fb [ try_; st ]) |> G.s in
           G.OtherStmtWithStmt (G.OSWS_Else_in_try, None, st) |> G.s)
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -393,7 +393,7 @@ let map_preproc_defined (env : env) (x : CST.preproc_defined) =
   | `Defi_id (v1, v2) ->
       let v1 = token env v1 (* "defined" *) in
       let v2 = str env v2 (* pattern [a-zA-Z_]\w* *) in
-      Call (IdSpecial (Defined, v1), fb [ Arg (expr_of_id v2) ])
+      Call (IdSpecial (Defined, v1), fb v1 [ Arg (expr_of_id v2) ])
 
 let map_variadic_declarator (env : env) ((v1, v2) : CST.variadic_declarator) =
   let v1 = token env v1 (* "..." *) in
@@ -675,7 +675,7 @@ let map_anon_choice_stmt_id_efddc5b (env : env)
   | `Id tok -> IdIdent (str env tok) (* pattern [a-zA-Z_]\w* *)
   | `Op_name tok ->
       let op = str env tok (* operator_name *) in
-      IdOperator (fake "operator", parse_operator env op)
+      IdOperator (fake (snd op) "operator", parse_operator env op)
   | `Dest_name x ->
       let x = map_destructor_name env x in
       x
@@ -1660,7 +1660,10 @@ and map_declarator (env : env) (x : CST.declarator) : declarator =
   | `Op_name tok ->
       let op = str env tok (* operator_name *) in
       let dn =
-        DN (None, noQscope, IdOperator (fake "operator", parse_operator env op))
+        DN
+          ( None,
+            noQscope,
+            IdOperator (fake (snd op) "operator", parse_operator env op) )
       in
       { dn; dt = id }
   | `Dest_name x ->
@@ -2089,7 +2092,11 @@ and map_field_declarator (env : env) (x : CST.field_declarator) : declarator =
   | `Op_name tok ->
       let x = str env tok (* operator_name *) in
       {
-        dn = DN (None, [], IdOperator (fake "operator", parse_operator env x));
+        dn =
+          DN
+            ( None,
+              [],
+              IdOperator (fake (snd x) "operator", parse_operator env x) );
         dt = id;
       }
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -175,10 +175,10 @@ let rec type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
         v2)
       v3
   in
-  let _v4 = token env v4 (* ":" *) in
+  let v4 = token env v4 (* ":" *) in
   let v5 = match v5 with Some x -> statement_list env x | None -> [] in
   let xs = v2 :: v3 in
-  (CaseExprs (v1, xs |> List.map (fun x -> Right x)), stmt1 v5)
+  (CaseExprs (v1, xs |> List.map (fun x -> Right x)), stmt1 v4 v5)
 
 and simple_statement (env : env) (x : CST.simple_statement) : simple =
   match x with
@@ -488,9 +488,9 @@ and call_expression (env : env) (x : CST.call_expression) =
 
 and default_case (env : env) ((v1, v2, v3) : CST.default_case) =
   let v1 = token env v1 (* "default" *) in
-  let _v2 = token env v2 (* ":" *) in
+  let v2 = token env v2 (* ":" *) in
   let v3 = match v3 with Some x -> statement_list env x | None -> [] in
-  (CaseDefault v1, stmt1 v3)
+  (CaseDefault v1, stmt1 v2 v3)
 
 and slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
   let v1 = token env v1 (* "[" *) in
@@ -863,9 +863,9 @@ and implicit_length_array_type (env : env)
 and expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
   let v1 = token env v1 (* "case" *) in
   let v2 = expression_list env v2 in
-  let _v3 = token env v3 (* ":" *) in
+  let v3 = token env v3 (* ":" *) in
   let v4 = match v4 with Some x -> statement_list env x | None -> [] in
-  (CaseExprs (v1, v2 |> List.map (fun x -> Left x)), stmt1 v4)
+  (CaseExprs (v1, v2 |> List.map (fun x -> Left x)), stmt1 v3 v4)
 
 and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
   let v1 = token env v1 (* "(" *) in
@@ -1137,9 +1137,9 @@ and communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
         | Some (xs, (_lr, tk)) ->
             CaseAssign (v1, xs |> List.map (fun e -> Left e), tk, e))
   in
-  let _v3 = token env v3 (* ":" *) in
+  let v3 = token env v3 (* ":" *) in
   let v4 = match v4 with Some x -> statement_list env x | None -> [] in
-  (v2, stmt1 v4)
+  (v2, stmt1 v3 v4)
 
 and literal_value (env : env) ((v1, v2, v3) : CST.literal_value) :
     init list bracket =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -40,7 +40,7 @@ let str = H.str
 
 let fb = fake_bracket
 
-let sc = PI.fake_info ";"
+let sc = PI.sc
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -1012,9 +1012,9 @@ and function_body (env : env) (x : CST.function_body) =
   match x with
   | `Blk x -> block env x
   | `EQ_exp (v1, v2) ->
-      let _v1 = token env v1 (* "=" *) in
+      let v1 = token env v1 (* "=" *) in
       let v2 = expression env v2 in
-      ExprStmt (v2, sc) |> G.s
+      ExprStmt (v2, sc v1) |> G.s
 
 and function_literal (env : env) (x : CST.function_literal) =
   match x with
@@ -1185,7 +1185,7 @@ and jump_expression (env : env) (x : CST.jump_expression) =
   | `Throw_exp (v1, v2) ->
       let v1 = token env v1 (* "throw" *) in
       let v2 = expression env v2 in
-      Throw (v1, v2, sc) |> G.s
+      Throw (v1, v2, sc v1) |> G.s
   | `Choice_ret_opt_exp (v1, v2) ->
       let v1 =
         match v1 with
@@ -1203,7 +1203,7 @@ and jump_expression (env : env) (x : CST.jump_expression) =
       in
       let return_tok, id = v1 in
       (match id with
-      | None -> Return (return_tok, v2, sc)
+      | None -> Return (return_tok, v2, sc return_tok)
       | Some simple_id -> (
           let id = N (Id (simple_id, empty_id_info ())) |> G.e in
           match v2 with
@@ -1216,20 +1216,20 @@ and jump_expression (env : env) (x : CST.jump_expression) =
       |> G.s
   | `Cont tok ->
       let v1 = token env tok (* "continue" *) in
-      Continue (v1, LNone, sc) |> G.s
+      Continue (v1, LNone, sc v1) |> G.s
   | `Cont_at (v1, v2) ->
       let v1 = token env v1 (* "continue@" *) in
       let v2 = lexical_identifier env v2 in
       let ident = LId v2 in
-      Continue (v1, ident, sc) |> G.s
+      Continue (v1, ident, sc v1) |> G.s
   | `Brk tok ->
       let v1 = token env tok (* "break" *) in
-      Break (v1, LNone, sc) |> G.s
+      Break (v1, LNone, sc v1) |> G.s
   | `Brk_at (v1, v2) ->
       let v1 = token env v1 (* "break@" *) in
       let v2 = lexical_identifier env v2 in
       let ident = LId v2 in
-      Break (v1, ident, sc) |> G.s
+      Break (v1, ident, sc v1) |> G.s
 
 and lambda_literal (env : env) ((v1, v2, v3, v4) : CST.lambda_literal) =
   let v1 = token env v1 (* "{" *) in
@@ -1677,12 +1677,12 @@ and type_ (env : env) ((v1, v2) : CST.type_) : type_ =
 
 and type_arguments (env : env) ((v1, v2, v3, v4) : CST.type_arguments) =
   let v1 = token env v1 (* "<" *) in
-  let v2 = type_projection env v2 in
+  let v2 = type_projection env ~tok:v1 v2 in
   let v3 =
     List.map
       (fun (v1, v2) ->
-        let _v1 = token env v1 (* "," *) in
-        let v2 = type_projection env v2 in
+        let v1 = token env v1 (* "," *) in
+        let v2 = type_projection env ~tok:v1 v2 in
         v2)
       v3
   in
@@ -1762,14 +1762,14 @@ and type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
   let _v4 = token env v4 (* ">" *) in
   v2 :: v3
 
-and type_projection (env : env) (x : CST.type_projection) =
+and type_projection (env : env) ~tok (x : CST.type_projection) =
   match x with
   | `Opt_type_proj_modifs_type (v1, v2) ->
       let _v1 =
         match v1 with Some x -> type_projection_modifiers env x | None -> []
       in
       let v2 = type_ env v2 in
-      let fake_token = Parse_info.fake_info "type projection" in
+      let fake_token = Parse_info.fake_info tok "type projection" in
       let list = [ TodoK ("type projection", fake_token); T v2 ] in
       let othertype = OtherType (OT_Todo, list) |> G.t in
       TypeArg othertype

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -41,7 +41,7 @@ let token = H.token
 let str = H.str
 
 (* like in parser_ml.mly *)
-let seq1 = function [ x ] -> x | xs -> Sequence (PI.fake_bracket xs)
+let seq1 = function [ x ] -> x | xs -> Sequence (PI.unsafe_fake_bracket xs)
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -967,9 +967,9 @@ and map_binding_pattern (env : env) (x : CST.binding_pattern) : pattern =
       PatPolyVariant (v1, Some v2)
   | `Tuple_bind_pat (v1, v2, v3) ->
       let v1 = map_binding_pattern_ext env v1 in
-      let _v2 = token env v2 (* "," *) in
+      let v2 = token env v2 (* "," *) in
       let v3 = map_binding_pattern_ext env v3 in
-      PatTuple (PI.fake_bracket [ v1; v3 ])
+      PatTuple (PI.fake_bracket v2 [ v1; v3 ])
   | `Cons_bind_pat_f2d0ae9 (v1, v2, v3) ->
       let v1 = map_binding_pattern_ext env v1 in
       let v2 = token env v2 (* "::" *) in
@@ -1878,7 +1878,7 @@ and map_module_expression (env : env) (x : CST.module_expression) =
             let _v2 = token env v2 (* ")" *) in
             []
       in
-      ModuleTodo (("App", PI.fake_info ""), v1 :: v2)
+      ModuleTodo (("App", PI.unsafe_fake_info ""), v1 :: v2)
 
 and map_module_expression_ext (env : env) (x : CST.module_expression_ext) =
   match x with
@@ -2174,9 +2174,9 @@ and map_pattern (env : env) (x : CST.pattern) : pattern =
       PatPolyVariant (v1, Some v2)
   | `Tuple_pat (v1, v2, v3) ->
       let v1 = map_pattern_ext env v1 in
-      let _v2 = token env v2 (* "," *) in
+      let v2 = token env v2 (* "," *) in
       let v3 = map_pattern_ext env v3 in
-      PatTuple (PI.fake_bracket [ v1; v3 ])
+      PatTuple (PI.fake_bracket v2 [ v1; v3 ])
   | `Cons_pat_9b4e481 (v1, v2, v3) ->
       let v1 = map_pattern_ext env v1 in
       let v2 = token env v2 (* "::" *) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -37,7 +37,7 @@ type env = unit H.env
 
 let _todo (_env : env) _ = failwith "not implemented, yikes."
 
-let fb = PI.fake_bracket
+let fb = PI.unsafe_fake_bracket
 
 let list_to_maybe_tuple = function
   | [] -> raise Impossible
@@ -1443,7 +1443,7 @@ and delimited_symbol (env : env) ((v1, v2, v3) : CST.delimited_symbol) : atom =
   let v1 = token2 env v1 (* symbol_start :" "*) in
   let res = match v2 with Some x -> literal_contents env x | None -> [] in
   let v3 = token2 env v3 (* string_end " "*) in
-  (Parse_info.fake_info ":", AtomFromString (v1, res, v3))
+  (Parse_info.fake_info v1 ":", AtomFromString (v1, res, v3))
 
 and literal_contents (env : env) (xs : CST.literal_contents) : AST.interp list =
   List.filter_map

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -365,7 +365,7 @@ let parse_string_and_adjust_wrt_base content tbase fparse =
             Map_AST.default_visitor with
             Map_AST.kinfo =
               (fun (_, _) t ->
-                let base_loc = PI.token_location_of_info tbase in
+                let base_loc = PI.unsafe_token_location_of_info tbase in
                 PI.adjust_info_wrt_base base_loc t);
           }
       in

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -284,7 +284,7 @@ let json_of_exn e =
         match pos with
         | { token = PI.FakeTokStr (str, _); _ } -> J.String str
         | _ ->
-            let s_loc = PI.token_location_of_info pos in
+            let s_loc = PI.unsafe_token_location_of_info pos in
             J.Object
               [
                 ("file", J.String s_loc.file);

--- a/semgrep-core/src/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Code.ml
@@ -57,7 +57,7 @@ let lookup env e =
 (* Helpers *)
 (*****************************************************************************)
 
-let fk = Parse_info.fake_info "fake"
+let fk = Parse_info.unsafe_fake_info "fake"
 
 let fk_stmt = ExprStmt (Ellipsis fk |> G.e, fk) |> G.s
 

--- a/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
@@ -120,7 +120,7 @@ let lookup env e =
   in
   look mapping
 
-let fk = Parse_info.fake_info "fake"
+let fk = Parse_info.unsafe_fake_info "fake"
 
 let fk_stmt = ExprStmt (Ellipsis fk |> G.e, fk) |> G.s
 


### PR DESCRIPTION
Also, replaced many unsafe fake tokens with safer ones.

Follows: returntocorp/pfff#472 ("Make safe fake tokens the default")

test plan:
make test



PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
