### PR TITLE
[AST generic] cleanup other_type_operator

### DIFF
--- a/semgrep-core/src/analyzing/lrvalue.ml
+++ b/semgrep-core/src/analyzing/lrvalue.ml
@@ -144,7 +144,7 @@ let rec visit_expr hook lhs expr =
            | Arg e -> recr e
            | ArgKwd (_id, e) -> recr e
            | ArgType _ -> ()
-           | ArgOther (_, anys) -> List.iter (anyhook hook Rhs) anys)
+           | OtherArg (_, anys) -> List.iter (anyhook hook Rhs) anys)
   | Cast (_t, _, e) -> recr e
   (* Do some languages allow this to be part of an assign? *)
   | Conditional (e, e1, e2) ->

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -469,7 +469,7 @@ and map_argument = function
   | ArgKwd (v1, v2) ->
       let v1 = map_ident v1 and v2 = map_expr v2 in
       `ArgKwd (v1, v2)
-  | ArgOther (v1, v2) ->
+  | OtherArg (v1, v2) ->
       let v1 = map_other_argument_operator v1 and v2 = map_of_list map_any v2 in
       `ArgOther (v1, v2)
 
@@ -553,6 +553,7 @@ and map_type_kind = function
   | OtherType (v1, v2) ->
       let v1 = map_other_type_operator v1 and v2 = map_of_list map_any v2 in
       `OtherType (v1, v2)
+  | OtherType2 (_v1, _v2) -> failwith "TODO"
 
 (* new: brackets *)
 and map_type_arguments (_, v, _) = map_of_list map_type_argument v

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -755,7 +755,7 @@ and argument =
   (* type argument for New, instanceof/sizeof/typeof, C macros *)
   | ArgType of type_
   (* e.g., ArgMacro for C/Rust, ArgQuestion for OCaml *)
-  | ArgOther of todo_kind * any list
+  | OtherArg of todo_kind * any list
 
 (* todo: reduce, or move in other_special? *)
 and other_expr_operator =
@@ -938,7 +938,7 @@ and case =
    * transformed in a pattern?
    *)
   | CaseEqualExpr of tok * expr
-  (* TODO: CaseRange for C++ *)
+  (* e.g., CaseRange for C++ *)
   | OtherCase of todo_kind * any list
 
 (* todo: merge with case at some point *)
@@ -1144,7 +1144,17 @@ and type_kind =
   | TyInterfaceAnon of tok (* 'interface' *) * field list bracket
   (* sgrep-ext: *)
   | TyEllipsis of tok
+  (* e.g., Struct/Union/Enum names (convert in unique TyName?), TypeOf, TSized
+   * in C++
+   *)
+  | OtherType2 of todo_kind * any list
+  (* TODO: get rid at some point *)
   | OtherType of other_type_operator * any list
+
+(* TODO: get rid at some point *)
+and other_type_operator = OT_Expr | OT_Arg
+
+(* Python: todo: should use expr_to_type() when can *)
 
 (* <> in Java/C#/C++/Kotlin/Rust/..., [] in Scala and Go (for Map) *)
 and type_arguments = type_argument list bracket
@@ -1159,22 +1169,6 @@ and type_argument =
   | TAExpr of expr
   (* TODO? Rust Lifetime 'x, Kotlin use-site variance *)
   | OtherTypeArg of todo_kind * any list
-
-and other_type_operator =
-  (* C *)
-  (* todo? convert in unique names with TyName? *)
-  | OT_StructName
-  | OT_UnionName
-  | OT_EnumName
-  (* PHP *)
-  | OT_Variadic (* ???? *)
-  (* Rust *)
-  | OT_Lifetime
-  (* Other *)
-  | OT_Expr
-  | OT_Arg (* Python: todo: should use expr_to_type() when can *)
-  (* TypeOf, etc. *)
-  | OT_Todo
 
 (*****************************************************************************)
 (* Attribute *)
@@ -1309,6 +1303,7 @@ and definition_kind =
    * local.
    *)
   | UseOuterDecl of tok (* 'global' or 'nonlocal' in Python, 'use' in PHP *)
+  (* e.g., MacroDecl and MacroVar in C++ *)
   | OtherDef of todo_kind * any list
 
 (* template/generics/polymorphic-type *)
@@ -1343,7 +1338,7 @@ and variance =
 and type_parameter_constraint =
   (* C# *)
   | HasConstructor of tok
-  (* TODO? Lifetime Rust? *)
+  (* e.g., Lifetime in Rust, complex types in OCaml *)
   | OtherTypeParam of todo_kind * any list
 
 (* ------------------------------------------------------------------------- *)
@@ -1478,6 +1473,7 @@ and type_definition_kind =
   (* OCaml/Rust *)
   | AbstractType of tok (* usually a fake token *)
   | Exception of ident (* same name than entity *) * type_ list
+  (* e.g., TdTodo types in OCaml *)
   | OtherTypeKind of todo_kind * any list
 
 and or_type_element =
@@ -1580,7 +1576,7 @@ and module_definition_kind =
   | ModuleAlias of dotted_ident
   (* newscope: *)
   | ModuleStruct of dotted_ident option * item list
-  (* TODO: OCaml (functors and their applications) *)
+  (* e.g., OCaml functors *)
   | OtherModule of todo_kind * any list
 
 (* ------------------------------------------------------------------------- *)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -259,7 +259,7 @@ let argument_to_expr arg =
       let k = N n |> G.e in
       G.keyval k (fake "") e
   | ArgType _
-  | ArgOther _ ->
+  | OtherArg _ ->
       raise NotAnExpr
 
 (* used in controlflow_build and semgrep *)
@@ -350,7 +350,7 @@ let ac_matching_nf op args =
          | Arg e -> e
          | ArgKwd _
          | ArgType _
-         | ArgOther _ ->
+         | OtherArg _ ->
              raise_notrace Exit)
     |> List.map nf_one |> List.flatten
   and nf_one e =

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -438,10 +438,10 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | ArgKwd (v1, v2) ->
         let v1 = map_ident v1 and v2 = map_expr v2 in
         ArgKwd (v1, v2)
-    | ArgOther (v1, v2) ->
+    | OtherArg (v1, v2) ->
         let v1 = map_other_argument_operator v1
         and v2 = map_of_list map_any v2 in
-        ArgOther (v1, v2)
+        OtherArg (v1, v2)
   and map_other_argument_operator x = x
   and map_action (v1, v2) =
     let v1 = map_pattern v1 and v2 = map_expr v2 in
@@ -517,6 +517,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | OtherType (v1, v2) ->
         let v1 = map_other_type_operator v1 and v2 = map_of_list map_any v2 in
         OtherType (v1, v2)
+    | OtherType2 (v1, v2) ->
+        let v1 = map_todo_kind v1 and v2 = map_of_list map_any v2 in
+        OtherType2 (v1, v2)
   and map_type_arguments v = map_bracket (map_of_list map_type_argument) v
   and map_type_argument = function
     | TA v1 ->

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -476,9 +476,9 @@ and vof_argument = function
   | ArgType v1 ->
       let v1 = vof_type_ v1 in
       OCaml.VSum ("ArgType", [ v1 ])
-  | ArgOther (v1, v2) ->
+  | OtherArg (v1, v2) ->
       let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
-      OCaml.VSum ("ArgOther", [ v1; v2 ])
+      OCaml.VSum ("OtherArg", [ v1; v2 ])
 
 and vof_action (v1, v2) =
   let v1 = vof_pattern v1 and v2 = vof_expr v2 in
@@ -594,6 +594,10 @@ and vof_type_kind = function
       let v1 = vof_other_type_operator v1 in
       let v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherType", [ v1; v2 ])
+  | OtherType2 (v1, v2) ->
+      let v1 = vof_todo_kind v1 in
+      let v2 = OCaml.vof_list vof_any v2 in
+      OCaml.VSum ("OtherType", [ v1; v2 ])
 
 and vof_type_arguments v = vof_bracket (OCaml.vof_list vof_type_argument) v
 
@@ -620,14 +624,8 @@ and vof_type_argument = function
       OCaml.VSum ("OtherTypeArg", [ v1; v2 ])
 
 and vof_other_type_operator = function
-  | OT_Todo -> OCaml.VSum ("OT_Todo", [])
   | OT_Expr -> OCaml.VSum ("OT_Expr", [])
   | OT_Arg -> OCaml.VSum ("OT_Arg", [])
-  | OT_StructName -> OCaml.VSum ("OT_StructName", [])
-  | OT_UnionName -> OCaml.VSum ("OT_UnionName", [])
-  | OT_EnumName -> OCaml.VSum ("OT_EnumName", [])
-  | OT_Variadic -> OCaml.VSum ("OT_Variadic", [])
-  | OT_Lifetime -> OCaml.VSum ("OT_Lifetime", [])
 
 and vof_keyword_attribute = function
   | SealedClass -> OCaml.VSum ("SealedClass", [])

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -497,7 +497,7 @@ let (mk_visitor :
     | ArgKwd (v1, v2) ->
         let v1 = v_ident v1 and v2 = v_expr v2 in
         ()
-    | ArgOther (v1, v2) ->
+    | OtherArg (v1, v2) ->
         let v1 = v_other_argument_operator v1 and v2 = v_list v_any v2 in
         ()
   and v_other_argument_operator _x = ()
@@ -563,6 +563,9 @@ let (mk_visitor :
           ()
       | OtherType (v1, v2) ->
           let v1 = v_other_type_operator v1 and v2 = v_list v_any v2 in
+          ()
+      | OtherType2 (v1, v2) ->
+          let v1 = v_todo_kind v1 and v2 = v_list v_any v2 in
           ()
     in
     vin.ktype_ (k, all_functions) x

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1323,12 +1323,12 @@ and m_argument a b =
   | G.ArgType a1, B.ArgType b1 -> m_type_ a1 b1
   | G.ArgKwd (a1, a2), B.ArgKwd (b1, b2) ->
       m_ident a1 b1 >>= fun () -> m_expr a2 b2
-  | G.ArgOther (a1, a2), B.ArgOther (b1, b2) ->
+  | G.OtherArg (a1, a2), B.OtherArg (b1, b2) ->
       m_other_argument_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.Arg _, _
   | G.ArgKwd _, _
   | G.ArgType _, _
-  | G.ArgOther _, _ ->
+  | G.OtherArg _, _ ->
       fail ()
 
 and m_other_argument_operator = m_other_xxx
@@ -1579,6 +1579,8 @@ and m_type_ a b =
       m_tok a2 b2 >>= fun () -> m_type_ a3 b3
   | G.OtherType (a1, a2), B.OtherType (b1, b2) ->
       m_other_type_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+  | G.OtherType2 (a1, a2), B.OtherType2 (b1, b2) ->
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.TyBuiltin _, _
   | G.TyFun _, _
   | G.TyApply _, _
@@ -1595,7 +1597,8 @@ and m_type_ a b =
   | G.TyRecordAnon _, _
   | G.TyInterfaceAnon _, _
   | G.TyRef _, _
-  | G.OtherType _, _ ->
+  | G.OtherType _, _
+  | G.OtherType2 _, _ ->
       fail ()
 
 and m_type_arguments a b =

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -134,7 +134,7 @@ let subexprs_of_expr e =
               | ArgKwd (_, e) ->
                   Some e
               | ArgType _
-              | ArgOther _ ->
+              | OtherArg _ ->
                   None))
   | SliceAccess (e1, e2) ->
       e1

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -139,10 +139,10 @@ and type_kind = function
       G.TyFun (params, ret)
   | TStructName (v1, v2) ->
       let v1 = struct_kind v1 and v2 = name v2 in
-      G.OtherType (v1, [ G.I v2 ])
+      G.OtherType2 (v1, [ G.I v2 ])
   | TEnumName v1 ->
       let v1 = name v1 in
-      G.OtherType (G.OT_EnumName, [ G.I v1 ])
+      G.OtherType2 (("EnumName", unsafe_fake ""), [ G.I v1 ])
   | TTypeName v1 ->
       let v1 = name v1 in
       G.TyN (G.Id (v1, G.empty_id_info ()))
@@ -172,8 +172,8 @@ and parameter_classic { p_type; p_name } =
   }
 
 and struct_kind = function
-  | Struct -> G.OT_StructName
-  | Union -> G.OT_UnionName
+  | Struct -> ("StructName", unsafe_fake "")
+  | Union -> ("UnionName", unsafe_fake "")
 
 and expr e =
   (match e with

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -217,7 +217,9 @@ and map_typeC env x : G.type_ =
       let v1 = map_of_list (map_sized_type env) v1
       and v2 = map_of_option (map_type_ env) v2 in
       let allt = v1 @ Common.opt_to_list v2 in
-      G.OtherType (OT_Todo, allt |> List.map (fun t -> G.T t)) |> G.t
+      G.OtherType2
+        (("TSized", PI.unsafe_fake_info ""), allt |> List.map (fun t -> G.T t))
+      |> G.t
   | TPointer (v1, v2, v3) ->
       let v1 = map_tok env v1
       and v2 = map_type_ env v2
@@ -228,7 +230,7 @@ and map_typeC env x : G.type_ =
       G.TyRef (v1, v2) |> G.t
   | TRefRef (v1, v2) ->
       let v1 = map_tok env v1 and v2 = map_type_ env v2 in
-      G.OtherType (G.OT_Todo, [ G.TodoK ("&&", v1); G.T v2 ]) |> G.t
+      G.OtherType2 (("&&", v1), [ G.T v2 ]) |> G.t
   | TArray (v1, v2) ->
       let v1 = map_bracket env (map_of_option (map_a_const_expr env)) v1
       and v2 = map_type_ env v2 in
@@ -262,7 +264,7 @@ and map_typeC env x : G.type_ =
         map_paren env (map_either env (map_type_ env) (map_expr env)) v2
       in
       let any = any_of_either_type_expr v2 in
-      G.OtherType (G.OT_Todo, [ G.TodoK ("Typeof", v1); any ]) |> G.t
+      G.OtherType2 (("Typeof", v1), [ any ]) |> G.t
   | TAuto v1 ->
       let v1 = map_tok env v1 in
       G.TyAny v1 |> G.t
@@ -272,8 +274,7 @@ and map_typeC env x : G.type_ =
   | TypeTodo (v1, v2) ->
       let v1 = map_todo_category env v1
       and v2 = map_of_list (map_type_ env) v2 in
-      G.OtherType (G.OT_Todo, G.TodoK v1 :: (v2 |> List.map (fun t -> G.T t)))
-      |> G.t
+      G.OtherType2 (v1, v2 |> List.map (fun t -> G.T t)) |> G.t
 
 and map_primitive_type _env = function
   | TVoid -> "void"
@@ -491,7 +492,7 @@ and map_argument env x : G.argument =
       G.ArgType v1
   | ArgAction v1 ->
       let v1 = map_action_macro env v1 in
-      G.ArgOther (("ArgMacro", G.fake ""), v1)
+      G.OtherArg (("ArgMacro", G.fake ""), v1)
   | ArgInits v1 ->
       let l, xs, r = map_brace env (map_of_list (map_initialiser env)) v1 in
       G.Arg (G.Container (G.Dict, (l, xs, r)) |> G.e)

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -455,9 +455,7 @@ and type_kind x =
   | TyName xs -> G.TyN (H.name_of_ids xs)
   | TyLiteral l ->
       let l = literal l in
-      G.OtherType
-        ( G.OT_Todo,
-          [ G.TodoK ("LitType", PI.unsafe_fake_info ""); G.E (G.L l |> G.e) ] )
+      G.OtherType2 (("LitType", PI.unsafe_fake_info ""), [ G.E (G.L l |> G.e) ])
   | TyQuestion (tok, t) ->
       let t = type_ t in
       G.TyQuestion (t, tok)
@@ -485,8 +483,7 @@ and type_kind x =
       let t1 = type_ t1 in
       let t2 = type_ t2 in
       G.TyAnd (t1, tk, t2)
-  | TypeTodo (categ, xs) ->
-      G.OtherType (G.OT_Todo, G.TodoK categ :: List.map any xs)
+  | TypeTodo (categ, xs) -> G.OtherType2 (categ, List.map any xs)
 
 and tuple_type_member x =
   match x with

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -148,7 +148,7 @@ and type_kind = function
   | TyTodo (t, v1) ->
       let t = todo_category t in
       let v1 = list type_ v1 in
-      G.OtherType (G.OT_Todo, G.TodoK t :: List.map (fun x -> G.T x) v1)
+      G.OtherType2 (t, List.map (fun x -> G.T x) v1)
 
 and expr_body e : G.stmt = stmt e
 
@@ -423,7 +423,7 @@ and argument = function
       G.ArgKwd (v1, v2)
   | ArgQuestion (v1, v2) ->
       let v1 = ident v1 and v2 = expr v2 in
-      G.ArgOther (("ArgQuestion", snd v1), [ G.I v1; G.E v2 ])
+      G.OtherArg (("ArgQuestion", snd v1), [ G.I v1; G.E v2 ])
 
 and match_case (v1, (v3, _t, v2)) =
   let v1 = pattern v1 and v2 = expr v2 and v3 = option expr v3 in

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -438,11 +438,9 @@ and hint_type_kind = function
       in
       G.TyFun (params, fret)
   | HintTypeConst (_, tok, _) ->
-      G.OtherType
-        ( G.OT_Todo,
-          [ G.TodoK ("HintTypeConst not supported, facebook-ext", tok) ] )
+      G.OtherType2 (("HintTypeConst not supported, facebook-ext", tok), [])
   | HintVariadic (tok, _) ->
-      G.OtherType (G.OT_Todo, [ G.TodoK ("HintVariadic not supported", tok) ])
+      G.OtherType2 (("HintVariadic not supported", tok), [])
 
 and class_name v = hint_type v
 

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -216,7 +216,7 @@ and v_encaps = function
       let v1 = v_expr v1 in
       Right v1
 
-and todo_type msg any = G.OtherType (G.OT_Todo, G.TodoK (msg, fake msg) :: any)
+and todo_type msg anys = G.OtherType2 ((msg, fake msg), anys)
 
 and v_type_ x = v_type_kind x |> G.t
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -278,7 +278,7 @@ let todo_pat _env tok = G.OtherPat (("Todo", tok), [])
 
 let todo_attr _env tok = G.OtherAttribute (("Todo", tok), [])
 
-let todo_type _env tok = G.OtherType (G.OT_Todo, [ G.Tk tok ]) |> G.t
+let todo_type _env tok = G.OtherType2 (("Todo", tok), []) |> G.t
 
 let _TODOparameter_modifier (env : env) (x : CST.parameter_modifier) =
   match x with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -1004,7 +1004,7 @@ and delegation_specifier (env : env) (x : CST.delegation_specifier) :
       in
       let v2 = token env v2 (* "by" *) in
       let v3 = expression env v3 in
-      ( OtherType (OT_Todo, [ TodoK ("ByDelagation", v2); G.T v1 ]) |> G.t,
+      ( OtherType2 (("ByDelagation", v2), [ G.T v1 ]) |> G.t,
         Some (fb [ G.Arg v3 ]) )
   | `User_type x ->
       let n = user_type env x in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -974,7 +974,8 @@ and map_bounded_type (env : env) (x : CST.bounded_type) : G.type_ =
       let lifetime = map_lifetime env v1 in
       let plus = token env v2 (* "+" *) in
       let type_ = map_type_ env v3 in
