### PR TITLE
logging: Tag log messages with the worker's PID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - TS: parse correctly type definitions (#4330)
 
 ### Changed
+- semgrep-core: Log messages are now tagged with the process id
 
 ## [0.75.0](https://github.com/returntocorp/semgrep/releases/tag/v0.75.0) - 11-23-2021
 

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -124,7 +124,8 @@ let map_targets ncores f (targets : Common.filename list) =
      *)
     Parmap.disable_core_pinning ();
     assert (ncores > 0);
-    Parmap.parmap ~ncores ~chunksize:1 f (Parmap.L targets))
+    let init _ = Logging.add_PID_tag () in
+    Parmap.parmap ~init ~ncores ~chunksize:1 f (Parmap.L targets))
 
 (*****************************************************************************)
 (* Timeout *)


### PR DESCRIPTION
We log messages such as "found N matches" that, when running parallel
analyses, one does not know to what file they correspond. Tagging each
log message with the worker's PID fixes that.

test plan:
Run semgrep --debug using two or more processes

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
