### PR TITLE
Use latest tree-sitter-rust

### DIFF
--- a/parsing-stats/run-lang
+++ b/parsing-stats/run-lang
@@ -121,6 +121,8 @@ main() {
     ./upload-parsing-rates lang/"$lang"/stats.json
   fi
   echo "stats available in lang/$lang/stats.json"
+  #alt: cat lang/$lang/stats.json | jq .global
+  semgrep-core -lang json -e '"global": { ... }' lang/"$lang"/stats.json
 }
 
 main

--- a/semgrep-core/tests/rust/parsing/inner_attr_stmt.rs
+++ b/semgrep-core/tests/rust/parsing/inner_attr_stmt.rs
@@ -1,0 +1,10 @@
+impl Drop for PerfMap {
+    fn drop(&mut self) {
+	// this used to cause some parse errors
+        #![allow(unused_must_use)]
+        perf_event_ioc_disable(self.ev_fd);
+        unsafe {
+            libc::close(self.ev_fd);
+        }
+    }
+}


### PR DESCRIPTION
This actually introduces some parsing regressions from 99.03%
to 98.85%
But as I explained in
https://github.com/returntocorp/ocaml-tree-sitter-semgrep/pull/277
there is no much choice. We need to start from the latest
tree-sitter-rust going forward.

test plan:
```
$ cd parsing-stats; ./run-lang rust
lang/rust/stats.json:3
   "global": {
     "name": "*",
     "parsing_rate": 0.9885293607901287,
     "line_count": 4413965,
     "error_line_count": 50631,
     "file_count": 32991,
     "error_file_count": 2815
   },
```


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)