### PR TITLE
style: Change colors and indentation of CLI output

### DIFF
--- a/semgrep/semgrep/commands/scan.py
+++ b/semgrep/semgrep/commands/scan.py
@@ -25,6 +25,7 @@ from semgrep.constants import MAX_LINES_FLAG_NAME
 from semgrep.constants import RuleSeverity
 from semgrep.core_runner import CoreRunner
 from semgrep.notifications import possibly_notify_user
+from semgrep.semgrep.constants import Colors
 from semgrep.semgrep_types import LANGUAGE
 from semgrep.types import MetricsState
 from semgrep.util import abort
@@ -633,7 +634,7 @@ def scan(
     if include and exclude:
         logger.warning(
             with_color(
-                "yellow",
+                Colors.yellow,
                 "Paths that match both --include and --exclude will be skipped by Semgrep.",
             )
         )

--- a/semgrep/semgrep/commands/scan.py
+++ b/semgrep/semgrep/commands/scan.py
@@ -16,6 +16,7 @@ from click_option_group import optgroup
 from semgrep import __VERSION__
 from semgrep import bytesize
 from semgrep.config_resolver import list_current_public_rulesets
+from semgrep.constants import Colors
 from semgrep.constants import DEFAULT_MAX_CHARS_PER_LINE
 from semgrep.constants import DEFAULT_MAX_LINES_PER_FINDING
 from semgrep.constants import DEFAULT_MAX_TARGET_SIZE
@@ -25,7 +26,6 @@ from semgrep.constants import MAX_LINES_FLAG_NAME
 from semgrep.constants import RuleSeverity
 from semgrep.core_runner import CoreRunner
 from semgrep.notifications import possibly_notify_user
-from semgrep.semgrep.constants import Colors
 from semgrep.semgrep_types import LANGUAGE
 from semgrep.types import MetricsState
 from semgrep.util import abort

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -10,7 +10,7 @@ RULES_KEY = "rules"
 ID_KEY = "id"
 CLI_RULE_ID = "-"
 SEMGREP_URL = os.environ.get("SEMGREP_URL", "https://semgrep.dev/")
-PLEASE_FILE_ISSUE_TEXT = "An error occurred while invoking the semgrep engine; please help us fix this by creating an issue at https://github.com/returntocorp/semgrep"
+PLEASE_FILE_ISSUE_TEXT = "An error occurred while invoking the Semgrep engine. Please help us fix this by creating an issue at https://github.com/returntocorp/semgrep"
 
 DEFAULT_SEMGREP_CONFIG_NAME = "semgrep"
 DEFAULT_CONFIG_FILE = f".{DEFAULT_SEMGREP_CONFIG_NAME}.yml"

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -2,6 +2,7 @@ import os
 import re
 from enum import auto
 from enum import Enum
+from types import SimpleNamespace
 from typing import Type
 
 from semgrep import __VERSION__
@@ -116,3 +117,20 @@ MAX_CHARS_FLAG_NAME = "--max-chars-per-line"
 DEFAULT_MAX_CHARS_PER_LINE = 160
 ELLIPSIS_STRING = " ... "
 DEFAULT_MAX_TARGET_SIZE = 1000000  # 1 MB
+
+
+class Colors(Enum):
+    # these colors come from user's terminal theme
+    foreground = 0
+    bright = 15  # also referred to as "bold color"
+    white = 7
+    black = 256
+    cyan = "cyan"  # for filenames
+    green = "green"  # for autofix
+    yellow = "yellow"  # TODO: benchmark timing output?
+    red = "red"  # for errors
+    bright_blue = "bright_blue"  # TODO: line numbers?
+
+    # these colors ignore user's terminal theme
+    forced_black = 16  # #000
+    forced_white = 231  # #FFF

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -2,7 +2,6 @@ import os
 import re
 from enum import auto
 from enum import Enum
-from types import SimpleNamespace
 from typing import Type
 
 from semgrep import __VERSION__

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -33,6 +33,7 @@ from semgrep.progress_bar import progress_bar
 from semgrep.rule import Rule
 from semgrep.rule_match import CoreLocation
 from semgrep.rule_match import RuleMatch
+from semgrep.semgrep.constants import Colors
 from semgrep.semgrep_core import SemgrepCore
 from semgrep.semgrep_types import LANGUAGE
 from semgrep.semgrep_types import Language
@@ -218,7 +219,7 @@ class CoreRunner:
         # for proper quoting of the command line.
         shell_command = " ".join(core_run.args)
         details = with_color(
-            "white",
+            Colors.white,
             f"semgrep-core exit code: {returncode}\n"
             f"semgrep-core command: {shell_command}\n"
             f"unexpected non-json output while invoking semgrep-core:\n"

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -17,6 +17,7 @@ from typing import Tuple
 from ruamel.yaml import YAML
 
 from semgrep.config_resolver import Config
+from semgrep.constants import Colors
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.core_output import CoreOutput
 from semgrep.core_output import RuleId
@@ -33,7 +34,6 @@ from semgrep.progress_bar import progress_bar
 from semgrep.rule import Rule
 from semgrep.rule_match import CoreLocation
 from semgrep.rule_match import RuleMatch
-from semgrep.semgrep.constants import Colors
 from semgrep.semgrep_core import SemgrepCore
 from semgrep.semgrep_types import LANGUAGE
 from semgrep.semgrep_types import Language

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -148,11 +148,11 @@ class SemgrepCoreError(SemgrepError):
                 self.error_type == "Rule parse error"
                 or self.error_type == "Pattern parse error"
             ):
-                msg = f"Semgrep Core {self.level.name} - {self.error_type}: In rule {self.rule_id}: {self.message}"
+                msg = f"Semgrep Core {self.level.name} \n{self.error_type}: In rule {self.rule_id}: {self.message}"
             else:
-                msg = f"Semgrep Core {self.level.name} - {self.error_type}: When running {self.rule_id} on {self.path}: {self.message}"
+                msg = f"Semgrep Core {self.level.name} \n{self.error_type}: When running {self.rule_id} on {self.path}: {self.message}"
         else:
-            msg = f"Semgrep Core {self.level.name} - {self.error_type} in file {self.path}:{self.start.line}\n\t{self.message}"
+            msg = f"Semgrep Core {self.level.name} \n{self.error_type} in file {self.path}:{self.start.line}\n\t{self.message}"
         return msg
 
     @property
@@ -162,13 +162,16 @@ class SemgrepCoreError(SemgrepError):
         """
         if self.error_type == "Fatal error":
             error_trace = self.details or "<no stack trace returned>"
-            return f"\n-----[ BEGIN error trace ]-----\n{error_trace}\n-----[ END error trace ]-----\n"
+            return f"\nSemgrep failed to run this rule, please file a GitHub issue or contact us on Slack.\n\n====[ BEGIN error trace ]====\n{error_trace}=====[ END error trace ]=====\n"
         else:
             return ""
 
     def __str__(self) -> str:
-        return with_color("red", self._error_message) + with_color(
-            "white", self._stack_trace
+        return (
+            with_color(231, f" ERROR ", bgcolor="red", bold=True)
+            + f" "
+            + self._error_message
+            + self._stack_trace
         )
 
 

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -162,7 +162,7 @@ class SemgrepCoreError(SemgrepError):
         """
         if self.error_type == "Fatal error":
             error_trace = self.details or "<no stack trace returned>"
-            return f"\nSemgrep failed to run this rule. Please file a GitHub issue or report this on Slack.\n\n====[ BEGIN error trace ]====\n{error_trace}=====[ END error trace ]=====\n"
+            return f"\nSemgrep failed to run this rule.\nWe don't know yet why this happened, but happy to help. Please file a GitHub issue or report it on Slack.\n\n====[ BEGIN error trace ]====\n{error_trace}=====[ END error trace ]=====\n"
         else:
             return ""
 

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -155,7 +155,7 @@ class SemgrepCoreError(SemgrepError):
             ):
                 msg = f"Semgrep Core — {self.error_type}\n{PLEASE_FILE_ISSUE_TEXT}\n\nIn rule {self.rule_id}: {self.message}\n"
             else:
