### PR TITLE
Fix 'make' if run after 'make -C semgrep-core dev'

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -45,7 +45,8 @@ test: all
 .PHONY: install
 install:
 	dune install
-	cp -f _build/install/default/bin/semgrep-core ../semgrep/semgrep/bin/
+	rm -f ../semgrep/semgrep/bin/semgrep-core
+	cp _build/install/default/bin/semgrep-core ../semgrep/semgrep/bin/
 
 ###############################################################################
 # Developer targets


### PR DESCRIPTION
The new `make dev` target puts a symlink in semgrep's bin (python). It causes this error message when later attempting a copy without deleting the symlink first:

```
cp -f _build/install/default/bin/semgrep-core ../semgrep/semgrep/bin/
cp: '_build/install/default/bin/semgrep-core' and '../semgrep/semgrep/bin/semgrep-core' are the same file
```

repro/test:
```
make -C semgrep-core dev
make
```

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
