### PR TITLE
[AST generic] remove TyBuiltin

### DIFF
--- a/semgrep-core/src/analyzing/Unit_typing_generic.ml
+++ b/semgrep-core/src/analyzing/Unit_typing_generic.ml
@@ -75,7 +75,7 @@ let tests parse_program parse_pattern =
                           | G.Arg { e = G.N (G.Id (_, { G.id_type; _ })); _ }
                             -> (
                               match !id_type with
-                              | Some { t = G.TyBuiltin ("int", _); _ } -> ()
+                              | Some { t = G.TyN (Id (("int", _), _)); _ } -> ()
                               | _ ->
                                   Alcotest.fail
                                     "Variable 2 referenced did not have \
@@ -117,7 +117,8 @@ let tests parse_program parse_pattern =
                           | G.Arg { e = G.N (G.Id (_, { G.id_type; _ })); _ }
                             -> (
                               match !id_type with
-                              | Some { t = G.TyBuiltin ("int", _); _ } -> ()
+                              | Some { t = G.TyN (G.Id (("int", _), _)); _ } ->
+                                  ()
                               | _ ->
                                   Alcotest.fail
                                     "Variable 1 referenced did not have \
@@ -127,7 +128,9 @@ let tests parse_program parse_pattern =
                           | G.Arg { e = G.N (G.Id (_, { G.id_type; _ })); _ }
                             -> (
                               match !id_type with
-                              | Some { t = G.TyBuiltin ("boolean", _); _ } -> ()
+                              | Some { t = G.TyN (G.Id (("boolean", _), _)); _ }
+                                ->
+                                  ()
                               | _ ->
                                   Alcotest.fail
                                     "Variable 2 referenced did not have \
@@ -156,14 +159,14 @@ let tests parse_program parse_pattern =
                       match exp.G.e with
                       | G.N (G.Id (("age", _), { G.id_type; _ })) -> (
                           match !id_type with
-                          | Some { t = G.TyBuiltin ("int", _); _ } -> ()
+                          | Some { t = G.TyN (G.Id (("int", _), _)); _ } -> ()
                           | _ ->
                               Alcotest.fail
                                 "Variable referenced did not have expected \
                                  type int")
                       | G.N (G.Id (("default_age", _), { G.id_type; _ })) -> (
                           match !id_type with
-                          | Some { t = G.TyBuiltin ("int", _); _ } -> ()
+                          | Some { t = G.TyN (G.Id (("int", _), _)); _ } -> ()
                           | _ ->
                               Alcotest.fail
                                 "Variable referenced did not have expected \

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -513,9 +513,6 @@ and map_type_kind = function
       let v2 = map_tok v2 in
       let v3 = map_type_ v3 in
       `TyAnd (v1, v2, v3)
-  | TyBuiltin v1 ->
-      let v1 = map_wrap map_of_string v1 in
-      `TyBuiltin v1
   | TyFun (v1, v2) ->
       let v1 = map_of_list map_parameter v1 and v2 = map_type_ v2 in
       `TyFun (v1, v2)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1084,21 +1084,10 @@ and type_ = {
 }
 
 and type_kind =
-  (* TODO: TyLiteral, for Scala/JS, or use TyExpr? *)
-  (* todo? a type_builtin = TInt | TBool | ...? see Literal.
-   * or just delete and use (TyN Id) instead?
-   *)
-  | TyBuiltin of string wrap (* int, bool, etc. could be TApply with no args *)
-  (* old: was 'TyFun of type_ list * type*' , but languages such as C and
-   * Go allow also to name those parameters, and Go even allow ParamRest
-   * parameters so we need at least 'type_ * attributes', at which point
-   * it's simpler to just reuse parameter.
-   *)
-  | TyFun of parameter list * type_ (* return type *)
-  (* a special case of TApply, also a special case of TPointer *)
-  | TyArray of (* const_expr *) expr option bracket * type_
-  | TyTuple of type_ list bracket
   (* old: was originally TyApply (name, []), but better to differentiate.
+   * old: there used to be also a 'TyBuiltin of string wrap' but simpler to
+   * just use (TyN Id) instead.
+   * todo? a type_builtin = TInt | TBool | ... that mimics the literal type?
    * todo? may need also TySpecial because the name can actually be
    *  self/parent/static (e.g., in PHP)
    *)
@@ -1110,6 +1099,15 @@ and type_kind =
    * TODO: could merge with TyN when name has proper qualifiers?
    *)
   | TyApply of type_ * type_arguments
+  (* old: was 'TyFun of type_ list * type*' , but languages such as C and
+   * Go allow also to name those parameters, and Go even allow ParamRest
+   * parameters so we need at least 'type_ * attributes', at which point
+   * it's simpler to just reuse parameter.
+   *)
+  | TyFun of parameter list * type_ (* return type *)
+  (* a special case of TApply, also a special case of TPointer *)
+  | TyArray of (* const_expr *) expr option bracket * type_
+  | TyTuple of type_ list bracket
   | TyVar of ident (* type variable in polymorphic types (not a typedef) *)
   (* anonymous type, '_' in OCaml, 'dynamic' in Kotlin, 'auto' in C++.
    * TODO: type bounds Scala? *)
@@ -1145,6 +1143,7 @@ and type_kind =
   (* For languages such as Python which abuse expr to represent types.
    * At some point AST_generic_helpers.expr_to_type should be good enough
    * to transpile every expr construct, but for now we have this.
+   * todo? have a TyLiteral of literal for Scala/JS, or use TyExpr for that?
    *)
   | TyExpr of expr
   (* e.g., Struct/Union/Enum names (convert in unique TyName?), TypeOf/TSized
@@ -1893,6 +1892,11 @@ let param_of_type ?(pattrs = []) ?(pdefault = None) ?(pname = None) typ =
     pattrs;
     pinfo = basic_id_info (Param, sid_TODO);
   }
+
+(* ------------------------------------------------------------------------- *)
+(* Types *)
+(* ------------------------------------------------------------------------- *)
+let ty_builtin id = TyN (Id (id, empty_id_info ())) |> t
 
 (* ------------------------------------------------------------------------- *)
 (* Type parameters *)

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -484,9 +484,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let v2 = map_tok v2 in
         let v3 = map_type_ v3 in
         TyAnd (v1, v2, v3)
-    | TyBuiltin v1 ->
-        let v1 = map_wrap map_of_string v1 in
-        TyBuiltin v1
     | TyFun (v1, v2) ->
         let v1 = map_of_list map_parameter v1 and v2 = map_type_ v2 in
         TyFun (v1, v2)

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -532,9 +532,6 @@ and vof_type_kind = function
       let v2 = vof_tok v2 in
       let v3 = vof_type_ v3 in
       OCaml.VSum ("TyAnd", [ v1; v2; v3 ])
-  | TyBuiltin v1 ->
-      let v1 = vof_wrap OCaml.vof_string v1 in
-      OCaml.VSum ("TyBuiltin", [ v1 ])
   | TyFun (v1, v2) ->
       let v1 = OCaml.vof_list vof_parameter v1 and v2 = vof_type_ v2 in
       OCaml.VSum ("TyFun", [ v1; v2 ])

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -532,9 +532,6 @@ let (mk_visitor :
           v_type_ v1;
           v_tok v2;
           v_type_ v3
-      | TyBuiltin v1 ->
-          let v1 = v_wrap v_string v1 in
-          ()
       | TyFun (v1, v2) ->
           let v1 = v_list v_parameter v1 and v2 = v_type_ v2 in
           ()

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -285,8 +285,8 @@ let rec just_parse_with_lang lang file =
   | Lang.Cplusplus ->
       run file
         [
-          (*Pfff (throw_tokens Parse_cpp.parse); *)
           TreeSitter Parse_cpp_tree_sitter.parse;
+          Pfff (throw_tokens Parse_cpp.parse);
         ]
         Cpp_to_generic.program
   | Lang.OCaml ->

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -410,23 +410,20 @@ let diff_pfff_tree_sitter xs =
   pr2 "NOTE: consider using -full_token_info to get also diff on tokens";
   xs
   |> List.iter (fun file ->
-         match Lang.langs_of_filename file with
-         | [ _lang ] ->
-             let ast1 =
-               Common.save_excursion Flag_semgrep.pfff_only true (fun () ->
-                   Parse_target.parse_program file)
-             in
-             let ast2 =
-               Common.save_excursion Flag_semgrep.tree_sitter_only true
-                 (fun () -> Parse_target.parse_program file)
-             in
-             let s1 = AST_generic.show_program ast1 in
-             let s2 = AST_generic.show_program ast2 in
-             Common2.with_tmp_file ~str:s1 ~ext:"x" (fun file1 ->
-                 Common2.with_tmp_file ~str:s2 ~ext:"x" (fun file2 ->
-                     let xs = Common2.unix_diff file1 file2 in
-                     xs |> List.iter pr2))
-         | _ -> failwith (spf "can't detect single language for %s" file))
+         let ast1 =
+           Common.save_excursion Flag_semgrep.pfff_only true (fun () ->
+               Parse_target.parse_program file)
+         in
+         let ast2 =
+           Common.save_excursion Flag_semgrep.tree_sitter_only true (fun () ->
+               Parse_target.parse_program file)
+         in
+         let s1 = AST_generic.show_program ast1 in
+         let s2 = AST_generic.show_program ast2 in
+         Common2.with_tmp_file ~str:s1 ~ext:"x" (fun file1 ->
+             Common2.with_tmp_file ~str:s2 ~ext:"x" (fun file2 ->
+                 let xs = Common2.unix_diff file1 file2 in
+                 xs |> List.iter pr2)))
 
 (*****************************************************************************)
 (* Rule parsing *)

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -118,36 +118,32 @@ and logicalOp = function
   | AndLog -> G.And
   | OrLog -> G.Or
 
-and type_ x =
-  let tk = type_kind x in
-  tk |> G.t
-
-and type_kind = function
+and type_ = function
   | TBase v1 ->
       let v1 = name v1 in
-      G.TyBuiltin v1
+      G.ty_builtin v1
   | TPointer (t, v1) ->
       let v1 = type_ v1 in
-      G.TyPointer (t, v1)
+      G.TyPointer (t, v1) |> G.t
   | TArray (v1, v2) ->
       let v1 = option const_expr v1 and v2 = type_ v2 in
-      G.TyArray (fb v1, v2)
+      G.TyArray (fb v1, v2) |> G.t
   | TFunction v1 ->
       let ret, params = function_type v1 in
-      G.TyFun (params, ret)
+      G.TyFun (params, ret) |> G.t
   | TStructName (v1, v2) ->
       let v1 = struct_kind v1 and v2 = name v2 in
-      G.OtherType (v1, [ G.I v2 ])
+      G.OtherType (v1, [ G.I v2 ]) |> G.t
   | TEnumName v1 ->
       let v1 = name v1 in
-      G.OtherType (("EnumName", unsafe_fake ""), [ G.I v1 ])
+      G.OtherType (("EnumName", unsafe_fake ""), [ G.I v1 ]) |> G.t
   | TTypeName v1 ->
       let v1 = name v1 in
-      G.TyN (G.Id (v1, G.empty_id_info ()))
+      G.TyN (H.name_of_id v1) |> G.t
   | TMacroApply (v1, (lp, v2, rp)) ->
       let v1 = H.name_of_id v1 in
       let v2 = type_ v2 in
-      G.TyApply (G.TyN v1 |> G.t, (lp, [ G.TA v2 ], rp))
+      G.TyApply (G.TyN v1 |> G.t, (lp, [ G.TA v2 ], rp)) |> G.t
 
 and function_type (v1, v2) =
   let v1 = type_ v1 and v2 = list (fun x -> parameter x) v2 in

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -227,7 +227,7 @@ and map_typeC env x : G.type_ =
   match x with
   | TPrimitive v1 ->
       let v1 = map_wrap env (map_primitive_type env) v1 in
-      G.TyBuiltin v1 |> G.t
+      G.ty_builtin v1
   | TSized (v1, v2) ->
       let v1 = map_of_list (map_sized_type env) v1
       and v2 = map_of_option (map_type_ env) v2 in
@@ -351,7 +351,7 @@ and map_sized_type env (kind, t) : G.type_ =
     | TShort -> "short"
     | TLong -> "long"
   in
-  G.TyBuiltin (s, t) |> G.t
+  G.ty_builtin (s, t)
 
 and map_type_qualifiers env v : G.attribute list =
   map_of_list (map_qualifier_wrap env) v

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -142,7 +142,7 @@ let top_func () =
         let params, ret = func_type v1 in
         let ret =
           match ret with
-          | None -> G.TyBuiltin (unsafe_fake_id "void") |> G.t
+          | None -> G.ty_builtin (unsafe_fake_id "void")
           | Some t -> t
         in
         G.TyFun (params, ret)

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -103,7 +103,7 @@ let special (x, tok) =
         (fun args ->
           match args with
           | [ e ] ->
-              let tvoid = G.TyBuiltin ("void", tok) |> G.t in
+              let tvoid = G.ty_builtin ("void", tok) in
               G.Cast (tvoid, PI.fake_info tok ":", e)
           | _ -> error tok "Impossible: Too many arguments to Void")
   | Spread -> SR_Special (G.Spread, tok)
@@ -448,43 +448,43 @@ and case = function
 (* used to be an AST_generic.type_ with no conversion needed, but now that
  * we moved AST_generic.ml out of pfff, we need the boilerplate below
  *)
-and type_ x = type_kind x |> G.t
-
-and type_kind x =
+and type_ x =
   match x with
-  | TyBuiltin id -> G.TyBuiltin (ident id)
-  | TyName xs -> G.TyN (H.name_of_ids xs)
+  | TyBuiltin id -> G.ty_builtin (ident id)
+  | TyName xs -> G.TyN (H.name_of_ids xs) |> G.t
+  (* TODO: use TyExpr now? or special TyLiteral? *)
   | TyLiteral l ->
       let l = literal l in
       G.OtherType (("LitType", PI.unsafe_fake_info ""), [ G.E (G.L l |> G.e) ])
+      |> G.t
   | TyQuestion (tok, t) ->
       let t = type_ t in
-      G.TyQuestion (t, tok)
+      G.TyQuestion (t, tok) |> G.t
   | TyArray (t, (lt, (), rt)) ->
       let t = type_ t in
-      G.TyArray ((lt, None, rt), t)
+      G.TyArray ((lt, None, rt), t) |> G.t
   | TyTuple (lt, xs, rt) ->
       let xs = List.map tuple_type_member xs in
-      G.TyTuple (lt, xs, rt)
+      G.TyTuple (lt, xs, rt) |> G.t
   | TyFun (params, typ_opt) ->
       let params = List.map parameter_binding params in
       let rett =
         match typ_opt with
-        | None -> G.TyBuiltin ("void", PI.unsafe_fake_info "void") |> G.t
+        | None -> G.ty_builtin ("void", PI.unsafe_fake_info "void")
         | Some t -> type_ t
       in
-      G.TyFun (params, rett)
+      G.TyFun (params, rett) |> G.t
   | TyRecordAnon (lt, (), rt) ->
-      G.TyRecordAnon ((G.Class, PI.fake_info lt ""), (lt, [], rt))
+      G.TyRecordAnon ((G.Class, PI.fake_info lt ""), (lt, [], rt)) |> G.t
   | TyOr (t1, tk, t2) ->
       let t1 = type_ t1 in
       let t2 = type_ t2 in
-      G.TyOr (t1, tk, t2)
+      G.TyOr (t1, tk, t2) |> G.t
   | TyAnd (t1, tk, t2) ->
       let t1 = type_ t1 in
       let t2 = type_ t2 in
-      G.TyAnd (t1, tk, t2)
-  | TypeTodo (categ, xs) -> G.OtherType (categ, List.map any xs)
+      G.TyAnd (t1, tk, t2) |> G.t
+  | TypeTodo (categ, xs) -> G.OtherType (categ, List.map any xs) |> G.t
 
 and tuple_type_member x =
   match x with

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -90,15 +90,14 @@ let modifierbis = function
   | Async -> G.Async
 
 let ptype (x, t) =
-  (match x with
-  | BoolTy -> G.TyBuiltin ("bool", t)
-  | IntTy -> G.TyBuiltin ("int", t)
-  | DoubleTy -> G.TyBuiltin ("double", t)
-  | StringTy -> G.TyBuiltin ("string", t)
+  match x with
+  | BoolTy -> G.ty_builtin ("bool", t)
+  | IntTy -> G.ty_builtin ("int", t)
+  | DoubleTy -> G.ty_builtin ("double", t)
+  | StringTy -> G.ty_builtin ("string", t)
   (* TODO: TyArray of gen? *)
-  | ArrayTy -> G.TyBuiltin ("array", t)
-  | ObjectTy -> G.TyBuiltin ("object", t))
-  |> G.t
+  | ArrayTy -> G.ty_builtin ("array", t)
+  | ObjectTy -> G.ty_builtin ("object", t)
 
 let list_expr_to_opt xs =
   match xs with
@@ -413,32 +412,31 @@ and foreach_pattern v =
 
 and array_value v = expr v
 
-and hint_type x = hint_type_kind x |> G.t
-
-and hint_type_kind = function
+and hint_type = function
   | Hint v1 ->
       let v1 = name v1 in
-      G.TyN (name_of_qualified_ident v1)
-  | HintArray t -> G.TyBuiltin ("array", t)
+      G.TyN (name_of_qualified_ident v1) |> G.t
+  | HintArray t -> G.ty_builtin ("array", t)
   | HintQuestion (t, v1) ->
       let v1 = hint_type v1 in
-      G.TyQuestion (v1, t)
+      G.TyQuestion (v1, t) |> G.t
   | HintTuple (t1, v1, t2) ->
       let v1 = list hint_type v1 in
-      G.TyTuple (t1, v1, t2)
+      G.TyTuple (t1, v1, t2) |> G.t
   | HintCallback (v1, v2) ->
       let v1 = list hint_type v1 and v2 = option hint_type v2 in
       let params = v1 |> List.map (fun x -> G.Param (G.param_of_type x)) in
       let fret =
         match v2 with
         | Some t -> t
-        | None -> G.TyBuiltin ("void", fake "void") |> G.t
+        | None -> G.ty_builtin ("void", fake "void")
       in
-      G.TyFun (params, fret)
+      G.TyFun (params, fret) |> G.t
   | HintTypeConst (_, tok, _) ->
       G.OtherType (("HintTypeConst not supported, facebook-ext", tok), [])
+      |> G.t
   | HintVariadic (tok, _) ->
-      G.OtherType (("HintVariadic not supported", tok), [])
+      G.OtherType (("HintVariadic not supported", tok), []) |> G.t
 
 and class_name v = hint_type v
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -320,7 +320,7 @@ let boolean_literal (env : env) (x : CST.boolean_literal) =
 (* "false" *)
 
 let predefined_type (env : env) (tok : CST.predefined_type) =
-  G.TyBuiltin (str env tok) |> G.t
+  G.ty_builtin (str env tok)
 
 let verbatim_string_literal (env : env) (tok : CST.verbatim_string_literal) =
   G.String (str env tok)
@@ -604,7 +604,7 @@ let literal (env : env) (x : CST.literal) : literal =
 let rec return_type (env : env) (x : CST.return_type) : type_ =
   match x with
   | `Type x -> type_constraint env x
-  | `Void_kw tok -> TyBuiltin (str env tok) |> G.t
+  | `Void_kw tok -> G.ty_builtin (str env tok)
 
 (* "void" *)
 and type_pattern (env : env) (x : CST.type_pattern) = type_ env x
@@ -1539,7 +1539,7 @@ and type_parameter_constraint (env : env) (x : CST.type_parameter_constraint) :
   | `Notn tok (* "notnull" *)
   | `Unma tok ->
       (* "unmanaged" *)
-      let t = TyBuiltin (str env tok) |> G.t in
+      let t = G.ty_builtin (str env tok) in
       Right t
   | `Cons_cons (v1, v2, v3) ->
       let v1 = token env v1 (* "new" *) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -1527,15 +1527,15 @@ and expression (env : env) (x : CST.expression) : G.expr =
           let v1 = (* "(" *) token env v1 in
           let v2 =
             match v2 with
-            | `Array tok -> (* "array" *) G.TyBuiltin (str env tok)
-            | `Int tok -> (* "int" *) G.TyBuiltin (str env tok)
-            | `Float tok -> (* "float" *) G.TyBuiltin (str env tok)
-            | `Str tok -> (* "string" *) G.TyBuiltin (str env tok)
-            | `Bool tok -> (* "bool" *) G.TyBuiltin (str env tok)
+            | `Array tok -> (* "array" *) G.ty_builtin (str env tok)
+            | `Int tok -> (* "int" *) G.ty_builtin (str env tok)
+            | `Float tok -> (* "float" *) G.ty_builtin (str env tok)
+            | `Str tok -> (* "string" *) G.ty_builtin (str env tok)
+            | `Bool tok -> (* "bool" *) G.ty_builtin (str env tok)
           in
           let _v3 = (* ")" *) token env v3 in
           let v4 = expression env v4 in
-          G.Cast (v2 |> G.t, v1, v4) |> G.e
+          G.Cast (v2, v1, v4) |> G.e
       | `Tern_exp (v1, v2, v3, v4, v5) ->
           let v1 = expression env v1 in
           let _v2 = (* "?" *) token env v2 in
@@ -2428,9 +2428,7 @@ and _trait_use_clause (env : env) ((v1, v2, v3, v4) : CST.trait_use_clause) =
   in
   todo env (v1, v2, v3, v4)
 
-and type_ env x = type_kind env x |> G.t
-
-and type_kind (env : env) (x : CST.type_) : G.type_kind =
+and type_ (env : env) (x : CST.type_) : G.type_ =
   match x with
   | `Type_spec (v1, v2, v3) ->
       let _v1TODO = List.map (type_modifier env) v1 in
@@ -2441,23 +2439,23 @@ and type_kind (env : env) (x : CST.type_) : G.type_kind =
       in
       let v2 =
         match v2 with
-        | `Choice_bool x -> G.TyBuiltin (primitive_type env x)
+        | `Choice_bool x -> G.ty_builtin (primitive_type env x)
         | `Qual_id x ->
             let xs = qualified_identifier env x in
             let n = H2.name_of_ids xs in
-            G.TyN (H2.add_type_args_opt_to_name n v3)
-        | `Choice_array x -> G.TyBuiltin (collection_type env x)
+            G.TyN (H2.add_type_args_opt_to_name n v3) |> G.t
+        | `Choice_array x -> G.ty_builtin (collection_type env x)
         | `Choice_xhp_id x ->
             let id = xhp_identifier_ env x in
             let n = H2.name_of_id id in
-            G.TyN (H2.add_type_args_opt_to_name n v3)
+            G.TyN (H2.add_type_args_opt_to_name n v3) |> G.t
       in
       v2
   | `Type_cst (v1, v2) ->
       (* TODO: What to do with modifier? *)
       let _v1TODO = List.map (type_modifier env) v1 in
       let v2 = type_constant_ env v2 in
-      G.TyN (H2.name_of_ids v2)
+      G.TyN (H2.name_of_ids v2) |> G.t
   | `Shape_type_spec (v1, v2, v3, v4, v5) ->
       let _v1TODO = List.map (type_modifier env) v1 in
       let v2 = (* "shape" *) token env v2 in
@@ -2483,7 +2481,7 @@ and type_kind (env : env) (x : CST.type_) : G.type_kind =
         | None -> []
       in
       let v5 = (* ")" *) token env v5 in
-      G.TyRecordAnon ((G.Class, v2), (v3, v4, v5))
+      G.TyRecordAnon ((G.Class, v2), (v3, v4, v5)) |> G.t
   | `Func_type_spec (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let _v1TODO = List.map (type_modifier env) v1 in
       let _v2 = (* "(" *) token env v2 in
@@ -2537,7 +2535,7 @@ and type_kind (env : env) (x : CST.type_) : G.type_kind =
       let _v6 = (* ":" *) token env v6 in
       let v7 = type_ env v7 in
       let _v8 = (* ")" *) token env v8 in
-      G.TyFun (v4, v7)
+      G.TyFun (v4, v7) |> G.t
   | `Tuple_type_spec (v1, v2, v3, v4, v5, v6) ->
       let _v1TODO = List.map (type_modifier env) v1 in
       let v2 = (* "(" *) token env v2 in
@@ -2556,7 +2554,7 @@ and type_kind (env : env) (x : CST.type_) : G.type_kind =
         | None -> None
       in
       let v6 = (* ")" *) token env v6 in
-      G.TyTuple (v2, v3 :: v4, v6)
+      G.TyTuple (v2, v3 :: v4, v6) |> G.t
 
 and type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) :
     G.type_arguments option =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -251,7 +251,7 @@ let map_primitive_type_ident (env : env) (x : CST.anon_choice_u8_6dad923) :
 
 let map_primitive_type (env : env) (x : CST.anon_choice_u8_6dad923) : G.type_ =
   let s, tok = map_primitive_type_ident env x in
-  G.TyBuiltin (s, tok) |> G.t
+  G.ty_builtin (s, tok)
 
 let map_string_literal (env : env) ((v1, v2, v3) : CST.string_literal) :
     G.literal =
@@ -1818,7 +1818,7 @@ and map_function_type (env : env) ((v1, v2, v3, v4) : CST.function_type) :
         let _arrow = token env v1 (* "->" *) in
         let ty = map_type_ env v2 in
         ty
-    | None -> G.TyBuiltin (fake_id "()") |> G.t
+    | None -> G.ty_builtin (fake_id "()")
   in
   G.TyFun (params, ret_type) |> G.t
 
@@ -2656,7 +2656,7 @@ and map_type_ (env : env) (x : CST.type_) : G.type_ =
       let lparen = str env v1 (* "(" *) in
       let rparen = str env v2 (* ")" *) in
       let str = List.map fst [ lparen; rparen ] |> String.concat "" in
-      G.TyBuiltin (str, PI.combine_infos (snd lparen) [ snd rparen ]) |> G.t
+      G.ty_builtin (str, PI.combine_infos (snd lparen) [ snd rparen ])
   | `Array_type (v1, v2, v3, v4) ->
       let lbracket = token env v1 (* "[" *) in
       let ty = map_type_ env v2 in
@@ -2681,7 +2681,7 @@ and map_type_ (env : env) (x : CST.type_) : G.type_ =
   | `Empty_type tok ->
       let bang = token env tok in
       (* "!" *)
-      G.TyBuiltin ("!", bang) |> G.t
+      G.ty_builtin ("!", bang)
   | `Dyna_type (v1, v2) ->
       let _dynTODO = token env v1 (* "dyn" *) in
       let ty = map_abstract_type_trait_name env v2 in

--- a/semgrep-core/src/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/src/synthesizing/Pretty_print_generic.ml
@@ -65,7 +65,6 @@ let token default tok =
 
 let print_type t =
   match t.t with
-  | TyBuiltin (s, _) -> s
   | TyN (Id (id, _)) -> ident id
   | _ -> todo (T t)
 

--- a/semgrep-core/src/typing/Typechecking_generic.ml
+++ b/semgrep-core/src/typing/Typechecking_generic.ml
@@ -40,10 +40,6 @@ let compatible_type t e =
   | TyExpr { e = N (Id (("int", _tok), _idinfo)); _ }, L (Int _) -> true
   | TyExpr { e = N (Id (("float", _tok), _idinfo)); _ }, L (Float _) -> true
   | TyExpr { e = N (Id (("str", _tok), _idinfo)); _ }, L (String _) -> true
-  | TyBuiltin (t1, _), N (Id (_, { id_type; _ })) -> (
-      match !id_type with
-      | Some { t = TyBuiltin (t2, _); _ } -> t1 = t2
-      | _ -> false)
   | TyN (Id ((t1, _), _)), N (Id (_, { id_type; _ })) -> (
       match !id_type with
       | Some { t = TyN (Id ((t2, _), _)); _ } -> t1 = t2

--- a/semgrep-core/tests/cpp/parsing/char.cpp
+++ b/semgrep-core/tests/cpp/parsing/char.cpp
@@ -1,0 +1,1 @@
+char grade = 'D';


### PR DESCRIPTION
It's redundant with TyN (Id). Actually there was places
where we were using TyBuiltin and other TyN (Id), so better
to be consistent.

test plan:
$ /home/pad/yy/_build/default/src/cli/Main.exe -diff_pfff_tree_sitter
tests/cpp/parsing/char.cpp

does not show anymore meaningful differences.


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)