### PR TITLE
Replace named pipes by regular files to avoid errors when re-reading the file

### DIFF
--- a/semgrep-core/src/core/Find_target.ml
+++ b/semgrep-core/src/core/Find_target.ml
@@ -7,6 +7,10 @@ module Resp = Semgrep_core_response_t
 
 type target_kind = Explicit | Filterable
 
+let string_of_kind = function
+  | Explicit -> "explicit"
+  | Filterable -> "filterable"
+
 (*
    The 7% threshold works well for javascript files based on looking at
    .min.js files and other .js found in various github repos.

--- a/semgrep-core/src/core/Find_target.mli
+++ b/semgrep-core/src/core/Find_target.mli
@@ -15,6 +15,9 @@
 *)
 type target_kind = Explicit | Filterable
 
+(* Show target kind as lowercase, English words. *)
+val string_of_kind : target_kind -> string
+
 (*
    Scan a list of folders or files recursively and return a list of files
    in the requested language. This takes care of ignoring undesirable


### PR DESCRIPTION
This now works:
```
$ semgrep-core -lang bash -e '... &' -target <(echo 'ls &')
/tmp/semgrep-core-95ab40-63:1
 ls &
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
