### PR TITLE
tainting: Avoid having "built-in" sources or sanitizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - taint-mode: Sanitizers that match exactly a source or a sink are filtered out,
   making it possible to use `- pattern: $F(...)` for declaring that any other
   function is a sanitizer
+- taint-mode: Remove built-in source `source(...)` and built-in sanitizer
+  `sanitize(...)` used for convenience during early development, this was causing
+  some unexpected behavior in real code that e.g. had a function called `source`!
 - Improved Kotlin parsing from 77% to 90% on our Kotlin corpus.
 
 ### Fixed

--- a/semgrep-core/src/analyzing/Dataflow_tainting.ml
+++ b/semgrep-core/src/analyzing/Dataflow_tainting.ml
@@ -72,11 +72,7 @@ let option_to_varmap = function
 (* Tainted *)
 (*****************************************************************************)
 
-let sanitized_instr config instr =
-  match instr.i with
-  | Call (_, { e = Fetch { base = Var (("sanitize", _), _); _ }; _ }, []) ->
-      true
-  | ___else___ -> config.is_sanitizer (G.E instr.iorig)
+let sanitized_instr config instr = config.is_sanitizer (G.E instr.iorig)
 
 (* Test whether an expression is tainted, and if it is also a sink,
  * report the finding too (by side effect).
@@ -142,8 +138,6 @@ let check_tainted_instr config fun_env env instr =
   let tainted_args = function
     | Assign (_, e) -> check_expr e
     | AssignAnon _ -> false (* TODO *)
-    | Call (_, { e = Fetch { base = Var (("source", _), _); _ }; _ }, []) ->
-        true
     | Call (_, e, args) ->
         let e_tainted = check_expr e in
         (* We must always go into the arguments regardless of whether `e` is

--- a/semgrep-core/tests/tainting_rules/go/nobuiltin.go
+++ b/semgrep-core/tests/tainting_rules/go/nobuiltin.go
@@ -1,0 +1,53 @@
+package fetch
+
+import (
+    "context"
+    "io/fs"
+    "net/http"
+    "os"
+    "sort"
+    "testing"
+    "time"
+
+    "golang.org/x/pkgsite/internal"
+    "golang.org/x/pkgsite/internal/licenses"
+    "golang.org/x/pkgsite/internal/log"
+    "golang.org/x/pkgsite/internal/proxy"
+    "golang.org/x/pkgsite/internal/proxy/proxytest"
+    "golang.org/x/pkgsite/internal/source"
+    "golang.org/x/pkgsite/internal/stdlib"
+    "golang.org/x/pkgsite/internal/testing/sample"
+    "golang.org/x/pkgsite/internal/testing/testhelper"
+)
+
+// proxyFetcher is a test helper function that sets up a test proxy, fetches
+// a module using FetchModule, and returns fetch result and a license detector.
+func proxyFetcher(t *testing.T, withLicenseDetector bool, ctx context.Context, mod *proxytest.Module, fetchVersion string) (*FetchResult, *licenses.Detector) {
+    t.Helper()
+
+    modulePath := mod.ModulePath
+    version := mod.Version
+    if version == "" {
+        version = sample.VersionString
+    }
+    if fetchVersion == "" {
+        fetchVersion = version
+    }
+
+    proxyClient, teardownProxy := proxytest.SetupTestClient(t, []*proxytest.Module{{
+        ModulePath: modulePath,
+        Version:    version,
+        Files:      mod.Files,
+    }})
+    defer teardownProxy()
+    //OK:
+    got := FetchModule(ctx, modulePath, fetchVersion, NewProxyModuleGetter(proxyClient, source.NewClientForTesting()))
+    if !withLicenseDetector {
+        return got, nil
+    }
+
+    //OK:
+    d := licenseDetector(ctx, t, modulePath, got.ResolvedVersion, proxyClient)
+    return got, d
+}
+

--- a/semgrep-core/tests/tainting_rules/go/nobuiltin.yaml
+++ b/semgrep-core/tests/tainting_rules/go/nobuiltin.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    languages:
+      - go
+    message: Test
+    severity: INFO
+    mode: taint
+    pattern-sources:
+      - pattern: do_not_match_anything
+    pattern-sinks:
+      - pattern: $ANYTHING(...)
+


### PR DESCRIPTION
I am guessing they were used for quick experiments during taint-mode
early days, but right now they have no use since both `pattern-sources`
and `pattern-sanitizers` are required anyways. This probably doesn't
happen very often, but if e.g. `source` happened to be an object or
function in some real-world code, then we were "magically" considering
it as a source of taint!

test plan:
make test # test file included

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
