### PR TITLE
Add `sh` as an alias for `bash` in semgrep-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Scala: parse `case object` within blocks
 - Go: match correctly braces in composite literals for autofix (#4210)
 - Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
+- semgrep-core accepts `sh` as an alias for bash
 
 ### Changed
 - C# support is now GA

--- a/semgrep-core/src/core/ast/Lang.ml
+++ b/semgrep-core/src/core/ast/Lang.ml
@@ -115,6 +115,8 @@ let list_of_lang =
     ("kotlin", Kotlin);
     ("lua", Lua);
     ("bash", Bash);
+    ("sh", Bash);
+    (* sh is not bash, but we are treating them as the same language for now *)
     ("rs", Rust);
     ("rust", Rust);
     ("r", R);


### PR DESCRIPTION
See title. Fixes the CI failure caused by the `bidi.yml` rule that was recently added to semgrep-rules.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
