### PR TITLE
Fix YAML parsing off by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - semgrep-core: Fix a segmentation fault on Apple M1 when using
   `-filter_irrelevant_rules` on rules with very large `pattern-either`s (#4305)
 - Python: generate proper lexical exn for unbalanced braces (#4310)  
+- YAML: fix off-by-one in location of arrays
 
 ### Changed
 - semgrep-core: Log messages are now tagged with the process id

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -111,16 +111,18 @@ let mk_bracket
         E.end_mark = { M.index = e_index; M.line = e_line; M.column = e_column };
         _;
       } ) v env =
+  (* The end index needs to be adjusted by one because the token is off *)
+  let e_index' = e_index - 1 in
   let e_line, e_column =
     match env.charpos_to_pos with
     | None -> (e_line, e_column)
     | Some f ->
-        let e_line, e_column = f (e_index - 1) in
+        let e_line, e_column = f e_index' in
         (e_line - 1, e_column)
   in
   ( tok (s_index, s_line, s_column) "(" env,
     v,
-    tok (e_index, e_line, e_column) ")" env )
+    tok (e_index', e_line, e_column) ")" env )
 
 let mk_id str pos env = G.Id ((str, mk_tok pos "" env), G.empty_id_info ())
 

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -118,6 +118,7 @@ let mk_bracket
     | None -> (e_line, e_column)
     | Some f ->
         let e_line, e_column = f e_index' in
+        (* e_line - 1 because tok expects e_line 0-indexed *)
         (e_line - 1, e_column)
   in
   ( tok (s_index, s_line, s_column) "(" env,

--- a/semgrep-core/tests/OTHER/rules/yaml_metavariable_pattern.test.yaml
+++ b/semgrep-core/tests/OTHER/rules/yaml_metavariable_pattern.test.yaml
@@ -1,0 +1,4 @@
+# ERROR:
+owasp:
+- 'A8: Insecure Deserialization'
+- 'A1: Injection'

--- a/semgrep-core/tests/OTHER/rules/yaml_metavariable_pattern.test.yaml
+++ b/semgrep-core/tests/OTHER/rules/yaml_metavariable_pattern.test.yaml
@@ -1,4 +1,4 @@
-# ERROR:
+# ruleid:
 owasp:
 - 'A8: Insecure Deserialization'
 - 'A1: Injection'

--- a/semgrep-core/tests/OTHER/rules/yaml_metavariable_pattern.yaml
+++ b/semgrep-core/tests/OTHER/rules/yaml_metavariable_pattern.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: my_pattern_id
+    patterns:
+      - pattern: |
+          owasp: 
+            $X
+      - metavariable-pattern:
+          metavariable: $X
+          pattern: $Y
+    message: Semgrep found a match - $X
+    languages:
+      - yaml
+    severity: WARNING
+


### PR DESCRIPTION
We had previously identified that the end index for a yaml array would be off by one compared to how semgrep expects tokens. However, we only adjusted this for the line and column.

Test plan: make test

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
