### PR TITLE
fix(ci): pin pipenv version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           cd semgrep
           export PATH=/github/home/.local/bin:$PATH
-          pip3 install pipenv
+          pip3 install pipenv==2021.5.29
           pipenv install --dev
       - name: Test semgrep
         run: |


### PR DESCRIPTION
pipenv 2021.11.5 seems to have regressions. Pinning to last released version for now

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
