### PR TITLE
Drop 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [build-core]
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9"]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [build-core]
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, 3.10]
+        python: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [build-core]
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.7, 3.8, 3.9, 3.10]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Changed
+- Required minimum version of python to run semgrep now 3.7 instead of EOL 3.6
+
 ### Fixed
 - Gracefully handle timeout errors with missing rule_id
 

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -22,13 +22,6 @@ IS_WINDOWS = platform.system() == "Windows"
 WHEEL_CMD = "bdist_wheel"
 
 
-def is_python_before_3_7():
-    """Can't user packaging.version on old systems so use this hack"""
-    current = sys.version.split(" ")[0]
-    major, minor, sub = current.split(".")
-    return int(major) < 3 or int(minor) < 7
-
-
 if WHEEL_CMD in sys.argv:
     try:
         from wheel.bdist_wheel import bdist_wheel
@@ -42,7 +35,7 @@ if WHEEL_CMD in sys.argv:
 
         def get_tag(self):
             _, _, plat = bdist_wheel.get_tag(self)
-            python = "cp36.cp37.cp38.cp39.py36.py37.py38.py39"
+            python = "cp37.cp38.cp39.cp310.py37.py38.py39.py310"
             abi = "none"
             plat = "macosx_10_14_x86_64" if "macosx" in plat else "any"
             return python, abi, plat
@@ -153,13 +146,13 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Security",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
 )

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -35,7 +35,7 @@ if WHEEL_CMD in sys.argv:
 
         def get_tag(self):
             _, _, plat = bdist_wheel.get_tag(self)
-            python = "cp37.cp38.cp39.cp310.py37.py38.py39.py310"
+            python = "cp37.cp38.cp39.py37.py38.py39"
             abi = "none"
             plat = "macosx_10_14_x86_64" if "macosx" in plat else "any"
             return python, abi, plat
@@ -149,7 +149,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Topic :: Security",
         "Topic :: Software Development :: Quality Assurance",
     ],

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -166,8 +166,7 @@ def _run_semgrep(
         encoding="utf-8",
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        # LANG is necessary to work with Python 3.6
-        env={**env, "LANG": "en_US.UTF-8"},
+        env=env,
     )
 
     if fail_on_nonzero and output.returncode > 0:

--- a/semgrep/tox.ini
+++ b/semgrep/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39
 
 [testenv]
 allowlist_externals = pipenv

--- a/semgrep/tox.ini
+++ b/semgrep/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39, py310
 
 [testenv]
 allowlist_externals = pipenv


### PR DESCRIPTION
Python 3.6 was EOL on Dec 23 2021 

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
