### PR TITLE
refactoring: prefer Option.xxx functions to Common.xxx

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -64,7 +64,7 @@ let impossible any_generic = raise (Fixme (Impossible, any_generic))
 
 let locate opt_tok s =
   let opt_loc =
-    try map_opt Parse_info.string_of_info opt_tok
+    try Option.map Parse_info.string_of_info opt_tok
     with Parse_info.NoTokenLocation _ -> None
   in
   match opt_loc with
@@ -873,9 +873,7 @@ let rec stmt_aux env st =
   | G.If (tok, cond, st1, st2) ->
       let ss, e' = cond_with_pre_stmts env cond in
       let st1 = stmt env st1 in
-      let st2 =
-        List.map (stmt env) (st2 |> Common.opt_to_list) |> List.flatten
-      in
+      let st2 = List.map (stmt env) (st2 |> Option.to_list) |> List.flatten in
       ss @ [ mk_s (If (tok, e', st1, st2)) ]
   | G.Switch (tok, switch_expr_opt, cases_and_bodies) ->
       let ss, translate_cases =

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -62,7 +62,7 @@ let add_arc (starti, nodei) g = g#add_arc ((starti, nodei), F.Direct)
 
 let add_arc_from_opt (starti_opt, nodei) g =
   starti_opt
-  |> Common.do_option (fun starti -> g#add_arc ((starti, nodei), F.Direct))
+  |> Option.iter (fun starti -> g#add_arc ((starti, nodei), F.Direct))
 
 let add_arc_opt_to_opt (starti_opt, nodei_opt) g =
   starti_opt

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -309,7 +309,7 @@ and eval_concat_string env args : literal option =
         | _else -> None)
       (Some "")
   in
-  args |> go_concat |> map_opt literal_of_string
+  args |> go_concat |> Option.map literal_of_string
 
 (*****************************************************************************)
 (* Entry point *)
@@ -385,7 +385,7 @@ let propagate_basic lang prog =
                 _,
                 rexp ) ->
               eval_expr env rexp
-              |> do_option (fun literal ->
+              |> Option.iter (fun literal ->
                      match Hashtbl.find_opt stats (H.str_of_ident id, sid) with
                      | Some stats ->
                          if

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1906,7 +1906,7 @@ let interpolated (lquote, xs, rquote) =
                      let special =
                        IdSpecial (InterpolatedElement, lbrace) |> e
                      in
-                     let args = eopt |> Common.opt_to_list |> List.map arg in
+                     let args = eopt |> Option.to_list |> List.map arg in
                      Arg (Call (special, (lbrace, args, rbrace)) |> e)
                  | Common.Middle3 e -> Arg e),
             rquote ) )

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -1264,14 +1264,14 @@ let mk_fix_token_locations fix =
           k
             {
               e with
-              e_range = Common.map_opt (fun (x, y) -> (fix x, fix y)) e.e_range;
+              e_range = Option.map (fun (x, y) -> (fix x, fix y)) e.e_range;
             });
       kstmt =
         (fun (k, _) s ->
           k
             {
               s with
-              s_range = Common.map_opt (fun (x, y) -> (fix x, fix y)) s.s_range;
+              s_range = Option.map (fun (x, y) -> (fix x, fix y)) s.s_range;
             });
       kinfo = (fun (_, _) t -> Parse_info.fix_token_location fix t);
     }

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -60,14 +60,14 @@ let subexprs_of_stmt_kind = function
       match condopt with
       | None -> []
       | Some cond -> [ H.cond_to_expr cond ])
-  | Return (_, eopt, _) -> Common.opt_to_list eopt
+  | Return (_, eopt, _) -> Option.to_list eopt
   (* n *)
   | For (_, ForClassic (xs, eopt1, eopt2), _) ->
       (xs
       |> Common.map_filter (function
            | ForInitExpr e -> Some e
            | ForInitVar (_, vdef) -> vdef.vinit))
-      @ Common.opt_to_list eopt1 @ Common.opt_to_list eopt2
+      @ Option.to_list eopt1 @ Option.to_list eopt2
   | Assert (_, (_, args, _), _) ->
       args
       |> Common.map_filter (function
@@ -144,9 +144,8 @@ let subexprs_of_expr with_symbolic_propagation e =
       e1
       :: (e2 |> unbracket
          |> (fun (a, b, c) -> [ a; b; c ])
-         |> List.map Common.opt_to_list
-         |> List.flatten)
-  | Yield (_, eopt, _) -> Common.opt_to_list eopt
+         |> List.map Option.to_list |> List.flatten)
+  | Yield (_, eopt, _) -> Option.to_list eopt
   | StmtExpr st -> subexprs_of_stmt st
   | OtherExpr (_, anys) ->
       (* in theory we should go deeper in any *)
