### PR TITLE
Address several autofix output issues by adding per-file line/column offset tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Python and other languages: allow matches of patterns containing
   non-ascii characters, but still with possibly many false positives (#4336)
 - Java: parse correctly constructor method patterns (#4418)
+- Fix several line/column-related bugs in autofix results (#4428, #3577, #3338)
 
 ### Changed
 - Constant propagation is now a proper must-analysis, if a variable is undefined

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Python and other languages: allow matches of patterns containing
   non-ascii characters, but still with possibly many false positives (#4336)
 - Java: parse correctly constructor method patterns (#4418)
-- Fix several line/column-related bugs in autofix results (#4428, #3577, #3338)
+- Address several autofix output issues (#4428, #3577, #3338) by adding per-
+  file line/column offset tracking
 
 ### Changed
 - Constant propagation is now a proper must-analysis, if a variable is undefined

--- a/semgrep/semgrep/autofix.py
+++ b/semgrep/semgrep/autofix.py
@@ -22,6 +22,9 @@ class Fix:
 
 
 class FileOffsets:
+    """
+    Used to track state when applying multiple fixes to a single file/line.
+    """
     def __init__(self, line_offset: int, col_offset: int, active_line: int):
         self.line_offset = line_offset
         self.col_offset = col_offset

--- a/semgrep/semgrep/autofix.py
+++ b/semgrep/semgrep/autofix.py
@@ -25,6 +25,7 @@ class FileOffsets:
     """
     Used to track state when applying multiple fixes to a single file/line.
     """
+
     def __init__(self, line_offset: int, col_offset: int, active_line: int):
         self.line_offset = line_offset
         self.col_offset = col_offset

--- a/semgrep/semgrep/autofix.py
+++ b/semgrep/semgrep/autofix.py
@@ -23,7 +23,13 @@ class Fix:
 
 class FileOffsets:
     """
-    Used to track state when applying multiple fixes to a single file/line.
+    This object is used to track state when applying multiple fixes to the same
+    or subsequent lines in a single file.
+
+    The assumption and current state here is that fixes are applied top-to-
+    bottom and in a single pass; semgrep will not come back and re-parse or
+    re-fix a file or line. This approach may need to be revisited or extended
+    to support more complex overlapping autofix cases in future.
     """
 
     def __init__(self, line_offset: int, col_offset: int, active_line: int):

--- a/semgrep/tests/e2e/rules/autofix/java-string-wrap.yaml
+++ b/semgrep/tests/e2e/rules/autofix/java-string-wrap.yaml
@@ -1,0 +1,7 @@
+rules:
+- id: wrap-strings
+  pattern: (String $S)
+  message: Wrap strings
+  languages: [java]
+  severity: WARNING
+  fix: wrap($S)

--- a/semgrep/tests/e2e/rules/autofix/python-assert-statement.yaml
+++ b/semgrep/tests/e2e/rules/autofix/python-assert-statement.yaml
@@ -1,0 +1,8 @@
+rules:
+    - id: assert_eq-true
+      message: Change assert_eq(True, x) to assert x
+      severity: INFO
+      languages:
+      - python
+      pattern: assert_eq(True, $ACTUAL)
+      fix: assert $ACTUAL

--- a/semgrep/tests/e2e/rules/autofix/terraform-ec2-instance-metadata-options.yaml
+++ b/semgrep/tests/e2e/rules/autofix/terraform-ec2-instance-metadata-options.yaml
@@ -1,0 +1,27 @@
+rules:
+- id: ec2-instance-metadata-options
+  languages:
+  - terraform
+  message: EC2 instance does not set metadata options
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      resource "aws_instance" "$RESNAME" {
+      ...
+      }
+  - pattern-not-inside: |
+      resource "aws_instance" "..." {
+        ...
+        metadata_options {
+          ...
+        }
+        ...
+      }
+  fix-regex:
+    regex: (.*)\}
+    replacement: |
+      \1
+        metadata_options {
+          http_tokens = "required"
+        }
+      }

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java/autofix/java-string-wrap.java-fixed
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java/autofix/java-string-wrap.java-fixed
@@ -1,0 +1,5 @@
+public class C {
+    String f() {
+        return wrap("a") + wrap("b");
+    }
+}

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java/results.json
@@ -1,0 +1,87 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.autofix.wrap-strings",
+      "end": {
+        "col": 19,
+        "line": 3,
+        "offset": 52
+      },
+      "extra": {
+        "fix": "wrap(\"a\")",
+        "is_ignored": false,
+        "lines": "        return \"a\" + \"b\";",
+        "message": "Wrap strings",
+        "metadata": {},
+        "metavars": {
+          "$S": {
+            "abstract_content": "\"a\"",
+            "end": {
+              "col": 19,
+              "line": 3,
+              "offset": 52
+            },
+            "start": {
+              "col": 16,
+              "line": 3,
+              "offset": 49
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/autofix/java-string-wrap.java",
+      "start": {
+        "col": 16,
+        "line": 3,
+        "offset": 49
+      }
+    },
+    {
+      "check_id": "rules.autofix.wrap-strings",
+      "end": {
+        "col": 25,
+        "line": 3,
+        "offset": 58
+      },
+      "extra": {
+        "fix": "wrap(\"b\")",
+        "is_ignored": false,
+        "lines": "        return \"a\" + \"b\";",
+        "message": "Wrap strings",
+        "metadata": {},
+        "metavars": {
+          "$S": {
+            "abstract_content": "\"b\"",
+            "end": {
+              "col": 25,
+              "line": 3,
+              "offset": 58
+            },
+            "start": {
+              "col": 22,
+              "line": 3,
+              "offset": 55
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/autofix/java-string-wrap.java",
+      "start": {
+        "col": 22,
+        "line": 3,
+        "offset": 55
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py/autofix/python-assert-statement.py-fixed
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py/autofix/python-assert-statement.py-fixed
@@ -1,0 +1,3 @@
+assert "a"
+assert "b"
+x = "abc"

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py/results.json
@@ -1,0 +1,87 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.autofix.assert_eq-true",
+      "end": {
+        "col": 2,
+        "line": 3,
+        "offset": 26
+      },
+      "extra": {
+        "fix": "assert \"a\"",
+        "is_ignored": false,
+        "lines": "assert_eq(\n    True, \"a\"\n)",
+        "message": "Change assert_eq(True, x) to assert x",
+        "metadata": {},
+        "metavars": {
+          "$ACTUAL": {
+            "abstract_content": "\"a\"",
+            "end": {
+              "col": 14,
+              "line": 2,
+              "offset": 24
+            },
+            "start": {
+              "col": 11,
+              "line": 2,
+              "offset": 21
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/autofix/python-assert-statement.py",
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0
+      }
+    },
+    {
+      "check_id": "rules.autofix.assert_eq-true",
+      "end": {
+        "col": 2,
+        "line": 6,
+        "offset": 53
+      },
+      "extra": {
+        "fix": "assert \"b\"",
+        "is_ignored": false,
+        "lines": "assert_eq(\n    True, \"b\"\n)",
+        "message": "Change assert_eq(True, x) to assert x",
+        "metadata": {},
+        "metavars": {
+          "$ACTUAL": {
+            "abstract_content": "\"b\"",
+            "end": {
+              "col": 14,
+              "line": 5,
+              "offset": 51
+            },
+            "start": {
+              "col": 11,
+              "line": 5,
+              "offset": 48
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "targets/autofix/python-assert-statement.py",
+      "start": {
+        "col": 1,
+        "line": 4,
+        "offset": 27
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl/autofix/terraform-ec2-instance-metadata-options.hcl-fixed
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl/autofix/terraform-ec2-instance-metadata-options.hcl-fixed
@@ -1,0 +1,17 @@
+resource "aws_instance" "example1" {
+  ami           = "ami-005e54dee72cc1d01"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_tokens = "required"
+  }
+}
+
+resource "aws_instance" "example2" {
+  ami           = "ami-005e54dee72cc1d02"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_tokens = "required"
+  }
+}

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_regex_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl/results.json
@@ -1,0 +1,93 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.autofix.ec2-instance-metadata-options",
+      "end": {
+        "col": 2,
+        "line": 4,
+        "offset": 109
+      },
+      "extra": {
+        "fix_regex": {
+          "regex": "(.*)\\}",
+          "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
+        },
+        "is_ignored": false,
+        "lines": "resource \"aws_instance\" \"example1\" {\n  ami           = \"ami-005e54dee72cc1d01\"\n  instance_type = \"t2.micro\"\n}",
+        "message": "EC2 instance does not set metadata options",
+        "metadata": {},
+        "metavars": {
+          "$RESNAME": {
+            "abstract_content": "example1",
+            "end": {
+              "col": 34,
+              "line": 1,
+              "offset": 33
+            },
+            "start": {
+              "col": 26,
+              "line": 1,
+              "offset": 25
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/autofix/terraform-ec2-instance-metadata-options.hcl",
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0
+      }
+    },
+    {
+      "check_id": "rules.autofix.ec2-instance-metadata-options",
+      "end": {
+        "col": 2,
+        "line": 9,
+        "offset": 220
+      },
+      "extra": {
+        "fix_regex": {
+          "regex": "(.*)\\}",
+          "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
+        },
+        "is_ignored": false,
+        "lines": "resource \"aws_instance\" \"example2\" {\n  ami           = \"ami-005e54dee72cc1d02\"\n  instance_type = \"t2.micro\"\n}",
+        "message": "EC2 instance does not set metadata options",
+        "metadata": {},
+        "metavars": {
+          "$RESNAME": {
+            "abstract_content": "example2",
+            "end": {
+              "col": 34,
+              "line": 6,
+              "offset": 144
+            },
+            "start": {
+              "col": 26,
+              "line": 6,
+              "offset": 136
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/autofix/terraform-ec2-instance-metadata-options.hcl",
+      "start": {
+        "col": 1,
+        "line": 6,
+        "offset": 111
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/targets/autofix/java-string-wrap.java
+++ b/semgrep/tests/e2e/targets/autofix/java-string-wrap.java
@@ -1,0 +1,5 @@
+public class C {
+    String f() {
+        return "a" + "b";
+    }
+}

--- a/semgrep/tests/e2e/targets/autofix/python-assert-statement.py
+++ b/semgrep/tests/e2e/targets/autofix/python-assert-statement.py
@@ -1,0 +1,7 @@
+assert_eq(
+    True, "a"
+)
+assert_eq(
+    True, "b"
+)
+x = "abc"

--- a/semgrep/tests/e2e/targets/autofix/terraform-ec2-instance-metadata-options.hcl
+++ b/semgrep/tests/e2e/targets/autofix/terraform-ec2-instance-metadata-options.hcl
@@ -1,0 +1,9 @@
+resource "aws_instance" "example1" {
+  ami           = "ami-005e54dee72cc1d01"
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "example2" {
+  ami           = "ami-005e54dee72cc1d02"
+  instance_type = "t2.micro"
+}

--- a/semgrep/tests/e2e/test_autofix.py
+++ b/semgrep/tests/e2e/test_autofix.py
@@ -44,6 +44,15 @@ def test_autofix(run_semgrep_in_tmp, snapshot):
             "rules/autofix/django-none-password-default.yaml",
             "autofix/django-none-password-default.py",
         ),
+        (
+            "rules/autofix/terraform-ec2-instance-metadata-options.yaml",
+            "autofix/terraform-ec2-instance-metadata-options.hcl",
+        ),
+        (
+            "rules/autofix/python-assert-statement.yaml",
+            "autofix/python-assert-statement.py",
+        ),
+        ("rules/autofix/java-string-wrap.yaml", "autofix/java-string-wrap.java"),
     ],
 )
 def test_regex_autofix(run_semgrep_in_tmp, snapshot, rule, target):


### PR DESCRIPTION
This change addresses several autofix-related issues by adding per-file line/column offset tracking, and using those offsets when making edits to files.

There is no change in usage or documentation; it just addresses several edge cases within the existing autofix implementation (multi-line fixes, multiple-fixes-in-one-line fixes) that were not cleanly handled until now.

This should address several open issues; https://github.com/returntocorp/semgrep/issues/4428, https://github.com/returntocorp/semgrep/issues/3577, and https://github.com/returntocorp/semgrep/issues/3388.

It adds several new e2e tests with rules/targets based on the issues above, and passes the existing tests in `tests/e2e/test_autofix.py` on my local machine.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)