### PR TITLE
Add attribute-expression equivalence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,18 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-## [0.66.0](https://github.com/returntocorp/semgrep/releases/tag/v0.66.0) - 09-22-2021
-
 ### Added
 - Added support for break and continue in the dataflow engine
 
 ### Changed
 - Taint no longer analyzes dead/unreachable code
-
-### Fixed
-
-## Unreleased
-
-### Added
-
-### Changed
 - Attribute-expression equivalence that allows matching expression patterns against
   attributes, it is enabled by default but can be disabled via rule `options:` with
   `attr_expr: false` (#3489)
 
 ### Fixed
 
-## Unreleased
+## [0.66.0](https://github.com/returntocorp/semgrep/releases/tag/v0.66.0) - 09-22-2021
 
 ### Added
 - HCL (a.k.a Terraform) experimental support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Added
+
+### Changed
+- Attribute-expression equivalence that allows matching expression patterns against
+  attributes, it is enabled by default but can be disabled via rule `options:` with
+  `attr_expr: false` (#3489)
+
+### Fixed
+
+## Unreleased
+
+### Added
 - HCL (a.k.a Terraform) experimental support
 
 ### Changed

--- a/semgrep-core/src/core/Config_semgrep.atd
+++ b/semgrep-core/src/core/Config_semgrep.atd
@@ -47,6 +47,8 @@ type t = {
 
   (* assign-patterns (e.g. `$X = $E`) will match var-defs (e.g. `var x = 1;`) *)
   ~vardef_assign <ocaml default="true"> : bool;
+  (* expression patterns (e.g. `f($X)`) will match attributes (e.g. `@f(a)`)  *)
+  ~attr_expr <ocaml default="true"> : bool;
 
   (* !experimental: a bit hacky, and may introduce big perf regressions! *)
   (* should be used with DeepEllipsis; do it implicitely has issues *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -280,7 +280,9 @@ and resolved_name_kind =
  * DEBT? Sometimes some DotAccess should really be transformed in IdQualified
  * with a better qualifier because the obj is actually the name of a package
  * or module, but you may need advanced semantic information and global
- * analysis to disambiguate.
+ * analysis to disambiguate. In the meantime, you can use
+ * AST_generic_helpers.name_of_dot_access to convert a DotAccess of idents
+ * into an IdQualified name.
  *
  * less: factorize the id_info in both and inline maybe name_info
  *)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -65,6 +65,18 @@ let name_of_ids ?(name_typeargs = None) xs =
 
 let name_of_id id = Id (id, empty_id_info ())
 
+let name_of_dot_access e =
+  let ( let* ) = Option.bind in
+  let rec fetch_ids = function
+    | G.N (G.Id (x, _)) -> Some [ x ]
+    | G.DotAccess (e1, _, G.EN (G.Id (x, _))) ->
+        let* xs = fetch_ids e1.e in
+        Some (xs @ [ x ])
+    | ___else___ -> None
+  in
+  let* xs = fetch_ids e.e in
+  Some (name_of_ids xs)
+
 (* TODO: you should not need to use that. This is mostly because
  * Constructor and PatConstructor currently takes a dotted_ident instead
  * of a name.

--- a/semgrep-core/src/core/ast/AST_generic_helpers.mli
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.mli
@@ -29,6 +29,9 @@ val name_of_ids :
   AST_generic.dotted_ident ->
   AST_generic.name
 
+(* Tries to re-interpreted a DotAccess expression a.b.c as an IdQualified. *)
+val name_of_dot_access : AST_generic.expr -> AST_generic.name option
+
 (* You should avoid this function! *)
 val dotted_ident_of_name : AST_generic.name -> AST_generic.dotted_ident
 

--- a/semgrep-core/src/core/ast/Visitor_AST.mli
+++ b/semgrep-core/src/core/ast/Visitor_AST.mli
@@ -34,8 +34,10 @@ and visitor_out = any -> unit
 
 val default_visitor : visitor_in
 
-val mk_visitor : ?vardef_assign:bool -> visitor_in -> visitor_out
-(** @param vardef_assign VarDef-Assign equivalence (default is [false]) *)
+val mk_visitor :
+  ?vardef_assign:bool -> ?attr_expr:bool -> visitor_in -> visitor_out
+(** @param vardef_assign VarDef-Assign equivalence (default is [false])
+    @param attr_expr Attribute-expression equivalence (default is [false]) *)
 
 (* Note that ii_of_any relies on Visitor_AST which itself
  * uses OCaml.v_ref_do_not_visit, so no need to worry about

--- a/semgrep-core/src/engine/Match_patterns.ml
+++ b/semgrep-core/src/engine/Match_patterns.ml
@@ -447,7 +447,8 @@ let check2 ~hook range_filter config rules equivs (file, lang, ast) =
     in
     let visitor =
       let vardef_assign = config.Config.vardef_assign in
-      V.mk_visitor ~vardef_assign hooks
+      let attr_expr = config.Config.attr_expr in
+      V.mk_visitor ~vardef_assign ~attr_expr hooks
     in
     (* later: opti: dont analyze certain ASTs if they do not contain
      * certain constants that interect with the pattern?

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -573,6 +573,15 @@ and m_expr a b =
       _b ) ->
       let full = names @ [ alabel ] in
       m_expr (make_dotted full) b
+  | G.DotAccess (_, _, _), B.N b1 -> (
+      (* Reinterprets a DotAccess expression such as a.b.c as a name, when
+       * a,b,c are all identifiers. Note that something like a.b.c could get
+       * parsed as either DotAccess or IdQualified depending on the context
+       * (e.g., in Python it is always a DotAccess *except* when it occurs
+       * in an attribute). *)
+      match H.name_of_dot_access a with
+      | None -> fail ()
+      | Some a1 -> m_name a1 b1)
   (* $X should not match an IdSpecial in a call context,
    * otherwise $X(...) would match a+b because this is transformed in a
    * Call(IdSpecial Plus, ...).

--- a/semgrep-core/tests/OTHER/rules/attr_expr_false.py
+++ b/semgrep-core/tests/OTHER/rules/attr_expr_false.py
@@ -1,0 +1,17 @@
+# https://github.com/returntocorp/semgrep/issues/3489
+
+#ruleid:test
+"bad string"
+
+#ruleid:test
+@function_that_makes_it_okay("bad string") # shouldn't be flagged
+def foo():
+    #ruleid:test
+    "bad string" # should be flagged
+
+def bar():
+    #ruleid:test
+    "bad string"
+
+#OK:test
+bar = function_that_makes_it_okay("bad string")(bar)

--- a/semgrep-core/tests/OTHER/rules/attr_expr_false.yaml
+++ b/semgrep-core/tests/OTHER/rules/attr_expr_false.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test
+  options:
+    attr_expr: false
+  patterns:
+    - pattern: |
+        "bad string"
+    - pattern-not-inside: function_that_makes_it_okay(...)
+  message: test
+  languages: [python]
+  severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/attr_expr_true.py
+++ b/semgrep-core/tests/OTHER/rules/attr_expr_true.py
@@ -1,0 +1,17 @@
+# https://github.com/returntocorp/semgrep/issues/3489
+
+#ruleid:test
+"bad string"
+
+#OK:test
+@function_that_makes_it_okay("bad string") # shouldn't be flagged
+def foo():
+    #ruleid:test
+    "bad string" # should be flagged
+
+def bar():
+    #ruleid:test
+    "bad string"
+
+#OK:test
+bar = function_that_makes_it_okay("bad string")(bar)

--- a/semgrep-core/tests/OTHER/rules/attr_expr_true.yaml
+++ b/semgrep-core/tests/OTHER/rules/attr_expr_true.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: test
+  options:
+    attr_expr: true
+  patterns:
+    - pattern: |
+        "bad string"
+    - pattern-not-inside: function_that_makes_it_okay(...)
+  message: test
+  languages: [python]
+  severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/attr_expr_true1.py
+++ b/semgrep-core/tests/OTHER/rules/attr_expr_true1.py
@@ -1,0 +1,11 @@
+# https://github.com/returntocorp/semgrep/issues/3489
+
+from foo.bar import baz
+
+#ruleid:test
+baz.func("HAI")
+
+#ruleid:test
+@baz.func("HAI")
+def f():
+    pass

--- a/semgrep-core/tests/OTHER/rules/attr_expr_true1.yaml
+++ b/semgrep-core/tests/OTHER/rules/attr_expr_true1.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: test
+  # attr_expr equivalence is enabled by default !
+  patterns:
+    - pattern: $VAR.func(...)
+    - pattern-inside: |
+        from foo.bar import $VAR
+        ...
+  message: Semgrep found a match
+  languages: [python]
+  severity: WARNING


### PR DESCRIPTION
A named attribute is essentially a function call, and it is useful to
be able to match it as such.

Plus, let a DotAccess of idents match a name.
 
Closes #3489
    
test plan:
make test # tests included

PR checklist:
- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)
