### PR TITLE
[AST generic][Refactoring] remove some other_xxx_operator

### DIFF
--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -566,10 +566,10 @@ and map_type_kind = function
 and map_type_arguments (_, v, _) = map_of_list map_type_argument v
 
 and map_type_argument = function
-  | TypeArg v1 ->
+  | TA v1 ->
       let v1 = map_type_ v1 in
       `TypeArg v1
-  | TypeWildcard (v1, v2) ->
+  | TAWildcard (v1, v2) ->
       let v1 = map_tok v1 in
       let v2 =
         map_of_option
@@ -577,17 +577,15 @@ and map_type_argument = function
           v2
       in
       `TypeWildcard (v1, v2)
-  | TypeLifetime v1 ->
-      let v1 = map_ident v1 in
-      `TypeLifetime v1
+  | TAExpr _ -> failwith "TODO"
   | OtherTypeArg (v1, v2) ->
-      let v1 = map_other_type_argument_operator v1 in
+      let v1 = map_todo_kind v1 in
       let v2 = map_of_list map_any v2 in
       `OtherTypeArg (v1, v2)
 
-and map_other_type_operator _x = "TODO"
+and map_todo_kind _x = "TODO"
 
-and map_other_type_argument_operator _x = "TODO"
+and map_other_type_operator _x = "TODO"
 
 and map_attribute = function
   | KeywordAttr v1 -> (

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1103,14 +1103,14 @@ and type_arguments = type_argument list bracket
 
 (* TODO? make a record also? *)
 and type_argument =
-  | TypeArg of type_
-  (* Java only *)
-  (* use-site variance *)
-  | TypeWildcard of
+  | TA of type_
+  (* Java use-site variance *)
+  | TAWildcard of
       tok (* '?' *) * (bool wrap (* extends|super, true=super *) * type_) option
-  (* Rust *)
-  | TypeLifetime of ident
-  | OtherTypeArg of other_type_argument_operator * any list
+  (* C++/Rust (Rust restrict expr to literals and ConstBlock) *)
+  | TAExpr of expr
+  (* Rust Lifetime 'x, Kotlin use-site variance *)
+  | OtherTypeArg of todo_kind * any list
 
 and other_type_operator =
   (* C *)
@@ -1126,13 +1126,6 @@ and other_type_operator =
   | OT_Expr
   | OT_Arg (* Python: todo: should use expr_to_type() when can *)
   | OT_Todo
-
-and other_type_argument_operator =
-  (* Rust *)
-  | OTA_Literal
-  | OTA_ConstBlock
-  (* Other *)
-  | OTA_Todo
 
 (*****************************************************************************)
 (* Attribute *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -726,13 +726,8 @@ and argument =
   | ArgKwd of ident * expr
   (* type argument for New, instanceof/sizeof/typeof, C macros *)
   | ArgType of type_
-  | ArgOther of other_argument_operator * any list
-
-and other_argument_operator =
-  (* OCaml *)
-  | OA_ArgQuestion
-  (* Rust *)
-  | OA_ArgMacro
+  (* e.g., ArgMacro for C/Rust, ArgQuestion for OCaml *)
+  | ArgOther of todo_kind * any list
 
 (* todo: reduce, or move in other_special? *)
 and other_expr_operator =

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1109,7 +1109,7 @@ and type_argument =
       tok (* '?' *) * (bool wrap (* extends|super, true=super *) * type_) option
   (* C++/Rust (Rust restrict expr to literals and ConstBlock) *)
   | TAExpr of expr
-  (* Rust Lifetime 'x, Kotlin use-site variance *)
+  (* TODO? Rust Lifetime 'x, Kotlin use-site variance *)
   | OtherTypeArg of todo_kind * any list
 
 and other_type_operator =
@@ -1293,14 +1293,8 @@ and variance =
 and type_parameter_constraint =
   (* C# *)
   | HasConstructor of tok
-  | OtherTypeParam of other_type_parameter_operator * any list
-
-(* TODO: get rid of *)
-and other_type_parameter_operator =
-  (* Rust *)
-  | OTP_Lifetime
-  (* Other *)
-  | OTP_Todo
+  (* TODO? Lifetime Rust? *)
+  | OtherTypeParam of todo_kind * any list
 
 (* ------------------------------------------------------------------------- *)
 (* Function (or method) definition *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1135,7 +1135,9 @@ and attribute =
   | KeywordAttr of keyword_attribute wrap
   (* a.k.a decorators, annotations *)
   | NamedAttr of tok (* @ *) * name * arguments bracket
-  | OtherAttribute of other_attribute_operator * any list
+  (* per-language specific keywords like 'transient', 'synchronized' *)
+  (* todo: Expr used for Python, but should transform in NamedAttr when can *)
+  | OtherAttribute of todo_kind * any list
 
 and keyword_attribute =
   (* the classic C modifiers *)
@@ -1176,19 +1178,6 @@ and keyword_attribute =
   (* Scala *)
   | Lazy (* By name application in Scala, via => T, in parameter *)
   | CaseClass
-
-and other_attribute_operator =
-  (* Java *)
-  | OA_StrictFP
-  | OA_Transient
-  | OA_Synchronized
-  | OA_Native
-  | OA_Default
-  | OA_AnnotThrow
-  (* Other *)
-  (* todo: used for Python, but should transform in NamedAttr when can *)
-  | OA_Expr
-  | OA_Todo
 
 (*****************************************************************************)
 (* Definitions *)
@@ -1308,6 +1297,7 @@ and function_definition = {
   fparams : parameters;
   (* return type *)
   frettype : type_ option;
+  (* TODO: fthrow *)
   (* newscope: *)
   fbody : function_body;
 }
@@ -1893,6 +1883,7 @@ let fieldEllipsis t = FieldStmt (exprstmt (e (Ellipsis t)))
 let attr kwd tok = KeywordAttr (kwd, tok)
 
 let unhandled_keywordattr (s, t) =
+  (* TODO? or use OtherAttribue? *)
   NamedAttr (t, Id ((s, t), empty_id_info ()), fake_bracket [])
 
 (*****************************************************************************)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1034,12 +1034,8 @@ and pattern =
   (* sgrep: *)
   | PatEllipsis of tok
   | DisjPat of pattern * pattern
-  | OtherPat of other_pattern_operator * any list
-
-and other_pattern_operator =
-  (* Other *)
-  | OP_Expr (* todo: Python should transform via expr_to_pattern() below *)
-  | OP_Todo
+  (* todo: Python should transform expr pattern via expr_to_pattern() *)
+  | OtherPat of todo_kind * any list
 
 (*****************************************************************************)
 (* Type *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1541,11 +1541,8 @@ and module_definition_kind =
   | ModuleAlias of dotted_ident
   (* newscope: *)
   | ModuleStruct of dotted_ident option * item list
-  | OtherModule of other_module_operator * any list
-
-and other_module_operator =
-  (* OCaml (functors and their applications) *)
-  | OMO_Todo
+  (* TODO: OCaml (functors and their applications) *)
+  | OtherModule of todo_kind * any list
 
 (* ------------------------------------------------------------------------- *)
 (* Macro definition *)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -105,7 +105,7 @@ let rec expr_to_pattern e =
       PatList (t1, xs |> List.map expr_to_pattern, t2)
   | Ellipsis t -> PatEllipsis t
   (* Todo:  PatKeyVal *)
-  | _ -> OtherPat (OP_Expr, [ E e ])
+  | _ -> OtherPat (("ExprToPattern", fake ""), [ E e ])
 
 exception NotAnExpr
 
@@ -118,7 +118,7 @@ let rec pattern_to_expr p =
   | PatLiteral l -> L l
   | PatList (t1, xs, t2) ->
       Container (List, (t1, xs |> List.map pattern_to_expr, t2))
-  | OtherPat (OP_Expr, [ E e ]) -> e.e
+  | OtherPat (("ExprToPattern", _), [ E e ]) -> e.e
   | PatAs _
   | PatVar _ ->
       raise NotAnExpr

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -501,26 +501,26 @@ let (mk_visitor : visitor_in -> visitor_out) =
         OtherType (v1, v2)
   and map_type_arguments v = map_bracket (map_of_list map_type_argument) v
   and map_type_argument = function
-    | TypeArg v1 ->
+    | TA v1 ->
         let v1 = map_type_ v1 in
-        TypeArg v1
-    | TypeWildcard (v1, v2) ->
+        TA v1
+    | TAWildcard (v1, v2) ->
         let v1 = map_tok v1 in
         let v2 =
           map_of_option
             (fun (v1, v2) -> (map_wrap map_of_bool v1, map_type_ v2))
             v2
         in
-        TypeWildcard (v1, v2)
-    | TypeLifetime v1 ->
-        let v1 = map_ident v1 in
-        TypeLifetime v1
+        TAWildcard (v1, v2)
+    | TAExpr v1 ->
+        let v1 = map_expr v1 in
+        TAExpr v1
     | OtherTypeArg (v1, v2) ->
-        let v1 = map_other_type_argument_operator v1 in
+        let v1 = map_todo_kind v1 in
         let v2 = map_of_list map_any v2 in
         OtherTypeArg (v1, v2)
+  and map_todo_kind x = x
   and map_other_type_operator x = x
-  and map_other_type_argument_operator x = x
   and map_attribute = function
     | KeywordAttr v1 ->
         let v1 = map_wrap map_keyword_attribute v1 in

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -1035,12 +1035,8 @@ and vof_module_definition_kind = function
       and v2 = OCaml.vof_list vof_item v2 in
       OCaml.VSum ("ModuleStruct", [ v1; v2 ])
   | OtherModule (v1, v2) ->
-      let v1 = vof_other_module_operator v1
-      and v2 = OCaml.vof_list vof_any v2 in
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherModule", [ v1; v2 ])
-
-and vof_other_module_operator = function
-  | OMO_Todo -> OCaml.VSum ("OMO_Todo", [])
 
 and vof_macro_definition
     { macroparams = v_macroparams; macrobody = v_macrobody } =

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -657,19 +657,8 @@ and vof_attribute = function
       and v3 = vof_bracket (OCaml.vof_list vof_argument) v3 in
       OCaml.VSum ("NamedAttr", [ t; v1; v3 ])
   | OtherAttribute (v1, v2) ->
-      let v1 = vof_other_attribute_operator v1
-      and v2 = OCaml.vof_list vof_any v2 in
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherAttribute", [ v1; v2 ])
-
-and vof_other_attribute_operator = function
-  | OA_Todo -> OCaml.VSum ("OA_Todo", [])
-  | OA_StrictFP -> OCaml.VSum ("OA_StrictFP", [])
-  | OA_Transient -> OCaml.VSum ("OA_Transient", [])
-  | OA_Synchronized -> OCaml.VSum ("OA_Synchronized", [])
-  | OA_Native -> OCaml.VSum ("OA_Native", [])
-  | OA_AnnotThrow -> OCaml.VSum ("OA_AnnotThrow", [])
-  | OA_Expr -> OCaml.VSum ("OA_Expr", [])
-  | OA_Default -> OCaml.VSum ("OA_Default", [])
 
 and vof_stmt st =
   (* todo: dump also the s_id? *)

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -953,13 +953,8 @@ and vof_pattern = function
       let v1 = vof_pattern v1 and v2 = vof_pattern v2 in
       OCaml.VSum ("DisjPat", [ v1; v2 ])
   | OtherPat (v1, v2) ->
-      let v1 = vof_other_pattern_operator v1
-      and v2 = OCaml.vof_list vof_any v2 in
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherPat", [ v1; v2 ])
-
-and vof_other_pattern_operator = function
-  | OP_Todo -> OCaml.VSum ("OP_Todo", [])
-  | OP_Expr -> OCaml.VSum ("OP_Expr", [])
 
 and vof_definition (v1, v2) =
   let v1 = vof_entity v1 and v2 = vof_definition_kind v2 in

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -586,10 +586,10 @@ and vof_type_kind = function
 and vof_type_arguments v = vof_bracket (OCaml.vof_list vof_type_argument) v
 
 and vof_type_argument = function
-  | TypeArg v1 ->
+  | TA v1 ->
       let v1 = vof_type_ v1 in
-      OCaml.VSum ("TypeArg", [ v1 ])
-  | TypeWildcard (v1, v2) ->
+      OCaml.VSum ("TA", [ v1 ])
+  | TAWildcard (v1, v2) ->
       let v1 = vof_tok v1 in
       let v2 =
         OCaml.vof_option
@@ -599,13 +599,12 @@ and vof_type_argument = function
             OCaml.VTuple [ v1; v2 ])
           v2
       in
-      OCaml.VSum ("TypeWildcard", [ v1; v2 ])
-  | TypeLifetime v1 ->
-      let v1 = vof_ident v1 in
-      OCaml.VSum ("TypeLifetime", [ v1 ])
+      OCaml.VSum ("AWildcard", [ v1; v2 ])
+  | TAExpr v1 ->
+      let v1 = vof_expr v1 in
+      OCaml.VSum ("TAExpr", [ v1 ])
   | OtherTypeArg (v1, v2) ->
-      let v1 = vof_other_type_argument_operator v1
-      and v2 = OCaml.vof_list vof_any v2 in
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherTypeArg", [ v1; v2 ])
 
 and vof_other_type_operator = function
@@ -617,11 +616,6 @@ and vof_other_type_operator = function
   | OT_EnumName -> OCaml.VSum ("OT_EnumName", [])
   | OT_Variadic -> OCaml.VSum ("OT_Variadic", [])
   | OT_Lifetime -> OCaml.VSum ("OT_Lifetime", [])
-
-and vof_other_type_argument_operator = function
-  | OTA_Todo -> OCaml.VSum ("OTA_Todo", [])
-  | OTA_Literal -> OCaml.VSum ("OTA_Literal", [])
-  | OTA_ConstBlock -> OCaml.VSum ("OTA_ConstBlock", [])
 
 and vof_keyword_attribute = function
   | CaseClass -> OCaml.VSum ("CaseClass", [])

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -1085,13 +1085,8 @@ and vof_type_parameter_constraint = function
       let t = vof_tok t in
       OCaml.VSum ("HasConstructor", [ t ])
   | OtherTypeParam (t, xs) ->
-      let t = vof_other_type_parameter_operator t
-      and xs = OCaml.vof_list vof_any xs in
+      let t = vof_todo_kind t and xs = OCaml.vof_list vof_any xs in
       OCaml.VSum ("OtherTypeParam", [ t; xs ])
-
-and vof_other_type_parameter_operator = function
-  | OTP_Todo -> OCaml.VSum ("OTP_Todo", [])
-  | OTP_Lifetime -> OCaml.VSum ("OTP_Lifetime", [])
 
 and vof_function_kind = function
   | Function -> OCaml.VSum ("Function", [])

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -460,13 +460,8 @@ and vof_argument = function
       let v1 = vof_type_ v1 in
       OCaml.VSum ("ArgType", [ v1 ])
   | ArgOther (v1, v2) ->
-      let v1 = vof_other_argument_operator v1
-      and v2 = OCaml.vof_list vof_any v2 in
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("ArgOther", [ v1; v2 ])
-
-and vof_other_argument_operator = function
-  | OA_ArgQuestion -> OCaml.VSum ("OA_ArgQuestion", [])
-  | OA_ArgMacro -> OCaml.VSum ("OA_ArgMacro", [])
 
 and vof_action (v1, v2) =
   let v1 = vof_pattern v1 and v2 = vof_expr v2 in

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -562,24 +562,24 @@ let (mk_visitor :
     vin.ktype_ (k, all_functions) x
   and v_type_arguments v = v_bracket (v_list v_type_argument) v
   and v_type_argument = function
-    | TypeArg v1 ->
+    | TA v1 ->
         let v1 = v_type_ v1 in
         ()
-    | TypeWildcard (v1, v2) -> (
+    | TAWildcard (v1, v2) -> (
         v_tok v1;
         match v2 with
         | None -> ()
         | Some (v1, v2) ->
             v_wrap v_bool v1;
             v_type_ v2)
-    | TypeLifetime v1 ->
-        let v1 = v_ident v1 in
+    | TAExpr v1 ->
+        let v1 = v_expr v1 in
         ()
     | OtherTypeArg (v1, v2) ->
-        let v1 = v_other_type_argument_operator v1 and v2 = v_list v_any v2 in
+        let v1 = v_todo_kind v1 and v2 = v_list v_any v2 in
         ()
+  and v_todo_kind x = v_ident x
   and v_other_type_operator _ = ()
-  and v_other_type_argument_operator _ = ()
   and v_type_parameter
       {
         tp_id = v1;

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1548,26 +1548,26 @@ and m_type_arguments a b =
 
 and m_type_argument a b =
   match (a, b) with
-  | G.TypeArg a1, B.TypeArg b1 -> m_type_ a1 b1
-  | G.TypeWildcard (a1, a2), B.TypeWildcard (b1, b2) ->
+  | G.TA a1, B.TA b1 -> m_type_ a1 b1
+  | G.TAWildcard (a1, a2), B.TAWildcard (b1, b2) ->
       let* () = m_tok a1 b1 in
       m_option m_wildcard a2 b2
-  | G.TypeLifetime a1, B.TypeLifetime b1 -> m_ident a1 b1
+  | G.TAExpr a1, B.TAExpr b1 -> m_expr a1 b1
   | G.OtherTypeArg (a1, a2), B.OtherTypeArg (b1, b2) ->
-      m_other_type_argument_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
-  | G.TypeArg _, _
-  | G.TypeWildcard _, _
-  | G.TypeLifetime _, _
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
+  | G.TA _, _
+  | G.TAWildcard _, _
+  | G.TAExpr _, _
   | G.OtherTypeArg _, _ ->
       fail ()
+
+and m_todo_kind a b = m_ident a b
 
 and m_wildcard (a1, a2) (b1, b2) =
   let* () = m_wrap m_bool a1 b1 in
   m_type_ a2 b2
 
 and m_other_type_operator = m_other_xxx
-
-and m_other_type_argument_operator = m_other_xxx
 
 (*****************************************************************************)
 (* Attribute *)
@@ -2688,7 +2688,7 @@ and m_any a b =
   | G.Modn a1, B.Modn b1 -> m_module_name a1 b1
   | G.ModDk a1, B.ModDk b1 -> m_module_definition_kind a1 b1
   | G.Tk a1, B.Tk b1 -> m_tok a1 b1
-  | G.TodoK a1, B.TodoK b1 -> m_ident a1 b1
+  | G.TodoK a1, B.TodoK b1 -> m_todo_kind a1 b1
   | G.Di a1, B.Di b1 -> m_dotted_name a1 b1
   | G.En a1, B.En b1 -> m_entity a1 b1
   | G.T a1, B.T b1 -> m_type_ a1 b1

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -149,7 +149,7 @@ and type_kind = function
   | TMacroApply (v1, (lp, v2, rp)) ->
       let v1 = H.name_of_id v1 in
       let v2 = type_ v2 in
-      G.TyApply (G.TyN v1 |> G.t, (lp, [ G.TypeArg v2 ], rp))
+      G.TyApply (G.TyN v1 |> G.t, (lp, [ G.TA v2 ], rp))
 
 and function_type (v1, v2) =
   let v1 = type_ v1 and v2 = list (fun x -> G.ParamClassic (parameter x)) v2 in

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -138,10 +138,10 @@ and map_template_argument env v : G.type_argument =
   match v with
   | Left t ->
       let t = map_type_ env t in
-      G.TypeArg t
+      G.TA t
   | Right e ->
       let e = map_expr env e in
-      complicated env e
+      G.TAExpr e
 
 and map_qualifier env = function
   | QClassname v1 ->

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -458,7 +458,7 @@ and map_argument env x : G.argument =
       G.ArgType v1
   | ArgAction v1 ->
       let v1 = map_action_macro env v1 in
-      G.ArgOther (G.OA_ArgMacro, v1)
+      G.ArgOther (("ArgMacro", G.fake ""), v1)
   | ArgInits v1 ->
       let l, xs, r = map_brace env (map_of_list (map_initialiser env)) v1 in
       G.Arg (G.Container (G.Dict, (l, xs, r)) |> G.e)

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -147,12 +147,10 @@ let top_func () =
     | TMap (t, (lp, v1, rp), v2) ->
         let v1 = type_ v1 and v2 = type_ v2 in
         G.TyApply
-          ( G.TyN (mk_name "map" t) |> G.t,
-            (lp, [ G.TypeArg v1; G.TypeArg v2 ], rp) )
+          (G.TyN (mk_name "map" t) |> G.t, (lp, [ G.TA v1; G.TA v2 ], rp))
     | TChan (t, v1, v2) ->
         let v1 = chan_dir v1 and v2 = type_ v2 in
-        G.TyApply
-          (G.TyN (mk_name "chan" t) |> G.t, fb [ G.TypeArg v1; G.TypeArg v2 ])
+        G.TyApply (G.TyN (mk_name "chan" t) |> G.t, fb [ G.TA v1; G.TA v2 ])
     | TStruct (t, v1) ->
         let v1 = bracket (list struct_field) v1 in
         G.TyRecordAnon (t, v1)

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -149,6 +149,7 @@ let type_parameter = function
       G.tparam_of_id v1 ~tp_bounds:v2
 
 let rec modifier (x, tok) =
+  let s = Parse_info.str_of_info tok in
   match x with
   | Public -> G.attr G.Public tok
   | Protected -> G.attr G.Protected tok
@@ -156,12 +157,12 @@ let rec modifier (x, tok) =
   | Abstract -> G.attr G.Abstract tok
   | Static -> G.attr G.Static tok
   | Final -> G.attr G.Final tok
-  | StrictFP -> G.OtherAttribute (G.OA_StrictFP, [])
-  | Transient -> G.OtherAttribute (G.OA_Transient, [])
+  | StrictFP -> G.unhandled_keywordattr (s, tok)
+  | Transient -> G.unhandled_keywordattr (s, tok)
   | Volatile -> G.attr G.Volatile tok
-  | Synchronized -> G.OtherAttribute (G.OA_Synchronized, [])
-  | Native -> G.OtherAttribute (G.OA_Native, [])
-  | DefaultModifier -> G.OtherAttribute (G.OA_Default, [])
+  | Synchronized -> G.unhandled_keywordattr (s, tok)
+  | Native -> G.unhandled_keywordattr (s, tok)
+  | DefaultModifier -> G.unhandled_keywordattr (s, tok)
   | Annotation v1 -> annotation v1
 
 and modifiers v = list modifier v
@@ -565,8 +566,9 @@ and method_decl { m_var; m_formals; m_throws; m_body } =
   let v2 = parameters m_formals in
   let v3 = list typ m_throws in
   let v4 = stmt m_body in
+  (* TODO: use fthrow field instead *)
   let throws =
-    v3 |> List.map (fun t -> G.OtherAttribute (G.OA_AnnotThrow, [ G.T t ]))
+    v3 |> List.map (fun t -> G.OtherAttribute (("Throw", G.fake ""), [ G.T t ]))
   in
   ( { ent with G.attrs = ent.G.attrs @ throws },
     {

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -130,7 +130,7 @@ and class_type v =
 and type_argument = function
   | TArgument v1 ->
       let v1 = ref_type v1 in
-      G.TypeArg v1
+      G.TA v1
   | TWildCard (v1, v2) ->
       let v2 =
         option
@@ -139,7 +139,7 @@ and type_argument = function
             (v1, v2))
           v2
       in
-      G.TypeWildcard (v1, v2)
+      G.TAWildcard (v1, v2)
 
 and ref_type v = typ v
 

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -421,7 +421,7 @@ and argument = function
       G.ArgKwd (v1, v2)
   | ArgQuestion (v1, v2) ->
       let v1 = ident v1 and v2 = expr v2 in
-      G.ArgOther (G.OA_ArgQuestion, [ G.I v1; G.E v2 ])
+      G.ArgOther (("ArgQuestion", snd v1), [ G.I v1; G.E v2 ])
 
 and match_case (v1, (v3, _t, v2)) =
   let v1 = pattern v1 and v2 = expr v2 and v3 = option expr v3 in

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -554,8 +554,7 @@ and type_parameter v =
   (* TODO *)
   | TyParamTodo (s, t) ->
       let id = ("TyParamTodo", fake "TyParamTodo") in
-      G.tparam_of_id id
-        ~tp_constraints:[ G.OtherTypeParam (OTP_Todo, [ TodoK (s, t) ]) ]
+      G.tparam_of_id id ~tp_constraints:[ G.OtherTypeParam ((s, t), []) ]
 
 and type_def_kind = function
   | AbstractType -> G.AbstractType (fake "")

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -141,7 +141,7 @@ and type_kind = function
       G.TyFun ([ G.ParamClassic (G.param_of_type v1) ], v2)
   | TyApp (v1, v2) ->
       let v1 = list type_ v1 and v2 = name v2 in
-      G.TyApply (G.TyN v2 |> G.t, fb (v1 |> List.map (fun t -> G.TypeArg t)))
+      G.TyApply (G.TyN v2 |> G.t, fb (v1 |> List.map (fun t -> G.TA t)))
   | TyTuple v1 ->
       let v1 = list type_ v1 in
       G.TyTuple (fb v1)

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -495,7 +495,7 @@ and pattern = function
   | PatTodo (t, xs) ->
       let t = todo_category t in
       let xs = list pattern xs in
-      G.OtherPat (G.OP_Todo, G.TodoK t :: List.map (fun x -> G.P x) xs)
+      G.OtherPat (t, List.map (fun x -> G.P x) xs)
 
 and let_binding = function
   | LetClassic v1 ->

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -607,7 +607,7 @@ and module_expr = function
   | ModuleTodo (t, xs) ->
       let t = todo_category t in
       let xs = list module_expr xs in
-      G.OtherModule (G.OMO_Todo, G.TodoK t :: List.map (fun x -> G.ModDk x) xs)
+      G.OtherModule (t, List.map (fun x -> G.ModDk x) xs)
 
 and attributes xs = list attribute xs
 

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -209,7 +209,7 @@ and formal_param_pattern = function
   | ( Formal_amp _ | Formal_star _ | Formal_rest _ | Formal_default _
     | Formal_hash_splat _ | Formal_kwd _ | ParamEllipsis _ ) as x ->
       let x = formal_param x in
-      G.OtherPat (G.OP_Todo, [ G.Pa x ])
+      G.OtherPat (("ParamPattern", PI.unsafe_fake_info ""), [ G.Pa x ])
 
 (* less: return a G.name *)
 and scope_resolution = function
@@ -642,14 +642,14 @@ and rescue_clause (t, exns, exnvaropt, sts) =
   | [], None -> (t, G.PatUnderscore t, st)
   | [], Some (t, lhs) ->
       let e = expr lhs in
-      (t, G.OtherPat (G.OP_Todo, [ G.Tk t; G.E e ]), st)
+      (t, G.OtherPat (("Rescue", t), [ G.E e ]), st)
   | x :: xs, None ->
       let disjs = List.fold_left (fun e acc -> G.PatDisj (e, acc)) x xs in
       (t, disjs, st)
   | x :: xs, Some (t, lhs) ->
       let disjs = List.fold_left (fun e acc -> G.PatDisj (e, acc)) x xs in
       let e = expr lhs in
-      (t, G.OtherPat (G.OP_Todo, [ G.Tk t; G.E e; G.P disjs ]), st)
+      (t, G.OtherPat (("RescueDisj", t), [ G.E e; G.P disjs ]), st)
 
 and exception_ e =
   let t = type_ e in

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -644,7 +644,7 @@ and v_modifier v : G.attribute =
   let kind, tok = v_wrap v_modifier_kind v in
   match kind with
   | Left kwd -> G.KeywordAttr (kwd, tok)
-  | Right s -> G.OtherAttribute (G.OA_Todo, [ G.TodoK (s, tok) ])
+  | Right s -> G.OtherAttribute ((s, tok), [])
 
 and v_modifier_kind = function
   | Abstract -> Left G.Abstract
@@ -670,8 +670,7 @@ and v_annotation (v1, v2, v3) : G.attribute =
   match v2.t with
   | TyN name -> G.NamedAttr (v1, name, fb args)
   | _ ->
-      G.OtherAttribute
-        (OA_Todo, [ G.TodoK ("AnnotationComplexType", v1); G.T v2; G.Args args ])
+      G.OtherAttribute (("AnnotationComplexType", v1), [ G.T v2; G.Args args ])
 
 and v_attribute x : G.attribute =
   match x with

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -236,7 +236,7 @@ and v_type_kind = function
   | TyApplied (v1, v2) -> (
       let v1 = v_type_ v1 and v2 = v_bracket (v_list v_type_) v2 in
       let lp, xs, rp = v2 in
-      let args = xs |> List.map (fun x -> G.TypeArg x) in
+      let args = xs |> List.map (fun x -> G.TA x) in
       match v1.t with
       | G.TyN n -> G.TyApply (G.TyN n |> G.t, (lp, args, rp))
       | _ ->
@@ -244,8 +244,7 @@ and v_type_kind = function
             (G.T v1 :: (xs |> List.map (fun x -> G.T x))))
   | TyInfix (v1, v2, v3) ->
       let v1 = v_type_ v1 and v2 = v_ident v2 and v3 = v_type_ v3 in
-      G.TyApply
-        (G.TyN (H.name_of_ids [ v2 ]) |> G.t, fb [ G.TypeArg v1; G.TypeArg v3 ])
+      G.TyApply (G.TyN (H.name_of_ids [ v2 ]) |> G.t, fb [ G.TA v1; G.TA v3 ])
   | TyFunction1 (v1, v2, v3) ->
       let v1 = v_type_ v1 and _v2 = v_tok v2 and v3 = v_type_ v3 in
       G.TyFun ([ G.ParamClassic (G.param_of_type v1) ], v3)

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -311,7 +311,7 @@ and v_type_bounds { supertype = v_supertype; subtype = v_subtype } =
 
 and v_ascription v = v_type_ v
 
-and todo_pattern msg any = G.OtherPat (G.OP_Todo, G.TodoK (msg, fake msg) :: any)
+and todo_pattern msg any = G.OtherPat ((msg, fake msg), any)
 
 and v_pattern = function
   | PatLiteral v1 -> (

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2294,7 +2294,7 @@ and type_argument_list (env : env) ((v1, v2, v3) : CST.type_argument_list) =
         v1 :: v2
   in
   let v3 = token env v3 (* ">" *) in
-  (v1, List.map (fun t -> TypeArg t) v2, v3)
+  (v1, List.map (fun t -> TA t) v2, v3)
 
 and type_parameter_constraints_clause (env : env)
     ((v1, v2, v3, v4, v5) : CST.type_parameter_constraints_clause) =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -331,7 +331,7 @@ let todo_stmt _env tok = G.OtherStmt (G.OS_Todo, [ G.Tk tok ]) |> G.s
 
 let todo_pat _env tok = G.OtherPat (("Todo", tok), [])
 
-let todo_attr _env tok = G.OtherAttribute (G.OA_Expr, [ G.Tk tok ])
+let todo_attr _env tok = G.OtherAttribute (("Todo", tok), [])
 
 let todo_type _env tok = G.OtherType (G.OT_Todo, [ G.Tk tok ]) |> G.t
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -329,7 +329,7 @@ let todo_expr _env tok = G.OtherExpr (G.OE_Todo, [ G.Tk tok ]) |> G.e
 
 let todo_stmt _env tok = G.OtherStmt (G.OS_Todo, [ G.Tk tok ]) |> G.s
 
-let todo_pat _env tok = G.OtherPat (G.OP_Todo, [ G.Tk tok ])
+let todo_pat _env tok = G.OtherPat (("Todo", tok), [])
 
 let todo_attr _env tok = G.OtherAttribute (G.OA_Expr, [ G.Tk tok ])
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2361,7 +2361,9 @@ and statement (env : env) (x : CST.statement) =
       let _v2 = (* "(" *) token env v2 in
       (* TODO: Modify TSH to make directly to pattern? *)
       (* TODO: Split expression to allow pattern use and expr use? *)
-      let v3 = G.OtherPat (OP_Expr, [ G.E (expression env v3) ]) in
+      let v3 =
+        G.OtherPat (("ExprToPattern", v1), [ G.E (expression env v3) ])
+      in
       let _v4TODO =
         match v4 with
         | Some tok -> (* "await" *) Some (token env tok)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2625,12 +2625,12 @@ and type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) :
   let v2 =
     match v2 with
     | Some (v1, v2, v3) ->
-        let v1 = G.TypeArg (type_ env v1) in
+        let v1 = G.TA (type_ env v1) in
         let v2 =
           List.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
-              let v2 = G.TypeArg (type_ env v2) in
+              let v2 = G.TA (type_ env v2) in
               v2)
             v2
         in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -688,36 +688,27 @@ and as_expression (env : env) ((v1, v2, v3) : CST.as_expression) =
   G.Cast (v3, v2, v1) |> G.e
 
 and attribute_modifier (env : env)
-    ((v1, v2, v3, v4, v5, v6) : CST.attribute_modifier) : G.attribute =
+    ((v1, v2, v3, v4, v5, v6) : CST.attribute_modifier) : G.attribute list =
   (* Attributes are actually constructors *)
   let v1 = (* "<<" *) token env v1 in
-  let v2 =
-    G.fake_bracket [ G.Arg (G.N (qualified_identifier env v2) |> G.e) ]
-  in
+  let v2 = qualified_identifier env v2 in
   let v3 =
     match v3 with
     | Some x -> arguments env x
     | None -> G.fake_bracket []
   in
-  let constr_call =
-    G.Call (G.Call (G.IdSpecial (New, fk v1) |> G.e, v2) |> G.e, v3)
-  in
-  let first_attr_mod = G.E (constr_call |> G.e) in
+  let attr1 = G.NamedAttr (v1, v2, v3) in
   let v4 =
     List.map
       (fun (v1, v2, v3) ->
         let v1 = (* "," *) token env v1 in
-        let v2 =
-          G.fake_bracket [ G.Arg (G.N (qualified_identifier env v2) |> G.e) ]
-        in
+        let v2 = qualified_identifier env v2 in
         let v3 =
           match v3 with
           | Some x -> arguments env x
           | None -> G.fake_bracket []
         in
-        G.E
-          (G.Call (G.Call (G.IdSpecial (New, fk v1) |> G.e, v2) |> G.e, v3)
-          |> G.e))
+        G.NamedAttr (v1, v2, v3))
       v4
   in
   let _v5 =
@@ -726,7 +717,7 @@ and attribute_modifier (env : env)
     | None -> None
   in
   let _v6 = (* ">>" *) token env v6 in
-  G.OtherAttribute (G.OA_Expr, first_attr_mod :: v4)
+  attr1 :: v4
 
 and binary_expression (env : env) (x : CST.binary_expression) : G.expr =
   match x with
@@ -1102,7 +1093,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Func_decl (v1, v2, v3) ->
       let attrs =
         match v1 with
-        | Some x -> [ attribute_modifier env x ]
+        | Some x -> attribute_modifier env x
         | None -> []
       in
       let func_def, identifier, type_params =
@@ -1115,7 +1106,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Class_decl (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) ->
       let v1 =
         match v1 with
-        | Some x -> [ attribute_modifier env x ]
+        | Some x -> attribute_modifier env x
         | None -> []
       in
       let v2 =
@@ -1182,7 +1173,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Inte_decl (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 =
         match v1 with
-        | Some x -> [ attribute_modifier env x ]
+        | Some x -> attribute_modifier env x
         | None -> []
       in
       let v2 = (* "interface" *) token env v2 in
@@ -1218,7 +1209,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Trait_decl (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 =
         match v1 with
-        | Some x -> [ attribute_modifier env x ]
+        | Some x -> attribute_modifier env x
         | None -> []
       in
       let v2 = (* "trait" *) token env v2 in
@@ -1254,7 +1245,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Alias_decl (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 =
         match v1 with
-        | Some x -> [ attribute_modifier env x ]
+        | Some x -> attribute_modifier env x
         | None -> []
       in
       let _v2 =
@@ -1276,7 +1267,7 @@ and declaration (env : env) (x : CST.declaration) =
         | Some (v1, v2) ->
             let v1 = (* "as" *) str env v1 in
             let v2 = type_ env v2 in
-            [ G.OtherAttribute (OA_Todo, [ G.TodoK v1; G.T v2 ]) ]
+            [ G.OtherAttribute (v1, [ G.T v2 ]) ]
         | None -> []
       in
       (* Q: AliasType vs NewType? *)
@@ -1289,7 +1280,7 @@ and declaration (env : env) (x : CST.declaration) =
   | `Enum_decl (v1, v2, v3, v4, v5, v6, v7, v8, v9) ->
       let v1 =
         match v1 with
-        | Some x -> [ attribute_modifier env x ]
+        | Some x -> attribute_modifier env x
         | None -> []
       in
       let _v2 = (* "enum" *) token env v2 in
@@ -1609,7 +1600,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       | `Lambda_exp (v1, v2, v3, v4, v5) ->
           let _v1TODO =
             match v1 with
-            | Some x -> [ attribute_modifier env x ]
+            | Some x -> attribute_modifier env x
             | None -> []
           in
           let _v2TODO =
@@ -1786,8 +1777,8 @@ and function_declaration_header (env : env)
         let _v1 = (* ":" *) token env v1 in
         let _v2TODO =
           match v2 with
-          | Some x -> Some (attribute_modifier env x)
-          | None -> None
+          | Some x -> attribute_modifier env x
+          | None -> []
         in
         let v3 = type_ env v3 in
         Some v3
@@ -1858,7 +1849,7 @@ and member_declarations (env : env) ((v1, v2, v3) : CST.member_declarations) =
 and method_declaration (env : env) ((v1, v2, v3, v4) : CST.method_declaration) =
   let v1 =
     match v1 with
-    | Some x -> [ attribute_modifier env x ]
+    | Some x -> attribute_modifier env x
     | None -> []
   in
   let v2 = List.map (member_modifier env) v2 in
@@ -1874,7 +1865,7 @@ and parameter (env : env) (x : CST.parameter) : G.parameter =
       (v1, v2, v3, v4, v5, v6, v7) -> (
       let v1 =
         match v1 with
-        | Some x -> [ attribute_modifier env x ]
+        | Some x -> attribute_modifier env x
         | None -> []
       in
       let v2 =
@@ -2034,7 +2025,7 @@ and property_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.property_declaration) =
   let v1 =
     match v1 with
-    | Some x -> [ attribute_modifier env x ]
+    | Some x -> attribute_modifier env x
     | None -> []
   in
   let v2 = List.map (member_modifier env) v2 in
@@ -2651,7 +2642,7 @@ and type_const_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6, v7, v8, v9) : CST.type_const_declaration) =
   let v1 =
     match v1 with
-    | Some x -> [ attribute_modifier env x ]
+    | Some x -> attribute_modifier env x
     | None -> []
   in
   let v2 = List.map (member_modifier env) v2 in
@@ -2700,7 +2691,7 @@ and type_parameter (env : env) ((v1, v2, v3, v4) : CST.type_parameter) :
     G.type_parameter =
   let tp_attrs =
     match v1 with
-    | Some x -> [ attribute_modifier env x ]
+    | Some x -> attribute_modifier env x
     | None -> []
   in
   let tp_variance =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -1905,14 +1905,10 @@ and type_projection (env : env) ~tok (x : CST.type_projection) =
         | None -> []
       in
       let v2 = type_ env v2 in
-      let fake_token = Parse_info.fake_info tok "type projection" in
-      let list = [ TodoK ("type projection", fake_token); T v2 ] in
-      let othertype = OtherType (OT_Todo, list) |> G.t in
-      TypeArg othertype
+      OtherTypeArg (("Projection", tok), [ T v2 ])
   | `STAR tok ->
-      let star = str env tok in
-      let othertype = OtherType (OT_Todo, [ TodoK star ]) |> G.t (* "*" *) in
-      TypeArg othertype
+      let star = str env tok (* "*" *) in
+      OtherTypeArg (star, [])
 
 and type_reference (env : env) (x : CST.type_reference) =
   match x with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -336,7 +336,7 @@ let map_extern_modifier (env : env) ((v1, v2) : CST.extern_modifier) :
     Option.map
       (fun x ->
         let str = map_string_literal env x in
-        G.OtherAttribute (G.OA_Expr, [ G.E (G.L str |> G.e) ]))
+        G.OtherAttribute (("Extern", extern), [ G.E (G.L str |> G.e) ]))
       v2
   in
 
@@ -2891,9 +2891,9 @@ and map_visibility_quantifier (env : env) (v1, v2, v3) : G.attribute =
     | `Super tok -> G.KeywordAttr (G.Private, token env tok) (* "super" *)
     | `Crate tok -> G.KeywordAttr (G.Protected, token env tok) (* "crate" *)
     | `In_choice_self (v1, v2) ->
-        let _in_ = token env v1 (* "in" *) in
+        let in_ = token env v1 (* "in" *) in
         let path = map_simple_path env v2 in
-        G.OtherAttribute (G.OA_Expr, [ G.Di path ])
+        G.OtherAttribute (("In", in_), [ G.Di path ])
   in
   let _rparen = token env v3 (* ")" *) in
   attribute

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -645,7 +645,7 @@ and map_type_parameter (env : env) (x : CST.anon_choice_life_859e88f) :
   | `Life x ->
       let id = map_lifetime env x in
       G.tparam_of_id id
-        ~tp_constraints:[ G.OtherTypeParam (G.OTP_Lifetime, []) ]
+        ~tp_constraints:[ G.OtherTypeParam (("LifeTime", snd id), []) ]
   | `Meta tok ->
       let meta = ident env tok in
       (* pattern \$[a-zA-Z_]\w* *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -775,21 +775,20 @@ and map_field_initializer (env : env)
 and map_type_argument (env : env) (x : CST.anon_choice_type_39799c3) :
     G.type_argument =
   match x with
-  | `Type x -> G.TypeArg (map_type_ env x)
+  | `Type x -> G.TA (map_type_ env x)
   | `Type_bind (v1, v2, v3) ->
-      (* TODO *)
       let _identTODO = ident env v1 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
-      let _equals = token env v2 (* "=" *) in
+      let equals = token env v2 (* "=" *) in
       let ty = map_type_ env v3 in
-      G.TypeArg ty
-  | `Life x -> G.TypeLifetime (map_lifetime env x)
+      G.OtherTypeArg (("TypeBind", equals), [ T ty ])
+  | `Life x -> G.OtherTypeArg (map_lifetime env x, [])
   | `Lit x ->
       let lit = map_literal env x in
-      G.OtherTypeArg (G.OTA_Literal, [ G.E (G.L lit |> G.e) ])
+      G.TAExpr (G.L lit |> G.e)
   | `Blk x ->
       let block_expr = map_block_expr env x in
-      G.OtherTypeArg (G.OTA_ConstBlock, [ G.E block_expr ])
+      G.TAExpr block_expr
 
 and map_tuple_pattern_list (env : env)
     ((v1, v2) : CST.anon_pat_rep_COMMA_pat_2a80f16) : G.pattern list =
@@ -2527,7 +2526,7 @@ and map_scoped_identifier_name (env : env)
   let ident = ident env v3 in
   (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
   let qualifier = Option.map (fun x -> G.QExpr (x, colons)) qualifier_expr in
-  let typeargs = Option.map (fun x -> fb [ G.TypeArg x ]) type_ in
+  let typeargs = Option.map (fun x -> fb [ G.TA x ]) type_ in
   G.IdQualified
     ( (ident, { G.name_qualifier = qualifier; G.name_typeargs = typeargs }),
       G.empty_id_info () )
@@ -2548,13 +2547,13 @@ and map_scoped_type_identifier_name (env : env)
             (Some (G.QExpr (ident, colons)), None)
         | `Gene_type_with_turb x ->
             let ty = map_generic_type_with_turbofish_type env x in
-            (None, Some (fb [ G.TypeArg ty ]))
+            (None, Some (fb [ G.TA ty ]))
         | `Brac_type x ->
             let _, ty, _ = map_bracketed_type env x in
-            (None, Some (fb [ G.TypeArg ty ]))
+            (None, Some (fb [ G.TA ty ]))
         | `Gene_type x ->
             let ty = map_generic_type env x in
-            (None, Some (fb [ G.TypeArg ty ])))
+            (None, Some (fb [ G.TA ty ])))
     | None -> (None, None)
   in
   let ident = ident env v3 in
@@ -2582,7 +2581,7 @@ and map_scoped_type_identifier_in_expression_position (env : env)
             (Some (G.QExpr (ident, colons)), None)
         | `Gene_type_with_turb x ->
             let ty = map_generic_type_with_turbofish_type env x in
-            (None, Some (fb [ G.TypeArg ty ])))
+            (None, Some (fb [ G.TA ty ])))
     | None -> (None, None)
   in
   let ident = ident env v3 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -637,7 +637,7 @@ and map_struct_pattern_field (env : env) (x : CST.anon_choice_field_pat_8e757e8)
       let ident = ident env tok in
       (* ".." *)
       let name = [ ident ] in
-      (name, G.OtherPat (G.OP_Todo, [ G.Tk (token env tok) ]))
+      (name, G.OtherPat (("..", token env tok), []))
 
 and map_type_parameter (env : env) (x : CST.anon_choice_life_859e88f) :
     G.type_parameter =
@@ -2005,7 +2005,7 @@ and map_match_arm (env : env) ((v1, v2, v3, v4) : CST.match_arm) : G.action =
     match v2 with
     | `Macro_invo x ->
         let invo = map_macro_invocation env x in
-        G.OtherPat (G.OP_Todo, [ G.E invo ])
+        G.OtherPat (("Macro", G.fake ""), [ G.E invo ])
     | `Match_pat x -> map_match_pattern env x
   in
   let _arrow = token env v3 (* "=>" *) in
@@ -2429,7 +2429,7 @@ and map_pattern (env : env) (x : CST.pattern) : G.pattern =
       G.DisjPat (pattern_lhs, pattern_rhs)
   | `Const_blk x ->
       let block = map_const_block env x in
-      G.OtherPat (G.OP_Expr, [ G.E block ])
+      G.OtherPat (("ConstBlock", G.fake ""), [ G.E block ])
   | `X__ tok -> G.PatUnderscore (token env tok)
 
 (* "_" *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -1994,7 +1994,7 @@ and map_macro_invocation (env : env) ((v1, v2, v3) : CST.macro_invocation) :
     match anys with
     (* look like a regular function call, just use Arg then *)
     | [ G.E e ] -> [ G.Arg e ]
-    | xs -> [ G.ArgOther (G.OA_ArgMacro, xs) ]
+    | xs -> [ G.ArgOther (("ArgMacro", G.fake ""), xs) ]
   in
   G.Call (G.N name |> G.e, (l, args, r)) |> G.e
 


### PR DESCRIPTION
The initial thought behind those other_xxx_operator was
to exhaustively list all the things not handled. However, as
the language list grew, it was easier to just have some very
general category like OE_Todo, OS_Todo, to the point
where those other_xxx_operator are just annoying and introduce
yet another type in an already long list of types in AST_generic.ml

test plan:
make


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)