### PR TITLE
Allow jsonschema version 4 to be used by Semgrep

### DIFF
--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -121,7 +121,7 @@ install_requires = [
     "ruamel.yaml>=0.16.0,<0.18",
     "tqdm>=4.46.1",
     "packaging>=20.4",
-    "jsonschema~=3.2.0",
+    "jsonschema>=3.2.0,<5",
     "wcmatch==8.3",
     "peewee~=3.14.4",
     # Include 'setuptools' for 'pkg_resources' usage. We shouldn't be


### PR DESCRIPTION
This broader constraint is similar to the one done for ruamel.yaml.  It should make it easier for Semgrep to coexist with other tools depending on jsonschema.

Looking at the jsonschema changelog for version 4.0.0, it doesn't look like any breaking change was introduced by that version.  I was also able to run Semgrep fine with version 4.3.2 of jsonschema but I can't guarantee everything will be all right. Does the test suite exercise paths which use that dependency?

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
