### PR TITLE
[AST_generic] refactor PatVar out of pattern

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -262,8 +262,7 @@ and pattern env pat eorig =
   | G.PatUnderscore tok ->
       let lval = fresh_lval env tok in
       (lval, [])
-  | G.PatId (id, id_info)
-  | G.PatVar (_, Some (id, id_info)) ->
+  | G.PatId (id, id_info) ->
       let lval = lval_of_id_info env id id_info in
       (lval, [])
   | G.PatTuple (tok1, pats, tok2) ->
@@ -286,6 +285,14 @@ and pattern env pat eorig =
       in
       (tmp_lval, ss)
   | _ -> todo (G.P pat)
+
+and _catch_exn env exn eorig =
+  match exn with
+  | G.CatchPattern pat -> pattern env pat eorig
+  | G.CatchParam (_, Some (id, id_info)) ->
+      let lval = lval_of_id_info env id id_info in
+      (lval, [])
+  | _ -> todo (G.Ce exn)
 
 and pattern_assign_statements env exp eorig pat =
   try
@@ -928,10 +935,10 @@ let rec stmt_aux env st =
       let try_stmt = stmt env try_st in
       let catches_stmt_rev =
         List.fold_left
-          (fun acc (ctok, pattern, catch_st) ->
-            (* TODO: Handle pattern properly. *)
+          (fun acc (ctok, exn, catch_st) ->
+            (* TODO: Handle exn properly. *)
             let name = fresh_var env ctok in
-            let todo_pattern = fixme_stmt ToDo (G.P pattern) in
+            let todo_pattern = fixme_stmt ToDo (G.Ce exn) in
             let catch_stmt = stmt env catch_st in
             (name, todo_pattern @ catch_stmt) :: acc)
           [] catches

--- a/semgrep-core/src/analyzing/Naming_AST.ml
+++ b/semgrep-core/src/analyzing/Naming_AST.ml
@@ -555,6 +555,15 @@ let resolve lang prog =
               add_ident_imported_scope alias resolved env.names
           | _ -> ());
           k x);
+      V.kcatch =
+        (fun (k, _vout) x ->
+          let _t, exn, _st = x in
+          (match exn with
+          | CatchParam (_e, Some (id, id_info))
+            when is_resolvable_name_ctx env lang ->
+              declare_var env lang id id_info ~explicit:true None None
+          | _ -> ());
+          k x);
       V.kpattern =
         (fun (k, _vout) x ->
           match x with
@@ -564,10 +573,6 @@ let resolve lang prog =
                * Also inside a PatAs(PatId x,b), the 'x' is actually
                * the name of a class, not a newly introduced local.
                *)
-              declare_var env lang id id_info ~explicit:true None None;
-              k x
-          | PatVar (_e, Some (id, id_info)) when is_resolvable_name_ctx env lang
-            ->
               declare_var env lang id id_info ~explicit:true None None;
               k x
           | OtherPat _

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -777,8 +777,23 @@ and map_case = function
 
 and map_catch (t, v1, v2) =
   let t = map_tok t in
-  let v1 = map_pattern v1 and v2 = map_stmt v2 in
+  let v1 = map_catch_condition v1 and v2 = map_stmt v2 in
   (t, v1, v2)
+
+and map_catch_condition = function
+  | CatchPattern v1 ->
+      let v1 = map_pattern v1 in
+      v1
+  | CatchParam (v1, v2) ->
+      let v1 = map_type_ v1
+      and v2 =
+        map_of_option
+          (fun (v1, v2) ->
+            let v1 = map_ident v1 and v2 = map_id_info v2 in
+            (v1, v2))
+          v2
+      in
+      `PatVar (v1, v2)
 
 and map_finally v = map_tok_and_stmt v
 
@@ -833,16 +848,6 @@ and map_pattern = function
   | PatId (v1, v2) ->
       let v1 = map_ident v1 and v2 = map_id_info v2 in
       `PatId (v1, v2)
-  | PatVar (v1, v2) ->
-      let v1 = map_type_ v1
-      and v2 =
-        map_of_option
-          (fun (v1, v2) ->
-            let v1 = map_ident v1 and v2 = map_id_info v2 in
-            (v1, v2))
-          v2
-      in
-      `PatVar (v1, v2)
   | PatLiteral v1 ->
       let v1 = map_literal v1 in
       `PatLiteral v1
@@ -1181,6 +1186,7 @@ and map_program v = map_of_list map_item v
 
 and map_any x : B.any =
   match x with
+  | Ce _ -> failwith "TODO"
   | Anys _ -> error x
   | E v1 ->
       let v1 = map_expr v1 in

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -910,7 +910,17 @@ and case =
 and action = pattern * expr
 
 (* newvar: newscope: usually a PatVar *)
