### PR TITLE
fix off by one in text formatter output highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - The environment variable used by Semgrep login changed from `SEMGREP_LOGIN_TOKEN` to `SEMGREP_APP_TOKEN`
 - A new subcommand `semgrep publish` allows users to upload private, unlisted, or public rules to the Semgrep Registry
+- Fix for: semgrep always highlights one extra character
 
 ### Added
 

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -55,17 +55,20 @@ class TextFormatter(BaseFormatter):
         end_line: int,
         end_col: int,
     ) -> str:
+        """
+        Assumes column start and end numbers are 1-indexed
+        """
         start_color = 0 if line_number > start_line else start_col
-        # column offset
+        # adjust for 1-indexed column number
         start_color = max(start_color - 1, 0)
+        # put the end color at the end of the line if this isn't the last line in the output
         end_color = end_col if line_number >= end_line else len(line) + 1 + 1
+        # adjust for 1-indexed column number
         end_color = max(end_color - 1, 0)
         line = (
             line[:start_color]
-            + with_color(
-                Colors.foreground, line[start_color : end_color + 1], bold=True
-            )  # want the color to include the end_col
-            + line[end_color + 1 :]
+            + with_color(Colors.foreground, line[start_color:end_color], bold=True)
+            + line[end_color:]
         )
         return line
 


### PR DESCRIPTION
Fixes #4400 

I'm suspicious of how simple this fix is, but manual testing seems to indicate we've just been adding an additional character to our output highlight for a long time.

I added tests for this along with a lot of our other text output in https://github.com/returntocorp/semgrep/pull/4706

PR checklist:

- [x] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
