### PR TITLE
sym-prop: Fix matching with deep expression patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 - Pre-alpha support for Dockerfile as a new target language
+- Semgrep is now able to symbolically propagate simple definitions. E.g., given
+  an assignment `x = foo.bar()` followed by a call `x.baz()`, Semgrep will keep
+  track of `x`'s definition, and it will successfully match `x.baz()` with a
+  pattern like `foo.bar().baz()`. This feature should help writing simple yet
+  powerful rules, by letting the dataflow engine take care of any intermediate
+  assignments. Symbolic propagation is still experimental and it is disabled by
+  default, it must be enabled in a per-rule basis using `options:` and setting
+  `symbolic_propagation: true`. (#2783, #2859, #3207)
 
 ### Fixed
 - Rust: inner attributes are allowed again inside functions (#4444) (#4445)
@@ -66,14 +74,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   for nodejsscan rules notably)
 - Semgrep CLI now respects .semgrepignore files
 - Java: support ellipsis in generics, e.g., `class Foo<...>` (#4335)
-- Semgrep is now able to symbolically propagate simple definitions. E.g., given
-  an assignment `x = foo.bar()` followed by a call `x.baz()`, Semgrep will keep
-  track of `x`'s definition, and it will successfully match `x.baz()` with a
-  pattern like `foo.bar().baz()`. This feature should help writing simple yet
-  powerful rules, by letting the dataflow engine take care of any intermediate
-  assignments. Symbolic propagation is still experimental and it is disabled by
-  default, it must be enabled in a per-rule basis using `options:` and setting
-  `symbolic_propagation: true`. (#2783, #2859)
 
 ### Fixed
 - Java: class patterns not using generics will match classes using generics

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -305,6 +305,7 @@ let rec is_symbolic_expr expr =
   match expr.G.e with
   | G.L _ -> true
   | G.N _ -> true
+  | G.IdSpecial _ -> true
   | G.DotAccess (e, _, FN _) -> is_symbolic_expr e
   | G.ArrayAccess (e1, (_, e2, _)) -> is_symbolic_expr e1 && is_symbolic_expr e2
   | G.Call (e, (_, args, _)) ->

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -549,8 +549,12 @@ and m_id_info a b =
  *   - <call>(<exprs).
  *)
 (* experimental! *)
-and m_expr_deep a b =
-  m_deep m_expr_deep m_expr SubAST_generic.subexprs_of_expr a b
+and m_expr_deep a b tin =
+  let symbolic_propagation = tin.config.Config.symbolic_propagation in
+  let subexprs_of_expr =
+    SubAST_generic.subexprs_of_expr ~symbolic_propagation
+  in
+  m_deep m_expr_deep m_expr subexprs_of_expr a b tin
 
 (* coupling: if you add special sgrep hooks here, you should probably
  * also add them in m_pattern
@@ -660,7 +664,6 @@ and m_expr a b =
   | G.Ellipsis _a1, _ -> return ()
   | G.DeepEllipsis (_, a1, _), _b ->
       m_expr_deep a1 b (*e: [[Generic_vs_generic.m_expr()]] ellipsis cases *)
-      >||> m_with_symbolic_propagation (fun b1 -> m_expr_deep a1 b1) b
   (* must be before constant propagation case below *)
   | G.L a1, B.L b1 -> m_literal a1 b1
   (* equivalence: constant propagation and evaluation!

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -93,8 +93,11 @@ let subexprs_of_stmt_kind = function
 let subexprs_of_stmt st = subexprs_of_stmt_kind st.s
 
 (* used for deep expression matching *)
-let subexprs_of_expr e =
+let subexprs_of_expr with_symbolic_propagation e =
   match e.e with
+  | N (Id (_, { id_svalue = { contents = Some (Sym e1) }; _ }))
+    when with_symbolic_propagation ->
+      [ e1 ]
   | L _
   | N _
   | IdSpecial _
@@ -159,6 +162,10 @@ let subexprs_of_expr e =
       []
   | DisjExpr _ -> raise Common.Impossible
   [@@profiling]
+
+(* Need this wrapper because [@@profiling] has the side-effect of removing labels. *)
+let subexprs_of_expr ?(symbolic_propagation = false) e =
+  subexprs_of_expr symbolic_propagation e
 
 (* used for deep statement matching *)
 let substmts_of_stmt st =

--- a/semgrep-core/src/matching/SubAST_generic.mli
+++ b/semgrep-core/src/matching/SubAST_generic.mli
@@ -1,4 +1,5 @@
-val subexprs_of_expr : AST_generic.expr -> AST_generic.expr list
+val subexprs_of_expr :
+  ?symbolic_propagation:bool -> AST_generic.expr -> AST_generic.expr list
 
 val subexprs_of_stmt_kind : AST_generic.stmt_kind -> AST_generic.expr list
 

--- a/semgrep-core/tests/OTHER/rules/sym_prop_deep.java
+++ b/semgrep-core/tests/OTHER/rules/sym_prop_deep.java
@@ -1,0 +1,23 @@
+// https://github.com/returntocorp/semgrep/issues/3207
+public class Test {
+
+  public final ZipEntry getNextEntry() {
+        String name;
+        ZipEntry nextEntry = super.getNextEntry();
+        if (nextEntry == null)
+            return nextEntry;
+        ZipEntry c = nextEntry;
+        name = c.getName();
+        if (name == null)
+            return nextEntry;
+        
+        boolean b1 = !name.contains("../");
+        boolean b2 = !name.contains("..\\");
+        // ruleid: test
+        if (b1 && b2)
+            return nextEntry;
+
+        throw new SecurityException(":" + nextEntry.getName());
+    }
+
+}

--- a/semgrep-core/tests/OTHER/rules/sym_prop_deep.yaml
+++ b/semgrep-core/tests/OTHER/rules/sym_prop_deep.yaml
@@ -1,0 +1,9 @@
+rules:
+- id: test
+  options:
+    symbolic_propagation: true
+  pattern: if (<... (ZipEntry $X).getName().contains("...") ...>) { ... }
+  message: Test
+  languages:
+  - java
+  severity: WARNING


### PR DESCRIPTION
Let's say you want to match pattern:

    return <... name.contains("...") ...>;

against this code:

    boolean b1 = !name.contains("../");
    boolean b2 = !name.contains("..\\");
    return b1 && b2;

It is not enough to compute the subexpressions of `b1 && b2` and then try
matching them with `name.contains("...")`. This does not work. We need to
consider symbolic values *while* computing the subexpressions, so that
`name.contains("../")` and `name.contains("..\\")` are enumerated.

Also allow special ids to be symbolically propagated.

Closes #3207

test plan:
make test # test included

changelog:
Symbolic propagation didn't exist in 0.76.0, but may have ended up there
by mistake when merging the release-0.76.0 branch. The feature never made
it into a release announcement, so I'm adding it for the next one.

PR checklist:
- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
