### PR TITLE
tainting: Always check subexpressions and function call arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Fixed
 - Respect --skip-unknown-extensions even for files with no extension
 (treat no extension as an unknown extension)
+- taint-mode: Fixed (another) bug where a tainted sink could go unreported when
+  the sink is a specific argument in a function call
 
 ## [0.68.1](https://github.com/returntocorp/semgrep/releases/tag/v0.68.1) - 10-07-2021
 

--- a/semgrep-core/tests/tainting_rules/js/everything_source.js
+++ b/semgrep-core/tests/tainting_rules/js/everything_source.js
@@ -1,0 +1,3 @@
+//ERROR:
+jwt.decode(token, true);
+

--- a/semgrep-core/tests/tainting_rules/js/everything_source.yaml
+++ b/semgrep-core/tests/tainting_rules/js/everything_source.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: test
+    languages:
+      - javascript
+      - typescript
+    message: Test
+    mode: taint
+    pattern-sinks:
+      - patterns:
+          - pattern: $JWT.decode($TOKEN, ...)
+          - pattern: $TOKEN
+    pattern-sources:
+      - pattern: $TOKEN
+    severity: WARNING
+


### PR DESCRIPTION
Follows: c31c31895b0 ("tainting: Make sure we always check function call arguments (#3996)")

test plan:
make test # test included

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
