### PR TITLE
Run dummy benchmarks on latest instead of develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,18 +18,6 @@ jobs:
   #    semgrep and whatever utilities we added.
   #
   # We use B out of necessity.
-  #
-  # Go through the same steps as the real benchmarks but quickly.
-  dummy-benchmarks-latest:
-    docker:
-      - image: returntocorp/semgrep-dev:latest
-    steps:
-      - checkout
-      - run:
-          name: dummy benchmarks
-          command: |
-            cd perf
-            ./run-benchmarks --dummy --upload
 
   # Real benchmarks
   benchmarks:
@@ -83,21 +71,6 @@ workflows:
             branches:
               only:
                 - develop
-
-  # This is to check whether we broke the benchmarks before merging a branch.
-  dummy-benchmarks-on-commit:
-    jobs:
-      - dummy-benchmarks-latest
-
-  # This is for testing. Requires pushing to a branch named 'force-benchmarks'.
-  # It can take hours, use with care.
-  benchmarks-on-commit:
-    jobs:
-      - benchmarks:
-          filters:
-            branches:
-              only:
-                - force-benchmarks
 
   scheduled-parsing-stats:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ jobs:
   # We use B out of necessity.
   #
   # Go through the same steps as the real benchmarks but quickly.
-  dummy-benchmarks:
+  dummy-benchmarks-latest:
     docker:
-      - image: returntocorp/semgrep-dev:develop
+      - image: returntocorp/semgrep-dev:latest
     steps:
       - checkout
       - run:
@@ -87,7 +87,7 @@ workflows:
   # This is to check whether we broke the benchmarks before merging a branch.
   dummy-benchmarks-on-commit:
     jobs:
-      - dummy-benchmarks
+      - dummy-benchmarks-latest
 
   # This is for testing. Requires pushing to a branch named 'force-benchmarks'.
   # It can take hours, use with care.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,6 +215,8 @@ jobs:
           pipenv install --dev
       - name: Test dummy benchmarks on latest
         run: |
+          pwd
+          ls
           cd semgrep
           pipenv run semgrep --version
           pipenv run python -m semgrep --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,6 +208,14 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
+      - name: Download artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: ocaml-build-artifacts
+      - name: Install artifacts
+        run: |
+          tar xf ocaml-build-artifacts/ocaml-build-artifacts.tgz
+          sudo cp ocaml-build-artifacts/bin/* /usr/bin
       - name: Install semgrep
         run: |
           cd semgrep

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,10 +214,8 @@ jobs:
           pip3 install pipenv==2021.5.29
           pipenv install --dev
       - name: Test dummy benchmarks on latest
+        working-directory: ./semgrep
         run: |
-          pwd
-          ls
-          cd semgrep
           pipenv run semgrep --version
           pipenv run python -m semgrep --version
           pipenv run semgrep-core -version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,6 +191,32 @@ jobs:
         env:
           GITHUB_REPO_CACHE: ~/.cache/semgrep-cache
 
+  # Run abbreviated version of benchmarks to check that they work
+  dummy-benchmarks:
+    name: semgrep dummy benchmarks
+    runs-on: ubuntu-latest
+    needs: [build-core]
+    strategy:
+      matrix:
+        python: [3.7]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install semgrep
+        run: |
+          cd semgrep
+          pip3 install pipenv==2021.5.29
+          pipenv install --dev
+      - name: Test dummy benchmarks on latest
+        run: |
+          pipenv run python3 ../perf/run-benchmarks --dummy
+
   # Run each benchmark twice to decrease effect of natural variance
   benchmark-test:
     name: semgrep benchmark tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -263,12 +263,6 @@ jobs:
           cd semgrep
           pip3 install pipenv==2021.5.29
           pipenv install --dev
-      - name: Test dummy benchmarks in docker from run-benchmarks
-        # This uploads the results, which should happen elsewhere so we run it explicitly for now.
-        #  make dummy
-        run: |
-          docker pull returntocorp/semgrep-dev:develop
-          python3 perf/run-benchmarks --docker returntocorp/semgrep-dev:develop --dummy
       - name: Get timing for latest semgrep
         run: |
           cd semgrep

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -215,6 +215,10 @@ jobs:
           pipenv install --dev
       - name: Test dummy benchmarks on latest
         run: |
+          cd semgrep
+          pipenv run semgrep --version
+          pipenv run python -m semgrep --version
+          pipenv run semgrep-core -version
           pipenv run python3 ../perf/run-benchmarks --dummy
 
   # Run each benchmark twice to decrease effect of natural variance

--- a/perf/variant.py
+++ b/perf/variant.py
@@ -27,6 +27,7 @@ SEMGREP_VARIANTS = [
     SemgrepVariant("no-bloom", "-no_bloom_filter"),
     SemgrepVariant("no-gc-tuning", "-no_gc_tuning"),
     SemgrepVariant("no-filter-irrelevant-rules", "-no_filter_irrelevant_rules"),
+    SemgrepVariant("set-filters", "-set_filters"),
 ]
 
 # For when you just want to test a single change

--- a/perf/variant.py
+++ b/perf/variant.py
@@ -27,7 +27,6 @@ SEMGREP_VARIANTS = [
     SemgrepVariant("no-bloom", "-no_bloom_filter"),
     SemgrepVariant("no-gc-tuning", "-no_gc_tuning"),
     SemgrepVariant("no-filter-irrelevant-rules", "-no_filter_irrelevant_rules"),
-    SemgrepVariant("set-filters", "-set_filters"),
 ]
 
 # For when you just want to test a single change


### PR DESCRIPTION
We run the dummy benchmarks to make sure semgrep didn't break anything required for the full benchmark suite. Previously, this was done in CircleCI, but there doesn't appear to be a nice way to run on latest with CircleCI. This PR moves the dummy benchmark test run into github actions.

Test plan:
See the run from the `Download artifacts` commit. Since a modification was made to the benchmarks to expect a nonexistent flag, this should fail (and indeed does).

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
