### PR TITLE
Set benchmark tests baseline to 0.73.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,9 +204,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: Run 0.70.0 Timing Benchmark
+      - name: Run 0.73.0 Timing Benchmark
         run: |
-          pip3 install semgrep==0.70.0
+          pip3 install semgrep==0.73.0
           semgrep --version
           python3 -m semgrep --version
           export PATH=/github/home/.local/bin:$PATH


### PR DESCRIPTION
There seems to be a 7-10% slowdown from 0.70.0 to 0.73.0, we update the
baseline while we investigate the issue.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
