### PR TITLE
cli: Do not print to stdout when --output is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - semgrep-core: Log messages are now tagged with the process id
 - Optimization: change bloom filters to use sets, move location of filter
 - Reduced the size of `--debug` dumps
+- Given `--output` Semgrep will no longer print search results to _stdout_,
+  but it will only save/post them to the specified file/URL
 
 ## [0.75.0](https://github.com/returntocorp/semgrep/releases/tag/v0.75.0) - 11-23-2021
 

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -320,18 +320,18 @@ class OutputHandler:
                 self.settings.output_per_finding_max_lines_limit,
                 self.settings.output_per_line_max_chars_limit,
             )
-            if output:
-                try:
-                    print(output, file=self.stdout)
-                except UnicodeEncodeError as ex:
-                    raise Exception(
-                        "Received output encoding error, please set PYTHONIOENCODING=utf-8"
-                    ) from ex
-            if self.stats_line:
-                logger.info(self.stats_line)
-
             if self.settings.output_destination:
                 self.save_output(self.settings.output_destination, output)
+            else:
+                if output:
+                    try:
+                        print(output, file=self.stdout)
+                    except UnicodeEncodeError as ex:
+                        raise Exception(
+                            "Received output encoding error, please set PYTHONIOENCODING=utf-8"
+                        ) from ex
+            if self.stats_line:
+                logger.info(self.stats_line)
 
         final_error = None
         error_stats = None


### PR DESCRIPTION
test plan:
```
$ semgrep --max-target-bytes=64000 -c p/auto -o results.txt parsing-stats/lang/javascript/tmp/mui-org-material-ui
# ^ Does not print any results to stdout, but only writes them to 'results.txt'
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
