### PR TITLE
Have the --validate flag call -check_rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 these metavariables correctly appear in match messages
 - Pre-alpha support for Bash as a new target language
 - Increase soft stack limit when running semgrep-core (#4120)
+- `semgrep --validate` runs metachecks on the rule
 
 ### Fixed
 - text_wrapping defaults to MAX_TEXT_WIDTH if get_terminal_size reports width < 1

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -154,7 +154,7 @@ let string_of_error err =
 
 let severity_of_error typ =
   match typ with
-  | SemgrepMatchFound _title -> Warning
+  | SemgrepMatchFound _title -> Error
   | MatchingError -> Warning
   | TooManyMatches -> Warning
   | LexicalError -> Warning

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -19,6 +19,8 @@ module R = Rule
 module E = Semgrep_error_code
 module PI = Parse_info
 module P = Pattern_match
+module RP = Report
+module SJ = Semgrep_core_response_j
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -176,7 +178,7 @@ let semgrep_check config metachecks rules =
  * circular dependencies.
  * Similar to Test_parsing.test_parse_rules.
  *)
-let run_checks mk_config fparser metachecks xs =
+let run_checks config fparser metachecks xs =
   let yaml_xs, skipped_paths =
     xs
     |> File_type.files_of_dirs_or_files (function
@@ -194,7 +196,7 @@ let run_checks mk_config fparser metachecks xs =
         "no valid yaml rules to run on (.test.yaml files are excluded)";
       []
   | _ ->
-      let semgrep_found_errs = semgrep_check (mk_config ()) metachecks rules in
+      let semgrep_found_errs = semgrep_check config metachecks rules in
       let ocaml_found_errs =
         rules
         |> List.map (fun file ->
@@ -208,14 +210,24 @@ let run_checks mk_config fparser metachecks xs =
       semgrep_found_errs @ ocaml_found_errs
 
 let check_files mk_config fparser input =
-  match input with
-  | []
-  | [ _ ] ->
-      logger#error
-        "check_rules needs a metacheck file or directory and rules to run on"
-  | metachecks :: xs ->
-      run_checks mk_config fparser metachecks xs
-      |> List.iter (fun err -> pr2 (E.string_of_error err))
+  let config = mk_config () in
+  let errors =
+    match input with
+    | []
+    | [ _ ] ->
+        logger#error
+          "check_rules needs a metacheck file or directory and rules to run on";
+        []
+    | metachecks :: xs -> run_checks config fparser metachecks xs
+  in
+  match config.output_format with
+  | Text -> List.iter (fun err -> pr2 (E.string_of_error err)) errors
+  | Json ->
+      let res =
+        { RP.matches = []; errors; skipped = []; rule_profiling = None }
+      in
+      let json = JSON_report.match_results_of_matches_and_errors [] res in
+      pr (SJ.string_of_match_results json)
 
 let stat_files fparser xs =
   let fullxs, _skipped_paths =

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -157,6 +157,7 @@ let check r =
 let semgrep_check config metachecks rules =
   let match_to_semgrep_error m =
     let loc, _ = m.P.range_loc in
+    (* TODO use the end location in errors *)
     let s = m.rule_id.message in
     let check_id = m.rule_id.id in
     E.mk_error ~rule_id:None loc s (E.SemgrepMatchFound check_id)

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -205,7 +205,11 @@ let run_checks config fparser metachecks xs =
                try
                  let rs = fparser file in
                  rs |> List.map (fun file -> check file) |> List.flatten
-               with exn -> [ E.exn_to_error file exn ])
+               with
+               (* TODO this error is special cased because YAML files that *)
+               (* aren't semgrep rules are getting scanned *)
+               | Rule.InvalidYaml _ -> []
+               | exn -> [ E.exn_to_error file exn ])
         |> List.flatten
       in
       semgrep_found_errs @ ocaml_found_errs

--- a/semgrep-core/src/metachecking/Check_rule.mli
+++ b/semgrep-core/src/metachecking/Check_rule.mli
@@ -3,7 +3,7 @@ val check : Rule.t -> Semgrep_error_code.error list
 
 (* to test -check_rules *)
 val run_checks :
-  (unit -> Runner_common.config) ->
+  Runner_common.config ->
   (Common.filename -> Rule.t list) ->
   Common.filename (* metachecks *) ->
   Common.filename list (* rules *) ->

--- a/semgrep-core/src/metachecking/Test_metachecking.ml
+++ b/semgrep-core/src/metachecking/Test_metachecking.ml
@@ -44,7 +44,7 @@ let first_xlang_of_rules rs =
   | [] -> failwith "no rules"
   | { R.languages = x; _ } :: _ -> x
 
-let mk_config () =
+let config =
   {
     Runner_common.log_config_file = "";
     test = false;
@@ -137,7 +137,7 @@ let test_rules ?(unit_testing = false) xs =
          (* actual *)
          Flag_semgrep.with_opt_cache := false;
          let actual_errors =
-           try Check_rule.run_checks mk_config Parse_rule.parse file [ target ]
+           try Check_rule.run_checks config Parse_rule.parse file [ target ]
            with exn ->
              failwith (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))
          in

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -27,6 +27,7 @@ rules:
        - Unit_*.ml
        - Test_*.ml
        - runner/*.ml
+       - Check_*.ml
 
 # not ready yet
 #  - id: no-exit-in-semgrep

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -651,24 +651,26 @@ def cli(
                     f"Nothing to validate, use the --config or --pattern flag to specify a rule"
                 )
             else:
-                configs, config_errors = semgrep.config_resolver.get_config(
+                resolved_configs, config_errors = semgrep.config_resolver.get_config(
                     pattern, lang, config or [], project_url=get_project_url()
                 )
 
-                metacheck_errors = CoreRunner(
-                    jobs=jobs,
-                    timeout=timeout,
-                    max_memory=max_memory,
-                    timeout_threshold=timeout_threshold,
-                    optimizations=optimizations,
-                ).validate_configs(configs)
+                # Run metachecks specifically on the config files
+                if config:
+                    metacheck_errors = CoreRunner(
+                        jobs=jobs,
+                        timeout=timeout,
+                        max_memory=max_memory,
+                        timeout_threshold=timeout_threshold,
+                        optimizations=optimizations,
+                    ).validate_configs(config)
 
                 config_errors = list(chain(config_errors, metacheck_errors))
 
                 valid_str = "invalid" if config_errors else "valid"
-                rule_count = len(configs.get_rules(True))
+                rule_count = len(resolved_configs.get_rules(True))
                 logger.info(
-                    f"Configuration is {valid_str} - found {len(configs.valid)} valid configuration(s), {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
+                    f"Configuration is {valid_str} - found {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
                 )
                 if config_errors:
                     OutputSettings.verbose_errors = True

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -654,18 +654,16 @@ def cli(
                 configs, config_errors = semgrep.config_resolver.get_config(
                     pattern, lang, config or [], project_url=get_project_url()
                 )
-                config_errors = list(
-                    chain(
-                        config_errors,
-                        CoreRunner(
-                            jobs=jobs,
-                            timeout=timeout,
-                            max_memory=max_memory,
-                            timeout_threshold=timeout_threshold,
-                            optimizations=optimizations,
-                        ).validate_configs(configs),
-                    )
-                )
+
+                metacheck_errors = CoreRunner(
+                    jobs=jobs,
+                    timeout=timeout,
+                    max_memory=max_memory,
+                    timeout_threshold=timeout_threshold,
+                    optimizations=optimizations,
+                ).validate_configs(configs)
+
+                config_errors = list(chain(config_errors, metacheck_errors))
 
                 valid_str = "invalid" if config_errors else "valid"
                 rule_count = len(configs.get_rules(True))

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -673,7 +673,6 @@ def cli(
                     f"Configuration is {valid_str} - found {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
                 )
                 if config_errors:
-                    OutputSettings.verbose_errors = True
                     output_handler.handle_semgrep_errors(config_errors)
                     raise SemgrepError("Please fix the above errors and try again.")
         elif generate_config:

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -673,6 +673,7 @@ def cli(
                     f"Configuration is {valid_str} - found {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
                 )
                 if config_errors:
+                    OutputSettings.verbose_errors = True
                     output_handler.handle_semgrep_errors(config_errors)
                     raise SemgrepError("Please fix the above errors and try again.")
         elif generate_config:

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -152,7 +152,7 @@ class SemgrepCoreError(SemgrepError):
             else:
                 msg = f"Semgrep Core {self.level.name} - {self.error_type}: When running {self.rule_id} on {self.path}: {self.message}"
         else:
-            msg = f"Semgrep Core {self.level.name} - {self.error_type} in file {self.path}\n\t{self.message}"
+            msg = f"Semgrep Core {self.level.name} - {self.error_type} in file {self.path}:{self.start.line}\n\t{self.message}"
         return msg
 
     @property

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -4,7 +4,7 @@ rules:
 - rules.assert-eqeq-is-ok
 - rules.eqeq-is-bad
 skipped 'targets/bad/invalid_python.py' [rule assert-eqeq-is-ok]: irrelevant_rule: target doesn't contain some elements required by rule 'assert-eqeq-is-ok'
-Semgrep Core WARN - Syntax error in file targets/bad/invalid_python.py
+Semgrep Core WARN - Syntax error in file targets/bad/invalid_python.py:1
 	`
     ` was unexpected
 ran 2 rules on 1 files: 0 findings


### PR DESCRIPTION
Run `p/semgrep-rule-lints` and built in metachecks when `semgrep --validate` is passed

Test plan: `semgrep --validate --config ../semgrep-core/tests/OTHER/metachecks`. One of the files here contains duplicates

Expected output:

```
➜  semgrep git:(EJ-semgrep-validates-rules) ✗ semgrep --validate --config ../semgrep-core/tests/OTHER/metachecks
Fetching rules from https://semgrep.dev/registry ...
Configuration is invalid - found 3 configuration error(s), and 2 rule(s).
Semgrep Core ERROR - Semgrep match found by 'yaml.semgrep.duplicate-pattern.duplicate-pattern' in file ../semgrep-core/tests/OTHER/metachecks/slow_pattern.rule.yaml:17
	Two identical pattern clauses were detected. This will cause Semgrep to run the same pattern twice. Remove one of the duplicate pattern clauses.
Semgrep Core ERROR - Semgrep match found by 'yaml.semgrep.duplicate-pattern.duplicate-pattern' in file ../semgrep-core/tests/OTHER/metachecks/slow_pattern.rule.yaml:22
	Two identical pattern clauses were detected. This will cause Semgrep to run the same pattern twice. Remove one of the duplicate pattern clauses.
Semgrep Core ERROR - Semgrep match found by 'semgrep-metacheck-builtin': When running express-sandbox-code-injection on ../semgrep-core/tests/OTHER/metachecks/slow_pattern.rule.yaml: Duplicate pattern of pattern at line 17
Please fix the above errors and try again.
```

Note that the message appears three times (twice from the semgrep rule, once from the equivalent OCaml rule). We should remove the OCaml rule, but I want to have at least one OCaml rule for the semgrep-core test.

Other TODO: use severity of semgrep rule, report full ranges in SemgrepCoreError

PR checklist:
- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
