### PR TITLE
feat(nosem): dont read target files when nosem disabled

### DIFF
--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -220,14 +220,14 @@ def main(
 
     profiler.save("total_time", start_time)
 
-    filtered_matches = process_ignores(
+    filtered_matches_by_rule, nosem_errors, num_ignored_by_nosem = process_ignores(
         rule_matches_by_rule, output_handler, strict=strict, disable_nosem=disable_nosem
     )
 
     output_handler.handle_semgrep_errors(semgrep_errors)
-    output_handler.handle_semgrep_errors(filtered_matches.errors)
+    output_handler.handle_semgrep_errors(nosem_errors)
 
-    num_findings = sum(len(v) for v in filtered_matches.matches.values())
+    num_findings = sum(len(v) for v in filtered_matches_by_rule.values())
     stats_line = f"ran {len(filtered_rules)} rules on {len(all_targets)} files: {num_findings} findings"
 
     error_types = list(e.semgrep_error_type() for e in semgrep_errors)
@@ -239,18 +239,18 @@ def main(
         metric_manager.set_num_rules(len(filtered_rules))
         metric_manager.set_num_targets(len(all_targets))
         metric_manager.set_num_findings(num_findings)
-        metric_manager.set_num_ignored(filtered_matches.num_matches)
+        metric_manager.set_num_ignored(num_ignored_by_nosem)
         metric_manager.set_run_time(profiler.calls["total_time"][0])
         total_bytes_scanned = sum(t.stat().st_size for t in all_targets)
         metric_manager.set_total_bytes_scanned(total_bytes_scanned)
         metric_manager.set_errors(error_types)
-        metric_manager.set_rules_with_findings(filtered_matches.matches)
+        metric_manager.set_rules_with_findings(filtered_matches_by_rule)
         metric_manager.set_run_timings(
             profiling_data, list(all_targets), filtered_rules
         )
 
     output_handler.handle_semgrep_core_output(
-        filtered_matches.matches,
+        filtered_matches_by_rule,
         debug_steps_by_rule=debug_steps_by_rule,
         stats_line=stats_line,
         all_targets=all_targets,
@@ -261,4 +261,4 @@ def main(
     )
 
     if autofix:
-        apply_fixes(filtered_matches.matches, dryrun)
+        apply_fixes(filtered_matches_by_rule, dryrun)

--- a/semgrep/tests/e2e/snapshots/test_ignores/test_nosem_rule__with_disable_nosem/results.json
+++ b/semgrep/tests/e2e/snapshots/test_ignores/test_nosem_rule__with_disable_nosem/results.json
@@ -9,7 +9,6 @@
         "offset": 34
       },
       "extra": {
-        "is_ignored": true,
         "lines": "    test_nosem_func(); // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -31,7 +30,6 @@
         "offset": 84
       },
       "extra": {
-        "is_ignored": false,
         "lines": "    test_nosem_func();",
         "message": "test-nosem-message",
         "metadata": {},
@@ -53,7 +51,6 @@
         "offset": 46
       },
       "extra": {
-        "is_ignored": true,
         "lines": "\ttest_nosem_func() // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -75,7 +72,6 @@
         "offset": 92
       },
       "extra": {
-        "is_ignored": false,
         "lines": "\ttest_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},
@@ -97,7 +93,6 @@
         "offset": 84
       },
       "extra": {
-        "is_ignored": true,
         "lines": "        test_nosem_func(); // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -119,7 +114,6 @@
         "offset": 138
       },
       "extra": {
-        "is_ignored": false,
         "lines": "        test_nosem_func();",
         "message": "test-nosem-message",
         "metadata": {},
@@ -141,7 +135,6 @@
         "offset": 17
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func() // nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -163,7 +156,6 @@
         "offset": 44
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func() // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -185,7 +177,6 @@
         "offset": 89
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func() // NOSEM: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -207,7 +198,6 @@
         "offset": 180
       },
       "extra": {
-        "is_ignored": false,
         "lines": "test_nosem_func(\n    invalid_line // nosem: rules.test-nosem\n)",
         "message": "test-nosem-message",
         "metadata": {},
@@ -229,7 +219,6 @@
         "offset": 199
       },
       "extra": {
-        "is_ignored": false,
         "lines": "test_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},
@@ -251,7 +240,6 @@
         "offset": 17
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func()  # nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -273,7 +261,6 @@
         "offset": 62
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func()  # NOSEM: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -295,7 +282,6 @@
         "offset": 107
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func()  # nosemgrep: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -317,7 +303,6 @@
         "offset": 156
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func()  # NOSEMGREP",
         "message": "test-nosem-message",
         "metadata": {},
@@ -339,7 +324,6 @@
         "offset": 187
       },
       "extra": {
-        "is_ignored": true,
         "lines": "test_nosem_func()  # nOseMgREP: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -361,7 +345,6 @@
         "offset": 236
       },
       "extra": {
-        "is_ignored": false,
         "lines": "test_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},


### PR DESCRIPTION
Even when --disable-nosem was set, we were still going through
all the findings and reading their files to see if there were nosem
comments for those findings.

With this PR we no longer do this unnecessary work

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
