### PR TITLE
feat(sarif): set name from rule metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Attribute-expression equivalence that allows matching expression patterns against
   attributes, it is enabled by default but can be disabled via rule `options:` with
   `attr_expr: false` (#3489)
+- The `name` field of rules in the SARIF output is now set by a rule's `name`
+  metadata, if such metadata is provided.
 
 ### Fixed
 - Fix CFG dummy nodes to always connect to exit node

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -46,12 +46,18 @@ class SarifFormatter(BaseFormatter):
         tags = SarifFormatter._rule_to_sarif_tags(rule)
         rule_json = {
             "id": rule.id,
-            "name": rule.id,
             "shortDescription": {"text": rule.message},
             "fullDescription": {"text": rule.message},
             "defaultConfiguration": {"level": severity},
             "properties": {"precision": "very-high", "tags": tags},
         }
+
+        rule_name = rule.metadata.get("name")
+        if rule_name is not None:
+            rule_json["name"] = rule_name
+            rule_json["deprecatedNames"] = [rule.id]
+        else:
+            rule_json["name"] = rule.id
 
         rule_url = rule.metadata.get("source")
         if rule_url is not None:

--- a/semgrep/tests/e2e/rules/eqeq-source.yml
+++ b/semgrep/tests/e2e/rules/eqeq-source.yml
@@ -30,6 +30,7 @@ rules:
     languages: [python]
     severity: ERROR
     metadata:
+      name: "Self-referential comparison"
       category: correctness
       source: "https://semgrep.dev/foo/bar/bad"
   - id: python37-compatability-os-module
@@ -50,4 +51,5 @@ rules:
     languages: [js]
     severity: ERROR
     metadata:
+      name: "Self-referential comparison"
       source: "https://semgrep.dev/foo/bar/js"

--- a/semgrep/tests/e2e/snapshots/test_output/test_sarif_output_with_source/results.sarif
+++ b/semgrep/tests/e2e/snapshots/test_output/test_sarif_output_with_source/results.sarif
@@ -80,12 +80,15 @@
               "defaultConfiguration": {
                 "level": "error"
               },
+              "deprecatedNames": [
+                "rules.eqeq-is-bad"
+              ],
               "fullDescription": {
                 "text": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
               },
               "helpUri": "https://semgrep.dev/foo/bar/bad",
               "id": "rules.eqeq-is-bad",
-              "name": "rules.eqeq-is-bad",
+              "name": "Self-referential comparison",
               "properties": {
                 "precision": "very-high",
                 "tags": []
@@ -98,12 +101,15 @@
               "defaultConfiguration": {
                 "level": "error"
               },
+              "deprecatedNames": [
+                "rules.javascript-basic-eqeq-bad"
+              ],
               "fullDescription": {
                 "text": "useless comparison"
               },
               "helpUri": "https://semgrep.dev/foo/bar/js",
               "id": "rules.javascript-basic-eqeq-bad",
-              "name": "rules.javascript-basic-eqeq-bad",
+              "name": "Self-referential comparison",
               "properties": {
                 "precision": "very-high",
                 "tags": []

--- a/semgrep/tests/e2e/test_output.py
+++ b/semgrep/tests/e2e/test_output.py
@@ -119,6 +119,10 @@ def test_sarif_output_with_source(run_semgrep_in_tmp, snapshot):
     for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
         assert rule.get("helpUri", None) is not None
 
+    # Assert that each sarif rule object has a name
+    for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
+        assert rule.get("name") is not None
+
 
 def test_sarif_output_with_source_edit(run_semgrep_in_tmp, snapshot):
     sarif_output = json.loads(
@@ -134,6 +138,10 @@ def test_sarif_output_with_source_edit(run_semgrep_in_tmp, snapshot):
     # Assert that each sarif rule object has a helpURI
     for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
         assert rule.get("help", None) is not None
+
+    # Assert that each sarif rule object has a name
+    for rule in sarif_output["runs"][0]["tool"]["driver"]["rules"]:
+        assert rule.get("name") is not None
 
 
 def test_sarif_output_with_nosemgrep_and_error(run_semgrep_in_tmp, snapshot):


### PR DESCRIPTION
According to `v2.1.0` of the SARIF spec ([link](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317843)),
the `name` property of a `reportingDescriptor` object may be a:

> localizable string containing an identifier that is understandable to an end user

Update the `name` property to be configurable based on each rule's
`metadata.name` field.

Additionally, for backwards compatibility, properly set the `deprecatedNames`
property when a metadata-sourced name is set.

PR checklist:
- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has security implications (if so, ping security team)
