### PR TITLE
[HCL] more test files for parsing stats

### DIFF
--- a/parsing-stats/lang/hcl/projects.txt
+++ b/parsing-stats/lang/hcl/projects.txt
@@ -9,3 +9,6 @@ https://github.com/hashicorp/terraform-provider-google
 https://github.com/hashicorp/terraform-google-vault
 https://github.com/hashicorp/terraform-google-consul
 https://github.com/hashicorp/terraform-google-nomad
+
+# in example/real_world_stuff/
+https://github.com/MichaHoffmann/tree-sitter-hcl


### PR DESCRIPTION
Thx to Michael Hoffman for pointing out the terraform
corpus he collected already in tree-sitter-hcl

test plan:
cd parsing-stats; ./run-lang hcl


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)