### PR TITLE
fix(tests): faster snapshot update

### DIFF
--- a/semgrep/Makefile
+++ b/semgrep/Makefile
@@ -1,7 +1,7 @@
 test:
 	pipenv run pytest -v --tb=short tests/
 regenerate-tests:
-	pipenv run pytest tests/ --snapshot-update
+	pipenv run pytest tests/ --snapshot-update --ignore=tests/qa/test_public_repos.py
 
 setup:
 	pipenv install --dev


### PR DESCRIPTION
test_public_repos do not have any snapshots anyway so no need to run
them when regenerating snapshots

PR checklist:
- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
