### PR TITLE
bash: Put "semgrep" into the name of the semgrep-specific constructs

### DIFF
--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -400,9 +400,9 @@ and expression =
   | Raw_string of (* '...' *) string wrap
   | Ansii_c_string of (* $'...' *) string wrap
   | Concatenation of loc * expression list
-  | Expr_ellipsis of (* ... *) tok
-  | Expr_deep_ellipsis of (* <... x ...> *) loc * expression bracket
-  | Expr_metavar of (* $X in pattern mode *) string wrap
+  | Expr_semgrep_ellipsis of (* ... *) tok
+  | Expr_semgrep_deep_ellipsis of (* <... x ...> *) loc * expression bracket
+  | Expr_semgrep_metavar of (* $X in pattern mode *) string wrap
   | Equality_test of loc * eq_op * right_eq_operand (* should it be here? *)
   | Empty_expression of loc
   | Array of (* ( a b ) *) loc * expression list bracket
@@ -413,7 +413,7 @@ and string_fragment =
   | String_content of string wrap
   | Expansion of (* $X in program mode, ${X}, ${X ... } *) loc * expansion
   | Command_substitution of (* $(foo; bar) or `foo; bar` *) blist bracket
-  | Frag_metavar of (* $X in pattern mode *) string wrap
+  | Frag_semgrep_metavar of (* $X in pattern mode *) string wrap
 
 (* $foo or something like ${foo ...} *)
 and expansion =
@@ -423,7 +423,7 @@ and expansion =
 and variable_name =
   | Simple_variable_name of string wrap
   | Special_variable_name of string wrap
-  | Var_metavar of string wrap
+  | Var_semgrep_metavar of string wrap
 
 and complex_expansion =
   | Variable of loc * variable_name
@@ -625,9 +625,9 @@ let expression_loc = function
   | Ansii_c_string x -> wrap_loc x
   | Special_character x -> wrap_loc x
   | Concatenation (loc, _) -> loc
-  | Expr_ellipsis tok -> (tok, tok)
-  | Expr_deep_ellipsis (loc, _) -> loc
-  | Expr_metavar x -> wrap_loc x
+  | Expr_semgrep_ellipsis tok -> (tok, tok)
+  | Expr_semgrep_deep_ellipsis (loc, _) -> loc
+  | Expr_semgrep_metavar x -> wrap_loc x
   | Equality_test (loc, _, _) -> loc
   | Empty_expression loc -> loc
   | Array (loc, _) -> loc
@@ -637,7 +637,7 @@ let string_fragment_loc = function
   | String_content x -> wrap_loc x
   | Expansion (loc, _) -> loc
   | Command_substitution x -> bracket_loc x
-  | Frag_metavar x -> wrap_loc x
+  | Frag_semgrep_metavar x -> wrap_loc x
 
 let expansion_loc = function
   | Simple_expansion (loc, _) -> loc
@@ -646,7 +646,7 @@ let expansion_loc = function
 let variable_name_wrap = function
   | Simple_variable_name x
   | Special_variable_name x
-  | Var_metavar x ->
+  | Var_semgrep_metavar x ->
       x
 
 let variable_name_tok x = variable_name_wrap x |> snd

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -143,7 +143,7 @@ let get_var_name (var : variable_name) : string wrap =
   match var with
   | Simple_variable_name name
   | Special_variable_name name
-  | Var_metavar name ->
+  | Var_semgrep_metavar name ->
       name
 
 let mk_var_expr (var : variable_name) : G.expr =
@@ -289,7 +289,8 @@ and command (env : env) (cmd : command) : stmt_or_expr =
       Common.map (assignment env) assignments |> block
   | Simple_command { loc; assignments = _; arguments } -> (
       match arguments with
-      | [ (Expr_ellipsis tok as e) ] -> Expr ((tok, tok), expression env e)
+      | [ (Expr_semgrep_ellipsis tok as e) ] ->
+          Expr ((tok, tok), expression env e)
       | arguments ->
           let args = List.map (expression env) arguments in
           Expr (loc, call loc C.cmd args))
@@ -330,7 +331,7 @@ and command (env : env) (cmd : command) : stmt_or_expr =
         match loop_var with
         | Simple_variable_name var
         | Special_variable_name var
-        | Var_metavar var ->
+        | Var_semgrep_metavar var ->
             let entity = G.basic_entity var in
             G.ForIn ([ ForInitVar (entity, G.empty_var) ], values)
       in
