### PR TITLE
use latest pfff, and make it compatible with pad's codegraph

### DIFF
--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -123,7 +123,10 @@ let no_submatches pms =
    at the moment.
 *)
 module Set = Set.Make (struct
-  type nonrec t = t
+  type previous_t = t
+
+  (* alt: use type nonrec t = t, but this causes pad's codegraph to blowup *)
+  type t = previous_t
 
   (* If the pattern matches are obviously different (have different ranges), this is enough to compare them.
      If their ranges are the same, compare their metavariable environments. This is not robust to reordering


### PR DESCRIPTION
I can now use 'make index' in semgrep-core with the latest codegraph


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)