### PR TITLE
metavariable-comparison: Handle arbitrary constant expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 - Rust: inner attributes are allowed again inside functions (#4444) (#4445)
 - Python: return statement can contain tuple expansions (#4461)
-- metavariable-comparison: do not throw a Not_found exn anymore (#4469)  
+- metavariable-comparison: do not throw a Not_found exn anymore (#4469)
 
 ## [0.77.0](https://github.com/returntocorp/semgrep/releases/tag/v0.77.0) - 12-16-2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   default, it must be enabled in a per-rule basis using `options:` and setting
   `symbolic_propagation: true`. (#2783, #2859, #3207)
 - `--verbose` outputs a timing and file breakdown summary at the end
+- `metavariable-comparison` now handles metavariables that bind to arbitrary
+  constant expressions (instead of just code variables)
 
 ### Fixed
 - Rust: inner attributes are allowed again inside functions (#4444) (#4445)
 - Python: return statement can contain tuple expansions (#4461)
-- metavariable-comparison: do not throw a Not_found exn anymore (#4469)
+- metavariable-comparison: do not throw a Not_found exn anymore (#4469)  
 
 ## [0.77.0](https://github.com/returntocorp/semgrep/releases/tag/v0.77.0) - 12-16-2021
 

--- a/semgrep-core/src/engine/Eval_generic.mli
+++ b/semgrep-core/src/engine/Eval_generic.mli
@@ -33,6 +33,7 @@ val test_eval : Common.filename -> unit
 val parse_json : Common.filename -> env * code
 
 (* for MetavarCond *)
-val bindings_to_env : Metavariable.bindings -> env
+val bindings_to_env : Config_semgrep.t -> Metavariable.bindings -> env
 
-val bindings_to_env_with_just_strings : Metavariable.bindings -> env
+val bindings_to_env_with_just_strings :
+  Config_semgrep.t -> Metavariable.bindings -> env

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -616,7 +616,7 @@ let rec filter_ranges env xs cond =
          let bindings = r.RM.mvars in
          match cond with
          | R.CondEval e ->
-             let env = Eval_generic.bindings_to_env bindings in
+             let env = Eval_generic.bindings_to_env (fst env.config) bindings in
              Eval_generic.eval_bool env e
          | R.CondNestedFormula (mvar, opt_lang, formula) ->
              satisfies_metavar_pattern_condition env r mvar opt_lang formula
@@ -651,7 +651,8 @@ let rec filter_ranges env xs cond =
              in
 
              let env =
-               Eval_generic.bindings_to_env_with_just_strings bindings
+               Eval_generic.bindings_to_env_with_just_strings (fst env.config)
+                 bindings
              in
              Eval_generic.eval_bool env e)
 

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_constness1.py
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_constness1.py
@@ -1,0 +1,5 @@
+n = 128
+#ok: test
+some_function(n*2)
+#ruleid: test
+some_function(n+2)

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_constness1.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_constness1.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: some_function called with $X < 256
+    patterns:
+      - pattern: some_function($X)
+      - metavariable-comparison:
+          metavariable: $X
+          comparison: $X < 256
+    severity: WARNING
+


### PR DESCRIPTION
And only use propagated constants if constant propagation is enabled!

Closes PA-763

test plan:
make test # test included

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
