### PR TITLE
Fix minor things

### DIFF
--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -200,7 +200,7 @@ let rec (cnf : Rule.formula -> cnf_step0) =
       let zs = Common.map (fun (_t, cond) -> And [ Or [ LCond cond ] ]) conds in
       And (ys @ zs |> Common.map (function And ors -> ors) |> List.flatten)
   | R.Or (_, xs) ->
-      let is_dangerously_large l = List.compare_length_with l 1_000_000 = 1 in
+      let is_dangerously_large l = List.compare_length_with l 1_000_000 > 0 in
       let ys = Common.map cnf xs in
       List.fold_left
         (fun (And ps) (And qs) ->

--- a/semgrep/Makefile
+++ b/semgrep/Makefile
@@ -2,3 +2,5 @@ test:
 	pipenv run pytest -v --tb=short tests/
 regenerate-tests:
 	pipenv run pytest tests/ --snapshot-update
+clean:
+	@# main Makefile expects a clean target, may be useful in the future


### PR DESCRIPTION
1. According to spec, Pervasives.compare may return any positive integer
   when the first argument is greater than the second.
2. Top-level `make clean` was failing because semgrep/Makefile had no
   `clean` target.

Fixes efb6eb649f9 ("cli: Do not print to stdout when --output is given (#4353)")

test plan:
Running `make clean` from the root no longer fails

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
