### PR TITLE
feat(config): run semgrep.dev policy locally

### DIFF
--- a/semgrep/semgrep/commands/login.py
+++ b/semgrep/semgrep/commands/login.py
@@ -55,7 +55,7 @@ class Authentication:
 
         headers = {"User-Agent": SEMGREP_USER_AGENT, "Authorization": f"Bearer {token}"}
         r = requests.get(
-            f"{SEMGREP_URL}/api/agent/deployment", timeout=10, headers=headers
+            f"{SEMGREP_URL}api/agent/deployment", timeout=10, headers=headers
         )
         return r.ok
 

--- a/semgrep/semgrep/commands/login.py
+++ b/semgrep/semgrep/commands/login.py
@@ -60,6 +60,22 @@ class Authentication:
         return r.ok
 
     @staticmethod
+    def get_deployment_id() -> Optional[int]:
+        """
+        Returns the deployment_id attached to an api_token as int
+        """
+        import requests
+
+        token = Authentication.get_token()
+
+        headers = {"User-Agent": SEMGREP_USER_AGENT, "Authorization": f"Bearer {token}"}
+        r = requests.get(
+            f"{SEMGREP_URL}api/agent/deployment", timeout=10, headers=headers
+        )
+        data = r.json()
+        return data.get("deployment").get("id")  # type: ignore
+
+    @staticmethod
     def get_token() -> Optional[str]:
         """
         Get saved token in following order:

--- a/semgrep/semgrep/commands/login.py
+++ b/semgrep/semgrep/commands/login.py
@@ -63,6 +63,8 @@ class Authentication:
     def get_deployment_id() -> Optional[int]:
         """
         Returns the deployment_id attached to an api_token as int
+
+        Returns None if api_token is invalid/doesn't have associated deployment
         """
         import requests
 
@@ -73,7 +75,7 @@ class Authentication:
             f"{SEMGREP_URL}api/agent/deployment", timeout=10, headers=headers
         )
         data = r.json()
-        return data.get("deployment").get("id")  # type: ignore
+        return data.get("deployment", {}).get("id")  # type: ignore
 
     @staticmethod
     def get_token() -> Optional[str]:

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -207,7 +207,9 @@ class ConfigPath:
         headers = {"User-Agent": SEMGREP_USER_AGENT, **(self._extra_headers or {})}
 
         token = Authentication.get_token()
-        if token:
+        # For now c/p endpoint fails with auth so only add it for policy
+        if token and "api/agent/deployment" in config_url:
+            logger.verbose("Using token")
             headers["Authorization"] = f"Bearer {token}"
 
         r = requests.get(config_url, stream=True, headers=headers, timeout=20)

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -567,6 +567,12 @@ def url_for_policy(config_str: str) -> str:
     Set SEMGREP_POLICY_INCLUDE_CAI env var to include CAI Rules
     """
     deployment_id = Authentication.get_deployment_id()
+
+    if deployment_id is None:
+        raise SemgrepError(
+            "Invalid API Key. Run `semgrep logout` and `semgrep login` again."
+        )
+
     repo_name = os.environ.get("SEMGREP_REPO_NAME")
     include_cai = os.environ.get("SEMGREP_POLICY_INCLUDE_CAI")
 

--- a/semgrep/tests/e2e/test_login.py
+++ b/semgrep/tests/e2e/test_login.py
@@ -8,16 +8,23 @@ from semgrep.constants import SEMGREP_SETTING_ENVVAR_NAME
 
 
 def test_login(tmp_path):
-    runner = CliRunner()
+    runner = CliRunner(env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)})
 
     # Patch Token Validation:
     with patch.object(Authentication, "is_valid_token", return_value=True):
+        # Logout
+        result = runner.invoke(
+            cli,
+            ["logout"],
+        )
+        assert result.exit_code == 0
+        assert result.output == "logged out\n"
+
         # Login
         result = runner.invoke(
             cli,
             ["login"],
             input="key123",
-            env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)},
         )
         print(result.output)
         assert result.exit_code == 0
@@ -25,21 +32,66 @@ def test_login(tmp_path):
 
         # Login should fail on second call
         result = runner.invoke(
-            cli, ["login"], env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)}
+            cli,
+            ["login"],
         )
         assert result.exit_code == 1
         assert "API token already exists in" in result.output
 
         # Clear login
         result = runner.invoke(
-            cli, ["logout"], env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)}
+            cli,
+            ["logout"],
         )
         assert result.exit_code == 0
         assert result.output == "logged out\n"
 
         # Logout twice should work
         result = runner.invoke(
-            cli, ["logout"], env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)}
+            cli,
+            ["logout"],
         )
         assert result.exit_code == 0
         assert result.output == "logged out\n"
+
+        # Check registry config works while logged in
+        # Login
+        result = runner.invoke(
+            cli,
+            ["login"],
+            input="key123",
+        )
+        print(result.output)
+        assert result.exit_code == 0
+        assert "Valid API Token saved in" in result.output
+
+        # Run p/ci
+        result = runner.invoke(
+            cli,
+            ["--config", "r/python.lang.correctness.useless-eqeq.useless-eqeq"],
+        )
+        assert result.exit_code == 0
+
+        # Run policy with bad token -> no associated deployment_id
+        result = runner.invoke(cli, ["--config", "policy"])
+        assert result.exit_code == 1
+        assert "Invalid API Key" in result.output
+
+        with patch.object(Authentication, "get_deployment_id", return_value=1):
+            # Run policy without SEMGREP_REPO_NAME
+            result = runner.invoke(
+                cli,
+                ["--config", "policy"],
+            )
+            assert result.exit_code == 1
+            assert "Need to set env var SEMGREP_REPO_NAME" in result.output
+
+            # Run policy. Check that request is made to correct deployment + org/repo
+            result = runner.invoke(
+                cli, ["--config", "policy"], env={"SEMGREP_REPO_NAME": "org/repo"}
+            )
+            assert result.exit_code == 1
+            assert (
+                "https://semgrep.dev/api/agent/deployment/1/repos/org/repo/rules.yaml"
+                in result.output
+            )


### PR DESCRIPTION
With this PR semgrep is able to run policies configured on semgrep.dev

```
semgrep login
SEMGREP_REPO_NAME=returntocorp/semgrep semgrep --config policy
```

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
