### PR TITLE
Track values of all user flags in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   for nodejsscan rules notably)
 - Semgrep CLI now respects .semgrepignore files
 - Java: support ellipsis in generics, e.g., `class Foo<...>` (#4335)
+- Metrics now track the value of all flags passed to semgrep
 
 ### Fixed
 - Java: class patterns not using generics will match classes using generics

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -533,6 +533,10 @@ def cli(
             version_check()
         return
 
+    # Creates a dict mapping all local variables to their arugments
+    # Because no other variables have been defined yet, this contains only the arguments to the function
+    user_flags = locals()
+
     # To keep version runtime fast, we defer non-version imports until here
     import semgrep.semgrep_main
     import semgrep.test
@@ -551,6 +555,8 @@ def cli(
     target_sequence: Sequence[str] = list(target) if target else [os.curdir]
 
     metric_manager.configure(metrics, metrics_legacy)
+    if metric_manager.is_enabled():
+        metric_manager.set_user_flags(user_flags)
 
     if include and exclude:
         logger.warning(

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -50,6 +50,7 @@ class _MetricManager:
         self._file_stats: List[Dict[str, Any]] = []
         self._rule_stats: List[Dict[str, Any]] = []
         self._rules_with_findings: Mapping[str, int] = {}
+        self._user_flags: Dict[str, Any] = {}
 
         self._send_metrics: MetricsState = MetricsState.OFF
         self._using_server = False
@@ -151,6 +152,12 @@ class _MetricManager:
     ) -> None:
         self._rules_with_findings = {r.full_hash: len(f) for r, f in findings.items()}
 
+    def set_user_flags(self, user_flags: Dict[str, Any]) -> None:
+        self._user_flags = user_flags
+        # Need to turn MetricState objects intro strings so they can be serialized
+        self._user_flags["metrics"] = str(self._user_flags["metrics"])
+        self._user_flags["metrics_legacy"] = str(self._user_flags["metrics_legacy"])
+
     def set_run_timings(
         self, profiling_data: ProfilingData, targets: List[Path], rules: List[Rule]
     ) -> None:
@@ -210,6 +217,7 @@ class _MetricManager:
                 "numFindings": self._num_findings,
                 "numIgnored": self._num_ignored,
                 "ruleHashesWithFindings": self._rules_with_findings,
+                "userFlags": self._user_flags,
             },
         }
 


### PR DESCRIPTION
This PR add a `user_flags` field to our metrics, which maps each flag to its value. This provides the value of every single flag, even if the user did not explicitly pass it.

PR checklist:
- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
