### PR TITLE
Add Xlang module and better error messages for invalid languages

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -488,7 +488,7 @@ let options () =
       Arg.Set_string config_file,
       " <file> obtain formula of patterns from YAML/JSON/Jsonnet file" );
     ( "-lang",
-      Arg.String (fun s -> lang := Xlang.of_string_opt s),
+      Arg.String (fun s -> lang := Some (Xlang.of_string s)),
       spf " <str> choose language (valid choices:\n     %s)"
         Xlang.supported_xlangs );
     ( "-target_file",

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -119,8 +119,8 @@ let config_file = ref ""
 
 let equivalences_file = ref ""
 
-(* todo: infer from basename argv(0) ? *)
-let lang = ref "unset"
+(* TODO: infer from basename argv(0) ? *)
+let lang = ref None
 
 let output_format = ref Text
 
@@ -219,7 +219,8 @@ let validate_pattern () =
   let chan = stdin in
   let s = read_all chan in
   try
-    let lang = lang_of_string !lang in
+    (* TODO: support generic and regex too. *)
+    let lang = Xlang.lang_of_opt_xlang !lang in
     let _ = S.parse_pattern lang s in
     Runner_exit.(exit_semgrep Success)
   with exn ->
@@ -269,7 +270,7 @@ let dump_pattern (file : Common.filename) =
   let file = Run_semgrep.replace_named_pipe_by_regular_file file in
   let s = Common.read_file file in
   (* mostly copy-paste of parse_pattern in runner, but with better error report *)
-  let lang = lang_of_string !lang in
+  let lang = Xlang.lang_of_opt_xlang !lang in
   E.try_with_print_exn_and_reraise file (fun () ->
       let any = Parse_pattern.parse_pattern lang ~print_errors:true s in
       let v = Meta_AST.vof_any any in
@@ -382,13 +383,13 @@ let all_actions () =
       " <file>",
       fun file ->
         Common.mk_action_1_arg
-          (dump_ast ~naming:false (lang_of_string !lang))
+          (dump_ast ~naming:false (Xlang.lang_of_opt_xlang !lang))
           file );
     ( "-dump_named_ast",
       " <file>",
       fun file ->
         Common.mk_action_1_arg
-          (dump_ast ~naming:true (lang_of_string !lang))
+          (dump_ast ~naming:true (Xlang.lang_of_opt_xlang !lang))
           file );
     ("-dump_v1_json", " <file>", Common.mk_action_1_arg dump_v1_json);
     ("-dump_equivalences", " <file>", Common.mk_action_1_arg dump_equivalences);
@@ -397,18 +398,20 @@ let all_actions () =
       " <file> dump the CST obtained from a tree-sitter parser",
       Common.mk_action_1_arg (fun file ->
           let file = Run_semgrep.replace_named_pipe_by_regular_file file in
-          Test_parsing.dump_tree_sitter_cst (lang_of_string !lang) file) );
+          Test_parsing.dump_tree_sitter_cst (Xlang.lang_of_opt_xlang !lang) file)
+    );
     ( "-dump_tree_sitter_pattern_cst",
       " <file>",
       Common.mk_action_1_arg (fun file ->
           let file = Run_semgrep.replace_named_pipe_by_regular_file file in
-          Parse_pattern.dump_tree_sitter_pattern_cst (lang_of_string !lang) file)
-    );
+          Parse_pattern.dump_tree_sitter_pattern_cst
+            (Xlang.lang_of_opt_xlang !lang)
+            file) );
     ( "-dump_pfff_ast",
       " <file> dump the generic AST obtained from a pfff parser",
       Common.mk_action_1_arg (fun file ->
           let file = Run_semgrep.replace_named_pipe_by_regular_file file in
-          Test_parsing.dump_pfff_ast (lang_of_string !lang) file) );
+          Test_parsing.dump_pfff_ast (Xlang.lang_of_opt_xlang !lang) file) );
     ("-dump_il", " <file>", Common.mk_action_1_arg Datalog_experiment.dump_il);
     ( "-diff_pfff_tree_sitter",
       " <file>",
@@ -434,16 +437,19 @@ let all_actions () =
     ( "-parsing_stats",
       " <files or dirs> generate parsing statistics (use -json for JSON output)",
       Common.mk_action_n_arg (fun xs ->
-          Test_parsing.parsing_stats (lang_of_string !lang)
+          Test_parsing.parsing_stats
+            (Xlang.lang_of_opt_xlang !lang)
             ~json:(!output_format = Json) ~verbose:true xs) );
     ( "-parsing_regressions",
       " <files or dirs> look for parsing regressions",
       Common.mk_action_n_arg (fun xs ->
-          Test_parsing.parsing_regressions (lang_of_string !lang) xs) );
+          Test_parsing.parsing_regressions (Xlang.lang_of_opt_xlang !lang) xs)
+    );
     ( "-test_parse_tree_sitter",
       " <files or dirs> test tree-sitter parser on target files",
       Common.mk_action_n_arg (fun xs ->
-          Test_parsing.test_parse_tree_sitter (lang_of_string !lang) xs) );
+          Test_parsing.test_parse_tree_sitter (Xlang.lang_of_opt_xlang !lang) xs)
+    );
     ( "-check_rules",
       " <metachecks file> <files or dirs>",
       Common.mk_action_n_arg (Check_rule.check_files mk_config Parse_rule.parse)
@@ -482,9 +488,9 @@ let options () =
       Arg.Set_string config_file,
       " <file> obtain formula of patterns from YAML/JSON/Jsonnet file" );
     ( "-lang",
-      Arg.Set_string lang,
+      Arg.String (fun s -> lang := Xlang.of_string_opt s),
       spf " <str> choose language (valid choices:\n     %s)"
-        Lang.supported_langs );
+        Xlang.supported_xlangs );
     ( "-target_file",
       Arg.Set_string target_file,
       " <file> obtain list of targets to run patterns on" );

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -86,7 +86,7 @@ let exn_to_error ?(rule_id = None) file exn =
         loc = PI.unsafe_token_location_of_info pos;
         msg =
           (* TODO: make message helpful *)
