### PR TITLE
Configurable comment support in spacegrep

### DIFF
--- a/semgrep-core/src/spacegrep/src/lib/Comment.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Comment.ml
@@ -1,0 +1,163 @@
+(*
+   Strip comments and the like as a preprocessing phase.
+*)
+
+open Printf
+
+type delimiters = { start : string; end_ : string }
+
+type style = {
+  name : string;
+  start : string option;
+  delimiters : delimiters option;
+}
+
+let style ?start ?delimiters name =
+  let delimiters =
+    match delimiters with
+    | None -> None
+    | Some (start, end_) -> Some { start; end_ }
+  in
+  { name; start; delimiters }
+
+let shell_style = style ~start:"#" "shell"
+
+let c_style = style ~delimiters:("/*", "*/") "c"
+
+let cpp_style = style ~start:"//" ~delimiters:("/*", "*/") "cpp"
+
+let predefined_styles = [ c_style; cpp_style; shell_style ]
+
+(* TODO: replace whole unicode characters by exactly space to avoid
+         location errors, then rename the function to 'whiteout_utf8'. *)
+let whiteout_ascii s =
+  String.map
+    (function
+      | ('\r' | '\n') as line_delimiter -> line_delimiter
+      | _byte -> ' ')
+    s
+
+let replace_end_of_line_comment ~start src =
+  (* match from first occurrence of 'start' in the line until the
+     end of line or end of input *)
+  let rex = sprintf "%s[^\n]*\n?" (Pcre.quote start) |> SPcre.regexp in
+  Pcre.substitute ~rex ~subst:whiteout_ascii src
+
+let replace_multiline_comment ~start ~end_ src =
+  let rex =
+    sprintf "%s.*?%s" (Pcre.quote start) (Pcre.quote end_)
+    |> SPcre.regexp ~flags:[ `DOTALL ]
+  in
+  Pcre.substitute ~rex ~subst:whiteout_ascii src
+
+let remove_comments_from_string style src =
+  let src =
+    match style.start with
+    | None -> src
+    | Some start -> replace_end_of_line_comment ~start src
+  in
+  let src =
+    match style.delimiters with
+    | None -> src
+    | Some { start; end_ } -> replace_multiline_comment ~start ~end_ src
+  in
+  src
+
+let remove_comments_from_src style src =
+  Src_file.replace_contents src (fun s -> remove_comments_from_string style s)
+
+(**************************************************************************)
+(* Command-line handling for spacecat and spacegrep *)
+(**************************************************************************)
+
+module CLI = struct
+  open Cmdliner
+
+  let comment_style_conv =
+    let parser name =
+      match List.find_opt (fun x -> x.name = name) predefined_styles with
+      | Some style -> Ok style
+      | None ->
+          Error (`Msg ("Invalid argument for --comment-style option: " ^ name))
+    in
+    let printer fmt style = Format.pp_print_string fmt style.name in
+    Cmdliner.Arg.conv (parser, printer)
+
+  let comment_style_term =
+    let info =
+      Arg.info [ "comment-style" ] ~docv:"NAME"
+        ~doc:
+          "Assume code comments that follow one of these predefined styles: c, \
+           cpp, shell. 'c' implements classic C-style comments of the form /* \
+           ... */. 'cpp' implements C++-style comments of the form /* ... */ \
+           or // ... . 'shell' implements end-of-line comments\n\
+          \            of the form # ... ."
+    in
+    Arg.value (Arg.opt (Arg.some comment_style_conv) None info)
+
+  let eol_comment_start_term =
+    let info =
+      Arg.info [ "eol-comment-start" ] ~docv:"DELIM"
+        ~doc:
+          "Ignore end-of-line comments starting with $(docv). No default value."
+    in
+    Arg.value (Arg.opt Arg.(some string) None info)
+
+  let multiline_comment_start_term =
+    let info =
+      Arg.info
+        [ "multiline-comment-start" ]
+        ~docv:"DELIM"
+        ~doc:
+          "Ignore multiline comments starting with $(docv). No default value."
+    in
+    Arg.value (Arg.opt Arg.(some string) None info)
+
+  let multiline_comment_end_term =
+    let info =
+      Arg.info
+        [ "multiline-comment-end" ]
+        ~docv:"DELIM"
+        ~doc:"Ignore multiline comments ending with $(docv). No default value."
+    in
+    Arg.value (Arg.opt Arg.(some string) None info)
+
+  let merge_comment_options ~comment_style ~eol_comment_start
+      ~multiline_comment_start ~multiline_comment_end : style =
+    let style =
+      match comment_style with
+      | None -> style "custom"
+      | Some x -> x
+    in
+    let style =
+      match eol_comment_start with
+      | None -> style
+      | Some _ as start -> { style with start }
+    in
+    let style =
+      let start, end_ =
+        match style.delimiters with
+        | None -> (None, None)
+        | Some { start; end_ } -> (Some start, Some end_)
+      in
+      let start =
+        match multiline_comment_start with
+        | None -> start
+        | Some x -> Some x
+      in
+      let end_ =
+        match multiline_comment_end with
+        | None -> end_
+        | Some x -> Some x
+      in
+      let delimiters =
+        match (start, end_) with
+        | None, None -> None
+        | Some start, Some end_ -> Some { start; end_ }
+        | Some _, None -> failwith "Missing --multiline-comment-end option"
+        | None, Some _ -> failwith "Missing --multiline-comment-start option"
+      in
+      { style with delimiters }
+    in
+    style
+end

