### PR TITLE
fix(tests): Make failing test_auto_config pass

### DIFF
--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -189,12 +189,12 @@ def test_registry_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
-# TODO: started to fail recently, commented until someone knows how to fix it
-# def test_auto_config(run_semgrep_in_tmp):
-#    # --config auto will change over time, so lets just make sure this doesn't error out
-#    # TODO: Mock config response for more detailed testing
-#    run_semgrep_in_tmp("auto")
-#    assert True
+def test_auto_config(run_semgrep_in_tmp):
+    # --config auto will change over time, so lets just make sure this doesn't error out
+    # TODO: Mock config response for more detailed testing
+    # Use --no-strict to avoid error from unmatched nosem comment
+    run_semgrep_in_tmp("auto", strict=False)
+    assert True
 
 
 def test_hidden_rule__explicit(run_semgrep_in_tmp, snapshot):


### PR DESCRIPTION
This was failing due to a behavior of --strict, that makes sure all
nosem comments have a corresponding rule id in the config. (TBH I'm not
clear as to why --strict has this behavior; also note that this behavior
exists even when --disable-nosem is selected as an option).

Not sure why this started failing, as presumably we never served the
rule ID that this nosem comment referenced ("test-nosem"). That's all
outside the point of this test, however, so I just added --no-strict to
the test run.

PR checklist:
- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
