### PR TITLE
Do not throw a Not_found exn for metavariable-comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 - Rust: inner attributes are allowed again inside functions (#4444) (#4445)
 - Python: return statement can contain tuple expansions (#4461)
+- metavariable-comparison: do not throw a Not_found exn anymore (#4469)
 
 ## [0.77.0](https://github.com/returntocorp/semgrep/releases/tag/v0.77.0) - 12-16-2021
 

--- a/semgrep-core/tests/OTHER/rules/not_found_exn.go
+++ b/semgrep-core/tests/OTHER/rules/not_found_exn.go
@@ -1,0 +1,7 @@
+package dkeyczar
+
+func generateRSAKey(size uint) (*rsaKey, error) {
+
+	return rsa.GenerateKey(rand.Reader, int(size))
+
+}

--- a/semgrep-core/tests/OTHER/rules/not_found_exn.yaml
+++ b/semgrep-core/tests/OTHER/rules/not_found_exn.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: asymmetric-rsa-weak-keylength
+    message: |
+      RSA-$KEYLENGTH
+    languages:
+      - go
+    severity: WARNING
+    patterns:
+      - pattern: |
+              rsa.GenerateKey(..., $KEYLENGTH)
+      - metavariable-comparison:
+          metavariable: $KEYLENGTH
+          comparison: $KEYLENGTH < 513

--- a/semgrep-core/tests/OTHER/rules/not_found_exn2.py
+++ b/semgrep-core/tests/OTHER/rules/not_found_exn2.py
@@ -1,0 +1,7 @@
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+def rsa_priv(foo, key_size='4096'):
+    size = int(key_size)
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=size,
+                                   backend=default_backend())

--- a/semgrep-core/tests/OTHER/rules/not_found_exn2.yaml
+++ b/semgrep-core/tests/OTHER/rules/not_found_exn2.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: asymmetric-hazmat-rsa-keylength
+    patterns:
+      - pattern: |
+          $VALUE = $KEYLENGTH
+          ... 
+          cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key(..., key_size=$VALUE, ...)
+      - metavariable-comparison:
+          metavariable: $KEYLENGTH
+          comparison: $KEYLENGTH < 999999
+    message: |
+      RSA-$KEYLENGTH
+    languages:
+      - python
+    severity: WARNING


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/4469

test plan:
test files included


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)