--- a/semgrep-core/src/spacegrep/src/lib/Comment.mli
+++ b/semgrep-core/src/spacegrep/src/lib/Comment.mli
@@ -1,0 +1,71 @@
+(*
+   Strip comments and the like as a preprocessing phase.
+
+   The issue is that comment syntax need to be configurable but the
+   ocamllex lexer isn't flexible enough. The solution adopted here
+   is to make a copy of the original input while replacing comments
+   by blanks.
+*)
+
+type delimiters = { start : string; end_ : string }
+
+(*
+   I don't like giving users the ability to specify regexps, but since
+   some syntaxes may be tricky to configure without regexps, the current
+   design restricts the user to a choice of predefined styles.
+*)
+type style = {
+  name : string;
+  (* end-of-line comment prefix *)
+  start : string option;
+  (* multiline comment delimiters *)
+  delimiters : delimiters option;
+}
+
+(* Shorthand for creating a 'style' record of a give name. *)
+val style : ?start:string -> ?delimiters:string * string -> string -> style
+
+(* Any occurrence of '#' until the end of the line.
+   Unlike proper Bash syntax, this doesn't take into account what precedes
+   the '#' to determine whether it's a comment. *)
+val shell_style : style
+
+(* Multiline comment starting with '/*' and ending with the earliest occurrence
+   of '*/'. *)
+val c_style : style
+
+(* Same as 'classic_c_style' but adds end-of-line comments that start with
+   '//' like in C++. *)
+val cpp_style : style
+
+(* A list of the predefined styles above. *)
+val predefined_styles : style list
+
+(* Replace comments by whitespace so as to preserve the (line, column)
+   position of the other characters in the file. *)
+val remove_comments_from_string : style -> string -> string
+
+val remove_comments_from_src : style -> Src_file.t -> Src_file.t
+
+(**************************************************************************)
+(* Command-line handling for spacecat and spacegrep *)
+(**************************************************************************)
+
+module CLI : sig
+  (* Command-line options *)
+  val comment_style_term : style option Cmdliner.Term.t
+
+  val eol_comment_start_term : string option Cmdliner.Term.t
+
+  val multiline_comment_start_term : string option Cmdliner.Term.t
+
+  val multiline_comment_end_term : string option Cmdliner.Term.t
+
+  (* Merge values collected from the command line into a style record. *)
+  val merge_comment_options :
+    comment_style:style option ->
+    eol_comment_start:string option ->
+    multiline_comment_start:string option ->
+    multiline_comment_end:string option ->
+    style
+end

--- a/semgrep-core/src/spacegrep/src/lib/Comment.mli
+++ b/semgrep-core/src/spacegrep/src/lib/Comment.mli
@@ -7,23 +7,16 @@
    by blanks.
 *)
 
