### PR TITLE
fix(nosem): restore disable-nosem functionality that modifies is_ignore field of findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Fixed
+- semgrep-ci relies on `--disable-nosem` still tagging findings with `is_ignored`
+  correctly. Reverting optimization in 0.74.0 that left this field None when said
+  flag was used
+
 ## [0.74.0](https://github.com/returntocorp/semgrep/releases/tag/v0.74.0) - 11-19-2021
 
 ### Added

--- a/semgrep/tests/e2e/snapshots/test_ignores/test_nosem_rule__with_disable_nosem/results.json
+++ b/semgrep/tests/e2e/snapshots/test_ignores/test_nosem_rule__with_disable_nosem/results.json
@@ -9,6 +9,7 @@
         "offset": 34
       },
       "extra": {
+        "is_ignored": true,
         "lines": "    test_nosem_func(); // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -30,6 +31,7 @@
         "offset": 84
       },
       "extra": {
+        "is_ignored": false,
         "lines": "    test_nosem_func();",
         "message": "test-nosem-message",
         "metadata": {},
@@ -51,6 +53,7 @@
         "offset": 46
       },
       "extra": {
+        "is_ignored": true,
         "lines": "\ttest_nosem_func() // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -72,6 +75,7 @@
         "offset": 92
       },
       "extra": {
+        "is_ignored": false,
         "lines": "\ttest_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},
@@ -93,6 +97,7 @@
         "offset": 84
       },
       "extra": {
+        "is_ignored": true,
         "lines": "        test_nosem_func(); // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -114,6 +119,7 @@
         "offset": 138
       },
       "extra": {
+        "is_ignored": false,
         "lines": "        test_nosem_func();",
         "message": "test-nosem-message",
         "metadata": {},
@@ -135,6 +141,7 @@
         "offset": 17
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func() // nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -156,6 +163,7 @@
         "offset": 44
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func() // nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -177,6 +185,7 @@
         "offset": 89
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func() // NOSEM: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -198,6 +207,7 @@
         "offset": 180
       },
       "extra": {
+        "is_ignored": false,
         "lines": "test_nosem_func(\n    invalid_line // nosem: rules.test-nosem\n)",
         "message": "test-nosem-message",
         "metadata": {},
@@ -219,6 +229,7 @@
         "offset": 199
       },
       "extra": {
+        "is_ignored": false,
         "lines": "test_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},
@@ -240,6 +251,7 @@
         "offset": 17
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func()  # nosem: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -261,6 +273,7 @@
         "offset": 62
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func()  # NOSEM: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -282,6 +295,7 @@
         "offset": 107
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func()  # nosemgrep: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -303,6 +317,7 @@
         "offset": 156
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func()  # NOSEMGREP",
         "message": "test-nosem-message",
         "metadata": {},
@@ -324,6 +339,7 @@
         "offset": 187
       },
       "extra": {
+        "is_ignored": true,
         "lines": "test_nosem_func()  # nOseMgREP: rules.test-nosem",
         "message": "test-nosem-message",
         "metadata": {},
@@ -345,6 +361,7 @@
         "offset": 236
       },
       "extra": {
+        "is_ignored": false,
         "lines": "test_nosem_func()",
         "message": "test-nosem-message",
         "metadata": {},


### PR DESCRIPTION
PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
