### PR TITLE
suggest semgrep login in certain cases

### DIFF
--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -74,6 +74,9 @@ class _MetricManager:
             )
         self._send_metrics = metrics_state or legacy_state or MetricsState.AUTO
 
+    def get_is_using_server(self) -> bool:
+        return self._using_server
+
     def set_using_server_true(self) -> None:
         if not self._using_server:
             logger.info("Fetching rules from https://semgrep.dev/registry ...")

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -17,6 +17,7 @@ from typing import Set
 from typing import Type
 
 from semgrep import config_resolver
+from semgrep.commands.login import Authentication
 from semgrep.constants import Colors
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
@@ -311,6 +312,7 @@ class OutputHandler:
                     and num_targets > 0
                     and num_rules > 0
                     and metric_manager.get_is_using_server()
+                    and Authentication.get_token() is None
                 ):
                     suggestion_line = "(need more rules? `semgrep login` for additional free Semgrep Registry rules)\n"
                 else:

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -306,9 +306,6 @@ class OutputHandler:
                 num_rules = len(self.filtered_rules)
 
                 ignores_line = str(ignore_log or "No ignore information available")
-                import pdb
-
-                pdb.set_trace()
                 if (
                     num_findings == 0
                     and num_targets > 0

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -17,6 +17,7 @@ from typing import Set
 from typing import Type
 
 from semgrep import config_resolver
+from semgrep import metric_manager
 from semgrep.constants import Colors
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
@@ -39,6 +40,7 @@ from semgrep.rule_match_map import RuleMatchMap
 from semgrep.stats import make_loc_stats
 from semgrep.stats import make_target_stats
 from semgrep.target_manager import IgnoreLog
+from semgrep.types import MetricsState
 from semgrep.util import is_url
 from semgrep.util import terminal_wrap
 from semgrep.util import with_color
@@ -305,10 +307,20 @@ class OutputHandler:
                 num_rules = len(self.filtered_rules)
 
                 ignores_line = str(ignore_log or "No ignore information available")
+                is_registry_run = metric_manager.MetricsState != MetricsState.OFF
+                if (
+                    num_findings == 0
+                    and num_targets > 0
+                    and num_rules > 0
+                    and is_registry_run
+                ):
+                    suggestion_line = "(Looking for more rules? Try `semgrep login` for additional free Semgrep Registry rules)\n"
+                else:
+                    suggestion_line = ""
                 stats_line = f"ran {num_rules} rules on {num_targets} files: {num_findings} findings"
                 if ignore_log is not None:
                     logger.verbose(ignore_log.verbose_output())
-                logger.info("\n" + ignores_line + "\n" + stats_line)
+                logger.info("\n" + ignores_line + "\n" + suggestion_line + stats_line)
 
         final_error = None
         error_stats = None

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -17,7 +17,6 @@ from typing import Set
 from typing import Type
 
 from semgrep import config_resolver
-from semgrep import metric_manager
 from semgrep.constants import Colors
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
@@ -32,6 +31,7 @@ from semgrep.formatter.junit_xml import JunitXmlFormatter
 from semgrep.formatter.sarif import SarifFormatter
 from semgrep.formatter.text import TextFormatter
 from semgrep.formatter.vim import VimFormatter
+from semgrep.metric_manager import metric_manager
 from semgrep.profile_manager import ProfileManager
 from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
@@ -40,7 +40,6 @@ from semgrep.rule_match_map import RuleMatchMap
 from semgrep.stats import make_loc_stats
 from semgrep.stats import make_target_stats
 from semgrep.target_manager import IgnoreLog
-from semgrep.types import MetricsState
 from semgrep.util import is_url
 from semgrep.util import terminal_wrap
 from semgrep.util import with_color
@@ -307,14 +306,16 @@ class OutputHandler:
                 num_rules = len(self.filtered_rules)
 
                 ignores_line = str(ignore_log or "No ignore information available")
-                is_registry_run = metric_manager.MetricsState != MetricsState.OFF
+                import pdb
+
+                pdb.set_trace()
                 if (
                     num_findings == 0
                     and num_targets > 0
                     and num_rules > 0
-                    and is_registry_run
+                    and metric_manager.get_is_using_server()
                 ):
-                    suggestion_line = "(Looking for more rules? Try `semgrep login` for additional free Semgrep Registry rules)\n"
+                    suggestion_line = "(need more rules? `semgrep login` for additional free Semgrep Registry rules)\n"
                 else:
                     suggestion_line = ""
                 stats_line = f"ran {num_rules} rules on {num_targets} files: {num_findings} findings"


### PR DESCRIPTION
we'll suggest to the user that more rules are available under semgrep login, for runs where there are 0 findings, with 1+ rules and 1+ files scanned, and config pulled from the registry

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
