### PR TITLE
fix(timeout error): add default rule_id for timeout errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Fixed
+- Gracefully handle timeout errors with missing rule_id
+
 ## [0.80.0](https://github.com/returntocorp/semgrep/releases/tag/v0.80.0) - 01-26-2022
 
 ### Added

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -193,8 +193,11 @@ class OutputHandler:
             ):
                 self.semgrep_structured_errors.append(err)
                 self.error_set.add(err)
-                assert err.rule_id  # Always defined for timeout errors
-                timeout_errors[err.path].append(err.rule_id)
+
+                if not err.rule_id:
+                    timeout_errors[err.path].append("<unknown rule_id>")
+                else:
+                    timeout_errors[err.path].append(err.rule_id)
             else:
                 self._handle_semgrep_error(err)
 


### PR DESCRIPTION
semgrep-core can sometimes report empty rule_id for timeout errors. Handle them gracefully instead of asserting

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
