### PR TITLE
fix(output): defatult to MAX_TEXT_WIDTH if os.get_terminal_size returns 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Fixed
+- text_wrapping defaults to MAX_TEXT_WIDTH if get_terminal_size reports width < 1
+
 ## [0.70.0](https://github.com/returntocorp/semgrep/releases/tag/v0.70.0) - 10-19-2021
 
 ### Added

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -119,7 +119,10 @@ def terminal_wrap(text: str) -> str:
     import textwrap
 
     paras = text.split("\n")
-    width = min(MAX_TEXT_WIDTH, get_terminal_size((MAX_TEXT_WIDTH, 1))[0])
+    terminal_size = get_terminal_size((MAX_TEXT_WIDTH, 1))[0]
+    if terminal_size <= 0:
+        terminal_size = MAX_TEXT_WIDTH
+    width = min(MAX_TEXT_WIDTH, terminal_size)
     wrapped_paras = ["\n".join(textwrap.wrap(p, width)) for p in paras]
     return "\n".join(wrapped_paras)
 


### PR DESCRIPTION
Fixes #4063

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
