### PR TITLE
[HCL] almost complete conversion to generic AST

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -27,7 +27,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 (* Helpers to build or convert AST_generic elements.
  *
- * Very often used helper functions are actually in AST_generic.ml at
+ * The very often used helper functions are actually in AST_generic.ml at
  * the end (e.g., AST_generic.basic_entity).
  * This module is for the more rarely used helpers.
  *)
@@ -225,8 +225,8 @@ let has_keyword_attr kwd attrs =
 
 (* update: you should now use AST_generic.equal_any which internally
  * does not care about position information.
+ * TODO: can we remove this function now then?
  *)
-
 let abstract_for_comparison_visitor recursor =
   let hooks =
     {
@@ -287,18 +287,18 @@ let undo_ac_matching_nf tok op : expr list -> expr option = function
       Some (List.fold_left mk_op (mk_op a1 a2) args)
 
 (*****************************************************************************)
-(* Conversion *)
+(* AST_generic_ conversions *)
 (*****************************************************************************)
 
 module G_ = AST_generic_
 
-(* This module is ugly, but it was written to allow to move AST_generic.ml
- * out of pfff/ and inside semgrep/. However there are many
- * language-specific ASTs that we using AST_generic.ml to factorize
+(* This AST_generic_ module is ugly, but it was written to allow to move
+ * AST_generic.ml out of pfff/ and inside semgrep/. However there are many
+ * language-specific ASTs that were using AST_generic.ml to factorize
  * the definitions of operators. To break the dependency we had
  * to duplicate that part of AST_generic in pfff/h_program-lang/AST_generic_.ml
- * (note that underscore at the end) and we need those boilerplate functions
- * below to convert them back to AST_generic.
+ * (note the underscore at the end), but then we need those boilerplate
+ * functions below to convert them back to AST_generic.
  *
  * alt: use polymorphic variants (e.g., `Plus)
  *)

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -328,7 +328,7 @@ let rec just_parse_with_lang lang file =
       run file
         [ TreeSitter (Parse_vue_tree_sitter.parse parse_embedded_js) ]
         (fun x -> x)
-  | Lang.HCL -> failwith "No HCL parser yet; improve the one in tree-sitter"
+  | Lang.HCL -> run file [ TreeSitter Parse_hcl_tree_sitter.parse ] (fun x -> x)
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -96,7 +96,9 @@ let parse_operator _env (s, t) : operator * tok list =
   in
   (op, [ t ])
 
-(* like Parse_c_tree_sitter.number_literal *)
+(* like Parse_c_tree_sitter.number_literal and H.parse_number_literal
+ * but for ast_cpp.ml, not AST_generic.ml
+ *)
 let parse_number_literal (s, t) =
   match Common2.int_of_string_c_octal_opt s with
   | Some i -> Int (Some i, t)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -12,9 +12,13 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
  *)
+open Common
 module PI = Parse_info
 module CST = Tree_sitter_hcl.CST
 module H = Parse_tree_sitter_helpers
+open AST_generic
+module G = AST_generic
+module H2 = AST_generic_helpers
 
 (*****************************************************************************)
 (* Prelude *)
@@ -22,6 +26,8 @@ module H = Parse_tree_sitter_helpers
 (* OCaml parser using tree-sitter-lang/semgrep-hcl and converting
  * to the generic AST directly.
  *
+ * See https://www.terraform.io/docs/language/ for more information
+ * on the HCL language (a.k.a terraform).
  *)
 
 (*****************************************************************************)
@@ -29,6 +35,10 @@ module H = Parse_tree_sitter_helpers
 (*****************************************************************************)
 
 type env = unit H.env
+
+let token = H.token
+
+let str = H.str
 
 (*****************************************************************************)
 (* Boilerplate converter *)
@@ -43,83 +53,67 @@ type env = unit H.env
 (* Disable warnings against unused variables *)
 [@@@warning "-26-27"]
 
-(* Disable warning against unused 'rec' *)
-[@@@warning "-39"]
-
-let token (env : env) (_tok : Tree_sitter_run.Token.t) =
-  failwith "not implemented"
-
 let todo (env : env) _ = failwith "not implemented"
 
-let _map_pat_b66053b (env : env) (tok : CST.pat_b66053b) =
-  (* pattern 0x[0-9a-zA-Z]+ *) token env tok
-
-let map_bool_lit (env : env) (x : CST.bool_lit) =
+let map_bool_lit (env : env) (x : CST.bool_lit) : bool wrap =
   match x with
-  | `True tok -> (* "true" *) token env tok
-  | `False tok -> (* "false" *) token env tok
-
-let _map_template_interpolation_end (env : env)
-    (tok : CST.template_interpolation_end) =
-  (* template_interpolation_end *) token env tok
-
-let _map_pat_e950a1b (env : env) (tok : CST.pat_e950a1b) =
-  (* pattern [0-9]+(\.[0-9]+([eE][-+]?[0-9]+)?)? *) token env tok
+  | `True tok -> (* "true" *) (true, token env tok)
+  | `False tok -> (* "false" *) (false, token env tok)
 
 let map_heredoc_start (env : env) (x : CST.heredoc_start) =
   match x with
   | `LTLT tok -> (* "<<" *) token env tok
   | `LTLTDASH tok -> (* "<<-" *) token env tok
 
-let _map_template_literal_chunk (env : env) (tok : CST.template_literal_chunk) =
-  (* template_literal_chunk *) token env tok
-
-let _map_identifier (env : env) (tok : CST.identifier) =
-  (* identifier *) token env tok
-
-let _map_quoted_template_start (env : env) (tok : CST.quoted_template_start) =
-  (* quoted_template_start *) token env tok
-
-let _map_template_interpolation_start (env : env)
-    (tok : CST.template_interpolation_start) =
-  (* template_interpolation_start *) token env tok
-
-let _map_ellipsis (env : env) (tok : CST.ellipsis) =
-  (* ellipsis *) token env tok
-
-let _map_heredoc_identifier (env : env) (tok : CST.heredoc_identifier) =
-  (* heredoc_identifier *) token env tok
-
 let map_template_directive (env : env) (x : CST.template_directive) =
   match x with
   | `PERC_5eef7bb tok -> (* "%{if TODO" *) token env tok
   | `PERC_58c37dd tok -> (* "%{for TODO" *) token env tok
 
-let map_numeric_lit (env : env) (x : CST.numeric_lit) =
+let map_numeric_lit (env : env) (x : CST.numeric_lit) : literal =
   match x with
   | `Pat_e950a1b tok ->
-      (* pattern [0-9]+(\.[0-9]+([eE][-+]?[0-9]+)?)? *) token env tok
-  | `Pat_b66053b tok -> (* pattern 0x[0-9a-zA-Z]+ *) token env tok
+      (* pattern [0-9]+(\.[0-9]+([eE][-+]?[0-9]+)?)? *)
+      let x = str env tok in
+      H.parse_number_literal x
+  | `Pat_b66053b tok ->
+      (* pattern 0x[0-9a-zA-Z]+ *)
+      let x = str env tok in
+      H.parse_number_literal x
 
-let map_template_literal (env : env) (xs : CST.template_literal) =
-  List.map (token env (* template_literal_chunk *)) xs
+let map_template_literal (env : env) (xs : CST.template_literal) :
+    string wrap option =
+  (* each character is a separate template_literal_chunk, so we need
+   * to merge them in a single string.
+   *)
+  let xs = List.map (str env (* template_literal_chunk *)) xs in
+  match xs with
+  | [] -> None
+  | (s1, t1) :: ys ->
+      let str = List.map fst ys |> String.concat "" in
+      let toks = List.map snd ys in
+      Some (s1 ^ str, PI.combine_infos t1 toks)
 
 let map_string_lit (env : env) ((v1, v2, v3) : CST.string_lit) =
   let v1 = (* quoted_template_start *) token env v1 in
   let v2 = map_template_literal env v2 in
   let v3 = (* quoted_template_end *) token env v3 in
-  todo env (v1, v2, v3)
+  match v2 with
+  | Some (s, t) -> G.String (s, PI.combine_infos v1 [ t; v3 ])
+  | None -> G.String ("", PI.combine_infos v1 [ v3 ])
 
 let map_get_attr (env : env) ((v1, v2) : CST.get_attr) =
   let v1 = (* "." *) token env v1 in
-  let v2 = (* identifier *) token env v2 in
-  todo env (v1, v2)
+  let v2 = (* identifier *) str env v2 in
+  fun e ->
+    let n = H2.name_of_id v2 in
+    G.DotAccess (e, v1, EN n) |> G.e
 
-let map_literal_value (env : env) (x : CST.literal_value) =
+let map_literal_value (env : env) (x : CST.literal_value) : literal =
   match x with
   | `Nume_lit x -> map_numeric_lit env x
-  | `Bool_lit x -> map_bool_lit env x
-  | `Null_lit tok -> (* "null" *) token env tok
+  | `Bool_lit x -> Bool (map_bool_lit env x)
+  | `Null_lit tok -> (* "null" *) Null (token env tok)
   | `Str_lit x -> map_string_lit env x
 
 let rec map_anon_choice_get_attr_7bbf24f (env : env)
@@ -129,25 +123,30 @@ let rec map_anon_choice_get_attr_7bbf24f (env : env)
 and map_anon_choice_temp_lit_c764a73 (env : env)
     (x : CST.anon_choice_temp_lit_c764a73) =
   match x with
-  | `Temp_lit x -> map_template_literal env x
+  | `Temp_lit x ->
+      let sopt = map_template_literal env x in
+      sopt |> Common.opt_to_list |> List.map (fun s -> Left3 s)
   | `Temp_interp (v1, v2, v3, v4, v5) ->
       let v1 = (* template_interpolation_start *) token env v1 in
-      let v2 =
+      (* TODO: what is this ~? *)
+      let _v2TODO =
         match v2 with
-        | Some tok -> (* "~" *) token env tok
-        | None -> todo env ()
+        | Some tok -> (* "~" *) Some (token env tok)
+        | None -> None
       in
       let v3 =
-        match v3 with Some x -> map_expression env x | None -> todo env ()
+        match v3 with Some x -> Some (map_expression env x) | None -> None
       in
-      let v4 =
+      let _v4TODO =
         match v4 with
-        | Some tok -> (* "~" *) token env tok
-        | None -> todo env ()
+        | Some tok -> (* "~" *) Some (token env tok)
+        | None -> None
       in
       let v5 = (* template_interpolation_end *) token env v5 in
-      todo env (v1, v2, v3, v4, v5)
-  | `Temp_dire x -> map_template_directive env x
+      [ Right3 (v1, v3, v5) ]
+  | `Temp_dire x ->
+      let t = map_template_directive env x in
+      [ Middle3 (G.OtherExpr (OE_Todo, [ TodoK ("directive", t) ]) |> G.e) ]
 
 and map_binary_operation (env : env) (x : CST.binary_operation) =
   match x with
@@ -155,178 +154,182 @@ and map_binary_operation (env : env) (x : CST.binary_operation) =
       let v1 = map_expr_term env v1 in
       let v2 =
         match v2 with
-        | `STAR tok -> (* "*" *) token env tok
-        | `SLASH tok -> (* "/" *) token env tok
-        | `PERC tok -> (* "%" *) token env tok
+        | `STAR tok -> (* "*" *) (Mult, token env tok)
+        | `SLASH tok -> (* "/" *) (Div, token env tok)
+        | `PERC tok -> (* "%" *) (Mod, token env tok)
       in
       let v3 = map_expr_term env v3 in
-      todo env (v1, v2, v3)
+      (v1, v2, v3)
   | `Expr_term_choice_PLUS_expr_term (v1, v2, v3) ->
       let v1 = map_expr_term env v1 in
       let v2 =
         match v2 with
-        | `PLUS tok -> (* "+" *) token env tok
-        | `DASH tok -> (* "-" *) token env tok
+        | `PLUS tok -> (* "+" *) (Plus, token env tok)
+        | `DASH tok -> (* "-" *) (Minus, token env tok)
       in
       let v3 = map_expr_term env v3 in
-      todo env (v1, v2, v3)
+      (v1, v2, v3)
   | `Expr_term_choice_GT_expr_term (v1, v2, v3) ->
       let v1 = map_expr_term env v1 in
       let v2 =
         match v2 with
-        | `GT tok -> (* ">" *) token env tok
-        | `GTEQ tok -> (* ">=" *) token env tok
-        | `LT tok -> (* "<" *) token env tok
-        | `LTEQ tok -> (* "<=" *) token env tok
+        | `GT tok -> (* ">" *) (Gt, token env tok)
+        | `GTEQ tok -> (* ">=" *) (GtE, token env tok)
+        | `LT tok -> (* "<" *) (Lt, token env tok)
+        | `LTEQ tok -> (* "<=" *) (LtE, token env tok)
       in
       let v3 = map_expr_term env v3 in
-      todo env (v1, v2, v3)
+      (v1, v2, v3)
   | `Expr_term_choice_EQEQ_expr_term (v1, v2, v3) ->
       let v1 = map_expr_term env v1 in
       let v2 =
         match v2 with
-        | `EQEQ tok -> (* "==" *) token env tok
-        | `BANGEQ tok -> (* "!=" *) token env tok
+        | `EQEQ tok -> (* "==" *) (Eq, token env tok)
+        | `BANGEQ tok -> (* "!=" *) (NotEq, token env tok)
       in
       let v3 = map_expr_term env v3 in
-      todo env (v1, v2, v3)
+      (v1, v2, v3)
   | `Expr_term_choice_AMPAMP_expr_term (v1, v2, v3) ->
       let v1 = map_expr_term env v1 in
-      let v2 = match v2 with `AMPAMP tok -> (* "&&" *) token env tok in
+      let v2 = match v2 with `AMPAMP tok -> (* "&&" *) (And, token env tok) in
       let v3 = map_expr_term env v3 in
-      todo env (v1, v2, v3)
+      (v1, v2, v3)
   | `Expr_term_choice_BARBAR_expr_term (v1, v2, v3) ->
       let v1 = map_expr_term env v1 in
-      let v2 = match v2 with `BARBAR tok -> (* "||" *) token env tok in
+      let v2 = match v2 with `BARBAR tok -> (* "||" *) (Or, token env tok) in
       let v3 = map_expr_term env v3 in
-      todo env (v1, v2, v3)
+      (v1, v2, v3)
 
-and map_collection_value (env : env) (x : CST.collection_value) =
+and map_collection_value (env : env) (x : CST.collection_value) : expr =
   match x with
   | `Tuple (v1, v2, v3) ->
       let v1 = (* "[" *) token env v1 in
-      let v2 =
-        match v2 with Some x -> map_tuple_elems env x | None -> todo env ()
-      in
+      let v2 = match v2 with Some x -> map_tuple_elems env x | None -> [] in
       let v3 = (* "]" *) token env v3 in
-      todo env (v1, v2, v3)
+      G.Tuple (v1, v2, v3) |> G.e
   | `Obj x -> map_object_ env x
 
-and map_expr_term (env : env) (x : CST.expr_term) =
+and map_expr_term (env : env) (x : CST.expr_term) : expr =
   match x with
-  | `Lit_value x -> map_literal_value env x
+  | `Lit_value x -> L (map_literal_value env x) |> G.e
   | `Temp_expr x -> map_template_expr env x
   | `Coll_value x -> map_collection_value env x
-  | `Var_expr tok -> (* identifier *) token env tok
+  | `Var_expr tok ->
+      (* identifier *)
+      let id = str env tok in
+      N (H2.name_of_id id) |> G.e
   | `Func_call (v1, v2, v3, v4) ->
-      let v1 = (* identifier *) token env v1 in
+      let v1 = (* identifier *) str env v1 in
       let v2 = (* "(" *) token env v2 in
       let v3 =
-        match v3 with
-        | Some x -> map_function_arguments env x
-        | None -> todo env ()
+        match v3 with Some x -> map_function_arguments env x | None -> []
       in
       let v4 = (* ")" *) token env v4 in
-      todo env (v1, v2, v3, v4)
+      let n = N (H2.name_of_id v1) |> G.e in
+      Call (n, (v2, v3, v4)) |> G.e
   | `For_expr x -> map_for_expr env x
   | `Oper x -> map_operation env x
   | `Expr_term_index (v1, v2) ->
       let v1 = map_expr_term env v1 in
       let v2 = map_index env v2 in
-      todo env (v1, v2)
+      v2 v1
   | `Expr_term_get_attr (v1, v2) ->
       let v1 = map_expr_term env v1 in
       let v2 = map_get_attr env v2 in
-      todo env (v1, v2)
+      v2 v1
   | `Expr_term_splat (v1, v2) ->
       let v1 = map_expr_term env v1 in
       let v2 = map_splat env v2 in
-      todo env (v1, v2)
+      v2 v1
   | `LPAR_exp_RPAR (v1, v2, v3) ->
-      let v1 = (* "(" *) token env v1 in
+      let _v1 = (* "(" *) token env v1 in
       let v2 = map_expression env v2 in
-      let v3 = (* ")" *) token env v3 in
-      todo env (v1, v2, v3)
+      let _v3 = (* ")" *) token env v3 in
+      v2
 
-and map_expression (env : env) (x : CST.expression) =
+and map_expression (env : env) (x : CST.expression) : expr =
   match x with
   | `Expr_term x -> map_expr_term env x
   | `Cond (v1, v2, v3, v4, v5) ->
       let v1 = map_expression env v1 in
-      let v2 = (* "?" *) token env v2 in
+      let _v2 = (* "?" *) token env v2 in
       let v3 = map_expression env v3 in
-      let v4 = (* ":" *) token env v4 in
+      let _v4 = (* ":" *) token env v4 in
       let v5 = map_expression env v5 in
-      todo env (v1, v2, v3, v4, v5)
+      Conditional (v1, v3, v5) |> G.e
 
 and map_for_cond (env : env) ((v1, v2) : CST.for_cond) =
   let v1 = (* "if" *) token env v1 in
   let v2 = map_expression env v2 in
-  todo env (v1, v2)
+  (v1, v2)
 
 and map_for_expr (env : env) (x : CST.for_expr) =
   match x with
   | `For_tuple_expr (v1, v2, v3, v4, v5) ->
       let v1 = (* "[" *) token env v1 in
-      let v2 = map_for_intro env v2 in
+      let tfor, ids, tin, e, tcolon = map_for_intro env v2 in
       let v3 = map_expression env v3 in
-      let v4 =
-        match v4 with Some x -> map_for_cond env x | None -> todo env ()
-      in
+      let v4 = match v4 with Some x -> [ map_for_cond env x ] | None -> [] in
       let v5 = (* "]" *) token env v5 in
       todo env (v1, v2, v3, v4, v5)
   | `For_obj_expr (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 = (* "{" *) token env v1 in
-      let v2 = map_for_intro env v2 in
+      let tfor, ids, tin, e, tcolon = map_for_intro env v2 in
       let v3 = map_expression env v3 in
       let v4 = (* "=>" *) token env v4 in
       let v5 = map_expression env v5 in
-      let v6 =
+      (* ??? *)
+      let _v6TODO =
         match v6 with
-        | Some tok -> (* ellipsis *) token env tok
-        | None -> todo env ()
+        | Some tok -> (* ellipsis *) Some (token env tok)
+        | None -> None
       in
-      let v7 =
-        match v7 with Some x -> map_for_cond env x | None -> todo env ()
-      in
+      let v7 = match v7 with Some x -> [ map_for_cond env x ] | None -> [] in
       let v8 = (* "}" *) token env v8 in
       todo env (v1, v2, v3, v4, v5, v6, v7, v8)
 
 and map_for_intro (env : env) ((v1, v2, v3, v4, v5, v6) : CST.for_intro) =
   let v1 = (* "for" *) token env v1 in
-  let v2 = (* identifier *) token env v2 in
+  let v2 = (* identifier *) str env v2 in
   let v3 =
     match v3 with
     | Some (v1, v2) ->
-        let v1 = (* "," *) token env v1 in
-        let v2 = (* identifier *) token env v2 in
-        todo env (v1, v2)
-    | None -> todo env ()
+        let _v1 = (* "," *) token env v1 in
+        let v2 = (* identifier *) str env v2 in
+        [ v2 ]
+    | None -> []
   in
   let v4 = (* "in" *) token env v4 in
   let v5 = map_expression env v5 in
   let v6 = (* ":" *) token env v6 in
-  todo env (v1, v2, v3, v4, v5, v6)
+  (v1, v2 :: v3, v4, v5, v6)
 
-and map_function_arguments (env : env) ((v1, v2, v3) : CST.function_arguments) =
+and map_function_arguments (env : env) ((v1, v2, v3) : CST.function_arguments) :
+    argument list =
   let v1 = map_expression env v1 in
   let v2 =
     List.map
       (fun (v1, v2) ->
-        let v1 = (* "," *) token env v1 in
+        let _v1 = (* "," *) token env v1 in
         let v2 = map_expression env v2 in
-        todo env (v1, v2))
+        Arg v2)
       v2
   in
   let v3 =
     match v3 with
     | Some x -> (
         match x with
-        | `COMMA tok -> (* "," *) token env tok
-        | `Ellips tok -> (* ellipsis *) token env tok)
-    | None -> todo env ()
+        | `COMMA tok ->
+            (* "," *)
+            let _t = token env tok in
+            []
+        | `Ellips tok ->
+            (* ellipsis *)
+            let t = token env tok in
+            [ Arg (Ellipsis t |> G.e) ])
+    | None -> []
   in
-  todo env (v1, v2, v3)
+  [ Arg v1 ] @ v2 @ v3
 
 and map_index (env : env) (x : CST.index) =
   match x with
@@ -334,71 +337,88 @@ and map_index (env : env) (x : CST.index) =
       let v1 = (* "[" *) token env v1 in
       let v2 = map_expression env v2 in
       let v3 = (* "]" *) token env v3 in
-      todo env (v1, v2, v3)
+      fun e -> G.ArrayAccess (e, (v1, v2, v3)) |> G.e
   | `Legacy_index (v1, v2) ->
       let v1 = (* "." *) token env v1 in
-      let v2 = (* pattern [0-9]+ *) token env v2 in
-      todo env (v1, v2)
+      let v2 = (* pattern [0-9]+ *) str env v2 in
+      let idx = L (H.parse_number_literal v2) |> G.e in
+      fun e -> G.ArrayAccess (e, (v1, idx, v1)) |> G.e
 
 and map_object_ (env : env) ((v1, v2, v3) : CST.object_) =
   let v1 = (* "{" *) token env v1 in
-  let v2 =
-    match v2 with Some x -> map_object_elems env x | None -> todo env ()
-  in
+  let v2 = match v2 with Some x -> map_object_elems env x | None -> [] in
   let v3 = (* "}" *) token env v3 in
-  todo env (v1, v2, v3)
+  Record (v1, v2, v3) |> G.e
 
-and map_object_elem (env : env) ((v1, v2, v3) : CST.object_elem) =
+and map_object_elem (env : env) ((v1, v2, v3) : CST.object_elem) : field =
   let v1 = map_expression env v1 in
   let v2 =
     match v2 with
-    | `EQ tok -> (* "=" *) token env tok
-    | `COLON tok -> (* ":" *) token env tok
+    | `EQ tok -> (* "=" *) Left (token env tok)
+    | `COLON tok -> (* ":" *) Right (token env tok)
   in
   let v3 = map_expression env v3 in
-  todo env (v1, v2, v3)
+  let n_or_dyn = match v1.e with N n -> EN n | _ -> EDynamic v1 in
+  let ent = { name = n_or_dyn; attrs = []; tparams = [] } in
+  let vdef = { vinit = Some v3; vtype = None } in
+  let def =
+    match v2 with
+    | Left _teq -> VarDef vdef
+    | Right _tcolon -> FieldDefColon vdef
+  in
+  (ent, def) |> G.fld
 
 and map_object_elems (env : env) ((v1, v2, v3) : CST.object_elems) =
   let v1 = map_object_elem env v1 in
   let v2 =
     List.map
       (fun (v1, v2) ->
-        let v1 =
+        let _v1 =
           match v1 with
-          | Some tok -> (* "," *) token env tok
-          | None -> todo env ()
+          | Some tok -> (* "," *) Some (token env tok)
+          | None -> None
         in
         let v2 = map_object_elem env v2 in
-        todo env (v1, v2))
+        v2)
       v2
   in
-  let v3 =
-    match v3 with Some tok -> (* "," *) token env tok | None -> todo env ()
+  let _v3 =
+    match v3 with Some tok -> (* "," *) Some (token env tok) | None -> None
   in
-  todo env (v1, v2, v3)
+  v1 :: v2
 
-and map_operation (env : env) (x : CST.operation) =
+and map_operation (env : env) (x : CST.operation) : expr =
   match x with
   | `Un_oper (v1, v2) ->
-      let v1 =
+      let op, t =
         match v1 with
-        | `DASH tok -> (* "-" *) token env tok
-        | `BANG tok -> (* "!" *) token env tok
+        | `DASH tok -> (* "-" *) (Minus, token env tok)
+        | `BANG tok -> (* "!" *) (Not, token env tok)
       in
       let v2 = map_expr_term env v2 in
-      todo env (v1, v2)
-  | `Bin_oper x -> map_binary_operation env x
+      Call (IdSpecial (Op op, t) |> G.e, fake_bracket [ Arg v2 ]) |> G.e
+  | `Bin_oper x ->
+      let a, (op, t), c = map_binary_operation env x in
+      Call (IdSpecial (Op op, t) |> G.e, fake_bracket [ Arg a; Arg c ]) |> G.e
 
 and map_splat (env : env) (x : CST.splat) =
   match x with
   | `Attr_splat (v1, v2) ->
       let v1 = (* ".*" *) token env v1 in
+      let f1 e =
+        let access = EDynamic (IdSpecial (HashSplat, v1) |> G.e) in
+        DotAccess (e, v1, access) |> G.e
+      in
       let v2 = List.map (map_anon_choice_get_attr_7bbf24f env) v2 in
-      todo env (v1, v2)
+      fun e -> v2 |> List.fold_left (fun acc f -> f acc) (f1 e)
   | `Full_splat (v1, v2) ->
       let v1 = (* "[*]" *) token env v1 in
+      let f1 e =
+        let access = IdSpecial (HashSplat, v1) |> G.e in
+        ArrayAccess (e, (v1, access, v1)) |> G.e
+      in
       let v2 = List.map (map_anon_choice_get_attr_7bbf24f env) v2 in
-      todo env (v1, v2)
+      fun e -> v2 |> List.fold_left (fun acc f -> f acc) (f1 e)
 
 and map_template_expr (env : env) (x : CST.template_expr) =
   match x with
@@ -406,69 +426,105 @@ and map_template_expr (env : env) (x : CST.template_expr) =
       let v1 = (* quoted_template_start *) token env v1 in
       let v2 =
         match v2 with
-        | Some xs -> List.map (map_anon_choice_temp_lit_c764a73 env) xs
-        | None -> todo env ()
+        | Some xs ->
+            List.map (map_anon_choice_temp_lit_c764a73 env) xs |> List.flatten
+        | None -> []
       in
       let v3 = (* quoted_template_end *) token env v3 in
-      todo env (v1, v2, v3)
+      G.interpolated (v1, v2, v3)
   | `Here_temp (v1, v2, v3, v4) ->
       let v1 = map_heredoc_start env v1 in
       let v2 = (* heredoc_identifier *) token env v2 in
       let v3 =
         match v3 with
-        | Some xs -> List.map (map_anon_choice_temp_lit_c764a73 env) xs
-        | None -> todo env ()
+        | Some xs ->
+            List.map (map_anon_choice_temp_lit_c764a73 env) xs |> List.flatten
+        | None -> []
       in
       let v4 = (* heredoc_identifier *) token env v4 in
-      todo env (v1, v2, v3, v4)
+      let t1 = PI.combine_infos v1 [ v2 ] in
+      G.interpolated (t1, v3, v4)
 
-and map_tuple_elems (env : env) ((v1, v2, v3) : CST.tuple_elems) =
+and map_tuple_elems (env : env) ((v1, v2, v3) : CST.tuple_elems) : expr list =
   let v1 = map_expression env v1 in
   let v2 =
     List.map
       (fun (v1, v2) ->
-        let v1 = (* "," *) token env v1 in
+        let _v1 = (* "," *) token env v1 in
         let v2 = map_expression env v2 in
-        todo env (v1, v2))
+        v2)
       v2
   in
-  let v3 =
-    match v3 with Some tok -> (* "," *) token env tok | None -> todo env ()
+  let _v3 =
+    match v3 with Some tok -> (* "," *) Some (token env tok) | None -> None
   in
-  todo env (v1, v2, v3)
+  v1 :: v2
 
-let map_attribute (env : env) ((v1, v2, v3) : CST.attribute) =
-  let v1 = (* identifier *) token env v1 in
+let map_attribute (env : env) ((v1, v2, v3) : CST.attribute) : definition =
+  let v1 = (* identifier *) str env v1 in
   let v2 = (* "=" *) token env v2 in
   let v3 = map_expression env v3 in
-  todo env (v1, v2, v3)
+  let ent = G.basic_entity v1 [] in
+  let def = { vinit = Some v3; vtype = None } in
+  (ent, VarDef def)
 
-let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) =
-  let v1 = (* identifier *) token env v1 in
+(* TODO? convert to a definition? a class_def? *)
+let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
+  (* TODO? usually 'resource', 'locals', 'variable', other? *)
+  let v1 = (* identifier *) str env v1 in
   let v2 =
     List.map
       (fun x ->
         match x with
-        | `Str_lit x -> map_string_lit env x
-        | `Id tok -> (* identifier *) token env tok)
+        | `Str_lit x ->
+            let x = map_string_lit env x in
+            L x |> G.e
+        | `Id tok ->
+            let id = (* identifier *) str env tok in
+            let n = H2.name_of_id id in
+            N n |> G.e)
       v2
   in
   let v3 = (* "{" *) token env v3 in
