### PR TITLE
Remove Scala 3 compiler from Scala parsing stat projects

### DIFF
--- a/parsing-stats/lang/scala/projects.txt
+++ b/parsing-stats/lang/scala/projects.txt
@@ -22,7 +22,6 @@ https://github.com/linkerd/linkerd
 https://github.com/gatling/gatling
 https://github.com/fpinscala/fpinscala
 https://github.com/enso-org/enso
-https://github.com/lampepfl/dotty
 https://github.com/airbnb/aerosolve
 https://github.com/typelevel/cats
 https://github.com/scalaz/scalaz


### PR DESCRIPTION
We aren't currently supporting Scala 3

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
