### PR TITLE
[C++] convert more to generic AST

### DIFF
--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -91,6 +91,10 @@ let parse_pattern lang ?(print_errors = false) str =
     | Lang.C ->
         let any = Parse_c.any_of_string str in
         C_to_generic.any any
+    | Lang.Cplusplus ->
+        (* TODO: use tree-sitter-cpp at some point, probably more robust *)
+        let any = Parse_cpp.any_of_string Flag_parsing_cpp.Cplusplus str in
+        Cpp_to_generic.any any
     | Lang.Java ->
         let any = Parse_java.any_of_string str in
         Java_to_generic.any any
@@ -119,7 +123,6 @@ let parse_pattern lang ?(print_errors = false) str =
     (* use adhoc parser (neither pfff nor tree-sitter) *)
     | Lang.Yaml -> Yaml_to_generic.any str
     (* not yet handled *)
-    | Lang.Cplusplus -> failwith "No C++ generic parser yet"
     | Lang.R -> failwith "No R generic parser yet"
   in
 

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -277,6 +277,12 @@ let lang_parsing_tests =
       let lang = Lang.Vue in
       parsing_tests_for_lang files lang
     );
+    pack_tests "C++" (
+      let dir = Filename.concat tests_path "cpp/parsing" in
+      let files = Common2.glob (spf "%s/*.cpp" dir) in
+      let lang = Lang.Cplusplus in
+      parsing_tests_for_lang files lang
+    );
   ]
 
 let lang_regression_tests ~with_caching =


### PR DESCRIPTION
Enough to parse the examples in tests/cpp/parsing/

This will help PA-16

test plan:
make test
semgrep-core -lang cpp -dump_ast tests/cpp/*.cpp


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)