### PR TITLE
Catch and log PCRE errors via wrappers in Pcre_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 ### Fixed
+- Catch PCRE errors
 
 ## [0.72.0](https://github.com/returntocorp/semgrep/releases/tag/v0.72.0) - 11-10-2021
 - CLI output no longer displays severity levels

--- a/semgrep-core/src/core/Pcre_settings.mli
+++ b/semgrep-core/src/core/Pcre_settings.mli
@@ -21,6 +21,99 @@ val regexp :
   Pcre.regexp
 
 (*
+   Same as Pcre.pmatch but makes errors explicit.
+   Option '?pat' was removed so as to force the use of our modified 'regexp'
+   function. TODO: add it back for convenience.
+*)
+val pmatch :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  (bool, Pcre.error) result
+
+(* Return 'false' in case of a PCRE error. The error is logged. *)
+val pmatch_noerr :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  bool
+
+(*
+   See notes about 'pmatch'.
+   Additionally, exception 'Not_found' is converted to a 'None' value.
+*)
+val exec :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  (Pcre.substrings option, Pcre.error) result
+
+(* Return 'None' in case of a PCRE error. The error is logged. *)
+val exec_noerr :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  Pcre.substrings option
+
+(*
+   See notes about 'pmatch'.
+   Additionally, exception 'Not_found' is converted to the empty array.
+*)
+val exec_all :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  (Pcre.substrings array, Pcre.error) result
+
+(* Return '[| |]' in case of a PCRE error. The error is logged. *)
+val exec_all_noerr :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  Pcre.substrings array
+
+(* See notes about 'pmatch'. *)
+val split :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?max:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  (string list, Pcre.error) result
+
+(* Return 'on_error' in case of a PCRE error. The error is logged. *)
+val split_noerr :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?max:int ->
+  ?callout:Pcre.callout ->
+  on_error:string list ->
+  string ->
+  string list
+
+(*
    Register printers for the Pcre module/library so that exceptions show up
    nicely with 'Printexc.to_string' e.g. 'Pcre.Error(RecursionLimit)'
    instead of 'Pcre.Error(5)'.

--- a/semgrep-core/src/core/Regexp_engine.ml
+++ b/semgrep-core/src/core/Regexp_engine.ml
@@ -115,5 +115,5 @@ module Pcre_engine = struct
     let re = "\b" ^ Pcre.quote s ^ "\b" in
     (re, Pcre_settings.regexp re)
 
-  let run (_, re) str = Pcre.pmatch ~rex:re str
+  let run (_, re) str = Pcre_settings.pmatch_noerr ~rex:re str
 end

--- a/semgrep-core/src/core/Regexp_engine.mli
+++ b/semgrep-core/src/core/Regexp_engine.mli
@@ -42,5 +42,7 @@ module Re_engine : sig
   (* nice! *)
   val alt : t -> t -> t
 
+  (* Warning: Returns false in case of an exception. This is not necessarily
+     always desired. *)
   val run : t -> string -> bool
 end

--- a/semgrep-core/src/core/Unit_pcre_settings.ml
+++ b/semgrep-core/src/core/Unit_pcre_settings.ml
@@ -4,16 +4,18 @@
 
 let test_match_limit_ok () =
   let rex = Pcre_settings.regexp "(a+)+$" in
-  try ignore (Pcre.pmatch ~rex "aaaaaaaaaaaaaaaaaaa!")
-  with Pcre.Error Pcre.MatchLimit ->
-    Alcotest.fail "should not have failed with error MatchLimit"
+  match Pcre_settings.pmatch ~rex "aaaaaaaaaaaaaaaaaaa!" with
+  | Ok _ -> ()
+  | Error Pcre.MatchLimit ->
+      Alcotest.fail "should not have failed with error MatchLimit"
+  | Error _ -> Alcotest.fail "unexpected error"
 
 let test_match_limit_fail () =
   let rex = Pcre_settings.regexp "(a+)+$" in
-  try
-    ignore (Pcre.pmatch ~rex "aaaaaaaaaaaaaaaaaaaaaaaaaa!");
-    Alcotest.fail "should have failed with error MatchLimit"
-  with Pcre.Error Pcre.MatchLimit -> ()
+  match Pcre_settings.pmatch ~rex "aaaaaaaaaaaaaaaaaaaaaaaaaa!" with
+  | Ok _ -> Alcotest.fail "should have failed with error MatchLimit"
+  | Error Pcre.MatchLimit -> ()
+  | Error _ -> Alcotest.fail "unexpected error"
 
 let test_register_exception_printer () =
   (* This is a little dirty since we can't undo it. *)

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -188,7 +188,7 @@ let rec eval env code =
       | String s ->
           (* todo? factorize with Matching_generic.regexp_matcher_of_regexp_.. *)
           let regexp = Pcre_settings.regexp ~flags:[ `ANCHORED ] re in
-          let res = Pcre.pmatch ~rex:regexp s in
+          let res = Pcre_settings.pmatch_noerr ~rex:regexp s in
           let v = Bool res in
           logger#info "regexp %s on %s return %s" re s (show_value v);
           v

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -453,7 +453,7 @@ let matches_of_spacegrep spacegreps file =
 (* Regexps *)
 (*-------------------------------------------------------------------*)
 let regexp_matcher big_str file (re_str, re) =
-  let subs = try Pcre.exec_all ~rex:re big_str with Not_found -> [||] in
+  let subs = Pcre_settings.exec_all_noerr ~rex:re big_str in
   subs |> Array.to_list
   |> List.map (fun sub ->
          let matched_str = Pcre.get_substring sub 0 in


### PR DESCRIPTION
I tried to cover all the cases where we run pcre to obtain matches. We should use the functions in `Pcre_settings` from now on.

The compilation of a regexp (`Pcre_settings.regexp`) may still raise an exception but it's less likely to fail and I think it's ok for now.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
