### PR TITLE
[Kotlin] add arguments to inherited parents

### DIFF
--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -1111,7 +1111,7 @@ and map_class_definition
   let v_cparams = map_parameters v_cparams in
   let v_cmixins = map_of_list map_type_ v_cmixins in
   let v_cimplements = map_of_list map_type_ v_cimplements in
-  let v_cextends = map_of_list map_type_ v_cextends in
+  let v_cextends = map_of_list map_class_parent v_cextends in
   let v_ckind = map_wrap map_class_kind v_ckind in
   {
     B.ckind = v_ckind;
@@ -1121,6 +1121,8 @@ and map_class_definition
     cmixins = v_cmixins;
     cparams = v_cparams;
   }
+
+and map_class_parent (_v1, _v2) = failwith "TODO"
 
 and map_class_kind = function
   | Class -> `Class

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1502,9 +1502,7 @@ and class_kind =
  * header can call its parent constructor using those cparams).
  * alt: keep just 'type_' and add constructor calls in cbody.
  *)
-and class_parent = type_
-
-(* TODO: * arguments option *)
+and class_parent = type_ * arguments option
 
 (* ------------------------------------------------------------------------- *)
 (* Enum entry  *)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -139,6 +139,10 @@ let expr_to_type e =
   (* TODO: diconstruct e and generate the right type (TyBuiltin, ...) *)
   OtherType (OT_Expr, [ E e ]) |> G.t
 
+(* TODO: recognize foo(args)? like in Kotlin/Java *)
+let expr_to_class_parent e : class_parent =
+  (OtherType (OT_Expr, [ E e ]) |> G.t, None)
+
 (* See also exprstmt, and stmt_to_expr in AST_generic.ml *)
 
 (* old: there was a stmt_to_item before *)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.mli
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.mli
@@ -9,6 +9,8 @@ val pattern_to_expr : AST_generic.pattern -> AST_generic.expr
 
 val expr_to_type : AST_generic.expr -> AST_generic.type_
 
+val expr_to_class_parent : AST_generic.expr -> AST_generic.class_parent
+
 val vardef_to_assign :
   AST_generic.entity * AST_generic.variable_definition -> AST_generic.expr
 

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -1009,7 +1009,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let v_cbody = map_bracket (map_of_list map_field) v_cbody in
     let v_cmixins = map_of_list map_type_ v_cmixins in
     let v_cimplements = map_of_list map_type_ v_cimplements in
-    let v_cextends = map_of_list map_type_ v_cextends in
+    let v_cextends = map_of_list map_class_parent v_cextends in
     let v_ckind = map_class_kind v_ckind in
     let cparams = map_parameters cparams in
     {
@@ -1021,6 +1021,10 @@ let (mk_visitor : visitor_in -> visitor_out) =
       cparams;
     }
   and map_class_kind (x, t) = (x, map_tok t)
+  and map_class_parent (v1, v2) =
+    let v1 = map_type_ v1 in
+    let v2 = map_of_option map_arguments v2 in
+    (v1, v2)
   and map_directive { d; d_attrs } =
     let d = map_directive_kind d in
     let d_attrs = map_of_list map_attribute d_attrs in

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -1251,13 +1251,18 @@ and vof_class_definition
   let arg = OCaml.vof_list vof_type_ v_cimplements in
   let bnd = ("cimplements", arg) in
   let bnds = bnd :: bnds in
-  let arg = OCaml.vof_list vof_type_ v_cextends in
+  let arg = OCaml.vof_list vof_class_parent v_cextends in
   let bnd = ("cextends", arg) in
   let bnds = bnd :: bnds in
   let arg = vof_class_kind v_ckind in
   let bnd = ("ckind", arg) in
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
+
+and vof_class_parent (v1, v2) =
+  let v1 = vof_type_ v1 in
+  let v2 = OCaml.vof_option vof_arguments v2 in
+  OCaml.VTuple [ v1; v2 ]
 
 and vof_class_kind x = vof_wrap vof_class_kind_bis x
 

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1149,7 +1149,7 @@ let (mk_visitor :
           cparams;
         } =
       let arg = v_class_kind v_ckind in
-      let arg = v_list v_type_ v_cextends in
+      let arg = v_list v_class_parent v_cextends in
       let arg = v_list v_type_ v_cimplements in
       let arg = v_list v_type_ v_mixins in
       v_parameters cparams;
@@ -1158,6 +1158,9 @@ let (mk_visitor :
     in
     vin.kclass_definition (k, all_functions) x
   and v_class_kind (_x, t) = v_tok t
+  and v_class_parent (v1, v2) =
+    v_type_ v1;
+    v_option v_arguments v2
   and v_module_definition { mbody = v_mbody } =
     let arg = v_module_definition_kind v_mbody in
     ()

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -433,9 +433,10 @@ and type_ v =
   let v = expr v in
   H.expr_to_type v
 
-and type_parent v =
+(* TODO: recognize idioms? *)
+and type_parent v : G.class_parent =
   let v = argument v in
-  G.OtherType (G.OT_Arg, [ G.Ar v ]) |> G.t
+  (G.OtherType (G.OT_Arg, [ G.Ar v ]) |> G.t, None)
 
 and list_stmt1 xs =
   match list stmt xs with

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -279,7 +279,7 @@ and expr e =
             G.AnonClass
               {
                 G.ckind = (G.Class, v0);
-                cextends = [ v1 ];
+                cextends = [ (v1, None) ];
                 cimplements = [];
                 cmixins = [];
                 cparams = [];
@@ -398,6 +398,10 @@ and expr e =
       let x = G.stmt_to_expr (G.Switch (v0, Some v1, v2) |> G.s) in
       x.G.e)
   |> G.e
+
+and class_parent v : G.class_parent =
+  let v = ref_type v in
+  (v, None)
 
 and expr_or_type = function
   | Left e -> G.E (expr e)
@@ -583,7 +587,7 @@ and field v = var_with_init v
 and enum_decl { en_name; en_mods; en_impls; en_body } =
   let v1 = ident en_name in
   let v2 = modifiers en_mods in
-  let v3 = list ref_type en_impls in
+  let v3 = list class_parent en_impls in
   let v4, v5 = en_body in
   let v4 = list enum_constant v4 |> List.map G.fld in
   let v5 = decls v5 |> List.map (fun st -> G.FieldStmt st) in
@@ -628,7 +632,7 @@ and class_decl
   let v2, more_attrs = class_kind_and_more cl_kind in
   let v3 = list type_parameter cl_tparams in
   let v4 = modifiers cl_mods in
-  let v5 = option typ cl_extends in
+  let v5 = option class_parent cl_extends in
   let v6 = list ref_type cl_impls in
   let cparams = parameters cl_formals in
   let fields = class_body cl_body in

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -614,8 +614,8 @@ and obj_ v = bracket (list property) v
 and parent = function
   | Left e ->
       let e = expr e in
-      H.expr_to_type e
-  | Right t -> type_ t
+      H.expr_to_class_parent e
+  | Right t -> (type_ t, None)
 
 and class_ { c_extends; c_implements; c_body; c_kind; c_attrs } =
   let cextends = list parent c_extends in

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -571,7 +571,7 @@ and class_def
 
   let id = ident c_name in
   let kind = class_kind c_kind in
-  let extends = option class_name c_extends in
+  let extends = option class_parent c_extends in
   let implements = list class_name c_implements in
   let uses = list class_name c_uses in
 
@@ -607,6 +607,10 @@ and class_def
     }
   in
   (ent, def)
+
+and class_parent x : G.class_parent =
+  let x = class_name x in
+  (x, None)
 
 and class_kind (x, t) =
   match x with

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -569,7 +569,7 @@ and definition def =
             | None -> []
             | Some (_t2, e) ->
                 let e = expr e in
-                [ H.expr_to_type e ]
+                [ H.expr_to_class_parent e ]
           in
           let ent =
             match name with

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -357,31 +357,32 @@ and v_pattern = function
       let v1 = v_pattern v1 and _v2 = v_tok v2 and v3 = v_pattern v3 in
       G.PatDisj (v1, v3)
 
-and todo_expr msg any = G.OtherExpr (G.OE_Todo, G.TodoK (msg, fake msg) :: any)
+and todo_expr msg any =
+  G.OtherExpr (G.OE_Todo, G.TodoK (msg, fake msg) :: any) |> G.e
 
-and v_expr e =
-  (match e with
-  | Ellipsis v1 -> G.Ellipsis v1
-  | DeepEllipsis v1 -> G.DeepEllipsis (v_bracket v_expr v1)
+and v_expr e : G.expr =
+  match e with
+  | Ellipsis v1 -> G.Ellipsis v1 |> G.e
+  | DeepEllipsis v1 -> G.DeepEllipsis (v_bracket v_expr v1) |> G.e
   | L v1 -> (
       let v1 = v_literal v1 in
       match v1 with
-      | Left lit -> G.L lit
-      | Right e -> e.G.e)
+      | Left lit -> G.L lit |> G.e
+      | Right e -> e)
   | Tuple v1 ->
       let v1 = v_bracket (v_list v_expr) v1 in
-      G.Container (G.Tuple, v1)
+      G.Container (G.Tuple, v1) |> G.e
   | Name v1 ->
       let sref, ids = v_path v1 in
       let start =
         match sref with
-        | Left id -> G.N (H.name_of_id id)
-        | Right e -> e.G.e
+        | Left id -> G.N (H.name_of_id id) |> G.e
+        | Right e -> e
       in
       ids
       |> List.fold_left
            (fun acc fld ->
-             G.DotAccess (acc |> G.e, fake ".", G.EN (H.name_of_id fld)))
+             G.DotAccess (acc, fake ".", G.EN (H.name_of_id fld)) |> G.e)
            start
   | ExprUnderscore v1 ->
       let v1 = v_tok v1 in
@@ -391,56 +392,48 @@ and v_expr e =
       todo_expr "InstanciatedExpr" (G.E v1 :: List.map (fun t -> G.T t) v2)
   | TypedExpr (v1, v2, v3) ->
       let v1 = v_expr v1 and v2 = v_tok v2 and v3 = v_ascription v3 in
-      G.Cast (v3, v2, v1)
+      G.Cast (v3, v2, v1) |> G.e
   | DotAccess (v1, v2, v3) ->
       let v1 = v_expr v1 and v2 = v_tok v2 and v3 = v_ident v3 in
       let name = H.name_of_id v3 in
-      G.DotAccess (v1, v2, G.EN name)
+      G.DotAccess (v1, v2, G.EN name) |> G.e
   | Apply (v1, v2) ->
       let v1 = v_expr v1 and v2 = v_list v_arguments v2 in
-      let x = v2 |> List.fold_left (fun acc xs -> G.Call (acc, xs) |> G.e) v1 in
-      x.G.e
+      v2 |> List.fold_left (fun acc xs -> G.Call (acc, xs) |> G.e) v1
   | Infix (v1, v2, v3) ->
       let v1 = v_expr v1 and v2 = v_ident v2 and v3 = v_expr v3 in
-      G.Call (G.N (H.name_of_id v2) |> G.e, fb [ G.Arg v1; G.Arg v3 ])
+      G.Call (G.N (H.name_of_id v2) |> G.e, fb [ G.Arg v1; G.Arg v3 ]) |> G.e
   | Prefix (v1, v2) ->
       let v1 = v_op v1 and v2 = v_expr v2 in
-      G.Call (G.N (H.name_of_id v1) |> G.e, fb [ G.Arg v2 ])
+      G.Call (G.N (H.name_of_id v1) |> G.e, fb [ G.Arg v2 ]) |> G.e
   | Postfix (v1, v2) ->
       let v1 = v_expr v1 and v2 = v_ident v2 in
-      G.Call (G.N (H.name_of_id v2) |> G.e, fb [ G.Arg v1 ])
+      G.Call (G.N (H.name_of_id v2) |> G.e, fb [ G.Arg v1 ]) |> G.e
   | Assign (v1, v2, v3) ->
       let v1 = v_lhs v1 and v2 = v_tok v2 and v3 = v_expr v3 in
-      G.Assign (v1, v2, v3)
+      G.Assign (v1, v2, v3) |> G.e
   | Lambda v1 ->
       let v1 = v_function_definition v1 in
-      G.Lambda v1
+      G.Lambda v1 |> G.e
   | New (v1, v2) ->
-      let v1 = v_tok v1 and v2, argss = v_template_definition v2 in
+      let v1 = v_tok v1 and v2 = v_template_definition v2 in
       let cl = G.AnonClass v2 |> G.e in
-      let special = G.IdSpecial (G.New, v1) |> G.e in
-      let start = G.Call (special, fb [ G.Arg cl ]) in
-      argss |> List.fold_left (fun acc args -> G.Call (acc |> G.e, args)) start
+      G.special (G.New, v1) [ cl ]
   | BlockExpr v1 -> (
       let lb, kind, _rb = v_block_expr v1 in
       match kind with
-      | Left stats ->
-          let x = expr_of_block stats in
-          x.G.e
-      | Right cases -> G.Lambda (cases_to_lambda lb cases))
+      | Left stats -> expr_of_block stats
+      | Right cases -> G.Lambda (cases_to_lambda lb cases) |> G.e)
   (* TODO: should move Match under S in ast_scala.ml *)
   | Match (v1, v2, v3) ->
       let v1 = v_expr v1
       and v2 = v_tok v2
       and v3 = v_bracket v_case_clauses v3 in
       let st = G.Match (v2, v1, G.unbracket v3) |> G.s in
-      let x = G.stmt_to_expr st in
-      x.G.e
+      G.stmt_to_expr st
   | S v1 ->
       let v1 = v_stmt v1 in
-      let x = G.stmt_to_expr v1 in
-      x.G.e)
-  |> G.e
+      G.stmt_to_expr v1
 
 (* alt: transform in a series of Seq? *)
 and expr_of_block xs : G.expr =
@@ -762,7 +755,7 @@ and v_definition_kind = function
       let v1 = v_type_definition v1 in
       G.TypeDef v1
   | Template v1 ->
-      let v1, _argssTODO = v_template_definition v1 in
+      let v1 = v_template_definition v1 in
       G.ClassDef v1
 
 and v_function_definition
@@ -847,30 +840,36 @@ and v_template_definition
       cparams = v_cparams;
       cparents = v_cparents;
       cbody = v_cbody;
-    } : G.class_definition * G.arguments list =
+    } : G.class_definition =
   let ckind = v_wrap v_template_kind v_ckind in
   (* TODO? flatten? *)
   let cparams = v_list v_bindings v_cparams |> List.flatten in
-  let (cextends, cmixins), argss = v_template_parents v_cparents in
+  let cextends, cmixins = v_template_parents v_cparents in
   let body = v_option v_template_body v_cbody in
   let cbody =
     match body with
     | None -> G.empty_body
     | Some (lb, xs, rb) -> (lb, xs |> List.map (fun st -> G.FieldStmt st), rb)
   in
-  ({ G.ckind; cextends; cmixins; cimplements = []; cparams; cbody }, argss)
+  { G.ckind; cextends; cmixins; cimplements = []; cparams; cbody }
 
 and v_template_parents { cextends = v_cextends; cwith = v_cwith } =
-  let parent, argss =
+  let parents =
     match v_cextends with
-    | None -> ([], [])
+    | None -> []
     | Some (v1, v2) ->
         let v1 = v_type_ v1 in
         let v2 = v_list v_arguments v2 in
-        ([ v1 ], v2)
+        let parent =
+          match v2 with
+          | [] -> (v1, None)
+          | [ args ] -> (v1, Some args)
+          | args :: _otherargsTODO -> (v1, Some args)
+        in
+        [ parent ]
   in
   let v2 = v_list v_type_ v_cwith in
-  ((parent, v2), argss)
+  (parents, v2)
 
 and v_template_body v =
   v_bracket

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2438,7 +2438,7 @@ let enum_member_declaration (env : env)
   let v3 = map_opt equals_value_clause env v3 in
   OrEnum (v2, v3)
 
-let base_list (env : env) ((v1, v2, v3) : CST.base_list) =
+let base_list (env : env) ((v1, v2, v3) : CST.base_list) : G.class_parent list =
   let v1 = token env v1 (* ":" *) in
   let v2 = type_constraint env v2 in
   let v3 =
@@ -2449,7 +2449,7 @@ let base_list (env : env) ((v1, v2, v3) : CST.base_list) =
         v2)
       v3
   in
-  v2 :: v3
+  v2 :: v3 |> List.map (fun t -> (t, None))
 
 let accessor_list (env : env) ((v1, v2, v3) : CST.accessor_list) =
   let v1 = token env v1 (* "{" *) in
@@ -2639,7 +2639,7 @@ and enum_declaration env (v1, v2, v3, v4, v5, v6, v7) =
   let v2 = List.map (modifier env) v2 in
   let v3 = token env v3 (* "enum" *) in
   let v4 = identifier env v4 (* identifier *) in
-  let v5 =
+  let v5TODO =
     match v5 with
     | Some x -> base_list env x
     | None -> []

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -1718,7 +1718,8 @@ and expression_statement (env : env) ((v1, v2) : CST.expression_statement) =
   let v2 = (* ";" *) token env v2 in
   G.ExprStmt (v1, v2)
 
-and extends_clause (env : env) ((v1, v2, v3) : CST.extends_clause) =
+and extends_clause (env : env) ((v1, v2, v3) : CST.extends_clause) :
+    G.class_parent list =
   let _v1 = (* "extends" *) token env v1 in
   let v2 = type_ env v2 in
   let v3 =
@@ -1729,7 +1730,7 @@ and extends_clause (env : env) ((v1, v2, v3) : CST.extends_clause) =
         v2)
       v3
   in
-  v2 :: v3
+  v2 :: v3 |> List.map (fun ty -> (ty, None))
 
 and field_initializer (env : env) ((v1, v2, v3) : CST.field_initializer) =
   let v1 =

--- a/semgrep-core/tests/kotlin/parsing/parent_with_args.kt
+++ b/semgrep-core/tests/kotlin/parsing/parent_with_args.kt
@@ -1,0 +1,3 @@
+open class Base(p: Int)
+
+class Derived(p: Int) : Base(p)


### PR DESCRIPTION
This will help PA-406
This is also useful for Scala

test plan:
```
pad@yrax yy (class_parent)]$ yy -lang kt -dump_ast tests/kotlin/parsing/parent_with_args.kt
+ /home/pad/yy/_build/default/src/cli/Main.exe -lang kt -dump_ast tests/kotlin/parsing/parent_with_args.kt
[0.059  Info       Main.Dune__exe__Main ] loaded log_config.json
[0.059  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -lang kt -dump_ast tests/kotlin/parsing/parent_with_args.kt
[0.059  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.67.0-6-g542f8237-dirty, pfff: 0.42
[0.059  Info       Main.Parse_target    ] trying to parse with TreeSitter parser tests/kotlin/parsing/parent_with_args.kt
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("Base", ()),
                {id_resolved=Ref(None); id_type=Ref(None);
                 id_constness=Ref(None); }));
       attrs=[NamedAttr((),
                Id(("open", ()),
                  {id_resolved=Ref(None); id_type=Ref(None);
                   id_constness=Ref(None); }), [])];
       tparams=[]; },
      ClassDef(
        {ckind=(Class, ()); cextends=[]; cimplements=[]; cmixins=[];
         cparams=[ParamClassic(
                    {pname=Some(("p", ())); pdefault=None;
                     ptype=Some({t_attrs=[];
                                 t=TyN(
                                     Id(("Int", ()),
                                       {id_resolved=Ref(None);
                                        id_type=Ref(None);
                                        id_constness=Ref(None); }));
                                 });
                     pattrs=[];
                     pinfo={id_resolved=Ref(Some((Param, -1)));
                            id_type=Ref(None); id_constness=Ref(None); };
                     })];
         cbody=[]; })));
   DefStmt(
     ({
       name=EN(
              Id(("Derived", ()),
                {id_resolved=Ref(None); id_type=Ref(None);
                 id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      ClassDef(
        {ckind=(Class, ());
         cextends=[({t_attrs=[];
                     t=TyN(
                         Id(("Base", ()),
                           {id_resolved=Ref(None); id_type=Ref(None);
                            id_constness=Ref(None); }));
                     },
                    Some([Arg(
                            N(
                              Id(("p", ()),
                                {id_resolved=Ref(None); id_type=Ref(None);
                                 id_constness=Ref(None); })))]))];
         cimplements=[]; cmixins=[];
         cparams=[ParamClassic(
                    {pname=Some(("p", ())); pdefault=None;
                     ptype=Some({t_attrs=[];
                                 t=TyN(
                                     Id(("Int", ()),
                                       {id_resolved=Ref(None);
                                        id_type=Ref(None);
                                        id_constness=Ref(None); }));
                                 });
                     pattrs=[];
                     pinfo={id_resolved=Ref(Some((Param, -1)));
                            id_type=Ref(None); id_constness=Ref(None); };
                     })];
         cbody=[]; })))])
```


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)