### PR TITLE
Improve Pcre error handling

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -1390,6 +1390,8 @@ let main () =
 (*****************************************************************************)
 let () =
   Common.main_boilerplate (fun () ->
+      (* semgrep-specific initializations. Move to a dedicated module? *)
+      Pcre_settings.register_exception_printer ();
       Common.finalize
         (fun () -> main ())
         (fun () -> !Hooks.exit |> List.iter (fun f -> f ())))

--- a/semgrep-core/src/core/Guess_lang.ml
+++ b/semgrep-core/src/core/Guess_lang.ml
@@ -91,9 +91,10 @@ let get_first_block ?(block_size = 4096) path =
       let len = min block_size (in_channel_length ic) in
       really_input_string ic len)
 
-let shebang_re = lazy (Pcre.regexp "^#![ \t]*([^ \t]*)[ \t]*([^ \t].*)?$")
+let shebang_re =
+  lazy (Pcre_settings.regexp "^#![ \t]*([^ \t]*)[ \t]*([^ \t].*)?$")
 
-let split_cmd_re = lazy (Pcre.regexp "[ \t]+")
+let split_cmd_re = lazy (Pcre_settings.regexp "[ \t]+")
 
 (*
    A shebang supports at most the name of the script and one argument:
@@ -157,7 +158,7 @@ let uses_shebang_command_name cmd_names =
 
 (* PCRE regexp using the default options *)
 let regexp pat =
-  let rex = Pcre.regexp pat in
+  let rex = Pcre_settings.regexp pat in
   let f path =
     let s = get_first_block path in
     Pcre.pmatch ~rex s

--- a/semgrep-core/src/core/Pcre_settings.ml
+++ b/semgrep-core/src/core/Pcre_settings.ml
@@ -2,6 +2,8 @@
    Shared settings for using the Pcre module (pcre-ocaml library).
 *)
 
