### PR TITLE
Small fixes to metrics messaging

### DIFF
--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -571,6 +571,11 @@ def cli(
             "The '--dangerously-allow-arbitrary-code-execution-from-rules' flag is now deprecated and does nothing. It will be removed in the future."
         )
 
+    if (config and "auto" in config) and metrics == MetricsState.OFF:
+        abort(
+            "Cannot create auto config when metrics are off. Please allow metrics or run with a specific config."
+        )
+
     output_time = time or json_time
 
     # set the flags

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -235,7 +235,7 @@ class _MetricManager:
         """
         import requests
 
-        logger.debug(
+        logger.verbose(
             f"{'Sending' if self.is_enabled() else 'Not sending'} pseudonymous metrics since metrics are configured to {self._send_metrics.name} and server usage is {self._using_server}"
         )
 

--- a/semgrep/semgrep/notifications.py
+++ b/semgrep/semgrep/notifications.py
@@ -21,7 +21,7 @@ def possibly_notify_user() -> None:
                 "yellow",
                 "METRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev."
                 """\nTo disable Registry rule metrics, use "--metrics=off"."""
-                "\nUsing configs from local files (like --config=xyz.yml) does not enable metrics."
+                "\nUsing configs only from local files (like --config=xyz.yml) does not enable metrics."
                 "\n"
                 "\nMore information: https://semgrep.dev/docs/metrics"
                 "\n",

--- a/semgrep/tests/e2e/snapshots/test_check/test_max_memory/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_max_memory/error.txt
@@ -5,3 +5,4 @@ rules:
 ran 1 rules on 1 files: 0 findings
 found problems analyzing 1 file; run with --verbose for details or run with --strict to exit non-zero if any file cannot
 be analyzed cleanly
+Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
@@ -11,3 +11,4 @@ threshold` for more info.
 ran 3 rules on 1 files: 0 findings
 found problems analyzing 1 file; run with --verbose for details or run with --strict to exit non-zero if any file cannot
 be analyzed cleanly
+Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
@@ -11,3 +11,4 @@ threshold` for more info.
 ran 3 rules on 1 files: 0 findings
 found problems analyzing 2 files; run with --verbose for details or run with --strict to exit non-zero if any file
 cannot be analyzed cleanly
+Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -7,3 +7,4 @@ Semgrep Core WARN - Syntax error in file targets/bad/invalid_python.py
 	`
     ` was unexpected
 ran 2 rules on 1 files: 0 findings
+Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False


### PR DESCRIPTION
Improve metrics messaging:
- Show information about whether metrics are enabled when run with `--verbose`
- Clarify in first-run output that local + registry = metrics
- Abort when running with `--config auto` and `--metrics off`

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
