### PR TITLE
Output details of a FatalError in text mode

### DIFF
--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -117,11 +117,6 @@ let exn_to_error ?(rule_id = None) file exn =
 (* Pretty printers *)
 (*****************************************************************************)
 
-let string_of_error err =
-  let pos = err.loc in
-  assert (pos.PI.file <> "");
-  spf "%s:%d:%d: %s" pos.PI.file pos.PI.line pos.PI.column err.msg
-
 let string_of_error_kind = function
   | LexicalError -> "Lexical error"
   | ParseError -> "Syntax error"
@@ -139,6 +134,18 @@ let string_of_error_kind = function
   | FatalError -> "Fatal error"
   | Timeout -> "Timeout"
   | OutOfMemory -> "Out of memory"
+
+let string_of_error err =
+  let pos = err.loc in
+  assert (pos.PI.file <> "");
+  let details =
+    match err.details with
+    | None -> ""
+    | Some s -> spf "\n%s" s
+  in
+  spf "%s:%d:%d: %s: %s%s" pos.PI.file pos.PI.line pos.PI.column
+    (string_of_error_kind err.typ)
+    err.msg details
 
 let severity_of_error typ =
   match typ with


### PR DESCRIPTION
Test plan:

Create `stack_overflow.yaml` as below:
```
rules:
- id: stack-overflow
  pattern: |
      <... $A ...>
      ...
      <... $B ...>
      ...
      <... $C ...>
      ...
      <... $D ...>
  message: Stack overflow
  languages: [js]
  severity: WARNING
```

In any folder with Javascript files, run

```
sc -config stack_overflow.yaml . -lang js
```

You should see something like:
```
./large_file.js:1:0: Fatal error: Stack overflow
Raised at Common.finalize in file "src/pfff/commons/Common.ml", line 619, characters 4-11
Called from Common.finalize in file "src/pfff/commons/Common.ml", line 614, characters 14-18
Re-raised at Common.finalize in file "src/pfff/commons/Common.ml", line 619, characters 4-11
Called from Common.finalize in file "src/pfff/commons/Common.ml", line 614, characters 14-18
Re-raised at Common.finalize in file "src/pfff/commons/Common.ml", line 619, characters 4-11
Called from Visitor_AST.mk_visitor.v_function_definition.k in file "src/core/ast/Visitor_AST.ml", line 989, characters 16-39
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has security implications (if so, ping security team)
