### PR TITLE
Add a 'dev' target for faster testing with semgrep after rebuilding semgrep-core.

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -39,6 +39,9 @@ test: all
 	$(MAKE) -C src/spacegrep test
 	dune runtest -f --no-buffer
 
+# This may install more than you want.
+# See the 'dev' target if all you need is access to the semgrep-core
+# executable for testing.
 .PHONY: install
 install:
 	dune install
@@ -47,6 +50,16 @@ install:
 ###############################################################################
 # Developer targets
 ###############################################################################
+
+# Build semgrep-core and place it where semgrep expects it.
+# This is for development purposes only as I'm not sure if a symlink is ok
+# for packaging things up on the python side.
+.PHONY: dev
+dev:
+	$(MAKE) all
+	rm -f ../semgrep/semgrep/bin/semgrep-core
+	ln -s ../../../semgrep-core/bin/semgrep-core \
+	  ../semgrep/semgrep/bin/semgrep-core
 
 .PHONY: e2etest
 e2etest:


### PR DESCRIPTION
I think it's a better solution than https://github.com/returntocorp/semgrep/pull/4495. It's faster and doesn't involve a new script at a weird location.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
