### PR TITLE
tainting: Filter out sanitizers that conflict with sources/sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Added
+
+### Changed
+- taint-mode: Sanitizers that match exactly a source or a sink are filtered out,
+  making it possible to use `- pattern: $F(...)` for declaring that any other
+  function is a sanitizer
+
+### Fixed
+
+## [0.67.0](https://github.com/returntocorp/semgrep/releases/tag/v0.67.0) - 09-29-2021
+
+### Added
 - Added support for break and continue in the dataflow engine
 - Added support for switch statements in the dataflow engine
 

--- a/semgrep-core/src/engine/Tainting_generic.ml
+++ b/semgrep-core/src/engine/Tainting_generic.ml
@@ -129,8 +129,18 @@ let taint_config_of_rule default_config equivs file ast_and_errors
     |> List.concat
   in
   let sources_ranges = find_ranges spec.sources
-  and sanitizers_ranges = find_ranges spec.sanitizers
   and sinks_ranges = find_ranges spec.sinks in
+  let sanitizers_ranges =
+    find_ranges spec.sanitizers
+    (* A sanitizer cannot conflict with a sink or a source, otherwise it is
+     * filtered out. This allows to e.g. declare `$F(...)` as a sanitizer,
+     * to assume that any other function will handle tainted data safely.
+     * Without this, `$F(...)` will automatically sanitize any other function
+     * call acting as a sink or a source. *)
+    |> List.filter (fun r ->
+           (* TODO: Warn user when we filter out a sanitizer? *)
+           not (List.mem r sinks_ranges || List.mem r sources_ranges))
+  in
   {
     Dataflow_tainting.is_source = (fun x -> any_in_ranges x sources_ranges);
     is_sanitizer = (fun x -> any_in_ranges x sanitizers_ranges);

--- a/semgrep-core/tests/tainting_rules/php/opaque_safe.php
+++ b/semgrep-core/tests/tainting_rules/php/opaque_safe.php
@@ -1,0 +1,9 @@
+<?php
+
+function not_tainted($data) {
+    // do stuff
+    return '2';
+}
+x = not_tainted(tainted('a'));
+// ok:tainted
+sink(x);

--- a/semgrep-core/tests/tainting_rules/php/opaque_safe.yaml
+++ b/semgrep-core/tests/tainting_rules/php/opaque_safe.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: tainted
+    languages:
+      - php
+    message: Match
+    mode: taint
+    pattern-sanitizers:
+      - pattern: $F(...)
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: tainted(...)
+    severity: WARNING
+


### PR DESCRIPTION
On certain codebases, assuming that every function call will always
propagate taint leads to too many false alarms. But fixing this via
a `$F(...)` sanitizer was very cumbersome, because `$F(...)` will
sanitize all sinks and sources, unless you re-enumerate all of them
via `pattern-not`s.

Closes PA-402

test plan:
make test # test included