### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM returntocorp/ocaml:alpine-2021-07-15 as build-semgrep-core
 USER root
 # for ocaml-pcre now used in semgrep-core
 # TODO: update root image to include python 3.9
-RUN apk add --update --no-cache pcre-dev python3 &&\
+RUN apk add --no-cache pcre-dev python3 &&\
      pip install --no-cache-dir pipenv==2021.11.23
 
 USER user


### PR DESCRIPTION
There is no need to use `--update` with `--no-cache` when using `apk` on
Alpine Linux, as using `--no-cache` will fetch the index every time and
leave no local cache, so the index will always be the latest without
temporary files remain in the image.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
