### PR TITLE
[Go] correctly match braces in composite literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Constant propagation: In a method call `x.f(y)`, if `x` is a constant then it will be recognized as such
+- Go: match correctly braces in composite literals for autofix (#4210)
 - Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
 
 ### Changed

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2020 r2c
+ * Copyright (C) 2020-2021 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -22,7 +22,7 @@ module H = AST_generic_helpers
 (*****************************************************************************)
 (* Ast_go to AST_generic.
  *
- * See ast_generic.ml for more information.
+ * See AST_generic.ml for more information.
  *)
 
 (*****************************************************************************)
@@ -262,9 +262,9 @@ let top_func () =
             fb ([ v1; v3 ] |> List.map G.arg) )
     | CompositeLit (v1, v2) ->
         let v1 = type_ v1
-        and t1, v2, _t2 = bracket (list init_for_composite_lit) v2 in
+        and l, v2, r = bracket (list init_for_composite_lit) v2 in
         G.Call
-          (G.IdSpecial (G.New, fake t1 "new") |> G.e, fb (G.ArgType v1 :: v2))
+          (G.IdSpecial (G.New, fake l "new") |> G.e, (l, G.ArgType v1 :: v2, r))
     | Slice (v1, (t1, v2, t2)) ->
         let e = expr v1 in
         let v1, v2, v3 = v2 in

--- a/semgrep-core/tests/go/misc_compositelit.go
+++ b/semgrep-core/tests/go/misc_compositelit.go
@@ -1,0 +1,8 @@
+package Foo
+
+func transport() {
+	//ERROR: match	
+	c := http.DefaultClient
+	// the {} used to not be in the generic AST, leading to bad autofix
+	c.Transport = &http.Transport{}
+}

--- a/semgrep-core/tests/go/misc_compositelit.sgrep
+++ b/semgrep-core/tests/go/misc_compositelit.sgrep
@@ -1,0 +1,2 @@
+$C := http.DefaultClient
+$C.$FIELD = $VALUE


### PR DESCRIPTION
This closes #4210

test plan:
```
/home/pad/yy/_build/default/src/cli/Main.exe -lang go -f
tests/go/misc_compositelit.sgrep tests/go/misc_compositelit.go -json |
jq
...
"$VALUE": {
            "start": {
              "line": 7,
              "col": 16,
              "offset": 158
            },
            "end": {
              "line": 7,
              "col": 33,
              "offset": 175
            },
            "abstract_content": "&http Transport{}",
```


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)