### PR TITLE
[PHP] allow public method pattern for semgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Added
+- PHP: support method patterns (#4262)
 
 ### Changed
 

--- a/semgrep-core/tests/php/misc_public_method.php
+++ b/semgrep-core/tests/php/misc_public_method.php
@@ -1,0 +1,7 @@
+<?php
+class Foo {
+  //ERROR: match
+  public function __construct($path) {
+    file_get_contents($path);
+  }
+}

--- a/semgrep-core/tests/php/misc_public_method.sgrep
+++ b/semgrep-core/tests/php/misc_public_method.sgrep
@@ -1,0 +1,3 @@
+public function __construct($VAR) {
+  file_get_contents($VAR);
+}


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/4262

test plan:
test file included


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)