### PR TITLE
[Ruby] put back equivalence on keyword argument syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - C: support ... in parameters and sizeof arguments (#4037)
 - C: support declaration and function patterns
 - Java: support @interface pattern (#4030)
-- Python: fix range of tuples (#3832)
-- C: fix some wrong typedef inference
 
 ### Fixed
 - Reverted change to exclude minified files from the scan (see changelog for
+- Python: fix range of tuples (#3832)
+- C: fix some wrong typedef inference
   0.66.0)
+- Ruby: put back equivalence on old syntax for keyword arguments (#3981)
 
 ### Changed
 - taint-mode: Introduce a new kind of _not conflicting_ sanitizer that must be

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -155,6 +155,10 @@ let rec expr e =
 
 and argument arg : G.argument =
   match arg with
+  (* sgrep: equivalence between different keyword argument syntax *)
+  | Arg (Binop (Atom (_tk, AtomSimple id), (Op_ASSOC, _v2), v3)) ->
+      let e3 = expr v3 in
+      G.ArgKwd (id, e3)
   | Arg e -> G.Arg (expr e)
   | ArgKwd (id, _tk, arg) ->
       let id = ident id in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -1637,6 +1637,7 @@ and pair (env : env) (x : CST.pair) =
       let v2 = token2 env v2 in
       (* => *)
       let v3 = arg env v3 in
+      (* will be converted to ArgKwd in ruby_to_generic.ml if needed *)
       Left (Binop (v1, (Op_ASSOC, v2), v3))
   | `Choice_hash_key_symb_imm_tok_COLON_arg (v1, v2, v3) -> (
       let v1 =

--- a/semgrep-core/tests/ruby/equivalence_keyword_args_hash.rb
+++ b/semgrep-core/tests/ruby/equivalence_keyword_args_hash.rb
@@ -1,0 +1,5 @@
+#ERROR: match, old style syntax
+Oj.load(user_input, :mode => :object)
+
+#ERROR: match, new style syntax
+Oj.load(user_input, mode: :object)

--- a/semgrep-core/tests/ruby/equivalence_keyword_args_hash.sgrep
+++ b/semgrep-core/tests/ruby/equivalence_keyword_args_hash.sgrep
@@ -1,0 +1,1 @@
+Oj.load(..., mode: :object, ...)


### PR DESCRIPTION
This closes #3981

test plan:
test file included


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)