### PR TITLE
fix(tests): make test_metrics less flakey

### DIFF
--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -82,6 +82,7 @@ def test_flags(
         options=[*options, "--debug"],
         env={"SEMGREP_USER_AGENT_APPEND": "testing", **env},
     )
+    print(output)
     assert (
         "Sent pseudonymous metrics" in output
         or "Failed to send pseudonymous metrics" in output

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -52,26 +52,61 @@ def mock_config_request(monkeypatch: MonkeyPatch) -> Iterator[None]:
     "config,options,env,should_send",
     [
         ("rules/eqeq.yaml", [], {}, False),
-        ("r/a", [], {}, True),
+        ("r/python.lang.correctness.useless-eqeq.useless-eqeq", [], {}, True),
         ("rules/eqeq.yaml", ["--metrics", "auto"], {}, False),
-        ("r/a", ["--metrics", "auto"], {}, True),
+        (
+            "r/python.lang.correctness.useless-eqeq.useless-eqeq",
+            ["--metrics", "auto"],
+            {},
+            True,
+        ),
         ("rules/eqeq.yaml", ["--metrics", "on"], {}, True),
-        ("r/a", ["--metrics", "on"], {}, True),
+        (
+            "r/python.lang.correctness.useless-eqeq.useless-eqeq",
+            ["--metrics", "on"],
+            {},
+            True,
+        ),
         ("rules/eqeq.yaml", ["--metrics", "off"], {}, False),
-        ("r/a", ["--metrics", "off"], {}, False),
+        (
+            "r/python.lang.correctness.useless-eqeq.useless-eqeq",
+            ["--metrics", "off"],
+            {},
+            False,
+        ),
         ("rules/eqeq.yaml", [], {"SEMGREP_SEND_METRICS": "auto"}, False),
-        ("r/a", [], {"SEMGREP_SEND_METRICS": "auto"}, True),
+        (
+            "r/python.lang.correctness.useless-eqeq.useless-eqeq",
+            [],
+            {"SEMGREP_SEND_METRICS": "auto"},
+            True,
+        ),
         ("rules/eqeq.yaml", [], {"SEMGREP_SEND_METRICS": "off"}, False),
-        ("r/a", [], {"SEMGREP_SEND_METRICS": "off"}, False),
+        (
+            "r/python.lang.correctness.useless-eqeq.useless-eqeq",
+            [],
+            {"SEMGREP_SEND_METRICS": "off"},
+            False,
+        ),
         ("rules/eqeq.yaml", [], {"SEMGREP_SEND_METRICS": "on"}, True),
-        ("r/a", [], {"SEMGREP_SEND_METRICS": "on"}, True),
+        (
+            "r/python.lang.correctness.useless-eqeq.useless-eqeq",
+            [],
+            {"SEMGREP_SEND_METRICS": "on"},
+            True,
+        ),
         (
             "rules/eqeq.yaml",
             ["--metrics", "auto"],
             {"SEMGREP_SEND_METRICS": "on"},
             False,
         ),
-        ("r/a", ["--metrics", "auto"], {"SEMGREP_SEND_METRICS": "off"}, True),
+        (
+            "r/python.lang.correctness.useless-eqeq.useless-eqeq",
+            ["--metrics", "auto"],
+            {"SEMGREP_SEND_METRICS": "off"},
+            True,
+        ),
     ],
 )
 def test_flags(
@@ -85,7 +120,6 @@ def test_flags(
     print(output)
     assert (
         "Sent pseudonymous metrics" in output
-        or "Failed to send pseudonymous metrics" in output
         if should_send
         else "Sent pseudonymous metrics" not in output
     )

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -131,13 +131,13 @@ def test_flags(
 
 
 @mark.parametrize(
-    "config,options,env,should_send",
+    "config,options,env",
     [
-        ("rules/eqeq.yaml", [], {"SEMGREP_SEND_METRICS": "on"}, True),
+        ("rules/eqeq.yaml", [], {"SEMGREP_SEND_METRICS": "on"}),
     ],
 )
 def test_flags_actual_send(
-    run_semgrep_in_tmp, mock_config_request, config, options, env, should_send
+    run_semgrep_in_tmp, mock_config_request, config, options, env
 ):
     """
     Test that the server for metrics sends back success
@@ -148,11 +148,8 @@ def test_flags_actual_send(
         env={"SEMGREP_USER_AGENT_APPEND": "testing", **env},
     )
     print(output)
-    assert (
-        "Sent pseudonymous metrics" in output
-        if should_send
-        else "Sent pseudonymous metrics" not in output
-    )
+    assert "Sent pseudonymous metrics" in output
+    assert "Failed to send pseudonymous metrics" not in output
 
 
 def test_legacy_flags(run_semgrep_in_tmp):

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -112,6 +112,36 @@ def mock_config_request(monkeypatch: MonkeyPatch) -> Iterator[None]:
 def test_flags(
     run_semgrep_in_tmp, mock_config_request, config, options, env, should_send
 ):
+    """
+    Test that we try to send metrics when we should be
+    """
+    _, output = run_semgrep_in_tmp(
+        config,
+        options=[*options, "--debug"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", **env},
+    )
+    print(output)
+    # Test that we try to send metrics. Even if it fails sending
+    assert (
+        "Sent pseudonymous metrics" in output
+        or "Failed to send pseudonymous metrics" in output
+        if should_send
+        else "Sent pseudonymous metrics" not in output
+    )
+
+
+@mark.parametrize(
+    "config,options,env,should_send",
+    [
+        ("rules/eqeq.yaml", [], {"SEMGREP_SEND_METRICS": "on"}, True),
+    ],
+)
+def test_flags_actual_send(
+    run_semgrep_in_tmp, mock_config_request, config, options, env, should_send
+):
+    """
+    Test that the server for metrics sends back success
+    """
     _, output = run_semgrep_in_tmp(
         config,
         options=[*options, "--debug"],

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -82,9 +82,9 @@ def test_flags(
         options=[*options, "--debug"],
         env={"SEMGREP_USER_AGENT_APPEND": "testing", **env},
     )
-    print(output)
     assert (
         "Sent pseudonymous metrics" in output
+        or "Failed to send pseudonymous metrics" in output
         if should_send
         else "Sent pseudonymous metrics" not in output
     )


### PR DESCRIPTION
Looks like in CI sometimes the tests running in parallel cause sending the metrics to fail. Intention of the tests is that the code path is going to send metrics.

Instead of testing that metrics were sent and we got 200 back in all the ways metrics should/should not be sent, just test for the fact that we tried to send metrics.

Have a single path for tests that check metrics actually respond with 200. This test could still be flakey but instead of having ~10 tests that rely on network we now just have 1.

Also instead of using r/all only use a single rule to test metrics since the actual rules that run are unimportant for this test

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