-                msg = f"Semgrep Core — {self.error_type}\n{PLEASE_FILE_ISSUE_TEXT}\n\nFailed to run {self.rule_id} on {self.path}: {self.message}\n"
+                msg = f"Semgrep Core — {self.error_type}\n{PLEASE_FILE_ISSUE_TEXT}\n\nWhen running {self.rule_id} on {self.path}: {self.message}\n"
         else:
             msg = f"Semgrep Core — {self.error_type}\n{PLEASE_FILE_ISSUE_TEXT}\n\nIn file {self.path}:{self.start.line}\n\t{self.message}\n"
         return msg

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -11,13 +11,12 @@ from typing import Tuple
 
 import attr
 
-from semgrep.constants import ANSI_COLORS
+from semgrep.constants import Colors
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.rule_lang import Position
 from semgrep.rule_lang import SourceTracker
 from semgrep.rule_lang import Span
 from semgrep.rule_match import CoreLocation
-from semgrep.semgrep.constants import Colors
 from semgrep.util import with_color
 
 OK_EXIT_CODE = 0

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -168,7 +168,9 @@ class SemgrepCoreError(SemgrepError):
 
     def __str__(self) -> str:
         return (
-            with_color(231, f" ERROR ", bgcolor="red", bold=True)
+            with_color("red", f"[", bgcolor="red")
+            + with_color(231, f"ERROR", bgcolor="red", bold=True)
+            + with_color("red", f"]", bgcolor="red")
             + f" "
             + self._error_message
             + self._stack_trace

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -11,6 +11,7 @@ from typing import Tuple
 
 import attr
 
+from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.rule_lang import Position
 from semgrep.rule_lang import SourceTracker
 from semgrep.rule_lang import Span
@@ -135,7 +136,11 @@ class SemgrepCoreError(SemgrepError):
         """
         Error message plus stack trace
         """
-        return self._error_message + self._stack_trace
+        return (
+            f"{with_color('red', f'[', bgcolor='red')}{with_color(231, f'{self.level.name}', bgcolor='red', bold=True)}{with_color('red', f']', bgcolor='red')} "
+            + self._error_message
+            + self._stack_trace
+        )
 
     @property
     def _error_message(self) -> str:
@@ -148,11 +153,11 @@ class SemgrepCoreError(SemgrepError):
                 self.error_type == "Rule parse error"
                 or self.error_type == "Pattern parse error"
             ):
