### PR TITLE
Change info log when downloading config from cdn

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -615,8 +615,7 @@ def download_pack_config(ruleset_name: str) -> Dict[str, YamlTree]:
         )
         return {"rules": hydrated}
 
-    DOWNLOADING_MESSAGE = f"downloading config from {SEMGREP_CDN_BASE_URL}..."
-    logger.info(DOWNLOADING_MESSAGE)
+    logger.info("downloading config from semgrep registry cdn...")
     logger.debug(f"Resolving latest version of {ruleset_name}")
     latest_version = get_latest_version(ruleset_name)
     ruleset_definition = get_ruleset(ruleset_name, latest_version)


### PR DESCRIPTION
CDN url doesnt show anything when visited and will just confuse users

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
