### PR TITLE
Remove false positive parsing warnings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Added
 - Improved filtering of rules based on file content
 
+### Fixed
+- Remove false positive parsing warnings in tests
+
 ## [0.75.0](https://github.com/returntocorp/semgrep/releases/tag/v0.75.0) - 11-23-2021
 
 ### Fixed

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -168,6 +168,9 @@ def score_output_json(
             todo_ok_in_line = line_has_todo_ok(line)
             num_todo += int(todo_rule_in_line) + int(todo_ok_in_line)
 
+            if not any([rule_in_line, ok_in_line, todo_rule_in_line, todo_ok_in_line]):
+                continue
+
             try:
                 rule_ids = normalize_rule_ids(line)
                 if (not ignore_todo and todo_rule_in_line) or rule_in_line:


### PR DESCRIPTION
PR checklist:
- [x] Documentation is up-to-date (N/A)
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)

I believe that #4237 is causing a large amount of false positive warnings to be emitted when running tests, owing to the fact that `normalize_rule_ids` is called at the top level instead of within the individual `if` statements.

Alternative approach would be to add

```python
    if line.count(":") != 1:
        # cannot be a rule annotation
        return set()
```

to `normalize_rule_ids`, but I feel like the change in this PR is a bit more explicit in the intention (we should not try to extract rule ids if we did not detect any rules in the first place on the line).

Apologies for not making an issue first, this seemed pretty small. Would be happy to make associated issue if preferred.