### PR TITLE
Scala: remove fp-in-scala from parsing stat projects

### DIFF
--- a/parsing-stats/lang/scala/projects.txt
+++ b/parsing-stats/lang/scala/projects.txt
@@ -20,7 +20,6 @@ https://github.com/guardian/frontend
 https://github.com/apache/openwhisk
 https://github.com/linkerd/linkerd
 https://github.com/gatling/gatling
-https://github.com/fpinscala/fpinscala
 https://github.com/enso-org/enso
 https://github.com/airbnb/aerosolve
 https://github.com/typelevel/cats


### PR DESCRIPTION
This repo is full of scala files containing uncommented expository text, because it's a tutorial/set of exercies.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
