### PR TITLE
Allow overriding .semgrepignore with an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Add an experimental key for internal team use:
   `r2c-internal-project-depends-on` that allows rules to filter based on the
   presence of 3rd-party dependencies at specific version ranges.
+- FOR INTERNAL USE: if the environment variable SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE
+  is set, then its value will be used as the path to find semgrepignore patterns, overriding
+  any existing .semgrepignore file
 
 ### Changed
 - CLI: parse errors (reported with `--verbose`) appear once per file, 

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -66,8 +66,10 @@ def notify_user_of_work(
 
 def get_file_ignore() -> FileIgnore:
     # Meant to be used only by semgrep-action
-    if "EXPLICIT_SEMGREPIGNORE" in environ:
-        semgrepignore_path = Path(environ["EXPLICIT_SEMGREPIGNORE"]).resolve()
+    if "SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE" in environ:
+        semgrepignore_path = Path(
+            environ["SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE"]
+        ).resolve()
         logger.verbose("Using explicit semgrepignore file from environment variable")
     else:
         TEMPLATES_DIR = Path(__file__).parent / "templates"

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -65,6 +65,7 @@ def notify_user_of_work(
 
 
 def get_file_ignore() -> FileIgnore:
+    # Meant to be used only by semgrep-action
     if "EXPLICIT_SEMGREPIGNORE" in environ:
         semgrepignore_path = Path(environ["EXPLICIT_SEMGREPIGNORE"]).resolve()
         logger.verbose("Using explicit semgrepignore file from environment variable")

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -65,6 +65,9 @@ def notify_user_of_work(
 
 
 def get_file_ignore() -> FileIgnore:
+    TEMPLATES_DIR = Path(__file__).parent / "templates"
+    workdir = Path.cwd()
+
     # Meant to be used only by semgrep-action
     if "SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE" in environ:
         semgrepignore_path = Path(
@@ -72,8 +75,6 @@ def get_file_ignore() -> FileIgnore:
         ).resolve()
         logger.verbose("Using explicit semgrepignore file from environment variable")
     else:
-        TEMPLATES_DIR = Path(__file__).parent / "templates"
-        workdir = Path.cwd()
         semgrepignore_path = Path(workdir / IGNORE_FILE_NAME)
         if not semgrepignore_path.is_file():
             logger.verbose(

--- a/semgrep/tests/e2e/snapshots/test_ignores/test_internal_explicit_semgrepignore/results.json
+++ b/semgrep/tests/e2e/snapshots/test_ignores/test_internal_explicit_semgrepignore/results.json
@@ -1,0 +1,205 @@
+{
+  "errors": [],
+  "results": [
+    {
+      "check_id": "rules.eqeq-bad",
+      "end": {
+        "col": 15,
+        "line": 1,
+        "offset": 14
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "var x = 0 == 0",
+        "message": "useless comparison",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "0",
+            "end": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "start": {
+              "col": 9,
+              "line": 1,
+              "offset": 8
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/ignores/find.js",
+      "start": {
+        "col": 9,
+        "line": 1,
+        "offset": 8
+      }
+    },
+    {
+      "check_id": "rules.eqeq-bad",
+      "end": {
+        "col": 15,
+        "line": 1,
+        "offset": 14
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "var x = 0 == 0",
+        "message": "useless comparison",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "0",
+            "end": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "start": {
+              "col": 9,
+              "line": 1,
+              "offset": 8
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/ignores/ignore.min.js",
+      "start": {
+        "col": 9,
+        "line": 1,
+        "offset": 8
+      }
+    },
+    {
+      "check_id": "rules.eqeq-bad",
+      "end": {
+        "col": 15,
+        "line": 1,
+        "offset": 14
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "var x = 0 == 0",
+        "message": "useless comparison",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "0",
+            "end": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "start": {
+              "col": 9,
+              "line": 1,
+              "offset": 8
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/ignores/ignore_test.js",
+      "start": {
+        "col": 9,
+        "line": 1,
+        "offset": 8
+      }
+    },
+    {
+      "check_id": "rules.eqeq-bad",
+      "end": {
+        "col": 15,
+        "line": 1,
+        "offset": 14
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "var x = 0 == 0",
+        "message": "useless comparison",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "0",
+            "end": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "start": {
+              "col": 9,
+              "line": 1,
+              "offset": 8
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/ignores/ok/find.js",
+      "start": {
+        "col": 9,
+        "line": 1,
+        "offset": 8
+      }
+    },
+    {
+      "check_id": "rules.eqeq-bad",
+      "end": {
+        "col": 15,
+        "line": 1,
+        "offset": 14
+      },
+      "extra": {
+        "is_ignored": false,
+        "lines": "var x = 0 == 0",
+        "message": "useless comparison",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "0",
+            "end": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "start": {
+              "col": 9,
+              "line": 1,
+              "offset": 8
+            },
+            "unique_id": {
+              "md5sum": "<masked in tests>",
+              "type": "AST"
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/ignores/tests/ignore.js",
+      "start": {
+        "col": 9,
+        "line": 1,
+        "offset": 8
+      }
+    }
+  ]
+}

--- a/semgrep/tests/e2e/test_ignores.py
+++ b/semgrep/tests/e2e/test_ignores.py
@@ -51,3 +51,19 @@ def test_file_not_relative_to_base_path(tmp_path, monkeypatch, snapshot):
     )
     stdout, _ = process.communicate("a")
     snapshot.assert_match(_clean_output_json(stdout), "results.json")
+
+
+def test_internal_explicit_semgrepignore(run_semgrep_in_tmp, tmp_path, snapshot):
+
+    (tmp_path / ".semgrepignore").symlink_to(
+        Path(TESTS_PATH / "e2e" / "targets" / "ignores" / ".semgrepignore").resolve()
+    )
+
+    explicit_ignore_file = tmp_path / ".semgrepignore_explicit"
+    explicit_ignore_file.touch()
+
+    env = {"SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE": str(explicit_ignore_file)}
+    snapshot.assert_match(
+        run_semgrep_in_tmp("rules/eqeq-basic.yaml", target_name="ignores", env=env)[0],
+        "results.json",
+    )


### PR DESCRIPTION
If the environment variable `SEMGREP_R2C_INTERNAL_EXPLICIT_SEMGREPIGNORE` is set, then Semgrep will use its value as the path to use to find semgrepignore patterns, ignoring any existing `.semgrepignore` file. This is meant to be used by semgrep-action, to allow including ignored files from semgrep-app, without disrupting a user's existing `.semgrepignore` file.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
