### PR TITLE
fix(test): dont treat todoruleid as false positive

### DIFF
--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -146,7 +146,7 @@ def score_output_json(
     todo_ok_lines: Dict[str, Dict[str, List[int]]] = collections.defaultdict(
         lambda: collections.defaultdict(list)
     )
-    todo_ruleid_lines: Dict[str, List[int]] = collections.defaultdict(
+    todo_ruleid_lines: Dict[str, Dict[str, List[int]]] = collections.defaultdict(
         lambda: collections.defaultdict(list)
     )
     score_by_checkid: Dict[str, List[int]] = collections.defaultdict(


### PR DESCRIPTION
When passing --test-ignore-todo dont return non zero exit code
when a rule fires on a line tagged with todoruleid

Fixes https://github.com/returntocorp/semgrep/issues/4204

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
