### PR TITLE
optimizing: Make bloom filter consider import file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Changed
 - Performance: send all rules directly to semgrep-core instead of invoking semgrep-core 
-  for each rule, reducing the overhead significantly. Other changes resulting from this:  Sarif output now includes all rules run. Error messages use full path of rules.
+  for each rule, reducing the overhead significantly. Other changes resulting from this:
+  Sarif output now includes all rules run. Error messages use full path of rules.
   Semgrep will not recover from timeouts in one rule by running others
-
 - Required minimum version of python to run semgrep now 3.7 instead of EOL 3.6
 - Bloom filter optimization now considers `import` module file names, thus
   speeding up matching of patterns like `import { $X } from 'foo'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   Semgrep will not recover from timeouts in one rule by running others
 
 - Required minimum version of python to run semgrep now 3.7 instead of EOL 3.6
+- Bloom filter optimization now considers `import` module file names, thus
+  speeding up matching of patterns like `import { $X } from 'foo'`
 
 ### Fixed
 - Typescript: Patterns `E as T` will be matched correctly. E.g. previously

--- a/semgrep-core/src/optimizing/Analyze_pattern.ml
+++ b/semgrep-core/src/optimizing/Analyze_pattern.ml
@@ -86,8 +86,10 @@ let extract_strings_and_mvars ?lang any =
               when str <> "..."
                    && (not (Metavariable.is_metavar_name str))
                    && (* deprecated *) not (Pattern.is_regexp_string str) ->
-                (* Semgrep can match "foo" against "foo/bar", so we just overapproximate taking the sub-strings. *)
-                Common.split "/\\|\\\\" str
+                (* Semgrep can match "foo" against "foo/bar", so we just
+                 * overapproximate taking the sub-strings, see
+                 * Generic_vs_generic.m_module_name_prefix. *)
+                Common.split {|/\|\\|} str
                 |> List.iter (fun s -> Common.push s strings);
                 k x
             | _ -> k x);

--- a/semgrep-core/src/optimizing/Analyze_pattern.ml
+++ b/semgrep-core/src/optimizing/Analyze_pattern.ml
@@ -50,6 +50,10 @@ let _error s = failwith s
 (* Extractions *)
 (*****************************************************************************)
 
+(* TODO(iago): This is partly redundant with Bloom_annotation.statement_strings,
+ * it might be more maintainable if we had a single visitor that worked for both
+ * statements and patterns. *)
+
 let extract_strings_and_mvars ?lang any =
   let strings = ref [] in
   let mvars = ref [] in
@@ -72,6 +76,20 @@ let extract_strings_and_mvars ?lang any =
                     We assume a match is possible without the identifier
                     being present in the target source, so we ignore it. *)
                 ()
+            | _ -> k x);
+        V.kdir =
+          (fun (k, _) x ->
+            match x with
+            | { d = ImportFrom (_, FileName (str, _), _, _); _ }
+            | { d = ImportAs (_, FileName (str, _), _); _ }
+            | { d = ImportAll (_, FileName (str, _), _); _ }
+              when str <> "..."
+                   && (not (Metavariable.is_metavar_name str))
+                   && (* deprecated *) not (Pattern.is_regexp_string str) ->
+                (* Semgrep can match "foo" against "foo/bar", so we just overapproximate taking the sub-strings. *)
+                Common.split "/\\|\\\\" str
+                |> List.iter (fun s -> Common.push s strings);
+                k x
             | _ -> k x);
         V.kexpr =
           (fun (k, _) x ->

--- a/semgrep-core/src/optimizing/Bloom_annotation.ml
+++ b/semgrep-core/src/optimizing/Bloom_annotation.ml
@@ -99,8 +99,10 @@ let rec statement_strings stmt =
               when str <> "..."
                    && (not (Metavariable.is_metavar_name str))
                    && (* deprecated *) not (Pattern.is_regexp_string str) ->
-                (* Semgrep can match "foo" against "foo/bar", so we just overapproximate taking the sub-strings. *)
-                Common.split "/\\|\\\\" str |> List.iter (fun s -> push s res);
+                (* Semgrep can match "foo" against "foo/bar", so we just
+                 * overapproximate taking the sub-strings, see
+                 * Generic_vs_generic.m_module_name_prefix. *)
+                Common.split {|/\|\\|} str |> List.iter (fun s -> push s res);
                 k x
             | _ -> k x);
         V.kexpr =

--- a/semgrep-core/src/optimizing/Bloom_annotation.ml
+++ b/semgrep-core/src/optimizing/Bloom_annotation.ml
@@ -90,6 +90,19 @@ let rec statement_strings stmt =
       {
         V.default_visitor with
         V.kident = (fun (_k, _) (str, _tok) -> push str res);
+        V.kdir =
+          (fun (k, _) x ->
+            match x with
+            | { d = ImportFrom (_, FileName (str, _), _, _); _ }
+            | { d = ImportAs (_, FileName (str, _), _); _ }
+            | { d = ImportAll (_, FileName (str, _), _); _ }
+              when str <> "..."
+                   && (not (Metavariable.is_metavar_name str))
+                   && (* deprecated *) not (Pattern.is_regexp_string str) ->
+                (* Semgrep can match "foo" against "foo/bar", so we just overapproximate taking the sub-strings. *)
+                Common.split "/\\|\\\\" str |> List.iter (fun s -> push s res);
+                k x
+            | _ -> k x);
         V.kexpr =
           (fun (k, _) x ->
             match x.e with


### PR DESCRIPTION
Previously, Bloom annotation did not extract any meaningful string from
a pattern such as `import { $X } from 'v8'`, making it 10x slower or
more than another pattern such as `import { foo } from 'v8'`, even in a
file where there was no `import ... from 'v8'` whatsoever.

This should fix a perf problem affecting a customer.

test plan:
$ semgrep -l ts --time -e 'import { $X } from "v8"' semgrep/parsing-stats/lang/typescript/tmp/*
 #^ This now runs in ~14s, about twice as fast as previously

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
