### PR TITLE
Don't let dune buffer test output

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -29,7 +29,7 @@ clean:
 # the cached file under _build/.../tests/ is still the old one.
 test: all
 	$(MAKE) -C src/spacegrep test
-	dune runtest -f
+	dune runtest -f --no-buffer
 e2etest:
 	python3 tests/e2e/test_target_file.py
 install:


### PR DESCRIPTION
This allows us to see what test crashes with a segfault, and also it's just nice to see the progress of the test suite.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has security implications (if so, ping security team)
