### PR TITLE
Scala: recognize metavariables in patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 - Performance: Deduplicate rules by rule-id + behavior so rules are not being run twice
+- Scala: recognize metavariables in patterns
 
 ## [0.73.0](https://github.com/returntocorp/semgrep/releases/tag/v0.73.0) - 11-12-2021
 

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -320,6 +320,9 @@ and v_pattern = function
       match v1 with
       | Left lit -> G.PatLiteral lit
       | Right e -> todo_pattern "PatLiteralExpr" [ G.E e ])
+  | PatName (Id id, [])
+    when AST_generic_.is_metavar_name (fst (v_varid_or_wildcard id)) ->
+      G.PatId (v_varid_or_wildcard id, G.empty_id_info ())
   | PatName v1 ->
       let ids = v_dotted_name_of_stable_id v1 in
       let name = H.name_of_ids ids in

--- a/semgrep-core/tests/scala/metavar_pat.scala
+++ b/semgrep-core/tests/scala/metavar_pat.scala
@@ -1,3 +1,4 @@
 object Foo {
+    //ERROR:
     val x = 0 match { case x => 1 }
 }

--- a/semgrep-core/tests/scala/metavar_pat.scala
+++ b/semgrep-core/tests/scala/metavar_pat.scala
@@ -1,0 +1,3 @@
+object Foo {
+    val x = 0 match { case x => 1 }
+}

--- a/semgrep-core/tests/scala/metavar_pat.sgrep
+++ b/semgrep-core/tests/scala/metavar_pat.sgrep
@@ -1,0 +1,1 @@
+$X match { case $V => ... }


### PR DESCRIPTION
Previously a pattern like `case $X => ...` would not match against `case x => x`, because we did not recognize metavariables in patterns.

test plan: make test (see test)

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