-  let v4 = match v4 with Some x -> map_body env x | None -> todo env () in
+  let v4 = match v4 with Some x -> map_body env x | None -> [] in
   let v5 = (* "}" *) token env v5 in
-  todo env (v1, v2, v3, v4, v5)
 
-and map_body (env : env) (xs : CST.body) =
+  let n = H2.name_of_id v1 in
+  (* convert in a Record like map_object *)
+  let flds = v4 |> List.map (fun st -> FieldStmt st) in
+  let body = Record (v3, flds, v5) |> G.e in
+  let es = [ N n |> G.e ] @ v2 @ [ body ] in
+  let args = es |> List.map G.arg in
+  (* TODO? convert in something else? *)
+  let special = IdSpecial (New, snd v1) |> G.e in
+  G.Call (special, fake_bracket args) |> G.e
+
+(* TODO? convert to a field, to be similar to map_object_, so maybe some
+ * object semgrep pattern can also match block body.
+ *)
+and map_body (env : env) (xs : CST.body) : item list =
   List.map
     (fun x ->
-      match x with `Attr x -> map_attribute env x | `Blk x -> map_block env x)
+      match x with
+      | `Attr x ->
+          let def = map_attribute env x in
+          DefStmt def |> G.s
+      | `Blk x ->
+          let blk = map_block env x in
+          G.exprstmt blk)
     xs
 
