### PR TITLE
[Graph_code] add type signatures in environment

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -197,8 +197,10 @@ let rec pattern_to_expr p =
   |> G.e
 
 let expr_to_type e =
+  match e.e with
+  | N n -> TyN n |> G.t
   (* TODO: diconstruct e and generate the right type (TyBuiltin, ...) *)
-  TyExpr e |> G.t
+  | _ -> TyExpr e |> G.t
 
 (* TODO: recognize foo(args)? like in Kotlin/Java *)
 let expr_to_class_parent e : class_parent = (expr_to_type e, None)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -198,7 +198,9 @@ let rec pattern_to_expr p =
 
 let expr_to_type e =
   match e.e with
-  | N n -> TyN n |> G.t
+  (* TODO: this introduces some regressions in semgrep-rules
+   * | N n -> TyN n |> G.t
+   *)
   (* TODO: diconstruct e and generate the right type (TyBuiltin, ...) *)
   | _ -> TyExpr e |> G.t
 

--- a/semgrep-core/src/naming/Graph_code_AST_visitor.ml
+++ b/semgrep-core/src/naming/Graph_code_AST_visitor.ml
@@ -233,17 +233,16 @@ and map_expr_kind env ekind : T.t option =
       H.when_uses_phase_or_none env (fun () ->
           let* t = v1 in
           match t with
-          (* less: should do type checking on arguments matching parameters *)
-          | T.N xs -> (
-              match env.lang with
-              (* in Python, calls to Foo() are actually disguised New that
-               * then should return the type Foo (the class Foo)
-               *)
-              | Lang.Python ->
-                  (* less: could also link to __init__ method *)
-                  Some (T.N xs)
-              (* should access the type signature of xs *)
-              | _ -> todo_type)
+          (* less: should do type checking on arguments matching parameters.
+           * later: if polymorphic type, need to instantiate it with the
+           * type of the arguments.
+           *)
+          | T.Function (_params, ty) -> Some ty
+          (* in Python, calls to Foo() are actually disguised New that
+           * then should return the type Foo (the class Foo).
+           * less: could also link to __init__ method
+           *)
+          | T.N xs when env.lang = Lang.Python -> Some (T.N xs)
           | _ -> None)
   | Alias (_, _) -> todo_type
   | L v1 ->

--- a/semgrep-core/tests/python/graph_code/dir1/a.py
+++ b/semgrep-core/tests/python/graph_code/dir1/a.py
@@ -3,5 +3,7 @@ class A:
         return 1
     def foo2():
         return 1
+    def foo3():
+        return 1
     def bar_dead_ok():
         return 2

--- a/semgrep-core/tests/python/graph_code/dir1/function_type.py
+++ b/semgrep-core/tests/python/graph_code/dir1/function_type.py
@@ -1,0 +1,5 @@
+from dir1.a import A
+
+def return_A() -> A:
+    return A()
+

--- a/semgrep-core/tests/python/graph_code/dir1/function_type2.py
+++ b/semgrep-core/tests/python/graph_code/dir1/function_type2.py
@@ -1,0 +1,4 @@
+from dir1.function_type import return_A
+
+def test_ret_function_type_dead_ok():
+    return return_A().foo2()


### PR DESCRIPTION
This will help resolve method calls after a function call.

test plan:
cd tests/python/graph_code
make
codegraph .
look the new edge between function_type2.py and a.py


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)