### PR TITLE
Allow additional fields in rule

### DIFF
--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -491,4 +491,3 @@ properties:
                 - pattern-sanitizers
               - required:
                 - join
-additionalProperties: false

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error-in-color.txt
@@ -1,20 +1,12 @@
-[31msemgrep error[0m: Invalid rule schema
+[31msemgrep error[0m: missing keys
   --> rules/syntax/missing-toplevel.yaml:2
-[94m2  | [0mrule:
-[94m3  | [0m- id: flask-secure-set-cookie
-[94m4  | [0m  languages: [python]
-[94m5  | [0m  patterns:
-[94m6  | [0m    - pattern-not: |
-[94m7  | [0m        flask.response.set_cookie(..., httponly=True, secure=True,...)
-[94m8  | [0m    - pattern: |
-[94m9  | [0m        flask.response.set_cookie(....)
-[94m10 | [0m  message: |
-[94m11 | [0m    Flask cookies should be handled securely by setting secure=True, httponly=True, and samesite='Lax' in  response.set_cookie(...). If your situation calls for different settings, explicitly disable the setting.
-[94m12 | [0m    If you want to send the cookie over http, set secure=False.  If you want to let client-side JavaScript
-[94m13 | [0m    read the cookie, set httponly=False. If you want to attach cookies to requests for external sites,
-[94m14 | [0m    set samesite=None.
-[94m15 | [0m  severity: error
+[94m2 | [0mrule:
+[94m3 | [0m- id: flask-secure-set-cookie
+[94m4 | [0m  languages: [python]
+[94m5 | [0m  patterns:
+[94m6 | [0m    - pattern-not: |
+[94m7 | [0m        flask.response.set_cookie(..., httponly=True, secure=True,...)
 
-[31mAdditional properties are not allowed ('rule' was unexpected)[0m
+[31mrules/syntax/missing-toplevel.yaml_0 is missing `rules` as top-level key[0m
 
 run with --strict and there were 1 errors loading configs

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
@@ -3,8 +3,8 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "Additional properties are not allowed ('rule' was unexpected)",
-      "short_msg": "Invalid rule schema",
+      "long_msg": "rules/syntax/missing-toplevel.yaml_0 is missing `rules` as top-level key",
+      "short_msg": "missing keys",
       "spans": [
         {
           "config_end": null,
@@ -13,8 +13,8 @@
           "context_end": null,
           "context_start": null,
           "end": {
-            "col": 1,
-            "line": 16
+            "col": 0,
+            "line": 7
           },
           "file": "rules/syntax/missing-toplevel.yaml",
           "source_hash": "c72a97211dabcaa3065612fb9c52d6a344855414a6d9f1eb5adea4305d4c47da",


### PR DESCRIPTION
In preparation of adding new fields to rule schema like `version` let's make semgrep still be able to run rules even with extra fields.