### PR TITLE
Pass JSON data to -targets

### DIFF
--- a/interfaces/Input_to_core.atd
+++ b/interfaces/Input_to_core.atd
@@ -1,6 +1,6 @@
 (*
-   Type definitions for semgrep-core's input and command-line flags,
-   meant for the python wrapper, 'semgrep'.
+   Type definitions for semgrep-core's JSON input, meant for the
+   python wrapper, 'semgrep'.
 
    There are other very important form of inputs which are not specified here:
     - The rule syntax and schema (see rule_schema.yaml; only the
@@ -13,4 +13,11 @@
 (* Targets *)
 (*****************************************************************************)
 
-(* TODO: --targets format *)
+(* for -targets *)
+
+type target = {
+  path: string (* source file *);
+  (* TODO: language, rule_ids *)
+}
+
+type targets = target list

--- a/interfaces/Input_to_core.atd
+++ b/interfaces/Input_to_core.atd
@@ -1,5 +1,5 @@
 (*
-   Type definitions for semgrep-core's JSON input, meant for the
+   Type definitions for semgrep-core's JSON input, coming from the
    python wrapper, 'semgrep'.
 
    There are other very important form of inputs which are not specified here:

--- a/interfaces/Input_to_core.atd
+++ b/interfaces/Input_to_core.atd
@@ -13,7 +13,10 @@
 (* Targets *)
 (*****************************************************************************)
 
-(* for -targets *)
+(* For -targets.
+ * coupling: if you change the type here, you probably also want to change
+ * semgrep-core/tests/e2e/target
+*)
 
 type target = {
   path: string (* source file *);

--- a/interfaces/Output_from_core.atd
+++ b/interfaces/Output_from_core.atd
@@ -1,5 +1,5 @@
 (*
-   Type definitions for semgrep-core's json output, meant for the
+   Type definitions for semgrep-core's JSON output, meant for the
    python wrapper, 'semgrep'.
 
    This file is translated into OCaml modules by atdgen:

--- a/semgrep-core/src/core/Input_to_core.atd
+++ b/semgrep-core/src/core/Input_to_core.atd
@@ -1,0 +1,1 @@
+../../../interfaces/Input_to_core.atd

--- a/semgrep-core/src/core/dune
+++ b/semgrep-core/src/core/dune
@@ -25,6 +25,7 @@
  )
 )
 
+;TODO: factorize this
 (rule
  (targets Config_semgrep_j.ml Config_semgrep_j.mli)
  (deps    Config_semgrep.atd)
@@ -43,4 +44,14 @@
 (rule
  (targets Output_from_core_t.ml Output_from_core_t.mli)
  (deps    Output_from_core.atd)
+ (action  (run atdgen -t %{deps})))
+
+(rule
+ (targets Input_to_core_j.ml Input_to_core_j.mli)
+ (deps    Input_to_core.atd)
+ (action  (run atdgen -j -j-std %{deps})))
+
+(rule
+ (targets Input_to_core_t.ml Input_to_core_t.mli)
+ (deps    Input_to_core.atd)
  (action  (run atdgen -t %{deps})))

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -165,13 +165,15 @@ let semgrep_check config metachecks rules =
   let config =
     {
       config with
-      Runner_common.lang = Some (Xlang.of_lang Yaml);
+      Runner_config.lang = Some (Xlang.of_lang Yaml);
       config_file = metachecks;
       output_format = Json;
+      (* the targets are actually the rules! metachecking! *)
+      roots = rules;
     }
   in
   let _success, res, _targets =
-    Run_semgrep.semgrep_with_raw_results_and_exn_handler config rules
+    Run_semgrep.semgrep_with_raw_results_and_exn_handler config
   in
   res.matches |> List.map match_to_semgrep_error
 

--- a/semgrep-core/src/metachecking/Check_rule.mli
+++ b/semgrep-core/src/metachecking/Check_rule.mli
@@ -3,7 +3,7 @@ val check : Rule.t -> Semgrep_error_code.error list
 
 (* to test -check_rules *)
 val run_checks :
-  Runner_common.config ->
+  Runner_config.t ->
   (Common.filename -> Rule.t list) ->
   Common.filename (* metachecks *) ->
   Common.filename list (* rules *) ->
@@ -11,7 +11,7 @@ val run_checks :
 
 (* -check_rules *)
 val check_files :
-  (unit -> Runner_common.config) ->
+  (unit -> Runner_config.t) ->
   (Common.filename -> Rule.t list) ->
   Common.filename list ->
   unit

--- a/semgrep-core/src/metachecking/Test_metachecking.ml
+++ b/semgrep-core/src/metachecking/Test_metachecking.ml
@@ -28,7 +28,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 
 let config =
   {
-    Runner_common.log_config_file = "";
+    Runner_config.log_config_file = "";
     log_to_file = None;
     test = false;
     debug = false;
@@ -53,6 +53,7 @@ let config =
     target_file = "";
     action = "";
     version = "test";
+    roots = [];
   }
 
 (*****************************************************************************)

--- a/semgrep-core/src/runner/Parse_with_caching.ml
+++ b/semgrep-core/src/runner/Parse_with_caching.ml
@@ -1,5 +1,5 @@
 open Common
-open Runner_common
+open Runner_config
 
 (*****************************************************************************)
 (* Purpose *)

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -1,20 +1,25 @@
 open Common
-open Runner_common
+open Runner_config
 module PI = Parse_info
 module E = Semgrep_error_code
 module MR = Mini_rule
 module R = Rule
-module SJ = Output_from_core_j
 module RP = Report
 module P = Parse_with_caching
+module In = Input_to_core_j
+module Out = Output_from_core_j
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
 (*****************************************************************************)
 (* Purpose *)
 (*****************************************************************************)
-
-(* All the entry points to run semgrep *)
+(* Entry points to the semgrep engine with its command-line configuration.
+ *
+ * This used to be in Main.ml, but Main.ml started to become really big,
+ * and we also need a way to run the semgrep engine from semgrep-core
+ * variants, hence this callable library.
+ *)
 
 (*****************************************************************************)
 (* Helpers *)
@@ -261,6 +266,9 @@ let exn_to_error file exn =
 (* Parsing (non-cached) *)
 (*****************************************************************************)
 
+(* TODO? this is currently deprecated, but pad still has hope the
+ * feature can be resurrected.
+ *)
 let parse_equivalences equivalences_file =
   match equivalences_file with
   | "" -> []
@@ -287,6 +295,7 @@ let parse_pattern lang_pattern str =
 let iter_files_and_get_matches_and_exn_to_errors config f files =
   files
   |> map_targets config.ncores (fun file ->
+         (* TODO let file = target.In.path in *)
          logger#info "Analyzing %s" file;
          let res, run_time =
            Common.with_time (fun () ->
@@ -348,6 +357,10 @@ let iter_files_and_get_matches_and_exn_to_errors config f files =
 (*****************************************************************************)
 (* File targeting and rule filtering *)
 (*****************************************************************************)
+(* TODO: this should be done by semgrep-python. We should just have
+ * a poor's man file targeting/filtering here, just enough to run
+ * semgrep-core independently of semgrep-python to test things.
+ *)
 
 let lang_opt_of_config config =
   match config.lang with
@@ -414,38 +427,51 @@ let file_and_more_of_file config langs file =
     lazy_ast_and_errors;
   }
 
-(* We should let semgrep-python computing the list of files (and pass it
- * via -target, but it's convenient to run semgrep-core without semgrep-python
- * and to recursively get a list of files.
- *)
-let files_of_roots config roots =
-  let lang_opt = lang_opt_of_config config in
-  Find_target.files_of_dirs_or_files lang_opt roots
+let targets_of_config (config : Runner_config.t) :
+    In.targets * Out.skipped_target list =
+  match (config.target_file, config.roots) with
+  | "", roots ->
+      (* We usually let semgrep-python computes the list of targets (and pass it
+       * via -target), but it's convenient to also run semgrep-core without
+       * semgrep-python and to recursively get a list of targets.
+       *)
+      let lang_opt = lang_opt_of_config config in
+      let files, skipped = Find_target.files_of_dirs_or_files lang_opt roots in
+      let targets = files |> List.map (fun file -> { In.path = file }) in
+      (targets, skipped)
+  | target_file, [] ->
+      let str = Common.read_file target_file in
+      let targets = In.targets_of_string str in
+      let skipped = [] in
+      (targets, skipped)
+  | _ -> failwith "if you use -targets, you should not specify files"
 
 (*****************************************************************************)
 (* Semgrep -config *)
 (*****************************************************************************)
 
 (* This is the main function used by the semgrep python wrapper right now.
- * It takes a language, a set of rules and a set of files or dirs and
- * recursively process those files or dirs.
+ * It takes a set of rules and a set of targets and
+ * recursively process those targets.
  *)
-let semgrep_with_rules config (rules, rule_parse_time) files_or_dirs =
-  (* todo: at some point we should infer the lang from the rules and
-   * apply different rules with different languages and different files
-   * automatically, like the semgrep python wrapper.
-   *
-   * For now python wrapper passes down all files that should be scanned
-   *)
-  let files, skipped = files_of_roots config files_or_dirs in
-  logger#info "processing %d files, skipping %d files" (List.length files)
+let semgrep_with_rules config (rules, rule_parse_time) =
+  let targets, skipped = targets_of_config config in
+  logger#info "processing %d files, skipping %d files" (List.length targets)
     (List.length skipped);
+  (* TODO: rename iter_files_... to iter_targets and pass a target
+   * to callback instead of a file *)
+  let files = targets |> List.map (fun t -> t.In.path) in
 
   let file_results =
     files
     |> iter_files_and_get_matches_and_exn_to_errors config (fun file ->
+           (* TODO: let file = target.I.path in *)
+           (* TODO: use the information in target at some point instead
+            * of using those 2 functions below.
+            *)
            let langs = langs_of_file_or_config config file in
            let rules = rules_for_langs_and_file langs file rules in
+
            let file_and_more = file_and_more_of_file config langs file in
            let match_hook str env matched_tokens =
              if config.output_format = Text then
@@ -480,7 +506,7 @@ let semgrep_with_rules config (rules, rule_parse_time) files_or_dirs =
   ( { RP.matches; errors; skipped; rule_profiling = res.RP.rule_profiling },
     files )
 
-let semgrep_with_raw_results_and_exn_handler config files_or_dirs =
+let semgrep_with_raw_results_and_exn_handler config =
   let rules_file = config.config_file in
   (* useful when using process substitution, e.g.
    * semgrep-core -config <(curl https://semgrep.dev/c/p/ocaml) ...
@@ -492,7 +518,7 @@ let semgrep_with_raw_results_and_exn_handler config files_or_dirs =
     let timed_rules =
       Common.with_time (fun () -> Parse_rule.parse rules_file)
     in
-    let res, files = semgrep_with_rules config timed_rules files_or_dirs in
+    let res, files = semgrep_with_rules config timed_rules in
     (None, res, files)
   with exn when not !Flag_semgrep.fail_fast ->
     let trace = Printexc.get_backtrace () in
@@ -507,10 +533,8 @@ let semgrep_with_raw_results_and_exn_handler config files_or_dirs =
     in
     (Some exn, res, [])
 
-let semgrep_with_formatted_output config files_or_dirs =
-  let exn, res, files =
-    semgrep_with_raw_results_and_exn_handler config files_or_dirs
-  in
+let semgrep_with_formatted_output config =
+  let exn, res, files = semgrep_with_raw_results_and_exn_handler config in
   (* note: uncomment the following and use semgrep-core -stat_matches
    * to debug too-many-matches issues.
    * Common2.write_value matches "/tmp/debug_matches";
@@ -525,7 +549,7 @@ let semgrep_with_formatted_output config files_or_dirs =
         User should use an external tool like jq or ydump (latter comes with
         yojson) for pretty-printing json.
       *)
-      let s = SJ.string_of_match_results res in
+      let s = Out.string_of_match_results res in
       logger#info "size of returned JSON string: %d" (String.length s);
       pr s;
       match exn with
@@ -569,6 +593,23 @@ let rule_of_pattern lang pattern_string pattern =
     metadata = None;
   }
 
+(* less: could be nice to generalize to rule_of_config, but we sometimes
+ * need to generate a rule, sometimes a minirule
+ *)
+let pattern_of_config lang config =
+  match (config.pattern_file, config.pattern_string) with
+  | "", "" -> failwith "I need a pattern; use -f or -e"
+  | s1, s2 when s1 <> "" && s2 <> "" ->
+      failwith "I need just one pattern; use -f OR -e (not both)"
+  | file, _ when file <> "" ->
+      let s = Common.read_file file in
+      (parse_pattern lang s, s)
+  (* this is for Emma, who often confuses -e with -f :) *)
+  | _, s when s =~ ".*\\.sgrep$" ->
+      failwith "you probably want -f with a .sgrep file, not -e"
+  | _, s when s <> "" -> (parse_pattern lang s, s)
+  | _ -> raise Impossible
+
 (* simpler code path compared to semgrep_with_rules *)
 (* FIXME: don't use a different processing logic depending on the output
    format:
@@ -576,41 +617,23 @@ let rule_of_pattern lang pattern_string pattern =
    - Have semgrep_with_patterns return the results and errors.
    - Print the final results (json or text) using dedicated functions.
 *)
-let semgrep_with_one_pattern config roots =
-  (* old: let xs = List.map Common.fullpath xs in
-   * better no fullpath here, not our responsability.
-   *)
+let semgrep_with_one_pattern config =
+  assert (config.config_file = "");
+  assert (config.target_file = "");
+
   (* TODO: support generic and regex patterns as well? See code in Deep. *)
   let lang = Xlang.lang_of_opt_xlang config.lang in
-  let pattern, pattern_string =
-    match (config.pattern_file, config.pattern_string) with
-    | "", "" -> failwith "I need a pattern; use -f or -e"
-    | s1, s2 when s1 <> "" && s2 <> "" ->
-        failwith "I need just one pattern; use -f OR -e (not both)"
-    | file, _ when file <> "" ->
-        let s = Common.read_file file in
-        (parse_pattern lang s, s)
-    (* this is for Emma, who often confuses -e with -f :) *)
-    | _, s when s =~ ".*\\.sgrep$" ->
-        failwith "you probably want -f with a .sgrep file, not -e"
-    | _, s when s <> "" -> (parse_pattern lang s, s)
-    | _ -> raise Impossible
-  in
-  let targets, _skipped =
-    Find_target.files_of_dirs_or_files (Some lang) roots
-  in
-  let targets = Common.map replace_named_pipe_by_regular_file targets in
+  let pattern, pattern_string = pattern_of_config lang config in
+
   match config.output_format with
   | Json ->
       let rule, rule_parse_time =
         Common.with_time (fun () ->
             [ rule_of_pattern lang pattern_string pattern ])
       in
-      let res, files =
-        semgrep_with_rules config (rule, rule_parse_time) targets
-      in
+      let res, files = semgrep_with_rules config (rule, rule_parse_time) in
       let json = JSON_report.match_results_of_matches_and_errors files res in
-      let s = SJ.string_of_match_results json in
+      let s = Out.string_of_match_results json in
       pr s
   | Text ->
       let minirule, _rule_parse_time =
@@ -618,6 +641,13 @@ let semgrep_with_one_pattern config roots =
             [ minirule_of_pattern lang pattern_string pattern ])
       in
       (* simpler code path than in semgrep_with_rules *)
+      let roots =
+        (* less: could also apply Common.fullpath? *)
+        config.roots |> Common.map replace_named_pipe_by_regular_file
+      in
+      let targets, _skipped =
+        Find_target.files_of_dirs_or_files (Some lang) roots
+      in
       targets
       |> List.iter (fun file ->
              logger#info "processing: %s" file;
@@ -648,3 +678,10 @@ let semgrep_with_one_pattern config roots =
       if n > 0 then pr2 (spf "error count: %d" n);
       (* TODO: what's that? *)
       Experiments.gen_layer_maybe _matching_tokens pattern_string targets
+
+(*****************************************************************************)
+(* Semgrep dispatch *)
+(*****************************************************************************)
+let semgrep_dispatch config =
+  if config.config_file <> "" then semgrep_with_formatted_output config
+  else semgrep_with_one_pattern config

--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -1,9 +1,12 @@
+(* Main entry point *)
+val semgrep_dispatch : Runner_config.t -> unit
+
+(* internal functions used in tests or semgrep-core variants *)
+
 val semgrep_with_raw_results_and_exn_handler :
-  Runner_common.config ->
-  Common.filename list ->
-  exn option * Report.rule_result * Common.filename list
-(** [semgrep_with_raw_results_and_exn_handler config roots] runs the semgrep
-    engine starting from a list of [roots] and returns
+  Runner_config.t -> exn option * Report.rule_result * Common.filename list
+(** [semgrep_with_raw_results_and_exn_handler config] runs the semgrep
+    engine with a starting list of targets and returns
     (success, result, targets).
     The targets are all the files that were considered valid targets for the
     semgrep scan. This excludes files that were filtered out on purpose
@@ -12,19 +15,15 @@ val semgrep_with_raw_results_and_exn_handler :
     a parsing error.
 *)
 
-val semgrep_with_formatted_output :
-  Runner_common.config -> Common.filename list -> unit
-(** [semgrep_with_formatted_output config roots] calls
+val semgrep_with_formatted_output : Runner_config.t -> unit
+(** [semgrep_with_formatted_output config] calls
     [semgrep_with_raw_results_and_exn_handler] and
     format the results on stdout either in a JSON or Textual format
     (depending on the value in config.output_format)
 *)
 
-val semgrep_with_one_pattern :
-  Runner_common.config -> Common.filename list -> unit
+val semgrep_with_one_pattern : Runner_config.t -> unit
 (** this is the function used when running semgrep with -e or -f *)
-
-(* internal functions used in tests or semgrep-core variants *)
 
 val replace_named_pipe_by_regular_file : Common.filename -> Common.filename
 (**
@@ -51,10 +50,9 @@ val exn_to_error : Common.filename -> exn -> Semgrep_error_code.error
   See also JSON_report.json_of_exn for non-target related exn handling.
 *)
 
-val files_of_roots :
-  Runner_common.config ->
-  Common.path list ->
-  Common.filename list * Output_from_core_j.skipped_target list
+val targets_of_config :
+  Runner_config.t ->
+  Input_to_core_t.targets * Output_from_core_t.skipped_target list
 (**
   Small wrapper over Find_target.files_of_dirs_or_files
  *)

--- a/semgrep-core/src/runner/Runner_config.ml
+++ b/semgrep-core/src/runner/Runner_config.ml
@@ -1,13 +1,15 @@
+open Common
+
 (*
    Type definitions, mostly.
 *)
 
 type output_format = Text | Json [@@deriving show]
 
-type config = {
+type t = {
   (* Debugging/profiling/logging flags *)
-  log_config_file : string;
-  log_to_file : string option;
+  log_config_file : filename;
+  log_to_file : filename option;
   test : bool;
   debug : bool;
   profile : bool;
@@ -16,10 +18,11 @@ type config = {
   profile_start : float;
   (* Main flags *)
   pattern_string : string;
-  pattern_file : string;
-  config_file : string;
+  pattern_file : filename;
+  config_file : filename;
   equivalences_file : string;
   lang : Xlang.t option;
+  roots : Common.path list;
   output_format : output_format;
   match_format : Matching_report.match_format;
   mvars : Metavariable.mvar list;

--- a/semgrep-core/src/runner/Setup_logging.ml
+++ b/semgrep-core/src/runner/Setup_logging.ml
@@ -3,7 +3,7 @@
    we found on the command line or config files.
 *)
 
-open Runner_common
+open Runner_config
 
 let logger = Logging.get_logger [ __MODULE__ ]
 

--- a/semgrep-core/src/runner/Setup_logging.mli
+++ b/semgrep-core/src/runner/Setup_logging.mli
@@ -2,4 +2,4 @@
    Set up logging globally and for each module based on what
    we found on the command line or config files.
 *)
-val setup : Runner_common.config -> unit
+val setup : Runner_config.t -> unit

--- a/semgrep-core/tests/e2e/target
+++ b/semgrep-core/tests/e2e/target
@@ -1,1 +1,1 @@
-tests/e2e/targets/basic.py
+[ {"path": "tests/e2e/targets/basic.py"} ]

--- a/semgrep-core/tests/e2e/test_target_file.py
+++ b/semgrep-core/tests/e2e/test_target_file.py
@@ -7,7 +7,7 @@ def test_target_file():
         as having that file in -target-file flag
     """
     output = subprocess.check_output(["semgrep-core", "-e", "$X==$X", "-lang", "python", "tests/e2e/targets/basic.py"], encoding="utf-8")
-    output2 = subprocess.check_output(["semgrep-core", "-e", "$X==$X", "-lang", "python", "-target_file", "tests/e2e/target"], encoding="utf-8")
+    output2 = subprocess.check_output(["semgrep-core", "-e", "$X==$X", "-lang", "python", "-targets", "tests/e2e/target"], encoding="utf-8")
     assert output == output2
 
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -317,8 +317,13 @@ class CoreRunner:
                             continue
                         all_targets = all_targets.union(targets)
 
-                        target_file.write("\n".join(map(lambda p: str(p), targets)))
+                        # TODO: use atdgen-py
+                        # The format of this JSON is specified in
+                        # interfaces/Input_to_core.atd
+                        array = [{"path": str(p)} for p in targets]
+                        target_file.write(json.dumps(array))
                         target_file.flush()
+
                         yaml = YAML()
                         yaml.dump({"rules": [rule._raw]}, rule_file)
                         rule_file.flush()
@@ -331,7 +336,7 @@ class CoreRunner:
                             rule_file.name,
                             "-j",
                             str(self._jobs),
-                            "-target_file",
+                            "-targets",
                             target_file.name,
                             "-use_parsing_cache",
                             semgrep_core_ast_cache_dir,

--- a/semgrep/tests/qa/test_public_repos.py
+++ b/semgrep/tests/qa/test_public_repos.py
@@ -88,7 +88,7 @@ def _assert_sentinel_results(
 
     if output["errors"]:
         pytest.fail(
-            f"Running on {repo_url} with lang {language} had errors ({semgrep_run.args}): "
+            f"Running on {repo_url} (cached in {repo_path}) with lang {language} had errors ({semgrep_run.args}): "
             + json.dumps(output["errors"], indent=4)
         )
 


### PR DESCRIPTION
This is part of  https://r2c.quip.com/Xk8ZAGJPBVlf/Semgrep-core-separation

The end goal is to pass the list of targets with more information attached to them such
as the language of the target, and the rule ids to use for this target, so all the
file targeting work can be done Python-side instead of currently spread over
Python and OCaml right now.


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)