### PR TITLE
taint-mode: Check variables as if they were subexpressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Java: class patterns not using generics will match classes using generics
   (#4335), e.g., `class $X { ...}` will now match `class Foo<T> { }`
 - TS: parse correctly type definitions (#4330)
+- taint-mode: Findings are now reported when the LHS of an access operator is
+  a sink (e.g. as in `$SINK->method`), and the LHS operand is a tainted
+  variable (#4320)
 
 ### Changed
 - semgrep-core: Log messages are now tagged with the process id

--- a/semgrep-core/tests/tainting_rules/php/lval_var_sink.php
+++ b/semgrep-core/tests/tainting_rules/php/lval_var_sink.php
@@ -1,0 +1,11 @@
+<?php
+// https://github.com/returntocorp/semgrep/issues/4320
+$doc = new DOMDocument();
+// We did not catch the error when the sink was the variable in an l-value,
+// because we assumed that only expressions or instructions could be sinks.
+//ERROR:
+$doc->load('file.xml');
+//ERROR:
+$doc->load($doc);
+//OK:
+$something->load($doc);

--- a/semgrep-core/tests/tainting_rules/php/lval_var_sink.yaml
+++ b/semgrep-core/tests/tainting_rules/php/lval_var_sink.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: domdocument-load
+    severity: INFO
+    message: DOMDocument::load
+    languages:
+      - php
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: new DOMDocument(...)
+    pattern-sinks:
+      - patterns:
+          - pattern-inside: $DOMDOCUMENT->load($FILENAME, ...)
+          - pattern: $DOMDOCUMENT
+


### PR DESCRIPTION
If the LHS of `->foo` was a sink, and we encountered `x->foo` where `x`
was a variable, we did not report a finding even if `x` was tainted. We
were not checking whether `x` was in a sink position.

Although they are not represented as such in the IL, variables are
themselves subexpressions, so we must check whether they are sinks or
sanitized.

Closes #4320

test plan:
make test # test included

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
