### PR TITLE
Correctly raise Timeout in the presence of multiples rules

### DIFF
--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -255,6 +255,11 @@ type rules = rule list [@@deriving show]
 (* Error Management *)
 (*****************************************************************************)
 
+(* This is used to let the user know which rule the engine was using when
+ * a Timeout or OutOfMemory exn occured.
+ *)
+let (last_matched_rule : rule_id option ref) = ref None
+
 exception InvalidLanguage of rule_id * string * Parse_info.t
 
 (* TODO: the Parse_info.t is not precise for now, it corresponds to the

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -989,15 +989,5 @@ let check ~match_hook default_config rules file_and_more =
   |> List.map (fun (r, pformula) ->
          let rule_id = fst r.R.id in
          Common.profile_code (spf "real_rule:%s" rule_id) (fun () ->
-             try
-               check_rule r match_hook default_config pformula file_and_more
-               (* TODO: why do we intercept errors here? We already do that in
-                * Run_semgrep.ml. *)
-             with exn when not !Flag_semgrep.fail_fast ->
-               {
-                 RP.matches = [];
-                 errors = [ E.exn_to_error ~rule_id:(Some rule_id) file exn ];
-                 skipped = [];
-                 profiling = { parse_time = -1.; match_time = -1. };
-               }))
+             check_rule r match_hook default_config pformula file_and_more))
   |> RP.collate_semgrep_results

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -988,6 +988,7 @@ let check ~match_hook default_config rules file_and_more =
   rules
   |> List.map (fun (r, pformula) ->
          let rule_id = fst r.R.id in
+         Rule.last_matched_rule := Some rule_id;
          Common.profile_code (spf "real_rule:%s" rule_id) (fun () ->
              check_rule r match_hook default_config pformula file_and_more))
   |> RP.collate_semgrep_results

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -255,9 +255,8 @@ let parsing_common ?(verbose = true) lang files_or_dirs =
              try
                match
                  Memory_limit.run_with_memory_limit ~mem_limit_mb (fun () ->
-                     Common.set_timeout ~verbose:false
-                       ~name:"Test_parsing.parsing_common" timeout_seconds
-                       (fun () ->
+                     Common.set_timeout ~name:"Test_parsing.parsing_common"
+                       timeout_seconds (fun () ->
                          Parse_target
                          .parse_and_resolve_name_use_pfff_or_treesitter lang
                            file))

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -145,8 +145,7 @@ let timeout_function file timeout f =
   let saved_busy_with_equal = !AST_utils.busy_with_equal in
   let timeout = if timeout <= 0. then None else Some timeout in
   match
-    Common.set_timeout_opt ~verbose:false ~name:"Run_semgrep.timeout_function"
-      timeout f
+    Common.set_timeout_opt ~name:"Run_semgrep.timeout_function" timeout f
   with
   | Some res -> res
   | None ->
@@ -344,6 +343,8 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
                      skipped = [];
                      profiling = RP.empty_partial_profiling file;
                    }
