### PR TITLE
Prepare semgrep-core to accept all rules

### DIFF
--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -52,12 +52,11 @@ val exn_to_error : Common.filename -> exn -> Semgrep_error_code.error
 *)
 
 val files_of_roots :
-  Xlang.t option ->
+  Runner_common.config ->
   Common.path list ->
   Common.filename list * Semgrep_core_response_j.skipped_target list
 (**
-  Small wrapper over Find_target.files_of_dirs_or_files to handle
-  also Xlang.t (LRegex and LGeneric)
+  Small wrapper over Find_target.files_of_dirs_or_files
  *)
 
 val filter_files_with_too_many_matches_and_transform_as_timeout :

--- a/semgrep-core/src/targeting/Find_target.ml
+++ b/semgrep-core/src/targeting/Find_target.ml
@@ -1,5 +1,9 @@
 (*
    Find and filter targets.
+
+   TODO: note that some of the functions below are also present in
+   semgrep-python so we might want to move all file-targeting in one
+   place.
 *)
 
 module Resp = Semgrep_core_response_t

--- a/semgrep-core/src/targeting/Find_target.mli
+++ b/semgrep-core/src/targeting/Find_target.mli
@@ -1,6 +1,5 @@
 (*
-   Find target files suitable to be analyzed by semgrep, assuming a given
-   language.
+   Find target files suitable to be analyzed by semgrep.
 *)
 
 (*

--- a/semgrep-core/src/targeting/Skip_target.ml
+++ b/semgrep-core/src/targeting/Skip_target.ml
@@ -1,5 +1,9 @@
 (*
    Filter targets.
+
+   TODO: note that some of the functions below are also present in
+   semgrep-python so we might want to move all file-filtering in one
+   place.
 *)
 open Common
 module Resp = Semgrep_core_response_t


### PR DESCRIPTION
This PR adds the ability for semgrep-core to accept a -config
without a -lang.

test plan:
```
$ semgrep-core -debug -config <(curl https://semgrep.dev/c/p/ci)
tests/OTHER/rules/
...
/home/pad/yy/tests/OTHER/rules/spacegrep_metavarbug.dockerfile:4 with rule generic.dockerfile.correctness.multiple-cmd-instructions.multiple-cmd-instructions
 CMD ["/hello"]
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)