### PR TITLE
simplifying test file and refactoring

### DIFF
--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -68,41 +68,6 @@ def normalize_rule_ids(line: str) -> Set[str]:
     return set(filter(None, [rule.strip() for rule in rules_clean]))
 
 
-def compute_confusion_matrix(
-    reported: Set[Any], expected: Set[Any], oked: Set[Any]
-) -> Tuple[int, int, int, int]:
-    true_positives = len(expected.intersection(reported))
-    false_positives = len(reported - expected)
-    true_negatives = len(oked)
-    false_negatives = len(expected - reported)
-
-    return (true_positives, true_negatives, false_positives, false_negatives)
-
-
-def _test_compute_confusion_matrix() -> None:
-    tp, tn, fp, fn = compute_confusion_matrix(set([1, 2, 3, 4]), set([1]), set())
-    assert tp == 1
-    assert tn == 0
-    assert fp == 3
-    assert fn == 0
-
-    tp, tn, fp, fn = compute_confusion_matrix(
-        set([1, 2, 3, 4]), set([1, 2, 3, 4]), set([1])
-    )
-    assert tp == 4
-    assert tn == 1
-    assert fp == 0
-    assert fn == 0
-
-    tp, tn, fp, fn = compute_confusion_matrix(
-        set([2, 3]), set([1, 2, 3, 4]), set([7, 8])
-    )
-    assert tp == 2
-    assert tn == 2
-    assert fp == 0
-    assert fn == 2
-
-
 def _annotations(annotation: str) -> Set[str]:
     # returns something like: {"#ruleid:", "# ruleid:", "//ruleid:", ...}
     return {
@@ -131,9 +96,40 @@ def line_has_todo_ok(line: str) -> bool:
     return any(annotation in line for annotation in rule_annotations)
 
 
-def score_output_json(
-    json_out: Dict[str, Any], test_files: List[Path], ignore_todo: bool
-) -> Tuple[Dict[str, List[int]], Dict[str, Dict[str, Any]], int]:
+def add_line_to_dict_of_ruleids(
+    rule_ids: Set[str],
+    line_dict: Dict[str, Dict[str, List[int]]],
+    effective_line_num: int,
+    test_file_resolved: str,
+) -> None:
+    for rule_id in rule_ids:
+        line_dict[test_file_resolved][rule_id].append(effective_line_num)
+
+
+def check_rule_id_mismatch(
+    reported_lines: Dict[str, Dict[str, List[int]]], test_lines: Dict[str, Set]
+) -> None:
+    rule_id_mismatch = False
+    if reported_lines:
+        for file_path, test_ids in test_lines.items():
+            reported_ids = set(reported_lines[file_path].keys())
+            if test_ids.symmetric_difference(reported_ids):
+                test_id_no_reported_ids = test_ids - reported_ids
+                logger.error(
+                    f"Found rule id mismatch - file={file_path} 'ruleid' annotation with no YAML rule={test_id_no_reported_ids}"
+                )
+                rule_id_mismatch = True
+
+    if rule_id_mismatch:
+        logger.error(
+            "Failing due to rule id mismatch. There is a test denoted with 'ruleid: <rule name>' where the rule name does not exist or is not expected in the test file."
+        )
+        sys.exit(EXIT_FAILURE)
+
+
+def get_expected_and_reported_lines(
+    json_out: Dict[str, Any], test_files: List[Path]
+) -> Dict[str, Dict[str, Any]]:
     ruleid_lines: Dict[str, Dict[str, List[int]]] = collections.defaultdict(
         lambda: collections.defaultdict(list)
     )
@@ -149,11 +145,8 @@ def score_output_json(
     todo_ruleid_lines: Dict[str, Dict[str, List[int]]] = collections.defaultdict(
         lambda: collections.defaultdict(list)
     )
-    score_by_checkid: Dict[str, List[int]] = collections.defaultdict(
-        lambda: [0, 0, 0, 0]
-    )
+
     matches_by_check_id: Dict[str, Dict[str, Any]] = collections.defaultdict(dict)
-    num_todo = 0
 
     for test_file in test_files:
         test_file_resolved = str(test_file.resolve())
@@ -166,7 +159,6 @@ def score_output_json(
             ok_in_line = line_has_ok(line)
             todo_rule_in_line = line_has_todo_rule(line)
             todo_ok_in_line = line_has_todo_ok(line)
-            num_todo += int(todo_rule_in_line) + int(todo_ok_in_line)
 
             has_parseable_rule_id = (
                 rule_in_line or todo_rule_in_line or ok_in_line or todo_ok_in_line
@@ -176,24 +168,25 @@ def score_output_json(
                 if not has_parseable_rule_id:
                     continue
                 rule_ids = normalize_rule_ids(line)
-                if (not ignore_todo and todo_rule_in_line) or rule_in_line:
-                    for rule_id in rule_ids:
-                        ruleid_lines[test_file_resolved][rule_id].append(
-                            effective_line_num
-                        )
-                if (not ignore_todo and todo_rule_in_line) or ok_in_line:
-                    for rule_id in rule_ids:
-                        ok_lines[test_file_resolved][rule_id].append(effective_line_num)
-                if ignore_todo and todo_ok_in_line:
-                    for rule_id in rule_ids:
-                        todo_ok_lines[test_file_resolved][rule_id].append(
-                            effective_line_num
-                        )
+                if todo_rule_in_line or rule_in_line:
+                    add_line_to_dict_of_ruleids(
+                        rule_ids, ruleid_lines, effective_line_num, test_file_resolved
+                    )
+                if todo_rule_in_line or ok_in_line:
+                    add_line_to_dict_of_ruleids(
+                        rule_ids, ok_lines, effective_line_num, test_file_resolved
+                    )
+                if todo_ok_in_line:
+                    add_line_to_dict_of_ruleids(
+                        rule_ids, todo_ok_lines, effective_line_num, test_file_resolved
+                    )
                 if todo_rule_in_line:
-                    for rule_id in rule_ids:
-                        todo_ruleid_lines[test_file_resolved][rule_id].append(
-                            effective_line_num
-                        )
+                    add_line_to_dict_of_ruleids(
+                        rule_ids,
+                        todo_ruleid_lines,
+                        effective_line_num,
+                        test_file_resolved,
+                    )
             except ValueError:  # comment looked like a test annotation but couldn't parse
                 logger.warning(
                     f"Could not parse {line} as a test annotation in file {test_file_resolved}. Skipping this line"
@@ -211,78 +204,44 @@ def score_output_json(
         for file_path, test_annotations in lines.items():
             test_lines[file_path].update(test_annotations.keys())
 
-    rule_id_mismatch = False
-    if reported_lines:
-        for file_path, test_ids in test_lines.items():
-            reported_ids = set(reported_lines[file_path].keys())
-            if test_ids.symmetric_difference(reported_ids):
-                logger.error(
-                    f"found rule id mismatch - file={file_path} results={reported_ids} expected={test_ids}"
-                )
-                rule_id_mismatch = True
-
-    if rule_id_mismatch:
-        logger.error("failing due to rule id mismatch")
-        sys.exit(EXIT_FAILURE)
+    check_rule_id_mismatch(reported_lines, test_lines)
 
     def join_keys(a: Dict[str, Any], b: Dict[str, Any]) -> Set[str]:
         return set(a.keys()).union(set(b.keys()))
 
-    false_positive_lines = False
     for file_path in join_keys(ruleid_lines, reported_lines):
         for check_id in join_keys(ruleid_lines[file_path], reported_lines[file_path]):
             all_reported = set(reported_lines[file_path][check_id])
             expected = set(ruleid_lines[file_path][check_id])
-            oked = set(ok_lines[file_path][check_id])
             todo_oked = set(todo_ok_lines[file_path][check_id])
             todo_ruleid = set(todo_ruleid_lines[file_path][check_id])
 
-            reported_oked_lines = oked.intersection(all_reported)
-            if reported_oked_lines:
-                logger.error(
-                    f"found false positives on ok'ed lines - file={file_path} fps={reported_oked_lines}"
-                )
-                false_positive_lines = True
-
             reported = all_reported - todo_oked - todo_ruleid
 
-            new_cm = compute_confusion_matrix(reported, expected, oked)
             matches_by_check_id[check_id][file_path] = {
                 "expected_lines": sorted(expected),
                 "reported_lines": sorted(reported),
             }
-            old_cm = score_by_checkid[check_id]
-            score_by_checkid[check_id] = [
-                old_cm[i] + new_cm[i] for i in range(len(new_cm))
-            ]
 
-    return (score_by_checkid, matches_by_check_id, num_todo)
-
-
-def generate_confusion_string(check_results: Mapping[str, Any]) -> str:
-    confusion_tp = f"TP: {check_results['tp']}"
-    confusion_tn = f"TN: {check_results['tn']}"
-    confusion_fp = f"FP: {check_results['fp']}"
-    confusion_fn = f"FN: {check_results['fn']}"
-    return f"{confusion_tp} {confusion_tn} {confusion_fp} {confusion_fn}"
+    return matches_by_check_id
 
 
 def generate_check_output_line(check_id: str, check_results: Mapping[str, Any]) -> str:
-    status = "✔" if check_results["passed"] else "✖"
-    return f"\t{status} {check_id.ljust(60)} {generate_confusion_string(check_results)}"
-
-
-def generate_matches_line(check_results: Mapping[str, Any]) -> str:
-    def _generate_line(test_file: Any, matches: Mapping[str, Any]) -> str:
-        test = f"test: {test_file}"
+    def _generate_expected_vs_reported_lines(matches: Mapping[str, Any]) -> str:
         expected = f"expected lines: {matches['expected_lines']}"
         reported = f"reported lines: {matches['reported_lines']}"
-        return f"{test}, {expected}, {reported}"
+        return f"{expected}, {reported}"
 
-    return "\t" + "\t\n".join(
-        _generate_line(test_file, matches)
-        for test_file, matches in check_results["matches"].items()
+    expected_vs_reported_lines = "\t\n".join(
+        _generate_expected_vs_reported_lines(matches)
+        for _, matches in check_results["matches"].items()
     )
+
+    test_file_names = " ".join(
+        test_file for test_file, _ in check_results["matches"].items()
+    )
+
+    return f"\t✖ {check_id.ljust(60)} {expected_vs_reported_lines} \n\t test file path: {test_file_names}"
 
 
 def invoke_semgrep_multi(
@@ -341,11 +300,20 @@ def get_config_test_filenames(
     }
 
 
-def generate_file_pairs(
+def checkid_passed(matches_for_checkid: Dict[str, Any]) -> bool:
+    for _filename, expected_and_reported_lines in matches_for_checkid.items():
+        if (
+            not expected_and_reported_lines["expected_lines"]
+            == expected_and_reported_lines["reported_lines"]
+        ):
+            return False
+    return True
+
+
+def generate_test_results(
     *,
     target: Path,
     config: Path,
-    ignore_todo: bool,
     strict: bool,
     json_output: bool,
     save_test_output_tar: bool = True,
@@ -375,28 +343,23 @@ def generate_file_pairs(
     ]
 
     tested = {
-        filename: score_output_json(
-            output, config_test_filenames[filename], ignore_todo
+        filename: get_expected_and_reported_lines(
+            output, config_test_filenames[filename]
         )
         for filename, _, output in config_without_errors
     }
 
     results_output: Mapping[str, Mapping[str, Any]] = {
         str(filename): {
-            "todo": todo,
             "checks": {
                 check_id: {
-                    "tp": tp,
-                    "tn": tn,
-                    "fp": fp,
-                    "fn": fn,
-                    "passed": (fp == 0) and (fn == 0),
-                    "matches": matches[check_id],
+                    "passed": checkid_passed(filename_and_matches),
+                    "matches": filename_and_matches,
                 }
-                for check_id, (tp, tn, fp, fn) in output.items()
-            },
+                for check_id, filename_and_matches in matches.items()
+            }
         }
-        for filename, (output, matches, todo) in tested.items()
+        for filename, matches in tested.items()
     }
 
     output = {
@@ -429,11 +392,25 @@ def generate_file_pairs(
         with tarfile.open(SAVE_TEST_OUTPUT_TAR, "w:gz") as tar:
             tar.add(SAVE_TEST_OUTPUT_JSON)
 
-    if config_missing_tests_output:
-        print("The following config files are missing tests:")
-        print("\t" + "\n\t".join(config_missing_tests_output))
+    all_tests_passed: bool = True
+    check_output_lines: str = ""
+    for _filename, rr in results_output.items():
+        for check_id, check_results in sorted(rr["checks"].items()):
+            if not check_results["passed"]:
+                all_tests_passed = False
+                check_output_lines += generate_check_output_line(
+                    check_id, check_results
+                )
+
+    if all_tests_passed:
+        print("✓ All tests passed!")
+    else:
+        print("The following unit tests did not pass:")
+        print(BREAK_LINE)
+        print(check_output_lines)
 
     if config_with_errors_output:
+        print(BREAK_LINE)
         print("The following config files produced errors:")
         print(
             "\t"
@@ -441,35 +418,6 @@ def generate_file_pairs(
                 f"{c['filename']}: {c['error']}" for c in config_with_errors_output
             )
         )
-
-    # Place failed and TODO tests at the bottom for higher visibility
-    passed_results_first = collections.OrderedDict(
-        sorted(
-            results_output.items(),
-            key=lambda t: any(
-                not c["passed"] or t[1]["todo"] for c in t[1]["checks"].values()
-            ),
-        )
-    )
-
-    print(f"{len(tested)} yaml files tested")
-    print("check id scoring:")
-    print(BREAK_LINE)
-
-    totals: Dict[str, Any] = collections.defaultdict(int)
-
-    for filename, rr in passed_results_first.items():
-        print(f"(TODO: {rr['todo']}) {filename}")
-        for check_id, check_results in sorted(rr["checks"].items()):
-            print(generate_check_output_line(check_id, check_results))
-            if not check_results["passed"]:
-                print(generate_matches_line(check_results))
-            for confusion in ["tp", "tn", "fp", "fn"]:
-                totals[confusion] += check_results[confusion]
-
-    print(BREAK_LINE)
-    print(f"final confusion matrix: {generate_confusion_string(totals)}")
-    print(BREAK_LINE)
 
     sys.exit(exit_code)
 
@@ -484,7 +432,6 @@ def test_main(
     save_test_output_tar: bool,
     optimizations: str,
 ) -> None:
-    _test_compute_confusion_matrix()
 
     if len(target) != 1:
         raise Exception("only one target directory allowed for tests")
@@ -497,10 +444,9 @@ def test_main(
     else:
         config_path = target_path
 
-    generate_file_pairs(
+    generate_test_results(
         target=target_path,
         config=config_path,
-        ignore_todo=test_ignore_todo,
         strict=strict,
         json_output=json,
         save_test_output_tar=save_test_output_tar,

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -217,6 +217,7 @@ def get_expected_and_reported_lines(
             todo_ruleid = set(todo_ruleid_lines[file_path][check_id])
 
             reported = all_reported - todo_oked - todo_ruleid
+            expected = expected - todo_ruleid - todo_oked
 
             matches_by_check_id[check_id][file_path] = {
                 "expected_lines": sorted(expected),
@@ -241,7 +242,7 @@ def generate_check_output_line(check_id: str, check_results: Mapping[str, Any]) 
         test_file for test_file, _ in check_results["matches"].items()
     )
 
-    return f"\t✖ {check_id.ljust(60)} {expected_vs_reported_lines} \n\t test file path: {test_file_names}"
+    return f"\t✖ {check_id.ljust(60)} {expected_vs_reported_lines} \n\t test file path: {test_file_names}\n\n"
 
 
 def invoke_semgrep_multi(

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_basic/results.json
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_basic/results.json
@@ -5,15 +5,10 @@
     "rules/cli_test/basic/basic.yaml": {
       "checks": {
         "basic-test": {
-          "fn": 0,
-          "fp": 0,
           "matches": "<masked in tests>",
-          "passed": true,
-          "tn": 0,
-          "tp": 1
+          "passed": true
         }
-      },
-      "todo": 0
+      }
     }
   }
 }

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_multiline_annotations/results.json
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_multiline_annotations/results.json
@@ -1,9 +1,1 @@
-1 yaml files tested
-check id scoring:
---------------------------------------------------------------------------------
-(TODO: 0) rules/cli_test/multiple_annotations/multiple-annotations.yaml
-	✔ basic-test                                                   TP: 1 TN: 0 FP: 0 FN: 0
-	✔ silly-test                                                   TP: 1 TN: 0 FP: 0 FN: 0
---------------------------------------------------------------------------------
-final confusion matrix: TP: 2 TN: 0 FP: 0 FN: 0
---------------------------------------------------------------------------------
+✓ All tests passed!

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_suffixes/results.json
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_suffixes/results.json
@@ -5,15 +5,10 @@
     "rules/cli_test/suffixes/this.that.check.yaml": {
       "checks": {
         "basic-test": {
-          "fn": 0,
-          "fp": 0,
           "matches": "<masked in tests>",
-          "passed": true,
-          "tn": 0,
-          "tp": 1
+          "passed": true
         }
-      },
-      "todo": 0
+      }
     }
   }
 }

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_yaml_language/results.json
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_yaml_language/results.json
@@ -5,15 +5,10 @@
     "rules/cli_test/language/yaml_language.yaml": {
       "checks": {
         "yaml-language": {
-          "fn": 0,
-          "fp": 0,
           "matches": "<masked in tests>",
-          "passed": true,
-          "tn": 0,
-          "tp": 1
+          "passed": true
         }
-      },
-      "todo": 0
+      }
     }
   }
 }


### PR DESCRIPTION
This PR:
* refactors test file
* removes the functionality to compute matrix of tn, fn, tp, fp
* removes todo output functionality
* improves error output for ruleid and rule mismatches

_To Test:_
* run `semgrep --test --strict --quiet .` in `semgrep-rules`.

_Test Output:_
For directories that pass:
<img width="616" alt="Screen Shot 2021-12-13 at 5 59 37 PM" src="https://user-images.githubusercontent.com/23181670/146097649-9cea0e25-9acb-46b9-ad5c-fc25854944b1.png">

For directories with errors:
<img width="942" alt="Screen Shot 2021-12-15 at 5 29 15 PM" src="https://user-images.githubusercontent.com/23181670/146280844-3872feb9-fb8b-4420-aa68-3e98bcfb12fc.png">

_Note:_
* this will not affect the output of the `semgrep_runs_output.tar.gz` file used to highlight the results in the `semgrep-app` registry. This is because `semgrep_runs_output.tar.gz` output is based on the `results` dictionary, which is not touched by these changes. So our later upgrades to this file will not cause the registry to have no highlights 👍 

Link for more thorough test file output outline: https://r2c.quip.com/hESGAvfkaHIv/Proposal-for-test-output