+open Printf
+
 (*
    'limit' and 'limit_recursion' are set explicitly to make semgrep
    fail consistently across platforms (e.g. CI vs. local Mac).
@@ -14,3 +16,35 @@ let regexp ?study ?iflags ?flags ?chtables pat =
   Pcre.regexp ?study ~limit:10_000_000 (* sets PCRE_EXTRA_MATCH_LIMIT *)
     ~limit_recursion:10_000_000 (* sets PCRE_EXTRA_MATCH_LIMIT_RECURSION *)
     ?iflags ?flags ?chtables pat
+
+let string_of_error (error : Pcre.error) =
+  match error with
+  | Partial -> "Partial"
+  | BadPartial -> "BadPartial"
+  | BadPattern (msg, pos) -> sprintf "Pcre.BadPattern(%S, pos=%i)" msg pos
+  | BadUTF8 -> "BadUTF8"
+  | BadUTF8Offset -> "BadUTF8Offset"
+  | MatchLimit -> "MatchLimit"
+  | RecursionLimit -> "RecursionLimit"
+  | WorkspaceSize -> "WorkspaceSize"
+  | InternalError msg -> sprintf "InternalError(%S)" msg
+
+let string_of_exn (e : exn) =
+  match e with
+  | Pcre.Error error -> Some (sprintf "Pcre.Error(%s)" (string_of_error error))
+  | Pcre.Backtrack -> Some "Pcre.Backtrack"
+  | Pcre.Regexp_or (pat, error) ->
+      Some (sprintf "Pcre.Regexp_or(pat=%S, %s)" pat (string_of_error error))
+  | _not_from_pcre -> None
+
+(*
+   You can test this with:
+
+     $ dune utop
+     # Pcre_settings.register_exception_printer ();;
+     # Pcre.pmatch ~pat:"(a+)+$" "aaaaaaaaaaaaaaaaaaaaaaaaaa!"
+         |> assert false
+       with e -> Printexc.to_string e;;
+     - : string = "Pcre.Error(MatchLimit)"
+*)
+let register_exception_printer () = Printexc.register_printer string_of_exn

--- a/semgrep-core/src/core/Pcre_settings.ml
+++ b/semgrep-core/src/core/Pcre_settings.ml
@@ -1,0 +1,16 @@
+(*
+   Shared settings for using the Pcre module (pcre-ocaml library).
+*)
+
+(*
+   'limit' and 'limit_recursion' are set explicitly to make semgrep
+   fail consistently across platforms (e.g. CI vs. local Mac).
+   The default compile-time defaults are 10_000_000 for both
+   'limit' and 'limit_recursion' but they can be overridden during
+   the installation of the pcre library. We protect ourselves
+   from such custom installs.
+*)
+let regexp ?study ?iflags ?flags ?chtables pat =
+  Pcre.regexp ?study ~limit:10_000_000 (* sets PCRE_EXTRA_MATCH_LIMIT *)
+    ~limit_recursion:10_000_000 (* sets PCRE_EXTRA_MATCH_LIMIT_RECURSION *)
+    ?iflags ?flags ?chtables pat

--- a/semgrep-core/src/core/Pcre_settings.mli
+++ b/semgrep-core/src/core/Pcre_settings.mli
@@ -1,0 +1,19 @@
+(*
+   Shared settings for using the Pcre module (pcre-ocaml library).
+*)
+
+(*
+   To be used instead of Pcre.regexp. Refer to the Pcre documentation
+   for usage.
+   https://mmottl.github.io/pcre-ocaml/api/pcre/Pcre/index.html#val-regexp
+
+   This takes care of setting PCRE_EXTRA_MATCH_LIMIT and
+   PCRE_EXTRA_MATCH_LIMIT_RECURSION to the same value across platforms.
+*)
+val regexp :
+  ?study:bool ->
+  ?iflags:Pcre.icflag ->
+  ?flags:Pcre.cflag list ->
+  ?chtables:Pcre.chtables ->
+  string ->
+  Pcre.regexp

--- a/semgrep-core/src/core/Pcre_settings.mli
+++ b/semgrep-core/src/core/Pcre_settings.mli
@@ -17,3 +17,12 @@ val regexp :
   ?chtables:Pcre.chtables ->
   string ->
   Pcre.regexp
+
+(*
+   Register printers for the Pcre module/library so that exceptions show up
+   nicely with 'Printexc.to_string' e.g. 'Pcre.Error(RecursionLimit)'
+   instead of 'Pcre.Error(5)'.
+
+   See issue https://github.com/mmottl/pcre-ocaml/issues/24
+*)
+val register_exception_printer : unit -> unit

--- a/semgrep-core/src/core/Regexp_engine.ml
+++ b/semgrep-core/src/core/Regexp_engine.ml
@@ -109,11 +109,11 @@ module Pcre_engine = struct
 
   let matching_exact_string s =
     let quoted = Pcre.quote s in
-    (quoted, Pcre.regexp quoted)
+    (quoted, Pcre_settings.regexp quoted)
 
   let matching_exact_word s =
     let re = "\b" ^ Pcre.quote s ^ "\b" in
-    (re, Pcre.regexp re)
+    (re, Pcre_settings.regexp re)
 
   let run (_, re) str = Pcre.pmatch ~rex:re str
 end

--- a/semgrep-core/src/core/Unit_pcre_settings.ml
+++ b/semgrep-core/src/core/Unit_pcre_settings.ml
@@ -7,7 +7,8 @@ let test_register_exception_printer () =
   Pcre_settings.register_exception_printer ();
 
   let msg =
-    try Pcre.pmatch ~pat:"(a+)+$" "aaaaaaaaaaaaaaaaaaaaaaaaaa!" |> assert false
+    let rex = Pcre_settings.regexp "(a+)+$" in
+    try Pcre.pmatch ~rex "aaaaaaaaaaaaaaaaaaaaaaaaaa!" |> assert false
     with e -> Printexc.to_string e
   in
   Alcotest.(check string) "equal" "Pcre.Error(MatchLimit)" msg

--- a/semgrep-core/src/core/Unit_pcre_settings.ml
+++ b/semgrep-core/src/core/Unit_pcre_settings.ml
@@ -25,7 +25,8 @@ let test_register_exception_printer () =
       Alcotest.fail "should have failed to compile the regexp"
     with e -> Printexc.to_string e
   in
-  Alcotest.(check string) "equal" "TODO" msg
+  Alcotest.(check string)
+    "equal" "Pcre.Error(Pcre.BadPattern(\"nothing to repeat\", pos=0))" msg
 
 let tests =
   Testutil.pack_tests "pcre settings"

--- a/semgrep-core/src/core/Unit_pcre_settings.ml
+++ b/semgrep-core/src/core/Unit_pcre_settings.ml
@@ -2,17 +2,35 @@
    Unit tests for Pcre_settings
 *)
 
