### PR TITLE
Introduce new property 'id_hidden' [PA-509]

### DIFF
--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -115,7 +115,12 @@ and map_resolved_name_kind = function
 
 and map_id_info x =
   match x with
-  | { G.id_resolved = v_id_resolved; id_type = v_id_type; id_constness = v3 } ->
+  | {
+   G.id_resolved = v_id_resolved;
+   id_type = v_id_type;
+   id_constness = v3;
+   id_hidden = _not_available_in_v1;
+  } ->
       let v3 = map_of_ref (map_of_option map_constness) v3 in
       let v_id_type = map_of_ref (map_of_option map_type_) v_id_type in
       let v_id_resolved =

--- a/semgrep-core/src/core/Pattern.ml
+++ b/semgrep-core/src/core/Pattern.ml
@@ -55,6 +55,8 @@ let is_js lang =
 
 (* This is used in Analyze_pattern.ml to skip
  * semgrep special identifiers.
+ * new TODO: instead of relying on this list of exceptions, set id_hidden=true
+ * in the AST.
  *)
 let is_special_identifier ?lang str =
   Metavariable.is_metavar_name str

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -346,8 +346,21 @@ and id_info = {
    *)
   id_constness : constness option ref; [@equal fun _a _b -> true]
   (* THINK: Drop option? *)
-  (* id_hidden=true must be set for any ordinary identifier that doesn't
-     appear in the source code but is introduced in the AST after parsing.
+  (* id_hidden=true must be set for any artificial identifier that never
+     appears in source code but is introduced in the AST after parsing.
+
+     Don't use this for syntax desugaring or transpilation because the
+     resulting function name might exist in some source code. Consider the
+     following normalization:
+
+       !foo -> foo.contents
+                   ^^^^^^^^
+                 should not be marked as hidden because it could appear
+                 in target source code.
+
+     However, an artificial identifier like "!sh_quoted_expand!" should
+     be marked as hidden in bash.
+
      This allows not breaking the -fast/-filter_irrelevant_rules optimization
      that skips a target file if some identifier in the pattern AST doesn't
      exist in the source of the target.

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -345,7 +345,14 @@ and id_info = {
    * depending where it is used.
    *)
   id_constness : constness option ref; [@equal fun _a _b -> true]
-      (* THINK: Drop option? *)
+  (* THINK: Drop option? *)
+  (* id_hidden=true must be set for any ordinary identifier that doesn't
+     appear in the source code but is introduced in the AST after parsing.
+     This allows not breaking the -fast/-filter_irrelevant_rules optimization
+     that skips a target file if some identifier in the pattern AST doesn't
+     exist in the source of the target.
+  *)
+  id_hidden : bool;
 }
 
 (*****************************************************************************)
@@ -1761,14 +1768,20 @@ let sid_TODO = -1
 
 let empty_var = { vinit = None; vtype = None }
 
-let empty_id_info () =
-  { id_resolved = ref None; id_type = ref None; id_constness = ref None }
+let empty_id_info ?(hidden = false) () =
+  {
+    id_resolved = ref None;
+    id_type = ref None;
+    id_constness = ref None;
+    id_hidden = hidden;
+  }
 
-let basic_id_info resolved =
+let basic_id_info ?(hidden = false) resolved =
   {
     id_resolved = ref (Some resolved);
     id_type = ref None;
     id_constness = ref None;
+    id_hidden = hidden;
   }
 
 (* TODO: move AST_generic_helpers.name_of_id and ids here *)
@@ -1778,8 +1791,8 @@ let basic_id_info resolved =
 (* ------------------------------------------------------------------------- *)
 
 (* alt: could use @@deriving make *)
-let basic_entity ?(attrs = []) ?(tparams = []) id =
-  let idinfo = empty_id_info () in
+let basic_entity ?hidden ?(attrs = []) ?(tparams = []) id =
+  let idinfo = empty_id_info ?hidden () in
   { name = EN (Id (id, idinfo)); attrs; tparams }
 
 (* ------------------------------------------------------------------------- *)

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -133,17 +133,23 @@ let (mk_visitor : visitor_in -> visitor_out) =
   and map_id_info v =
     let k x =
       match x with
-      | { id_resolved = v_id_resolved; id_type = v_id_type; id_constness = v3 }
-        ->
+      | {
+       id_resolved = v_id_resolved;
+       id_type = v_id_type;
+       id_constness = v3;
+       id_hidden;
+      } ->
           let v3 = map_of_ref (map_of_option map_constness) v3 in
           let v_id_type = map_of_ref (map_of_option map_type_) v_id_type in
           let v_id_resolved =
             map_of_ref (map_of_option map_resolved_name) v_id_resolved
           in
+          let id_hidden = map_of_bool id_hidden in
           {
             id_resolved = v_id_resolved;
             id_type = v_id_type;
             id_constness = v3;
+            id_hidden;
           }
     in
     vin.kidinfo (k, all_functions) v

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -94,7 +94,12 @@ and vof_name_info
   OCaml.VDict bnds
 
 and vof_id_info
-    { id_resolved = v_id_resolved; id_type = v_id_type; id_constness = v3 } =
+    {
+      id_resolved = v_id_resolved;
+      id_type = v_id_type;
+      id_constness = v3;
+      id_hidden;
+    } =
   let bnds = [] in
   let arg = OCaml.vof_ref (OCaml.vof_option vof_constness) v3 in
   let bnd = ("id_constness", arg) in
@@ -104,6 +109,9 @@ and vof_id_info
   let bnds = bnd :: bnds in
   let arg = OCaml.vof_ref (OCaml.vof_option vof_resolved_name) v_id_resolved in
   let bnd = ("id_resolved", arg) in
+  let bnds = bnd :: bnds in
+  let arg = OCaml.vof_bool id_hidden in
+  let bnd = ("id_hidden", arg) in
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
 

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -83,6 +83,7 @@ let default_visitor =
           id_resolved = v_id_resolved;
           id_type = v_id_type;
           id_constness = _IGNORED;
+          id_hidden = _IGNORED2;
         } =
           x
         in
