### PR TITLE
Enable back -json when used with -e/-f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,30 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-## Fixed
-- Go: fixed bug where using an ellipsis to stand for a list of key-value pairs w  would sometimes cause a parse error
-- Patterns like List(...) now correctly match against patterns in code
+### Added
+- New language Solidity with experimental support.
+- Scala: Patterns like List(...) now correctly match against patterns in code
 
-## Added
+### Fixed
+- Go: fixed bug where using an ellipsis to stand for a list of key-value pairs w  would sometimes cause a parse error
 - Scala: Translate definitions using patterns like `val List(x,y,z) = List(1,2,3)` to the generic AST
 - Allow name resolution on imported packages named just vN, where N is a number
+- The -json option in semgrep-core works again when used with -e/-f
+
+### Changed
 
 ## [0.76.2](https://github.com/returntocorp/semgrep/releases/tag/v0.76.2) - 12-08-2021
 
-### Added
-- New language Solidity with experimental support.
-
-## Fixed
+### Fixed
 - Python: set the right scope for comprehension variables (#4260)
 - Fixed bug where the presence of .semgrepignore would cause reported targets
   to have absolute instead of relative file paths
 
 ## [0.76.1](https://github.com/returntocorp/semgrep/releases/tag/v0.76.1) - 12-07-2021
 
-## Fixed
-- Fixed bug where the presence of .semgrepignore would cause runs to fail on files that
-  were not subpaths of the directory where semgrep was being run
+### Fixed
+- Fixed bug where the presence of .semgrepignore would cause runs to fail on
+  files that were not subpaths of the directory where semgrep was being run
 
 ## [0.76.0](https://github.com/returntocorp/semgrep/releases/tag/v0.76.0) - 12-06-2021
 


### PR DESCRIPTION
The ability got lost because of some previous tech-debt refactoring.
This restores it.

test plan:
make test and
```
$ semgrep-core -lang py -f tests/python/misc_comprehension.sgrep
tests/python/misc_comprehension.py -json
```
works again


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)