### PR TITLE
Convert named pipes

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -631,12 +631,8 @@ let main () =
   (* does side effect on many global flags *)
   let args = Common.parse_options (options ()) usage_msg (Array.of_list argv) in
   let args =
-    if !target_file = "" then
-      Common.map S.replace_named_pipe_by_regular_file args
-    else
-      (* no conversion from named pipes in this mode so we don't have to worry
-         about possible performance issues *)
-      Common.cat !target_file
+    (* not necessarily file paths, depending on command *)
+    if !target_file = "" then args else Common.cat !target_file
   in
 
   let config = mk_config () in
@@ -670,6 +666,14 @@ let main () =
       (* --------------------------------------------------------- *)
       | _ :: _ as roots -> (
           if !Flag.gc_tuning && config.max_memory_mb = 0 then set_gc ();
+          let roots =
+            if config.target_file = "" then
+              Common.map S.replace_named_pipe_by_regular_file roots
+            else
+              (* leave files as is if they come from a file list so as to
+                 not worry about performance *)
+              roots
+          in
           match () with
           | _ when config.config_file <> "" ->
               S.semgrep_with_formatted_output config roots

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -630,7 +630,14 @@ let main () =
 
   (* does side effect on many global flags *)
   let args = Common.parse_options (options ()) usage_msg (Array.of_list argv) in
-  let args = if !target_file = "" then args else Common.cat !target_file in
+  let args =
+    if !target_file = "" then
+      Common.map S.replace_named_pipe_by_regular_file args
+    else
+      (* no conversion from named pipes in this mode so we don't have to worry
+         about possible performance issues *)
+      Common.cat !target_file
+  in
 
   let config = mk_config () in
 
@@ -663,7 +670,6 @@ let main () =
       (* --------------------------------------------------------- *)
       | _ :: _ as roots -> (
           if !Flag.gc_tuning && config.max_memory_mb = 0 then set_gc ();
-
           match () with
           | _ when config.config_file <> "" ->
               S.semgrep_with_formatted_output config roots

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -141,15 +141,20 @@ let string_of_error_kind = function
   | Timeout -> "Timeout"
   | OutOfMemory -> "Out of memory"
 
+let source_of_string = function
+  | "" -> "<input>"
+  | path -> path
+
 let string_of_error err =
   let pos = err.loc in
-  assert (pos.PI.file <> "");
   let details =
     match err.details with
     | None -> ""
     | Some s -> spf "\n%s" s
   in
-  spf "%s:%d:%d: %s: %s%s" pos.PI.file pos.PI.line pos.PI.column
+  spf "%s:%d:%d: %s: %s%s"
+    (source_of_string pos.PI.file)
+    pos.PI.line pos.PI.column
     (string_of_error_kind err.typ)
     err.msg details
 

--- a/semgrep-core/src/core/ast/Pipfile.lock
+++ b/semgrep-core/src/core/ast/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fde76e2491d9dc44f411d90432295b6547cc42759dc1606b96e4bd38842347d5"
+            "sha256": "ebe889c47490e50d453e5d0dd4b05a897c8b9bff05f42b7102377bce0aba8255"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.9"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -15,8 +13,7 @@
             }
         ]
     },
-    "default": {},
-    "develop": {
+    "default": {
         "jinja2": {
             "hashes": [
                 "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
@@ -97,8 +94,8 @@
                 "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
                 "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
         }
-    }
+    },
+    "develop": {}
 }

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -438,7 +438,8 @@ let semgrep_with_rules config (rules, rule_parse_time) files_or_dirs =
 let semgrep_with_raw_results_and_exn_handler config files_or_dirs =
   let rules_file = config.config_file in
   try
-    logger#info "Parsing %s" rules_file;
+    logger#linfo
+      (lazy (spf "Parsing %s:\n%s" rules_file (read_file rules_file)));
     let timed_rules =
       Common.with_time (fun () -> Parse_rule.parse rules_file)
     in

--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -31,7 +31,8 @@ val replace_named_pipe_by_regular_file : Common.filename -> Common.filename
    Copy named pipes created with <(echo 'foo') on the command line
    into a regular file to avoid illegal seeks when reporting match results
    or parsing errors.
-   Used outside Run_semgrep in Main.ml for -dump_pattern.
+   Any file coming from the command line should go through this so as to
+   allows easy manual testing.
 *)
 
 val print_match :


### PR DESCRIPTION
This ensures target files passed directly on the command line are converted from named pipes to regular files whenever applicable.

test plan: from bash, we should get a match and this match should be reported without raising an exception:
```
$ cat foo.yml
rules:
- id: '-'
  pattern: foo
  message: yay
  languages:
  - python
  severity: ERROR

$ semgrep-core -lang python -config foo.yml <(echo 'foo')
/tmp/semgrep-core-9d4b6d-63:1 with rule -
 foo
```

Previous behavior:
```
$ semgrep-core -lang python -config foo.yml <(echo 'foo')
/dev/fd/63:1:0: Fatal error: (Sys_error "Illegal seek")
Raised at Parse_target.run in file "src/parsing/Parse_target.ml", line 185, characters 17-26
Called from Parse_target.parse_and_resolve_name_use_pfff_or_treesitter in file "src/parsing/Parse_target.ml", line 349, characters 30-60
...
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
