### PR TITLE
Add support hexadecimal Unicode code points in regexps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Scala: parse typed patterns with variables that begin with an underscore: `case _x : Int => ...`
 - Scala: parse unicode identifiers
 - semgrep-core accepts `sh` as an alias for bash
-- Scala: parse nullary constructors with no arguments in more positions
+- Scala: parse nullary constructors with no arguments in more
+positions
+- pattern-regex: Hexadecimal notation of Unicode code points is now
+  supported and assumes UTF-8 (#4240).
+- pattern-regex: Update documentation, specifying we use PCRE (#3974).
 
 ### Changed
 - C# support is now GA

--- a/semgrep-core/src/core/Pcre_settings.ml
+++ b/semgrep-core/src/core/Pcre_settings.ml
@@ -5,6 +5,12 @@
 open Printf
 
 (*
+   Flag required for the following to succeed:
+     Pcre.regexp ~flags:[`UTF8] "\\x{200E}"
+*)
+let extra_flag = `UTF8
+
+(*
    'limit' and 'limit_recursion' are set explicitly to make semgrep
    fail consistently across platforms (e.g. CI vs. local Mac).
    The default compile-time defaults are 10_000_000 for both
@@ -12,10 +18,12 @@ open Printf
    the installation of the pcre library. We protect ourselves
    from such custom installs.
 *)
-let regexp ?study ?iflags ?flags ?chtables pat =
+let regexp ?study ?iflags ?(flags = []) ?chtables pat =
+  (* pcre doesn't mind if a flag is duplicated so we just append extra flags *)
+  let flags = extra_flag :: flags in
   Pcre.regexp ?study ~limit:10_000_000 (* sets PCRE_EXTRA_MATCH_LIMIT *)
     ~limit_recursion:10_000_000 (* sets PCRE_EXTRA_MATCH_LIMIT_RECURSION *)
-    ?iflags ?flags ?chtables pat
+    ?iflags ~flags ?chtables pat
 
 let string_of_error (error : Pcre.error) =
   match error with

--- a/semgrep-core/src/core/Pcre_settings.mli
+++ b/semgrep-core/src/core/Pcre_settings.mli
@@ -9,6 +9,8 @@
 
    This takes care of setting PCRE_EXTRA_MATCH_LIMIT and
    PCRE_EXTRA_MATCH_LIMIT_RECURSION to the same value across platforms.
+
+   Any flags needed to make things work with UTF-8 are passed automatically.
 *)
 val regexp :
   ?study:bool ->

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -145,6 +145,12 @@ def _run_semgrep(
     )
 
     if fail_on_nonzero and output.returncode > 0:
+        print("--- stdout from semgrep process ---")
+        print(output.stdout)
+        print("--- end semgrep stdout ---")
+        print("--- stderr from semgrep process ---")
+        print(output.stderr)
+        print("--- end semgrep stderr ---")
         raise subprocess.CalledProcessError(
             returncode=output.returncode,
             cmd=cmd,

--- a/semgrep/tests/e2e/rules/regex-utf8.yaml
+++ b/semgrep/tests/e2e/rules/regex-utf8.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: test-regex
+    # U+1F680 is the rocket emoji 🚀
+    # α-ϖ is the lowercase Greek alphabet without diacritics
+    pattern-regex: "[\\x{1F680}😊]|<[α-ϖ]+>"
+    message: "check different ways to match UTF-8-encoded Unicode text"
+    languages: [regex]
+    severity: ERROR

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__utf8/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__utf8/results.json
@@ -44,6 +44,28 @@
         "line": 5,
         "offset": 31
       }
+    },
+    {
+      "check_id": "rules.test-regex",
+      "end": {
+        "col": 9,
+        "line": 11,
+        "offset": 87
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "<\u03b2\u03b3\u03b4> (Greek letters)",
+        "message": "check different ways to match UTF-8-encoded Unicode text",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/regex-utf8.txt",
+      "start": {
+        "col": 1,
+        "line": 11,
+        "offset": 79
+      }
     }
   ]
 }

--- a/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__utf8/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_regex_rule__utf8/results.json
@@ -1,0 +1,49 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.test-regex",
+      "end": {
+        "col": 5,
+        "line": 2,
+        "offset": 12
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "\ud83d\ude0a (smiley)",
+        "message": "check different ways to match UTF-8-encoded Unicode text",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/regex-utf8.txt",
+      "start": {
+        "col": 1,
+        "line": 2,
+        "offset": 8
+      }
+    },
+    {
+      "check_id": "rules.test-regex",
+      "end": {
+        "col": 5,
+        "line": 5,
+        "offset": 35
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "\ud83d\ude80 (rocket)",
+        "message": "check different ways to match UTF-8-encoded Unicode text",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "path": "targets/basic/regex-utf8.txt",
+      "start": {
+        "col": 1,
+        "line": 5,
+        "offset": 31
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/basic/regex-utf8.txt
+++ b/semgrep/tests/e2e/targets/basic/regex-utf8.txt
@@ -1,0 +1,11 @@
+# match
+😊 (smiley)
+
+# match
+🚀 (rocket)
+
+# don't match
+\x{1F680}
+
+# match
+<βγδ> (Greek letters)

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -215,6 +215,15 @@ def test_regex_rule__top(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/regex-top.yaml")[0], "results.json")
 
 
+def test_regex_rule__utf8(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/regex-utf8.yaml", target_name="basic/regex-utf8.txt")[
+            0
+        ],
+        "results.json",
+    )
+
+
 def test_regex_rule__child(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/regex-child.yaml")[0], "results.json"


### PR DESCRIPTION
Fixes this: https://github.com/returntocorp/semgrep/issues/3974#issuecomment-962931778

I also updated the documentation at https://semgrep.dev/docs/writing-rules/rule-syntax/ to indicate we use PCRE, not Python's re + details on what PCRE provides.

Closes #3974

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
