### PR TITLE
[Internal] expose Parse_rule.parse_xpattern

### DIFF
--- a/semgrep-core/src/core/Flag_semgrep.ml
+++ b/semgrep-core/src/core/Flag_semgrep.ml
@@ -41,3 +41,7 @@ let gc_tuning = ref true
  * code equivalences.
  *)
 let equivalence_mode = ref false
+
+(* Note that an important flag used during parsing is actually in pfff in
+ * Flag_parsing.sgrep_mode
+ *)

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -112,10 +112,7 @@ let parse_pattern lang ?(print_errors = false) str =
         Ruby_to_generic.any any
     | Lang.PHP ->
         let any_cst = Parse_php.any_of_string str in
-        let any =
-          Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->
-              Ast_php_build.any any_cst)
-        in
+        let any = Ast_php_build.any any_cst in
         Php_to_generic.any any
     | Lang.Hack ->
         let res = Parse_hack_tree_sitter.parse_pattern str in

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -1,9 +1,5 @@
 (* may raise all the exns in Rule *)
 val parse : Common.filename -> Rule.rules
 
-(* internals used by other parsers (e.g., Parse_mini_rule.ml) *)
-
-val parse_severity : id:Rule.rule_id -> string Rule.wrap -> Rule.severity
-
-val parse_pattern :
-  id:Rule.rule_id -> lang:Lang.t -> string Rule.loc -> Pattern.t
+(* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml *)
+val parse_xpattern : Xlang.t -> string Rule.wrap -> Rule.xpattern

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -262,12 +262,7 @@ let parse_equivalences equivalences_file =
   [@@profiling]
 
 let parse_pattern lang_pattern str =
-  try
-    Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->
-        let res =
-          Parse_pattern.parse_pattern lang_pattern ~print_errors:false str
-        in
-        res)
+  try Parse_pattern.parse_pattern lang_pattern ~print_errors:false str
   with exn ->
     raise
       (Rule.InvalidPattern

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -133,10 +133,8 @@ let language_exceptions = [
 (*****************************************************************************)
 
 let any_gen_of_string str =
-  Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->
   let any = Parse_python.any_of_string str in
   Python_to_generic.any any
-  )
 
 
 let parsing_tests_for_lang files lang =
@@ -200,7 +198,6 @@ let regression_tests_for_lang ~with_caching files lang =
                     (Common.exn_to_s exn))
     in
     let pattern = 
-      Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->
         try 
           Parse_pattern.parse_pattern lang ~print_errors:true (Common.read_file sgrep_file)
         with exn ->
@@ -208,7 +205,6 @@ let regression_tests_for_lang ~with_caching files lang =
                       sgrep_file 
                       (Lang.string_of_lang lang)
                       (Common.exn_to_s exn))
-      )
     in
     E.g_errors := [];
 


### PR DESCRIPTION
This will help to have -e/-f to also handle extended patterns

test plan:
make test


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)