### PR TITLE
[AST generic] migration path towards simpler OtherXxx

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -580,6 +580,7 @@ and expr_aux env ?(void = false) eorig =
   | G.DotAccessEllipsis _ ->
       sgrep_construct (G.E eorig)
   | G.OtherExpr (_, _) -> todo (G.E eorig)
+  | G.OtherExpr2 (_, _) -> todo (G.E eorig)
 
 and expr env ?void eorig =
   try expr_aux env ?void eorig

--- a/semgrep-core/src/analyzing/lrvalue.ml
+++ b/semgrep-core/src/analyzing/lrvalue.ml
@@ -188,6 +188,7 @@ let rec visit_expr hook lhs expr =
       raise Impossible
   | Ellipsis _tok -> ()
   | OtherExpr (_other_xxx, anys) -> List.iter (anyhook hook Rhs) anys
+  | OtherExpr2 (_other_xxx, anys) -> List.iter (anyhook hook Rhs) anys
 
 (*****************************************************************************)
 (* Entry points *)

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -291,6 +291,7 @@ and map_expr x : B.expr =
   | OtherExpr (v1, v2) ->
       let v1 = map_other_expr_operator v1 and v2 = map_of_list map_any v2 in
       `OtherExpr (v1, v2)
+  | OtherExpr2 (_v1, _v2) -> failwith "TODO"
 
 and map_name_or_dynamic = function
   | EN v1 ->
@@ -1014,6 +1015,7 @@ and map_parameter = function
       let v1 = map_other_parameter_operator v1
       and v2 = map_of_list map_any v2 in
       `OtherParam (v1, v2)
