### PR TITLE
fix(logging): keep track of logging level with global

### DIFF
--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -37,7 +37,11 @@ def is_quiet() -> bool:
     Returns true if logging level is quiet or quieter (higher)
     (i.e. only critical logs surfaced)
     """
-    return logging.getLogger("semgrep").getEffectiveLevel() >= logging.CRITICAL
+    handlers = logging.getLogger("semgrep").handlers
+    stream_handler = (
+        handlers[0] if isinstance(handlers[0], logging.StreamHandler) else handlers[-1]
+    )
+    return stream_handler.level >= logging.CRITICAL
 
 
 def is_debug() -> bool:
@@ -45,7 +49,11 @@ def is_debug() -> bool:
     Returns true if logging level is debug or noisier (lower)
     (i.e. want more logs)
     """
-    return logging.getLogger("semgrep").getEffectiveLevel() <= logging.DEBUG
+    handlers = logging.getLogger("semgrep").handlers
+    stream_handler = (
+        handlers[0] if isinstance(handlers[0], logging.StreamHandler) else handlers[-1]
+    )
+    return stream_handler.level <= logging.DEBUG
 
 
 def is_url(url: str) -> bool:

--- a/semgrep/semgrep/util.py
+++ b/semgrep/semgrep/util.py
@@ -28,6 +28,9 @@ T = TypeVar("T")
 global FORCE_COLOR
 FORCE_COLOR = False
 
+global VERBOSITY
+VERBOSITY = logging.INFO
+
 
 MAX_TEXT_WIDTH = 120
 
@@ -37,11 +40,7 @@ def is_quiet() -> bool:
     Returns true if logging level is quiet or quieter (higher)
     (i.e. only critical logs surfaced)
     """
-    handlers = logging.getLogger("semgrep").handlers
-    stream_handler = (
-        handlers[0] if isinstance(handlers[0], logging.StreamHandler) else handlers[-1]
-    )
-    return stream_handler.level >= logging.CRITICAL
+    return VERBOSITY >= logging.CRITICAL
 
 
 def is_debug() -> bool:
@@ -49,11 +48,7 @@ def is_debug() -> bool:
     Returns true if logging level is debug or noisier (lower)
     (i.e. want more logs)
     """
-    handlers = logging.getLogger("semgrep").handlers
-    stream_handler = (
-        handlers[0] if isinstance(handlers[0], logging.StreamHandler) else handlers[-1]
-    )
-    return stream_handler.level <= logging.DEBUG
+    return VERBOSITY <= logging.DEBUG
 
 
 def is_url(url: str) -> bool:
@@ -98,6 +93,9 @@ def set_flags(*, verbose: bool, debug: bool, quiet: bool, force_color: bool) -> 
 
     # Needs to be DEBUG otherwise will filter before sending to handlers
     logger.setLevel(logging.DEBUG)
+
+    global VERBOSITY
+    VERBOSITY = stdout_level
 
     global FORCE_COLOR
     if force_color:


### PR DESCRIPTION
After https://github.com/returntocorp/semgrep/pull/4651 the change in global logging level caused progress bar to be hidden. This fixes that.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
