### PR TITLE
Report rule_id whenever possible

### DIFF
--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -42,36 +42,23 @@ let options () = []
 (* Convertor functions *)
 (****************************************************************************)
 
-let mk_error rule_id loc msg err =
-  {
-    rule_id = Some rule_id;
-    loc;
-    typ = err;
-    msg;
-    details = None;
-    yaml_path = None;
-  }
+let mk_error ?(rule_id = None) loc msg err =
+  { rule_id; loc; typ = err; msg; details = None; yaml_path = None }
 
-let mk_error_tok rule_id tok msg err =
+let mk_error_tok ?(rule_id = None) tok msg err =
   let loc = PI.unsafe_token_location_of_info tok in
-  mk_error rule_id loc msg err
-
-let mk_error_no_rule loc msg err =
-  { rule_id = None; loc; typ = err; msg; details = None; yaml_path = None }
-
-let mk_error_tok_no_rule tok msg err =
-  let loc = PI.unsafe_token_location_of_info tok in
-  mk_error_no_rule loc msg err
+  mk_error ~rule_id loc msg err
 
 let error rule_id loc msg err =
-  Common.push (mk_error rule_id loc msg err) g_errors
+  Common.push (mk_error ~rule_id:(Some rule_id) loc msg err) g_errors
 
 let error_tok rule_id tok msg err =
-  Common.push (mk_error_tok rule_id tok msg err) g_errors
+  Common.push (mk_error_tok ~rule_id:(Some rule_id) tok msg err) g_errors
 
-let exn_to_error file exn =
+let exn_to_error ?(rule_id = None) file exn =
   match exn with
-  | Parse_info.Lexical_error (s, tok) -> mk_error_tok_no_rule tok s LexicalError
+  | Parse_info.Lexical_error (s, tok) ->
+      mk_error_tok ~rule_id tok s LexicalError
   | Parse_info.Parsing_error tok ->
       let msg =
         match tok with
@@ -79,17 +66,19 @@ let exn_to_error file exn =
             spf "`%s` was unexpected" str
         | _ -> "unknown reason"
       in
-      mk_error_tok_no_rule tok msg ParseError
+      mk_error_tok ~rule_id tok msg ParseError
   | Parse_info.Other_error (s, tok) ->
-      mk_error_tok_no_rule tok s SpecifiedParseError
+      mk_error_tok ~rule_id tok s SpecifiedParseError
   | Rule.InvalidRule (rule_id, s, pos) ->
-      mk_error_tok rule_id pos s RuleParseError
+      mk_error_tok ~rule_id:(Some rule_id) pos s RuleParseError
   | Rule.InvalidLanguage (rule_id, language, pos) ->
-      mk_error_tok rule_id pos
+      mk_error_tok ~rule_id:(Some rule_id) pos
         (spf "invalid language %s" language)
         RuleParseError
   | Rule.InvalidRegexp (rule_id, message, pos) ->
-      mk_error_tok rule_id pos (spf "invalid regex %s" message) RuleParseError
+      mk_error_tok ~rule_id:(Some rule_id) pos
+        (spf "invalid regex %s" message)
+        RuleParseError
   | Rule.InvalidPattern (rule_id, _pattern, xlang, _message, pos, yaml_path) ->
       {
         rule_id = Some rule_id;
@@ -101,22 +90,22 @@ let exn_to_error file exn =
         details = None;
         yaml_path = Some yaml_path;
       }
-  | Rule.InvalidYaml (msg, pos) -> mk_error_tok_no_rule pos msg InvalidYaml
-  | Rule.DuplicateYamlKey (s, pos) -> mk_error_tok_no_rule pos s InvalidYaml
+  | Rule.InvalidYaml (msg, pos) -> mk_error_tok ~rule_id pos msg InvalidYaml
+  | Rule.DuplicateYamlKey (s, pos) -> mk_error_tok ~rule_id pos s InvalidYaml
   | Common.Timeout timeout_info ->
       (* This exception should always be reraised. *)
       let loc = Parse_info.first_loc_of_file file in
       let msg = Common.string_of_timeout_info timeout_info in
-      mk_error_no_rule loc msg Timeout
+      mk_error ~rule_id loc msg Timeout
   | Out_of_memory ->
       let loc = Parse_info.first_loc_of_file file in