-          spf "Invalid pattern for %s" (Rule.string_of_xlang xlang);
+          spf "Invalid pattern for %s" (Xlang.to_string xlang);
         details = None;
         yaml_path = Some yaml_path;
       }

--- a/semgrep-core/src/core/Xlang.ml
+++ b/semgrep-core/src/core/Xlang.ml
@@ -1,0 +1,75 @@
+(*
+   Extended languages: everything from Lang.t + spacegrep (generic) and regex.
+*)
+
+(* eXtended language, stored in the languages: field in the rule.
+ * less: merge with xpattern_kind? *)
+type t =
+  (* for "real" semgrep (the first language is used to parse the pattern) *)
+  | L of Lang.t * Lang.t list
+  (* for pattern-regex (referred as 'regex' or 'none' in languages:) *)
+  | LRegex
+  (* for spacegrep *)
+  | LGeneric
+[@@deriving show, eq]
+
+exception InternalInvalidLanguage of string (* rule id *) * string (* msg *)
+
+let of_lang (x : Lang.t) = L (x, [])
+
+let to_lang (x : t) : Lang.t =
+  match x with
+  | L (lang, _) -> lang
+  | LRegex -> failwith (Lang.unsupported_language_message "regex")
+  | LGeneric -> failwith (Lang.unsupported_language_message "generic")
+
+let of_opt_xlang (x : t option) : t =
+  match x with
+  | None -> failwith (Lang.unsupported_language_message "unset")
+  | Some xlang -> xlang
+
+let lang_of_opt_xlang (x : t option) : Lang.t =
+  match x with
+  | None -> failwith (Lang.unsupported_language_message "unset")
+  | Some xlang -> to_lang xlang
+
+let assoc : (string * t) list =
+  List.map (fun (k, v) -> (k, of_lang v)) Lang.assoc
+  @ [ ("regex", LRegex); ("generic", LGeneric) ]
+
+let map = Common.hash_of_list assoc
+
+let of_string_opt x = Hashtbl.find_opt map (String.lowercase_ascii x)
+
+let keys = Common2.hkeys map
+
+let supported_xlangs : string = String.concat ", " keys
+
+let unsupported_xlang_message (xlang_s : string) =
+  if xlang_s = "unset" then "no language specified; use -lang"
+  else
+    Common.spf "unsupported language: %s; supported language tags are: %s"
+      xlang_s supported_xlangs
+
+(* coupling: Parse_mini_rule.parse_languages *)
+let of_string ?id:(id_opt = None) s =
+  match s with
+  | "none"
+  | "regex" ->
+      LRegex
+  | "generic" -> LGeneric
+  | _ -> (
+      match Lang.lang_of_string_opt s with
+      | None -> (
+          match id_opt with
+          | None -> failwith (unsupported_xlang_message s)
+          | Some id ->
+              raise
+                (InternalInvalidLanguage
+                   (id, Common.spf "unsupported language: %s" s)))
+      | Some l -> L (l, []))
+
+let to_string = function
+  | L (l, _) -> Lang.string_of_lang l
+  | LRegex -> "regex"
+  | LGeneric -> "generic"