-      G.TyOr (G.OtherType (G.OT_Lifetime, [ G.I lifetime ]) |> G.t, plus, type_)
+      G.TyOr
+        (G.OtherType2 (("Lifetime", plus), [ G.I lifetime ]) |> G.t, plus, type_)
       |> G.t
   | `Type_PLUS_type (v1, v2, v3) ->
       let type_a = map_type_ env v1 in
@@ -985,7 +986,8 @@ and map_bounded_type (env : env) (x : CST.bounded_type) : G.type_ =
       let type_ = map_type_ env v1 in
       let plus = token env v2 (* "+" *) in
       let lifetime = map_lifetime env v3 in
-      G.TyOr (type_, plus, G.OtherType (G.OT_Lifetime, [ G.I lifetime ]) |> G.t)
+      G.TyOr
+        (type_, plus, G.OtherType2 (("Lifetime", plus), [ G.I lifetime ]) |> G.t)
       |> G.t
 
 and map_bracketed_type (env : env) ((v1, v2, v3) : CST.bracketed_type) =
@@ -1961,7 +1963,7 @@ and map_macro_invocation (env : env) ((v1, v2, v3) : CST.macro_invocation) :
     match anys with
     (* look like a regular function call, just use Arg then *)
     | [ G.E e ] -> [ G.Arg e ]
-    | xs -> [ G.ArgOther (("ArgMacro", G.fake ""), xs) ]
+    | xs -> [ G.OtherArg (("ArgMacro", G.fake ""), xs) ]
   in
   G.Call (G.N name |> G.e, (l, args, r)) |> G.e
 
@@ -2389,7 +2391,7 @@ and map_qualified_type (env : env) ((v1, v2, v3) : CST.qualified_type) : G.type_
   let lhs = map_type_ env v1 in
   let as_ = token env v2 (* "as" *) in
   let rhs = map_type_ env v3 in
-  G.OtherType (G.OT_Todo, [ G.T lhs; G.Tk as_; G.T rhs ]) |> G.t
+  G.OtherType2 (("As", as_), [ G.T lhs; G.T rhs ]) |> G.t
 
 and map_range_expression (env : env) (x : CST.range_expression) : G.expr =
   match x with


### PR DESCRIPTION
The long list of todos was not really useful.
Better to use a general todo_kind instead of adding
each time a new constructor.

test plan:
make test


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)