-                msg = f"Semgrep Core {self.level.name} \n{self.error_type}: In rule {self.rule_id}: {self.message}"
+                msg = f"Semgrep Core — {self.error_type}\n{PLEASE_FILE_ISSUE_TEXT}\n\nIn rule {self.rule_id}: {self.message}\n"
             else:
-                msg = f"Semgrep Core {self.level.name} \n{self.error_type}: When running {self.rule_id} on {self.path}: {self.message}"
+                msg = f"Semgrep Core — {self.error_type}\n{PLEASE_FILE_ISSUE_TEXT}\n\nFailed to run {self.rule_id} on {self.path}: {self.message}\n"
         else:
-            msg = f"Semgrep Core {self.level.name} \n{self.error_type} in file {self.path}:{self.start.line}\n\t{self.message}"
+            msg = f"Semgrep Core — {self.error_type}\n{PLEASE_FILE_ISSUE_TEXT}\n\nIn file {self.path}:{self.start.line}\n\t{self.message}\n"
         return msg
 
     @property
@@ -162,16 +167,13 @@ class SemgrepCoreError(SemgrepError):
         """
         if self.error_type == "Fatal error":
             error_trace = self.details or "<no stack trace returned>"
-            return f"\nSemgrep failed to run this rule.\nWe don't know yet why this happened, but happy to help. Please file a GitHub issue or report it on Slack.\n\n====[ BEGIN error trace ]====\n{error_trace}=====[ END error trace ]=====\n"
+            return f"\n====[ BEGIN error trace ]====\n{error_trace}=====[ END error trace ]=====\n"
         else:
             return ""
 
     def __str__(self) -> str:
         return (
-            with_color("red", f"[", bgcolor="red")
-            + with_color(231, f"ERROR", bgcolor="red", bold=True)
-            + with_color("red", f"]", bgcolor="red")
-            + f" "
+            f"{with_color('red', f'[', bgcolor='red')}{with_color(231, f'{self.level.name}', bgcolor='red', bold=True)}{with_color('red', f']', bgcolor='red')} "
             + self._error_message
             + self._stack_trace
         )

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -162,7 +162,7 @@ class SemgrepCoreError(SemgrepError):
         """
         if self.error_type == "Fatal error":
             error_trace = self.details or "<no stack trace returned>"
-            return f"\nSemgrep failed to run this rule, please file a GitHub issue or contact us on Slack.\n\n====[ BEGIN error trace ]====\n{error_trace}=====[ END error trace ]=====\n"
+            return f"\nSemgrep failed to run this rule. Please file a GitHub issue or report this on Slack.\n\n====[ BEGIN error trace ]====\n{error_trace}=====[ END error trace ]=====\n"
         else:
             return ""
 

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 from itertools import groupby
 from pathlib import Path
