### PR TITLE
Remove early exit after detecting a false positive while testing rules

### DIFF
--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -256,10 +256,6 @@ def score_output_json(
                 old_cm[i] + new_cm[i] for i in range(len(new_cm))
             ]
 
-    if false_positive_lines:
-        logger.error("failing due to false positives")
-        sys.exit(EXIT_FAILURE)
-
     return (score_by_checkid, matches_by_check_id, num_todo)
 
 


### PR DESCRIPTION
Early exit prevents printing the confusion matric or the JSON output to stdout.
Without the early exit, I can more easily integrate into our CI pipeline for rules.
The process still exits with `1` if any rule hasn't 'passed'. (Which a false positive counts as).

Resolves https://github.com/returntocorp/semgrep/issues/4365

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [X] Change has no security implications (otherwise, ping security team)
