### PR TITLE
Update benchmark version and add nodejsscan rules on django benchmark

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,9 +208,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
-      - name: Run 0.73.0 Timing Benchmark
+      - name: Run 0.76.2 Timing Benchmark
         run: |
-          pip3 install semgrep==0.73.0
+          pip3 install semgrep==0.76.2
           semgrep --version
           python3 -m semgrep --version
           export PATH=/github/home/.local/bin:$PATH

--- a/perf/configs/ci_medium_repos.yaml
+++ b/perf/configs/ci_medium_repos.yaml
@@ -21,6 +21,13 @@ runs:
   - r2c-rules/r2c-ci.yml
   - r2c-rules/r2c-security-audit.yml
   opts: []
+- name: socket  # javascript rules on a JS repo
+  repos:
+  - url: https://github.com/socketio/socket.io
+    commit_hash: 1faa7e3aea1414ec814aa935021356e8ed2b054c
+  rule_configs:
+  - r2c-rules/javascript.yml
+  opts: []
 - name: draios  # r2c-ci and r2c-security audit packs on a JS/other repo
   repos:
   - url: https://github.com/draios/sysdig-inspect

--- a/perf/configs/ci_small_repos.yaml
+++ b/perf/configs/ci_small_repos.yaml
@@ -21,6 +21,13 @@ runs:
   - r2c-rules/r2c-ci.yml
   - r2c-rules/r2c-security-audit.yml
   opts: []
+- name: njs-django  # njsscan rules on a JS/other repo
+  repos:
+  - url: https://github.com/django/django
+    commit_hash: 9ee693bd6cf4074f04ec51c6f3cfe87cad392f12
+  rule_configs:
+  - njsscan
+  opts: []
 - name: apache  # django rulepack on a large python repo
   repos:
   - url: https://github.com/apache/libcloud
@@ -74,13 +81,6 @@ runs:
   rule_configs:
   - r2c-rules/python.yml
   - r2c-rules/flask.yml
-  opts: []
-- name: socket  # javascript rules on a JS repo
-  repos:
-  - url: https://github.com/socketio/socket.io
-    commit_hash: 1faa7e3aea1414ec814aa935021356e8ed2b054c
-  rule_configs:
-  - r2c-rules/javascript.yml
   opts: []
 # For more comprehensive rule timing information
 - name: coolMenu  # small java corpus


### PR DESCRIPTION
To prevent making the mistake fixed in https://github.com/returntocorp/semgrep/pull/4349, add a benchmark to run nodejsscan rules on django.

Also update the benchmark semgrep version to 0.76.0.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
