### PR TITLE
Add script to hash project urls

### DIFF
--- a/scripts/hash-project.py
+++ b/scripts/hash-project.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+"""
+E.g.
+
+  pipenv run scripts/hash-project.py $(git ls-remote --get-url)
+"""
 from sys import argv
 
 from semgrep.metric_manager import metric_manager

--- a/scripts/hash-project.py
+++ b/scripts/hash-project.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+from sys import argv
+
+from semgrep.metric_manager import metric_manager
+
+metric_manager.set_project_hash(argv[1])
+print(metric_manager._project_hash)


### PR DESCRIPTION
For ease in calculating hashes of known (viz., public or r2c-internal)
projects.

Fixes PA-443
