### PR TITLE
[HCL] adding parsing stats

### DIFF
--- a/parsing-stats/lang/terraform/projects.txt
+++ b/parsing-stats/lang/terraform/projects.txt
@@ -1,0 +1,11 @@
+# Git URLs of publicly-accessible projects to be used for parsing stats,
+# one per line.
+#
+https://github.com/hashicorp/terraform-provider-aws
+https://github.com/hashicorp/terraform-aws-vault
+https://github.com/hashicorp/terraform-aws-consul
+https://github.com/hashicorp/terraform-aws-nomad
+https://github.com/hashicorp/terraform-provider-google
+https://github.com/hashicorp/terraform-google-vault
+https://github.com/hashicorp/terraform-google-consul
+https://github.com/hashicorp/terraform-google-nomad


### PR DESCRIPTION
This just copy the projects.txt in ocaml-tree-sitter-semgrep

test plan:
cd parsing-stats; ./run-lang terraform
head lang/terraform/stats.json
=> 1.0 = 100%


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)