### PR TITLE
implement make clean in semgrep/

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -103,7 +103,7 @@ report-perf:
 
 pr:
 	git push origin `git rev-parse --abbrev-ref HEAD`
-	hub pull-request -b develop -r mjambon -r IagoAbal -r emjin -r mmcqd
+	hub pull-request -b develop -r returntocorp/pa
 
 push:
 	git push origin `git rev-parse --abbrev-ref HEAD`

--- a/semgrep/Makefile
+++ b/semgrep/Makefile
@@ -2,5 +2,13 @@ test:
 	pipenv run pytest -v --tb=short tests/
 regenerate-tests:
 	pipenv run pytest tests/ --snapshot-update
+
+setup:
+	pipenv install --dev
+
+.PHONY: clean
 clean:
-	@# main Makefile expects a clean target, may be useful in the future
+	rm -rf build/ semgrep.egg-info/ .eggs/
+	rm -rf .pytest_cache/ .benchmarks/
+	rm -f semgrep/bin/semgrep-core
+	rm -rf semgrep/__pycache__ semgrep/*/__pycache__

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -82,7 +82,7 @@ def find_executable(env_name, exec_name):
 
 
 #
-# The default behavior is to copy the semgrep-core and spacegrep binaries
+# The default behavior is to copy the semgrep-core binary
 # into some other folder known to the semgrep wrapper. If somebody knows why,
 # please explain why we do this.
 #


### PR DESCRIPTION
This removes autogenerated files in the python semgrep/ directory.

test plan:
make clean
make setup
pipenv shell
semgrep --help


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)