### PR TITLE
Fix CI failure, add more xfail()

### DIFF
--- a/semgrep/tests/public_repos.py
+++ b/semgrep/tests/public_repos.py
@@ -178,10 +178,6 @@ PASSING_REPOS = [
         "repo": "https://github.com/returntocorp/bento-report",
         "languages": ALL_LANGUAGES,
     },
-    {
-        "repo": "https://github.com/returntocorp/buffer-rule-tests",
-        "languages": ALL_LANGUAGES,
-    },
     {"repo": "https://github.com/returntocorp/check-docs", "languages": ALL_LANGUAGES},
     {"repo": "https://github.com/returntocorp/cli", "languages": ALL_LANGUAGES},
     {
@@ -220,7 +216,6 @@ PASSING_REPOS = [
         "languages": ALL_LANGUAGES,
     },
     {"repo": "https://github.com/secdev/scapy", "languages": ALL_LANGUAGES},
-    {"repo": "https://github.com/apache/airflow", "languages": ALL_LANGUAGES},
     {
         "repo": "https://github.com/preset-io/elasticsearch-dbapi",
         "languages": ALL_LANGUAGES,
@@ -268,12 +263,6 @@ PASSING_REPOS = [
     {"repo": "https://github.com/dropbox/questions", "languages": ALL_LANGUAGES},
     {"repo": "https://github.com/coinbase/gtt-ui", "languages": ALL_LANGUAGES},
     {"repo": "https://github.com/DevSlop/Pixi", "languages": ALL_LANGUAGES},
-    # Excluding cause of https://github.com/returntocorp/semgrep/issues/2613
-    {
-        "repo": "https://github.com/zulip/zulip",
-        "languages": ALL_LANGUAGES,
-        "excludes": ["frontend_tests/puppeteer_lib/common.ts"],
-    },
 ]
 
 FAILING_REPOS = [
@@ -285,6 +274,14 @@ FAILING_REPOS = [
     #        },
     #        reason="MatchTimeout error but happens only in CI",
     #    ),
+    xfail_repo(
+        {"repo": "https://github.com/zulip/zulip", "languages": ["javascript"]},
+        reason="static/js/blueslip.ts: `name` was unexpected",
+    ),
+    xfail_repo(
+        {"repo": "https://github.com/apache/airflow", "languages": ["javascript"]},
+        reason="ui/src/views/Pipelines/PipelinesTable.tsx: `} =` was unexpected",
+    ),
     xfail_repo(
         {"repo": "https://github.com/rails/rails", "languages": ["ruby"]},
         reason="https://github.com/tree-sitter/tree-sitter-ruby/issues/167",


### PR DESCRIPTION
One regression was because a repository does not exist anymore (returntocorp/check-buffer-rules)
one was because of a real parse error in returntocorp/semgrep-rules
=> I've created https://github.com/returntocorp/semgrep-rules/pull/1698
the two other are JS parse errors
=> I've created https://github.com/returntocorp/semgrep/issues/4473

test plan:
pipenv shell
pytest  -v --tb=short tests/qa/test_public_repos.py


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)