### PR TITLE
[Python] allow tuple expansion inside return statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+- Pre-alpha support for Dockerfile as a new target language
+
+### Fixed
+- Rust: inner attributes are allowed again inside functions (#4444) (#4445)
+- Python: return statement can contain tuple expansions (#4461)
+
 ## [0.77.0](https://github.com/returntocorp/semgrep/releases/tag/v0.77.0) - 12-16-2021
 
 ### Added

--- a/semgrep-core/tests/python/parsing/tuple_expansion.py
+++ b/semgrep-core/tests/python/parsing/tuple_expansion.py
@@ -1,0 +1,7 @@
+def foo():
+    a = 1,
+    # star_expr was handled in most context in the grammar except
+    # in return_stmt, where it should be allowed too
+    return 2, *a
+
+print()


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/4461

test plan:
test file included


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)