+from shutil import get_terminal_size
 from typing import Any
 from typing import cast
 from typing import Iterable
@@ -11,12 +12,13 @@ from typing import Mapping
 from typing import Optional
 from typing import Sequence
 
-import colorama
 import click
+import colorama
 
 from semgrep.constants import BREAK_LINE_CHAR
 from semgrep.constants import BREAK_LINE_WIDTH
 from semgrep.constants import CLI_RULE_ID
+from semgrep.constants import Colors
 from semgrep.constants import ELLIPSIS_STRING
 from semgrep.constants import MAX_CHARS_FLAG_NAME
 from semgrep.constants import MAX_LINES_FLAG_NAME
@@ -27,11 +29,9 @@ from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.semgrep_types import LANGUAGE
 from semgrep.semgrep_types import Language
-from semgrep.semgrep.constants import Colors
 from semgrep.util import format_bytes
 from semgrep.util import truncate
 from semgrep.util import with_color
-from shutil import get_terminal_size
 
 MAX_TEXT_WIDTH = 120
 

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -131,14 +131,14 @@ class TextFormatter(BaseFormatter):
                 if trimmed > 0:
                     yield trimmed_str.center(BREAK_LINE_WIDTH, BREAK_LINE_CHAR)
                 elif show_separator:
-                    yield f" " * 10 + f"╌┆" + f"╌" * 40
+                    yield f" " * 10 + f"⋮┆" + f"-" * 40
 
     @staticmethod
     def _get_details_shortlink(rule_match: RuleMatch) -> Optional[str]:
         source_url = rule_match._metadata.get("shortlink")
         if not source_url:
             return ""
-        return f"Details: {with_color(0,  source_url, bold=False)}"
+        return f"Details: {source_url}"
 
     @staticmethod
     def _build_summary(
@@ -337,10 +337,10 @@ class TextFormatter(BaseFormatter):
             )
 
             if fix:
-                yield f"{with_color('green', '     ▶▶ Autofix')} {fix}"
+                yield f"{with_color('green', '         ▶▶┆ Autofix ▶')} {fix}"
             elif rule_match.fix_regex:
                 fix_regex = rule_match.fix_regex
-                yield f"{with_color('green', '     ▶▶ Autofix')} s/{fix_regex.get('regex')}/{fix_regex.get('replacement')}/{fix_regex.get('count', 'g')}"
+                yield f"{with_color('green', '         ▶▶┆ Autofix ▶')} s/{fix_regex.get('regex')}/{fix_regex.get('replacement')}/{fix_regex.get('count', 'g')}"
 
             is_same_file = (
                 next_rule_match.path == rule_match.path if next_rule_match else False

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -91,7 +91,7 @@ class TextFormatter(BaseFormatter):
                             end_line,
                             end_col,
                         )
-                        line_number = with_color(0, f"{start_line + i}")
+                        line_number = f"{start_line + i}"
                     else:
                         line_number = f"{start_line + i}"
 
@@ -118,7 +118,9 @@ class TextFormatter(BaseFormatter):
                         # while stripping a string, the ANSI code for resetting color might also get stripped.
                         line = line + colorama.Style.RESET_ALL
 
-                yield f"        {line_number}┆ {line}" if line_number else f"{line}"
+                yield f" " * (
+                    11 - len(line_number)
+                ) + f"{line_number}┆ {line}" if line_number else f"{line}"
 
             if stripped:
                 yield f"[Shortened a long line from output, adjust with {MAX_CHARS_FLAG_NAME}]"
@@ -129,7 +131,7 @@ class TextFormatter(BaseFormatter):
                 if trimmed > 0:
                     yield trimmed_str.center(BREAK_LINE_WIDTH, BREAK_LINE_CHAR)
                 elif show_separator:
-                    yield BREAK_LINE
+                    yield f" " * 10 + f"╌┆" + f"╌" * 40
 
     @staticmethod
     def _get_details_shortlink(rule_match: RuleMatch) -> Optional[str]:

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -31,6 +31,18 @@ from semgrep.semgrep_types import Language
 from semgrep.util import format_bytes
 from semgrep.util import truncate
 from semgrep.util import with_color