-and catch = tok (* 'catch', 'except' in Python *) * pattern * stmt
+and catch = tok (* 'catch', 'except' in Python *) * catch_exn * stmt
+
+and catch_exn =
+  | CatchPattern of pattern
+  (* for Java/C++/PHP/etc.
+   * less: do instead PatAs (PatType(TyApply, var))?
+   *       or even    PatAs (PatConstructor(id, []), var)?
+   * old: PatVar of type_ * (ident * id_info) option
+   * was in pattern as PatVar, but better to move out of pattern.
+   *)
+  | CatchParam of (* TODO parameter_classic *) type_ * (ident * id_info) option
 
 (* newscope: *)
 and finally = tok (* 'finally' *) * stmt
@@ -995,7 +1005,7 @@ and other_stmt_operator =
 (*****************************************************************************)
 (* This is quite similar to expr. A few constructs in expr have
  * equivalent here prefixed with Pat (e.g., PaLiteral, PatId). We could
- * maybe factorize with expr, and this may help sgrep, but I think it's
+ * maybe factorize with expr, and this may help semgrep, but I think it's
  * cleaner to have a separate type because the scoping rules for a pattern and
  * an expr are quite different and not any expr is allowed here.
  *)
@@ -1023,12 +1033,6 @@ and pattern =
   | PatAs of pattern * (ident * id_info)
   (* For Go also in switch x.(type) { case int: ... } *)
   | PatType of type_
-  (* In catch for Java/PHP, and foreach in Java.
-   * less: do instead PatAs (PatType(TyApply, var))?
-   *       or even    PatAs (PatConstructor(id, []), var)?
-   * or move out of pattern and improve the 'catch' type?
-   *)
-  | PatVar of type_ * (ident * id_info) option
   (* sgrep: *)
   | PatEllipsis of tok
   | DisjPat of pattern * pattern
@@ -1657,6 +1661,7 @@ and any =
   | ModDk of module_definition_kind
   | En of entity
   | Pa of parameter
+  | Ce of catch_exn
   | Dk of definition_kind
   | Di of dotted_ident
   | Lbli of label_ident

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -129,9 +129,6 @@ let rec pattern_to_expr p =
   | PatList (t1, xs, t2) ->
       Container (List, (t1, xs |> List.map pattern_to_expr, t2))
   | OtherPat (("ExprToPattern", _), [ E e ]) -> e.e
-  | PatAs _
-  | PatVar _ ->
-      raise NotAnExpr
   | _ -> raise NotAnExpr)
   |> G.e
 

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -675,8 +675,22 @@ let (mk_visitor : visitor_in -> visitor_out) =
         Default t
   and map_catch (t, v1, v2) =
     let t = map_tok t in
-    let v1 = map_pattern v1 and v2 = map_stmt v2 in
+    let v1 = map_catch_exn v1 and v2 = map_stmt v2 in
     (t, v1, v2)
+  and map_catch_exn = function
+    | CatchPattern v1 ->
+        let v1 = map_pattern v1 in
+        CatchPattern v1
+    | CatchParam (v1, v2) ->
+        let v1 = map_type_ v1
+        and v2 =
+          map_of_option
+            (fun (v1, v2) ->
+              let v1 = map_ident v1 and v2 = map_id_info v2 in
+              (v1, v2))
+            v2
+        in
+        CatchParam (v1, v2)
   and map_finally v = map_tok_and_stmt v
   and map_tok_and_stmt (t, v) =
     let t = map_tok t in
@@ -724,16 +738,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | PatId (v1, v2) ->
         let v1 = map_ident v1 and v2 = map_id_info v2 in
         PatId (v1, v2)
-    | PatVar (v1, v2) ->
-        let v1 = map_type_ v1
-        and v2 =
-          map_of_option
-            (fun (v1, v2) ->
-              let v1 = map_ident v1 and v2 = map_id_info v2 in
-              (v1, v2))
-            v2
-        in
-        PatVar (v1, v2)
     | PatLiteral v1 ->
         let v1 = map_literal v1 in
         PatLiteral v1
@@ -1163,6 +1167,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | Pa v1 ->
         let v1 = map_parameter v1 in
         Pa v1
+    | Ce v1 ->
+        let v1 = map_catch_exn v1 in
+        Ce v1
     | Ar v1 ->
         let v1 = map_argument v1 in
         Ar v1

