### PR TITLE
Add bash to the languages supported by the semgrep/python CLI

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -487,7 +487,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout matches =
                       Semgrep_core_response_t.path = file;
                       reason = Too_many_matches;
                       details;
-                      skipped_rule = Some rule_id;
+                      rule_id = Some rule_id;
                     })
            in
            (error, skipped))

--- a/semgrep-core/src/core-response/Semgrep_core_response.atd
+++ b/semgrep-core/src/core-response/Semgrep_core_response.atd
@@ -147,14 +147,14 @@ type target_time = {
 }
 
 (*
-   If the 'skipped_rule' field is missing, the target is assumed to have
+   If the 'rule_id' field is missing, the target is assumed to have
    been skipped for all the rules.
 *)
 type skipped_target = {
   path: string;
   reason: skip_reason;
   details: string;
-  ?skipped_rule: rule_id option;
+  ?rule_id: rule_id option;
 }
 
 (*

--- a/semgrep-core/src/core/Find_target.ml
+++ b/semgrep-core/src/core/Find_target.ml
@@ -84,7 +84,7 @@ let is_minified path =
             spf "file contains too little whitespace: %.3f%% (min = %.1f%%)"
               (100. *. stat.ws_freq)
               (100. *. min_whitespace_frequency);
-          skipped_rule = None;
+          rule_id = None;
         }
     else if stat.line_freq < min_line_frequency then
       Error
@@ -96,7 +96,7 @@ let is_minified path =
               "file contains too few lines for its size: %.4f%% (min = %.2f%%)"
               (100. *. stat.line_freq)
               (100. *. min_line_frequency);
-          skipped_rule = None;
+          rule_id = None;
         }
     else Ok path
   else Ok path
@@ -115,7 +115,7 @@ let exclude_files_in_skip_lists roots =
              Resp.path;
              reason = Excluded_by_config;
              details = "excluded by 'skip list' file";
-             skipped_rule = None;
+             rule_id = None;
            })
   in
   (paths, skipped)
@@ -141,7 +141,7 @@ let filter_by_size _lang paths =
                details =
                  spf "target file size exceeds %i bytes at %i bytes" max_bytes
                    size;
-               skipped_rule = None;
+               rule_id = None;
              }
          else Ok path)
 

--- a/semgrep-core/src/core/Guess_lang.ml
+++ b/semgrep-core/src/core/Guess_lang.ml
@@ -257,7 +257,7 @@ let wrap_with_error_message lang path bool_res :
           details =
             spf "target file doesn't look like language %s"
               (Lang.to_string lang);
-          skipped_rule = None;
+          rule_id = None;
         }
 
 let inspect_file lang path =

--- a/semgrep-core/src/engine/Run_rules.ml
+++ b/semgrep-core/src/engine/Run_rules.ml
@@ -13,6 +13,7 @@
  * license.txt for more details.
  *)
 
+open Common
 module R = Rule
 module RP = Report
 module FM = File_and_more
@@ -73,11 +74,15 @@ let filter_and_partition_rules rules file_and_more =
 
 let skipped_target_of_rule (file_and_more : FM.t) (rule : R.rule) :
     Resp.skipped_target =
+  let rule_id, _ = rule.id in
+  let details =
+    spf "target doesn't contain some elements required by rule '%s'" rule_id
+  in
   {
     path = file_and_more.file;
     reason = Irrelevant_rule;
-    details = "target doesn't contain some elements required by the rule";
-    skipped_rule = Some (fst rule.id);
+    details;
+    rule_id = Some rule_id;
   }
 
 let check hook default_config rules equivs file_and_more =

--- a/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
@@ -77,7 +77,7 @@ let run_all ~case_sensitive ~debug ~force ~warn ~no_skip_search patterns docs :
                       reason = Minified;
                       details =
                         "not a source file: target file appears to be minified";
-                      skipped_rule = None;
+                      rule_id = None;
                     }
                     :: !skipped;
                   None
@@ -88,7 +88,7 @@ let run_all ~case_sensitive ~debug ~force ~warn ~no_skip_search patterns docs :
                       Semgrep_core_response_t.path;
                       reason = Binary;
                       details = "target looks like a binary file";
-                      skipped_rule = None;
+                      rule_id = None;
                     }
                     :: !skipped;
                   None

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -182,6 +182,7 @@ class CoreSkipped:
         path = Path(raw_json["path"])
         reason = SkipReason(raw_json["reason"])
         details = SkipDetails(raw_json["details"])
+        logger.verbose(f"skipped '{path}': {reason}: {details}")
         return cls(rule_id, path, reason, details)
 
 

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -182,7 +182,11 @@ class CoreSkipped:
         path = Path(raw_json["path"])
         reason = SkipReason(raw_json["reason"])
         details = SkipDetails(raw_json["details"])
