### PR TITLE
[PHP] allow 'for', 'global', 'as', 'array' as valid constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Ruby: treat 'foo' as a function call when alone on its line (#3811)
 - Fixed bug in semgrep-core's `-filter_irrelevant_rules` causing Semgrep to
   incorrectly skip a file (#3755)
+- PHP: allows more keywords as valid field names (#3954)
 
 ## [0.66.0](https://github.com/returntocorp/semgrep/releases/tag/v0.66.0) - 09-22-2021
 

--- a/semgrep-core/tests/php/misc_parsing_keyword_as_id.php
+++ b/semgrep-core/tests/php/misc_parsing_keyword_as_id.php
@@ -1,0 +1,38 @@
+<?php
+
+class SyncOrderPgRouter extends Job
+{
+    //parsing: array keyword used as function name
+    public function array(): array
+    {
+        return $this->data;
+    }
+   
+    public function handle()
+    {
+        //ERROR: match
+        $this->trace->info(TraceCode::ORDER_DATA_SYNC_TO_PG_ROUTER,
+            [
+                'data' => $this->data,
+                'data' => $traceRequest
+            ]
+        );
+
+    
+
+
+        //parsing: 'for', 'global', 'as' keywords used as constants
+        $this->settingsAccessor = A::for($this->batch, Settings\Module::BATCH);
+        list($this->settings[K::GLOBAL], $this->settings[K::ID_LEVEL]) = $settings;
+
+        return json_encode([
+            Constants::ASYNC_TRANSFER_RESPONSE_IDENTIFIER => [
+                Constants::VERSION              => self::VERSION,
+                Constants::REQUEST_REFERENCE_NO => $this->entity->getId(),
+                Constants::UNIQUE_RESPONSE_NO   => PublicEntity::generateUniqueId(),
+                Constants::REQ_TRANSFER_TYPE    => $this->transferType,
+                Constants::STATUS_CODE          => Status::AS,
+            ],
+        ]);
+    }
+}

--- a/semgrep-core/tests/php/misc_parsing_keyword_as_id.sgrep
+++ b/semgrep-core/tests/php/misc_parsing_keyword_as_id.sgrep
@@ -1,0 +1,1 @@
+$this->trace->$TRACE_FUNC(...,$TRACE_CODE,[...,$DATA=>$this->data,...]);


### PR DESCRIPTION
This closes #3954

test plan:
test file included
make test


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)