--- a/semgrep-core/src/core/Xlang.mli
+++ b/semgrep-core/src/core/Xlang.mli
@@ -1,0 +1,50 @@
+(*
+   Extended languages: everything from Lang.t + spacegrep (generic) and regex.
+*)
+
+type t =
+  (* For "real" semgrep.
+     The first language is used to parse the pattern and targets.
+     The other languages are extra target languages that can use the
+     same pattern. *)
+  | L of Lang.t * Lang.t list
+  (* for pattern-regex (referred as 'regex' or 'none' in languages:) *)
+  | LRegex
+  (* for spacegrep *)
+  | LGeneric
+[@@deriving show, eq]
+
+exception InternalInvalidLanguage of string (* rule id *) * string (* msg *)
+
+val of_lang : Lang.t -> t
+
+(* raises an exception with error message *)
+val to_lang : t -> Lang.t
+
+(* raises an exception with error message *)
+val of_opt_xlang : t option -> t
+
+(* raises an exception with error message *)
+val lang_of_opt_xlang : t option -> Lang.t
+
+(* map from valid extended language names to unique xlang ID *)
+val assoc : (string * t) list
+
+(* efficient map from valid extended language names to unique xlang ID *)
+val map : (string, t) Hashtbl.t
+
+val of_string_opt : string -> t option
+
+(* list of valid names for extended languages, sorted alphabetically *)
+val keys : string list
+
+(* comma-separated list of the supported languages *)
+val supported_xlangs : string
+
+(*
+   Convert from a string or raise an exception with an error message.
+   TODO: explain the 'id' option
+*)
+val of_string : ?id:string option -> string -> t
+
+val to_string : t -> string

--- a/semgrep-core/src/core/ast/Lang.ml
+++ b/semgrep-core/src/core/ast/Lang.ml
@@ -85,7 +85,7 @@ let is_python = function
 (* Helpers *)
 (*****************************************************************************)
 
-let list_of_lang =
+let assoc =
   [
     ("py", Python);
     ("python", Python);
@@ -129,12 +129,11 @@ let list_of_lang =
     ("hcl", HCL);
   ]
 
-let lang_of_string_map = Common.hash_of_list list_of_lang
+let lang_map = Common.hash_of_list assoc
 
-let lang_of_string_opt x =
-  Hashtbl.find_opt lang_of_string_map (String.lowercase_ascii x)
+let lang_of_string_opt x = Hashtbl.find_opt lang_map (String.lowercase_ascii x)
 
-let keys = Common2.hkeys lang_of_string_map
+let keys = Common2.hkeys lang_map
 
 let supported_langs : string = String.concat ", " keys
 

--- a/semgrep-core/src/core/ast/Lang.mli
+++ b/semgrep-core/src/core/ast/Lang.mli
@@ -48,9 +48,12 @@ val is_js : t -> bool
 
 val is_python : t -> bool
 
-val lang_of_string_map : (string, t) Hashtbl.t
+val lang_map : (string, t) Hashtbl.t
 
 val lang_of_string_opt : string -> t option
+
+(* Association from a valid name for a language to its unique internal ID. *)
+val assoc : (string * t) list
 
 (* list of languages *)
 val keys : string list

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -82,7 +82,7 @@ let parse_json file =
        ("metavars", J.Object xs);
       ] ->
           let lang =
-            try Hashtbl.find Lang.lang_of_string_map lang
+            try Hashtbl.find Lang.lang_map lang
             with Not_found -> failwith (spf "unsupported language %s" lang)
           in
           (* less: could also use Parse_pattern *)

