### PR TITLE
Scala: Parse underscores and long suffix in number literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - text_wrapping defaults to MAX_TEXT_WIDTH if get_terminal_size reports width < 1
 - Correctly parse metavariables in JS template strings
 - Constant propagation: Tuple/Array destructuring assignments now correctly prevent constant propagation
+- Scala: parse underscore separators in number literals, and parse 'l'/'L' long suffix on number literals
 
 ### Changed
 - Report CI environment variable in metrics for better environment


### PR DESCRIPTION
Expressions like `1_00` and `10_0L` now correctly parse as literals in Scala. The lexing strategy for this was taken directly from the pfff Java lexer.

Test plan: make test (see added tests in pfff)
PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
