### PR TITLE
Report lexical errors as code 3

### DIFF
--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -148,7 +148,9 @@ class CoreError:
 
     def to_semgrep_error(self, rule_id: RuleId) -> SemgrepCoreError:
         # TODO benchmarking code relies on error code value right now
-        if self.error_type == CoreErrorType("Syntax error"):
+        if self.error_type == CoreErrorType(
+            "Syntax error"
+        ) or self.error_type == CoreErrorType("Lexical error"):
             code = 3
         else:
             code = 2

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -148,6 +148,7 @@ class CoreError:
 
     def to_semgrep_error(self, rule_id: RuleId) -> SemgrepCoreError:
         # TODO benchmarking code relies on error code value right now
+        # See https://semgrep.dev/docs/cli-usage/ for meaning of codes
         if self.error_type == CoreErrorType(
             "Syntax error"
         ) or self.error_type == CoreErrorType("Lexical error"):


### PR DESCRIPTION
We use code 3 to denote parse errors. While lexical errors are not parse errors in semgrep-core, to the user (and our benchmarking code) they are still errors encountered while parsing. Code 2 denotes a failure

TODO: understand how these error codes actually translate to semgrep exit status

This should fix our failing benchmark in CircleCI

PR checklist:
- [x] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
