### PR TITLE
Edit all CFGs to carry their entry points, build dataflow worklist by traversal

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -40,12 +40,19 @@ type env = {
    * usually simple Instr, but can be also If when handling Conditional expr.
    *)
   stmts : stmt list ref;
+  (* When entering a loop, we create a two labels, one to jump to if a Continue stmt is found
+     and another to jump to if a Goto stmt is found. Since PHP supports breaking an arbitrary
+     number of loops up, we keep a stack of break labels instead of just one
+  *)
+  (* TODO: Bad to mix mutable + unmutable fields? *)
+  break_labels : label list;
+  cont_label : label option;
 }
 
 (*e: type [[AST_to_IL.env]] *)
 
 (*s: function [[AST_to_IL.empty_env]] *)
-let empty_env () = { stmts = ref [] }
+let empty_env () = { stmts = ref []; break_labels = []; cont_label = None }
 
 (*e: function [[AST_to_IL.empty_env]] *)
 
@@ -718,16 +725,52 @@ let rec stmt_aux env st =
       ss @ [ mk_s (If (tok, e', st1, st2)) ]
   | G.Switch (_, _, _) -> todo (G.S st)
   | G.While (tok, e, st) ->
+      (* TODO: should these use the While tok? *)
+      let cont_label = _fresh_label env tok in
+      let break_label = _fresh_label env tok in
+      let st_env =
+        {
+          env with
+          break_labels = break_label :: env.break_labels;
+          cont_label = Some cont_label;
+        }
+      in
+      let cont_label_s = [ mk_s (Label cont_label) ] in
+      let break_label_s = [ mk_s (Label break_label) ] in
       let ss, e' = expr_with_pre_stmts env e in
-      let st = stmt env st in
-      ss @ [ mk_s (Loop (tok, e', st @ ss)) ]
+      let st = stmt st_env st in
+      ss @ [ mk_s (Loop (tok, e', st @ cont_label_s @ ss)) ] @ break_label_s
   | G.DoWhile (tok, st, e) ->
-      let st = stmt env st in
+      let cont_label = _fresh_label env tok in
+      let break_label = _fresh_label env tok in
+      let st_env =
+        {
+          env with
+          break_labels = break_label :: env.break_labels;
+          cont_label = Some cont_label;
+        }
+      in
+      let cont_label_s = [ mk_s (Label cont_label) ] in
+      let break_label_s = [ mk_s (Label break_label) ] in
+      let st = stmt st_env st in
       let ss, e' = expr_with_pre_stmts env e in
-      st @ ss @ [ mk_s (Loop (tok, e', st @ ss)) ]
+      st @ ss
+      @ [ mk_s (Loop (tok, e', st @ cont_label_s @ ss)) ]
+      @ break_label_s
   | G.For (tok, G.ForEach (pat, tok2, e), st) ->
+      let cont_label = _fresh_label env tok in
+      let break_label = _fresh_label env tok in
+      let st_env =
+        {
+          env with
+          break_labels = break_label :: env.break_labels;
+          cont_label = Some cont_label;
+        }
+      in
+      let cont_label_s = [ mk_s (Label cont_label) ] in
+      let break_label_s = [ mk_s (Label break_label) ] in
       let ss, e' = expr_with_pre_stmts env e in
-      let st = stmt env st in
+      let st = stmt st_env st in
 
       let next_lval = fresh_lval env tok2 in
       let hasnext_lval = fresh_lval env tok2 in
@@ -759,11 +802,24 @@ let rec stmt_aux env st =
             (Loop
                ( tok,
                  cond,
-                 [ next_call ] @ assign @ st @ [ (* ss @ ?*) hasnext_call ] ));
+                 [ next_call ] @ assign @ st @ cont_label_s
+                 @ [ (* ss @ ?*) hasnext_call ] ));
         ]
+      @ break_label_s
   | G.For (tok, G.ForClassic (xs, eopt1, eopt2), st) ->
+      let cont_label = _fresh_label env tok in
+      let break_label = _fresh_label env tok in
+      let st_env =
+        {
+          env with
+          break_labels = break_label :: env.break_labels;
+          cont_label = Some cont_label;
+        }
+      in
+      let cont_label_s = [ mk_s (Label cont_label) ] in
+      let break_label_s = [ mk_s (Label break_label) ] in
       let ss1 = for_var_or_expr_list env xs in
-      let st = stmt env st in
+      let st = stmt st_env st in
       let ss2, cond =
         match eopt1 with
         | None ->
@@ -778,15 +834,52 @@ let rec stmt_aux env st =
             let ss, _eIGNORE = expr_with_pre_stmts env e in
             ss
       in
-      ss1 @ ss2 @ [ mk_s (Loop (tok, cond, st @ next @ ss2)) ]
+      ss1 @ ss2
+      @ [ mk_s (Loop (tok, cond, st @ cont_label_s @ next @ ss2)) ]
+      @ break_label_s
   | G.For (_, G.ForEllipsis _, _) -> sgrep_construct (G.S st)
   | G.For (tok, G.ForIn (xs, e), st) ->
+      let cont_label = _fresh_label env tok in
+      let break_label = _fresh_label env tok in
+      let st_env =
+        {
+          env with
+          break_labels = break_label :: env.break_labels;
+          cont_label = Some cont_label;
+        }
+      in
+      let cont_label_s = [ mk_s (Label cont_label) ] in
+      let break_label_s = [ mk_s (Label break_label) ] in
       let ss1 = for_var_or_expr_list env xs in
-      let st = stmt env st in
+      let st = stmt st_env st in
       let ss2, cond = expr_with_pre_stmts env (List.nth e 0) (* TODO list *) in
-      ss1 @ ss2 @ [ mk_s (Loop (tok, cond, st @ ss2)) ]
+      ss1 @ ss2
+      @ [ mk_s (Loop (tok, cond, st @ cont_label_s @ ss2)) ]
+      @ break_label_s
   (* TODO: repeat env work of controlflow_build.ml *)
-  | G.Continue _ | G.Break _ -> todo (G.S st)
+  | G.Continue (tok, lbl_ident, _) -> (
+      match lbl_ident with
+      | G.LNone -> (
+          match env.cont_label with
+          | None ->
+              todo (G.S st) (* Continue outside of loop? Should never happen *)
+          | Some lbl -> [ mk_s (Goto (tok, lbl)) ])
+      | G.LId lbl -> [ mk_s (Goto (tok, label_of_label env lbl)) ]
+      | G.LInt _ | G.LDynamic _ -> todo (G.S st))
+  | G.Break (tok, lbl_ident, _) -> (
+      match lbl_ident with
+      | G.LNone -> (
+          match env.break_labels with
+          | [] -> todo (G.S st) (* Break outside of loop? Should never happen *)
+          | lbl :: _ -> [ mk_s (Goto (tok, lbl)) ])
+      | G.LId lbl -> [ mk_s (Goto (tok, label_of_label env lbl)) ]
+      | G.LInt (i, _) -> (
+          match List.nth_opt env.break_labels i with
+          | None ->
+              todo (G.S st)
+              (* Breaking out of too many loops? Should never happen *)
+          | Some lbl -> [ mk_s (Goto (tok, lbl)) ])
+      | G.LDynamic _ -> todo (G.S st))
   | G.Label (lbl, st) ->
       let lbl = label_of_label env lbl in
       let st = stmt env st in

--- a/semgrep-core/src/analyzing/Dataflow.mli
+++ b/semgrep-core/src/analyzing/Dataflow.mli
@@ -113,7 +113,10 @@ module type Flow = sig
 
   type edge
 
-  type flow = (node, edge) Ograph_extended.ograph_mutable
+  type flow = {
+    graph : (node, edge) Ograph_extended.ograph_mutable;
+    entry : int;
+  }
 
   val short_string_of_node : node -> string
 end

--- a/semgrep-core/src/analyzing/controlflow.ml
+++ b/semgrep-core/src/analyzing/controlflow.ml
@@ -110,7 +110,7 @@ and simple_node =
  *)
 type edge = Direct
 
-type flow = (node, edge) Ograph_extended.ograph_mutable
+type flow = { graph : (node, edge) Ograph_extended.ograph_mutable; entry : int }
 
 type nodei = Ograph_extended.nodei
 
@@ -196,7 +196,7 @@ let any_of_simple_node = function
 (*****************************************************************************)
 
 let find_node f cfg =
-  cfg#nodes#tolist
+  cfg.graph#nodes#tolist
   |> Common.find_some (fun (nodei, node) -> if f node then Some nodei else None)
 
 let find_exit cfg = find_node (fun node -> node.n = Exit) cfg
@@ -206,7 +206,7 @@ let find_enter cfg = find_node (fun node -> node.n = Enter) cfg
 (* using internally graphviz dot and ghostview on X11 *)
 let (display_flow : flow -> unit) =
  fun flow ->
-  flow
+  flow.graph
   |> Ograph_extended.print_ograph_mutable_generic
        ~s_of_node:(fun (_nodei, node) ->
          (short_string_of_node_kind node.n, None, None))

--- a/semgrep-core/src/analyzing/controlflow.mli
+++ b/semgrep-core/src/analyzing/controlflow.mli
@@ -48,7 +48,7 @@ and simple_node =
  *)
 type edge = Direct
 
-type flow = (node, edge) Ograph_extended.ograph_mutable
+type flow = { graph : (node, edge) Ograph_extended.ograph_mutable; entry : int }
 
 (* an int representing the index of a node in the graph *)
 type nodei = Ograph_extended.nodei

--- a/semgrep-core/src/analyzing/controlflow_visitor.ml
+++ b/semgrep-core/src/analyzing/controlflow_visitor.ml
@@ -101,7 +101,7 @@ let exprs_of_node node =
 
 (* this can also be used as an iter; just pass () to acc *)
 let fold_on_node_and_expr hook (flow : flow) acc =
-  flow#nodes#fold
+  flow.graph#nodes#fold
     (fun acc (ni, node) ->
       let xs = exprs_of_node node in
       xs |> List.fold_left (fun acc e -> hook (ni, node) e acc) acc)

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -38,7 +38,7 @@ let short_string_of_node_kind nkind =
 (* using internally graphviz dot and ghostview on X11 *)
 let (display_cfg : cfg -> unit) =
  fun flow ->
-  flow
+  flow.graph
   |> Ograph_extended.print_ograph_mutable_generic
        ~s_of_node:(fun (_nodei, node) ->
          (short_string_of_node_kind node.n, None, None))

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -384,7 +384,7 @@ type edge = Direct
 (*e: type [[IL.edge]] *)
 
 (*s: type [[IL.cfg]] *)
-type cfg = (node, edge) Ograph_extended.ograph_mutable
+type cfg = { graph : (node, edge) Ograph_extended.ograph_mutable; entry : int }
 
 (*e: type [[IL.cfg]] *)
 

--- a/semgrep-core/src/engine/Tainting_generic.ml
+++ b/semgrep-core/src/engine/Tainting_generic.ml
@@ -76,15 +76,20 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 module F2 = IL
 
-module DataflowY = Dataflow.Make (struct
+module Y = struct
   type node = F2.node
 
   type edge = F2.edge
 
-  type flow = (node, edge) Ograph_extended.ograph_mutable
+  type flow = {
+    graph : (node, edge) Ograph_extended.ograph_mutable;
+    entry : int;
+  }
 
   let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
-end)
+end
+
+module DataflowY = Dataflow.Make (Y)
 
 let any_in_ranges any ranges =
   (* This is potentially slow. We may need to store range position in

--- a/semgrep-core/src/testing/Test_analyze_generic.ml
+++ b/semgrep-core/src/testing/Test_analyze_generic.ml
@@ -43,15 +43,22 @@ let test_cfg_generic file =
 
 module F = Controlflow
 
-module DataflowX = Dataflow.Make (struct
+module X = struct
   type node = F.node
 
   type edge = F.edge
 
-  type flow = (node, edge) Ograph_extended.ograph_mutable
+  type flow = {
+    graph : (node, edge) Ograph_extended.ograph_mutable;
+    entry : int;
+  }
 
   let short_string_of_node = F.short_string_of_node
-end)
+end
+
+module DataflowX = Dataflow.Make (X)
+
+let cfg_to_flow ({ graph; entry } : F.flow) : X.flow = { graph; entry }
 
 (*s: function [[Test_analyze_generic.test_dfg_generic]] *)
 let test_dfg_generic file =
@@ -63,10 +70,12 @@ let test_dfg_generic file =
              let flow = Controlflow_build.cfg_of_func def in
              pr2 "Reaching definitions";
              let mapping = Dataflow_reaching.fixpoint flow in
-             DataflowX.display_mapping flow mapping Dataflow.ns_to_str;
+             DataflowX.display_mapping (cfg_to_flow flow) mapping
+               Dataflow.ns_to_str;
              pr2 "Liveness";
              let mapping = Dataflow_liveness.fixpoint flow in
-             DataflowX.display_mapping flow mapping (fun () -> "()")
+             DataflowX.display_mapping (cfg_to_flow flow) mapping (fun () ->
+                 "()")
          | _ -> ())
 
 (*e: function [[Test_analyze_generic.test_dfg_generic]] *)
@@ -133,15 +142,22 @@ let test_cfg_il file =
 
 module F2 = IL
 
-module DataflowY = Dataflow.Make (struct
+module Y = struct
   type node = F2.node
 
   type edge = F2.edge
 
-  type flow = (node, edge) Ograph_extended.ograph_mutable
+  type flow = {
+    graph : (node, edge) Ograph_extended.ograph_mutable;
+    entry : int;
+  }
 
   let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
-end)
+end
+
+module DataflowY = Dataflow.Make (Y)
+
+let cfg_to_flow2 ({ graph; entry } : F2.cfg) : Y.flow = { graph; entry }
 
 (*s: function [[Test_analyze_generic.test_dfg_tainting]] *)
 let test_dfg_tainting file =
@@ -168,7 +184,8 @@ let test_dfg_tainting file =
              let mapping =
                Dataflow_tainting.fixpoint config fun_env opt_name flow
              in
-             DataflowY.display_mapping flow mapping (fun () -> "()")
+             DataflowY.display_mapping (cfg_to_flow2 flow) mapping (fun () ->
+                 "()")
          | _ -> ())
 
 (*e: function [[Test_analyze_generic.test_dfg_tainting]] *)
@@ -188,7 +205,7 @@ let test_dfg_constness file =
             pr2 "Constness";
             let mapping = Dataflow_constness.fixpoint inputs flow in
             Dataflow_constness.update_constness flow mapping;
-            DataflowY.display_mapping flow mapping
+            DataflowY.display_mapping (cfg_to_flow2 flow) mapping
               Dataflow_constness.string_of_constness;
             let s = AST_generic.show_any (S def.fbody) in
             pr2 s);

--- a/semgrep-core/tests/tainting_rules/php/break.php
+++ b/semgrep-core/tests/tainting_rules/php/break.php
@@ -1,0 +1,14 @@
+<?php
+$arr = array(1,2,3,4,5);
+foreach ($arr as $i) {
+    $bad = "ok";
+    foreach ($arr as $j) {
+        foreach ($arr as $k) {
+            $bad = $source;
+            if ($val == 2) {
+                break 2; 
+            }
+        }
+    }
+    sink($bad);
+}

--- a/semgrep-core/tests/tainting_rules/php/break.yaml
+++ b/semgrep-core/tests/tainting_rules/php/break.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test-multi-break
+    languages:
+      - php
+    message: Match Found!
+    mode: taint
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: $source
+    severity: WARNING
+


### PR DESCRIPTION
This PR changes all CFGs from `(node, edge) Ograph_extended.ograph_mutable` to `{ graph : (node, edge) Ograph_extended.ograph_mutable; entry : int }`. Then in `Dataflow.ml`, the work set is created by DFS, instead of simply including all nodes. This avoids situations where unreachable nodes in a CFG are analyzed.


PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)
