### PR TITLE
Fix CFG builder creating dummy nodes that do not connect to exit node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   `attr_expr: false` (#3489)
 
 ### Fixed
+- Fix CFG dummy nodes to always connect to exit node
+
 
 ## [0.66.0](https://github.com/returntocorp/semgrep/releases/tag/v0.66.0) - 09-22-2021
 

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -238,7 +238,7 @@ and cfg_stmt_list state previ xs =
       let dummyi = state.g#add_node { n = NOther Noop } in
       label_node state (l :: ls) dummyi;
       add_arc (lasti, dummyi) state.g;
-      lasti_opt
+      Some dummyi
   | _ -> lasti_opt
 
 (*****************************************************************************)


### PR DESCRIPTION
If a dummy node created for label with no accompanying statement is the final node in a CFG, it was previously not connected to the exit node. Now it is.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)
