### PR TITLE
Sort semgrep-core match results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Rust: inner attributes are allowed again inside functions (#4444) (#4445)
 - Python: return statement can contain tuple expansions (#4461)
 - metavariable-comparison: do not throw a Not_found exn anymore (#4469)
+- better ordering of match results with respect to captured
+  metavariables (#4488)
 
 ## [0.77.0](https://github.com/returntocorp/semgrep/releases/tag/v0.77.0) - 12-16-2021
 

--- a/semgrep-core/src/core/Semgrep_core_response_util.ml
+++ b/semgrep-core/src/core/Semgrep_core_response_util.ml
@@ -8,7 +8,7 @@ open Semgrep_core_response_t
 let compare_position (a : position) b = Int.compare a.offset b.offset
 
 let compare_location (a : location) b =
-  let c = String.compare a.path a.path in
+  let c = String.compare a.path b.path in
   if c <> 0 then c
   else
     let c = compare_position a.start b.start in

--- a/semgrep-core/src/core/Semgrep_core_response_util.ml
+++ b/semgrep-core/src/core/Semgrep_core_response_util.ml
@@ -1,0 +1,74 @@
+(*
+   Utilities for working with the types defined in Semgrep_core_response.atd
+   (Semgrep_core_response_t module)
+*)
+
+open Semgrep_core_response_t
+
+let compare_position (a : position) b = Int.compare a.offset b.offset
+
+let compare_location (a : location) b =
+  let c = String.compare a.path a.path in
+  if c <> 0 then c
+  else
+    let c = compare_position a.start b.start in
+    if c <> 0 then c else compare_position a.end_ b.end_
+
+let compare_metavar_value (a : metavar_value) (b : metavar_value) =
+  let c = compare_position a.start b.start in
+  if c <> 0 then c else compare_position a.end_ b.end_
+
+(* Generic list comparison. The input lists must already be sorted according
+   to 'compare_elt'.
+
+   [1] < [2]
+   [1] < [1; 2]
+   [1; 2] < [2]
+*)
+let rec compare_sorted_list compare_elt a b =
+  match (a, b) with
+  | [], [] -> 0
+  | [], _ :: _ -> -1
+  | _ :: _, [] -> 1
+  | a :: aa, b :: bb ->
+      let c = compare_elt a b in
+      if c <> 0 then c else compare_sorted_list compare_elt aa bb
+
+(*
+   Order the metavariable bindings by location first, then by name.
+   (could go the other way too; feel free to change)
+*)
+let compare_metavar_binding (name1, mv1) (name2, mv2) =
+  let c = compare_metavar_value mv1 mv2 in
+  if c <> 0 then c else String.compare name1 name2
+
+(* Assumes the metavariable captures within each match_extra are already
+   sorted. *)
+let compare_match_extra (a : match_extra) (b : match_extra) =
+  let c = compare_sorted_list compare_metavar_binding a.metavars b.metavars in
+  if c <> 0 then c else compare a.message b.message
+
+(*
+   While the locations of the matches are already in correct order, they
+   come in a reverse order when looking at the metavariables that they
+   match. This function makes a best a effort to return the results
+   in a natural order.
+*)
+let compare_match (a : match_) (b : match_) =
+  let c = compare_location a.location b.location in
+  if c <> 0 then c else compare_match_extra a.extra b.extra
+
+let sort_metavars (metavars : (string * metavar_value) list) =
+  List.stable_sort compare_metavar_binding metavars
+
+let sort_extra (extra : match_extra) =
+  { extra with metavars = sort_metavars extra.metavars }
+
+let sort_match_list (matches : match_ list) : match_ list =
+  let matches =
+    Common.map (fun x -> { x with extra = sort_extra x.extra }) matches
+  in
+  List.stable_sort compare_match matches
+
+let sort_match_results (res : match_results) : match_results =
+  { res with matches = sort_match_list res.matches }

--- a/semgrep-core/src/core/Semgrep_core_response_util.mli
+++ b/semgrep-core/src/core/Semgrep_core_response_util.mli
@@ -1,0 +1,11 @@
+(*
+   Utilities for working with the types defined in Semgrep_core_response.atd
+   (Semgrep_core_response_t module)
+*)
+
+(*
+   Sort results in the most natural way possible, typically preferring
+   match location first.
+*)
+val sort_match_results :
+  Semgrep_core_response_t.match_results -> Semgrep_core_response_t.match_results

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -214,6 +214,7 @@ let match_results_of_matches_and_errors files res =
     stats = { okfiles = count_ok; errorfiles = count_errors };
     time = res.RP.rule_profiling |> Common.map_opt json_time_of_profiling_data;
   }
+  |> Semgrep_core_response_util.sort_match_results
   [@@profiling]
 
 let json_of_profile_info profile_start =

--- a/semgrep/tests/e2e/snapshots/test_check/test_deduplication_different_message/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_deduplication_different_message/results.json
@@ -11,63 +11,6 @@
       "extra": {
         "is_ignored": false,
         "lines": "foo(1,2)",
-        "message": "Error message with both metavars 2 foo",
-        "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "foo",
-            "end": {
-              "col": 4,
-              "line": 1,
-              "offset": 3
-            },
-            "start": {
-              "col": 1,
-              "line": 1,
-              "offset": 0
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          },
-          "$Y": {
-            "abstract_content": "2",
-            "end": {
-              "col": 8,
-              "line": 1,
-              "offset": 7
-            },
-            "start": {
-              "col": 7,
-              "line": 1,
-              "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          }
-        },
-        "severity": "ERROR"
-      },
-      "path": "targets/deduplication/deduplication.py",
-      "start": {
-        "col": 1,
-        "line": 1,
-        "offset": 0
-      }
-    },
-    {
-      "check_id": "rules.deduplication.duplicate",
-      "end": {
-        "col": 9,
-        "line": 1,
-        "offset": 8
-      },
-      "extra": {
-        "is_ignored": false,
-        "lines": "foo(1,2)",
         "message": "Error message with both metavars 1 foo",
         "metadata": {},
         "metavars": {
@@ -99,6 +42,63 @@
               "col": 5,
               "line": 1,
               "offset": 4
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/deduplication/deduplication.py",
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0
+      }
+    },
+    {
+      "check_id": "rules.deduplication.duplicate",
+      "end": {
+        "col": 9,
+        "line": 1,
+        "offset": 8
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "foo(1,2)",
+        "message": "Error message with both metavars 2 foo",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "foo",
+            "end": {
+              "col": 4,
+              "line": 1,
+              "offset": 3
+            },
+            "start": {
+              "col": 1,
+              "line": 1,
+              "offset": 0
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          },
+          "$Y": {
+            "abstract_content": "2",
+            "end": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            },
+            "start": {
+              "col": 7,
+              "line": 1,
+              "offset": 6
             },
             "unique_id": {
               "md5sum": "<masked in tests>",

--- a/semgrep/tests/e2e/snapshots/test_check/test_deduplication_same_message/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_deduplication_same_message/results.json
@@ -32,16 +32,16 @@
             }
           },
           "$Y": {
-            "abstract_content": "2",
+            "abstract_content": "1",
             "end": {
-              "col": 8,
+              "col": 6,
               "line": 1,
-              "offset": 7
+              "offset": 5
             },
             "start": {
-              "col": 7,
+              "col": 5,
               "line": 1,
-              "offset": 6
+              "offset": 4
             },
             "unique_id": {
               "md5sum": "<masked in tests>",

--- a/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
@@ -13,25 +13,7 @@
         "lines": "    nested_patterns_func('foo', 1)",
         "message": "test",
         "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "'foo'",
-            "end": {
-              "col": 31,
-              "line": 2,
-              "offset": 48
-            },
-            "start": {
-              "col": 26,
-              "line": 2,
-              "offset": 43
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          }
-        },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/nested-patterns.js",
@@ -53,25 +35,7 @@
         "lines": "    nested_patterns_func('bar', 2)",
         "message": "test",
         "metadata": {},
-        "metavars": {
-          "$X": {
-            "abstract_content": "'bar'",
-            "end": {
-              "col": 31,
-              "line": 3,
-              "offset": 83
-            },
-            "start": {
-              "col": 26,
-              "line": 3,
-              "offset": 78
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
-            }
-          }
-        },
+        "metavars": {},
         "severity": "WARNING"
       },
       "path": "targets/basic/nested-patterns.js",


### PR DESCRIPTION
This adds a pass to sort the results just before export. The issue was [this](https://semgrep.dev/s/08Zv):

![image](https://user-images.githubusercontent.com/343265/148613038-e281c0a3-1937-4be0-bfd3-6d47b6fdf0c8.png)
^ the matches presented here are actually where the `$SOURCE` metavariable matches, while the whole match is at the same location.

This may break a bunch of tests due to the json output of semgrep-core being reordered. Meanwhile, testing can be done manually with this:
```
$ semgrep-core -lang json -e '[...,$X,...]' <(echo $'["first",\n"second"]') -json | jq .matches[].extra.metavars
{
  "$X": {
    "start": {
      "line": 1,
      "col": 2,
      "offset": 1
    },
    "end": {
      "line": 1,
      "col": 9,
      "offset": 8
    },
    "abstract_content": "\"first\"",
    "unique_id": {
      "type": "AST",
      "md5sum": "061635551a453cba667bcafb772a1f53"
    }
  }
}
{
  "$X": {
    "start": {
      "line": 2,
      "col": 1,
      "offset": 10
    },
    "end": {
      "line": 2,
      "col": 9,
      "offset": 18
    },
    "abstract_content": "\"second\"",
    "unique_id": {
      "type": "AST",
      "md5sum": "2d63ad48d9657782f7af8782745a44c8"
    }
  }
}
```
^ the `line` fields should be 1 then 2 as in the above.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
