### PR TITLE
Correctly compare metavariables bounded to Metavariable.N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Reverted change to exclude minified files from the scan (see changelog for
+  0.66.0)
+- Java: Fixed equality of metavariables bounded to imported classes (#3748)
 - Python: fix range of tuples (#3832)
 - C: fix some wrong typedef inference
-  0.66.0)
 - Ruby: put back equivalence on old syntax for keyword arguments (#3981)
 
 ### Changed

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -240,6 +240,7 @@ let rec equal_ast_binded_code (config : Config_semgrep.t) (a : MV.mvalue)
      * TODO? missing MV.Ss _, MV.Ss _ ??
      *)
     | MV.Id _, MV.Id _
+    | MV.N _, MV.N _
     | MV.E _, MV.E _
     | MV.S _, MV.S _
     | MV.P _, MV.P _
@@ -283,7 +284,8 @@ let rec equal_ast_binded_code (config : Config_semgrep.t) (a : MV.mvalue)
 
   if not res then
     logger#ldebug
-      (lazy (spf "A = %s\nB = %s\n" (MV.str_of_mval a) (MV.str_of_mval b)));
+      (lazy
+        (spf "A != B\nA = %s\nB = %s\n" (MV.str_of_mval a) (MV.str_of_mval b)));
   res
 
 let check_and_add_metavar_binding ((mvar : MV.mvar), valu) (tin : tin) =

--- a/semgrep-core/tests/OTHER/rules/misc_name_and_neg.java
+++ b/semgrep-core/tests/OTHER/rules/misc_name_and_neg.java
@@ -1,0 +1,9 @@
+import test.A;
+
+class Test {
+    // This caused to be matched because A was resolved, and
+    // we were not handling correctly MV.N vs MV.N in equal_ast
+    public A foo() { }
+
+    public B bar() { }
+}

--- a/semgrep-core/tests/OTHER/rules/misc_name_and_neg.yaml
+++ b/semgrep-core/tests/OTHER/rules/misc_name_and_neg.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: test-template
+  patterns:
+  - pattern: |
+        $RETURNTYPE $METHOD(...) { ... }
+  - pattern-not-inside: |
+        $RETURNTYPE $METHOD(...) { ... }
+  message: Working!
+  severity: WARNING
+  languages: [java]


### PR DESCRIPTION
This closes #3748

test plan:
test file included


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)