### PR TITLE
use non-foreground color for higlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Required minimum version of python to run semgrep now 3.7 instead of EOL 3.6
 - Bloom filter optimization now considers `import` module file names, thus
   speeding up matching of patterns like `import { $X } from 'foo'`
+- Indentation is now removed from matches to conserve horizontal space
 
 ### Fixed
 
 - Typescript: Patterns `E as T` will be matched correctly. E.g. previously
   a pattern like `v as $T` would match `v` but not `v as any`, now it
   correctly matches `v as any` but not `v`. (#4515)
+- Highlighting has been restored for matching code fragments within a finding
 
 ## [0.81.0](https://github.com/returntocorp/semgrep/releases/tag/v0.81.0) - 02-02-2022
 

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -1,4 +1,5 @@
 import itertools
+import textwrap
 from itertools import groupby
 from pathlib import Path
 from shutil import get_terminal_size
@@ -89,7 +90,15 @@ class TextFormatter(BaseFormatter):
                 trimmed = len(lines) - per_finding_max_lines_limit
                 lines = lines[:per_finding_max_lines_limit]
 
-            for i, line in enumerate(lines):
+            # we remove indentation at the start of the snippet to avoid wasting space
+            dedented_lines = textwrap.dedent("".join(lines)).splitlines()
+            indent_len = len(lines[0].rstrip()) - len(dedented_lines[0].rstrip())
+
+            # since we dedented each line, we need to adjust where the highlighting is
+            start_col -= indent_len
+            end_col -= indent_len
+
+            for i, line in enumerate(dedented_lines):
                 line = line.rstrip()
                 line_number = ""
                 if start_line:

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -62,7 +62,7 @@ class TextFormatter(BaseFormatter):
         line = (
             line[:start_color]
             + with_color(
-                Colors.foreground, line[start_color : end_color + 1]
+                Colors.bright, line[start_color : end_color + 1]
             )  # want the color to include the end_col
             + line[end_color + 1 :]
         )

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -62,7 +62,7 @@ class TextFormatter(BaseFormatter):
         line = (
             line[:start_color]
             + with_color(
-                Colors.bright, line[start_color : end_color + 1]
+                Colors.foreground, line[start_color : end_color + 1], bold=True
             )  # want the color to include the end_col
             + line[end_color + 1 :]
         )

--- a/semgrep/tests/e2e/snapshots/test_check/test_terminal_output/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_terminal_output/output.txt
@@ -12,4 +12,4 @@
         useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?
         Details: https://sg.run/xyz1
 
-          3┆     return a + b == a + b
+          3┆ return a + b == a + b

--- a/semgrep/tests/e2e/snapshots/test_check/test_terminal_output/output_second.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_terminal_output/output_second.txt
@@ -12,4 +12,4 @@
         useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?
         Details: https://sg.run/xyz1
 
-          3┆     return a + b == a + b
+          3┆ return a + b == a + b

--- a/semgrep/tests/e2e/snapshots/test_check/test_terminal_output_quiet/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_terminal_output_quiet/output.txt
@@ -12,4 +12,4 @@
         useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?
         Details: https://sg.run/xyz1
 
-          3┆     return a + b == a + b
+          3┆ return a + b == a + b


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/4637

v.80:
<img width="632" alt="Screen Shot 2022-02-08 at 10 28 29 AM" src="https://user-images.githubusercontent.com/409041/153052812-e75d0a78-544a-43b2-b4eb-00569926b36f.png">

v.81:
<img width="705" alt="Screen Shot 2022-02-08 at 10 28 23 AM" src="https://user-images.githubusercontent.com/409041/153052806-c7431dd3-edfe-4cc9-8999-95a37f724377.png">

this PR:
<img width="674" alt="Screen Shot 2022-02-08 at 10 31 18 AM" src="https://user-images.githubusercontent.com/409041/153052814-7db6d712-9fe0-47ac-b6a0-fac086d7a63c.png">

@underyx @adamboros Is there a brighter code we can use / way to get more contrast? It is still very subtle to me.

PR checklist:
- [x] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
