### PR TITLE
Log warning when a worker consumes too much memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Constant propagation is now a proper must-analysis, if a variable is undefined
   in some path then it will be considered as non-constant
 - Dataflow: Only consider reachable nodes, which prevents some FPs/FNs
+- semgrep-core will log a warning when a worker process is consuming above 400 MiB
+  of memory, or reached 80% of the specified memory limit, whatever happens first.
+  This is meant to help diagnosing OOM-related crashes.
 
 ## [0.76.2](https://github.com/returntocorp/semgrep/releases/tag/v0.76.2) - 12-08-2021
 

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -639,7 +639,7 @@ let main () =
 
   Setup_logging.setup config;
 
-  logger#info "Executed as: %s" (Sys.argv |> Array.to_list |> String.concat " ");
+  logger#info "Executed as: %s" (argv |> String.concat " ");
   logger#info "Version: %s" version;
   let config =
     if config.profile then (

--- a/semgrep-core/src/system/Memory_limit.ml
+++ b/semgrep-core/src/system/Memory_limit.ml
@@ -8,6 +8,8 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 let default_stack_warning_kb = 100
 
+let default_heap_warning_mb = 400
+
 (*
    Fail gracefully if memory becomes insufficient.
 
@@ -19,7 +21,7 @@ let default_stack_warning_kb = 100
 
 *)
 let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
-    ~mem_limit_mb f =
+    ?(heap_warning_mb = default_heap_warning_mb) ~mem_limit_mb f =
   if stack_warning_kb < 0 then
     invalid_arg
       (spf "run_with_memory_limit: negative argument stack_warning_kb %i"
@@ -33,6 +35,15 @@ let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
   let mem_limit = mem_limit_mb * mb in
   let stack_warning = stack_warning_kb * 1024 in
   let stack_already_warned = ref false in
+  let heap_warning =
+    (* If there is a memory limit, and we reach 80% of that limit, then we
+     * also warn. Whatever happens first. *)
+    let mem_limit_warning = int_of_float (float_of_int mem_limit *. 0.8) in
+    if mem_limit_mb = 0 || heap_warning_mb < mem_limit_warning then
+      heap_warning_mb * mb
+    else mem_limit_warning
+  in
+  let heap_already_warned = ref false in
   let limit_memory () =
     let stat = Gc.quick_stat () in
     let heap_bytes = stat.heap_words * (Sys.word_size / 8) in
@@ -43,6 +54,14 @@ let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
         "exceeded heap+stack memory limit: %d bytes (stack=%d, heap=%d)"
         mem_bytes stack_bytes heap_bytes;
       raise (ExceededMemoryLimit "Exceeded memory limit"))
+    else if
+      heap_warning > 0 && heap_bytes > heap_warning && not !heap_already_warned
+    then (
+      logger#warning
+        "large heap size: %d MiB (memory limit is %d MiB). If a crash follows, \
+         you could suspect OOM."
+        (heap_bytes / mb) mem_limit_mb;
+      heap_already_warned := true)
     else if
       stack_warning > 0
       && stack_bytes > stack_warning

--- a/semgrep-core/src/system/Memory_limit.mli
+++ b/semgrep-core/src/system/Memory_limit.mli
@@ -48,9 +48,11 @@
 
    Function parameters:
 
-   - stack_size_warning_mb: a warning will be printed if the stack size
-     is found to exceed this value (in MiB). This is often not detected
+   - stack_warning_kb: a warning will be printed if the stack size
+     is found to exceed this value (in KiB). This is often not detected
      early enough or at all if there's not enough allocation (GC activity).
+   - heap_warning_mb: a warning will be printed if the heap size
+     is found to exceed this value (in MiB).
    - mem_limit_mb: an 'Out_of_memory' exception will be raised if the
      combined heap+stack size is found to exceed this value (in MiB).
 
@@ -59,9 +61,14 @@
 
    Default values are the minimum values we're willing to support for
    semgrep-core:
-   - default stack_size_warning_mb: 100 KiB
+   - default stack_warning_kb: 100 KiB
+   - default heap_warning_mb: 500 MiB
 *)
 val run_with_memory_limit :
-  ?stack_warning_kb:int -> mem_limit_mb:int -> (unit -> 'a) -> 'a
+  ?stack_warning_kb:int ->
+  ?heap_warning_mb:int ->
+  mem_limit_mb:int ->
+  (unit -> 'a) ->
+  'a
 
 val default_stack_warning_kb : int


### PR DESCRIPTION
Also, log *all* the options passed to semgrep-core, including those
coming from environment variables.

test plan:
$ semgrep -c r/javascript --exclude="*.min.js" parsing-stats/lang/javascript/tmp/* --debug
^^^ This produces a total of three warnings.
$ semgrep --time -c r/javascript --exclude="*.min.js" lang/javascript/tmp/* --max-memory=500 --debug
^^^ This produces a total of two warnings.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
