### PR TITLE
optimizing: Analyze_rule: Fix OR simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Fix CFG dummy nodes to always connect to exit node
-
+- Fixed bug in semgrep-core's `-filter_irrelevant_rules` causing Semgrep to
+  incorrectly skip a file (#3755)
 
 ## [0.66.0](https://github.com/returntocorp/semgrep/releases/tag/v0.66.0) - 09-22-2021
 

--- a/semgrep-core/tests/OTHER/irrelevant_rules/pattern-either.py
+++ b/semgrep-core/tests/OTHER/irrelevant_rules/pattern-either.py
@@ -1,0 +1,1 @@
+irrelevant

--- a/semgrep-core/tests/OTHER/irrelevant_rules/pattern-either.yaml
+++ b/semgrep-core/tests/OTHER/irrelevant_rules/pattern-either.yaml
@@ -1,0 +1,25 @@
+rules:
+- id: python.django.best-practice.upsell_django_environ.use-django-environ
+  patterns:
+  - pattern-not: |
+      ...
+      import environ
+      ...
+  - pattern-either:
+    - pattern: |
+        import django
+        ...
+        import os
+        ...
+        $FOO = $M.environ[...]
+    - pattern: |
+        import os
+        ...
+        import django
+        ...
+        $FOO = $M.environ[...]
+  message: You are using environment variables inside django app. Use `django-environ`
+    as it a better alternative for deployment.
+  languages:
+  - python
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/rules/non_irrelevant_rule.java
+++ b/semgrep-core/tests/OTHER/rules/non_irrelevant_rule.java
@@ -1,0 +1,6 @@
+public class Test {
+    public void test() {
+        //ruleid:insecure-crypto-usage
+        MessageDigest.sha1("MD2");
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/non_irrelevant_rule.yaml
+++ b/semgrep-core/tests/OTHER/rules/non_irrelevant_rule.yaml
@@ -1,0 +1,16 @@
+# https://github.com/returntocorp/semgrep/issues/3755
+rules:
+  - id: insecure-crypto-usage
+    languages:
+      - java
+    message: Found insecure crypto usage
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern: $X.sha1("$RE")
+              - metavariable-regex:
+                  metavariable: $RE
+                  regex: (?i)md2
+          - patterns:
+              - pattern: $X.getMd2Digest(...)
+    severity: ERROR

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -408,7 +408,8 @@ let lang_regression_tests ~with_caching =
 let full_rule_regression_tests = [
   "full rule", (fun () ->
     let path = Filename.concat tests_path "OTHER/rules" in
-    Test_engine.test_rules ~unit_testing:true [path]
+    Common2.save_excursion_and_enable Flag_semgrep.filter_irrelevant_rules (fun () ->
+    Test_engine.test_rules ~unit_testing:true [path])
   )
 ]
 
@@ -532,6 +533,42 @@ let metachecker_regression_tests =
     )
   )
 
+let test_irrelevant_rule rule_file target_file =
+  let rules = Parse_rule.parse rule_file in
+  rules |> List.iter (fun rule ->
+    match Analyze_rule.regexp_prefilter_of_rule rule with
+    | None -> Alcotest.fail (spf "Rule %s: no regex prefilter formula" (fst rule.id))
+    | Some (re, f) ->
+      let content = read_file target_file in
+      if f content then
+        Alcotest.fail (spf "Rule %s considered relevant by regex prefilter: %s" (fst rule.id) re)
+  )
+
+let test_irrelevant_rule_file rule_file =
+  Filename.basename rule_file, (fun () ->
+    let target_file =
+      let (d,b,_e) = Common2.dbe_of_filename rule_file in
+      (* TODO: Support other extensions, note that we don't need
+       * to parse the target files! *)
+      let candidate1 = Common2.filename_of_dbe (d,b,"py") in
+      if Sys.file_exists candidate1
+      then candidate1
+      else failwith (spf "could not find target file for irrelevant rule %s" rule_file)
+    in
+    test_irrelevant_rule rule_file target_file
+  )
+
+let filter_irrelevant_rules_tests =
+  pack_tests "filter irrelevant rules testing" (
+    let dir = Filename.concat tests_path "OTHER/irrelevant_rules" in
+    let files = Common2.glob (spf "%s/*.yaml" dir) in
+    files |> List.map (fun file ->
+      test_irrelevant_rule_file file
+    )
+  )
+
+(*                 *)
+
 let tests = List.flatten [
   (* just expression vs expression testing for one language (Python) *)
   Unit_matcher.tests ~any_gen_of_string;
@@ -557,6 +594,7 @@ let tests = List.flatten [
   full_rule_regression_tests;
   lang_tainting_tests;
   metachecker_regression_tests;
+  filter_irrelevant_rules_tests;
 ]
 
 let main () =


### PR DESCRIPTION
When a term in an OR cannot be checked with a regex, we have to assume
that the term holds and thus reduce the entire OR to "true".

Plus, enable -filter_irrelevant_rules for full-rule tests.

Plus, prevent Analyze_rule from crashing when given a "new" formula
where things like `Not (Or ...)` are possible, otherwise e.g. test
tests/OTHER/rules/negation_ajin fails (by `failwith "Not Or"`).

Closes #3755

test plan:
make test # tests included

TL;DR

For example:

    - pattern-either:
        - patterns:
            - pattern: $X.sha1("$RE")
            - metavariable-regex:
                metavariable: $RE
                regex: (?i)md2
        - patterns:
            - pattern: $X.getMd2Digest(...)

This is seen by Analyze_rule as:

    OR
        AND (contains "sha1") (dont-know-how-to-check)
        AND (contains "getMd2Digest")

Sometimes Analyze_rule does not know how to extract a regex from a
pattern, here we represent that with `(dont-know-how-to-check)`. The
"problem" with the `metavariable-regex` here is that Analyze_rule does
not know how to handle the case-insensitive mode `(?i)`.

When converting the regex formula into CNF we get:

    AND
        OR (contains "sha1") (contains "getMd2Digest")
        OR (dont-know-how-to-check) (contains "getMd2Digest")

Then in step1 we try to get rid of these `(dont-know-how-to-check)`. The
bug was caused by incorrectly simplifying this as:

    AND
        OR (contains "sha1") (contains "getMd2Digest")
        OR (contains "getMd2Digest")

That is, treating `(dont-know-how-to-check)` as "false" rather than
"true". The correct simplification is:

    AND
        OR (contains "sha1") (contains "getMd2Digest")