### PR TITLE
Scala: parse patterns starting with underscores as variable patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Constant propagation: In a method call `x.f(y)`, if `x` is a constant then it will be recognized as such
+- Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
 
 ### Changed
 - C# support is now GA


### PR DESCRIPTION
Improves parse rate from 97.1 to 97.2
Previously `case _x : Int => ...` would fail because `_x` was not properly parsed as a variable pattern, and types can only be used with variable patterns.


Test plan: make test (see added test in pfff)
PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
