### PR TITLE
[Python] generate VarDef for typed fields, not TypedExpr

### DIFF
--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -612,6 +612,13 @@ and stmt_aux env x =
         }
       in
       [ G.DefStmt (ent, G.ClassDef def) |> G.s ]
+  | ExprStmt (TypedExpr (Name (id, _kind, _ref), ty)) ->
+      (* no need to guard with assign_to_vardef here *)
+      let id = name env id in
+      let ty = type_ env ty in
+      let ent = G.basic_entity id in
+      let def = G.VarDef { G.vtype = Some ty; vinit = None } in
+      [ G.DefStmt (ent, def) |> G.s ]
   (* TODO: v1 contains actually a list of lhs, because a = b = c is
    * translated in Assign ([a;b], c)
    *)

--- a/semgrep-core/tests/python/parsing/field.py
+++ b/semgrep-core/tests/python/parsing/field.py
@@ -1,0 +1,4 @@
+class Ex:
+    fld1: int
+    fld2_dead_ok: int
+    fld3: int = 42


### PR DESCRIPTION
test plan:
See the DefStmt now below (it was a TypedExpr before)
```
+ /home/pad/yy/_build/default/src/cli/Main.exe -l py -dump_named_ast field.py
Pr(
  [DefStmt(
     ({name=EN(Id(("Ex", ()), {id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[]; tparams=[]; },
      ClassDef(
        {ckind=(Class, ()); cextends=[]; cimplements=[]; cmixins=[]; cparams=[
         ];
         cbody=[F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("fld1", ()),
                               {id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
                      attrs=[]; tparams=[]; },
                     VarDef(
                       {vinit=None;
                        vtype=Some({t_attrs=[];
                                    t=TyExpr(
                                        N(
                                          Id(("int", ()),
                                            {id_hidden=false; id_resolved=Ref(
                                             None); id_type=Ref(None); id_svalue=Ref(
                                             None); })));
                                    });
                        }))));
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)