### PR TITLE
Add a correctness check to the perf comparison

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,9 +206,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: Run 0.65.0 Timing Benchmark
+      - name: Run 0.69.1 Timing Benchmark
         run: |
-          pip3 install semgrep==0.65.0
+          pip3 install semgrep==0.69.1
           semgrep --version
           python3 -m semgrep --version
           export PATH=/github/home/.local/bin:$PATH

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -175,6 +175,18 @@ def standardize_findings(findings: dict, include_time: bool) -> Tuple[dict, dict
     return results, timings
 
 
+def jsonify_findings(findings: dict) -> dict:
+    """
+    Turn findings into a jsonifiable dictionary.
+    This will later be used in scripts/compare_perf to confirm correctness of benchmarks.
+    Important that the results are sorted, so that the results are order-independent
+    """
+    return {
+        "errors": findings["errors"],
+        "results": sorted(finding.str for finding in findings["results"]),
+    }
+
+
 def output_differences(
     findings: set, std_findings: set, variant: str
 ) -> Tuple[int, int]:
@@ -415,7 +427,7 @@ def run_benchmarks(
         variants = STD_VARIANTS
 
     results_msgs = []
-    durations = []
+    benchmark_results = []
     results: dict = {variant.name: [] for variant in variants}
     output_per_rule_json_results = RepositoryTimePerRule(
         output_file=output_time_per_rule_json
@@ -484,15 +496,16 @@ def run_benchmarks(
                 msg = f"{metric_name} = {duration:.3f} s"
                 print(msg)
                 results_msgs.append(msg)
-                durations.append(
+
+                findings, timings = standardize_findings(semgrep_results, include_time)
+                benchmark_results.append(
                     {
                         "name": name,
                         "time": duration,
+                        "findings": jsonify_findings(findings),
                     }
                 )
                 results[variant.name].append(duration)
-
-                findings, timings = standardize_findings(semgrep_results, include_time)
 
                 if upload:
                     upload_result(variant.name, metric_name, duration, timings)
@@ -520,7 +533,7 @@ def run_benchmarks(
     if summary_file_path:
         with chdir(called_dir):
             with open(summary_file_path, "w") as f:
-                json.dump(durations, f)
+                json.dump(benchmark_results, f)
 
     if plot_benchmarks:
         import matplotlib.pyplot as plt

--- a/scripts/compare-perf
+++ b/scripts/compare-perf
@@ -201,11 +201,11 @@ def main() -> None:
         )
         msg = "\n\n".join(messages)
         print(f"Sending warnings and errors as a PR comment:\n{msg}")
-        # send_comment(
-        #    msg,
-        #    github_token,
-        #    pull_request_number,
-        # )
+        send_comment(
+            msg,
+            github_token,
+            pull_request_number,
+        )
 
     # Fail only after printing and sending all messages
     assert not errors

--- a/scripts/compare-perf
+++ b/scripts/compare-perf
@@ -46,13 +46,13 @@ def send_comment(message: str, github_token: str, pull_request_number: str) -> N
     r.raise_for_status()
 
 
-Timing = namedtuple("Timing", "name time")
+Timing = namedtuple("Timing", "name time findings")
 
 
 def read_timing(filename: Path) -> List[Timing]:
     print(f"Reading {filename}")
     with open(filename) as f:
-        return [Timing(a["name"], a["time"]) for a in json.load(f)]
+        return [Timing(a["name"], a["time"], a["findings"]) for a in json.load(f)]
 
 
 def select_min_timings(al: List[Timing], bl: List[Timing]) -> List[Timing]:
@@ -63,6 +63,30 @@ def select_min_timings(al: List[Timing], bl: List[Timing]) -> List[Timing]:
         else:
             res.append(b)
     return res
+
+
+def findings_differ(baseline_timing: Timing, latest_timing: Timing, name: str) -> bool:
+    baseline = set(baseline_timing.findings["results"])
+    latest = set(latest_timing.findings["results"])
+
+    def output_diff(diff: set) -> None:
+        for d in sorted(diff):
+            print(d)
+
+    b_diff = baseline.difference(latest)
+    l_diff = latest.difference(baseline)
+    bd_len = len(b_diff)
+    ld_len = len(l_diff)
+    if bd_len > 0 or ld_len > 0:
+        print("*" * 70)
+        print(f"Error running benchmark {name}")
+        print(f"Missing {bd_len} findings:")
+        output_diff(b_diff)
+        print(f"Extra {ld_len} findings:")
+        output_diff(l_diff)
+        print(f"*" * 70)
+        return True
+    return False
 
 
 def main() -> None:
@@ -144,6 +168,9 @@ def main() -> None:
                 f"{perc:.1f}% ({diff:.3f} s)"
             )
 
+        if findings_differ(baseline, latest, name):
+            errors += 1
+
     mean_rel_dur = total_rel_dur / n
     mean_perc = 100 * (mean_rel_dur - 1)
     if mean_perc > 0:
@@ -174,11 +201,11 @@ def main() -> None:
         )
         msg = "\n\n".join(messages)
         print(f"Sending warnings and errors as a PR comment:\n{msg}")
-        send_comment(
-            msg,
-            github_token,
-            pull_request_number,
-        )
+        # send_comment(
+        #    msg,
+        #    github_token,
+        #    pull_request_number,
+        # )
 
     # Fail only after printing and sending all messages
     assert not errors


### PR DESCRIPTION
We run benchmarks latest against an older version. While we're at it, we may as well make sure the results are correct.

The one annoyance is that if semgrep output changes, we would have to reset the benchmarks. Unfortunately, since we benchmark against a release, we can't just update a snapshot and make it pass. We _can_ mask certain parts of the semgrep output in `./run-benchmarks`, it's just a bit annoying.

The upside is that with these correctness checks, we can add a taint benchmarking pass that also serves as real world taint tests cc @IagoAbal 

I will do a separate documentation PR for all the benchmark changes

Test plan:

The script is run in two stages. First, get four different json output files by running (in `perf/`)

```
./run-benchmarks --config configs/temp.yaml --std-only --save-to bench_temp1.json
./run-benchmarks --config configs/temp.yaml --std-only --save-to bench_temp2.json
```

Next go to `../scripts/compare-perf` and comment out the call to `send_comment`, since you are running it locally, not on a PR.

Then run:

```
../scripts/compare-perf bench_temp1.json bench_temp1.json bench_temp2.json bench_temp2.json 0 0
```

The 0 0 will be ignored, since you commented out `send_comment`. We use `bench_temp1.json` twice because it's the same run, just done again to make timing more accurate.

You should get only timings and no error. If you change the results of `bench_temp1.json`, you should run into an error. The script currently assumes that the results of the first two arguments will always be the same, and ditto for the second.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
