### PR TITLE
[HCL] Fix CST-to-Generic translation of heredocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Configure the PCRE engine with lower match-attempts and recursion limits in order
   to prevent regex matching from potentially "hanging" Semgrep
+- Terraform: Parse heredocs respecting newlines and whitespaces, so that it is
+  possible to correctly match these strings with `metavariable-regex` or
+  `metavariable-pattern`. Previously, Semgrep had problems analyzing e.g. embedded
+  YAML content. (#4582)
 
 ## [0.82.0](https://github.com/returntocorp/semgrep/releases/tag/v0.82.0) - 02-08-2022
 

--- a/semgrep-core/tests/OTHER/rules/terraform_nested_yaml.tf
+++ b/semgrep-core/tests/OTHER/rules/terraform_nested_yaml.tf
@@ -1,0 +1,28 @@
+# https://github.com/returntocorp/semgrep/issues/4582
+resource "aws_ssm_document" "s3_enabled_not_encrypted_yaml" {
+  name          = "SSM-SessionManagerRunShell"
+  document_type = "Session"
+
+  document_format = "YAML"
+  
+  # ruleid: aws-ssm-document-logging-issues
+  content = <<DOC
+  schemaVersion: '1.0'
+  description: Document to hold regional settings for Session Manager
+  sessionType: Standard_Stream
+  inputs:
+    s3BucketName: 'example'
+    s3KeyPrefix: ''
+    s3EncryptionEnabled: false
+    cloudWatchLogGroupName: ''
+    cloudWatchEncryptionEnabled: true
+    cloudWatchStreamingEnabled: true
+    kmsKeyId: ''
+    runAsEnabled: true
+    runAsDefaultUser: ''
+    idleSessionTimeout: '20'
+    shellProfile:
+      windows: ''
+      linux: ''
+DOC
+}

--- a/semgrep-core/tests/OTHER/rules/terraform_nested_yaml.yaml
+++ b/semgrep-core/tests/OTHER/rules/terraform_nested_yaml.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: aws-ssm-document-logging-issues
+    message: blah
+    languages:
+      - hcl
+    severity: INFO
+    patterns:
+      - pattern: content = "$STRING"
+      - metavariable-pattern:
+          metavariable: $STRING
+          language: yaml
+          pattern: |
+            schemaVersion: '1.0'
+


### PR DESCRIPTION
Heredocs are parsed as a list of tokens without any newline or
whitespace. But heredocs may represent code that we want to analyze with
metavariable-regex or metavariable-pattern, so we must parse these
strings correctly. Ideally, we should preserve these newlines and
whitespace already during parsing... but for now we just "restore" them
using token location info.

Closes #4582

test plan:
make test # test included

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