+let test_match_limit_ok () =
+  let rex = Pcre_settings.regexp "(a+)+$" in
+  try ignore (Pcre.pmatch ~rex "aaaaaaaaaaaaaaaaaaa!")
+  with Pcre.Error Pcre.MatchLimit ->
+    Alcotest.fail "should not have failed with error MatchLimit"
+
+let test_match_limit_fail () =
+  let rex = Pcre_settings.regexp "(a+)+$" in
+  try
+    ignore (Pcre.pmatch ~rex "aaaaaaaaaaaaaaaaaaaaaaaaaa!");
+    Alcotest.fail "should have failed with error MatchLimit"
+  with Pcre.Error Pcre.MatchLimit -> ()
+
 let test_register_exception_printer () =
   (* This is a little dirty since we can't undo it. *)
   Pcre_settings.register_exception_printer ();
 
   let msg =
-    let rex = Pcre_settings.regexp "(a+)+$" in
-    try Pcre.pmatch ~rex "aaaaaaaaaaaaaaaaaaaaaaaaaa!" |> assert false
+    try
+      ignore (Pcre_settings.regexp "???");
+      Alcotest.fail "should have failed to compile the regexp"
     with e -> Printexc.to_string e
   in
-  Alcotest.(check string) "equal" "Pcre.Error(MatchLimit)" msg
+  Alcotest.(check string) "equal" "TODO" msg
 
 let tests =
   Testutil.pack_tests "pcre settings"
-    [ ("exception printer", test_register_exception_printer) ]
+    [
+      ("match limit ok", test_match_limit_ok);
+      ("match limit fail", test_match_limit_fail);
+      ("exception printer", test_register_exception_printer);
+    ]

--- a/semgrep-core/src/core/Unit_pcre_settings.ml
+++ b/semgrep-core/src/core/Unit_pcre_settings.ml
@@ -1,0 +1,17 @@
+(*
+   Unit tests for Pcre_settings
+*)
+
+let test_register_exception_printer () =
+  (* This is a little dirty since we can't undo it. *)
+  Pcre_settings.register_exception_printer ();
+
+  let msg =
+    try Pcre.pmatch ~pat:"(a+)+$" "aaaaaaaaaaaaaaaaaaaaaaaaaa!" |> assert false
+    with e -> Printexc.to_string e
+  in
+  Alcotest.(check string) "equal" "Pcre.Error(MatchLimit)" msg
+
+let tests =
+  Testutil.pack_tests "pcre settings"
+    [ ("exception printer", test_register_exception_printer) ]

--- a/semgrep-core/src/core/Unit_pcre_settings.mli
+++ b/semgrep-core/src/core/Unit_pcre_settings.mli
@@ -1,0 +1,5 @@
+(*
+   Unit tests for Pcre_settings
+*)
+
+val tests : Testutil.test list

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -187,8 +187,7 @@ let rec eval env code =
       match v with
       | String s ->
           (* todo? factorize with Matching_generic.regexp_matcher_of_regexp_.. *)
-          (* use of `ANCHORED to simulate Python re.match() (vs re.search) *)
-          let regexp = Pcre.regexp ~flags:[ `ANCHORED ] re in
+          let regexp = Pcre_settings.regexp ~flags:[ `ANCHORED ] re in
           let res = Pcre.pmatch ~rex:regexp s in
           let v = Bool res in
           logger#info "regexp %s on %s return %s" re s (show_value v);

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -317,7 +317,7 @@ let parse_metavar_cond env key s =
   | exn -> error_at_key env key ("exn: " ^ Common.exn_to_s exn)
 
 let parse_regexp env (s, t) =
-  try (s, Pcre.regexp s)
+  try (s, Pcre_settings.regexp s)
   with Pcre.Error exn ->
     raise (R.InvalidRegexp (env.id, pcre_error_to_string s exn, t))
 

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -581,6 +581,7 @@ let tests = List.flatten [
   Unit_naming_generic.tests Parse_target.parse_program;
   Unit_guess_lang.tests;
   Unit_memory_limit.tests;
+  Unit_pcre_settings.tests;
 
   lang_parsing_tests;
   (* full testing for many languages *)


### PR DESCRIPTION
* Enforce consistent match limits across all installs (implements part of #3988)
* Print Pcre exceptions in a less cryptic format (closes #3987)

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