@@ -475,10 +476,10 @@ and expression (env : env) (e : expression) : G.expr =
   | Ansii_c_string str -> G.L (G.String str) |> G.e
   | Special_character str -> G.L (G.String str) |> G.e
   | Concatenation (loc, el) -> List.map (expression env) el |> call loc C.concat
-  | Expr_ellipsis tok -> G.Ellipsis tok |> G.e
-  | Expr_deep_ellipsis (_loc, (open_, e, close)) ->
+  | Expr_semgrep_ellipsis tok -> G.Ellipsis tok |> G.e
+  | Expr_semgrep_deep_ellipsis (_loc, (open_, e, close)) ->
       G.DeepEllipsis (open_, expression env e, close) |> G.e
-  | Expr_metavar mv -> G.N (mk_name mv) |> G.e
+  | Expr_semgrep_metavar mv -> G.N (mk_name mv) |> G.e
   | Equality_test (loc, _, _) -> (* don't know what this is *) todo_expr loc
   | Empty_expression loc -> G.L (G.String ("", fst loc)) |> G.e
   | Array (loc, (open_, elts, close)) ->
@@ -499,7 +500,7 @@ and string_fragment (env : env) (frag : string_fragment) : G.expr =
       let loc = (open_, close) in
       let arg = blist env x |> block |> as_expr in
       call loc C.cmd_subst [ arg ]
-  | Frag_metavar mv -> G.N (mk_name mv) |> G.e
+  | Frag_semgrep_metavar mv -> G.N (mk_name mv) |> G.e
 
 (*
    '$' followed by a variable to transform and expand into a list.

--- a/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml
@@ -198,7 +198,8 @@ let test_operator (env : env) (tok : CST.test_operator) : string wrap =
 let simple_variable_name (env : env) (x : CST.simple_variable_name) :
     variable_name =
   match x with
-  | `Semg_meta tok -> (* pattern \$[A-Z_][A-Z_0-9]* *) Var_metavar (str env tok)
+  | `Semg_meta tok ->
+      (* pattern \$[A-Z_][A-Z_0-9]* *) Var_semgrep_metavar (str env tok)
   | `Pat_42e353e tok -> (* pattern \w+ *) Simple_variable_name (str env tok)
 
 let special_variable_name (env : env) (x : CST.special_variable_name) :
@@ -218,14 +219,14 @@ let heredoc_body_beginning (env : env) (tok : CST.heredoc_body_beginning) =
 
 let word (env : env) (tok : CST.word) : expression =
   match str env tok with
-  | "...", tok when env.extra = Pattern -> Expr_ellipsis tok
+  | "...", tok when env.extra = Pattern -> Expr_semgrep_ellipsis tok
   | x -> Word x
 
 (* Function identifier. These can contain some punctuation. '...' is a valid
    function identifier. *)
 let extended_word (env : env) (x : CST.extended_word) =
   match x with
-  | `Semg_meta tok -> Var_metavar (str env tok)
+  | `Semg_meta tok -> Var_semgrep_metavar (str env tok)
   | `Word tok -> Simple_variable_name (str env tok)
 
 let heredoc_start (env : env) (tok : CST.heredoc_start) = token env tok
@@ -276,7 +277,7 @@ let simple_expansion (env : env) ((v1, v2) : CST.simple_expansion) :
         when Metavariable.is_metavar_name ("$" ^ name_s) ->
           let mv_s = "$" ^ name_s in
           let mv_tok = PI.combine_infos dollar_tok [ name_tok ] in
-          Frag_metavar (mv_s, mv_tok)
+          Frag_semgrep_metavar (mv_s, mv_tok)
       | _ -> Expansion (loc, Simple_expansion (loc, var_name)))
   | Program -> Expansion (loc, Simple_expansion (loc, var_name))
 
@@ -812,7 +813,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expression =
       let e = literal env v2 in
       let close = (* "...>" *) token env v3 in
       let loc = (open_, close) in
-      Expr_deep_ellipsis (loc, (open_, e, close))
+      Expr_semgrep_deep_ellipsis (loc, (open_, e, close))
   | `Choice_word x -> (
       match x with
       | `Word tok -> word env tok (* word *)


### PR DESCRIPTION
Follow-up to https://github.com/returntocorp/semgrep/pull/4179#pullrequestreview-792729400

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
