### PR TITLE
Propagate core errors up when using --test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Rust: inner attributes are allowed again inside functions (#4444) (#4445)
 - Python: return statement can contain tuple expansions (#4461)
 - metavariable-comparison: do not throw a Not_found exn anymore (#4469)
+- `--test` will now report parse errors on unit test files. This will also cause a non-zero exit code when run with `--strict`.
 
 ## [0.77.0](https://github.com/returntocorp/semgrep/releases/tag/v0.77.0) - 12-16-2021
 

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -267,8 +267,15 @@ def invoke_semgrep_multi(
 ) -> Tuple[Path, Optional[str], Any]:
     try:
         output = invoke_semgrep(config, targets, **kwargs)
-        if len(output['errors']) > 0:
-            raise Exception(output['errors'][0].get('message', "Semgrep core reported an error but no error message."))
+
+        assert isinstance(output, dict)  # placate mypy
+
+        if len(output["errors"]) > 0:
+            raise Exception(
+                output["errors"][0].get(
+                    "message", "Semgrep core reported an error but no error message."
+                )
+            )
     except Exception as error:
         # We must get the string of the error because the multiprocessing library
         # will fail the marshal the error and hang

--- a/semgrep/semgrep/test.py
+++ b/semgrep/semgrep/test.py
@@ -267,6 +267,8 @@ def invoke_semgrep_multi(
 ) -> Tuple[Path, Optional[str], Any]:
     try:
         output = invoke_semgrep(config, targets, **kwargs)
+        if len(output['errors']) > 0:
+            raise Exception(output['errors'][0].get('message', "Semgrep core reported an error but no error message."))
     except Exception as error:
         # We must get the string of the error because the multiprocessing library
         # will fail the marshal the error and hang


### PR DESCRIPTION
 This enables Semgrep to fail tests when parse errors occur when also running --test with --strict.

Part of fixing https://github.com/returntocorp/semgrep-rules/issues/1699

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
