### PR TITLE
[Ruby] refactor arguments, introduce ArgKwd

### DIFF
--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -82,7 +82,9 @@ let rec expr e =
       let name = scope_resolution x in
       G.N (G.IdQualified (name, G.empty_id_info ()))
   | Hash (_bool, xs) -> G.Container (G.Dict, bracket (list expr) xs)
-  | Array xs -> G.Container (G.Array, bracket (list expr) xs)
+  | Array (l, xs, r) ->
+      let xs = args_to_exprs xs in
+      G.Container (G.Array, (l, list expr xs, r))
   | Tuple xs -> G.Container (G.Tuple, G.fake_bracket (list expr xs))
   | Unary (op, e) ->
       let e = expr e in
@@ -98,10 +100,10 @@ let rec expr e =
       G.Conditional (e1, e2, e3)
   | Call (e, xs, bopt) ->
       let e = expr e in
-      let lb, xs, rb = bracket (list expr) xs in
+      let lb, xs, rb = bracket (list argument) xs in
       (* TODO: maybe make an extra separate Call for the block? *)
       let last = option expr bopt |> Common.opt_to_list in
-      G.Call (e, (lb, xs @ last |> List.map G.arg, rb))
+      G.Call (e, (lb, xs @ (last |> List.map G.arg), rb))
   | DotAccess (e, t, m) ->
       let e = expr e in
       let fld =
@@ -150,6 +152,14 @@ let rec expr e =
       let v3 = type_ v3 in
       G.TypedMetavar (v1, v2, v3))
   |> G.e
+
+and argument arg : G.argument =
+  match arg with
+  | Arg e -> G.Arg (expr e)
+  | ArgKwd (id, _tk, arg) ->
+      let id = ident id in
+      let arg = expr arg in
+      G.ArgKwd (id, arg)
 
 and formal_param = function
   | Formal_id id -> G.ParamClassic (G.param_of_id id)
@@ -452,22 +462,22 @@ and stmt st =
       let header = G.ForEach (pat, t2, e) in
       G.For (t1, header, st) |> G.s
   | Return (t, es) ->
-      let eopt = exprs_to_eopt es in
+      let eopt = args_to_eopt es in
       G.Return (t, eopt, G.sc) |> G.s
   | Yield (t, es) ->
-      let eopt = exprs_to_eopt es in
+      let eopt = args_to_eopt es in
       G.exprstmt (G.Yield (t, eopt, false) |> G.e)
   | Break (t, es) ->
-      let lbl = exprs_to_label_ident es in
+      let lbl = args_to_label_ident es in
       G.Break (t, lbl, G.sc) |> G.s
   | Next (t, es) ->
-      let lbl = exprs_to_label_ident es in
+      let lbl = args_to_label_ident es in
       G.Continue (t, lbl, G.sc) |> G.s
   | Redo (t, es) ->
-      let lbl = exprs_to_label_ident es in
+      let lbl = args_to_label_ident es in
       G.OtherStmt (G.OS_Redo, [ G.Tk t; G.Lbli lbl ]) |> G.s
   | Retry (t, es) ->
-      let lbl = exprs_to_label_ident es in
+      let lbl = args_to_label_ident es in
       G.OtherStmt (G.OS_Retry, [ G.Tk t; G.Lbli lbl ]) |> G.s
   | Case (t, { case_guard = eopt; case_whens = whens; case_else = stopt }) ->
       let eopt = option expr eopt in
@@ -488,6 +498,8 @@ and when_clause (t, pats, sts) =
   let st = list_stmt1 sts in
   (pats |> List.map (fun pat -> G.Case (t, pat)), st)
 
+and args_to_label_ident xs = xs |> args_to_exprs |> exprs_to_label_ident
+
 and exprs_to_label_ident = function
   | [] -> G.LNone
   (* TODO: check if x is an Int or label? *)
@@ -497,6 +509,8 @@ and exprs_to_label_ident = function
   | xs ->
       let xs = list expr xs in
       G.LDynamic (G.Container (G.Tuple, G.fake_bracket xs) |> G.e)
+
+and args_to_eopt xs = xs |> args_to_exprs |> exprs_to_eopt
 
 and exprs_to_eopt = function
   | [] -> None

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -734,7 +734,7 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         | Some (v1, v2, v3) ->
             let v1 =
               match v1 with
-              | `Pair x -> pair env x
+              | `Pair x -> pair_for_hash env x
               | `Hash_splat_arg x -> hash_splat_argument env x
             in
             let v2 =
@@ -743,7 +743,7 @@ and primary (env : env) (x : CST.primary) : AST.expr =
                   let _v1 = token2 env v1 in
                   let v2 =
                     match v2 with
-                    | `Pair x -> pair env x
+                    | `Pair x -> pair_for_hash env x
                     | `Hash_splat_arg x -> hash_splat_argument env x
                   in
                   v2)
