### PR TITLE
metavariable-comparison: Fix order of re.match arguments

### DIFF
--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -169,13 +169,13 @@ let rec eval env code =
                 FN (Id (("match", _), _)) );
           _;
         },
-        (_, [ G.Arg e1; G.Arg { e = G.L (G.String (re, _)); _ } ], _) ) -> (
+        (_, [ G.Arg { e = G.L (G.String (re, _)); _ }; G.Arg e2 ], _) ) -> (
       (* alt: take the text range of the metavariable in the original file,
        * and enforce e1 can only be an Id metavariable.
        * alt: let s = value_to_string v in
        * to convert anything in a string before using regexps on it
        *)
-      let v = eval env e1 in
+      let v = eval env e2 in
 
       match v with
       | String s ->

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -643,8 +643,8 @@ let rec filter_ranges env xs cond =
                    |> G.e,
                    ( fk,
                      [
-                       G.Arg (G.N (G.Id ((mvar, fk), fki)) |> G.e);
                        G.Arg (G.L (G.String (re_str, fk)) |> G.e);
+                       G.Arg (G.N (G.Id ((mvar, fk), fki)) |> G.e);
                      ],
                      fk ) )
                |> G.e

--- a/semgrep-core/tests/OTHER/eval/regexp.json
+++ b/semgrep-core/tests/OTHER/eval/regexp.json
@@ -3,5 +3,5 @@
     "$X": "0"
   },
   "language": "python",
-  "code": "re.match($X, '0|null|false')"
+  "code": "re.match('0|null|false', $X)"
 }

--- a/semgrep-core/tests/OTHER/eval/regexp2.json
+++ b/semgrep-core/tests/OTHER/eval/regexp2.json
@@ -3,5 +3,5 @@
     "$X": "sodium_crypto_generichash"
   },
   "language": "python",
-  "code": "re.match($X, '.*crypt|md5|md5_file|sha1|sha1_file|str_rot13')"
+  "code": "re.match('.*crypt|md5|md5_file|sha1|sha1_file|str_rot13', $X)"
 }

--- a/semgrep-core/tests/OTHER/eval/regexp3.json
+++ b/semgrep-core/tests/OTHER/eval/regexp3.json
@@ -3,5 +3,5 @@
     "$X": "sodium_crypto_generichash"
   },
   "language": "python",
-  "code": "re.match($X, '(?!crypt|md5|md5_file|sha1|sha1_file|str_rot13)')"
+  "code": "re.match('(?!crypt|md5|md5_file|sha1|sha1_file|str_rot13)', $X)"
 }

--- a/semgrep-core/tests/OTHER/rules/metavar_cond.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_cond.yaml
@@ -5,6 +5,6 @@ rules:
   match:
     and:
     - foo($ARG)
-    - where: re.match($ARG, ".*bar.*")
+    - where: re.match(".*bar.*", $ARG)
   message: rule_template_message
   severity: ERROR


### PR DESCRIPTION
The pattern is the first argument, the string is the second!
See https://docs.python.org/3/library/re.html#re.match

Hoping that this won't break many rules since I expect most users will
be using `metavariable-regex` for this.

Related to #4419 (potential workaround)

test plan:
make test # tests updated

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