-type delimiters = { start : string; end_ : string }
-
 (*
    I don't like giving users the ability to specify regexps, but since
    some syntaxes may be tricky to configure without regexps, the current
    design restricts the user to a choice of predefined styles.
 *)
-type style = {
-  name : string;
-  (* end-of-line comment prefix *)
-  start : string option;
-  (* multiline comment delimiters *)
-  delimiters : delimiters option;
-}
+type comment_syntax =
+  | End_of_line of (* start *) string
+  | Multiline of (* start, end *) string * string
 
-(* Shorthand for creating a 'style' record of a give name. *)
-val style : ?start:string -> ?delimiters:string * string -> string -> style
+type style = comment_syntax list
 
 (* Any occurrence of '#' until the end of the line.
    Unlike proper Bash syntax, this doesn't take into account what precedes
@@ -38,8 +31,8 @@ val c_style : style
    '//' like in C++. *)
 val cpp_style : style
 
-(* A list of the predefined styles above. *)
-val predefined_styles : style list
+(* A list of the predefined styles above keyed by name. *)
+val predefined_styles : (string * style) list
 
 (* Replace comments by whitespace so as to preserve the (line, column)
    position of the other characters in the file. *)
@@ -53,7 +46,7 @@ val remove_comments_from_src : style -> Src_file.t -> Src_file.t
 
 module CLI : sig
   (* Command-line options *)
-  val comment_style_term : style option Cmdliner.Term.t
+  val comment_style_term : (string * style) option Cmdliner.Term.t
 
   val eol_comment_start_term : string option Cmdliner.Term.t
 
@@ -63,7 +56,7 @@ module CLI : sig
 
   (* Merge values collected from the command line into a style record. *)
   val merge_comment_options :
-    comment_style:style option ->
+    comment_style:(string * style) option ->
     eol_comment_start:string option ->
     multiline_comment_start:string option ->
     multiline_comment_end:string option ->

--- a/semgrep-core/src/spacegrep/src/lib/Src_file.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Src_file.ml
@@ -24,6 +24,8 @@ let contents x = x.contents
 
 let length x = String.length x.contents
 
+let replace_contents x f = { x with contents = f x.contents }
+
 let of_string ?(source = String) contents = { source; contents }
 
 let partial_input max_len ic =

--- a/semgrep-core/src/spacegrep/src/lib/Src_file.mli
+++ b/semgrep-core/src/spacegrep/src/lib/Src_file.mli
@@ -33,6 +33,12 @@ val contents : t -> string
 val length : t -> int
 
 (*
+   Replace some of the contents, typically for blanking out comments
+   as part of a preprocessing phase.
+*)
+val replace_contents : t -> (string -> string) -> t
+
+(*
    Extract a specific region specified as
    (start position, end position to be excluded).
  *)

