### PR TITLE
[Kotlin] improve Parse_kotlin_tree_sitter.ml and AST_generic.ml too

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -181,8 +181,15 @@ let add_stmts env xs = xs |> List.iter (add_stmt env)
 
 let bracket_keep f (t1, x, t2) = (t1, f x, t2)
 
+let ident_of_entity_opt ent =
+  match ent.G.name with
+  | G.EN (G.Id (i, pinfo))
+  | G.EN (G.IdQualified ((i, _), pinfo)) ->
+      Some (i, pinfo)
+  | G.EDynamic _ -> None
+
 let name_of_entity ent =
-  match AST_generic_helpers.name_of_entity ent with
+  match ident_of_entity_opt ent with
   | Some (i, pinfo) ->
       let name = var_of_id_info i pinfo in
       Some name

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -275,7 +275,7 @@ and eval_op env op args =
   | __else__ -> None
 
 and eval_concat_string env args : literal option =
-  let go_concat : arguments -> string option =
+  let go_concat : argument list -> string option =
     List.fold_left
       (fun res arg ->
         match arg with

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -631,7 +631,10 @@ and map_keyword_attribute = function
   | DefaultImpl -> Left `DefaultImpl
   (* new: *)
   | Lazy -> Right "lazy"
-  | CaseClass -> Right "CaseClass"
+  | RecordClass -> Right "RecordClass"
+  | AnnotationClass -> Right "AnnotationClass"
+  | EnumClass -> Right "EnumClass"
+  | SealedClass -> Right "SealedClass"
 
 and map_other_attribute_operator _x = "TODO"
 
@@ -1124,9 +1127,6 @@ and map_class_kind = function
   | Interface -> `Interface
   | Trait -> `Trait
   | Object -> `Object
-  | AtInterface -> `AtInterface
-  | RecordClass -> `RecordClass
-  | EnumClass -> failwith "TODO"
 
 and map_directive { d; d_attrs } =
   let d = map_directive_kind d in

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -395,7 +395,7 @@ and expr_kind =
   | N of name
   | IdSpecial of special wrap (*e: [[AST_generic.expr]] other identifier cases *)
   (* operators and function application *)
-  | Call of expr * arguments bracket (* can be fake '()' for OCaml/Ruby *)
+  | Call of expr * arguments
   (* TODO? Separate regular Calls from OpCalls where no need bracket and Arg *)
   (* (XHP, JSX, TSX), could be transpiled also (done in IL.ml?) *)
   | Xml of xml
@@ -718,7 +718,8 @@ and xml_body =
   | XmlExpr of expr option bracket
   | XmlXml of xml
 
-and arguments = argument list
+(* brackets can be fake '()' for OCaml/Ruby *)
+and arguments = argument list bracket
 
 and argument =
   (* regular argument *)
@@ -1131,7 +1132,7 @@ and attribute =
   (* a.k.a modifiers *)
   | KeywordAttr of keyword_attribute wrap
   (* a.k.a decorators, annotations *)
-  | NamedAttr of tok (* '@' *) * name * arguments bracket (* less: option *)
+  | NamedAttr of tok (* '@' *) * name * arguments (* less: option *)
   (* per-language specific keywords like 'transient', 'synchronized' *)
   (* todo: Expr used for Python, but should transform in NamedAttr when can *)
   | OtherAttribute of todo_kind * any list
@@ -1474,7 +1475,7 @@ and class_definition = {
    * This parent can have arguments, as in Scala/Java/Kotlin, to call super
    * or when used inside a New.
    *)
-  cextends : type_ list;
+  cextends : type_ (* * arguments option*) list;
   (* the class_kind in type_ must be Interface *)
   cimplements : type_ list;
   (* the class_kind in type_ are usually Trait *)
@@ -1505,7 +1506,7 @@ and class_kind =
 (* for EnumClass, complex enums-as-classes in Java/Kotlin/Scala? *)
 and enum_entry_definition = {
   (* the enum identifier is in the corresponding entity *)
-  ee_args : arguments bracket option;
+  ee_args : arguments option;
   ee_body : field list bracket option;
 }
 

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -17,7 +17,7 @@
 (* Prelude *)
 (*****************************************************************************)
 (* A generic AST, to factorize similar "analysis" in different programming
- * languages (e.g., naming, semantic code highlighting, semgrep).
+ * languages (e.g., naming, semantic code highlighting, semgrep!).
  *
  * Right now this generic AST is mostly the factorized union of:
  *  - Python, Ruby, Lua
@@ -78,7 +78,7 @@
  * TODO? it may be time to rename this file CST_generic.ml
  *
  * todo:
- *  - add C++ (argh)
+ *  - add C++ (argh) and improve things for Kotlin/Scala/Rust
  *  - see ast_fuzzy.ml todos for ideas to use AST_generic for sgrep?
  *
  * related work:
@@ -182,7 +182,7 @@ type 'a bracket = tok * 'a * tok [@@deriving show, eq, hash]
  *)
 type sc = tok [@@deriving show, eq, hash]
 
-(* an AST element not yet handled; works with the Xx_Todo and Todo in any *)
+(* an AST element not yet handled *)
 type todo_kind = string wrap [@@deriving show, eq, hash]
 
 (*****************************************************************************)
@@ -1471,11 +1471,8 @@ and field =
 (* less: could be a special kind of type_definition *)
 and class_definition = {
   ckind : class_kind wrap;
-  (* 'cextends' contains usually 0 or 1 parent, and type_ should be TyN.
-   * This parent can have arguments, as in Scala/Java/Kotlin, to call super
-   * or when used inside a New.
-   *)
-  cextends : type_ (* * arguments option*) list;
+  (* 'cextends' contains usually 0 or 1 parent, and type_ should be TyN *)
+  cextends : class_parent list;
   (* the class_kind in type_ must be Interface *)
   cimplements : type_ list;
   (* the class_kind in type_ are usually Trait *)
@@ -1490,7 +1487,9 @@ and class_definition = {
   cbody : field list bracket;
 }
 
-(* invariant: this must remain a simple enum; Map_AST relies on it *)
+(* invariant: this must remain a simple enum; Map_AST relies on it.
+ * for EnumClass/AnnotationClass/etc. see keyword_attribute.
+ *)
 and class_kind =
   | Class
   | Interface
@@ -1498,7 +1497,14 @@ and class_kind =
   (* Kotlin/Scala *)
   | Object
 
-(* for EnumClass/AnnotationClass/etc. see keyword_attribute *)
+(* A parent can have arguments in Scala/Java/Kotlin (because constructors
+ * can be defined in the class header via cparams and then this class
+ * header can call its parent constructor using those cparams).
+ * alt: keep just 'type_' and add constructor calls in cbody.
+ *)
+and class_parent = type_
+
+(* TODO: * arguments option *)
 
 (* ------------------------------------------------------------------------- *)
 (* Enum entry  *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1130,7 +1130,7 @@ and attribute =
   (* a.k.a modifiers *)
   | KeywordAttr of keyword_attribute wrap
   (* a.k.a decorators, annotations *)
-  | NamedAttr of tok (* @ *) * name * arguments bracket
+  | NamedAttr of tok (* '@' *) * name * arguments bracket (* less: option *)
   (* per-language specific keywords like 'transient', 'synchronized' *)
   (* todo: Expr used for Python, but should transform in NamedAttr when can *)
   | OtherAttribute of todo_kind * any list

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1066,6 +1066,7 @@ and type_kind =
    * note: the type_ should always be a TyN, so really it's a TyNameApply
    * but it's simpler to not repeat TyN to factorize code in semgrep regarding
    * aliasing.
+   * TODO: could merge with TyN when name has proper qualifiers?
    *)
   | TyApply of type_ * type_arguments
   | TyVar of ident (* type variable in polymorphic types (not a typedef) *)
@@ -1469,8 +1470,8 @@ and field =
 (* less: could be a special kind of type_definition *)
 and class_definition = {
   ckind : class_kind wrap;
-  (* cextends contains usually just one parent, and type_ should be TyApply *)
-  (* TODO? the parent can have arguments, as in Scala, to call super
+  (* 'cextends' contains usually 0 or 1 parent, and type_ should be TyN.
+   * This parent can have arguments, as in Scala/Java/Kotlin, to call super
    * or when used inside a New.
    *)
   cextends : type_ list;
@@ -1479,7 +1480,7 @@ and class_definition = {
   (* the class_kind in type_ are usually Trait *)
   (* PHP 'uses' *)
   cmixins : type_ list;
-  (* for Java Record and Kotlin/Scala (we could transpile them into fields) *)
+  (* for Java/Kotlin/Scala RecordClass (we could transpile them into fields) *)
   cparams : parameters;
   (* newscope:
    * note: this can be an empty fake bracket when used in Partial.

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -276,7 +276,8 @@ let ac_matching_nf op args =
     with Exit ->
       logger#error
         "ac_matching_nf: %s(%s): unexpected ArgKwd | ArgType | ArgOther"
-        (show_operator op) (show_arguments args);
+        (show_operator op)
+        (show_arguments (fake_bracket args));
       None)
   else None
 

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -35,13 +35,6 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 let str_of_ident = fst
 
-let name_of_entity ent =
-  match ent.name with
-  | EN (Id (i, pinfo))
-  | EN (IdQualified ((i, _), pinfo)) ->
-      Some (i, pinfo)
-  | EDynamic _ -> None
-
 (* You can use 0 for globals, even though this will work only on a single
  * file. Any global analysis will need to set a unique ID for globals too. *)
 let gensym_counter = ref 0
@@ -51,17 +44,6 @@ let gensym_counter = ref 0
 let gensym () =
   incr gensym_counter;
   !gensym_counter
-
-(* before Naming_AST.resolve can do its job *)
-
-let name_of_ids ?(name_typeargs = None) xs =
-  match List.rev xs with
-  | [] -> failwith "name_of_ids: empty ids"
-  | [ x ] -> Id (x, empty_id_info ())
-  | x :: xs ->
-      let qualif = if xs = [] then None else Some (QDots (List.rev xs)) in
-      IdQualified
-        ((x, { name_qualifier = qualif; name_typeargs }), empty_id_info ())
 
 (* TODO: refactor name_qualifier and correctly handle this,
  * and factorize code in name_of_ids by calling this function.
@@ -81,6 +63,15 @@ let name_of_ids_with_opt_typeargs xs =
       IdQualified
         ( (x, { name_qualifier = qualif; name_typeargs = None (*TODO*) }),
           empty_id_info () )
+
+let name_of_ids ?(name_typeargs = None) xs =
+  match List.rev xs with
+  | [] -> failwith "name_of_ids: empty ids"
+  | [ x ] -> Id (x, empty_id_info ())
+  | x :: xs ->
+      let qualif = if xs = [] then None else Some (QDots (List.rev xs)) in
+      IdQualified
+        ((x, { name_qualifier = qualif; name_typeargs }), empty_id_info ())
 
 let name_of_id id = Id (id, empty_id_info ())
 

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -63,6 +63,25 @@ let name_of_ids ?(name_typeargs = None) xs =
       IdQualified
         ((x, { name_qualifier = qualif; name_typeargs }), empty_id_info ())
 
+(* TODO: refactor name_qualifier and correctly handle this,
+ * and factorize code in name_of_ids by calling this function.
+ *)
+let name_of_ids_with_opt_typeargs xs =
+  match List.rev xs with
+  | [] -> failwith "name_of_ids_with_opt_typeargs: empty ids"
+  | [ (x, None) ] -> Id (x, empty_id_info ())
+  | (x, _toptTODO) :: xs ->
+      let qualif =
+        if xs = [] then None
+        else
+          Some
+            (QDots
+               (xs |> List.rev |> List.map fst (* TODO use typeargs in xs!! *)))
+      in
+      IdQualified
+        ( (x, { name_qualifier = qualif; name_typeargs = None (*TODO*) }),
+          empty_id_info () )
+
 let name_of_id id = Id (id, empty_id_info ())
 
 let name_of_dot_access e =

--- a/semgrep-core/src/core/ast/AST_generic_helpers.mli
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.mli
@@ -29,6 +29,10 @@ val name_of_ids :
   AST_generic.dotted_ident ->
   AST_generic.name
 
+val name_of_ids_with_opt_typeargs :
+  (AST_generic.ident * AST_generic.type_arguments option) list ->
+  AST_generic.name
+
 (* Tries to re-interpreted a DotAccess expression a.b.c as an IdQualified. *)
 val name_of_dot_access : AST_generic.expr -> AST_generic.name option
 

--- a/semgrep-core/src/core/ast/AST_generic_helpers.mli
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.mli
@@ -54,7 +54,9 @@ val is_associative_operator : AST_generic.operator -> bool
 (** Test whether an operator is suitable for associative-matching.  *)
 
 val ac_matching_nf :
-  AST_generic.operator -> AST_generic.arguments -> AST_generic.expr list option
+  AST_generic.operator ->
+  AST_generic.argument list ->
+  AST_generic.expr list option
 (** [ac_matching_nf op args] converts the operands [args] of an
  * AC-operator [op] to a normal form (NF) better suited for AC-matching.
  * Essentially, we flatten out all [op]-operations. Note that this is not

--- a/semgrep-core/src/core/ast/AST_generic_helpers.mli
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.mli
@@ -19,9 +19,6 @@ val funcdef_to_lambda :
 
 val funcbody_to_stmt : AST_generic.function_body -> AST_generic.stmt
 
-val name_of_entity :
-  AST_generic.entity -> (AST_generic.ident * AST_generic.id_info) option
-
 val name_of_id : AST_generic.ident -> AST_generic.name
 
 val name_of_ids :

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -613,7 +613,10 @@ and vof_other_type_operator = function
   | OT_Lifetime -> OCaml.VSum ("OT_Lifetime", [])
 
 and vof_keyword_attribute = function
-  | CaseClass -> OCaml.VSum ("CaseClass", [])
+  | SealedClass -> OCaml.VSum ("SealedClass", [])
+  | AnnotationClass -> OCaml.VSum ("AnnotationClass", [])
+  | RecordClass -> OCaml.VSum ("RecordClass", [])
+  | EnumClass -> OCaml.VSum ("EnumClass", [])
   | Lazy -> OCaml.VSum ("Lazy", [])
   | Static -> OCaml.VSum ("Static", [])
   | Volatile -> OCaml.VSum ("Volatile", [])
@@ -1262,10 +1265,7 @@ and vof_class_kind_bis = function
   | Class -> OCaml.VSum ("Class", [])
   | Interface -> OCaml.VSum ("Interface", [])
   | Trait -> OCaml.VSum ("Trait", [])
-  | AtInterface -> OCaml.VSum ("AtInterface", [])
   | Object -> OCaml.VSum ("Object", [])
-  | RecordClass -> OCaml.VSum ("RecordClass", [])
-  | EnumClass -> OCaml.VSum ("EnumClass", [])
 
 and vof_ident_and_id_info (v1, v2) =
   let v1 = vof_ident v1 in

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -2533,18 +2533,12 @@ and m_class_kind_bis a b =
   | G.Class, B.Class
   | G.Interface, B.Interface
   | G.Trait, B.Trait
-  | G.AtInterface, B.AtInterface
-  | G.Object, B.Object
-  | G.EnumClass, B.EnumClass
-  | G.RecordClass, B.RecordClass ->
+  | G.Object, B.Object ->
       return ()
   | G.Class, _
   | G.Interface, _
   | G.Trait, _
-  | G.AtInterface, _
-  | G.Object, _
-  | G.EnumClass, _
-  | G.RecordClass, _ ->
+  | G.Object, _ ->
       fail ()
 
 (* ------------------------------------------------------------------------- *)

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -649,7 +649,7 @@ and v_modifier v : G.attribute =
 and v_modifier_kind = function
   | Abstract -> Left G.Abstract
   | Final -> Left G.Final
-  | Sealed -> Right "sealed"
+  | Sealed -> Left G.SealedClass
   | Implicit -> Right "implicit"
   | Lazy -> Left G.Lazy
   | Private v1 ->
@@ -659,7 +659,7 @@ and v_modifier_kind = function
       let _v1TODO = v_option (v_bracket v_ident_or_this) v1 in
       Left G.Protected
   | Override -> Left G.Override
-  | CaseClassOrObject -> Left G.CaseClass
+  | CaseClassOrObject -> Left G.RecordClass
   | PackageObject -> Right "PackageObject"
   | Val -> Left G.Const
   | Var -> Left G.Mutable

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -847,7 +847,7 @@ and v_template_definition
       cparams = v_cparams;
       cparents = v_cparents;
       cbody = v_cbody;
-    } : G.class_definition * G.arguments bracket list =
+    } : G.class_definition * G.arguments list =
   let ckind = v_wrap v_template_kind v_ckind in
   (* TODO? flatten? *)
   let cparams = v_list v_bindings v_cparams |> List.flatten in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2216,8 +2216,7 @@ and attribute (env : env) ((v1, v2) : CST.attribute) =
   (* TODO get the first [ as token here? *)
   G.NamedAttr (fake "[", v1, v2)
 
-and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
-    G.arguments bracket =
+and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) : G.arguments =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     match v2 with
@@ -2324,7 +2323,7 @@ and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
   v2
 
 and attribute_argument_list (env : env)
-    ((v1, v2, v3) : CST.attribute_argument_list) : arguments bracket =
+    ((v1, v2, v3) : CST.attribute_argument_list) : arguments =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     match v2 with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -650,8 +650,7 @@ and argument (env : env) (x : CST.argument) : G.argument =
       (* pattern \$\.\.\.[A-Z_][A-Z_0-9]* *)
       G.Arg (G.N (G.Id (str env tok, G.empty_id_info ())) |> G.e)
 
-and arguments (env : env) ((v1, v2, v3) : CST.arguments) : G.arguments G.bracket
-    =
+and arguments (env : env) ((v1, v2, v3) : CST.arguments) : G.arguments =
   let v1 = (* "(" *) token env v1 in
   let v2 =
     match v2 with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -160,20 +160,20 @@ let hex_literal (env : env) (tok : CST.hex_literal) =
   (int_of_string_opt s, t)
 
 let use_site_target (env : env) ((v1, v2) : CST.use_site_target) =
-  let v1 =
+  let s, t =
     match v1 with
-    | `Field tok -> token env tok (* "field" *)
-    | `Prop tok -> token env tok (* "property" *)
-    | `Get tok -> token env tok (* "get" *)
-    | `Set tok -> token env tok (* "set" *)
-    | `Rece tok -> token env tok (* "receiver" *)
-    | `Param tok -> token env tok (* "param" *)
-    | `Setp tok -> token env tok (* "setparam" *)
-    | `Dele tok -> token env tok
+    | `Field tok -> str env tok (* "field" *)
+    | `Prop tok -> str env tok (* "property" *)
+    | `Get tok -> str env tok (* "get" *)
+    | `Set tok -> str env tok (* "set" *)
+    | `Rece tok -> str env tok (* "receiver" *)
+    | `Param tok -> str env tok (* "param" *)
+    | `Setp tok -> str env tok (* "setparam" *)
+    | `Dele tok -> str env tok
     (* "delegate" *)
   in
   let _v2 = token env v2 (* ":" *) in
-  v1
+  (s, t)
 
 let additive_operator (env : env) (x : CST.additive_operator) =
   match x with
@@ -429,52 +429,42 @@ let import_header (env : env) ((v1, v2, v3, v4) : CST.import_header) : directive
 let rec _annotated_lambda (env : env) (v1 : CST.annotated_lambda) =
   lambda_literal env v1
 
-and annotation (env : env) (x : CST.annotation) : attribute =
+and annotation (env : env) (x : CST.annotation) : attribute list =
   match x with
   | `Single_anno (origv1, v2, v3) ->
       let v1 = token env origv1 (* "@" *) in
-      let v3 = unescaped_annotation env v3 in
-      let v2 =
+      let _v2TODO =
         match v2 with
         | Some x ->
             let v2 = use_site_target env x in
-            NamedAttr
-              ( v1,
-                Id (("use site target", v2), empty_id_info ()),
-                fake_bracket [ v3 ] )
-        | None ->
-            NamedAttr
-              (v1, Id (str env origv1, empty_id_info ()), fake_bracket [ v3 ])
+            Some v2
+        | None -> None
       in
-      v2
-  | `Multi_anno (origv1, v2, v3, v4, v5) ->
-      let v1 = token env origv1 (* "@" *) in
+      let n, args = unescaped_annotation env v3 in
+      [ NamedAttr (v1, n, args) ]
+  | `Multi_anno (v1, v2, v3, v4, v5) ->
+      let v1 = token env v1 (* "@" *) in
+      let _v2TODO =
+        match v2 with
+        | Some x ->
+            let v2 = use_site_target env x in
+            Some v2
+        | None -> None
+      in
       let _v3 = token env v3 (* "[" *) in
       let v4 = List.map (unescaped_annotation env) v4 in
       let _v5 = token env v5 (* "]" *) in
-      let v2 =
-        match v2 with
-        | Some x ->
-            let v2 = use_site_target env x in
-            NamedAttr
-              ( v1,
-                Id (("use site target", v2), empty_id_info ()),
-                fake_bracket v4 )
-        | None ->
-            NamedAttr
-              (v1, Id (str env origv1, empty_id_info ()), fake_bracket v4)
-      in
-      v2
+      v4 |> List.map (fun (n, args) -> NamedAttr (v1, n, args))
 
 and anon_choice_param_b77c1d8 (env : env) (x : CST.anon_choice_param_b77c1d8) =
   match x with
   | `Param x ->
       let v1, v2 = parameter env x in
-      let param = param_of_id v1 ~ptype:(Some v2) in
+      let param = G.param_of_id v1 ~ptype:(Some v2) in
       ParamClassic param
   | `Type x ->
       let v1 = type_ env x in
-      ParamClassic (param_of_type v1)
+      ParamClassic (G.param_of_type v1)
 
 and assignment (env : env) (x : CST.assignment) : expr =
   match x with
@@ -490,29 +480,28 @@ and binary_expression (env : env) (x : CST.binary_expression) =
       let v1 = expression env v1 in
       let v2, tok = multiplicative_operator env v2 in
       let v3 = expression env v3 in
-      (* TODO: use G.opcall *)
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Addi_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok = additive_operator env v2 in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Range_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok = (Range, token env v2) (* ".." *) in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Infix_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = simple_identifier env v2 in
-      let v2_id = N (Id (v2, empty_id_info ())) |> G.e in
+      let v2_id = N (H2.name_of_id v2) |> G.e in
       let v3 = expression env v3 in
-      Call (v2_id, fb [ Arg v1; Arg v3 ])
+      Call (v2_id, fb [ Arg v1; Arg v3 ]) |> G.e
   | `Elvis_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok = (Elvis, token env v2) (* "?:" *) in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Check_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok =
@@ -521,27 +510,27 @@ and binary_expression (env : env) (x : CST.binary_expression) =
         | `Is_op x -> is_operator env x
       in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Comp_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok = comparison_operator env v2 in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Equa_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok = equality_operator env v2 in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Conj_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok = (And, token env v2) (* "&&" *) in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
   | `Disj_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2, tok = (Or, token env v2) (* "||" *) in
       let v3 = expression env v3 in
-      Call (IdSpecial (Op v2, tok) |> G.e, fb [ Arg v1; Arg v3 ])
+      G.opcall (v2, tok) [ v1; v3 ]
 
 and block (env : env) ((v1, v2, v3) : CST.block) =
   let v1 = token env v1 (* "{" *) in
@@ -561,7 +550,7 @@ and call_suffix (env : env) (v1 : CST.call_suffix) =
         | Some x -> value_arguments env x
         | None -> fake_bracket []
       in
-      (*let v2 = annotated_lambda env v2 in*)
+      (*TODO let v2 = annotated_lambda env v2 in*)
       v1
   | `Value_args x -> value_arguments env x
 
@@ -846,9 +835,8 @@ and constructor_delegation_call (env : env)
 
 and constructor_invocation (env : env) ((v1, v2) : CST.constructor_invocation) =
   let v1 = user_type env v1 in
-  let _v2 = value_arguments env v2 in
-  (* TODO: add in v2 *)
-  v1
+  let v2 = value_arguments env v2 in
+  (v1, v2)
 
 and control_structure_body (env : env) (x : CST.control_structure_body) : stmt =
   match x with
@@ -990,17 +978,23 @@ and declaration (env : env) (x : CST.declaration) : definition =
 
 and delegation_specifier (env : env) (x : CST.delegation_specifier) : type_ =
   match x with
-  | `Cons_invo x -> constructor_invocation env x
+  | `Cons_invo x ->
+      let _n, _args = constructor_invocation env x in
+      failwith "TODO"
   | `Expl_dele (v1, v2, v3) ->
       let v1 =
         match v1 with
-        | `User_type x -> user_type env x
+        | `User_type x ->
+            let n = user_type env x in
+            TyN n |> G.t
         | `Func_type x -> function_type env x
       in
       let v2 = token env v2 (* "by" *) in
       let v3 = expression env v3 in
       OtherType (OT_Todo, [ TodoK ("ByDelagation", v2); G.T v1; G.E v3 ]) |> G.t
-  | `User_type x -> user_type env x
+  | `User_type x ->
+      let n = user_type env x in
+      TyN n |> G.t
   | `Func_type x -> function_type env x
 
 and delegation_specifiers (env : env) ((v1, v2) : CST.delegation_specifiers) :
@@ -1080,8 +1074,8 @@ and expression (env : env) (x : CST.expression) : expr =
   match x with
   | `Choice_un_exp x -> (
       match x with
-      | `Un_exp x -> unary_expression env x |> G.e
-      | `Bin_exp x -> binary_expression env x |> G.e
+      | `Un_exp x -> unary_expression env x
+      | `Bin_exp x -> binary_expression env x
       | `Prim_exp x -> primary_expression env x)
   | `Ellips x -> Ellipsis (token env x) |> G.e
   | `Deep_ellips (x1, x2, x3) ->
@@ -1430,7 +1424,8 @@ and modifiers (env : env) (xs : CST.modifiers) : attribute list =
   xs
   |> List.map (function
        | `Anno x -> annotation env x
-       | `Modi x -> modifier env x)
+       | `Modi x -> [ modifier env x ])
+  |> List.flatten
 
 and navigation_suffix (env : env) ((v1, v2) : CST.navigation_suffix) =
   let op = member_access_operator env v1 in
@@ -1449,8 +1444,9 @@ and navigation_suffix (env : env) ((v1, v2) : CST.navigation_suffix) =
   in
   fun e ->
     match op with
-    | Left tdot -> DotAccess (e, tdot, fld)
-    | Right otherop -> OtherExpr (OE_Todo, [ TodoK otherop; NoD fld; E e ])
+    | Left tdot -> DotAccess (e, tdot, fld) |> G.e
+    | Right otherop ->
+        OtherExpr (OE_Todo, [ TodoK otherop; NoD fld; E e ]) |> G.e
 
 and nullable_type (env : env) ((v1, v2) : CST.nullable_type) =
   let v1 =
@@ -1474,7 +1470,8 @@ and parameter_modifiers (env : env) (xs : CST.parameter_modifiers) =
   xs
   |> List.map (function
        | `Anno x -> annotation env x
-       | `Param_modi x -> parameter_modifier env x)
+       | `Param_modi x -> [ parameter_modifier env x ])
+  |> List.flatten
 
 and parameter_with_optional_type (env : env)
     ((v1, v2, v3) : CST.parameter_with_optional_type) : parameter_classic =
@@ -1835,15 +1832,15 @@ and type_constraints (env : env) ((v1, v2, v3) : CST.type_constraints) =
   in
   v2 :: v3
 
-and type_modifier (env : env) (x : CST.type_modifier) : attribute =
+and type_modifier (env : env) (x : CST.type_modifier) : attribute list =
   match x with
   | `Anno x -> annotation env x
   | `Susp tok ->
       let x = str env tok (* "suspend" *) in
-      G.unhandled_keywordattr x
+      [ G.unhandled_keywordattr x ]
 
 and type_modifiers (env : env) (xs : CST.type_modifiers) : attribute list =
-  List.map (type_modifier env) xs
+  List.map (type_modifier env) xs |> List.flatten
 
 and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
   let tp_modifiers =
@@ -1861,6 +1858,7 @@ and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
     | None -> []
   in
   let tp_attrs, variances = Common.partition_either (fun x -> x) tp_modifiers in
+  let tp_attrs = List.flatten tp_attrs in
   let tp_variance =
     match variances with
     | [] -> None
@@ -1874,7 +1872,7 @@ and type_parameter_modifier (env : env) (x : CST.type_parameter_modifier) =
   | `Reif_modi tok ->
       let x = str env tok in
       (* "reified" *)
-      Left (unhandled_keywordattr x)
+      Left [ unhandled_keywordattr x ]
   | `Vari_modi x -> Right (type_projection_modifier env x)
   | `Anno x -> Left (annotation env x)
 
@@ -1911,7 +1909,9 @@ and type_projection (env : env) ~tok (x : CST.type_projection) =
 
 and type_reference (env : env) (x : CST.type_reference) =
   match x with
-  | `User_type x -> user_type env x
+  | `User_type x ->
+      let n = user_type env x in
+      TyN n |> G.t
   | `Dyna tok (* "dynamic" *) -> TyBuiltin (str env tok) |> G.t
 
 and unary_expression (env : env) (x : CST.unary_expression) =
@@ -1920,19 +1920,16 @@ and unary_expression (env : env) (x : CST.unary_expression) =
       let v1 = expression env v1 in
       let v2, v3 = postfix_unary_operator env v2 in
       match v2 with
-      | Left incr_decr ->
-          Call
-            (IdSpecial (IncrDecr (incr_decr, Postfix), v3) |> G.e, fb [ Arg v1 ])
-      | Right operator ->
-          Call (IdSpecial (Op operator, v3) |> G.e, fb [ Arg v1 ]))
+      | Left incr_decr -> G.special (IncrDecr (incr_decr, Postfix), v3) []
+      | Right operator -> G.special (Op operator, v3) [ v1 ])
   | `Call_exp (v1, v2) ->
       let v1 = expression env v1 in
       let v2 = call_suffix env v2 in
-      Call (v1, v2)
+      Call (v1, v2) |> G.e
   | `Inde_exp (v1, v2) ->
       let v1 = expression env v1 in
       let v2 = indexing_suffix env v2 in
-      Call (v1, v2)
+      Call (v1, v2) |> G.e
   | `Navi_exp (v1, v2) ->
       let v1 = expression env v1 in
       let v2 = navigation_suffix env v2 in
@@ -1950,33 +1947,31 @@ and unary_expression (env : env) (x : CST.unary_expression) =
       in
       let v2 = expression env v2 in
       match v1 with
-      | None -> v2.G.e
+      | None -> v2
       | Some (Left incr_decr, tok) ->
-          Call
-            ( IdSpecial (IncrDecr (incr_decr, Postfix), tok) |> G.e,
-              fb [ Arg v2 ] )
-      | Some (Right operator, tok) ->
-          Call (IdSpecial (Op operator, tok) |> G.e, fb [ Arg v2 ]))
+          G.special (IncrDecr (incr_decr, Postfix), tok) [ v2 ]
+      | Some (Right operator, tok) -> G.opcall (operator, tok) [ v2 ])
   | `As_exp (v1, v2, v3) ->
       let v1 = expression env v1 in
       let v2 = as_operator env v2 in
       let v3 = type_ env v3 in
-      Cast (v3, v2, v1)
+      Cast (v3, v2, v1) |> G.e
   | `Spread_exp (v1, v2) ->
       let v1 = token env v1 (* "*" *) in
       let v2 = expression env v2 in
-      Call (IdSpecial (Spread, v1) |> G.e, fb [ Arg v2 ])
+      G.special (Spread, v1) [ v2 ]
 
-and unescaped_annotation (env : env) (x : CST.unescaped_annotation) =
+and unescaped_annotation (env : env) (x : CST.unescaped_annotation) :
+    name * arguments bracket =
   match x with
   | `Cons_invo x ->
       let v1 = constructor_invocation env x in
-      ArgType v1
+      v1
   | `User_type x ->
       let v1 = user_type env x in
-      ArgType v1
+      (v1, fb [])
 
-and user_type (env : env) ((v1, v2) : CST.user_type) =
+and user_type (env : env) ((v1, v2) : CST.user_type) : name =
   let v1 = simple_user_type env v1 in
   let v2 =
     List.map
@@ -1986,9 +1981,8 @@ and user_type (env : env) ((v1, v2) : CST.user_type) =
         v2)
       v2
   in
-  let list = v1 :: v2 in
-  (* TODO: need extend type qualifier, it is not a TyTuple but a TyN! *)
-  TyTuple (fake_bracket list) |> G.t
+  let _list = v1 :: v2 in
+  failwith "TODO"
 
 and value_argument (env : env) ((v1, v2, v3, v4) : CST.value_argument) :
     argument =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -1961,7 +1961,7 @@ and unary_expression (env : env) (x : CST.unary_expression) =
       G.special (Spread, v1) [ v2 ]
 
 and unescaped_annotation (env : env) (x : CST.unescaped_annotation) :
-    name * arguments bracket =
+    name * arguments =
   match x with
   | `Cons_invo x ->
       let v1 = constructor_invocation env x in
@@ -2012,8 +2012,8 @@ and value_argument (env : env) ((v1, v2, v3, v4) : CST.value_argument) :
   | None -> Arg e
   | Some (id, _t) -> ArgKwd (id, e)
 
-and value_arguments (env : env) ((v1, v2, v3) : CST.value_arguments) :
-    arguments bracket =
+and value_arguments (env : env) ((v1, v2, v3) : CST.value_arguments) : arguments
+    =
   let v1 = token env v1 (* "(" *) in
   let v2 =
     match v2 with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -224,11 +224,11 @@ and map_expression_tuple (env : env)
   G.Container (G.Tuple, G.fake_bracket v1) |> G.e
 
 and map_anon_arguments (env : env)
-    ((v1, v2) : CST.anon_exp_rep_COMMA_exp_0bb260c) : G.arguments =
+    ((v1, v2) : CST.anon_exp_rep_COMMA_exp_0bb260c) : G.argument list =
   let v1 = map_expression_list env (v1, v2) in
   List.map (fun (v1 : G.expr) -> G.Arg v1) v1
 
-and map_arguments (env : env) (x : CST.arguments) : G.arguments G.bracket =
+and map_arguments (env : env) (x : CST.arguments) : G.arguments =
   match x with
   | `LPAR_opt_exp_rep_COMMA_exp_RPAR (v1, v2, v3) ->
       let v1 = token env v1 (* "(" *) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -804,7 +804,7 @@ and map_tuple_pattern_list (env : env)
   pattern_first :: pattern_rest
 
 and map_arguments (env : env) ((v1, v2, _v3TODO, v4) : CST.arguments) :
-    G.arguments G.bracket =
+    G.arguments =
   let lparen = token env v1 (* "(" *) in
   let args =
     match v2 with

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -34,6 +34,7 @@ module SJ = Semgrep_core_response_j (* JSON conversions *)
  * the callers of semgrep (semgrep python) can check if multiple metavariables
  * reference the same entity, or reference exactly the same code.
  * See Naming_AST.ml for more information.
+ * TODO: can we delete now that the boolean logic is done in semgrep-core?
  *)
 let unique_id any =
   match any with

--- a/semgrep-core/tests/kotlin/parsing/navigation.kt
+++ b/semgrep-core/tests/kotlin/parsing/navigation.kt
@@ -1,0 +1,3 @@
+fun main(args: Array<String>) {
+    val x = args.foo
+}


### PR DESCRIPTION
This will help PA-406

test plan:

See the correct DotAccess now below (it was a Call before).

```
 /home/pad/yy/_build/default/src/cli/Main.exe -lang kt -dump_ast tests/kotlin/parsing/navigation.kt
[0.062  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.062  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang kt -dump_ast tests/kotlin/parsing/navigation.kt
[0.062  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.66.0-28-g60b07ff3-dirty, pfff: 0.42
[0.062  Info       Main.Parse_target    ] trying to parse with TreeSitter parser tests/kotlin/parsing/navigation.kt
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("main", ()),
                {id_resolved=Ref(None); id_type=Ref(None);
                 id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      FuncDef(
        {fkind=(Function, ());
         fparams=[ParamClassic(
                    {pname=Some(("args", ())); pdefault=None;
                     ptype=Some({t_attrs=[];
                                 t=TyTuple(
                                     [{t_attrs=[];
                                       t=TyApply(
                                           {t_attrs=[];
                                            t=TyN(
                                                Id(("Array", ()),
                                                  {id_resolved=Ref(None);
                                                   id_type=Ref(None);
                                                   id_constness=Ref(None); }));
                                            },
                                           [OtherTypeArg(("Projection", ()),
                                              [T(
                                                 {t_attrs=[];
                                                  t=TyTuple(
                                                      [{t_attrs=[];
                                                        t=TyN(
                                                            Id(
                                                              ("String", ()),
                                                              {
                                                               id_resolved=Ref(
                                                               None);
                                                               id_type=Ref(
                                                               None);
                                                               id_constness=Ref(
                                                               None); }));
                                                        }]);
                                                  })])]);
                                       }]);
                                 });
                     pattrs=[];
                     pinfo={id_resolved=Ref(Some((Param, -1)));
                            id_type=Ref(None); id_constness=Ref(None); };
                     })];
         frettype=None;
         fbody=FBStmt(
                 Block(
                   [DefStmt(
                      ({
                        name=EN(
                               Id(("x", ()),
                                 {id_resolved=Ref(None); id_type=Ref(
                                  None); id_constness=Ref(None); }));
                        attrs=[]; tparams=[]; },
                       VarDef(
                         {
                          vinit=Some(DotAccess(
                                       N(
                                         Id(("args", ()),
                                           {id_resolved=Ref(None);
                                            id_type=Ref(None);
                                            id_constness=Ref(None); })), (),
                                       EN(
                                         Id(("foo", ()),
                                           {id_resolved=Ref(None);
                                            id_type=Ref(None);
                                            id_constness=Ref(None); }))));
                          vtype=None; })))]));
         })))])
```


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)