-      mk_error_no_rule loc "Out of memory" OutOfMemory
+      mk_error ~rule_id loc "Out of memory" OutOfMemory
   | UnixExit _ as exn -> raise exn
   (* general case, can't extract line information from it, default to line 1 *)
   | exn ->
       let loc = Parse_info.first_loc_of_file file in
       {
-        rule_id = None;
+        rule_id;
         typ = FatalError;
         loc;
         msg = Common.exn_to_s exn;

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -66,7 +66,7 @@ let exn_to_error ?(rule_id = None) file exn =
             spf "`%s` was unexpected" str
         | _ -> "unknown reason"
       in
-      mk_error_tok ~rule_id tok msg ParseError
+      mk_error_tok tok msg ParseError
   | Parse_info.Other_error (s, tok) ->
       mk_error_tok ~rule_id tok s SpecifiedParseError
   | Rule.InvalidRule (rule_id, s, pos) ->

--- a/semgrep-core/src/core/Semgrep_error_code.mli
+++ b/semgrep-core/src/core/Semgrep_error_code.mli
@@ -40,17 +40,19 @@ val options : unit -> Common.cmdline_options
 (*****************************************************************************)
 
 val mk_error :
-  Rule.rule_id -> Parse_info.token_location -> string -> error_kind -> error
-
-val mk_error_no_rule :
-  Parse_info.token_location -> string -> error_kind -> error
+  ?rule_id:Rule.rule_id option ->
+  Parse_info.token_location ->
+  string ->
+  error_kind ->
+  error
 
 val error :
   Rule.rule_id -> Parse_info.token_location -> string -> error_kind -> unit
 
 val error_tok : Rule.rule_id -> Parse_info.t -> string -> error_kind -> unit
 
-val exn_to_error : Common.filename -> exn -> error
+val exn_to_error :
+  ?rule_id:Rule.rule_id option -> Common.filename -> exn -> error
 
 (*****************************************************************************)
 (* Try with error *)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -995,7 +995,6 @@ let check hook default_config rules equivs file_and_more =
   |> List.map (fun (r, pformula) ->
          let rule_id = fst r.R.id in
          Common.profile_code (spf "real_rule:%s" rule_id) (fun () ->
-             pr2 "hello";
              try check_rule r hook default_config pformula equivs file_and_more
              with exn ->
                {

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -135,7 +135,7 @@ let error env msg =
    * the target file. *)
   let loc = PI.first_loc_of_file env.file in
   (* TODO: warning or error? MatchingError or ... ? *)
-  let err = E.mk_error env.rule_id loc msg E.MatchingError in
+  let err = E.mk_error ~rule_id:(Some env.rule_id) loc msg E.MatchingError in
   Common.push err env.errors
 
 let (xpatterns_in_formula : S.sformula -> (R.xpattern * R.inside option) list) =
@@ -958,6 +958,31 @@ and matches_of_formula config equivs rule_id file_and_more formula opt_context :
 (* Main entry point *)
 (*****************************************************************************)
 
+let check_rule r hook default_config pformula equivs file_and_more =
+  let config = r.R.options ||| default_config in
+  let formula = R.formula_of_pformula pformula in
+  let rule_id = fst r.id in
+  let res, final_ranges =
+    matches_of_formula config equivs rule_id file_and_more formula None
+  in
+  {
+    RP.matches =
+      final_ranges
+      |> List.map (range_to_pattern_match_adjusted r)
+      (* dedup similar findings (we do that also in Match_patterns.ml,
+       * but different mini-rules matches can now become the same match)
+       *)
+      |> PM.uniq
+      |> before_return (fun v ->
+             v
+             |> List.iter (fun (m : Pattern_match.t) ->
+                    let str = spf "with rule %s" rule_id in
+                    hook str m.env m.tokens));
+    errors = res.errors |> List.map (error_with_rule_id rule_id);
+    skipped = res.skipped;
+    profiling = res.profiling;
+  }
+
 let check hook default_config rules equivs file_and_more =
   let { FM.file; lazy_ast_and_errors; _ } = file_and_more in
   logger#info "checking %s with %d rules" file (List.length rules);
@@ -968,33 +993,17 @@ let check hook default_config rules equivs file_and_more =
 
   rules
   |> List.map (fun (r, pformula) ->
-         Common.profile_code
-           (spf "real_rule:%s" (fst r.R.id))
-           (fun () ->
-             let config = r.options ||| default_config in
-             let formula = R.formula_of_pformula pformula in
-             let rule_id = fst r.id in
-             let res, final_ranges =
-               matches_of_formula config equivs rule_id file_and_more formula
-                 None
-             in
-             {
-               RP.matches =
-                 final_ranges
-                 |> List.map (range_to_pattern_match_adjusted r)
-                 (* dedup similar findings (we do that also in Match_patterns.ml,
-                  * but different mini-rules matches can now become the same match)
-                  *)
-                 |> PM.uniq
-                 |> before_return (fun v ->
-                        v
-                        |> List.iter (fun (m : Pattern_match.t) ->
-                               let str = spf "with rule %s" rule_id in
-                               hook str m.env m.tokens));
-               errors = res.errors |> List.map (error_with_rule_id rule_id);
-               skipped = res.skipped;
-               profiling = res.profiling;
-             }))
+         let rule_id = fst r.R.id in
+         Common.profile_code (spf "real_rule:%s" rule_id) (fun () ->
+             pr2 "hello";
+             try check_rule r hook default_config pformula equivs file_and_more
+             with exn ->
+               {
+                 RP.matches = [];
+                 errors = [ E.exn_to_error ~rule_id:(Some rule_id) file exn ];
+                 skipped = [];
+                 profiling = { parse_time = -1.; match_time = -1. };
+               }))
   |> RP.collate_semgrep_results
   [@@profiling]
 

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -62,7 +62,9 @@ let error env t s =
   let loc = Parse_info.unsafe_token_location_of_info t in
   let check_id = "semgrep-metacheck-builtin" in
   let rule_id, _ = env.r.id in
-  let err = E.mk_error rule_id loc s (E.SemgrepMatchFound check_id) in
+  let err =
+    E.mk_error ~rule_id:(Some rule_id) loc s (E.SemgrepMatchFound check_id)
+  in
   Common.push err env.errors
 
 (*****************************************************************************)

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -158,7 +158,7 @@ let match_to_match x =
     let s =
       spf "NoTokenLocation with pattern %s, %s" x.rule_id.pattern_string s
     in
-    let err = E.mk_error x.rule_id.id loc s E.MatchingError in
+    let err = E.mk_error ~rule_id:(Some x.rule_id.id) loc s E.MatchingError in
     Right err
   [@@profiling]
 

--- a/semgrep/tests/e2e/snapshots/test_check/test_max_memory/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_max_memory/results.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "warn",
-      "message": "Semgrep Core WARN - Out of memory: When running rules.forcetimeout on targets/equivalence/open_redirect.py: ",
+      "message": "Semgrep Core WARN - Out of memory: When running rules.forcetimeout on targets/equivalence/open_redirect.py: Out of memory",
       "path": "targets/equivalence/open_redirect.py",
       "rule_id": "rules.forcetimeout",
       "type": "Out of memory"

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout/results.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "warn",
-      "message": "Semgrep Core WARN - Timeout: When running rules.forcetimeout on targets/equivalence/open_redirect.py: ",
+      "message": "Semgrep Core WARN - Timeout: When running rules.forcetimeout on targets/equivalence/open_redirect.py: Main.timeout_function:1",
       "path": "targets/equivalence/open_redirect.py",
       "rule_id": "rules.forcetimeout",
       "type": "Timeout"

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/results.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "warn",
-      "message": "Semgrep Core WARN - Timeout: When running rules.forcetimeout on targets/equivalence/open_redirect.py: ",
+      "message": "Semgrep Core WARN - Timeout: When running rules.forcetimeout on targets/equivalence/open_redirect.py: Main.timeout_function:1",
       "path": "targets/equivalence/open_redirect.py",
       "rule_id": "rules.forcetimeout",
       "type": "Timeout"


### PR DESCRIPTION
Closes #3861

Catch errors in Match_rules.ml and report the rule_id of the rule being run if not already present in the exception.



PR checklist:
- [ ] documentation is up to date
- [ ] changelog is up to date
