### PR TITLE
[HCL] add hcl/tf/terraform option to -l

### DIFF
--- a/semgrep-core/src/core/ast/Lang.ml
+++ b/semgrep-core/src/core/ast/Lang.ml
@@ -123,6 +123,8 @@ let list_of_lang =
     ("html", HTML);
     ("vue", Vue);
     ("tf", HCL);
+    ("terraform", HCL);
+    ("hcl", HCL);
   ]
 
 let lang_of_string_map = Common.hash_of_list list_of_lang

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -13,7 +13,8 @@ FileExtension = NewType("FileExtension", str)
 JOIN_MODE = Mode("join")
 SEARCH_MODE = DEFAULT_MODE = Mode("search")
 
-
+# coupling: if you add a new language here, you probably need to modify
+# also target_manager_extensions.py
 class Language(Enum):
     PYTHON: str = "python"
     PYTHON2: str = "python2"
@@ -36,6 +37,7 @@ class Language(Enum):
     VUE: str = "vue"
     HTML: str = "html"
     JSON: str = "json"
+    HCL: str = "hcl"
     REGEX: str = "regex"
     GENERIC: str = "generic"
 
@@ -63,6 +65,7 @@ class Language_util:
         Language.HTML: [Language.HTML.value],
         Language.ML: [Language.ML.value, "ocaml"],
         Language.JSON: [Language.JSON.value, "JSON", "Json"],
+        Language.HCL: [Language.HCL.value, "tf", "terraform", "HCL"],
         Language.REGEX: [Language.REGEX.value, "none"],
         Language.GENERIC: [Language.GENERIC.value],
     }

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -32,6 +32,7 @@ JSON_EXTENSIONS = [FileExtension(".json")]
 SCALA_EXTENSIONS = [FileExtension(".scala")]
 VUE_EXTENSIONS = [FileExtension(".vue")]
 HTML_EXTENSIONS = [FileExtension(".html"), FileExtension(".html")]
+HCL_EXTENSIONS = [FileExtension(".tf")]
 
 # This is used to determine the set of files with known extensions,
 # i.e. those for which we have a proper parser.
@@ -52,6 +53,7 @@ ALL_EXTENSIONS = (
     + SCALA_EXTENSIONS
     + VUE_EXTENSIONS
     + HTML_EXTENSIONS
+    + HCL_EXTENSIONS
 )
 
 # This is used to select the files suitable for spacegrep, which is
@@ -83,6 +85,7 @@ _LANGS_TO_EXTS: Dict[Language, List[FileExtension]] = {
     Language.SCALA: SCALA_EXTENSIONS,
     Language.VUE: VUE_EXTENSIONS,
     Language.HTML: HTML_EXTENSIONS,
+    Language.HCL: HCL_EXTENSIONS,
 }
 
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -5,5 +5,5 @@
 [94m  | [0m               [31m^^^^^^^^^^[0m
 [94m8 | [0m    severity: WARNING
 
-[31munsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, hack, hacklang, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml[0m
+[31munsupported language: intercal. supported languages are: C#, HCL, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, hack, hacklang, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, terraform, tf, ts, typescript, vue, yaml[0m
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,7 +3,7 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language: intercal. supported languages are: C#, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, hack, hacklang, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, ts, typescript, vue, yaml",
+      "long_msg": "unsupported language: intercal. supported languages are: C#, HCL, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, hack, hacklang, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, terraform, tf, ts, typescript, vue, yaml",
       "short_msg": "invalid language: intercal",
       "spans": [
         {


### PR DESCRIPTION
This should help https://github.com/returntocorp/semgrep/issues/1147

test plan:
```
semgrep -l tf -e 'Name = $FOO' tests/terraform/
tests/terraform/dots_resource.tf
7:    Name = "abcd-ebs"
--------------------------------------------------------------------------------
17:    Name = "abcd-ebs"
ran 1 rules on 1 files: 2 findings

```


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)