### PR TITLE
fix(metrics): dont raise if both metrics value are the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Kotlin: store trailing lambdas in the AST (#4741)
 - Autofix: Semgrep no longer errors during `--dry-run`s where one fix changes the line numbers in a file that also has a second autofix.
 - Performance regression when running with --debug (#4761)
+- Allow metrics flag and metrics env var at the same time if both are set to the same value (#4703)
 
 ## [0.83.0](https://github.com/returntocorp/semgrep/releases/tag/v0.83.0) - 2022-02-24
 

--- a/semgrep/semgrep/metric_manager.py
+++ b/semgrep/semgrep/metric_manager.py
@@ -66,9 +66,14 @@ class _MetricManager:
         :param metrics_state: The value of the --metrics option
         :param legacy_state: Value of the --enable-metrics/--disable-metrics option
         :raises click.BadParameter: if both --metrics and --enable-metrics/--disable-metrics are passed
+        and their values are different
         """
 
-        if metrics_state is not None and legacy_state is not None:
+        if (
+            metrics_state is not None
+            and legacy_state is not None
+            and metrics_state != legacy_state
+        ):
             raise click.BadParameter(
                 "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
             )

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -187,3 +187,25 @@ def test_legacy_flags(run_semgrep_in_tmp):
         "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
         in output
     )
+
+    _, output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        options=["--disable-metrics"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", "SEMGREP_SEND_METRICS": "off"},
+        fail_on_nonzero=False,
+    )
+    assert (
+        "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
+        not in output
+    )
+
+    _, output = run_semgrep_in_tmp(
+        "rules/eqeq.yaml",
+        options=["--enable-metrics"],
+        env={"SEMGREP_USER_AGENT_APPEND": "testing", "SEMGREP_SEND_METRICS": "on"},
+        fail_on_nonzero=False,
+    )
+    assert (
+        "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
+        not in output
+    )


### PR DESCRIPTION
Hello team!

I was copy-pasting a few snippets that had the `--disable-metrics` switch and because I also set `SEMGREP_SEND_METRICS` to `off` the commands failed. It makes sense not to allow different values to be set, but I felt like it was harmless to set the same value in two different ways so I'm proposing this change.

Do I need a changelog modification here?

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