+  | OtherParam2 (_v1, _v2) -> failwith "TODO"
 
 and map_parameter_classic
     {
@@ -1142,10 +1144,6 @@ and map_directive_kind = function
       let t = map_tok t in
       let v1 = map_module_name v1 and v2 = map_tok v2 in
       `ImportAll (t, v1, v2)
-  | OtherDirective (v1, v2) ->
-      let v1 = map_other_directive_operator v1
-      and v2 = map_of_list map_any v2 in
-      `OtherDirective (v1, v2)
   | Pragma (v1, v2) ->
       let v1 = map_ident v1 and v2 = map_of_list map_any v2 in
       `Pragma (v1, v2)
@@ -1156,6 +1154,11 @@ and map_directive_kind = function
   | PackageEnd t ->
       let t = map_tok t in
       `PackageEnd t
+  | OtherDirective (v1, v2) ->
+      let v1 = map_other_directive_operator v1
+      and v2 = map_of_list map_any v2 in
+      `OtherDirective (v1, v2)
+  | OtherDirective2 (_v1, _v2) -> failwith "TODO"
 
 and map_ident_and_id_info (v1, v2) =
   let v1 = map_ident v1 in

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -301,7 +301,9 @@ let parameter_to_catch_exn_opt p =
   | ParamRest (_, _p)
   | ParamHashSplat (_, _p) ->
       None
-  | OtherParam _ -> None
+  | OtherParam _
+  | OtherParam2 _ ->
+      None
 
 (*****************************************************************************)
 (* Abstract position and constness for comparison *)

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -313,6 +313,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
             let v1 = map_other_expr_operator v1
             and v2 = map_of_list map_any v2 in
             OtherExpr (v1, v2)
+        | OtherExpr2 (v1, v2) ->
+            let v1 = map_todo_kind v1 and v2 = map_of_list map_any v2 in
+            OtherExpr2 (v1, v2)
       in
       (* TODO? reuse the e_id or create a new one? *)
       G.e ekind
@@ -938,6 +941,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let v1 = map_other_parameter_operator v1
         and v2 = map_of_list map_any v2 in
         OtherParam (v1, v2)
+    | OtherParam2 (v1, v2) ->
+        let v1 = map_todo_kind v1 and v2 = map_of_list map_any v2 in
+        OtherParam2 (v1, v2)
   and map_parameter_classic
       {
         pname = v_pname;
@@ -1065,10 +1071,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let t = map_tok t in
         let v1 = map_module_name v1 and v2 = map_tok v2 in
         ImportAll (t, v1, v2)
-    | OtherDirective (v1, v2) ->
-        let v1 = map_other_directive_operator v1
-        and v2 = map_of_list map_any v2 in
-        OtherDirective (v1, v2)
     | Pragma (v1, v2) ->
         let v1 = map_ident v1 and v2 = map_of_list map_any v2 in
         Pragma (v1, v2)
@@ -1079,6 +1081,13 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | PackageEnd t ->
         let t = map_tok t in
         PackageEnd t
+    | OtherDirective (v1, v2) ->
+        let v1 = map_other_directive_operator v1
+        and v2 = map_of_list map_any v2 in
+        OtherDirective (v1, v2)
+    | OtherDirective2 (v1, v2) ->
+        let v1 = map_todo_kind v1 and v2 = map_of_list map_any v2 in
+        OtherDirective2 (v1, v2)
   and map_ident_and_id_info (v1, v2) =
     let v1 = map_ident v1 in
     let v2 = map_id_info v2 in

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -282,6 +282,9 @@ and vof_expr e =
   | OtherExpr (v1, v2) ->
       let v1 = vof_other_expr_operator v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherExpr", [ v1; v2 ])
+  | OtherExpr2 (v1, v2) ->
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
+      OCaml.VSum ("OtherExpr", [ v1; v2 ])
 
 and vof_name_or_dynamic = function
   | EN v1 ->
@@ -1142,6 +1145,9 @@ and vof_parameter = function
       let v1 = vof_other_parameter_operator v1
       and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherParam", [ v1; v2 ])
+  | OtherParam2 (v1, v2) ->
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
+      OCaml.VSum ("OtherParam", [ v1; v2 ])
 
 and vof_parameter_classic
     {
@@ -1333,6 +1339,9 @@ and vof_directive_kind = function
   | OtherDirective (v1, v2) ->
       let v1 = vof_other_directive_operator v1
       and v2 = OCaml.vof_list vof_any v2 in
+      OCaml.VSum ("OtherDirective", [ v1; v2 ])
+  | OtherDirective2 (v1, v2) ->
+      let v1 = vof_todo_kind v1 and v2 = OCaml.vof_list vof_any v2 in
       OCaml.VSum ("OtherDirective", [ v1; v2 ])
 
 and vof_alias (v1, v2) =

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -377,6 +377,9 @@ let (mk_visitor :
       | OtherExpr (v1, v2) ->
           let v1 = v_other_expr_operator v1 and v2 = v_list v_any v2 in
           ()
+      | OtherExpr2 (v1, v2) ->
+          let v1 = v_todo_kind v1 and v2 = v_list v_any v2 in
+          ()
     in
     vin.kexpr (k, all_functions) x
   and v_name_or_dynamic = function
@@ -1047,6 +1050,9 @@ let (mk_visitor :
       | OtherParam (v1, v2) ->
           let v1 = v_other_parameter_operator v1 and v2 = v_list v_any v2 in
           ()
+      | OtherParam2 (v1, v2) ->
+          let v1 = v_todo_kind v1 and v2 = v_list v_any v2 in
+          ()
     in
     vin.kparam (k, all_functions) x
   and v_parameter_classic
@@ -1216,6 +1222,9 @@ let (mk_visitor :
           v_list v_any v2
       | OtherDirective (v1, v2) ->
           let v1 = v_other_directive_operator v1 and v2 = v_list v_any v2 in
+          ()
+      | OtherDirective2 (v1, v2) ->
+          let v1 = v_todo_kind v1 and v2 = v_list v_any v2 in
           ()
     in
     vin.kdir (k, all_functions) x

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -822,6 +822,8 @@ and m_expr a b =
   | G.DeRef (a0, a1), B.DeRef (b0, b1) -> m_tok a0 b0 >>= fun () -> m_expr a1 b1
   | G.OtherExpr (a1, a2), B.OtherExpr (b1, b2) ->
       m_other_expr_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+  | G.OtherExpr2 (a1, a2), B.OtherExpr2 (b1, b2) ->
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.Container _, _
   | G.Comprehension _, _
   | G.Record _, _
@@ -846,6 +848,7 @@ and m_expr a b =
   | G.Ref _, _
   | G.DeRef _, _
   | G.OtherExpr _, _
+  | G.OtherExpr2 _, _
   | G.TypedMetavar _, _
   | G.DotAccessEllipsis _, _ ->
       fail ()
@@ -2337,12 +2340,15 @@ and m_parameter a b =
   | G.ParamPattern a1, B.ParamPattern b1 -> m_pattern a1 b1
   | G.OtherParam (a1, a2), B.OtherParam (b1, b2) ->
       m_other_parameter_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+  | G.OtherParam2 (a1, a2), B.OtherParam2 (b1, b2) ->
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.ParamEllipsis a1, B.ParamEllipsis b1 -> m_tok a1 b1
   | G.ParamClassic _, _
   | G.ParamPattern _, _
   | G.ParamRest _, _
   | G.ParamHashSplat _, _
   | G.ParamEllipsis _, _
+  | G.OtherParam2 _, _
   | G.OtherParam _, _ ->
       fail ()
 
@@ -2687,6 +2693,7 @@ and m_directive a b =
   | G.Package _
   | G.PackageEnd _
   | G.Pragma _
+  | G.OtherDirective2 _
   | G.OtherDirective _ ->
       fail ()
 
@@ -2724,9 +2731,12 @@ and m_directive_basic a b =
       m_ident a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.OtherDirective (a1, a2), B.OtherDirective (b1, b2) ->
       m_other_directive_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+  | G.OtherDirective2 (a1, a2), B.OtherDirective2 (b1, b2) ->
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.ImportFrom _, _
   | G.ImportAs _, _
   | G.OtherDirective _, _
+  | G.OtherDirective2 _, _
   | G.Pragma _, _
   | G.ImportAll _, _
   | G.Package _, _

--- a/semgrep-core/src/matching/Normalize_generic.ml
+++ b/semgrep-core/src/matching/Normalize_generic.ml
@@ -63,6 +63,7 @@ let normalize_import_opt is_pattern i =
   | Package _
   | PackageEnd _
   | Pragma _
+  | OtherDirective2 _
   | OtherDirective _ ->
       None
 

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -143,7 +143,8 @@ let subexprs_of_expr e =
          |> List.map Common.opt_to_list
          |> List.flatten)
   | Yield (_, eopt, _) -> Common.opt_to_list eopt
-  | OtherExpr (_, anys) ->
+  | OtherExpr (_, anys)
+  | OtherExpr2 (_, anys) ->
       (* in theory we should go deeper in any *)
       subexprs_of_any_list anys
   | Lambda def -> subexprs_of_stmt (H.funcbody_to_stmt def.fbody)


### PR DESCRIPTION
Those OtherXxx2 will at some point replace the OtherXxx
and other_xxx types.

test plan:
make


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)