### PR TITLE
Add Scala projects for parsing stas

### DIFF
--- a/parsing-stats/lang/scala/projects.txt
+++ b/parsing-stats/lang/scala/projects.txt
@@ -1,0 +1,34 @@
+#
+# Top scala projects from GitHub, sorted by stars.
+# Created by ../../../semgrep-core/src/ocaml-tree-sitter-core/scripts/most-starred-for-language.
+#
+https://github.com/apache/spark
+https://github.com/prisma/prisma1
+https://github.com/scala/scala
+https://github.com/apache/predictionio
+https://github.com/playframework/playframework
+https://github.com/akka/akka
+https://github.com/yahoo/CMAK
+https://github.com/ornicar/lila
+https://github.com/gitbucket/gitbucket
+https://github.com/twitter/finagle
+https://github.com/rtyley/bfg-repo-cleaner
+https://github.com/twitter-archive/snowflake
+https://github.com/lhartikk/ArnoldC
+https://github.com/snowplow/snowplow
+https://github.com/guardian/frontend
+https://github.com/apache/openwhisk
+https://github.com/linkerd/linkerd
+https://github.com/gatling/gatling
+https://github.com/fpinscala/fpinscala
+https://github.com/enso-org/enso
+https://github.com/lampepfl/dotty
+https://github.com/airbnb/aerosolve
+https://github.com/typelevel/cats
+https://github.com/scalaz/scalaz
+https://github.com/sbt/sbt
+https://github.com/mesos/chronos
+https://github.com/scala-js/scala-js
+https://github.com/polynote/polynote
+https://github.com/scala-native/scala-native
+https://github.com/mesosphere/marathon


### PR DESCRIPTION
Now we'll start generating Scala parsing statistics again.
Test plan: `parsing-stats/run-lang scala`
PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
