### PR TITLE
engine: Make metavariable-comparison work on constant variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Constant propagation: In a method call `x.f(y)`, if `x` is a constant then it will be recognized as such
 - Scala: parse `case object` within blocks
 - Go: match correctly braces in composite literals for autofix (#4210)
+- `metavariable-comparison`: if a metavariable binds to a code variable that
+  is known to be constant, then we use that constant value in the comparison (#3727)
+
+### Fixed
+- Constant propagation: In a method call `x.f(y)`, if `x` is a constant then
+  it will be recognized as such
 - Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
 - Scala: parse unicode identifiers
 - semgrep-core accepts `sh` as an alias for bash

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_constness.c
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_constness.c
@@ -1,0 +1,10 @@
+/* https://github.com/returntocorp/semgrep/issues/3727 */
+int main() {
+    int x = 3;
+    int y = 5;
+    /* ruleid: c-comparing-const-vars */
+    if (x < y) {
+        print("less");
+    }
+}
+

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_constness.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_constness.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: c-comparing-const-vars
+    languages:
+      - c
+    message: Trying to compare constant variables
+    patterns:
+      - pattern: |
+          $X < $Y
+      - metavariable-comparison:
+          comparison: $X < $Y
+          metavariable: $X
+    severity: WARNING


### PR DESCRIPTION
Closes #3727

test plan:
make test # test included

PR checklist:
- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
