### PR TITLE
Add support for GitHub annotations as formatter output

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -304,6 +304,11 @@ def __validate_lang(option: str, lang: Optional[str]) -> str:
     is_flag=True,
     help="Output results in vim single-line format.",
 )
+@optgroup.option(
+    "--github",
+    is_flag=True,
+    help="Output results in github annotation format.",
+)
 @optgroup.group("Verbosity options", cls=MutuallyExclusiveOptionGroup)
 @optgroup.option(
     "-q",
@@ -408,6 +413,7 @@ def cli(
     exclude: Optional[Tuple[str, ...]],
     force_color: bool,
     generate_config: bool,
+    github: bool,
     include: Optional[Tuple[str, ...]],
     jobs: int,
     json: bool,
@@ -519,6 +525,8 @@ def cli(
         output_format = OutputFormat.EMACS
     elif vim:
         output_format = OutputFormat.VIM
+    elif github:
+        output_format = OutputFormat.GITHUB
 
     output_settings = OutputSettings(
         output_format=output_format,

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -35,6 +35,7 @@ class OutputFormat(Enum):
     SARIF = auto()
     EMACS = auto()
     VIM = auto()
+    GITHUB = auto()
 
     def is_json(self) -> bool:
         return self in [OutputFormat.JSON, OutputFormat.SARIF]

--- a/semgrep/semgrep/formatter/github.py
+++ b/semgrep/semgrep/formatter/github.py
@@ -1,0 +1,33 @@
+from typing import Any
+from typing import FrozenSet
+from typing import Mapping
+from typing import Sequence
+
+from semgrep.constants import CLI_RULE_ID
+from semgrep.error import SemgrepError
+from semgrep.formatter.base import BaseFormatter
+from semgrep.rule import Rule
+from semgrep.rule_match import RuleMatch
+
+
+class GitHubFormatter(BaseFormatter):
+    @staticmethod
+    def _rule_match_to_github(rule_match: RuleMatch) -> str:
+        return '::{level} file={file},line={start},endLine={end},title={title}::{message}'.format(
+            level   = str(rule_match.severity.value.lower()), # FIXME: this needs to be filtered?
+            title   = str(rule_match.id),
+            file    = str(rule_match.path),
+            start   = str(rule_match.start.line),
+            end     = str(rule_match.end.line),
+            message = str(rule_match.extra["message"]), # FIXME: This could be prettier
+        )
+
+    def output(
+        self,
+        rules: FrozenSet[Rule],
+        rule_matches: Sequence[RuleMatch],
+        semgrep_structured_errors: Sequence[SemgrepError],
+        extra: Mapping[str, Any],
+    ) -> str:
+        rule_matches = sorted(rule_matches, key=lambda r: (r.path, r.id))
+        return "\n".join(self._rule_match_to_github(rm) for rm in rule_matches)

--- a/semgrep/semgrep/formatter/github.py
+++ b/semgrep/semgrep/formatter/github.py
@@ -28,7 +28,7 @@ class GitHubFormatter(BaseFormatter):
             file=str(rule_match.path),
             start=str(rule_match.start.line),
             end=str(rule_match.end.line),
-            message=str(rule_match.extra["message"]),
+            message=str(rule_match.extra["message"]).replace("\n", " "),
         )
 
     def output(

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -24,12 +24,12 @@ from semgrep.error import SemgrepCoreError
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
 from semgrep.formatter.emacs import EmacsFormatter
+from semgrep.formatter.github import GitHubFormatter
 from semgrep.formatter.json import JsonFormatter
 from semgrep.formatter.junit_xml import JunitXmlFormatter
 from semgrep.formatter.sarif import SarifFormatter
 from semgrep.formatter.text import TextFormatter
 from semgrep.formatter.vim import VimFormatter
-from semgrep.formatter.github import GitHubFormatter
 from semgrep.profile_manager import ProfileManager
 from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -29,6 +29,7 @@ from semgrep.formatter.junit_xml import JunitXmlFormatter
 from semgrep.formatter.sarif import SarifFormatter
 from semgrep.formatter.text import TextFormatter
 from semgrep.formatter.vim import VimFormatter
+from semgrep.formatter.github import GitHubFormatter
 from semgrep.profile_manager import ProfileManager
 from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
@@ -50,6 +51,7 @@ FORMATTERS: Mapping[OutputFormat, Type[BaseFormatter]] = {
     OutputFormat.SARIF: SarifFormatter,
     OutputFormat.TEXT: TextFormatter,
     OutputFormat.VIM: VimFormatter,
+    OutputFormat.GITHUB: GitHubFormatter,
 }
 
 

--- a/semgrep/tests/e2e/snapshots/test_output/test_output_format/--github/results.out
+++ b/semgrep/tests/e2e/snapshots/test_output/test_output_format/--github/results.out
@@ -1,0 +1,1 @@
+::error file=semgrep/tests/e2e/targets/basic/stupid.py,line=3,endLine=3,title=semgrep rule:semgrep.tests.e2e.rules.eqeq-is-bad::useless comparison operation `$X == $X` or `$X != $X`; possible bug?

--- a/semgrep/tests/e2e/test_output.py
+++ b/semgrep/tests/e2e/test_output.py
@@ -62,7 +62,9 @@ CLEANERS: Mapping[str, Callable[[str], str]] = {
 
 
 # junit-xml is tested in a test_junit_xml_output due to ambiguous XML attribute ordering
-@pytest.mark.parametrize("format", ["--json", "--sarif", "--emacs", "--vim"])
+@pytest.mark.parametrize(
+    "format", ["--json", "--sarif", "--emacs", "--github", "--vim"]
+)
 def test_output_format(run_semgrep_in_tmp, snapshot, format):
     stdout, stderr = run_semgrep_in_tmp(
         "rules/eqeq.yaml",


### PR DESCRIPTION
I was trying to use semgrep in github, and I _really_ wanted it's finding as annotations in the PR. This led me down a path of needing to get the dashboard/SaaS setup, and get permissions, and none of it worked, and I was chatted on slack. Etc. 

But, I think there's a much simpler route. According to the github [workflow docs](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-a-notice-message), github will parse specially formatted messages and treat them as annotations. This completely alleviates the need for any kind of permissions wrangling. 

This does run locally, though I have not tested this code as an action. I think there's a lot more plumbing for that, and I'm not sure if this is a direction y'all want to go in. But, I did test a basic PoC version of this, and it appears to work. 

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
