### PR TITLE
Fix failure on non-relative files if semgrepignore present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+## Fixed
+- Fixed bug where the presence of .semgrepignore would cause runs to fail on files that
+  were not subpaths of the directory where semgrep was being run
+
 ## [0.76.0](https://github.com/returntocorp/semgrep/releases/tag/v0.76.0) - 12-06-2021
 
 ### Added

--- a/semgrep/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.json
+++ b/semgrep/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.json
@@ -1,0 +1,47 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "-",
+      "end": {
+        "col": 2,
+        "line": 1,
+        "offset": 1
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "a",
+        "message": "a",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0
+      }
+    },
+    {
+      "check_id": "-",
+      "end": {
+        "col": 2,
+        "line": 1,
+        "offset": 1
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "a",
+        "message": "a",
+        "metadata": {},
+        "metavars": {},
+        "severity": "ERROR"
+      },
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/test_ignores.py
+++ b/semgrep/tests/e2e/test_ignores.py
@@ -1,5 +1,7 @@
+import subprocess
 from pathlib import Path
 
+from ..conftest import _clean_output_json
 from ..conftest import TESTS_PATH
 
 
@@ -12,3 +14,32 @@ def test_semgrepignore(run_semgrep_in_tmp, tmp_path, snapshot):
         run_semgrep_in_tmp("rules/eqeq-js.yaml", target_name="ignores")[0],
         "results.json",
     )
+
+
+# Input from stdin will not have a path that is relative to tmp_path, where we're running semgrep
+def test_file_not_relative_to_base_path(tmp_path, monkeypatch, snapshot):
+    (tmp_path / ".semgrepignore").symlink_to(
+        Path(TESTS_PATH / "e2e" / "targets" / "ignores" / ".semgrepignore").resolve()
+    )
+    monkeypatch.chdir(tmp_path)
+    process = subprocess.Popen(
+        [
+            "python3",
+            "-m",
+            "semgrep",
+            "--disable-version-check",
+            "--metrics",
+            "off",
+            "--json",
+            "-e",
+            "a",
+            "--lang",
+            "js",
+            "-",
+        ],
+        encoding="utf-8",
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    stdout, _ = process.communicate("a")
+    snapshot.assert_match(_clean_output_json(stdout), "results.json")


### PR DESCRIPTION
Previously if a `.semgrepignore` file was present, and semgrep was run on a path that was not relative to the directory where semgrep was being run, it would fail. This prevented input from stdin, for example.

test plan: make test (see added test)

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
