### PR TITLE
Exempt issues with planned-project label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,5 +17,6 @@ issues:
     - tech-debt
     - new-language
     - bug
+    - planned-project
   markComment: >
     This issue is being marked `stale` because there hasn't been any activity in 30 days. Please leave a comment if you think this issue is still relevant and should be prioritized, otherwise it will be automatically closed in 7 days (you can always reopen it later).


### PR DESCRIPTION
(Note: label needs to be created) Sometimes we believe a user's request should be addressed, but not in the next 90 days. With the planned-project label, the flow on such issues would be:
1. Issue is created or stalebot marks it stale
2. Decide the issue is planned work
3. Assign the issue to a project in linear and copy the label
4. Add the `planned-project` label
5. After the project starts, remove the label

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