+from shutil import get_terminal_size
+
+MAX_TEXT_WIDTH = 120
+
+terminal_size = get_terminal_size((MAX_TEXT_WIDTH, 1))[0]
+if terminal_size <= 0:
+    terminal_size = MAX_TEXT_WIDTH
+width = min(MAX_TEXT_WIDTH, terminal_size)
+if width <= 110:
+    width = width - 5
+else:
+    width = width - (width - 100)
 
 
 class TextFormatter(BaseFormatter):
@@ -326,7 +338,7 @@ class TextFormatter(BaseFormatter):
                 and (last_message is None or last_message != message)
             ):
                 shortlink = TextFormatter._get_details_shortlink(rule_match)
-                yield f"     {with_color(0, f'{check_id} ', bold=True)}\n{click.wrap_text(f'{message}', 84, '        ', '        ', True)}\n        {shortlink}\n"
+                yield f"{click.wrap_text(f'{with_color(0, check_id, bold=True)}', width + 10, '     ', '     ', False)}\n{click.wrap_text(f'{message}', width, '        ', '        ', True)}\n        {shortlink}\n"
 
             last_file = current_file
             last_message = message

--- a/semgrep/semgrep/notifications.py
+++ b/semgrep/semgrep/notifications.py
@@ -1,3 +1,4 @@
+from semgrep.semgrep.constants import Colors
 from semgrep.util import with_color
 from semgrep.verbose_logging import getLogger
 
