### PR TITLE
tainting: Introduce a special kind of sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Changed
+- taint-mode: Introduce a new kind of _not conflicting_ sanitizer that must be
+  declared with `not_conflicting: true`. This affects the change made in 0.68.0
+  that allowed a sanitizer like `- pattern: $F(...)` to work, but turned out to
+  affect our ability to specify sanitization by side-effect. Now the default
+  semantics of sanitizers is reverted back to the same as before 0.68.0, and
+  `- pattern: $F(...)` is supported via the new not-conflicting sanitizers.
+
 ## [0.68.2](https://github.com/returntocorp/semgrep/releases/tag/v0.68.2) - 10-07-2021
 
 ## Fixed

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -233,9 +233,21 @@ type pformula = New of formula | Old of formula_old [@@deriving show, eq]
  *     type rule   = Search of search | Taint of taint
  *)
 
+type sanitizer_spec = {
+  not_conflicting : bool;
+      (** If [not_conflicting] is enabled, the sanitizer cannot conflict with
+    a sink or a source (i.e., match the exact same range) otherwise
+    it is filtered out. This allows to e.g. declare `$F(...)` as a sanitizer,
+    to assume that any other function will handle tainted data safely.
+    Without this, `$F(...)` would automatically sanitize any other function
+    call acting as a sink or a source. *)
+  pformula : pformula;
+}
+[@@deriving show]
+
 type taint_spec = {
   sources : pformula list;
-  sanitizers : pformula list;
+  sanitizers : sanitizer_spec list;
   sinks : pformula list;
 }
 [@@deriving show]

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -675,6 +675,19 @@ let parse_severity ~id (s, t) =
            (id, spf "Bad severity: %s (expected ERROR, WARNING or INFO)" s, t))
 
 (*****************************************************************************)
+(* Sub parsers taint *)
+(*****************************************************************************)
+
+let parse_sanitizer env (key : key) (value : G.expr) =
+  let sanitizer_dict = yaml_to_dict env key value in
+  let not_conflicting =
+    take_opt sanitizer_dict env parse_bool "not_conflicting"
+    |> Option.value ~default:false
+  in
+  let pformula = parse_formula env sanitizer_dict in
+  { R.not_conflicting; pformula }
+
+(*****************************************************************************)
 (* Main entry point *)
 (*****************************************************************************)
 
@@ -685,18 +698,20 @@ let parse_mode env mode_opt (rule_dict : dict) : R.mode =
       let formula = parse_formula env rule_dict in
       R.Search formula
   | Some ("taint", _) ->
-      let parse_sub_patterns env key patterns =
-        let parse_sub_pattern name env pattern =
-          parse_formula env (yaml_to_dict env name pattern)
-        in
+      let parse_sub_formula env name pattern =
+        parse_formula env (yaml_to_dict env name pattern)
+      in
+      let parse_specs parse_spec env key x =
         parse_list env key
-          (parse_sub_pattern (fst key ^ "list item", snd key))
-          patterns
+          (fun env -> parse_spec env (fst key ^ "list item", snd key))
+          x
       in
       let sources, sanitizers_opt, sinks =
-        ( take rule_dict env parse_sub_patterns "pattern-sources",
-          take_opt rule_dict env parse_sub_patterns "pattern-sanitizers",
-          take rule_dict env parse_sub_patterns "pattern-sinks" )
+        ( take rule_dict env (parse_specs parse_sub_formula) "pattern-sources",
+          take_opt rule_dict env
+            (parse_specs parse_sanitizer)
+            "pattern-sanitizers",
+          take rule_dict env (parse_specs parse_sub_formula) "pattern-sinks" )
       in
       R.Taint { sources; sanitizers = optlist_to_list sanitizers_opt; sinks }
   | Some key ->

--- a/semgrep-core/tests/tainting_rules/js/everything_source.js
+++ b/semgrep-core/tests/tainting_rules/js/everything_source.js
@@ -1,3 +1,2 @@
-//ERROR:
+// ERROR: test
 jwt.decode(token, true);
-

--- a/semgrep-core/tests/tainting_rules/js/everything_source1.js
+++ b/semgrep-core/tests/tainting_rules/js/everything_source1.js
@@ -1,0 +1,3 @@
+jwt.verify(token, key);
+// ok: test
+jwt.decode(token, true);

--- a/semgrep-core/tests/tainting_rules/js/everything_source1.yaml
+++ b/semgrep-core/tests/tainting_rules/js/everything_source1.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: test
+    languages:
+      - javascript
+      - typescript
+    message: Test
+    mode: taint
+    pattern-sanitizers:
+      - patterns:
+          - pattern-inside: |
+              $JWT.verify($TOKEN, ...)
+              ...
+          - pattern: $TOKEN
+    pattern-sinks:
+      - patterns:
+          - pattern: $JWT.decode($TOKEN, ...)
+          - pattern: $TOKEN
+    pattern-sources:
+      - pattern: $TOKEN
+    severity: WARNING

