### PR TITLE
feat(release): correctly tag wheels

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
       - name: Post-checkout fixes
         run: ./.github/post-checkout
-      - name: Build semgrep-core and spacegrep
+      - name: Build semgrep-core
         run: ./scripts/install-alpine-semgrep-core
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
@@ -73,9 +73,7 @@ jobs:
       - name: Test build artifacts
         run: |
           chmod +x ./artifacts/semgrep-core
-          chmod +x ./artifacts/spacegrep
           ./artifacts/semgrep-core -help
-          ./artifacts/spacegrep --help
 
   release-ubuntu:
     name: Check builds for ubuntu

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -74,30 +74,3 @@ jobs:
         run: |
           chmod +x ./artifacts/semgrep-core
           ./artifacts/semgrep-core -help
-
-  release-ubuntu:
-    name: Check builds for ubuntu
-    needs: [build-core]
-    runs-on: ubuntu-latest
-    container: returntocorp/sgrep-build:ubuntu-16.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Download artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: ocaml-build-artifacts
-      - name: Install artifacts
-        run: |
-          tar xf ocaml-build-artifacts/ocaml-build-artifacts.tgz
-          mkdir -p semgrep-files
-          cp ocaml-build-artifacts/bin/* semgrep-files
-      - name: Run Ubuntu build script
-        run: ./scripts/ubuntu-release.sh
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: semgrep-ubuntu-16.04-${{ github.sha }}
-          path: artifacts.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,11 +222,10 @@ jobs:
       - name: Install artifacts
         run: tar xf ocaml-build-artifacts/ocaml-build-artifacts.tgz
       - name: Setup Python
-        run: |
-          sudo rm /usr/bin/python
-          sudo ln `which python3.7` /usr/bin/python
-      - name: Install zip & musl-tools
-        run: apt-get update && apt install -y zip musl-tools
+        uses: actions/setup-python@v1
+        with:
+          # This is just the Python version to build the wheels
+          python-version: 3.7
       - name: Install setuptools and wheel
         run: pip install setuptools wheel
       - name: Build musllinux_1_2_x86_64 wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           name: ocaml-build-artifacts
           path: ocaml-build-artifacts.tgz
-      - name: Test semgrep-core and spacegrep
+      - name: Test semgrep-core
         run: opam exec -- make -C semgrep-core test
 
   build-core-osx:
@@ -193,7 +193,6 @@ jobs:
         env:
           # Relative because build-wheels does a 'cd semgrep'
           SEMGREP_CORE_BIN: ../artifacts/semgrep-core
-          SPACEGREP_BIN: ../artifacts/spacegrep
         run: ./scripts/build-wheels.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
@@ -226,7 +225,6 @@ jobs:
         env:
           # Relative because build-wheels does a 'cd semgrep'
           SEMGREP_CORE_BIN: ../ocaml-build-artifacts/bin/semgrep-core
-          SPACEGREP_BIN: ../ocaml-build-artifacts/bin/spacegrep
         run: ./scripts/build-wheels.sh
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
         run: tar xf ocaml-build-artifacts/ocaml-build-artifacts.tgz
       - name: Setup Python
         run: |
-          rm /usr/bin/python
+          sudo rm /usr/bin/python
           ln `which python3.7` /usr/bin/python
       - name: Install zip & musl-tools
         run: apt-get update && apt install -y zip musl-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,7 @@ jobs:
         run: python setup.py bdist_wheel -p macosx-11-0-x86_64 --python-tag 'cp36.cp37.cp38.cp39.py36.py37.py38.py39'
       - name: Zip wheels
         run: zip -r dist.zip dist
+        working-directory: semgrep
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -238,6 +239,9 @@ jobs:
           SEMGREP_CORE_BIN: ../ocaml-build-artifacts/bin/semgrep-core
         working-directory: semgrep
         run: python setup.py bdist_wheel -p manylinux2014_x86_64 --python-tag 'cp36.cp37.cp38.cp39.py36.py37.py38.py39'
+      - name: Zip wheels
+        run: zip -r dist.zip dist
+        working-directory: semgrep
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,8 @@ jobs:
           path: manylinux-wheel
       - name: unzip dist
         run: unzip ./manylinux-wheel/dist.zip
+      - name: ls
+        run: ls dist
       - name: install package
         run: /opt/python/cp36-cp36m/bin/pip install dist/*manylinux*.whl
       - name: test package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
       - name: ls
         run: ls dist
       - name: install package
-        run: /opt/python/cp36-cp36m/bin/pip install dist/*manylinux*.whl
+        run: sudo /opt/python/cp36-cp36m/bin/pip -H install dist/*manylinux*.whl
       - name: test package
         working-directory: /opt/python/cp36-cp36m/bin/
         run: ./semgrep --version
@@ -275,7 +275,7 @@ jobs:
 
   upload-wheels:
     runs-on: ubuntu-latest
-    needs: [test-wheels-manylinux, build-wheels-osx]
+    needs: [build-wheels-manylinux, build-wheels-osx]
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Setup Python
         run: |
           sudo rm /usr/bin/python
-          ln `which python3.7` /usr/bin/python
+          sudo ln `which python3.7` /usr/bin/python
       - name: Install zip & musl-tools
         run: apt-get update && apt install -y zip musl-tools
       - name: Install setuptools and wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,104 +2,103 @@
 name: release
 
 on:
-  push:
-    branches:
-      # Sequence of patterns matched against refs/tags
-      - '**-test-release'
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+  # push:
+  #   branches:
+  #     # Sequence of patterns matched against refs/tags
+  #     - '**-test-release'
+  #   tags:
+  #     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  create_release:
-    name: Create the Github Release
-    runs-on: ubuntu-latest
-    needs: [upload-wheels, release-ubuntu-16-04]
-    steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: true
-          prerelease: false
+  # create_release:
+  #   name: Create the Github Release
+  #   runs-on: ubuntu-latest
+  #   needs: [upload-wheels, release-ubuntu-16-04]
+  #   steps:
+  #     - name: Create Release
+  #       id: create_release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ github.ref }}
+  #         release_name: Release ${{ github.ref }}
+  #         draft: true
+  #         prerelease: false
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: semgrep-osx-${{ github.sha }}
+  #         path: semgrep-osx
+  #     - name: Compute checksum
+  #       run: cat ./semgrep-osx/artifacts.zip | sha256sum > ./semgrep-osx/artifacts.zip.sha256
+  #     - name: Get the version
+  #       id: get_version
+  #       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+  #     - name: Upload Release Asset
+  #       id: upload-release-asset-osx
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: ./semgrep-osx/artifacts.zip
+  #         asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
+  #         asset_content_type: application/zip
+  #     - name: Upload Release Checksum
+  #       id: upload-checksum-asset-osx
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: ./semgrep-osx/artifacts.zip.sha256
+  #         asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
+  #         asset_content_type: application/zip
 
-          # OSX
-      - uses: actions/download-artifact@v1
-        with:
-          name: semgrep-osx-${{ github.sha }}
-          path: semgrep-osx
-      - name: Compute checksum
-        run: cat ./semgrep-osx/artifacts.zip | sha256sum > ./semgrep-osx/artifacts.zip.sha256
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - name: Upload Release Asset
-        id: upload-release-asset-osx
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./semgrep-osx/artifacts.zip
-          asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
-          asset_content_type: application/zip
-      - name: Upload Release Checksum
-        id: upload-checksum-asset-osx
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./semgrep-osx/artifacts.zip.sha256
-          asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
-          asset_content_type: application/zip
+  #         ## UBUNTU
+  #     - uses: actions/download-artifact@v1
+  #       with:
+  #         name: semgrep-ubuntu-16.04-${{ github.sha }}
+  #         path: semgrep-ubuntu
+  #     - name: Compute checksum
+  #       run: cat ./semgrep-ubuntu/artifacts.tar.gz | sha256sum > ./semgrep-ubuntu/artifacts.tar.gz.sha256
+  #     - name: Upload Release Asset
+  #       id: upload-release-asset-ubuntu
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: ./semgrep-ubuntu/artifacts.tar.gz
+  #         asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
+  #         asset_content_type: application/gzip
+  #     - name: Upload Release Checksum
+  #       id: upload-release-checksum-ubuntu
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create_release.outputs.upload_url }}
+  #         asset_path: ./semgrep-ubuntu/artifacts.tar.gz.sha256
+  #         asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz.sha256
+  #         asset_content_type: application/gzip
 
-          ## UBUNTU
-      - uses: actions/download-artifact@v1
-        with:
-          name: semgrep-ubuntu-16.04-${{ github.sha }}
-          path: semgrep-ubuntu
-      - name: Compute checksum
-        run: cat ./semgrep-ubuntu/artifacts.tar.gz | sha256sum > ./semgrep-ubuntu/artifacts.tar.gz.sha256
-      - name: Upload Release Asset
-        id: upload-release-asset-ubuntu
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./semgrep-ubuntu/artifacts.tar.gz
-          asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
-          asset_content_type: application/gzip
-      - name: Upload Release Checksum
-        id: upload-release-checksum-ubuntu
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./semgrep-ubuntu/artifacts.tar.gz.sha256
-          asset_name: semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz.sha256
-          asset_content_type: application/gzip
-
-  release-docker:
-    name: Build and Push Semgrep Docker Container
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get the version without leading v
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
-      - name: build-and-push
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: returntocorp/semgrep
-          tags: ${{ steps.get_version.outputs.VERSION }}, latest
+  # release-docker:
+  #   name: Build and Push Semgrep Docker Container
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Get the version without leading v
+  #       id: get_version
+  #       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+  #     - name: build-and-push
+  #       uses: docker/build-push-action@v1
+  #       with:
+  #         username: ${{ secrets.DOCKER_USERNAME }}
+  #         password: ${{ secrets.DOCKER_PASSWORD }}
+  #         repository: returntocorp/semgrep
+  #         tags: ${{ steps.get_version.outputs.VERSION }}, latest
 
   build-core:
     name: semgrep-core make test and semgrep make test/qa-test
@@ -146,7 +145,6 @@ jobs:
 
   release-ubuntu-16-04:
     runs-on: ubuntu-latest
-    container: returntocorp/sgrep-build:ubuntu-16.04
     needs: [build-core]
     steps:
       - name: Checkout
@@ -189,11 +187,20 @@ jobs:
         with:
           # This is just the Python version to build the wheels
           python-version: 3.7
-      - name: Build the wheels
+      - name: Install setuptools and wheel
+        run: pip install setuptools wheel
+      - name: Build macosx 10.15 wheel
+        working-directory: semgrep
         env:
-          # Relative because build-wheels does a 'cd semgrep'
           SEMGREP_CORE_BIN: ../artifacts/semgrep-core
-        run: ./scripts/build-wheels.sh
+        run: python setup.py bdist_wheel -p macosx-10-15-x86_64 --python-tag 'cp36.cp37.cp38.cp39.py36.py37.py38.py39'
+      - name: Build macosx 11.0 wheel
+        working-directory: semgrep
+        env:
+          SEMGREP_CORE_BIN: ../artifacts/semgrep-core
+        run: python setup.py bdist_wheel -p macosx-11-0-x86_64 --python-tag 'cp36.cp37.cp38.cp39.py36.py37.py38.py39'
+      - name: Zip wheels
+        run: zip -r dist.zip dist
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -202,7 +209,6 @@ jobs:
 
   build-wheels-manylinux:
     runs-on: ubuntu-latest
-    container: returntocorp/sgrep-build:ubuntu-16.04
     needs: [build-core]
     steps:
       - name: Checkout
@@ -221,11 +227,18 @@ jobs:
           ln `which python3.7` /usr/bin/python
       - name: Install zip & musl-tools
         run: apt-get update && apt install -y zip musl-tools
-      - name: Build the wheels
+      - name: Install setuptools and wheel
+        run: pip install setuptools wheel
+      - name: Build musllinux_1_2_x86_64 wheel
         env:
-          # Relative because build-wheels does a 'cd semgrep'
           SEMGREP_CORE_BIN: ../ocaml-build-artifacts/bin/semgrep-core
-        run: ./scripts/build-wheels.sh
+        working-directory: semgrep
+        run: python setup.py sdist bdist_wheel -p  musllinux_1_2_x86_64 --python-tag 'cp36.cp37.cp38.cp39.py36.py37.py38.py39'
+      - name: Build manylinux2014_x86_64 wheel
+        env:
+          SEMGREP_CORE_BIN: ../ocaml-build-artifacts/bin/semgrep-core
+        working-directory: semgrep
+        run: python setup.py bdist_wheel -p manylinux2014_x86_64 --python-tag 'cp36.cp37.cp38.cp39.py36.py37.py38.py39'
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -244,7 +257,7 @@ jobs:
       - name: unzip dist
         run: unzip ./manylinux-wheel/dist.zip
       - name: install package
-        run: /opt/python/cp36-cp36m/bin/pip install dist/*.whl
+        run: /opt/python/cp36-cp36m/bin/pip install dist/*manylinux*.whl
       - name: test package
         working-directory: /opt/python/cp36-cp36m/bin/
         run: ./semgrep --version
@@ -272,47 +285,48 @@ jobs:
       - name: Unzip
         run: unzip ./manylinux-wheel/dist.zip
       - name: Unzip OSX Wheel
-        # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
-        run: unzip ./osx-wheel/dist.zip "*.whl"
-      - name: Publish to Pypi
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_upload_token }}
-          skip_existing: true
+        run: unzip ./osx-wheel/dist.zip
+      - name: ls
+        run: ls
+      # - name: Publish to Pypi
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.pypi_upload_token }}
+      #     skip_existing: true
 
-  sleep-before-homebrew:
-    name: Sleep 10 min before releasing to homebrew
-    # Need to wait for pypi to propagate ssince pipgrip relies on it being published on pypi
-    needs: [upload-wheels]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Sleep 10 min
-        run: sleep 10m
+  # sleep-before-homebrew:
+  #   name: Sleep 10 min before releasing to homebrew
+  #   # Need to wait for pypi to propagate since pipgrip relies on it being published on pypi
+  #   needs: [upload-wheels]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Sleep 10 min
+  #       run: sleep 10m
 
-  homebrew-core-pr:
-    name: Update on Homebrew-Core
-    needs: [sleep-before-homebrew]  # Needs to run after pypi released so brew can update pypi dependency hashes
-    runs-on: macos-10.15
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          # Needs to be < 3.10 see https://github.com/returntocorp/semgrep/issues/4213
-          python-version: 3.9
-      - name: Brew update
-        run: brew update
-      - name: Install brew pipgrip
-        run: brew install pipgrip
-      - name: Install pip pipgrip
-        run: pip install pipgrip
-      - name: Point homebrew pipgrip to pip pipgrip
-        # Homebrew brew calls brew pipgrip internally but brew pipgrip is pinned to python3.10
-        # this tricks it into using our 3.9 pipgrip
-        run: rm /usr/local/opt/pipgrip/bin/pipgrip && ln /Users/runner/hostedtoolcache/Python/3.9.8/x64/bin/pipgrip /usr/local/opt/pipgrip/bin/pipgrip
-      - uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          formula: semgrep
-          org: returntocorp
-          force: true
+  # homebrew-core-pr:
+  #   name: Update on Homebrew-Core
+  #   needs: [sleep-before-homebrew]  # Needs to run after pypi released so brew can update pypi dependency hashes
+  #   runs-on: macos-10.15
+  #   steps:
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         # Needs to be < 3.10 see https://github.com/returntocorp/semgrep/issues/4213
+  #         python-version: 3.9
+  #     - name: Brew update
+  #       run: brew update
+  #     - name: Install brew pipgrip
+  #       run: brew install pipgrip
+  #     - name: Install pip pipgrip
+  #       run: pip install pipgrip
+  #     - name: Point homebrew pipgrip to pip pipgrip
+  #       # Homebrew brew calls brew pipgrip internally but brew pipgrip is pinned to python3.10
+  #       # this tricks it into using our 3.9 pipgrip
+  #       run: rm /usr/local/opt/pipgrip/bin/pipgrip && ln /Users/runner/hostedtoolcache/Python/3.9.8/x64/bin/pipgrip /usr/local/opt/pipgrip/bin/pipgrip
+  #     - uses: dawidd6/action-homebrew-bump-formula@v3
+  #       with:
+  #         token: ${{ secrets.HOMEBREW_PR_TOKEN }}
+  #         formula: semgrep
+  #         org: returntocorp
+  #         force: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
           submodules: true
       - name: Post-checkout fixes
         run: ./.github/post-checkout
-      - name: Build semgrep-core and spacegrep
+      - name: Build semgrep-core
         run: ./scripts/install-alpine-semgrep-core
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
           name: ocaml-build-artifacts
           path: ocaml-build-artifacts.tgz
-      - name: Test semgrep-core and spacegrep
+      - name: Test semgrep-core
         run: |
           eval $(opam env)
           cd semgrep-core

--- a/scripts/install-alpine-semgrep-core
+++ b/scripts/install-alpine-semgrep-core
@@ -53,7 +53,7 @@ echo "Install pfff dependencies"
   opam install --deps-only -y .
 )
 
-echo "Install semgrep-core and spacegrep"
+echo "Install semgrep-core"
 (
   cd semgrep-core
   opam install --deps-only -y .
@@ -65,6 +65,5 @@ echo "Copy executables to artifacts archive"
 rm -rf ocaml-build-artifacts
 bin=ocaml-build-artifacts/bin
 mkdir -p "$bin"
-cp ./semgrep-core/_build/install/default/bin/spacegrep "$bin"
 cp ./semgrep-core/_build/install/default/bin/semgrep-core "$bin"
 tar czf ocaml-build-artifacts.tgz ocaml-build-artifacts

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -26,5 +26,4 @@ make build-core
 
 mkdir -p artifacts
 cp ./semgrep-core/_build/install/default/bin/semgrep-core artifacts
-cp ./semgrep-core/_build/install/default/bin/spacegrep artifacts
 zip -r artifacts.zip artifacts

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -16,8 +16,6 @@ BIN_DIR = "bin"
 PACKAGE_BIN_DIR = os.path.join(SOURCE_DIR, "semgrep", BIN_DIR)
 SEMGREP_CORE_BIN = "semgrep-core"
 SEMGREP_CORE_BIN_ENV = "SEMGREP_CORE_BIN"
-SPACEGREP_BIN = "spacegrep"
-SPACEGREP_BIN_ENV = "SPACEGREP_BIN"
 SEMGREP_SKIP_BIN = "SEMGREP_SKIP_BIN" in os.environ
 SEMGREP_FORCE_INSTALL = "SEMGREP_FORCE_INSTALL" in os.environ
 IS_WINDOWS = platform.system() == "Windows"
@@ -83,21 +81,9 @@ def find_executable(env_name, exec_name):
     )
 
 
-#
-# The default behavior is to copy the semgrep-core and spacegrep binaries
-# into some other folder known to the semgrep wrapper. If somebody knows why,
-# please explain why we do this.
-#
-# It makes testing of semgrep-core error-prone since recompiling
-# semgrep-core won't perform this copy. If we can't get rid of this, can
-# we use a symlink instead?
-#
-# The environment variable SEMGREP_SKIP_BIN bypasses this copy. What is it for?
-#
 if not SEMGREP_SKIP_BIN:
     binaries = [
         (SEMGREP_CORE_BIN_ENV, SEMGREP_CORE_BIN),
-        (SPACEGREP_BIN_ENV, SPACEGREP_BIN),
     ]
 
     for binary_env, binary_name in binaries:

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -29,27 +29,28 @@ def is_python_before_3_7():
     return int(major) < 3 or int(minor) < 7
 
 
-if WHEEL_CMD in sys.argv:
-    try:
-        from wheel.bdist_wheel import bdist_wheel
-    except ImportError:
-        raise Exception(f"The 'wheel' package is required when running '{WHEEL_CMD}'")
+# if WHEEL_CMD in sys.argv:
+#     try:
+#         from wheel.bdist_wheel import bdist_wheel
+#     except ImportError:
+#         raise Exception(f"The 'wheel' package is required when running '{WHEEL_CMD}'")
 
-    class BdistWheel(bdist_wheel):
-        def finalize_options(self):
-            bdist_wheel.finalize_options(self)
-            self.root_is_pure = False  # We have platform specific binaries
+#     class BdistWheel(bdist_wheel):
+#         def finalize_options(self):
+#             bdist_wheel.finalize_options(self)
+#             self.root_is_pure = False  # We have platform specific binaries
 
-        def get_tag(self):
-            _, _, plat = bdist_wheel.get_tag(self)
-            python = "cp36.cp37.cp38.cp39.py36.py37.py38.py39"
-            abi = "none"
-            plat = "macosx_10_14_x86_64" if "macosx" in plat else "any"
-            return python, abi, plat
+#         def get_tag(self):
+#             a, b, plat = bdist_wheel.get_tag(self)
+#             print(a, b, plat)
+#             python = "cp36.cp37.cp38.cp39.py36.py37.py38.py39"
+#             abi = "none"
+#             # plat = "macosx_10_14_x86_64" if "macosx" in plat else "any"
+#             return python, abi, plat
 
-    cmdclass = {WHEEL_CMD: BdistWheel}
-else:
-    cmdclass = {}
+#     cmdclass = {WHEEL_CMD: BdistWheel}
+# else:
+#     cmdclass = {}
 
 if IS_WINDOWS and not SEMGREP_FORCE_INSTALL:
     raise Exception(
@@ -128,7 +129,7 @@ setuptools.setup(
     author="Return To Corporation",
     author_email="support@r2c.dev",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",
-    cmdclass=cmdclass,
+    # cmdclass=cmdclass,
     install_requires=install_requires,
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add tags for musllinux, manylinux, macosx10.15, macosx11.0 instead of using the any platform tag
in pypi wheels.

Tested locally using test.pypi.org upload

Also removing all install code for spacegrep

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