-let map_config_file (env : env) (opt : CST.config_file) =
+let map_config_file (env : env) (opt : CST.config_file) : program =
   match opt with
   | Some x -> (
-      match x with `Body x -> map_body env x | `Obj x -> map_object_ env x)
-  | None -> todo env ()
+      match x with
+      | `Body x ->
+          let bd = map_body env x in
+          bd
+      | `Obj x ->
+          let x = map_object_ env x in
+          [ G.exprstmt x ])
+  | None -> []
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
@@ -13,6 +13,7 @@
  *)
 open Common
 module PI = Parse_info
+module G = AST_generic
 
 (*****************************************************************************)
 (* Prelude *)
@@ -173,3 +174,11 @@ let wrap_parser tree_sitter_parser ast_mapper =
       raise exn
 
 *)
+
+let parse_number_literal (s, t) =
+  match Common2.int_of_string_c_octal_opt s with
+  | Some i -> G.Int (Some i, t)
+  | None -> (
+      match float_of_string_opt s with
+      | Some f -> G.Float (Some f, t)
+      | None -> G.Int (None, t))

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli
@@ -28,3 +28,5 @@ val wrap_parser :
   (unit -> 'cst Tree_sitter_run.Parsing_result.t) ->
   ('cst -> 'ast) ->
   'ast Tree_sitter_run.Parsing_result.t
+
+val parse_number_literal : string * Parse_info.t -> AST_generic.literal


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1147

This closes PA-277

test plan:
```
pad@yrax yy (hcl_to_ast)]$ yy -lang tf -dump_ast ~/constant_propagation.tf
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang tf -dump_ast /home/pad/constant_propagation.tf
[0.103  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.103  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang tf -dump_ast /home/pad/constant_propagation.tf
[0.103  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.64.0-32-ge4869649-dirty, pfff: 0.42
[0.103  Info       Main.Parse_target    ] trying to parse with TreeSitter parser /home/pad/constant_propagation.tf
Pr(
  [ExprStmt(
     Call(IdSpecial((New, ())),
       [Arg(
          N(
            Id(("locals", ()),
              {id_resolved=Ref(None); id_type=Ref(None);
               id_constness=Ref(None); })));
        Arg(
          Record(
            [FieldStmt(
               DefStmt(
                 ({
                   name=EN(
                          Id(("data_science", ()),
                            {id_resolved=Ref(None); id_type=Ref(None);
                             id_constness=Ref(None); }));
                   attrs=[]; tparams=[]; },
                  VarDef(
                    {vinit=Some(L(String(("data-science", ())))); vtype=None; }))))]))]),
     ());
   ExprStmt(
     Call(IdSpecial((New, ())),
       [Arg(
          N(
            Id(("resource", ()),
              {id_resolved=Ref(None); id_type=Ref(None);
               id_constness=Ref(None); })));
        Arg(L(String(("aws_s3_bucket", ()))));
        Arg(L(String(("athena_output_data_science", ()))));
        Arg(
          Record(
            [FieldStmt(
               DefStmt(
                 ({
                   name=EN(
                          Id(("bucket", ()),
                            {id_resolved=Ref(None); id_type=Ref(None);
                             id_constness=Ref(None); }));
                   attrs=[]; tparams=[]; },
                  VarDef(
                    {
                     vinit=Some(Call(
                                  IdSpecial(
                                    (ConcatString(InterpolatedConcat), ())),
                                  [Arg(L(String(("prefix-", ()))));
                                   Arg(
                                     Call(
                                       IdSpecial((InterpolatedElement, ())),
                                       [Arg(
                                          DotAccess(
                                            N(
                                              Id(("local", ()),
                                                {id_resolved=Ref(None);
                                                 id_type=Ref(None);
                                                 id_constness=Ref(None); })),
                                            (),
                                            EN(
                                              Id(("data_science", ()),
                                                {id_resolved=Ref(None);
                                                 id_type=Ref(None);
                                                 id_constness=Ref(None); }))))]))]));
                     vtype=None; }))))]))]), ())])
```




PR checklist:
- [x] documentation is up to date
- [x] changelog is up to date