--- a/semgrep-core/tests/tainting_rules/js/sanitized_by_side_effect.js
+++ b/semgrep-core/tests/tainting_rules/js/sanitized_by_side_effect.js
@@ -1,0 +1,34 @@
+const { ok } = require('assert');
+const jwt = require('jsonwebtoken');
+
+token = getToken();
+// ERROR: jwt-decode-without-verify
+if (jwt.decode(token, true).param === true) {
+  console.log('token is valid');
+}
+
+function ok(token, key) {
+  jwt.verify(token, key);
+  // ok: jwt-decode-without-verify
+  if (jwt.decode(token, true).param === true) {
+    console.log('token is valid');
+  }
+}
+
+const ok2 = (token, key) => {
+  jwt.verify(token, key);
+  // ok: jwt-decode-without-verify
+  if (jwt.decode(token, true).param === true) {
+    console.log('token is valid');
+  }
+};
+
+function bad_different_token(token, key) {
+    token2 = getToken();
+    jwt.verify(token2, key);
+
+    // ERROR: jwt-decode-without-verify
+    if (jwt.decode(token, true).param === true) {
+      console.log('token is valid');
+    }
+}

--- a/semgrep-core/tests/tainting_rules/js/sanitized_by_side_effect.yaml
+++ b/semgrep-core/tests/tainting_rules/js/sanitized_by_side_effect.yaml
@@ -1,0 +1,42 @@
+rules:
+  - id: jwt-decode-without-verify
+    languages:
+      - javascript
+      - typescript
+    message: Detected the decoding of a JWT token without a verify step. JWT tokens
+      must be verified before use, otherwise the token's integrity is unknown.
+      This means a malicious actor could forge a JWT token with any claims. Call
+      '.verify()' before using the token.
+    metadata:
+      asvs:
+        control_id: 3.5.3 Insecue Stateless Session Tokens
+        control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x12-V3-Session-management.md#v35-token-based-session-management
+        section: "V3: Session Management Verification Requirements"
+        version: "4"
+      category: security
+      cwe: "CWE-345: Insufficient Verification of Data Authenticity"
+      owasp: "A2: Broken Authentication"
+      source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+      technology:
+        - jwt
+    mode: taint
+    pattern-sanitizers:
+      - patterns:
+          - pattern-inside: |
+              $JWT = require('jsonwebtoken');
+              ...
+          - pattern-inside: |
+              $JWT.verify($TOKEN, ...)
+              ...
+          - pattern: $TOKEN
+    pattern-sinks:
+      - patterns:
+          - pattern-inside: |
+              $JWT = require('jsonwebtoken');
+              ...
+          - pattern: $JWT.decode($TOKEN, ...)
+          - pattern: $TOKEN
+    pattern-sources:
+      - pattern: $TOKEN
+    severity: WARNING
+

--- a/semgrep-core/tests/tainting_rules/php/opaque_safe_bad.php
+++ b/semgrep-core/tests/tainting_rules/php/opaque_safe_bad.php
@@ -1,0 +1,22 @@
+<?php
+
+function not_tainted($data) {
+    // do stuff
+    return '2';
+}
+
+//OK:
+sink(not_tainted(tainted('a')));
+
+$ok = not_tainted(tainted('a'));
+//OK:
+sink($ok);
+
+// $F(...) sanitizes *everything*
+//OK:
+sink(tainted('b'));
+
+$bad = tainted('b');
+// $F(...) sanitizes *everyting*
+//OK:
+sink($bad);

--- a/semgrep-core/tests/tainting_rules/php/opaque_safe_bad.yaml
+++ b/semgrep-core/tests/tainting_rules/php/opaque_safe_bad.yaml
@@ -5,8 +5,8 @@ rules:
     message: Match
     mode: taint
     pattern-sanitizers:
-      - not_conflicting: true
-        pattern: $F(...)
+      - pattern: $F(...)
+        # not_conflicting: true
     pattern-sinks:
       - pattern: sink(...)
     pattern-sources:


### PR DESCRIPTION
In PA-402 we made all sanitizers "not-conflicting" so that one could
declare `$F(...)` as a sanitizer without conflicting with sources and
sinks. That makes sense in that particular use case, but it partially
breaks our ability to simulate sanitizers by side effect. For example:

    pattern-sanitizers:
      - patterns:
          - pattern-inside: |
              $JWT.verify($TOKEN, ...)
              ...
          - pattern: $TOKEN
    pattern-sinks:
      - patterns:
          - pattern: $JWT.decode($TOKEN, ...)
          - pattern: $TOKEN
    pattern-sources:
      - pattern: $TOKEN

no longer works on this example:

    jwt.verify(token, key);
    // ok: test
    jwt.decode(token, true);

Since the second `token` is both matched by a sanitizer and a sink (and
a source), the sanitizer is now "disabled" due to the changes made by
0b35ab5004c in connection with PA-402. This is not at all desirable, but
we still want the ability to declare `$F(...)` as a sanitizer. Then the
simplest solution seems to be to support two different kinds of
sanitizers.

Closes: PA-455
Changes: 0b35ab5004c ("tainting: Filter out sanitizers that conflict with sources/sinks (#3958)")

test plan:
make test # tests included

PR checklist:
- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