@@ -18,7 +19,7 @@ def possibly_notify_user() -> None:
     if not has_shown:
         logger.warning(
             with_color(
-                "yellow",
+                Colors.yellow,
                 "METRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev."
                 """\nTo disable Registry rule metrics, use "--metrics=off"."""
                 "\nUsing configs only from local files (like --config=xyz.yml) does not enable metrics."

--- a/semgrep/semgrep/notifications.py
+++ b/semgrep/semgrep/notifications.py
@@ -1,4 +1,4 @@
-from semgrep.semgrep.constants import Colors
+from semgrep.constants import Colors
 from semgrep.util import with_color
 from semgrep.verbose_logging import getLogger
 

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -17,6 +17,7 @@ from typing import Set
 from typing import Type
 
 from semgrep import config_resolver
+from semgrep.constants import Colors
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
 from semgrep.error import FINDINGS_EXIT_CODE
@@ -35,7 +36,6 @@ from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.rule_match_map import RuleMatchMap
-from semgrep.semgrep.constants import Colors
 from semgrep.stats import make_loc_stats
 from semgrep.stats import make_target_stats
 from semgrep.util import is_url

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -35,6 +35,7 @@ from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.rule_match_map import RuleMatchMap
+from semgrep.semgrep.constants import Colors
 from semgrep.stats import make_loc_stats
 from semgrep.stats import make_target_stats
 from semgrep.util import is_url
@@ -215,12 +216,12 @@ class OutputHandler:
             print_threshold_hint = print_threshold_hint or (
                 num_errs > 5 and not self.settings.timeout_threshold
             )
-            logger.error(with_color("red", terminal_wrap(error_msg)))
+            logger.error(with_color(Colors.red, terminal_wrap(error_msg)))
 
         if print_threshold_hint:
             logger.error(
                 with_color(
-                    "red",
+                    Colors.red,
                     f"You can use the `--timeout-threshold` flag to set a number of timeouts after which a file will be skipped.",
                 )
             )
@@ -236,7 +237,7 @@ class OutputHandler:
             if self.settings.output_format == OutputFormat.TEXT and (
                 error.level != Level.WARN or self.settings.verbose_errors
             ):
-                logger.error(with_color("red", str(error)))
+                logger.error(with_color(Colors.red, str(error)))
 
     def _final_raise(self, ex: Optional[Exception], error_stats: Optional[str]) -> None:
         if ex is None:

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 
 import click
 
+from semgrep.constants import Colors
 from semgrep.constants import YML_SUFFIXES
 from semgrep.constants import YML_TEST_SUFFIXES
 
@@ -112,9 +113,9 @@ def abort(message: str) -> None:
 
 
 def with_color(
-    color: str,
+    color: Colors,
     text: str,
-    bgcolor: str = None,
+    bgcolor: Optional[Colors] = None,
     bold: bool = False,
     underline: bool = False,
 ) -> str:
@@ -123,16 +124,16 @@ def with_color(
 
     Use ANSI color names or 8 bit colors (24-bit is not well supported by terminals)
     In click bold always switches colors to their bright variant (if there is one)
-    0 = default foreground color
-    15 = the color 'bold' or bright foreground
-    7 = theme 'white'
-    256 = theme 'black'
-    16 = real black #000
-    231 = real white #fff
     """
     if not sys.stderr.isatty() and not FORCE_COLOR:
         return text
-    return click.style(text, fg=color, bg=bgcolor, underline=underline, bold=bold)
+    return click.style(
+        text,
+        fg=color.value,
+        bg=(bgcolor.value if bgcolor is not None else None),
+        underline=underline,
+        bold=bold,
+    )
 
 
 def terminal_wrap(text: str) -> str:

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -120,6 +120,15 @@ def with_color(
 ) -> str:
     """
     Wrap text in color & reset
+
+    Use ANSI color names or 8 bit colors (24-bit is not well supported by terminals)
+    In click bold always switches colors to their bright variant (if there is one)
+    0 = default foreground color
+    15 = the color 'bold' or bright foreground
+    7 = theme 'white'
+    256 = theme 'black'
+    16 = real black #000
+    231 = real white #fff
     """
     if not sys.stderr.isatty() and not FORCE_COLOR:
         return text

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -111,13 +111,19 @@ def abort(message: str) -> None:
     sys.exit(1)
 
 
-def with_color(color: str, text: str, bold: bool = False) -> str:
+def with_color(
+    color: str,
+    text: str,
+    bgcolor: str = None,
+    bold: bool = False,
+    underline: bool = False,
+) -> str:
     """
     Wrap text in color & reset
     """
     if not sys.stderr.isatty() and not FORCE_COLOR:
         return text
-    return click.style(text, fg=color)
+    return click.style(text, fg=color, bg=bgcolor, underline=underline, bold=bold)
 
 
 def terminal_wrap(text: str) -> str:


### PR DESCRIPTION
PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)

**Errors and warnings**
Before/after
![image](https://user-images.githubusercontent.com/31987121/150162072-5db790e0-0738-452f-861b-391409a820cf.png)
Changes
- Begin/End error trace separator changed to `=`. Also Begin has 2 more `=`, so full length is the same for both lines.
- Added short explanation for error and where to get help.
- Used bgcolor for marking errors, so it shows up right in every terminal. In terminal without colors `[ ]` brackets will be shown (for those with color it won't be visible)
- Moved newline characters (\n), so each error, the useful error message and the error trace is better separated from each other
- in util.py extended `with_color` with new variables

To do
- [x] Mention 'error' and 'warn' only once. It should be `[ERROR] Semgrep CORE`
- [ ] For warn it should be `[WARNING] Semgrep CORE` with same red styling as errors
- [x] Make sure all errors show up with the new style
- [x] Grammar check new help line
- [x] Check if colored brackets can be refactored for a cleaner code

**Results output**
Before/after
![image](https://user-images.githubusercontent.com/31987121/150164520-cb06e582-c90d-49bb-a786-78762bded429.png)

Changes
- Changed colors and tested new ones in 5 different themes and 3 different terminal softwares. Focused using colors only if necessary and to create a visual rhythm.
- For file name moved away from green as it has a success/repair meaning to it. Used cyan as its readable in every theme and helps separating results.
- For autofix used green color and a fast-forward char to imply action.
- Added new lines and indents to create white-space to increase scannability.
- For line numbers switched from `:` to `┆`
- Before file name there is a space to match the space in Error tags and for premium feel.

To do
- [ ] Fix wrap as it's not using util.py, but import click itself to work. `Terminal_wrap` does not seem to handle indents.
- [x] Separator dashes should start where the rule name/`▶▶` starts.
- [ ] The seperator should end 3-5 characters before the wrap. The text wrap for the rule message should be
- [ ] >>    for smaller windows (<100) at least 5 spaces away from the window border
- [ ] >>    for larger windows (100<) about 15 spaces away from border
- [ ] Indentations should match the current one in the code. Equal tab groups: (filename) // (rule name, autofix, separator) // (rule message, details link, line numbers)
- [ ] There is a double new line under each result, but in the code they add up from two different places.
- [ ] If possible the file name should be bold as well. But in click bolding changes colors to their bright version, especially visible in solarized themes. Only do this, if there is an easy way to do bolding without color change.

Current bugs this PR fixes:
Unreadable/hard to read text in solarized themes and overall scannability
#4377

![image](https://user-images.githubusercontent.com/31987121/150170122-5b083714-f064-4b6c-b702-256363cda044.png)
