### PR TITLE
[AST generic] support for enum classes in Kotlin and Java

### DIFF
--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -902,6 +902,7 @@ and map_entity { G.name = v_name; attrs = v_attrs; tparams = v_tparams } =
   { B.name = v_name; attrs = v_attrs; tparams = v_tparams }
 
 and map_definition_kind = function
+  | EnumEntryDef _v -> failwith "TODO"
   | FuncDef v1 ->
       let v1 = map_function_definition v1 in
       `FuncDef v1
@@ -1062,6 +1063,7 @@ and map_type_definition { G.tbody = v_tbody } =
   { B.tbody = v_tbody }
 
 and map_type_definition_kind = function
+  | AbstractType _v1 -> failwith "TODO"
   | OrType v1 ->
       let v1 = map_of_list map_or_type_element v1 in
       `OrType v1
@@ -1094,12 +1096,6 @@ and map_or_type_element = function
   | OrUnion (v1, v2) ->
       let v1 = map_ident v1 and v2 = map_type_ v2 in
       `OrUnion (v1, v2)
-  | OtherOr (v1, v2) ->
-      let v1 = map_other_or_type_element_operator v1
-      and v2 = map_of_list map_any v2 in
-      `OtherOr (v1, v2)
-
-and map_other_or_type_element_operator _x = "TODO"
 
 and map_class_definition
     {
@@ -1132,6 +1128,7 @@ and map_class_kind = function
   | Object -> `Object
   | AtInterface -> `AtInterface
   | RecordClass -> `RecordClass
+  | EnumClass -> failwith "TODO"
 
 and map_directive { d; d_attrs } =
   let d = map_directive_kind d in

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -788,7 +788,14 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let v_attrs = map_of_list map_attribute v_attrs in
     let v_name = map_name_or_dynamic v_name in
     { name = v_name; attrs = v_attrs; tparams = v_tparams }
+  and map_enum_entry_definition { ee_args; ee_body } =
+    let ee_args = map_of_option map_arguments ee_args in
+    let ee_body = map_of_option (map_bracket (map_of_list map_field)) ee_body in
+    { ee_args; ee_body }
   and map_definition_kind = function
+    | EnumEntryDef v1 ->
+        let v1 = map_enum_entry_definition v1 in
+        EnumEntryDef v1
     | FuncDef v1 ->
         let v1 = map_function_definition v1 in
         FuncDef v1
@@ -972,6 +979,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | Exception (v1, v2) ->
         let v1 = map_ident v1 and v2 = map_of_list map_type_ v2 in
         Exception (v1, v2)
+    | AbstractType v1 ->
+        let v1 = map_tok v1 in
+        AbstractType v1
     | OtherTypeKind (v1, v2) ->
         let v1 = map_other_type_kind_operator v1
         and v2 = map_of_list map_any v2 in
@@ -987,11 +997,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | OrUnion (v1, v2) ->
         let v1 = map_ident v1 and v2 = map_type_ v2 in
         OrUnion (v1, v2)
-    | OtherOr (v1, v2) ->
-        let v1 = map_other_or_type_element_operator v1
-        and v2 = map_of_list map_any v2 in
-        OtherOr (v1, v2)
-  and map_other_or_type_element_operator x = x
   and map_class_definition
       {
         ckind = v_ckind;

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -23,6 +23,8 @@ let vof_bracket of_a (t1, x, t2) =
 
 let vof_ident v = vof_wrap OCaml.vof_string v
 
+let vof_todo_kind v = vof_wrap OCaml.vof_string v
+
 let vof_dotted_name v = OCaml.vof_list vof_ident v
 
 let vof_module_name = function
@@ -632,7 +634,7 @@ and vof_keyword_attribute = function
   | Protected -> OCaml.VSum ("Protected", [])
   | Abstract -> OCaml.VSum ("Abstract", [])
   | Final -> OCaml.VSum ("Final", [])
-  | Override -> OCaml.VSum ("Over", [])
+  | Override -> OCaml.VSum ("Override", [])
   | Var -> OCaml.VSum ("Var", [])
   | Let -> OCaml.VSum ("Let", [])
   | Const -> OCaml.VSum ("Const", [])
@@ -976,7 +978,20 @@ and vof_entity { name = v_name; attrs = v_attrs; tparams = v_tparams } =
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
 
+and vof_enum_entry_definition { ee_args; ee_body } =
+  let bnds = [] in
+  let arg = OCaml.vof_option (vof_bracket (OCaml.vof_list vof_field)) ee_body in
+  let bnd = ("ee_body", arg) in
+  let bnds = bnd :: bnds in
+  let arg = OCaml.vof_option vof_arguments ee_args in
+  let bnd = ("ee_args", arg) in
+  let bnds = bnd :: bnds in
+  OCaml.VDict bnds
+
 and vof_definition_kind = function
+  | EnumEntryDef v1 ->
+      let v1 = vof_enum_entry_definition v1 in
+      OCaml.VSum ("EnumEntryDef", [ v1 ])
   | FuncDef v1 ->
       let v1 = vof_function_definition v1 in
       OCaml.VSum ("FuncDef", [ v1 ])
@@ -1005,12 +1020,9 @@ and vof_definition_kind = function
       let v1 = vof_tok v1 in
       OCaml.VSum ("UseOuterDecl", [ v1 ])
   | OtherDef (v1, v2) ->
-      let v1 = vof_other_def_operator v1 in
+      let v1 = vof_todo_kind v1 in
       let v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherDef", [ v1; v2 ])
-
-and vof_other_def_operator = function
-  | OD_Todo -> OCaml.VSum ("OD_Todo", [])
 
 and vof_module_definition { mbody = v_mbody } =
   let bnds = [] in
@@ -1232,14 +1244,12 @@ and vof_type_definition_kind = function
   | Exception (v1, v2) ->
       let v1 = vof_ident v1 and v2 = OCaml.vof_list vof_type_ v2 in
       OCaml.VSum ("Exception", [ v1; v2 ])
+  | AbstractType v1 ->
+      let v1 = vof_tok v1 in
+      OCaml.VSum ("AbstractType", [ v1 ])
   | OtherTypeKind (v1, v2) ->
-      let v1 = vof_other_type_kind_operator v1
-      and v2 = OCaml.vof_list vof_any v2 in
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherTypeKind", [ v1; v2 ])
-
-and vof_other_type_kind_operator = function
-  | OTKO_AbstractType -> OCaml.VSum ("OTKO_AbstractType", [])
-  | OTKO_Todo -> OCaml.VSum ("OTKO_Todo", [])
 
 and vof_or_type_element = function
   | OrConstructor (v1, v2) ->
@@ -1251,14 +1261,6 @@ and vof_or_type_element = function
   | OrUnion (v1, v2) ->
       let v1 = vof_ident v1 and v2 = vof_type_ v2 in
       OCaml.VSum ("OrUnion", [ v1; v2 ])
-  | OtherOr (v1, v2) ->
-      let v1 = vof_other_or_type_element_operator v1
-      and v2 = OCaml.vof_list vof_any v2 in
-      OCaml.VSum ("OtherOr", [ v1; v2 ])
-
-and vof_other_or_type_element_operator = function
-  | OOTEO_EnumWithMethods -> OCaml.VSum ("OOTEO_EnumWithMethods", [])
-  | OOTEO_EnumWithArguments -> OCaml.VSum ("OOTEO_EnumWithArguments", [])
 
 and vof_class_definition
     {
@@ -1299,6 +1301,7 @@ and vof_class_kind_bis = function
   | AtInterface -> OCaml.VSum ("AtInterface", [])
   | Object -> OCaml.VSum ("Object", [])
   | RecordClass -> OCaml.VSum ("RecordClass", [])
+  | EnumClass -> OCaml.VSum ("EnumClass", [])
 
 and vof_ident_and_id_info (v1, v2) =
   let v1 = vof_ident v1 in

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -962,7 +962,13 @@ let (mk_visitor :
       ()
     in
     vin.kentity (k, all_functions) x
+  and v_enum_entry_definition { ee_args; ee_body } =
+    v_option v_arguments ee_args;
+    v_option (v_bracket (v_list v_field)) ee_body
   and v_def_kind = function
+    | EnumEntryDef v1 ->
+        let v1 = v_enum_entry_definition v1 in
+        ()
     | FuncDef v1 ->
         let v1 = v_function_definition v1 in
         ()
@@ -1117,6 +1123,7 @@ let (mk_visitor :
     | Exception (v1, v2) ->
         let v1 = v_ident v1 and v2 = v_list v_type_ v2 in
         ()
+    | AbstractType v1 -> v_tok v1
     | OtherTypeKind (v1, v2) ->
         let v1 = v_other_type_kind_operator v1 and v2 = v_list v_any v2 in
         ()
@@ -1131,10 +1138,6 @@ let (mk_visitor :
     | OrUnion (v1, v2) ->
         let v1 = v_ident v1 and v2 = v_type_ v2 in
         ()
-    | OtherOr (v1, v2) ->
-        let v1 = v_other_or_type_element_operator v1 and v2 = v_list v_any v2 in
-        ()
-  and v_other_or_type_element_operator _x = ()
   and v_class_definition x =
     let k
         {

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -197,6 +197,7 @@ let substmts_of_stmt st =
         match def with
         | VarDef _
         | FieldDefColon _
+        | EnumEntryDef _
         | TypeDef _
         | MacroDef _
         | Signature _

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -516,7 +516,7 @@ and definition (ent, def) =
       ({ ent with G.attrs = ent.G.attrs @ more_attrs }, G.ClassDef def)
   | DefTodo (v1, v2) ->
       let v2 = list any v2 in
-      (ent, G.OtherDef (G.OD_Todo, G.TodoK v1 :: v2))
+      (ent, G.OtherDef (v1, v2))
 
 and var_of_var
     ({ name = x_name; attrs }, { v_kind = x_kind; v_init = x_init; v_type }) =

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -558,8 +558,8 @@ and type_parameter v =
         ~tp_constraints:[ G.OtherTypeParam (OTP_Todo, [ TodoK (s, t) ]) ]
 
 and type_def_kind = function
-  | AbstractType -> G.OtherTypeKind (G.OTKO_AbstractType, [])
-  | TdTodo categ -> G.OtherTypeKind (G.OTKO_Todo, [ G.TodoK categ ])
+  | AbstractType -> G.AbstractType (fake "")
+  | TdTodo categ -> G.OtherTypeKind (categ, [])
   | CoreType v1 ->
       let v1 = type_ v1 in
       G.AliasType v1

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -904,7 +904,8 @@ and v_type_definition_kind = function
       G.NewType v2
   | TDcl v1 ->
       let _v1TODO = v_type_bounds v1 in
-      G.OtherTypeKind (G.OTKO_AbstractType, [])
+      (* abstract type with constraints? *)
+      G.AbstractType (fake "")
 
 let v_program v = v_list v_top_stat v |> List.flatten
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2679,7 +2679,7 @@ and type_const_declaration (env : env)
         Some v2
     | None -> None
   in
-  let _v9 = (* ";" *) token env v9 in
+  let v9 = (* ";" *) token env v9 in
   match v8 with
   (* Q: AliasType vs NewType? *)
   | Some v8 ->
@@ -2691,7 +2691,7 @@ and type_const_declaration (env : env)
   | None ->
       G.DefStmt
         ( basic_typed_entity id (v1 @ v2 @ v3) type_params,
-          G.OtherDef (G.OD_Todo, []) )
+          G.TypeDef { tbody = AbstractType v9 } )
       |> G.s
 
 and type_parameter (env : env) ((v1, v2, v3, v4) : CST.type_parameter) :

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -851,11 +851,11 @@ and map_associated_type (env : env)
         ty)
       v5
   in
-  let _semicolon = token env v6 (* ";" *) in
+  let semicolon = token env v6 (* ";" *) in
   let type_def_kind =
     match ty with
     | Some ty -> G.AliasType ty
-    | None -> G.OtherTypeKind (G.OTKO_AbstractType, [])
+    | None -> G.AbstractType semicolon
   in
   let type_def = { G.tbody = type_def_kind } in
   let ent =

--- a/semgrep-core/tests/kotlin/parsing/enum.kt
+++ b/semgrep-core/tests/kotlin/parsing/enum.kt
@@ -1,0 +1,23 @@
+// from https://kotlinlang.org/docs/enum-classes.html
+
+enum class Direction {
+    NORTH, SOUTH, WEST, EAST
+}
+
+enum class Color(val rgb: Int) {
+    RED(0xFF0000),
+    GREEN(0x00FF00),
+    BLUE(0x0000FF)
+}
+
+enum class ProtocolState {
+    WAITING {
+        override fun signal() = TALKING
+    },
+
+    TALKING {
+        override fun signal() = WAITING
+    };
+
+    abstract fun signal(): ProtocolState
+}


### PR DESCRIPTION
Previously those constructs were partially represented in the AST
via a Typedef OrType, but they are really classes, so better
to extend class_definition to support those special kind of classes.

test plan:

```
pad@yrax yy (enum_entry_class)]$ yy -lang kotlin -dump_ast tests/kotlin/parsing/enum.kt
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang kotlin -dump_ast tests/kotlin/parsing/enum.kt
[0.038  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.038  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang kotlin -dump_ast tests/kotlin/parsing/enum.kt
[0.038  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.66.0-11-gdccdef57-dirty, pfff: 0.42
[0.038  Info       Main.Parse_target    ] trying to parse with TreeSitter parser tests/kotlin/parsing/enum.kt
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("Direction", ()),
                {id_resolved=Ref(None); id_type=Ref(None);
                 id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      ClassDef(
        {ckind=(EnumClass, ()); cextends=[]; cimplements=[]; cmixins=[
         ]; cparams=[];
         cbody=[FieldStmt(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("NORTH", ()),
                               {id_resolved=Ref(None); id_type=Ref(None);
                                id_constness=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef({ee_args=None; ee_body=None; }))));
                FieldStmt(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("SOUTH", ()),
                               {id_resolved=Ref(None); id_type=Ref(None);
                                id_constness=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef({ee_args=None; ee_body=None; }))));
                FieldStmt(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("WEST", ()),
                               {id_resolved=Ref(None); id_type=Ref(None);
                                id_constness=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef({ee_args=None; ee_body=None; }))));
                FieldStmt(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("EAST", ()),
                               {id_resolved=Ref(None); id_type=Ref(None);
                                id_constness=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef({ee_args=None; ee_body=None; }))))];
         })));
   DefStmt(
     ({
       name=EN(
              Id(("Color", ()),
                {id_resolved=Ref(None); id_type=Ref(None);
                 id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      ClassDef(
        {ckind=(EnumClass, ()); cextends=[]; cimplements=[]; cmixins=[
         ];
         cparams=[ParamClassic(
                    {pname=Some(("rgb", ())); pdefault=None;
                     ptype=Some({t_attrs=[];
                                 t=TyTuple(
                                     [{t_attrs=[];
                                       t=TyN(
                                           Id(("Int", ()),
                                             {id_resolved=Ref(None);
                                              id_type=Ref(None);
                                              id_constness=Ref(None); }));
                                       }]);
                                 });
                     pattrs=[KeywordAttr((Const, ()))];
                     pinfo={id_resolved=Ref(Some((Param, -1)));
                            id_type=Ref(None); id_constness=Ref(None); };
                     })];
         cbody=[FieldStmt(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("RED", ()),
                               {id_resolved=Ref(None); id_type=Ref(None);
                                id_constness=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef(
                       {ee_args=Some([Arg(L(Int((Some(16711680), ()))))]);
                        ee_body=None; }))));
...
```


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)