### PR TITLE
Add core_runner.pyi

### DIFF
--- a/semgrep/semgrep/core_runner.pyi
+++ b/semgrep/semgrep/core_runner.pyi
@@ -1,0 +1,38 @@
+from pathlib import Path
+from semgrep.rule import Rule
+from semgrep.target_manager import TargetManager
+from semgrep.profile_manager import ProfileManager
+from semgrep.rule_match import RuleMatch
+import semgrep.error as error
+import semgrep.profiling as profiling
+import semgrep.semgrep_types as semgrep_types
+from typing import Any, Dict, List, Sequence, Set, Tuple
+
+class CoreRunner:
+    """
+    Handles interactions between semgrep and semgrep-core
+
+    This includes properly invoking semgrep-core and parsing the output
+    """
+    def __init__(self,
+                 jobs: int,
+                 timeout: int,
+                 max_memory: int,
+                 timeout_threshold: int,
+                 optimizations: str) -> None: ...
+
+    def invoke_semgrep(self,
+                       target_manager: TargetManager,
+                       profiler: ProfileManager,
+                       rules: List[Rule]) -> Tuple[Dict[Rule, List[RuleMatch]],
+                                                   List[error.SemgrepError],
+                                                   Set[Path],
+                                                   profiling.ProfilingData]:
+        """
+        Takes in rules and targets and retuns object with findings
+        """
+        ...
+
+    def validate_configs(self,
+                         configs: Tuple[str, ...]) -> Sequence[error.SemgrepError]:
+        ...

--- a/semgrep/semgrep/nosemgrep.pyi
+++ b/semgrep/semgrep/nosemgrep.pyi
@@ -1,0 +1,18 @@
+import semgrep.error as error
+from semgrep.rule_match import RuleMatch
+from semgrep.rule_match_map import RuleMatchMap
+from typing import Any, Sequence, Tuple
+
+def process_ignores(rule_matches_by_rule: RuleMatchMap,
+                    keep_ignored: bool,
+                    strict: bool) -> Tuple[RuleMatchMap,
+                                           Sequence[error.SemgrepError], int]:
+    """
+    Handles ignoring Semgrep findings via inline code comments
+
+    Currently supports ignoring a finding on a single line by adding a
+    `# nosemgrep:ruleid` comment (or `// nosemgrep:ruleid`).
+
+    To use, create a RuleMatchMap, then pass it to process_ignores().
+    """
+    ...

--- a/semgrep/semgrep/rule.pyi
+++ b/semgrep/semgrep/rule.pyi
@@ -1,0 +1,84 @@
+import semgrep.constants as constants
+import semgrep.rule_lang as rule_lang
+import semgrep.semgrep_types as semgrep_types
+from typing import Any, Dict, List, Optional, Sequence
+
+class Rule:
+    def __init__(self, raw: rule_lang.YamlTree[rule_lang.YamlMap]) -> None:
+        ...
+
+    @property
+    def id(self) -> str:
+        ...
+    @property
+    def message(self) -> str:
+        ...
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        ...
+    @property
+    def severity(self) -> constants.RuleSeverity:
+        ...
+    @property
+    def mode(self) -> str:
+        ...
+
+    @property
+    def fix(self) -> Optional[str]:
+        ...
+    @property
+    def fix_regex(self) -> Optional[Dict[str, Any]]:
+        ...
+
+    @property
+    def project_depends_on(self) -> Optional[List[List[Dict[str, str]]]]:
+        """
+        If the rule contains `project-depends-on` keys under patterns, return the values of those keys
+        Otherwise return None
+        """
+        ...
+
+    @property
+    def raw(self) -> Dict[str, Any]:
+        ...
+
+    @classmethod
+    def from_json(cls, rule_json: Dict[str, Any]) -> Rule:
+        ...
+    @classmethod
+    def from_yamltree(cls, rule_yaml: rule_lang.YamlTree[rule_lang.YamlMap]) -> Rule:
+        ...
+
+    def rename_id(self, new_id: str) -> None:
+        ...
+
+    @property
+    def full_hash(self) -> str:
+        """
+        sha256 hash of the whole rule object instead of just the id
+        """
+        ...
+
+    @property
+    def should_run_on_semgrep_core(self) -> bool:
+        """
+        Used to detect whether the rule had patterns that need to run on the core
+        (beyond Python-handled patterns, like `pattern-depends-on`).
+        Remove this code once all rule runnning is done in the core and the answer is always 'yes'
+        """
+        ...
+
+#TODO: this seems dead and not used outside the class
+#    def __eq__(self, other: object) -> bool: ...
+#    def __hash__(self) -> int: ...
+#    @property
+#    def includes(self) -> Sequence[str]: ...
+#    @property
+#    def excludes(self) -> Sequence[str]: ...
+#    @property
+#    def languages(self) -> List[semgrep_types.Language]: ...
+#    @property
+#    def languages_span(self) -> rule_lang.Span: ...
+
+def rule_without_metadata(rule: Rule) -> Rule:
+    ...


### PR DESCRIPTION
This is an experiment is starting to use real interface files to
define Python modules. This is similar to the .mli defining
the interface of .ml files in OCaml.

test plan:
mypy --config-file ../mypy.ini semgrep/


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)