--- a/semgrep-core/src/engine/File_and_more.ml
+++ b/semgrep-core/src/engine/File_and_more.ml
@@ -14,7 +14,7 @@
 
 type t = {
   file : Common.filename;
-  xlang : Rule.xlang;
+  xlang : Xlang.t;
   lazy_content : string lazy_t;
   lazy_ast_and_errors :
     (AST_generic.program * Semgrep_error_code.error list) lazy_t;

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -113,7 +113,7 @@ type env = {
   file : Common.filename;
   lazy_ast_and_errors : (G.program * E.error stack) lazy_t;
   rule_id : R.rule_id;
-  xlang : R.xlang;
+  xlang : Xlang.t;
   equivalences : Equivalence.equivalences;
   (* problems found during evaluation, one day these may be caught earlier by
    * the meta-checker *)
@@ -199,7 +199,7 @@ let lazy_force x = Lazy.force x [@@profiling]
  * this will raise Impossible... Thus, now we have to pass the language(s) that
  * we are specifically targeting. *)
 let (mini_rule_of_pattern :
-      R.xlang -> Pattern.t * R.inside option * Rule.pattern_id * string -> MR.t)
+      Xlang.t -> Pattern.t * R.inside option * Rule.pattern_id * string -> MR.t)
     =
  fun xlang (pattern, inside, id, pstr) ->
   {
@@ -213,9 +213,9 @@ let (mini_rule_of_pattern :
     severity = R.Error;
     languages =
       (match xlang with
-      | R.L (x, xs) -> x :: xs
-      | R.LRegex
-      | R.LGeneric ->
+      | L (x, xs) -> x :: xs
+      | LRegex
+      | LGeneric ->
           raise Impossible);
     (* useful for debugging timeout *)
     pattern_string = pstr;
@@ -259,7 +259,7 @@ let debug_semgrep config mini_rules equivalences file lang ast =
 let matches_of_patterns ?range_filter config equivalences
     (file, xlang, lazy_ast_and_errors) patterns =
   match xlang with
-  | R.L (lang, _) ->
+  | Xlang.L (lang, _) ->
       let (ast, errors), parse_time =
         Common.with_time (fun () -> lazy_force lazy_ast_and_errors)
       in
@@ -737,7 +737,7 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
                   let lazy_ast_and_errors =
                     lazy
                       (match xlang with
-                      | R.L (lang, _) ->
+                      | L (lang, _) ->
                           let { Parse_target.ast; errors; _ } =
                             Parse_target
                             .parse_and_resolve_name_use_pfff_or_treesitter lang
@@ -752,8 +752,8 @@ and satisfies_metavar_pattern_condition env r mvar opt_xlang formula =
                                   fully parse the content of %s"
                                  env.rule_id mvar);
                           (ast, errors)
-                      | R.LRegex
-                      | R.LGeneric ->
+                      | LRegex
+                      | LGeneric ->
                           failwith "requesting generic AST for LRegex|LGeneric")
                   in
                   nested_formula_has_matches { env with file; xlang } formula

--- a/semgrep-core/src/engine/Run_rules.ml
+++ b/semgrep-core/src/engine/Run_rules.ml
@@ -30,9 +30,9 @@ let check_taint hook default_config taint_rules equivs file_and_more =
       let { FM.file; xlang; lazy_ast_and_errors; _ } = file_and_more in
       let lang =
         match xlang with
-        | R.L (lang, _) -> lang
-        | R.LGeneric
-        | R.LRegex ->
+        | L (lang, _) -> lang
+        | LGeneric
+        | LRegex ->
             failwith "taint-mode and generic/regex matching are incompatible"
       in
       let (ast, errors), parse_time =

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -38,7 +38,7 @@ let (lang_of_rules: Rule.t list -> Lang.t) = fun rs ->
   | None -> failwith "could not find a language"
 *)
 
-let (xlangs_of_rules : Rule.t list -> Rule.xlang list) =
+let (xlangs_of_rules : Rule.t list -> Xlang.t list) =
  fun rs -> rs |> List.map (fun r -> r.R.languages) |> List.sort_uniq compare
 
 let first_xlang_of_rules rs =
@@ -87,7 +87,7 @@ let test_rules ?(unit_testing = false) xs =
                pr2
                  (spf
                     "too many languages found in %s, picking the first one: %s"
-                    file (Rule.show_xlang fst));
+                    file (Xlang.show fst));
                fst
          in
          let target =
@@ -120,9 +120,9 @@ let test_rules ?(unit_testing = false) xs =
           * to parse the pattern but YAML to parse the target *)
          let xlang =
            match (xlang, Lang.langs_of_filename target) with
-           | R.L (l, [ l2 ]), xs when not (List.mem l xs) ->
+           | L (l, [ l2 ]), xs when not (List.mem l xs) ->
                pr2 (spf "switching to another language: %s" (Lang.show l2));
-               R.L (l2, [])
+               Xlang.L (l2, [])
            | _ -> xlang
          in
 