@@ -1159,7 +1159,7 @@ and call_ (env : env) (x : CST.call_) : AST.expr =
       Call (v1, fb [], Some v2)
 
 and command_argument_list (env : env) ((v1, v2) : CST.command_argument_list) :
-    AST.expr list =
+    AST.argument list =
   let v1 = argument env v1 in
   let v2 =
     List.map
@@ -1172,7 +1172,7 @@ and command_argument_list (env : env) ((v1, v2) : CST.command_argument_list) :
   v1 :: v2
 
 and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
-    AST.expr list AST.bracket =
+    AST.argument list AST.bracket =
   let lp = token2 env v1 in
   let v2 =
     match v2 with
@@ -1183,7 +1183,7 @@ and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
   (lp, v2, rp)
 
 and argument_list_with_trailing_comma (env : env)
-    ((v1, v2, v3) : CST.argument_list_with_trailing_comma) : AST.expr list =
+    ((v1, v2, v3) : CST.argument_list_with_trailing_comma) : AST.argument list =
   let v1 = argument env v1 in
   let v2 =
     List.map
@@ -1200,16 +1200,16 @@ and argument_list_with_trailing_comma (env : env)
   in
   v1 :: v2
 
-and argument (env : env) (x : CST.argument) : AST.expr =
+and argument (env : env) (x : CST.argument) : AST.argument =
   match x with
-  | `Exp x -> expression env x
-  | `Splat_arg x -> splat_argument env x
-  | `Hash_splat_arg x -> hash_splat_argument env x
+  | `Exp x -> Arg (expression env x)
+  | `Splat_arg x -> Arg (splat_argument env x)
+  | `Hash_splat_arg x -> Arg (hash_splat_argument env x)
   | `Blk_arg (v1, v2) ->
       let v1 = token2 env v1 in
       let v2 = arg env v2 in
-      Unary ((Op_UAmper, v1), v2)
-  | `Pair x -> pair env x
+      Arg (Unary ((Op_UAmper, v1), v2))
+  | `Pair x -> pair_for_argument env x
 
 and splat_argument (env : env) ((v1, v2) : CST.splat_argument) =
   let v1 = token2 env v1 in
@@ -1637,7 +1637,7 @@ and pair (env : env) (x : CST.pair) =
       let v2 = token2 env v2 in
       (* => *)
       let v3 = arg env v3 in
-      Binop (v1, (Op_ASSOC, v2), v3)
+      Left (Binop (v1, (Op_ASSOC, v2), v3))
   | `Choice_hash_key_symb_imm_tok_COLON_arg (v1, v2, v3) -> (
       let v1 =
         match v1 with
@@ -1650,8 +1650,18 @@ and pair (env : env) (x : CST.pair) =
       (* : *)
       let v3 = arg env v3 in
       match v1 with
-      | Id (x, _) -> AST.keyword_arg_to_expr x v2 v3
-      | _ -> Binop (v1, (Op_ASSOC, v2), v3))
+      | Id (x, _) -> Right (x, v2, v3)
+      | _ -> Left (Binop (v1, (Op_ASSOC, v2), v3)))
+
+and pair_for_hash env x : AST.expr =
+  match pair env x with
+  | Left e -> e
+  | Right (a, b, c) -> AST.keyword_arg_to_expr a b c
+
+and pair_for_argument env x : AST.argument =
+  match pair env x with
+  | Left e -> Arg e
+  | Right (a, b, c) -> ArgKwd (a, b, c)
 
 let program (env : env) ((v1, _v2interpreted) : CST.program) : AST.stmts =
   match v1 with

--- a/semgrep-core/tests/ruby/equivalence_keyword_args.rb
+++ b/semgrep-core/tests/ruby/equivalence_keyword_args.rb
@@ -1,0 +1,5 @@
+#ERROR: match
+example(a: :foo, b: :bar)
+
+#ERROR: match
+example(b: :bar, a: :foo)

--- a/semgrep-core/tests/ruby/equivalence_keyword_args.sgrep
+++ b/semgrep-core/tests/ruby/equivalence_keyword_args.sgrep
@@ -1,0 +1,1 @@
+example(..., a: :foo, ..., b: :bar, ...)


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/3872

This took far more time than I expected. Maybe
doing the transformation to ArgKwd in ruby_to_generic.ml was
far simpler, but I kinda like having a more precise ast_ruby.ml too.

test plan:
test file included


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)