### PR TITLE
Fix invocation of 'docker run' which was redirecting stderr to stdout.

### DIFF
--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -233,7 +233,6 @@ def run_semgrep(
             # so we override it here
             "--entrypoint",
             "semgrep",
-            "-t",
             docker,
             "--quiet",
             "--config",


### PR DESCRIPTION
See https://stackoverflow.com/questions/69534750/why-does-docker-run-t-redirect-stderr-to-stdout

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