@@ -137,14 +137,14 @@ let test_rules ?(unit_testing = false) xs =
          let lazy_ast_and_errors =
            lazy
              (match xlang with
-             | R.L (lang, _) ->
+             | L (lang, _) ->
                  let { Parse_target.ast; errors; _ } =
                    Parse_target.parse_and_resolve_name_use_pfff_or_treesitter
                      lang target
                  in
                  (ast, errors)
-             | R.LRegex
-             | R.LGeneric ->
+             | LRegex
+             | LGeneric ->
                  raise Impossible)
          in
          let file_and_more =

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -85,7 +85,7 @@ let error env t s =
 
 let equal_formula x y = AST_utils.with_structural_equal R.equal_formula x y
 
-let check_formula env lang f =
+let check_formula env (lang : Xlang.t) f =
   (* check duplicated patterns, essentially:
    *  $K: $PAT
    *  ...
@@ -165,7 +165,7 @@ let semgrep_check config metachecks rules =
   let config =
     {
       config with
-      Runner_common.lang = "yaml";
+      Runner_common.lang = Some (Xlang.of_lang Yaml);
       config_file = metachecks;
       output_format = Json;
     }

--- a/semgrep-core/src/metachecking/Test_metachecking.ml
+++ b/semgrep-core/src/metachecking/Test_metachecking.ml
@@ -36,7 +36,7 @@ let (lang_of_rules: Rule.t list -> Lang.t) = fun rs ->
   | None -> failwith "could not find a language"
 *)
 
-let (xlangs_of_rules : Rule.t list -> Rule.xlang list) =
+let (xlangs_of_rules : Rule.t list -> Xlang.t list) =
  fun rs -> rs |> List.map (fun r -> r.R.languages) |> List.sort_uniq compare
 
 let first_xlang_of_rules rs =
@@ -60,7 +60,7 @@ let config =
     rules_file = "";
     config_file = "";
     equivalences_file = "";
-    lang = "";
+    lang = None;
     output_format = Text;
     match_format = Matching_report.Normal;
     mvars = [];

--- a/semgrep-core/src/runner/Runner_common.ml
+++ b/semgrep-core/src/runner/Runner_common.ml
@@ -21,7 +21,7 @@ type config = {
   rules_file : string;
   config_file : string;
   equivalences_file : string;
-  lang : string;
+  lang : Xlang.t option;
   output_format : output_format;
   match_format : Matching_report.match_format;
   mvars : Metavariable.mvar list;

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -161,7 +161,7 @@ let tainting_test lang rules_file file =
     rules
     |> List.filter (fun r ->
       match r.Rule.languages with
-      | Rule.L (x, xs) -> List.mem lang (x :: xs)
+      | Xlang.L (x, xs) -> List.mem lang (x :: xs)
       | _ -> false)
   in
   let search_rules, taint_rules = Rule.partition_rules rules in


### PR DESCRIPTION
Now, we store the result of the `-lang` option after parsing it instead of keeping it as a string. In general, we now expect a language of type `Xlang.t`, which used to be defined in `Rule.ml` and now has its own module. In practice, we still expect a "normal" semgrep language for most operations, that is `generic` (spacegrep) and `regex` are excluded. The goal is to progressively add support for these as well. For example, scanning for a pattern specified on the command line with `-e` should eventually work with `-lang generic` but doesn't work at the moment.

Testing: we expect invalid languages specified with `-lang` to show the correct list of languages

Case 1: invalid language - `generic` and `regex` are shown in the list
```
$ semgrep-core -lang bf
Uncaught exception:
  
  (Failure
   "unsupported language: bf; supported language tags are: bash, c, c#, c++, cpp, cs, csharp, generic, go, golang, hack, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, ocaml, php, py, python, python2, python3, r, rb, regex, rs, ruby, rust, scala, sh, terraform, tf, ts, typescript, vue, yaml")
...
```

Case 2: valid extended language that's not supported for the given operation - `generic` and `regex` are not in the list
```
$ semgrep-core -lang regex -e foo <(echo foo)
Uncaught exception:
  
  (Failure
   "unsupported language: regex; supported language tags are: bash, c, c#, c++, cpp, cs, csharp, go, golang, hack, hcl, html, java, javascript, js, json, kotlin, kt, lua, ml, ocaml, php, py, python, python2, python3, r, rb, rs, ruby, rust, scala, sh, terraform, tf, ts, typescript, vue, yaml")
...
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
