### PR TITLE
fix(ci): change github mac runner version

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
   mac-build:
     name: Check builds for macOS
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
 
   mac-build-linking-test:
     name: Check that semgrep-core runs
-    runs-on: macos-latest
+    runs-on: macos-10.15
     needs: [mac-build]
     steps:
       - name: Download artifacts

--- a/.github/workflows/homebrew-core-head.yml
+++ b/.github/workflows/homebrew-core-head.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   mac-build:
     name: Check brew install formula works for develop head
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Brew update
         run: brew update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
 
   build-core-osx:
     name: Build the OSX binaries
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -171,7 +171,7 @@ jobs:
           path: artifacts.tar.gz
 
   build-wheels-osx:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     needs: [build-core-osx]
     steps:
       - name: Checkout
@@ -295,7 +295,7 @@ jobs:
   homebrew-core-pr:
     name: Update on Homebrew-Core
     needs: [sleep-before-homebrew]  # Needs to run after pypi released so brew can update pypi dependency hashes
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Brew update
         run: brew update

--- a/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -15,7 +15,10 @@
         "metadata": {
           "category": "correctness",
           "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
-          "source": "https://semgrep.dev/r/javascript.lang.correctness.useless-eqeq.eqeq-is-bad"
+          "source": "https://semgrep.dev/r/javascript.lang.correctness.useless-eqeq.eqeq-is-bad",
+          "technology": [
+            "javascript"
+          ]
         },
         "metavars": {
           "$X": {
@@ -59,7 +62,10 @@
         "metadata": {
           "category": "correctness",
           "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
-          "source": "https://semgrep.dev/r/python.lang.correctness.useless-eqeq.useless-eqeq"
+          "source": "https://semgrep.dev/r/python.lang.correctness.useless-eqeq.useless-eqeq",
+          "technology": [
+            "python"
+          ]
         },
         "metavars": {
           "$X": {


### PR DESCRIPTION
Github Actions changes the macos-latest runner to use mac os 11 instead
of 10.15. See https://github.com/actions/virtual-environments/issues/4060

This broke some of our build process since it looks like ocamlopt is only available
on homebrew as an intel binary and not ARM. So for now pin to macos-10.15 runners

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
