### PR TITLE
[Go] do not drop closing paren in Cast in autofix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Constant propagation: In a method call `x.f(y)`, if `x` is a constant then it will be recognized as such
-- Scala: parse `case object` within blocks
 - Go: match correctly braces in composite literals for autofix (#4210)
+- Go: match correctly parens in cast for autofix (#3387)
+- Scala: parse `case object` within blocks
 - Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
 - Scala: parse unicode identifiers
 - semgrep-core accepts `sh` as an alias for bash

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -574,6 +574,7 @@ and expr_aux env ?(void = false) eorig =
       add_instr env
         (mk_i (CallSpecial (Some lval, (Await, tok), [ expr env e ])) eorig);
       lvalexp
+  | G.ParenExpr (_, e, _) -> expr env e
   | G.Xml _ -> todo (G.E eorig)
   | G.Constructor (_, _) -> todo (G.E eorig)
   | G.Yield (_, _, _) -> todo (G.E eorig)

--- a/semgrep-core/src/analyzing/lrvalue.ml
+++ b/semgrep-core/src/analyzing/lrvalue.ml
@@ -179,6 +179,7 @@ let rec visit_expr hook lhs expr =
   | LetPattern (pat, e) ->
       anyhook hook Lhs (P pat);
       recr e
+  | ParenExpr (_, e, _) -> recr e
   | Seq xs -> List.iter recr xs
   (* we should not be called on a sgrep pattern *)
   | TypedMetavar (_id, _, _t) -> raise Impossible

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -186,6 +186,7 @@ and map_name = function
 
 and map_expr x : B.expr =
   match x.e with
+  | ParenExpr (_, e, _) -> map_expr e
   | N v1 ->
       let v1 = map_name v1 in
       `N v1

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -476,6 +476,13 @@ and expr_kind =
   (* less: could be in Special, but pretty important so I've lifted them here*)
   | Ref of tok (* &, address of *) * expr
   | DeRef of tok (* '*' in C, '!' or '<-' in OCaml, ^ in Reason *) * expr
+  (* In some rare cases, we need to keep the parenthesis around an expression
+   * otherwise in autofix semgrep could produce incorrect code. For example,
+   * in Go a cast int(3.0) requires the parenthesis.
+   * alt: change cast to take a expr bracket, but this is used only for Go.
+   * Note that this data structure is really becoming more a CST than an AST.
+   *)
+  | ParenExpr of expr bracket
   (* sgrep: ... in expressions, args, stmts, items, and fields
    * (and unfortunately also in types in Python) *)
   | Ellipsis of tok (* '...' *)
@@ -1130,6 +1137,9 @@ and type_kind =
    *)
   | TyRecordAnon of
       class_kind wrap (* 'struct/shape', fake in other *) * field list bracket
+  (* TODO? a TyParen, like ParenExpr? A few languages may need that
+   * for autofix to work correctly.
+   *)
   (* sgrep-ext: *)
   | TyEllipsis of tok
   (* For languages such as Python which abuse expr to represent types.

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -207,6 +207,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let k x =
       let ekind =
         match x.e with
+        | ParenExpr v1 ->
+            let v1 = map_bracket map_expr v1 in
+            ParenExpr v1
         | N v1 ->
             let v1 = map_name v1 in
             N v1

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -181,6 +181,9 @@ and vof_name = function
 and vof_expr e =
   (* TODO: also dump e_id? *)
   match e.e with
+  | ParenExpr v1 ->
+      let v1 = vof_bracket vof_expr v1 in
+      OCaml.VSum ("ParenExpr", [ v1 ])
   | DotAccessEllipsis (v1, v2) ->
       let v1 = vof_expr v1 in
       let v2 = vof_tok v2 in

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -249,6 +249,7 @@ let (mk_visitor :
   and v_expr x =
     let k x =
       match x.e with
+      | ParenExpr v1 -> v_bracket v_expr v1
       | DotAccessEllipsis (v1, v2) ->
           v_expr v1;
           v_tok v2

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -723,6 +723,10 @@ and m_expr a b =
   | ( G.Call ({ e = G.IdSpecial (G.Op aop, toka); _ }, aargs),
       B.Call ({ e = B.IdSpecial (B.Op bop, tokb); _ }, bargs) ) ->
       m_call_op aop toka aargs bop tokb bargs
+  (* TODO? should probably do some equivalence like allowing extra
+   * paren in the pattern to still match code without parens
+   *)
+  | G.ParenExpr a1, B.ParenExpr b1 -> m_bracket m_expr a1 b1
   (* boilerplate *)
   | G.Call (a1, a2), B.Call (b1, b2) ->
       m_expr a1 b1 >>= fun () -> m_arguments a2 b2
@@ -832,6 +836,7 @@ and m_expr a b =
   | G.N _, _
   | G.IdSpecial _, _
   | G.Call _, _
+  | G.ParenExpr _, _
   | G.Xml _, _
   | G.Assign _, _
   | G.AssignOp _, _

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -148,6 +148,8 @@ let subexprs_of_expr e =
       (* in theory we should go deeper in any *)
       subexprs_of_any_list anys
   | Lambda def -> subexprs_of_stmt (H.funcbody_to_stmt def.fbody)
+  (* TODO? or call recursively on e? *)
+  | ParenExpr (_, e, _) -> [ e ]
   (* currently skipped over but could recurse *)
   | Constructor _
   | AnonClass _

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -241,9 +241,14 @@ let top_func () =
     | Call v1 ->
         let e, args = call_expr v1 in
         G.Call (e, args)
-    | Cast (v1, v2) ->
-        let v1 = type_ v1 and v2 = expr v2 in
-        G.Cast (v1, unsafe_fake "(", v2)
+    | Cast (t, (l, e, r)) ->
+        let t = type_ t and e = expr e in
+        (* for semgrep and autofix to get the right range by including
+         * 'r' in the AST.
+         * alt: change G.Cast to take a bracket
+         *)
+        let e = G.ParenExpr (l, e, r) |> G.e in
+        G.Cast (t, l, e)
     | Deref (v1, v2) ->
         let v1 = tok v1 and v2 = expr v2 in
         G.DeRef (v1, v2)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -602,15 +602,15 @@ and expression (env : env) (x : CST.expression) : expr =
       TypeAssert (v1, (v3, v4, v5))
   | `Type_conv_exp (v1, v2, v3, v4, v5) ->
       let v1 = type_ env v1 in
-      let _v2 = token env v2 (* "(" *) in
+      let v2 = token env v2 (* "(" *) in
       let v3 = expression env v3 in
       let _v4 =
         match v4 with
         | Some tok -> Some (token env tok (* "," *))
         | None -> None
       in
-      let _v5 = token env v5 (* ")" *) in
-      Cast (v1, v3)
+      let v5 = token env v5 (* ")" *) in
+      Cast (v1, (v2, v3, v5))
   | `Id tok -> mk_Id (identifier env tok) (* identifier *)
   | `Choice_new x -> mk_Id (anon_choice_new_0342769 env x)
   | `Comp_lit (v1, v2) ->

--- a/semgrep-core/tests/go/misc_cast_autofix.go
+++ b/semgrep-core/tests/go/misc_cast_autofix.go
@@ -1,0 +1,6 @@
+func foo() {
+	//ERROR: match
+        ioutil.WriteFile("foo", []byte{}, 0666)
+	//ERROR: match
+        ioutil.WriteFile("foo", []byte(data), 0666)
+}

--- a/semgrep-core/tests/go/misc_cast_autofix.sgrep
+++ b/semgrep-core/tests/go/misc_cast_autofix.sgrep
@@ -1,0 +1,8 @@
+// The fix was os.WriteFile($F, $D, $P) but
+// the range for $D was wrong because we were missing
+// the closing ')' in the cast, or the closing '}' in the CompositeLit.
+// This test does not really check that, but at least if you
+// use -dump_ast -full_token_info on the .go you should now see
+// that the closing paren or brace is in the generic AST
+
+ioutil.WriteFile($F, $D, $P)


### PR DESCRIPTION
This will help #3387

test plan:
```
$ yy -full_token_info -lang go -dump_ast tests/go/misc_cast_autofix.go
...
ParenExpr(
                                 ({
                                   token=OriginTok(
                                           {str="("; charpos=131; line=5;
                                            column=38;
                                            file="tests/go/misc_cast_autofix.go";
                                            });
                                   transfo=NoTransfo; },
                                  N(
                                    Id(
                                      ("data",
                                       {
                                        token=OriginTok(
                                                {str="data"; charpos=132;
                                                 line=5; column=39;
                                                 file="tests/go/misc_cast_autofix.go";
                                                 });
                                        transfo=NoTransfo; }),
                                      {id_hidden=false;
                                       id_resolved=Ref(None);
                                       id_type=Ref(None);
                                       id_constness=Ref(None); })),
                                  {
                                   token=OriginTok(
                                           {str=")"; charpos=136; line=5;
                                            column=43;
                                            file="tests/go/misc_cast_autofix.go";
                                            });
                                   transfo=NoTransfo; }))));
...
```

So the closing paren is now in the AST so the metavariable will have
a correct range and the autofix will work better


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)