### PR TITLE
feat(config_resolver): don't use pack cdn for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   also match just `o.foo()`.
 - Config files with only a comment give bad error message (#3773)
 
+### Changed
+- Resulution of rulesets use legacy registry instead of cdn registry
+
 ## [0.69.1](https://github.com/returntocorp/semgrep/releases/tag/v0.69.1) - 10-14-2021
 
 ### Fixed

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -117,9 +117,6 @@ class ConfigPath:
                     )
                 )
             self._config_path = f"{SEMGREP_URL}{AUTO_CONFIG_LOCATION}"
-        elif is_pack_id(config_str) and SEMGREP_CDN_BASE_URL:
-            self._origin = ConfigType.CDN
-            self._config_path = config_str[2:]
         else:
             self._origin = ConfigType.LOCAL
             self._config_path = config_str


### PR DESCRIPTION
cdn registry updating is still WIP so for now, use legacy registry

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
