### PR TITLE
Scala: parse nullary constructors with no arguments in more locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
 - Scala: parse unicode identifiers
 - semgrep-core accepts `sh` as an alias for bash
+- Scala: parse nullary constructors with no arguments in more positions
 
 ### Changed
 - C# support is now GA

--- a/semgrep-core/tests/scala/constructor_annots.scala
+++ b/semgrep-core/tests/scala/constructor_annots.scala
@@ -1,0 +1,15 @@
+
+//ERROR:
+class A @AnnotX() {
+    val x = 0
+}
+
+//ERROR:
+class B @AnnotX @AnnotY private {
+    val x = 0
+}
+
+//OK:
+class C @AnnotZ private[Outer] {
+    val x = 0
+}

--- a/semgrep-core/tests/scala/constructor_annots.sgrep
+++ b/semgrep-core/tests/scala/constructor_annots.sgrep
@@ -1,0 +1,3 @@
+class $CLASS @AnnotX() {
+    ...
+}


### PR DESCRIPTION
Improves parse rate from 98% to 98.1%

This is meant to handle the following case:
```
class A @Annot private {
   body
}
```
Where `Annot` can be written as is, instead of as `Annot()`.
The PR fixes this, but the change is to a sufficiently general function that it probably affects other places too. The change this makes is exactly what the actual Scala parser does.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
