### PR TITLE
Scala: parse unicode characters in identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Scala: parse `case object` within blocks
 - Go: match correctly braces in composite literals for autofix (#4210)
 - Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
+- Scala: parse unicode identifiers
 
 ### Changed
 - C# support is now GA

--- a/semgrep-core/src/core/ast/Lang.ml
+++ b/semgrep-core/src/core/ast/Lang.ml
@@ -115,6 +115,8 @@ let list_of_lang =
     ("kotlin", Kotlin);
     ("lua", Lua);
     ("bash", Bash);
+    ("sh", Bash);
+    (* sh is not bash, but we are treating them as the same language for now *)
     ("rs", Rust);
     ("rust", Rust);
     ("r", R);


### PR DESCRIPTION
Improves parse rate from 97.2 to 97.8.
We can now parse unicode identifiers.

Test plan: make test (see added test in pfff)

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