@@ -182,12 +183,14 @@ let (mk_visitor :
         id_resolved = v_id_resolved;
         id_type = v_id_type;
         id_constness = v_id_constness;
+        id_hidden = v_id_hidden;
       } =
         x
       in
       let arg = v_ref_do_visit (v_option v_resolved_name) v_id_resolved in
       let arg = v_ref_do_visit (v_option v_type_) v_id_type in
       let arg = v_ref_do_visit (v_option v_constness) v_id_constness in
+      let arg = v_hidden v_id_hidden in
       ()
     in
     vin.kid_info (k, all_functions) x
@@ -434,6 +437,7 @@ let (mk_visitor :
       | NotCst -> ()
     in
     vin.kconstness (k, all_functions) x
+  and v_hidden _is_hidden = ()
   and v_container_operator _x = ()
   and v_comprehension (v1, v2) =
     let v1 = v_expr v1 in

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -498,8 +498,13 @@ and m_ident_and_empty_id_info a1 b1 =
  *)
 and m_id_info a b =
   match (a, b) with
-  | ( { G.id_resolved = _a1; id_type = _a2; id_constness = _a3 },
-      { B.id_resolved = _b1; id_type = _b2; id_constness = _b3 } ) ->
+  | ( { G.id_resolved = _a1; id_type = _a2; id_constness = _a3; id_hidden = _a4 },
+      {
+        B.id_resolved = _b1;
+        id_type = _b2;
+        id_constness = _b3;
+        id_hidden = _b4;
+      } ) ->
       (* old: (m_ref m_resolved_name) a3 b3  >>= (fun () ->
        * but doing import flask in a source file means every reference
        * to flask.xxx will be tagged with a ImportedEntity, but

--- a/semgrep-core/src/optimizing/Analyze_pattern.ml
+++ b/semgrep-core/src/optimizing/Analyze_pattern.ml
@@ -75,6 +75,11 @@ let extract_strings_and_mvars ?lang any =
             | L (String (str, _tok)) ->
                 if not (Pattern.is_special_string_literal str) then
                   Common.push str strings
+            | N (Id (_id, { id_hidden = true; _ })) ->
+                (* This identifier is not present in the pattern source.
+                   We assume a match is possible without the identifier
+                   being present in the target source, so we ignore it. *)
+                ()
             | IdSpecial (Eval, t) ->
                 if Parse_info.is_origintok t then
                   Common.push (Parse_info.str_of_info t) strings

--- a/semgrep-core/src/optimizing/Analyze_pattern.mli
+++ b/semgrep-core/src/optimizing/Analyze_pattern.mli
@@ -1,4 +1,7 @@
 val extract_specific_strings : ?lang:Lang.t -> Pattern.t -> string list
 
+(*
+   Extract strings and metavariables that occur in the source code.
+*)
 val extract_strings_and_mvars :
   ?lang:Lang.t -> Pattern.t -> string list * Metavariable.mvar list

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -153,7 +153,7 @@ let mk_var_expr (var : variable_name) : G.expr =
 module C = struct
   let mk (loc : loc) (name : string) =
     let id = "!sh_" ^ name ^ "!" in
-    let id_info = G.empty_id_info () in
+    let id_info = G.empty_id_info ~hidden:true () in
     G.N (G.Id ((id, fst loc), id_info)) |> G.e
 
   (* For simple commands, e.g.

--- a/semgrep-core/src/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Code.ml
@@ -69,8 +69,12 @@ let default_id str =
   G.N
     (Id
        ( (str, fk),
-         { id_resolved = ref None; id_type = ref None; id_constness = ref None }
-       ))
+         {
+           id_resolved = ref None;
+           id_type = ref None;
+           id_constness = ref None;
+           id_hidden = false;
+         } ))
   |> G.e
 
 let default_tyvar str typ = TypedMetavar ((str, fk), fk, typ) |> G.e

--- a/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/src/synthesizing/Pattern_from_Targets.ml
@@ -132,8 +132,12 @@ let default_id str =
   N
     (Id
        ( (str, fk),
-         { id_resolved = ref None; id_type = ref None; id_constness = ref None }
-       ))
+         {
+           id_resolved = ref None;
+           id_type = ref None;
+           id_constness = ref None;
+           id_hidden = false;
+         } ))
   |> G.e
 
 let count_to_id count =

