### PR TITLE
Add hooks for inheritance lookup extension

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.mli
+++ b/semgrep-core/src/matching/Generic_vs_generic.mli
@@ -22,3 +22,6 @@ val m_fields : AST_generic.field list Matching_generic.matcher
 
 (* used only for unit testing *)
 val m_any : AST_generic.any Matching_generic.matcher
+
+val hook_find_possible_parents :
+  (AST_generic.dotted_ident -> AST_generic.name list) option ref

--- a/semgrep-core/src/matching/Normalize_generic.ml
+++ b/semgrep-core/src/matching/Normalize_generic.ml
@@ -118,6 +118,7 @@ let rec eval x : svalue option =
       eval e
   (* TODO: partial evaluation for ints/floats/... *)
   | _ -> (
+      (* deep: *)
       match !hook_constant_propagation_and_evaluate_literal with
       | None -> None
       | Some f -> f x)

--- a/semgrep-core/src/naming/Graph_code_AST.ml
+++ b/semgrep-core/src/naming/Graph_code_AST.ml
@@ -50,7 +50,11 @@ type hooks = Graph_code_AST_env.hooks = {
 *)
 
 let default_hooks : hooks =
-  { on_def_node = (fun _ _ -> ()); on_misc = (fun _ -> ()) }
+  {
+    on_def_node = (fun _ _ -> ());
+    on_extend_edge = (fun _ _ _ -> ());
+    on_misc = (fun _ -> ());
+  }
 
 (*****************************************************************************)
 (* Helpers *)

--- a/semgrep-core/src/naming/Graph_code_AST_env.ml
+++ b/semgrep-core/src/naming/Graph_code_AST_env.ml
@@ -58,6 +58,11 @@ and phase =
 
 and hooks = {
   on_def_node : Graph_code.node -> AST_generic.definition -> unit;
+  on_extend_edge :
+    Graph_code.node ->
+    Graph_code.node ->
+    AST_generic.entity * AST_generic.class_definition ->
+    unit;
   (* TODO: fill with something useful *)
   on_misc : unit -> unit;
 }

--- a/semgrep-core/src/naming/Graph_code_AST_helpers.ml
+++ b/semgrep-core/src/naming/Graph_code_AST_helpers.ml
@@ -43,6 +43,8 @@ let str_of_dotted_ident xs = xs |> List.map fst |> Common.join "."
  *)
 let dotted_ident_of_str str = Common.split "\\." str
 
+(* see also AST_generic_helpers.name_of_ids *)
+
 let last_ident_of_dotted_ident xs =
   match List.rev xs with
   | [] -> raise Impossible


### PR DESCRIPTION
This can be used by semgrep variants

test plan:
make test


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)