@@ -190,7 +189,7 @@ let substmts_of_stmt st =
   | OtherStmtWithStmt (_, _, st) ->
       [ st ]
   (* 2 *)
-  | If (_, _, st1, st2) -> st1 :: Common.opt_to_list st2
+  | If (_, _, st1, st2) -> st1 :: Option.to_list st2
   | WithUsingResource (_, st1, st2) -> [ st1; st2 ]
   (* n *)
   | Block (_, xs, _) -> xs

--- a/semgrep-core/src/naming/Graph_code_AST_visitor.ml
+++ b/semgrep-core/src/naming/Graph_code_AST_visitor.ml
@@ -40,7 +40,7 @@ let map_of_bool _x = ()
 
 let map_of_ref _f _x = ()
 
-let map_of_option = Common.map_opt
+let map_of_option = Option.map
 
 let map_of_list = Common.map
 
@@ -106,11 +106,11 @@ and map_resolved_name_kind env = function
 
 let rec map_name env n =
   H.dotted_ident_of_name_opt n
-  |> Common.do_option (fun xs ->
+  |> Option.iter (fun xs ->
          if env.phase = Uses then
            (* !!the uses!! *)
            let n2opt = L.lookup_dotted_ident_opt env xs in
-           n2opt |> Common.do_option (fun n2 -> H.add_use_edge env n2));
+           n2opt |> Option.iter (fun n2 -> H.add_use_edge env n2));
   match n with
   | Id (v1, v2) ->
       (if env.phase = Uses then
@@ -119,7 +119,7 @@ let rec map_name env n =
        | None ->
            (* try locally *)
            let n2opt = L.lookup_local_file_opt env v1 in
-           n2opt |> Common.do_option (fun n2 -> H.add_use_edge env n2)
+           n2opt |> Option.iter (fun n2 -> H.add_use_edge env n2)
        (* TODO: ImportedModule Filename => lookup E.File *)
        | _ -> ());
       (* ----------- *)
@@ -206,9 +206,9 @@ and map_expr_kind env ekind =
   | DotAccess (v1, v2, v3) ->
       if env.phase = Uses then
         H.dotted_ident_of_exprkind_opt ekind