--- a/semgrep/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
@@ -15,6 +15,7 @@
                   "id_constness": {
                     "ref@": null
                   },
+                  "id_hidden": "false",
                   "id_resolved": {
                     "ref@": null
                   },
@@ -71,6 +72,7 @@
                                                 "id_constness": {
                                                   "ref@": null
                                                 },
+                                                "id_hidden": "false",
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -94,6 +96,7 @@
                                                 "id_constness": {
                                                   "ref@": null
                                                 },
+                                                "id_hidden": "false",
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -133,6 +136,7 @@
                                                 "id_constness": {
                                                   "ref@": null
                                                 },
+                                                "id_hidden": "false",
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -156,6 +160,7 @@
                                                 "id_constness": {
                                                   "ref@": null
                                                 },
+                                                "id_hidden": "false",
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -194,6 +199,7 @@
                     "id_constness": {
                       "ref@": null
                     },
+                    "id_hidden": "false",
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -223,6 +229,7 @@
                     "id_constness": {
                       "ref@": null
                     },
+                    "id_hidden": "false",
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -265,6 +272,7 @@
                   "id_constness": {
                     "ref@": null
                   },
+                  "id_hidden": "false",
                   "id_resolved": {
                     "ref@": null
                   },
@@ -307,6 +315,7 @@
                                       "id_constness": {
                                         "ref@": null
                                       },
+                                      "id_hidden": "false",
                                       "id_resolved": {
                                         "ref@": null
                                       },
@@ -330,6 +339,7 @@
                                       "id_constness": {
                                         "ref@": null
                                       },
+                                      "id_hidden": "false",
                                       "id_resolved": {
                                         "ref@": null
                                       },
@@ -363,6 +373,7 @@
                     "id_constness": {
                       "ref@": null
                     },
+                    "id_hidden": "false",
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -392,6 +403,7 @@
                     "id_constness": {
                       "ref@": null
                     },
+                    "id_hidden": "false",
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -434,6 +446,7 @@
                     "id_constness": {
                       "ref@": null
                     },
+                    "id_hidden": "false",
                     "id_resolved": {
                       "ref@": null
                     },
@@ -469,6 +482,7 @@
                                 "id_constness": {
                                   "ref@": null
                                 },
+                                "id_hidden": "false",
                                 "id_resolved": {
                                   "ref@": null
                                 },
@@ -492,6 +506,7 @@
                                 "id_constness": {
                                   "ref@": null
                                 },
+                                "id_hidden": "false",
                                 "id_resolved": {
                                   "ref@": null
                                 },


### PR DESCRIPTION
Fixes #4080

This allows bash to work with -fast/-filter_irrelevant_rules because many hidden/fake function calls are created in the generic AST to support constructs that don't have a dedicated constructor already.

This solution adds an `id_hidden` field to the existing `id_info` record. The main advantage is that it doesn't make things more complicated except where we care about excluding hidden identifiers.

Other solutions that were considered include:
* extending the global list of exclusions implemented in `Pattern.is_special_identifier`. This isn't great because that list is global and an ID that's special in one language may not be special in another.
* adding a new `Hidden` kind of `special` identifier. Either this essentially disables the possibility of equality between a hidden and non-hidden identifier of the same name or it makes matching and other analyses more complicated.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
