### PR TITLE
logging: Reduce the size of --debug dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Changed
 - semgrep-core: Log messages are now tagged with the process id
+- Reduced the size of `--debug` dumps
 
 ## [0.75.0](https://github.com/returntocorp/semgrep/releases/tag/v0.75.0) - 11-23-2021
 

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -71,7 +71,7 @@ let locate opt_tok s =
   | Some loc -> spf "%s: %s" loc s
   | None -> s
 
-let log_warning opt_tok msg = logger#warning "%s" (locate opt_tok msg)
+let log_warning opt_tok msg = logger#trace "warning: %s" (locate opt_tok msg)
 
 let log_error opt_tok msg = logger#error "%s" (locate opt_tok msg)
 

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -316,7 +316,7 @@ and eval_concat_string env args : literal option =
 (*****************************************************************************)
 (* !Note that this assumes Naming_AST.resolve has been called before! *)
 let propagate_basic lang prog =
-  logger#info "Constant_propagation.propagate_basic progran";
+  logger#trace "Constant_propagation.propagate_basic program";
   let env = default_env () in
 
   (* step1: first pass const analysis for languages without 'const/final' *)
@@ -415,7 +415,7 @@ let propagate_basic a b =
   Common.profile_code "Constant_propagation.xxx" (fun () -> propagate_basic a b)
 
 let propagate_dataflow lang ast =
-  logger#info "Constant_propagation.propagate_dataflow progran";
+  logger#trace "Constant_propagation.propagate_dataflow program";
   let v =
     V.mk_visitor
       {

--- a/semgrep-core/src/analyzing/Naming_AST.ml
+++ b/semgrep-core/src/analyzing/Naming_AST.ml
@@ -299,7 +299,7 @@ let error_report = false
 
 let error tok s =
   if error_report then raise (Parse_info.Other_error (s, tok))
-  else logger#error "%s at %s" s (Parse_info.string_of_info tok)
+  else logger#trace "%s at %s" s (Parse_info.string_of_info tok)
 
 (*****************************************************************************)
 (* Other Helpers *)
@@ -372,7 +372,7 @@ let assign_implicitly_declares lang =
 (*****************************************************************************)
 
 let resolve lang prog =
-  logger#info "Naming_AST.resolve program";
+  logger#trace "Naming_AST.resolve program";
   let env = default_env lang in
 
   (* coupling: we do similar things in Constant_propagation.ml so if you

--- a/semgrep-core/src/engine/Match_patterns.ml
+++ b/semgrep-core/src/engine/Match_patterns.ml
@@ -194,7 +194,7 @@ let must_analyze_statement_bloom_opti_failed pattern_strs
  *   unless they fall in specific regions of the code.
  *   See also docs for {!check} in Match_pattern.mli. *)
 let check2 ~hook range_filter config rules equivs (file, lang, ast) =
-  logger#info "checking %s with %d mini rules" file (List.length rules);
+  logger#trace "checking %s with %d mini rules" file (List.length rules);
 
   let rules =
     (* simple opti using regexps; the bloom filter opti might supersede this *)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -932,7 +932,7 @@ and matches_of_formula config equivs rule_id file_and_more formula opt_context :
       (file, xlang, lazy_ast_and_errors, lazy_content)
       xpatterns
   in
-  logger#info "found %d matches" (List.length res.matches);
+  logger#trace "found %d matches" (List.length res.matches);
   (* match results per minirule id which is the same than pattern_id in
    * the formula *)
   let pattern_matches_per_id = group_matches_per_pattern_id res.matches in
@@ -948,9 +948,9 @@ and matches_of_formula config equivs rule_id file_and_more formula opt_context :
       errors = ref [];
     }
   in
-  logger#info "evaluating the formula";
+  logger#trace "evaluating the formula";
   let final_ranges = evaluate_formula env opt_context formula in
