### PR TITLE
Allow name resolution on packages named vN, where N is a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Fixed
 - Go: fixed bug where using an ellipsis to stand for a list of key-value pairs w  would sometimes cause a parse error
+- Allow name resolution on imported packages named just vN, where N is a number
 
 ## [0.76.2](https://github.com/returntocorp/semgrep/releases/tag/v0.76.2) - 12-08-2021
 

--- a/semgrep-core/src/analyzing/Naming_AST.ml
+++ b/semgrep-core/src/analyzing/Naming_AST.ml
@@ -541,7 +541,9 @@ let resolve lang prog =
                 let pkgpath, pkgbase = Common2.dirs_and_base_of_file s in
                 if pkgbase =~ "v[0-9]+" then
                   (* e.g. google.golang.org/api/youtube/v3 *)
-                  Common2.list_last pkgpath
+                  match pkgpath with
+                  | [] -> pkgbase
+                  | _ -> Common2.list_last pkgpath
                 else if pkgbase =~ "\\(.+\\)-go" then
                   (* e.g. github.com/dgrijalva/jwt-go *)
                   matched1 pkgbase

--- a/semgrep-core/tests/ts/import_vN.sgrep
+++ b/semgrep-core/tests/ts/import_vN.sgrep
@@ -1,0 +1,1 @@
+import * as v8 from "v8";

--- a/semgrep-core/tests/ts/import_vN.ts
+++ b/semgrep-core/tests/ts/import_vN.ts
@@ -1,0 +1,2 @@
+//ERROR:
+import * as v8 from "v8";


### PR DESCRIPTION
Previously the code
```
import * as v8 from "v8";
```
would raise an error during name resolution, because we assumed any package that matched `v[0-9]+` would be part of some non-empty path like `google.golang.org/api/youtube/v3`. This PR fixes this.

test plan: make test (see added test)

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