--- a/semgrep-core/src/spacegrep/src/lib/dune
+++ b/semgrep-core/src/spacegrep/src/lib/dune
@@ -4,7 +4,8 @@
   (libraries
      ANSITerminal
      unix
-
+     pcre
+     semgrep_utils
   )
   (preprocess
    (pps

--- a/semgrep-core/src/spacegrep/src/test/.ocamlformat-ignore
+++ b/semgrep-core/src/spacegrep/src/test/.ocamlformat-ignore
@@ -1,0 +1,1 @@
+Comment.ml

--- a/semgrep-core/src/spacegrep/src/test/Comment.ml
+++ b/semgrep-core/src/spacegrep/src/test/Comment.ml
@@ -1,8 +1,14 @@
 (*
    Unit tests for spacegrep comment support
 
-   Note that ocamlformat removes end-of-line spaces from string literals.
-   Make sure it's disabled on this file.
+   Note that pre-commit hooks don't like trailing whitespace:
+   - a tool removes trailing whitespace, that's why we have to resort
+     to using '\n\' instead of just a newline in some places.
+   - ocamlformat may also rearrange string literals in a less readable way,
+     so it's disabled via a .ocamlformat-ignore file.
+   Additionally, OCaml ignores leading blanks in string literals
+   if the previous line ends with a '\' (line continuation).
+   If this gets too hard, just avoid line breaks in string literals.
 *)
 
 module C = Spacegrep.Comment
@@ -17,9 +23,9 @@ b
 c # yyy
 ",
   "\
-a
-b
-c
+a    \n\
+b\n\
+c      \n\
 ";
 
   "end of file comment",
@@ -43,7 +49,7 @@ c
 hello // ignore this
 world // ignore this too",
   "\
-hello
+hello               \n\
 world                   ";
 
   "end-of-line comments first",
@@ -51,9 +57,7 @@ world                   ";
   "\
 hello /* //
 // */ world",
-  "\
-hello /*
-           ";
+  "hello /*   \n           ";
 
   "identical start and end",
   C.style ~delimiters:("|", "|") "custom",
@@ -72,16 +76,7 @@ comment end not
 end
 bye
 ",
-  "\
-hello
-
-
-
-hey
-
-
-bye
-"
+  "hello\n       \n     \n         \nhey\n               \n   \nbye\n"
 ]
 
 let test =

--- a/semgrep-core/src/spacegrep/src/test/Comment.ml
+++ b/semgrep-core/src/spacegrep/src/test/Comment.ml
@@ -1,0 +1,46 @@
+(*
+   Unit tests for spacegrep comment support
+*)
+
+module C = Spacegrep.Comment
+
+(* name, comment style, input, expected output *)
+let tests =
+  [
+    ("shell-style comments", C.shell_style, "a#xxx\nb\nc # yyy\n", "a\nb\nc\n");
+    ("end of file comment", C.shell_style, "a #end", "a     ");
+    ( "c-style comments",
+      C.c_style,
+      "hello */ /* ignore /* this */ world",
+      "hello */                      world" );
+    ( "cpp-style comments 1",
+      C.cpp_style,
+      "hello */ /* ignore /* this */ world",
+      "hello */                      world" );
+    ( "cpp-style comments 2",
+      C.cpp_style,
+      "hello // ignore this\nworld // ignore this too",
+      "hello\nworld                   " );
+    ( "end-of-line comments first",
+      C.cpp_style,
+      "hello /* //\n// */ world",
+      "hello /*\n           " );
+    ( "identical start and end",
+      C.style ~delimiters:("|", "|") "custom",
+      "a | ignore | b | c",
+      "a            b | c" );
+    ( "newline in delimiter",
+      C.style ~delimiters:("comment", "end\n") "custom",
+      "hello\ncomment\n  ign\n  ign end\nhey\ncomment end not\nend\nbye\n",
+      "hello\n\n\n\nhey\n\n\nbye\n" );
+  ]
+
+let test =
+  ( "Comment",
+    tests
+    |> List.map (fun (name, style, input, expected_output) ->
+           let run () =
+             let output = C.remove_comments_from_string style input in
+             Alcotest.(check string "equal" expected_output output)
+           in
+           (name, `Quick, run)) )

--- a/semgrep-core/src/spacegrep/src/test/Comment.ml
+++ b/semgrep-core/src/spacegrep/src/test/Comment.ml
@@ -1,46 +1,95 @@
 (*
    Unit tests for spacegrep comment support
+
+   Note that ocamlformat removes end-of-line spaces from string literals.
+   Make sure it's disabled on this file.
 *)
 
 module C = Spacegrep.Comment
 
 (* name, comment style, input, expected output *)
-let tests =
-  [
-    ("shell-style comments", C.shell_style, "a#xxx\nb\nc # yyy\n", "a\nb\nc\n");
-    ("end of file comment", C.shell_style, "a #end", "a     ");
-    ( "c-style comments",
-      C.c_style,
-      "hello */ /* ignore /* this */ world",
-      "hello */                      world" );
-    ( "cpp-style comments 1",
-      C.cpp_style,
-      "hello */ /* ignore /* this */ world",
-      "hello */                      world" );
-    ( "cpp-style comments 2",
-      C.cpp_style,
-      "hello // ignore this\nworld // ignore this too",
-      "hello\nworld                   " );
-    ( "end-of-line comments first",
-      C.cpp_style,
-      "hello /* //\n// */ world",
-      "hello /*\n           " );
-    ( "identical start and end",
-      C.style ~delimiters:("|", "|") "custom",
-      "a | ignore | b | c",
-      "a            b | c" );
-    ( "newline in delimiter",
-      C.style ~delimiters:("comment", "end\n") "custom",
-      "hello\ncomment\n  ign\n  ign end\nhey\ncomment end not\nend\nbye\n",
-      "hello\n\n\n\nhey\n\n\nbye\n" );
-  ]
+let tests = [
+  "shell-style comments",
+  C.shell_style,
+  "\
+a#xxx
+b
+c # yyy
+",
+  "\
+a
+b
+c
+";
+
+  "end of file comment",
+  C.shell_style,
+  "a #end",
+  "a     ";
+
+  "c-style comments",
+  C.c_style,
+  "hello */ /* ignore /* this */ world",
+  "hello */                      world";
+
+  "cpp-style comments 1",
+  C.cpp_style,
+  "hello */ /* ignore /* this */ world",
+  "hello */                      world";
+
+  "cpp-style comments 2",
+  C.cpp_style,
+  "\
+hello // ignore this
+world // ignore this too",
+  "\
+hello
+world                   ";
+
+  "end-of-line comments first",
+  C.cpp_style,
+  "\
+hello /* //
+// */ world",
+  "\
+hello /*
+           ";
+
+  "identical start and end",
+  C.style ~delimiters:("|", "|") "custom",
+  "a | ignore | b | c",
+  "a            b | c";
+
+  "newline in delimiter",
+  C.style ~delimiters:("comment", "end\n") "custom",
+  "\
+hello
+comment
+  ign
+  ign end
+hey
+comment end not
+end
+bye
+",
+  "\
+hello
+
+
+
+hey
+
+
+bye
+"
+]
 
 let test =
-  ( "Comment",
-    tests
-    |> List.map (fun (name, style, input, expected_output) ->
-           let run () =
-             let output = C.remove_comments_from_string style input in
-             Alcotest.(check string "equal" expected_output output)
-           in
-           (name, `Quick, run)) )
+  "Comment",
+  tests |> List.map (fun (name, style, input, expected_output) ->
+    let run () =
+      let output = C.remove_comments_from_string style input in
+      Alcotest.(check string "equal" expected_output output)
+    in
+    (name, `Quick, run)
+  )

--- a/semgrep-core/src/spacegrep/src/test/Comment.ml
+++ b/semgrep-core/src/spacegrep/src/test/Comment.ml
@@ -60,12 +60,12 @@ hello /* //
   "hello /*   \n           ";
 
   "identical start and end",
-  C.style ~delimiters:("|", "|") "custom",
+  [C.Multiline ("|", "|")],
   "a | ignore | b | c",
   "a            b | c";
 
   "newline in delimiter",
-  C.style ~delimiters:("comment", "end\n") "custom",
+  [C.Multiline ("comment", "end\n")],
   "\
 hello
 comment

--- a/semgrep-core/src/spacegrep/src/test/test.ml
+++ b/semgrep-core/src/spacegrep/src/test/test.ml
@@ -3,7 +3,7 @@
 *)
 
 let test_suites : unit Alcotest.test list =
-  [ File_type.test; Parser.test; Matcher.test; Src_file.test ]
+  [ File_type.test; Parser.test; Matcher.test; Src_file.test; Comment.test ]
 
 let main () =
   Spacegrep.Match.debug := true;


### PR DESCRIPTION
I added configurable support for comments to spacegrep. This is not integrated into semgrep, for which we would need to read options from a yaml rule file.

This works as a preprocessing pass on the source file that replaces comments by spaces, keeping newlines intact. For each preprocessing pass, we support at most one kind of end-of-line comments and one kind of multiline comments.

This is the first step to ignore comments in generic mode (#3428).

test plan:
* `make test` (unit tests)
* exercise the `spacegrep` command line to make sure it's there:
```
$ cd semgrep-core/src/spacegrep
$ make
$ echo $'hello # ignore this\nworld!!!\nend' | ./bin/spacegrep 'hello world' --comment-style shell
hello # ignore this
world!!!
```
(highlights region from `hello` to `world`)

This shows the tokenization (and the AST which here is flat):
```
$ echo $'hello # ignore this\nworld!!!\nend' | ./bin/spacecat --comment-style shell
hello
world
!
!
!
end
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
