### PR TITLE
[Solidity] update to latest semgrep-langs with Solidity

### DIFF
--- a/semgrep-core/src/core/Guess_lang.ml
+++ b/semgrep-core/src/core/Guess_lang.ml
@@ -244,6 +244,7 @@ let inspect_file_p (lang : Lang.t) path =
     | Ruby
     | Rust
     | Scala
+    | Solidity
     | Hcl
     | Ts
     | Vue

--- a/semgrep-core/src/parsing/Check_pattern.ml
+++ b/semgrep-core/src/parsing/Check_pattern.ml
@@ -27,7 +27,8 @@ let lang_has_no_dollar_ids =
     | Hack
     | Bash
     | Rust
-    | Scala ->
+    | Scala
+    | Solidity ->
         false)
 
 let check_pattern_metavars error lang ast =

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -66,6 +66,9 @@ let parse_pattern lang ?(print_errors = false) str =
     | Lang.Kotlin ->
         let res = Parse_kotlin_tree_sitter.parse_pattern str in
         extract_pattern_from_tree_sitter_result res print_errors
+    | Lang.Solidity ->
+        let res = Parse_solidity_tree_sitter.parse_pattern str in
+        extract_pattern_from_tree_sitter_result res print_errors
     | Lang.Html ->
         let res = Parse_html_tree_sitter.parse_pattern str in
         extract_pattern_from_tree_sitter_result res print_errors

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -250,6 +250,8 @@ let rec just_parse_with_lang lang file =
       run file [ TreeSitter Parse_csharp_tree_sitter.parse ] (fun x -> x)
   | Lang.Kotlin ->
       run file [ TreeSitter Parse_kotlin_tree_sitter.parse ] (fun x -> x)
+  | Lang.Solidity ->
+      run file [ TreeSitter Parse_solidity_tree_sitter.parse ] (fun x -> x)
   | Lang.Lua -> run file [ TreeSitter Parse_lua_tree_sitter.parse ] (fun x -> x)
   | Lang.Bash ->
       run file [ TreeSitter Parse_bash_tree_sitter.parse ] (fun x -> x)

--- a/semgrep-core/src/synthesizing/Pretty_print_generic.ml
+++ b/semgrep-core/src/synthesizing/Pretty_print_generic.ml
@@ -94,6 +94,7 @@ let print_bool env = function
       | Lang.Bash
       | Lang.Rust
       | Lang.Scala
+      | Lang.Solidity
       | Lang.Html
       | Lang.Hcl ->
           "true"
@@ -123,6 +124,7 @@ let print_bool env = function
       | Lang.Bash
       | Lang.Rust
       | Lang.Scala
+      | Lang.Solidity
       | Lang.Html
       | Lang.Hcl ->
           "false"
@@ -224,6 +226,7 @@ and if_stmt env level (tok, e, s, sopt) =
     | Lang.Ruby
     | Lang.Ocaml
     | Lang.Scala
+    | Lang.Solidity
     | Lang.Php
     | Lang.Hack
     | Lang.Yaml
@@ -283,6 +286,7 @@ and while_stmt env level (tok, e, s) =
     | Lang.Lua
     | Lang.Yaml
     | Lang.Scala
+    | Lang.Solidity
     | Lang.Html
     | Lang.Hcl ->
         raise Todo
@@ -318,6 +322,7 @@ and do_while stmt env level (s, e) =
     | Lang.Lua
     | Lang.Yaml
     | Lang.Scala
+    | Lang.Solidity
     | Lang.Html
     | Lang.Hcl ->
         raise Todo
@@ -353,6 +358,7 @@ and for_stmt env level (for_tok, hdr, s) =
     | Lang.Lua
     | Lang.Yaml
     | Lang.Scala
+    | Lang.Solidity
     | Lang.Hcl ->
         raise Todo
     | Lang.Java
@@ -415,6 +421,7 @@ and def_stmt env (entity, def_kind) =
       | Lang.Lua
       | Lang.Yaml
       | Lang.Scala
+      | Lang.Solidity
       | Lang.Html
       | Lang.Hcl ->
           raise Todo
@@ -477,6 +484,7 @@ and return env (tok, eopt) _sc =
   | Lang.Hack
   | Lang.Yaml
   | Lang.Scala
+  | Lang.Solidity
   | Lang.Html
   | Lang.Hcl ->
       raise Todo
@@ -515,6 +523,7 @@ and break env (tok, lbl) _sc =
   | Lang.Hack
   | Lang.Yaml
   | Lang.Scala
+  | Lang.Solidity
   | Lang.Html
   | Lang.Hcl ->
       raise Todo
@@ -553,6 +562,7 @@ and continue env (tok, lbl) _sc =
   | Lang.Hack
   | Lang.Yaml
   | Lang.Scala
+  | Lang.Solidity
   | Lang.Html
   | Lang.Hcl ->
       raise Todo
@@ -661,6 +671,7 @@ and literal env l =
       | Lang.Hack
       | Lang.Yaml
       | Lang.Scala
+      | Lang.Solidity
       | Lang.Html
       | Lang.Hcl ->
           raise Todo


### PR DESCRIPTION
This closes PA-724

test plan:
make


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)