-  logger#info "found %d final ranges" (List.length final_ranges);
+  logger#trace "found %d final ranges" (List.length final_ranges);
   let res' = { res with RP.errors = res.RP.errors @ !(env.errors) } in
   (res', final_ranges)
   [@@profiling]
@@ -986,8 +986,7 @@ let check_rule r hook default_config pformula equivs file_and_more =
 
 let check hook default_config rules equivs file_and_more =
   let { FM.file; lazy_ast_and_errors; _ } = file_and_more in
-  logger#info "checking %s with %d rules" file (List.length rules);
-  if rules = [] then logger#error "empty rules";
+  logger#trace "checking %s with %d rules" file (List.length rules);
   if !Common.profile = Common.ProfAll then (
     logger#info "forcing eval of ast outside of rules, for better profile";
     lazy_force lazy_ast_and_errors |> ignore);

--- a/semgrep-core/src/engine/Run_rules.ml
+++ b/semgrep-core/src/engine/Run_rules.ml
@@ -61,12 +61,12 @@ let filter_and_partition_rules rules file_and_more =
                | None -> true
                | Some (re, f) ->
                    let content = Lazy.force lazy_content in
-                   logger#info "looking for %s in %s" re file;
+                   logger#trace "looking for %s in %s" re file;
                    f content)
              else true
            in
            if not relevant_rule then
-             logger#info "skipping rule %s for %s" (fst r.R.id) file;
+             logger#trace "skipping rule %s for %s" (fst r.R.id) file;
            relevant_rule)
   in
   let search_rules, taint_rules = R.partition_rules rules in

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -450,7 +450,7 @@ let eval_and p (And xs) =
   |> List.for_all (function Or xs ->
          if null xs then raise EmptyOr;
          xs |> List.exists (fun x -> p x) |> fun v ->
-         if not v then logger#info "this Or failed: %s" (Common.dump (Or xs));
+         if not v then logger#trace "this Or failed: %s" (Common.dump (Or xs));
          v)
 
 let run_cnf_step2 cnf big_str =

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -84,7 +84,7 @@ let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =
   match parser with
   | Pfff f ->
       Common.save_excursion Flag_parsing.show_parsing_error false (fun () ->
-          logger#info "trying to parse with Pfff parser %s" file;
+          logger#trace "trying to parse with Pfff parser %s" file;
           try
             let res = f file in
             Ok res
@@ -95,7 +95,7 @@ let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =
               logger#error "exn (%s) with Pfff parser" (Common.exn_to_s exn);
               Error exn)
   | TreeSitter f -> (
-      logger#info "trying to parse with TreeSitter parser %s" file;
+      logger#trace "trying to parse with TreeSitter parser %s" file;
       try
         let res = f file in
         let stat = stat_of_tree_sitter_stat file res.stat in

--- a/semgrep-core/src/runner/Parse_with_caching.ml
+++ b/semgrep-core/src/runner/Parse_with_caching.ml
@@ -39,7 +39,7 @@ let cache_computation ~parsing_cache_exists version_cur file cache_file_of_file
         let file_cache = cache_file_of_file file in
         if Sys.file_exists file_cache && filemtime file_cache >= filemtime file
         then (
-          logger#info "using cache: %s" file_cache;
+          logger#trace "using cache: %s" file_cache;
           let version, file2, res = Common2.get_value file_cache in
           if version <> version_cur then
             failwith
@@ -96,7 +96,7 @@ let parse_generic parsing_cache version lang file =
         cache_file_of_file parsing_cache full_filename)
       (fun () ->
         try
-          logger#info "parsing %s" file;
+          logger#trace "parsing %s" file;
           (* finally calling the actual function *)
           let { Parse_target.ast; errors; _ } =
             Parse_target.parse_and_resolve_name_use_pfff_or_treesitter lang file

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -298,7 +298,7 @@ let iter_files_and_get_matches_and_exn_to_errors config f files =
                           * not testing -max_memory.
                           *)
                          if config.test then Gc.full_major ();
-                         logger#info "done with %s" file;
+                         logger#trace "done with %s" file;
                          v))
                with
                (* note that Semgrep_error_code.exn_to_error already handles Timeout


### PR DESCRIPTION
In a first step, we typically just want `semgrep --debug` to help us
identify which files are causing problems. For this we use the default
INFO level. If a message is logged rarely then it does no harm having it
at the INFO level. But, if it is logged often, then it may just be making
the dump larger without really helping that much in most situations.

This will move some frequently-logged messages to the TRACE level to
reduce the size of --debug dump. My intuition is that these messages are
not particularly useful when one is trying to find "the file" causing
trouble.

test plan:
$ semgrep --time --debug -c p/auto lang/javascript/tmp/* &>log
The size of the log files went down from 838M to 174M (~5x smaller).

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
