### PR TITLE
optimizing: Analyze_rule: Fix segfault on Apple M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   a sink (e.g. as in `$SINK->method`), and the LHS operand is a tainted
   variable (#4320)
 - metavariable-comparison: do not throw a NotHandled exn anymore (#4328)
+- semgrep-core: Fix a segmentation fault on Apple M1 when using
+  `-filter_irrelevant_rules` on rules with very large `pattern-either`s (#4305)
 
 ### Changed
 - semgrep-core: Log messages are now tagged with the process id


### PR DESCRIPTION
In 7e28cd2104b (#4317) we added test example 'tainted-filename.yaml'
that has a very large `pattern-either` causing CNF computation to
"explode". The code was non tail-rec so this example lead to a
stack overflow, and we relied on OCaml's runtime intercepting it and
raising a Stack_overflow exception. Unfortunately this does not work on
Apple M1, no Stack_overflow is raised, and instead we get a segfault.

This rewrites the application of the distributive law in a tail-rec
manner, and instead we check the size of the accumulated formula to
detect a potential blow up

Fixes 7e28cd2104b ("Fix Stack_overflow when using -filter_irrelevant_rules (#4317)")

test plan:
Run this on Apple M1:
$ semgrep-core -lang php -config tests/OTHER/rules/tainted-filename.yaml -filter_irrelevant_rules tests/OTHER/rules/tainted-filename.php
It should no longer segfault.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