+               (* those were converted in Main_timeout in timeout_function()*)
+               | Timeout _ -> assert false
                | exn when not !Flag_semgrep.fail_fast ->
                    {
                      RP.matches = [];

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -330,7 +330,7 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
                      RP.matches = [];
                      errors =
                        [
-                         E.mk_error loc ""
+                         E.mk_error ~rule_id:!Rule.last_matched_rule loc ""
                            (match exn with
                            | Main_timeout file ->
                                logger#info "Timeout on %s" file;

--- a/semgrep-core/tests/OTHER/perf1/force_timeout.py
+++ b/semgrep-core/tests/OTHER/perf1/force_timeout.py
@@ -1,0 +1,81 @@
+# this used to not through a Timeout exn at some point, even with
+# -timeout 1 because of some bugs in Match_search_rules where Timeout
+# was wrongly intercepted and swallowed by exn_to_error.
+
+from django.http import HttpResponse
+from django.http import HttpResponseRedirect
+from django.shortcuts import redirect
+from django.utils.http import is_safe_url
+
+
+def arg(request):
+    # ruleid: open-redirect
+    return redirect(request.POST.get("next"))
+
+
+def argh(request):
+    # ruleid: open-redirect
+    return redirect(request.get_host())
+
+
+def arghh(request):
+    # ruleid: open-redirect
+    return redirect(request.method)
+
+
+def argh2(request):
+    # ruleid: open-redirect
+    url = request.get_host()
+    print("something")
+    return redirect(url)
+
+
+def unsafe(request):
+    # ruleid: open-redirect
+    url = request.headers.get("referrer")
+    print("something")
+    return redirect(url)
+
+
+def safe(request):
+    # ok
+    url = "https://lmnop.qrs"
+    return redirect(url)
+
+
+def fine(request):
+    # ok
+    return HttpResponseRedirect("https://google.com")
+
+
+def unsafe2(request):
+    # ruleid: open-redirect
+    url = request.POST.get("url")
+    return HttpResponseRedirect(url)
+
+
+def legit(request):
+    # ok
+    return HttpResponseRedirect(request.get_full_path())
+
+
+def url_validation(request):
+    # ok
+    next = request.POST.get("next", request.GET.get("next"))
+    if (next or not request.is_ajax()) and not is_safe_url(
+        url=next, allowed_hosts=request.get_host()
+    ):
+        next = "/index"
+    response = HttpResponseRedirect(next) if next else HttpResponse(status=204)
+    return response
+
+
+def url_validation2(request):
+    # ok
+    next = request.POST.get("next", request.GET.get("next"))
+    ok = is_safe_url(url=next, allowed_hosts=request.get_host())
+    if ok:
+        response = HttpResponseRedirect(next) if next else HttpResponse(status=204)
+    else:
+        response = HttpResponseRedirect("index")
+    return response

--- a/semgrep-core/tests/OTHER/perf1/force_timeout.yaml
+++ b/semgrep-core/tests/OTHER/perf1/force_timeout.yaml
@@ -1,0 +1,34 @@
+rules:
+- id: tests.e2e.rules.forcetimeout
+  pattern: |
+    ...
+    <... $A ...>
+    ...
+    <... $B ...>
+    ...
+    <... $C ...>
+    ...
+    <... $D ...>
+    ...
+  message: >-
+    This rule will time out
+  severity: ERROR
+  languages:
+  - python
+- id: tests.e2e.rules.forcetimeout2
+  pattern: |
+    ...
+    <... $A ...>
+    ...
+    <... $B ...>
+    ...
+    <... $C ...>
+    ...
+    <... $D ...>
+    ...
+  message: >-
+    This rule will time out
+  severity: ERROR
+  languages:
+  - python
+  

--- a/semgrep/tests/e2e/snapshots/test_check/test_max_memory/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_max_memory/results.json
@@ -3,9 +3,8 @@
     {
       "code": 2,
       "level": "warn",
-      "message": "Semgrep Core WARN - Out of memory: When running forcetimeout on targets/equivalence/open_redirect.py: Exceeded memory limit",
+      "message": "Semgrep Core WARN - Out of memory in file targets/equivalence/open_redirect.py:1\n\tExceeded memory limit",
       "path": "targets/equivalence/open_redirect.py",
-      "rule_id": "forcetimeout",
       "type": "Out of memory"
     }
   ],

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout/results.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "warn",
-      "message": "Semgrep Core WARN - Timeout: When running forcetimeout on targets/equivalence/open_redirect.py: Run_semgrep.timeout_function:1",
+      "message": "Semgrep Core WARN - Timeout: When running forcetimeout on targets/equivalence/open_redirect.py: ",
       "path": "targets/equivalence/open_redirect.py",
       "rule_id": "forcetimeout",
       "type": "Timeout"

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/results.json
@@ -3,7 +3,7 @@
     {
       "code": 2,
       "level": "warn",
-      "message": "Semgrep Core WARN - Timeout: When running forcetimeout on targets/equivalence/open_redirect.py: Run_semgrep.timeout_function:1",
+      "message": "Semgrep Core WARN - Timeout: When running forcetimeout on targets/equivalence/open_redirect.py: ",
       "path": "targets/equivalence/open_redirect.py",
       "rule_id": "forcetimeout",
       "type": "Timeout"


### PR DESCRIPTION
Emma found this problem while passing all the rules from
semgrep to semgrep-core.

test plan:
semgrep-core -rules ~/force_timeout.yaml ~/force_timeout.py -timeout 2
-lang python
now correctly raise a timeout instead of continuing forever.


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)