--- a/semgrep-core/src/core/ast/Visitor_AST.mli
+++ b/semgrep-core/src/core/ast/Visitor_AST.mli
@@ -17,6 +17,7 @@ type visitor_in = {
   kdef : (definition -> unit) * visitor_out -> definition -> unit;
   kdir : (directive -> unit) * visitor_out -> directive -> unit;
   kparam : (parameter -> unit) * visitor_out -> parameter -> unit;
+  kcatch : (catch -> unit) * visitor_out -> catch -> unit;
   kident : (ident -> unit) * visitor_out -> ident -> unit;
   kname : (name -> unit) * visitor_out -> name -> unit;
   kentity : (entity -> unit) * visitor_out -> entity -> unit;

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -733,22 +733,23 @@ and excepthandler = function
       let v1 = option expr v1 (* a type actually, even tuple of types *)
       and v2 = option name v2
       and v3 = list_stmt1 v3 in
-      ( t,
-        (match (v1, v2) with
+      let exn : G.catch_exn =
+        match (v1, v2) with
         | Some e, None -> (
             match e.G.e with
-            | G.Ellipsis tok -> G.PatEllipsis tok
-            | G.Container (G.Tuple, _) -> G.PatVar (H.expr_to_type e, None)
+            | G.Ellipsis tok -> G.CatchPattern (G.PatEllipsis tok)
+            | G.Container (G.Tuple, _) -> G.CatchParam (H.expr_to_type e, None)
             | _ ->
-                G.PatVar
+                G.CatchParam
                   ( H.expr_to_type
                       (G.Container (G.Tuple, G.fake_bracket [ e ]) |> G.e),
                     None ))
-        | None, None -> G.PatUnderscore (fake t "_")
+        | None, None -> G.CatchPattern (G.PatUnderscore (fake t "_"))
         | None, Some _ -> raise Impossible (* see the grammar *)
         | Some e, Some n ->
-            G.PatVar (H.expr_to_type e, Some (n, G.empty_id_info ()))),
-        v3 )
+            G.CatchParam (H.expr_to_type e, Some (n, G.empty_id_info ()))
+      in
+      (t, exn, v3)
 
 and decorator (t, v1, v2) =
   let v1 = dotted_name v1 in

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -782,16 +782,17 @@ and map_handler env (v1, v2, v3) : G.catch =
   let v1 = map_tok env v1
   and _, xs, _ = map_paren env (map_of_list (map_exception_declaration env)) v2
   and v3 = map_compound env v3 in
-  let pat : G.pattern = complicated env xs in
+  let pat : G.catch_exn = complicated env xs in
   (v1, pat, G.Block v3 |> G.s)
 
-and map_exception_declaration env = function
+and map_exception_declaration env x : G.catch_exn =
+  match x with
   | ExnDecl v1 ->
       let v1 = map_parameter env v1 in
-      todo env v1
+      complicated env v1
   | ExnDeclEllipsis v1 ->
       let v1 = map_tok env v1 in
-      todo env v1
+      G.CatchPattern (G.PatEllipsis v1)
 
 and map_stmt_or_decl env x : G.stmt list =
   match x with

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -505,9 +505,10 @@ and for_control tok = function
   | Foreach (v1, v2) ->
       let ent, typ = var v1 and v2 = expr v2 in
       let id, _idinfo = id_of_entname ent.G.name in
+      let patid = G.PatId (id, G.empty_id_info ()) in
       let pat =
         match typ with
-        | Some t -> G.PatVar (t, Some (id, G.empty_id_info ()))
+        | Some t -> G.PatTyped (patid, t)
         | None -> error tok "TODO: Foreach without a type"
       in
       G.ForEach (pat, fake (snd id) "in", v2)
@@ -530,12 +531,12 @@ and catch (tok, (v1, _union_types), v2) =
   let ent, typ = var v1 in
   let id, _idinfo = id_of_entname ent.G.name in
   let v2 = stmt v2 in
-  let pat =
+  let exn =
     match typ with
-    | Some t -> G.PatVar (t, Some (id, G.empty_id_info ()))
+    | Some t -> G.CatchParam (t, Some (id, G.empty_id_info ()))
     | None -> error tok "TODO: Catch without a type"
   in
-  (tok, pat, v2)
+  (tok, exn, v2)
 
 and catches v = list catch v
 

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -378,14 +378,14 @@ and stmt x =
 and catch_block = function
   | BoundCatch (t, v1, v2) ->
       let v1 = H.expr_to_pattern (expr v1) and v2 = stmt v2 in
-      (t, v1, v2)
+      (t, G.CatchPattern v1, v2)
   | UnboundCatch (t, v1) ->
       let v1 =
         stmt v1
         (* bugfix: reusing 't' to avoid NoTokenLocation error when
          * a semgrep patter like catch($ERR) matches an UnboundCatch. *)
       in
-      (t, G.PatUnderscore t, v1)
+      (t, G.CatchPattern (G.PatUnderscore t), v1)
 
 and tok_and_stmt (t, v) =
   let v = stmt v in

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -172,7 +172,9 @@ and stmt e : G.stmt =
   | Try (t, v1, v2) ->
       let v1 = stmt v1 and v2 = list match_case v2 in
       let catches =
-        v2 |> List.map (fun (pat, e) -> (fake "catch", pat, G.exprstmt e))
+        v2
+        |> List.map (fun (pat, e) ->
+               (fake "catch", G.CatchPattern pat, G.exprstmt e))
       in
       G.Try (t, v1, catches, None) |> G.s
   | While (t, v1, v2) ->

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -232,8 +232,8 @@ and case = function
 
 and catch (t, v1, v2, v3) =
   let v1 = hint_type v1 and v2 = var v2 and v3 = stmt v3 in
-  let pat = G.PatVar (v1, Some (v2, G.empty_id_info ())) in
-  (t, pat, v3)
+  let exn = G.CatchParam (v1, Some (v2, G.empty_id_info ())) in
+  (t, exn, v3)
 
 (* a list of finally??? php ... *)
 and finally (v : finally list) =

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -598,11 +598,11 @@ and v_catch_clause (v1, v2) : G.catch list =
              (* todo? e was the result of expr_of_block, so maybe we
               * should revert because we want a stmt here with block_of_expr
               *)
-             (fake "case", pat, G.exprstmt e))
+             (fake "case", G.CatchPattern pat, G.exprstmt e))
   | CatchExpr e ->
       let e = v_expr e in
       let pat = G.PatUnderscore v1 in
