### PR TITLE
[Python] set the right scope for comprehension variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+- New language Solidity with experimental support.
+
+## Fixed
+- Python: set the right scope for comprehension variables (#4260)
+
 ## [0.76.1](https://github.com/returntocorp/semgrep/releases/tag/v0.76.1) - 12-07-2021
 
 ## Fixed

--- a/semgrep-core/src/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/api/AST_generic_to_v1.ml
@@ -1163,6 +1163,7 @@ and map_program v = map_of_list map_item v
 
 and map_any x : B.any =
   match x with
+  | ForOrIfComp _
   | Tp _
   | Ta _ ->
       failwith "TODO"

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -546,9 +546,10 @@ and container_operator =
    *)
   | Tuple
 
-(* For Python/HCL (and Haskell later). The 'expr' is a 'Tuple' to
+(* For Python/HCL (and Haskell later). The 'expr' can be a 'Tuple' to
  * represent a Key/Value pair (like in Container). See keyval() below.
- * newscope:
+ * newscope: for_or_if_comp introduce new local variables whose scope
+ *  is just the first expr.
  *)
 and comprehension = expr * for_or_if_comp list
 
@@ -1709,6 +1710,7 @@ and any =
   | Modn of module_name
   | Ce of catch_exn
   | Cs of case
+  | ForOrIfComp of for_or_if_comp
   (* todo: get rid of some? *)
   | ModDk of module_definition_kind
   | En of entity

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -1128,6 +1128,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let v3 = map_expr v3 in
         PartialSingleField (v1, v2, v3)
   and map_any = function
+    | ForOrIfComp v1 ->
+        let v1 = map_for_or_if_comp v1 in
+        ForOrIfComp v1
     | Tp v1 ->
         let v1 = map_type_parameter v1 in
         Tp v1

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -1346,6 +1346,9 @@ and vof_partial = function
       OCaml.VSum ("PartialSingleField", [ v1; v2; v3 ])
 
 and vof_any = function
+  | ForOrIfComp v1 ->
+      let v1 = vof_for_or_if_comp v1 in
+      OCaml.VSum ("ForOrIfComp", [ v1 ])
   | Tp v1 ->
       let v1 = vof_type_parameter v1 in
       OCaml.VSum ("Tp", [ v1 ])

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1258,6 +1258,7 @@ let (mk_visitor :
     v_id_info v2
   and v_program v = v_stmts v
   and v_any = function
+    | ForOrIfComp v1 -> v_for_or_if_comp v1
     | Tp v1 -> v_type_parameter v1
     | Ta v1 -> v_type_argument v1
     | Cs v1 -> v_case v1

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -2835,6 +2835,7 @@ and m_any a b =
   | G.Pr a1, B.Pr b1 -> m_program a1 b1
   | G.I a1, B.I b1 -> m_ident a1 b1
   | G.Lbli a1, B.Lbli b1 -> m_label_ident a1 b1
+  | G.ForOrIfComp a1, B.ForOrIfComp b1 -> m_for_or_if_comp a1 b1
   | G.I _, _
   | G.Modn _, _
   | G.Di _, _
@@ -2863,6 +2864,7 @@ and m_any a b =
   | G.TodoK _, _
   | G.Partial _, _
   | G.Args _, _
+  | G.ForOrIfComp _, _
   | G.Anys _, _
   | G.Str _, _ ->
       fail ()

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -266,19 +266,24 @@ let rec equal_ast_binded_code (config : Config_semgrep.t) (a : MV.mvalue)
          * - id_constness (see the special @equal for id_constness)
          *)
         MV.Structural.equal_mvalue a b
+    (* TODO still needed now that we have the better MV.Id of id_info? *)
     | MV.Id _, MV.E { e = G.N (G.Id (b_id, b_id_info)); _ } ->
-        (* TODO still needed now that we have the better MV.Id of id_info? *)
         (* TOFIX: regression if remove this code *)
         (* Allow identifier nodes to match pure identifier expressions *)
 
         (* You should prefer to add metavar as expression (G.E), not id (G.I),
          * (see Generic_vs_generic.m_ident_and_id_info_add_in_env_Expr)
-         * but in some cases you have no choice and you need to match an expression
+         * but in some cases you have no choice and you need to match an expr
          * metavar with an id metavar.
-         * For example, we want the pattern 'const $X = foo.$X' to match 'const bar = foo.bar'
-         * (this is useful in the Javascript transpilation context of complex pattern parameter).
+         * For example, we want the pattern 'const $X = foo.$X' to match
+         *  'const bar = foo.bar'
+         * (this is useful in the Javascript transpilation context of
+         * complex pattern parameter).
          *)
         equal_ast_binded_code config a (MV.Id (b_id, Some b_id_info))
+    (* TODO: we should get rid of that too, we should properly bind to MV.N *)
+    | MV.E { e = G.N (G.Id (a_id, a_id_info)); _ }, MV.Id _ ->
+        equal_ast_binded_code config (MV.Id (a_id, Some a_id_info)) b
     | _, _ -> false
   in
 

--- a/semgrep-core/tests/python/metavar_iterator.py
+++ b/semgrep-core/tests/python/metavar_iterator.py
@@ -1,0 +1,8 @@
+def test():
+    
+  #ERROR: match
+  [v for v in iterator]
+
+  #ok:redundant-iterator
+  [f(v) for v in iterator]
+

--- a/semgrep-core/tests/python/metavar_iterator.sgrep
+++ b/semgrep-core/tests/python/metavar_iterator.sgrep
@@ -1,0 +1,1 @@
+[$X for $X in $ITERATOR]


### PR DESCRIPTION
This closes #4260

test plan:
test files included and also see how the same variables "v" now
resolve to the same Local each time
```
$ semgrep-core -lang py -dump_named_ast python/metavar_iterator.py
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("test", ()),
                {id_hidden=false; id_resolved=Ref(None); id_type=Ref(
                 None); id_constness=Ref(None); }));
       attrs=[]; tparams=[]; },
      FuncDef(
        {fkind=(Function, ()); fparams=[]; frettype=None;
         fbody=FBStmt(
                 Block(
                   [ExprStmt(
                      Comprehension(List,
                        (N(
                           Id(("v", ()),
                             {id_hidden=false;
                              id_resolved=Ref(Some((Local, 1)));
                              id_type=Ref(None); id_constness=Ref(None); })),
                         [CompFor((),
                            PatId(("v", ()),
                              {id_hidden=false;
                               id_resolved=Ref(Some((Local, 1)));
                               id_type=Ref(None); id_constness=Ref(None); }),
                            (),
                            N(
                              Id(("iterator", ()),
                                {id_hidden=false; id_resolved=Ref(None);
                                 id_type=Ref(None); id_constness=Ref(
                                 None); })))])), ());
                    ExprStmt(
                      Comprehension(List,
                        (Call(
                           N(
                             Id(("f", ()),
                               {id_hidden=false; id_resolved=Ref(None);
                                id_type=Ref(None); id_constness=Ref(None); })),
                           [Arg(
                              N(
                                Id(("v", ()),
                                  {id_hidden=false;
                                   id_resolved=Ref(Some((Local, 2)));
                                   id_type=Ref(None); id_constness=Ref(
                                   None); })))]),
                         [CompFor((),
                            PatId(("v", ()),
                              {id_hidden=false;
                               id_resolved=Ref(Some((Local, 2)));
                               id_type=Ref(None); id_constness=Ref(None); }),
                            (),
                            N(
                              Id(("iterator", ()),
                                {id_hidden=false; id_resolved=Ref(None);
                                 id_type=Ref(None); id_constness=Ref(
                                 None); })))])), ())]));
         })))])
```


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)