### PR TITLE
Allow metavariable used for atoms to match also identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+
+### Changed
+- Ruby: a metavariable matching an atom can also be used to match an identifier
+  with the same name (#4550)
+
+### Fixed
+
 ## [0.79.0](https://github.com/returntocorp/semgrep/releases/tag/v0.79.0) - 01-20-2022
 
 ### Added

--- a/semgrep-core/src/core/Metavariable.ml
+++ b/semgrep-core/src/core/Metavariable.ml
@@ -66,8 +66,14 @@ type mvalue =
   | Ss of AST_generic.stmt list
   | Args of AST_generic.argument list
   | Params of AST_generic.parameter list
-  (* This is to match the content of a string or atom, without the
-   * enclosing quotes. For a string this can actually be empty. *)
+  (* Text below is used to match the content of a string or atom, without the
+   * enclosing quotes. For a string this can actually be empty.
+   * TODO? use a separate 'Atom of string wrap' for atoms? This could be useful
+   * to allow 'foo :$ATOM ... obj.$ATOM', but not
+   * '"$STR" ... obj.$STR'? (even though this could also be useful for PHP
+   * where strings are often used to represent entities (e.g., function
+   * names).
+   *)
   | Text of string AST_generic.wrap
 [@@deriving show, eq, hash]
 

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -220,6 +220,17 @@ let rec equal_ast_binded_code (config : Config_semgrep.t) (a : MV.mvalue)
     | ( MV.Id ((s1, _), _),
         MV.Id ((s2, _), Some { G.id_resolved = { contents = None }; _ }) ) ->
         s1 = s2
+    (* In Ruby, they use atoms for metaprogramming to generate fields
+     * (e.g., 'serialize :tags ... post.tags') in which case we want
+     * a Text metavariable like :$INPUT to be compared with an Id
+     * metavariable like post.$INPUT.
+     * TODO? split MV.Text in a separate MV.Atom?
+     *)
+    | ( MV.Id ((s1, _), Some { G.id_resolved = { contents = None }; _ }),
+        MV.Text (s2, _) )
+    | ( MV.Text (s1, _),
+        MV.Id ((s2, _), Some { G.id_resolved = { contents = None }; _ }) ) ->
+        s1 = s2
     (* A variable occurrence that is known to have a constant value is equal to
      * that same constant value.
      *

--- a/semgrep-core/tests/ruby/metavar_atom_or_id.rb
+++ b/semgrep-core/tests/ruby/metavar_atom_or_id.rb
@@ -1,0 +1,9 @@
+#ERROR: match
+class Post < ActiveRecord::Base
+  serialize :tags
+#end
+#
+#def bad1()
+#  post = Post.new
+  post.tags = params[:tags] # expect this to match
+end

--- a/semgrep-core/tests/ruby/metavar_atom_or_id.sgrep
+++ b/semgrep-core/tests/ruby/metavar_atom_or_id.sgrep
@@ -1,0 +1,6 @@
+class $CLASS < ActiveRecord::Base
+  ...
+  serialize :$INPUT
+  ...
+  $OBJECT.$INPUT = params[...]
+end


### PR DESCRIPTION
This closes #4550

test plan:
test file included


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)