### PR TITLE
Catch badUTF8 exception in Guess_lang

### DIFF
--- a/semgrep-core/src/core/Guess_lang.ml
+++ b/semgrep-core/src/core/Guess_lang.ml
@@ -121,7 +121,10 @@ let split_cmd_re = lazy (Pcre_settings.regexp "[ \t]+")
 *)
 let parse_shebang_line s =
   let matched =
-    try Some (Pcre.exec ~rex:(Lazy.force shebang_re) s) with Not_found -> None
+    try Some (Pcre.exec ~rex:(Lazy.force shebang_re) s) with
+    | Not_found
+    | Pcre.Error BadUTF8 ->
+        None
   in
   match matched with
   | None -> None


### PR DESCRIPTION
If we try to read a binary executable file for a shebang line, we'll get the `Prce.Error BadUTF8` exception. Now we handle this possibility.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
