### PR TITLE
Allow invisible rules

### DIFF
--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -247,7 +247,7 @@ type taint_spec = {
 type mode = Search of pformula | Taint of taint_spec [@@deriving show]
 
 (* TODO? just reuse Error_code.severity *)
-type severity = Error | Warning | Info [@@deriving show]
+type severity = Error | Warning | Info | Inventory [@@deriving show]
 
 type rule = {
   (* MANDATORY fields *)

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -271,8 +271,9 @@ let parse_int env (key : key) x =
   match x.G.e with
   | G.L (Int (Some i, _)) -> i
   | G.L (String (s, _)) -> (
-      try int_of_string s with
-      | Failure _ -> error_at_key env key (spf "parse_int for %s" (fst key)))
+      try int_of_string s
+      with Failure _ ->
+        error_at_key env key (spf "parse_int for %s" (fst key)))
   | G.L (Float (Some f, _)) ->
       let i = int_of_float f in
       if float_of_int i = f then i else error_at_key env key "not an int"
@@ -316,9 +317,9 @@ let parse_metavar_cond env key s =
   | exn -> error_at_key env key ("exn: " ^ Common.exn_to_s exn)
 
 let parse_regexp env (s, t) =
-  try (s, Pcre.regexp s) with
-  | Pcre.Error exn ->
-      raise (R.InvalidRegexp (env.id, pcre_error_to_string s exn, t))
+  try (s, Pcre.regexp s)
+  with Pcre.Error exn ->
+    raise (R.InvalidRegexp (env.id, pcre_error_to_string s exn, t))
 
 let parse_fix_regex (env : env) (key : key) fields =
   let fix_regex_dict = yaml_to_dict env key fields in
@@ -576,13 +577,11 @@ and parse_extra (env : env) (key : key) (value : G.expr) : Rule.extra =
   match fst key with
   | "metavariable-regex" ->
       let mv_regex_dict =
-        try yaml_to_dict env key value with
-        | R.DuplicateYamlKey (msg, t) ->
-            raise
-              (R.InvalidRule
-                 ( env.id,
-                   msg ^ ". You should use multiple metavariable-regex",
-                   t ))
+        try yaml_to_dict env key value
+        with R.DuplicateYamlKey (msg, t) ->
+          raise
+            (R.InvalidRule
+               (env.id, msg ^ ". You should use multiple metavariable-regex", t))
       in
       let metavar, regexp =
         ( take mv_regex_dict env parse_string "metavariable",

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -45,6 +45,7 @@ class RuleSeverity(Enum):
     INFO = "INFO"
     WARNING = "WARNING"
     ERROR = "ERROR"
+    INVENTORY = "INVENTORY"
 
     @classmethod
     def _missing_(cls: Type[Enum], value: object) -> Enum:

--- a/semgrep/semgrep/formatter/base.py
+++ b/semgrep/semgrep/formatter/base.py
@@ -1,20 +1,37 @@
 import abc
 from typing import Any
+from typing import Collection
 from typing import FrozenSet
+from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 
 
 class BaseFormatter(abc.ABC):
-    @abc.abstractmethod
     def output(
         self,
         rules: FrozenSet[Rule],
         rule_matches: Sequence[RuleMatch],
+        semgrep_structured_errors: Sequence[SemgrepError],
+        extra: Mapping[str, Any],
+        shown_severities: Collection[RuleSeverity],
+    ) -> str:
+        filtered_rules = (r for r in rules if r.severity in shown_severities)
+        filtered_matches = (m for m in rule_matches if m.severity in shown_severities)
+        return self.format(
+            filtered_rules, filtered_matches, semgrep_structured_errors, extra
+        )
+
+    @abc.abstractmethod
+    def format(
+        self,
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
         extra: Mapping[str, Any],
     ) -> str:

--- a/semgrep/semgrep/formatter/emacs.py
+++ b/semgrep/semgrep/formatter/emacs.py
@@ -1,5 +1,5 @@
 from typing import Any
-from typing import FrozenSet
+from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
@@ -27,12 +27,12 @@ class EmacsFormatter(BaseFormatter):
             rule_match.message,
         ]
 
-    def output(
+    def format(
         self,
-        rules: FrozenSet[Rule],
-        rule_matches: Sequence[RuleMatch],
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
         extra: Mapping[str, Any],
     ) -> str:
-        rule_matches = sorted(rule_matches, key=lambda r: (r.path, r.id))
-        return "\n".join(":".join(self._get_parts(rm)) for rm in rule_matches)
+        sorted_matches = sorted(rule_matches, key=lambda r: (r.path, r.id))
+        return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any
-from typing import FrozenSet
+from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
@@ -36,10 +36,10 @@ class JsonFormatter(BaseFormatter):
             "extra": extra,
         }
 
-    def output(
+    def format(
         self,
-        rules: FrozenSet[Rule],
-        rule_matches: Sequence[RuleMatch],
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
         extra: Mapping[str, Any],
     ) -> str:

--- a/semgrep/semgrep/formatter/junit_xml.py
+++ b/semgrep/semgrep/formatter/junit_xml.py
@@ -1,6 +1,6 @@
 from typing import Any
 from typing import cast
-from typing import FrozenSet
+from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
@@ -29,10 +29,10 @@ class JunitXmlFormatter(BaseFormatter):
         )
         return test_case
 
-    def output(
+    def format(
         self,
-        rules: FrozenSet[Rule],
-        rule_matches: Sequence[RuleMatch],
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
         extra: Mapping[str, Any],
     ) -> str:

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -1,6 +1,6 @@
 import json
-from collections import Iterable
 from typing import Any
+from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -1,6 +1,6 @@
 import json
+from collections import Iterable
 from typing import Any
-from typing import FrozenSet
 from typing import Mapping
 from typing import Sequence
 
@@ -126,10 +126,10 @@ class SarifFormatter(BaseFormatter):
         # https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10541099
         return True
 
-    def output(
+    def format(
         self,
-        rules: FrozenSet[Rule],
-        rule_matches: Sequence[RuleMatch],
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
         extra: Mapping[str, Any],
     ) -> str:

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -2,7 +2,7 @@ import functools
 import itertools
 from pathlib import Path
 from typing import Any
-from typing import FrozenSet
+from typing import Iterable
 from typing import Iterator
 from typing import Mapping
 from typing import Optional
@@ -181,7 +181,7 @@ class TextFormatter(BaseFormatter):
 
     @staticmethod
     def _build_text_output(
-        rule_matches: Sequence[RuleMatch],
+        rule_matches: Iterable[RuleMatch],
         color_output: bool,
         per_finding_max_lines_limit: Optional[int],
         per_line_max_chars_limit: Optional[int],
@@ -240,10 +240,10 @@ class TextFormatter(BaseFormatter):
                 is_same_file,
             )
 
-    def output(
+    def format(
         self,
-        rules: FrozenSet[Rule],
-        rule_matches: Sequence[RuleMatch],
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
         extra: Mapping[str, Any],
     ) -> str:

--- a/semgrep/semgrep/formatter/vim.py
+++ b/semgrep/semgrep/formatter/vim.py
@@ -1,5 +1,5 @@
 from typing import Any
-from typing import FrozenSet
+from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
@@ -27,10 +27,10 @@ class VimFormatter(BaseFormatter):
             rule_match.message,
         ]
 
-    def output(
+    def format(
         self,
-        rules: FrozenSet[Rule],
-        rule_matches: Sequence[RuleMatch],
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
         extra: Mapping[str, Any],
     ) -> str:

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -341,6 +341,7 @@ properties:
           - ERROR
           - WARNING
           - INFO
+          - INVENTORY
         pattern-sinks:
           $ref: '#/definitions/taint-content'
         pattern-sources:

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -14,11 +14,13 @@ from semgrep.autofix import apply_fixes
 from semgrep.config_resolver import get_config
 from semgrep.constants import DEFAULT_TIMEOUT
 from semgrep.constants import OutputFormat
+from semgrep.constants import RuleSeverity
 from semgrep.core_runner import CoreRunner
 from semgrep.error import MISSING_CONFIG_EXIT_CODE
 from semgrep.error import SemgrepError
 from semgrep.ignores import process_ignores
 from semgrep.metric_manager import metric_manager
+from semgrep.output import DEFAULT_SHOWN_SEVERITIES
 from semgrep.output import OutputHandler
 from semgrep.output import OutputSettings
 from semgrep.profile_manager import ProfileManager
@@ -128,8 +130,10 @@ def main(
     all_rules = configs_obj.get_rules(no_rewrite_rule_ids)
 
     if not severity:
+        shown_severities = DEFAULT_SHOWN_SEVERITIES
         filtered_rules = all_rules
     else:
+        shown_severities = {RuleSeverity(s) for s in severity}
         filtered_rules = [rule for rule in all_rules if rule.severity.value in severity]
 
     output_handler.handle_semgrep_errors(errors)
@@ -264,12 +268,13 @@ The two most popular are:
 
     output_handler.handle_semgrep_core_output(
         filtered_matches.matches,
-        debug_steps_by_rule,
-        stats_line,
-        all_targets,
-        profiler,
-        filtered_rules,
-        profiling_data,
+        debug_steps_by_rule=debug_steps_by_rule,
+        stats_line=stats_line,
+        all_targets=all_targets,
+        profiler=profiler,
+        filtered_rules=filtered_rules,
+        profiling_data=profiling_data,
+        severities=shown_severities,
     )
 
     if autofix:

--- a/semgrep/tests/e2e/rules/inventory/invent.yaml
+++ b/semgrep/tests/e2e/rules/inventory/invent.yaml
@@ -1,0 +1,8 @@
+rules:
+- id: invent-subprocess
+  languages:
+    - python
+  message: |-
+    Detected subprocess dependency
+  pattern: import subprocess
+  severity: INVENTORY

--- a/semgrep/tests/e2e/snapshots/test_output/test_omit_inventory/results.out
+++ b/semgrep/tests/e2e/snapshots/test_output/test_omit_inventory/results.out
@@ -1,0 +1,4 @@
+{
+  "errors": [],
+  "results": []
+}

--- a/semgrep/tests/e2e/targets/inventory/invent.py
+++ b/semgrep/tests/e2e/targets/inventory/invent.py
@@ -1,0 +1,3 @@
+import subprocess
+
+subprocess.check_output(["echo", "3"])

--- a/semgrep/tests/e2e/test_output.py
+++ b/semgrep/tests/e2e/test_output.py
@@ -74,6 +74,13 @@ def test_output_format(run_semgrep_in_tmp, snapshot, format):
     snapshot.assert_match(clean, "results.out")
 
 
+def test_omit_inventory(run_semgrep_in_tmp, snapshot):
+    stdout, _ = run_semgrep_in_tmp(
+        "rules/inventory/invent.yaml", target_name="inventory/invent.py"
+    )
+    snapshot.assert_match(stdout, "results.out")
+
+
 def test_junit_xml_output(run_semgrep_in_tmp, snapshot):
     output, _ = run_semgrep_in_tmp(
         "rules/eqeq.yaml", output_format=OutputFormat.JUNIT_XML


### PR DESCRIPTION
These will be used in conjunction with --config auto (see #3944) to
determine the languages and frameworks of a project, in order to tune
rules on a per-project basis.

Because these are used internally, and are not "findings", we hide their
results from the user.

PR checklist:
- [X] Documentation is up-to-date
- [X] Changelog is up-to-date
- [X] Change has no security implications (otherwise, ping security team)
