### PR TITLE
[Python] convert some Assign to Vardef when possible

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -31,6 +31,8 @@
  *  - TODO Bash, SQL, Docker
  *
  * See Lang.ml for the list of supported languages.
+ * See IL.ml for a generic IL (Intermediate language) better suited for
+ * advanced static analysis (e.g., dataflow).
  *
  * rational: In the end, programming languages have a lot in Common.
  * Even though some interesting analysis are probably better done on a
@@ -433,10 +435,15 @@ and expr_kind =
   (* The left part should be an lvalue (Id, DotAccess, ArrayAccess, Deref)
    * but it can also be a pattern (Container, even Record), but
    * you should really use LetPattern for that.
-   * Assign can also be abused to declare new variables, but you should use
-   * variable_definition for that.
-   * less: should be in stmt, but most languages allow this at expr level :(
-   * todo: see IL.ml where we normalize this AST with expr/instr/stmt
+   *
+   * newvar: Assign is also sometimes abused to declare new variables
+   * (e.g., in Python/PHP), but you should prefer variable_definition if
+   * you can.
+   *
+   * less: it would be better to have Assign as a stmt, but most languages
+   * allow this at expr level :(
+   * Note that IL.ml improves the situation by normalizing this AST with
+   * separate expr/instr/stmt types.
    * update: should even be in a separate simple_stmt, as in Go
    *)
   | Assign of
@@ -1308,6 +1315,7 @@ and definition_kind =
   (* newvar: can be used also for constants.
    * note: can contain special_multivardef_pattern!! ident in which case vinit
    * is the pattern assignment.
+   * TODO: still true? We should use EPattern for those cases no?
    *)
   | VarDef of variable_definition
   (* FieldDefColon can be used only inside a record (in a FieldStmt).

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.mli
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.mli
@@ -1,4 +1,5 @@
-val program : AST_python.program -> AST_generic.program
+val program :
+  ?assign_to_vardef:bool -> AST_python.program -> AST_generic.program
 
 val any : AST_python.any -> AST_generic.any
 

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -24,6 +24,8 @@ module H = AST_generic_helpers
 (* Ast_php to AST_generic.
  *
  * See AST_generic.ml for more information.
+ *
+ * TODO: convert some Assign in VarDef like Python_to_generic.ml
  *)
 
 (*****************************************************************************)
@@ -302,6 +304,9 @@ and expr e : G.expr =
    *   and v3 = expr v3
    *   in
    *   G.AssignOp (v1, (G.Append, t), v3)
+   *
+   * TODO: Some of those Assign are really VarDef. Do like in
+   * Python_to_generic.ml
    *)
   | Assign (v1, t, v3) ->
       let v1 = expr v1 and v3 = expr v3 in

--- a/semgrep-core/tests/python/naming/assign_vardef.py
+++ b/semgrep-core/tests/python/naming/assign_vardef.py
@@ -1,0 +1,13 @@
+from x import foo
+
+x = 1
+x = 2
+
+foo = 3
+
+def foo():
+    y = 1
+    y = 2
+
+
+    


### PR DESCRIPTION
This is currently not useful for semgrep but for codegraph.

test plan:
make test


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)