-      [ (v1, pat, G.exprstmt e) ]
+      [ (v1, G.CatchPattern pat, G.exprstmt e) ]
 
 and v_finally_clause (v1, v2) =
   let v1 = v_tok v1 and v2 = v_expr_for_stmt v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1072,17 +1072,17 @@ and catch_clause (env : env) ((v1, v2, v3, v4) : CST.catch_clause) =
   let v2 =
     match v2 with
     | Some x -> catch_declaration env x
-    | None -> PatUnderscore (fake "_")
+    | None -> CatchPattern (PatUnderscore (fake "_"))
   in
-  let pat =
+  let exn =
     match v3 with
     | Some x ->
-        let filter = catch_filter_clause env x in
-        PatWhen (v2, filter)
+        let _filterTODO = catch_filter_clause env x in
+        v2
     | None -> v2
   in
   let v4 = block env v4 in
-  (v1, pat, v4)
+  (v1, exn, v4)
 
 and ordering (env : env) ((v1, v2) : CST.ordering) =
   let v1 = expression env v1 in
@@ -1884,7 +1884,8 @@ and tuple_element (env : env) ((v1, v2) : CST.tuple_element) =
 and constant_pattern (env : env) (x : CST.constant_pattern) =
   H2.expr_to_pattern (expression env x)
 
-and catch_declaration (env : env) ((v1, v2, v3, v4) : CST.catch_declaration) =
+and catch_declaration (env : env) ((v1, v2, v3, v4) : CST.catch_declaration) :
+    G.catch_exn =
   let _v1 = token env v1 (* "(" *) in
   let v2 = type_constraint env v2 in
   let v3 = Common.map_opt (identifier env) v3 (* identifier *) in
@@ -1894,7 +1895,7 @@ and catch_declaration (env : env) ((v1, v2, v3, v4) : CST.catch_declaration) =
     | Some ident -> Some (ident, empty_id_info ())
     | None -> None
   in
-  PatVar (v2, var)
+  CatchParam (v2, var)
 
 and case_pattern_switch_label (env : env)
     ((v1, v2, v3, v4) : CST.case_pattern_switch_label) =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -1031,9 +1031,8 @@ and catch_clause (env : env) ((v1, v2, v3, v4, v5, v6) : CST.catch_clause) =
   let v4 = (* variable *) Some (str env v4, G.empty_id_info ()) in
   let _v5 = (* ")" *) token env v5 in
   let v6 = compound_statement env v6 in
-  (* Q: PatTyped vs PVal? *)
-  let pattern = G.PatVar (v3, v4) in
-  (v1, pattern, v6)
+  let exn = G.CatchParam (v3, v4) in
+  (v1, exn, v6)
 
 and class_const_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.class_const_declaration) =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -579,8 +579,8 @@ and catch_block (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.catch_block)
   let _v7 = token env v7 (* ")" *) in
   let v8 = block env v8 in
   let id = Some (v4, empty_id_info ()) in
-  let pattern = PatVar (v6, id) in
-  (v1, pattern, v8)
+  let exn = CatchParam (v6, id) in
+  (v1, exn, v8)
 
 and class_body (env : env) ((v1, v2, v3) : CST.class_body) =
   let v1 = token env v1 (* "{" *) in


### PR DESCRIPTION
Better to define a more precise catch_exn type instead
of abusing pattern to store catch exception handler.

This will help PA-290

test plan:
make test


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)