### PR TITLE
fix(ci): trick brew to use pip installed pipgrip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,15 +297,21 @@ jobs:
     needs: [sleep-before-homebrew]  # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-10.15
     steps:
-      - name: Brew update
-        run: brew update
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
           # Needs to be < 3.10 see https://github.com/returntocorp/semgrep/issues/4213
           python-version: 3.9
-      - name: Install pipgrip
+      - name: Brew update
+        run: brew update
+      - name: Install brew pipgrip
+        run: brew install pipgrip
+      - name: Install pip pipgrip
         run: pip install pipgrip
+      - name: Point homebrew pipgrip to pip pipgrip
+        # Homebrew brew calls brew pipgrip internally but brew pipgrip is pinned to python3.10
+        # this tricks it into using our 3.9 pipgrip
+        run: rm /usr/local/opt/pipgrip/bin/pipgrip && ln /Users/runner/hostedtoolcache/Python/3.9.8/x64/bin/pipgrip /usr/local/opt/pipgrip/bin/pipgrip
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           token: ${{ secrets.HOMEBREW_PR_TOKEN }}


### PR DESCRIPTION
brew bump-formula-pr expects pipgrip to be installed using brew so https://github.com/returntocorp/semgrep/pull/4233 did not correctly fix #4213 

Instead we have to install pipgrip with brew and pypi and link where the brew pipgrip executable should be to the pypi installed executable

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
