### PR TITLE
Add list of projects for bash parsing stats

### DIFF
--- a/parsing-stats/lang/bash/projects.txt
+++ b/parsing-stats/lang/bash/projects.txt
@@ -1,0 +1,34 @@
+#
+# Top bash projects from GitHub, sorted by stars.
+# Created by ../../scripts/most-starred-for-language.
+#
+https://github.com/sindresorhus/awesome
+https://github.com/ohmyzsh/ohmyzsh
+https://github.com/gothinkster/realworld
+https://github.com/nvm-sh/nvm
+https://github.com/papers-we-love/papers-we-love
+https://github.com/pi-hole/pi-hole
+https://github.com/open-guides/og-aws
+https://github.com/dylanaraps/pure-bash-bible
+https://github.com/shengxinjing/programmer-job-blacklist
+https://github.com/mathiasbynens/dotfiles
+https://github.com/nvie/gitflow
+https://github.com/acmesh-official/acme.sh
+https://github.com/StreisandEffect/streisand
+https://github.com/powerline/fonts
+https://github.com/dokku/dokku
+https://github.com/mbadolato/iTerm2-Color-Schemes
+https://github.com/romkatv/powerlevel10k
+https://github.com/dwmkerr/hacker-laws
+https://github.com/zsh-users/zsh-autosuggestions
+https://github.com/fish-shell/fish-shell
+https://github.com/hwdsl2/setup-ipsec-vpn
+https://github.com/dotnet/core
+https://github.com/tj/git-extras
+https://github.com/sickcodes/Docker-OSX
+https://github.com/tj/n
+https://github.com/spaceship-prompt/spaceship-prompt
+https://github.com/233boy/v2ray
+https://github.com/source-foundry/Hack
+https://github.com/taizilongxu/interview_python
+https://github.com/rbenv/rbenv


### PR DESCRIPTION
This gives us a parsing rate of 31%, whereas it's 90% out of the tree-sitter parser alone.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