-        logger.verbose(f"skipped '{path}': {reason}: {details}")
+        if raw_rule_id:
+            rule_info = f"rule {raw_rule_id}"
+        else:
+            rule_info = "all rules"
+        logger.verbose(f"skipped '{path}' [{rule_info}]: {reason}: {details}")
         return cls(rule_id, path, reason, details)
 
 

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -38,6 +38,7 @@ class Language(Enum):
     HTML: str = "html"
     JSON: str = "json"
     HCL: str = "hcl"
+    BASH: str = "bash"
     REGEX: str = "regex"
     GENERIC: str = "generic"
 
@@ -66,6 +67,7 @@ class Language_util:
         Language.ML: [Language.ML.value, "ocaml"],
         Language.JSON: [Language.JSON.value, "JSON", "Json"],
         Language.HCL: [Language.HCL.value, "tf", "terraform", "HCL"],
+        Language.BASH: [Language.BASH.value, "sh"],
         Language.REGEX: [Language.REGEX.value, "none"],
         Language.GENERIC: [Language.GENERIC.value],
     }

--- a/semgrep/semgrep/target_manager_extensions.py
+++ b/semgrep/semgrep/target_manager_extensions.py
@@ -33,6 +33,7 @@ SCALA_EXTENSIONS = [FileExtension(".scala")]
 VUE_EXTENSIONS = [FileExtension(".vue")]
 HTML_EXTENSIONS = [FileExtension(".html"), FileExtension(".html")]
 HCL_EXTENSIONS = [FileExtension(".tf")]
+BASH_EXTENSIONS = [FileExtension(".bash"), FileExtension(".sh")]
 
 # This is used to determine the set of files with known extensions,
 # i.e. those for which we have a proper parser.
@@ -54,6 +55,7 @@ ALL_EXTENSIONS = (
     + VUE_EXTENSIONS
     + HTML_EXTENSIONS
     + HCL_EXTENSIONS
+    + BASH_EXTENSIONS
 )
 
 # This is used to select the files suitable for spacegrep, which is
@@ -86,6 +88,7 @@ _LANGS_TO_EXTS: Dict[Language, List[FileExtension]] = {
     Language.VUE: VUE_EXTENSIONS,
     Language.HTML: HTML_EXTENSIONS,
     Language.HCL: HCL_EXTENSIONS,
+    Language.BASH: BASH_EXTENSIONS,
 }
 
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error-in-color.txt
@@ -5,5 +5,5 @@
 [94m  | [0m               [31m^^^^^^^^^^[0m
 [94m8 | [0m    severity: WARNING
 
-[31munsupported language: intercal. supported languages are: C#, HCL, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, hack, hacklang, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, terraform, tf, ts, typescript, vue, yaml[0m
+[31munsupported language: intercal. supported languages are: C#, HCL, JSON, Json, Kotlin, Rust, Yaml, bash, c, cs, csharp, generic, go, golang, hack, hacklang, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, sh, terraform, tf, ts, typescript, vue, yaml[0m
 [0m

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -3,7 +3,7 @@
     {
       "code": 8,
       "level": "error",
-      "long_msg": "unsupported language: intercal. supported languages are: C#, HCL, JSON, Json, Kotlin, Rust, Yaml, c, cs, csharp, generic, go, golang, hack, hacklang, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, terraform, tf, ts, typescript, vue, yaml",
+      "long_msg": "unsupported language: intercal. supported languages are: C#, HCL, JSON, Json, Kotlin, Rust, Yaml, bash, c, cs, csharp, generic, go, golang, hack, hacklang, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, none, ocaml, php, py, python, python2, python3, rb, regex, rs, ruby, rust, scala, sh, terraform, tf, ts, typescript, vue, yaml",
       "short_msg": "invalid language: intercal",
       "spans": [
         {

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -3,6 +3,7 @@ Running 2 rules...
 rules:
 - rules.assert-eqeq-is-ok
 - rules.eqeq-is-bad
+skipped 'targets/bad/invalid_python.py' [rule assert-eqeq-is-ok]: irrelevant_rule: target doesn't contain some elements required by rule 'assert-eqeq-is-ok'
 Semgrep Core WARN - Syntax error in file targets/bad/invalid_python.py
 	`
     ` was unexpected


### PR DESCRIPTION
* This is a minimal change that supports only targets with the `.sh` or `.bash` extensions.
* I also added a debug log line for each skipped target, which was useful for debugging and something a user was requesting earlier this week. This is how I found about bug #4080.

semgrep currently won't return matches on bash programs due to #4080, which will be fixed independently.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