-        |> Common.do_option (fun xs ->
+        |> Option.iter (fun xs ->
                let n2opt = L.lookup_dotted_ident_opt env xs in
-               n2opt |> Common.do_option (fun n2 -> H.add_use_edge env n2));
+               n2opt |> Option.iter (fun n2 -> H.add_use_edge env n2));
       (* boilerplate *)
       let v1 = map_expr env v1
       and v2 = map_tok env v2

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -173,7 +173,7 @@ let yaml_to_dict_helper error_fun_f error_fun_d (enclosing : string R.wrap)
 let (take_opt :
       dict -> env -> (env -> key -> G.expr -> 'a) -> string -> 'a option) =
  fun dict env f key_str ->
-  Common.map_opt
+  Option.map
     (fun (key, value) ->
       let res = f env key value in
       Hashtbl.remove dict.h key_str;
@@ -197,7 +197,7 @@ let yaml_to_dict env =
 (* Mutates the Hashtbl! *)
 let (take_opt_no_env : dict -> (key -> G.expr -> 'a) -> string -> 'a option) =
  fun dict f key_str ->
-  Common.map_opt
+  Option.map
     (fun (key, value) ->
       let res = f key value in
       Hashtbl.remove dict.h key_str;

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -91,7 +91,7 @@ let is_in_scope env s =
 (*****************************************************************************)
 let id x = x
 
-let option = Common.map_opt
+let option = Option.map
 
 let list = List.map
 
@@ -778,7 +778,7 @@ and stmt_aux env x =
       [ G.Try (t, v1, [], Some (t2, v2)) |> G.s ]
   | Assert (t, v1, v2) ->
       let v1 = expr env v1 and v2 = option (expr env) v2 in
-      let es = v1 :: Common.opt_to_list v2 in
+      let es = v1 :: Option.to_list v2 in
       let args = es |> List.map G.arg in
       [ G.Assert (t, fb args, G.sc) |> G.s ]
   | ImportAs (t, v1, v2) ->

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -31,7 +31,7 @@ open Ast_c
 (*****************************************************************************)
 let id x = x
 
-let option = Common.map_opt
+let option = Option.map
 
 let list = Common.map
 

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -231,7 +231,7 @@ and map_typeC env x : G.type_ =
   | TSized (v1, v2) ->
       let v1 = map_of_list (map_sized_type env) v1
       and v2 = map_of_option (map_type_ env) v2 in
-      let allt = v1 @ Common.opt_to_list v2 in
+      let allt = v1 @ Option.to_list v2 in
       G.OtherType (("TSized", G.fake ""), allt |> List.map (fun t -> G.T t))
       |> G.t
   | TPointer (v1, v2, v3) ->
@@ -1015,7 +1015,7 @@ and map_jump env = function
       fun sc -> G.Break (v1, G.LNone, sc) |> G.s
   | Return (v1, v2) ->
       let v1 = map_tok env v1 and v2 = map_of_option (map_argument env) v2 in
-      let v2 = Common.map_opt H.argument_to_expr v2 in
+      let v2 = Option.map H.argument_to_expr v2 in
       fun sc -> G.Return (v1, v2, sc) |> G.s
   | GotoComputed (v1, v2, v3) ->
       let v1 = map_tok env v1
@@ -1130,7 +1130,7 @@ and map_decl env x : G.stmt list =
       let v1 = map_tok env v1
       and v2 = map_of_option (map_ident env) v2
       and _l, v3, r = map_declarations env v3 in
-      let dir1 = G.Package (v1, opt_to_list v2) |> G.d in
+      let dir1 = G.Package (v1, Option.to_list v2) |> G.d in
       let dir2 = G.PackageEnd r |> G.d in
       [ G.DirectiveStmt dir1 |> G.s ] @ v3 @ [ G.DirectiveStmt dir2 |> G.s ]
   | StaticAssert (v1, v2) ->

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -34,7 +34,7 @@ let string = id
 
 let list = List.map
 
-let option = Common.map_opt
+let option = Option.map
 
 let either = OCaml.map_of_either
 
@@ -472,9 +472,7 @@ let top_func () =
         [ G.For (t, vx, v4) |> G.s ]
     | Return (v1, v2) ->
         let v1 = tok v1 and v2 = option (list expr) v2 in
-        [
-          G.Return (v1, v2 |> Common.map_opt list_to_tuple_or_expr, G.sc) |> G.s;
-        ]
+        [ G.Return (v1, v2 |> Option.map list_to_tuple_or_expr, G.sc) |> G.s ]
     | Break (v1, v2) ->
         let v1 = tok v1 and v2 = option ident v2 in
         [ G.Break (v1, H.opt_to_label_ident v2, G.sc) |> G.s ]

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -30,7 +30,7 @@ module H = AST_generic_helpers
 (*****************************************************************************)
 let id x = x
 
-let option = Common.map_opt
+let option = Option.map
 
 let list = List.map
 
@@ -320,7 +320,7 @@ and expr e =
       let anys =
         [ G.E v0; G.T v2 ]
         @ (v3 |> G.unbracket |> List.map (fun arg -> G.Ar arg))
-        @ (Common.opt_to_list v4 |> List.map G.unbracket |> List.flatten
+        @ (Option.to_list v4 |> List.map G.unbracket |> List.flatten
           |> List.map (fun st -> G.S st))
       in
       G.OtherExpr (("NewQualifiedClass", tok2), anys)
@@ -482,7 +482,7 @@ and stmt st =
   | DirectiveStmt v1 -> directive v1
   | Assert (t, v1, v2) ->
       let v1 = expr v1 and v2 = option expr v2 in
-      let es = v1 :: Common.opt_to_list v2 in
+      let es = v1 :: Option.to_list v2 in
       let args = es |> List.map G.arg in
       G.Assert (t, fb args, G.sc) |> G.s
 
@@ -652,7 +652,7 @@ and class_decl
   let cdef =
     {
       G.ckind = v2;
-      cextends = Common.opt_to_list v5;
+      cextends = Option.to_list v5;
       cimplements = v6;
       cmixins = [];
       cparams;

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -30,7 +30,7 @@ module H = AST_generic_helpers
 (*****************************************************************************)
 let id x = x
 
-let option = Common.map_opt
+let option = Option.map
 
 let list = List.map
 
@@ -370,7 +370,7 @@ and stmt x =
       let v1 = stmt v1
       and v2 = option catch_block v2
       and v3 = option tok_and_stmt v3 in
-      G.Try (t, v1, Common.opt_to_list v2, v3) |> G.s
+      G.Try (t, v1, Option.to_list v2, v3) |> G.s
   | With (_v1, v2, v3) ->
       let e = expr v2 in
       let v3 = stmt v3 in

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -30,7 +30,7 @@ module H = AST_generic_helpers
 (*****************************************************************************)
 let id x = x
 
-let option = Common.map_opt
+let option = Option.map
 
 let list = List.map
 
@@ -454,13 +454,13 @@ and pattern = function
       G.PatLiteral v1
   | PatConstructor (v1, v2) ->
       let v1 = name v1 and v2 = option pattern v2 in
-      G.PatConstructor (v1, Common.opt_to_list v2)
+      G.PatConstructor (v1, Option.to_list v2)
   | PatPolyVariant ((v0, v1), v2) ->
       let v0 = tok v0 in
       let v1 = ident v1 in
       let v2 = option pattern v2 in
       let name = H.name_of_ids [ ("`", v0); v1 ] in
-      G.PatConstructor (name, Common.opt_to_list v2)
+      G.PatConstructor (name, Option.to_list v2)
   | PatConsInfix (v1, v2, v3) ->
       let v1 = pattern v1 and v2 = tok v2 and v3 = pattern v3 in
       let n = H.name_of_ids [ ("::", v2) ] in

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -33,7 +33,7 @@ module H = AST_generic_helpers
 (*****************************************************************************)
 let id x = x
 
-let option = Common.map_opt
+let option = Option.map
 
 let list = List.map
 
@@ -586,7 +586,7 @@ and class_def
   let def =
     {
       G.ckind = kind;
-      cextends = extends |> Common.opt_to_list;
+      cextends = extends |> Option.to_list;
       cimplements = implements;
       cmixins = uses;
       cparams = [];

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -37,7 +37,7 @@ module PI = Parse_info
 (*****************************************************************************)
 let id x = x
 
-let option = Common.map_opt
+let option = Option.map
 
 let list = List.map
 
@@ -124,7 +124,7 @@ let rec expr e =
           in
           G.DotAccess (e, t, fld))
   | Splat (t, eopt) ->
-      let xs = option expr eopt |> Common.opt_to_list |> List.map G.arg in
+      let xs = option expr eopt |> Option.to_list |> List.map G.arg in
       let special = G.IdSpecial (G.Spread, t) |> G.e in
       G.Call (special, fb xs)
   | CodeBlock ((t1, _, t2), params_opt, xs) ->

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -50,7 +50,7 @@ let v_bool = id
 
 let v_list = List.map
 
-let v_option = Common.map_opt
+let v_option = Option.map
 
 let cases_to_lambda lb (cases : G.action list) : G.function_definition =
   let id = ("!hidden_scala_param!", lb) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -818,8 +818,8 @@ and variable_declarator (env : env) ((v1, v2, v3) : CST.variable_declarator) =
         let pat = Some (tuple_pattern env x) in
         (id, pat)
   in
-  let _v2TODO = Common.map_opt (element_binding_expression env) v2 in
-  let v3 = Common.map_opt (equals_value_clause env) v3 in
+  let _v2TODO = Option.map (element_binding_expression env) v2 in
+  let v3 = Option.map (equals_value_clause env) v3 in
   let vinit =
     match (pattern, v3) with
     | Some pat, Some init -> Some (LetPattern (pat, init) |> G.e)
@@ -949,12 +949,12 @@ and array_rank_specifier (env : env) ((v1, v2, v3) : CST.array_rank_specifier) =
   let v2 =
     match v2 with
     | Some (v1, v2) ->
-        let v1 = Common.map_opt (expression env) v1 in
+        let v1 = Option.map (expression env) v1 in
         let v2 =
           List.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
-              let v2 = Common.map_opt (expression env) v2 in
+              let v2 = Option.map (expression env) v2 in
               v2)
             v2
         in
@@ -966,7 +966,7 @@ and array_rank_specifier (env : env) ((v1, v2, v3) : CST.array_rank_specifier) =
   (v1, v2, v3)
 
 and argument (env : env) ((v1, v2, v3) : CST.argument) : G.argument =
-  let v1 = Common.map_opt (name_colon env) v1 in
+  let v1 = Option.map (name_colon env) v1 in
   let _v2TODO =
     match v2 with
     | Some x -> (
@@ -989,7 +989,7 @@ and initializer_expression (env : env)
     ((v1, v2, v3, v4) : CST.initializer_expression) : expr list G.bracket =
   let v1 = token env v1 (* "{" *) in
   let v2 = anon_opt_cst_pat_rep_interp_alig_clause_080fdff env v2 in
-  let _v3 = Common.map_opt (token env) v3 (* "," *) in
+  let _v3 = Option.map (token env) v3 (* "," *) in
   let v4 = token env v4 (* "}" *) in
   (v1, v2, v4)
 
@@ -1147,7 +1147,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
             v1 :: v2
         | None -> []
       in
-      let _v4 = Common.map_opt (token env) v4 (* "," *) in
+      let _v4 = Option.map (token env) v4 (* "," *) in
       let v5 = token env v5 (* "}" *) in
       AnonClass
         {
@@ -1636,7 +1636,7 @@ and statement (env : env) (x : CST.statement) =
       let _v5 = statement env v5 in
       todo_stmt env v1
   | `For_each_stmt (v1, v2, v3, v4, v5, v6, v7, v8) ->
-      let v1 = Common.map_opt (token env) v1 (* "await" *) in
+      let v1 = Option.map (token env) v1 (* "await" *) in
       let v2 = token env v2 (* "foreach" *) in
       let _v3 = token env v3 (* "(" *) in
       let v4 =
@@ -1684,7 +1684,7 @@ and statement (env : env) (x : CST.statement) =
         | None -> []
       in
       let _v4 = token env v4 (* ";" *) in
-      let v5 = Common.map_opt (expression env) v5 in
+      let v5 = Option.map (expression env) v5 in
       let v6 = token env v6 (* ";" *) in
       let v7 = anon_opt_cst_pat_rep_interp_alig_clause_080fdff env v7 in
       let v8 = token env v8 (* ")" *) in
@@ -1732,8 +1732,8 @@ and statement (env : env) (x : CST.statement) =
       let v3 = statement env v3 in
       Label (v1, v3) |> G.s
   | `Local_decl_stmt (v1, v2, v3, v4, v5) ->
-      let _V1TODO = Common.map_opt (token env) v1 (* "await" *) in
-      let _V2TODO = Common.map_opt (token env) v2 (* "using" *) in
+      let _V1TODO = Option.map (token env) v1 (* "await" *) in
+      let _V2TODO = Option.map (token env) v2 (* "using" *) in
       let v3 = List.map (modifier env) v3 in
       let v4 = variable_declaration env v4 in
       let _v5 = token env v5 (* ";" *) in
@@ -1774,7 +1774,7 @@ and statement (env : env) (x : CST.statement) =
       OtherStmtWithStmt (OSWS_Sync, [ E v3 ], v5) |> G.s
   | `Ret_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "return" *) in
-      let v2 = Common.map_opt (expression env) v2 in
+      let v2 = Option.map (expression env) v2 in
       let v3 = token env v3 (* ";" *) in
       Return (v1, v2, v3) |> G.s
   | `Switch_stmt (v1, v2, v3) ->
@@ -1788,7 +1788,7 @@ and statement (env : env) (x : CST.statement) =
       G.Switch (v1, Some (G.Cond v2), v3) |> G.s
   | `Throw_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "throw" *) in
-      let v2 = Common.map_opt (expression env) v2 in
+      let v2 = Option.map (expression env) v2 in
       let v3 = token env v3 (* ";" *) in
       (match v2 with
       | Some expr -> Throw (v1, expr, v3)
@@ -1798,14 +1798,14 @@ and statement (env : env) (x : CST.statement) =
       let v1 = token env v1 (* "try" *) in
       let v2 = block env v2 in
       let v3 = List.map (catch_clause env) v3 in
-      let v4 = Common.map_opt (finally_clause env) v4 in
+      let v4 = Option.map (finally_clause env) v4 in
       Try (v1, v2, v3, v4) |> G.s
   | `Unsafe_stmt (v1, v2) ->
       let _v1 = token env v1 (* "unsafe" *) in
       let v2 = block env v2 in
       OtherStmtWithStmt (OSWS_UnsafeBlock, [], v2) |> G.s
   | `Using_stmt (v1, v2, v3, v4, v5, v6) ->
-      let _v1TODO = Common.map_opt (token env) v1 (* "await" *) in
+      let _v1TODO = Option.map (token env) v1 (* "await" *) in
       let v2 = token env v2 (* "using" *) in
       let _v3 = token env v3 (* "(" *) in
       let v4 =
@@ -1864,7 +1864,7 @@ and interpolated_string_expression (env : env)
 
 and tuple_element (env : env) ((v1, v2) : CST.tuple_element) =
   let v1 = type_constraint env v1 in
-  let _v2TODO = Common.map_opt (identifier env) v2 (* identifier *) in
+  let _v2TODO = Option.map (identifier env) v2 (* identifier *) in
   v1
 
 and constant_pattern (env : env) (x : CST.constant_pattern) =
@@ -1874,7 +1874,7 @@ and catch_declaration (env : env) ((v1, v2, v3, v4) : CST.catch_declaration) :
     G.catch_exn =
   let _v1 = token env v1 (* "(" *) in
   let v2 = type_constraint env v2 in
-  let v3 = Common.map_opt (identifier env) v3 (* identifier *) in
+  let v3 = Option.map (identifier env) v3 (* identifier *) in
   let _v4 = token env v4 (* ")" *) in
   CatchParam (G.param_of_type v2 ~pname:v3)
 
@@ -1895,7 +1895,7 @@ and query_clause (env : env) (x : CST.query_clause) =
   | `From_clause x -> from_clause env x
   | `Join_clause (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) ->
       let v1 = token env v1 (* "join" *) in
-      let v2 = Common.map_opt (type_constraint env) v2 in
+      let v2 = Option.map (type_constraint env) v2 in
       let v3 = identifier env v3 (* identifier *) in
       let _v4 = token env v4 (* "in" *) in
       let v5 = expression env v5 in
@@ -1903,7 +1903,7 @@ and query_clause (env : env) (x : CST.query_clause) =
       let v7 = expression env v7 in
       let _v8 = token env v8 (* "equals" *) in
       let v9 = expression env v9 in
-      let v10 = Common.map_opt (join_into_clause env) v10 in
+      let v10 = Option.map (join_into_clause env) v10 in
       Join (v1, (v2, v3), v5, v7, v9, v10)
   | `Let_clause (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "let" *) in
@@ -1998,7 +1998,7 @@ and attribute_list (env : env) ((v1, v2, v3, v4, v5, v6) : CST.attribute_list) :
     attribute list =
   (* TODO: Handle unused tokens. *)
   let _v1 = token env v1 (* "[" *) in
-  let _v2 = Common.map_opt (attribute_target_specifier env) v2 in
+  let _v2 = Option.map (attribute_target_specifier env) v2 in
   let v3 = attribute env v3 in
   let v4 =
     List.map
@@ -2007,7 +2007,7 @@ and attribute_list (env : env) ((v1, v2, v3, v4, v5, v6) : CST.attribute_list) :
         attribute env y)
       v4
   in
-  let _v5 = Common.map_opt (token env) v5 (* "," *) in
+  let _v5 = Option.map (token env) v5 (* "," *) in
   let _v6 = token env v6 (* "]" *) in
   v3 :: v4
 
@@ -2096,7 +2096,7 @@ and positional_pattern_clause (env : env)
   PatTuple (v1, v2, v3)
 
 and subpattern (env : env) ((v1, v2) : CST.subpattern) =
-  let _V1TODO = Common.map_opt (name_colon env) v1 in
+  let _V1TODO = Option.map (name_colon env) v1 in
   let v2 = pattern env v2 in
   v2
 
@@ -2152,9 +2152,9 @@ and explicit_parameter (env : env) (v1, _v2param_modifier_TODO, v3, v4, v5) =
     TODO: add v2 as a keyword attribute? Pass v2 to parameter_modifier.
   *)
   let v1 = List.concat_map (attribute_list env) v1 in
-  let v3 = Common.map_opt (type_constraint env) v3 in
+  let v3 = Option.map (type_constraint env) v3 in
   let v4 = identifier env v4 (* identifier *) in
-  let v5 = Common.map_opt (equals_value_clause env) v5 in
+  let v5 = Option.map (equals_value_clause env) v5 in
   Param
     {
       pname = Some v4;
@@ -2167,7 +2167,7 @@ and explicit_parameter (env : env) (v1, _v2param_modifier_TODO, v3, v4, v5) =
 and from_clause (env : env) ((v1, v2, v3, v4, v5) : CST.from_clause) :
     linq_query_part =
   let v1 = token env v1 (* "from" *) in
-  let v2 = Common.map_opt (type_constraint env) v2 in
+  let v2 = Option.map (type_constraint env) v2 in
   let v3 = identifier env v3 (* identifier *) in
   let _v4 = token env v4 (* "in" *) in
   let v5 = expression env v5 in
@@ -2337,8 +2337,8 @@ and interpolation (env : env) ((v1, v2, v3, v4, v5) : CST.interpolation) :
     expr bracket =
   let v1 = token env v1 (* "{" *) in
   let v2 = expression env v2 in
-  let _v3_TODO = Common.map_opt (interpolation_alignment_clause env) v3 in
-  let _v4_TODO = Common.map_opt (interpolation_format_clause env) v4 in
+  let _v3_TODO = Option.map (interpolation_alignment_clause env) v3 in
+  let _v4_TODO = Option.map (interpolation_format_clause env) v4 in
   let v5 = token env v5 (* "}" *) in
   (v1, v2, v5)
 
@@ -2400,7 +2400,7 @@ let enum_member_declaration (env : env)
     ((v1, v2, v3) : CST.enum_member_declaration) =
   let _v1TODO = List.concat_map (attribute_list env) v1 in
   let v2 = identifier env v2 (* identifier *) in
-  let v3 = Common.map_opt (equals_value_clause env) v3 in
+  let v3 = Option.map (equals_value_clause env) v3 in
   OrEnum (v2, v3)
 
 let base_list (env : env) ((v1, v2, v3) : CST.base_list) : G.class_parent list =
@@ -2440,7 +2440,7 @@ let enum_member_declaration_list (env : env)
         v1 :: v2
     | None -> []
   in
-  let _v3 = Common.map_opt (token env) v3 (* "," *) in
+  let _v3 = Option.map (token env) v3 (* "," *) in
   let _v4 = token env v4 (* "}" *) in
   v2
 
@@ -2612,7 +2612,7 @@ and enum_declaration env (v1, v2, v3, v4, v5, v6, v7) =
     | None -> []
   in
   let v6 = enum_member_declaration_list env v6 in
-  let _v7 = Common.map_opt (token env) v7 (* ";" *) in
+  let _v7 = Option.map (token env) v7 (* ";" *) in
   let idinfo = empty_id_info () in
   let ent = { name = EN (Id (v4, idinfo)); attrs = v1 @ v2; tparams = [] } in
   G.DefStmt (ent, G.TypeDef { tbody = OrType v6 }) |> G.s
@@ -2658,7 +2658,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let v3 = identifier env v3 (* identifier *) in
       let _, tok = v3 in
       let v4 = parameter_list env v4 in
-      let v5 = Common.map_opt (constructor_initializer env) v5 in
+      let v5 = Option.map (constructor_initializer env) v5 in
       let v6 = function_body env v6 in
       (* TODO? separate ctor initializer from body in G.function_definition?*)
       let fbody =
@@ -2727,7 +2727,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let _v2TODO = List.map (modifier env) v2 in
       let v3 = unhandled_keywordattr (str env v3) (* "event" *) in
       let v4 = type_constraint env v4 in
-      let _v5TODO = Common.map_opt (explicit_interface_specifier env) v5 in
+      let _v5TODO = Option.map (explicit_interface_specifier env) v5 in
       let v6 = identifier env v6 (* identifier *) in
       let fname, _ftok = v6 in
       let v7 =
@@ -2790,7 +2790,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let v1 = List.concat_map (attribute_list env) v1 in
       let v2 = List.map (modifier env) v2 in
       let v3 = type_constraint env v3 in
-      let _v4TODO = Common.map_opt (explicit_interface_specifier env) v4 in
+      let _v4TODO = Option.map (explicit_interface_specifier env) v4 in
       let _v5 = token env v5 (* "this" *) in
       let v6 = bracketed_parameter_list env v6 in
       let indexer_attrs = v1 @ v2 in
@@ -2918,7 +2918,7 @@ and declaration (env : env) (x : CST.declaration) : stmt =
       let v1 = List.concat_map (attribute_list env) v1 in
       let v2 = List.map (modifier env) v2 in
       let v3 = type_constraint env v3 in
-      let _v4TODO = Common.map_opt (explicit_interface_specifier env) v4 in
+      let _v4TODO = Option.map (explicit_interface_specifier env) v4 in
       let v5 = identifier env v5 (* identifier *) in
       let fname, _ftok = v5 in
       let accessors, vinit =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -137,7 +137,7 @@ and map_anon_choice_temp_lit_c764a73 (env : env)
   match x with
   | `Temp_lit x ->
       let sopt = map_template_literal env x in
-      sopt |> Common.opt_to_list |> List.map (fun s -> Left3 s)
+      sopt |> Option.to_list |> List.map (fun s -> Left3 s)
   | `Temp_interp (v1, v2, v3, v4, v5) ->
       let v1 = (* template_interpolation_start *) token env v1 in
       (* TODO: what is this ~? *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -44,7 +44,7 @@ let token = H.token
 
 let str = H.str
 
-let option = Common.map_opt
+let option = Option.map
 
 (*****************************************************************************)
 (* Boilerplate converter *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -580,7 +580,7 @@ and block (env : env) ((v1, v2, v3) : CST.block) =
   Block (v1, v2, v3) |> G.s
 
 and call_suffix (env : env) ((v1, v2) : CST.call_suffix) : G.arguments =
-  let _v1TODO = Common.map_opt (type_arguments env) v1 in
+  let _v1TODO = Option.map (type_arguments env) v1 in
   let v2 =
     match v2 with
     | `Opt_value_args_anno_lambda (v1, _v2) ->
@@ -1376,7 +1376,7 @@ and jump_expression (env : env) (x : CST.jump_expression) =
       | None -> Return (tret, v2, sc tret) |> G.s
       | Some id ->
           let n = N (H2.name_of_id id) |> G.e in
-          let any = Common.opt_to_list v2 |> List.map (fun e -> E e) in
+          let any = Option.to_list v2 |> List.map (fun e -> E e) in
           OtherStmt (OS_Todo, TodoK ("return@", tret) :: E n :: any) |> G.s)
   | `Cont tok ->
       let v1 = token env tok (* "continue" *) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -2465,7 +2465,7 @@ and map_reference_type (env : env) ((v1, v2, v3, v4) : CST.reference_type) :
   in
   let type_ = map_type_ env v4 in
   (* TODO TyRef with lifetime *)
-  { t = G.TyRef (ref_, type_); t_attrs = mutability |> Common.opt_to_list }
+  { t = G.TyRef (ref_, type_); t_attrs = mutability |> Option.to_list }
 
 and map_return_expression (env : env) (x : CST.return_expression) : G.expr =
   let return_stmt =

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -212,7 +212,7 @@ let match_results_of_matches_and_errors files res =
     errors = errs |> List.map error_to_error;
     skipped = res.RP.skipped;
     stats = { okfiles = count_ok; errorfiles = count_errors };
-    time = res.RP.rule_profiling |> Common.map_opt json_time_of_profiling_data;
+    time = res.RP.rule_profiling |> Option.map json_time_of_profiling_data;
   }
   |> Output_from_core_util.sort_match_results
   [@@profiling]

--- a/semgrep-core/src/runner/Experiments.ml
+++ b/semgrep-core/src/runner/Experiments.ml
@@ -145,6 +145,6 @@ let gen_layer ~root ~query _matching_tokens file =
 
 let gen_layer_maybe _matching_tokens pattern_string xs =
   !layer_file
-  |> Common.do_option (fun file ->
+  |> Option.iter (fun file ->
          let root = Common2.common_prefix_of_files_or_dirs xs in
          gen_layer ~root ~query:pattern_string _matching_tokens file)


### PR DESCRIPTION
example: Option.iter instead of Common.do_option
Done with this refactoring.yaml:
```
rules:
 - id: Common.do_option
   pattern: Common.do_option
   fix: Option.iter
   languages: [ ocaml ]
   message: found one
   severity: ERROR
 - id: Common.opt
   pattern: Common.opt
   fix: Option.iter
   languages: [ ocaml ]
   message: found one
   severity: ERROR
 - id: Common.opt_to_list
   pattern: Common.opt_to_list
   fix: Option.to_list
   languages: [ ocaml ]
   message: found one
   severity: ERROR
 - id: Common.map_opt
   pattern: Common.map_opt
   fix: Option.map
   languages: [ ocaml ]
   message: found one
   severity: ERROR
```

test plan:
make


PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)