### PR TITLE
feat(core_runner): increase stacklimit soft limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 - Pre-alpha support for Bash as a new target language
+- Increase soft stack limit when running semgrep-core (#4120)
 
 ### Fixed
 - text_wrapping defaults to MAX_TEXT_WIDTH if get_terminal_size reports width < 1

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -363,7 +363,7 @@ def test_stack_size(run_semgrep_in_tmp, snapshot):
     # it means the actual test below does not accurately verify that
     # we are solving the stack exhaustion
     output = subprocess.run(
-        f"ulimit -s 3000 && semgrep --config {rulepath} --verbose {targetpath}",
+        f"ulimit -s 1000 && semgrep --config {rulepath} --verbose {targetpath}",
         shell=True,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -374,7 +374,7 @@ def test_stack_size(run_semgrep_in_tmp, snapshot):
 
     # If only set soft limit, semgrep should raise it as necessary so we don't hit soft limit
     output = subprocess.run(
-        f"ulimit -S -s 3000 && semgrep --config {rulepath} --verbose {targetpath}",
+        f"ulimit -S -s 1000 && semgrep --config {rulepath} --verbose {targetpath}",
         shell=True,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -370,7 +370,10 @@ def test_stack_size(run_semgrep_in_tmp, snapshot):
         encoding="utf-8",
     )
     print(output.stderr)
-    assert "semgrep-core exit code: -11" in output.stderr
+    assert (
+        "semgrep-core exit code: -11" in output.stderr
+        or "Stack overflow" in output.stderr
+    )
 
     # If only set soft limit, semgrep should raise it as necessary so we don't hit soft limit
     output = subprocess.run(
@@ -381,6 +384,7 @@ def test_stack_size(run_semgrep_in_tmp, snapshot):
         encoding="utf-8",
     )
     assert "semgrep-core exit code: -11" not in output.stderr
+    assert "Stack overflow" not in output.stderr
 
 
 def test_timeout_threshold(run_semgrep_in_tmp, snapshot):

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -357,11 +357,10 @@ def test_stack_size(run_semgrep_in_tmp, snapshot):
     targetpath = Path(e2e_dir / "targets").resolve() / "equivalence"
     rulepath = Path(e2e_dir / "rules").resolve() / "long.yaml"
 
-    # If set hard and soft stack limit we should hit stack overflow
-    # If this test fails means we might have changed the output when
-    # semgrep-core hits stack exhaustion. Do not just delete this assertion
-    # it means the actual test below does not accurately verify that
-    # we are solving the stack exhaustion
+    # Set the hard as well as the soft stack limit. This should force a stack
+    # overflow. If this fails, the test is broken and needs to be fixed.
+    # Do not just delete this assertion. It means the actual test below does
+    # not accurately verify that we are solving the stack exhaustion
     output = subprocess.run(
         f"ulimit -s 1000 && semgrep --config {rulepath} --verbose {targetpath}",
         shell=True,


### PR DESCRIPTION
Try to increase the limit in the child fork process running
semgrep-core to prevent occurences of stack exhaustion

Note set soft limit to (hard limit / 3 etc) because for some reason
setting the soft limit to the hard limit gets a "current limit exceeds maximum limit"
error. If users are still hitting this issue we might want to look into this / increasing 
the multiplier.

Closes #3623

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
