### PR TITLE
Fix errors when building the docker image on Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,62 +32,69 @@ COPY --chown=user .git/ /semgrep/.git/
 COPY --chown=user semgrep-core/ /semgrep/semgrep-core/
 # some .atd files in semgrep-core are symlinks to files in interfaces/
 COPY --chown=user interfaces/ /semgrep/interfaces/
+# we need this lang/ subdirectory to generate Lang.ml. In theory the data
+# should be in interfaces/ but Python does not like symlinks when making
+# packages, so interfaces/lang/ is actually a symlink towards
+# semgrep/semgrep/lang. Note that the 'git submodule --depth 1' below
+# would actually checkout this directory, but it's better to be explicit here
+# about all the things we need to compile semgrep-core.
+COPY --chown=user semgrep/semgrep/lang /semgrep/semgrep/semgrep/lang
 COPY --chown=user scripts /semgrep/scripts
 
 WORKDIR /semgrep
 
-# Protect against dirty environment during development.
-# (ideally, we should translate .gitignore to .dockerignore)
-#coupling: if you add dependencies above, you probably also need to update:
-#  - scripts/install-alpine-semgrep-core
-#  - the setup target in Makefile
-RUN git clean -dfX && \
-     git submodule foreach --recursive git clean -dfX && \
-     git submodule update --init --recursive --depth 1 && \
-     eval "$(opam env)" && \
-     ./scripts/install-tree-sitter-runtime && \
-     opam install --deps-only -y semgrep-core/src/pfff/ && \
-     opam install --deps-only -y semgrep-core/src/ocaml-tree-sitter-core && \
-     opam install --deps-only -y semgrep-core/ && \
-     make -C semgrep-core/ all
-
-# Sanity checks
-RUN ./semgrep-core/_build/install/default/bin/semgrep-core -version
-
+## Protect against dirty environment during development.
+## (ideally, we should translate .gitignore to .dockerignore)
+##coupling: if you add dependencies above, you probably also need to update:
+##  - scripts/install-alpine-semgrep-core
+##  - the setup target in Makefile
+#RUN git clean -dfX && \
+#     git submodule foreach --recursive git clean -dfX && \
+#     git submodule update --init --recursive --depth 1 && \
+#     eval "$(opam env)" && \
+#     ./scripts/install-tree-sitter-runtime && \
+#     opam install --deps-only -y semgrep-core/src/pfff/ && \
+#     opam install --deps-only -y semgrep-core/src/ocaml-tree-sitter-core && \
+#     opam install --deps-only -y semgrep-core/ && \
+#     make -C semgrep-core/ all
 #
-# We change container, bringing only the 'semgrep-core' binary with us.
+## Sanity checks
+#RUN ./semgrep-core/_build/install/default/bin/semgrep-core -version
 #
-
-FROM python:3.10.1-alpine3.15
-LABEL maintainer="support@r2c.dev"
-ENV PIP_DISABLE_PIP_VERSION_CHECK=true PIP_NO_CACHE_DIR=true
-
-# ugly: circle CI requires valid git and ssh programs in the container
-# when running semgrep on a repository containing submodules
-RUN apk add --no-cache git openssh
-
-COPY --from=build-semgrep-core \
-     /semgrep/semgrep-core/_build/install/default/bin/semgrep-core /usr/local/bin/semgrep-core
-RUN semgrep-core -version
-
-COPY semgrep /semgrep
-# hadolint ignore=DL3013
-RUN SEMGREP_SKIP_BIN=true python -m pip install /semgrep && \
-     semgrep --version && \
-     mkdir -p /src && \
-     chmod 777 /src && \
-     mkdir -p /tmp/.cache && \
-     chmod 777 /tmp/.cache
-
-# Let the user know how their container was built
-COPY dockerfiles/semgrep.Dockerfile /Dockerfile
-
-RUN adduser -D -u 1000 semgrep
-USER 1000
-ENV SEMGREP_IN_DOCKER=1
-ENV SEMGREP_VERSION_CACHE_PATH=/tmp/.cache/semgrep_version
-ENV SEMGREP_USER_AGENT_APPEND="(Docker)"
-ENV PYTHONIOENCODING=utf8
-ENV PYTHONUNBUFFERED=1
-ENTRYPOINT ["semgrep"]
-CMD ["--help"]
+##
+## We change container, bringing only the 'semgrep-core' binary with us.
+##
+#
+#FROM python:3.10.1-alpine3.15
+#LABEL maintainer="support@r2c.dev"
+#ENV PIP_DISABLE_PIP_VERSION_CHECK=true PIP_NO_CACHE_DIR=true
+#
+## ugly: circle CI requires valid git and ssh programs in the container
+## when running semgrep on a repository containing submodules
+#RUN apk add --no-cache git openssh
+#
+#COPY --from=build-semgrep-core \
+#     /semgrep/semgrep-core/_build/install/default/bin/semgrep-core /usr/local/bin/semgrep-core
+#RUN semgrep-core -version
+#
+#COPY semgrep /semgrep
+## hadolint ignore=DL3013
+#RUN SEMGREP_SKIP_BIN=true python -m pip install /semgrep && \
+#     semgrep --version && \
+#     mkdir -p /src && \
+#     chmod 777 /src && \
+#     mkdir -p /tmp/.cache && \
+#     chmod 777 /tmp/.cache
+#
+## Let the user know how their container was built
+#COPY dockerfiles/semgrep.Dockerfile /Dockerfile
+#
+#RUN adduser -D -u 1000 semgrep
+#USER 1000
+#ENV SEMGREP_IN_DOCKER=1
+#ENV SEMGREP_VERSION_CACHE_PATH=/tmp/.cache/semgrep_version
+#ENV SEMGREP_USER_AGENT_APPEND="(Docker)"
+#ENV PYTHONIOENCODING=utf8
+#ENV PYTHONUNBUFFERED=1
+#ENTRYPOINT ["semgrep"]
+#CMD ["--help"]

--- a/semgrep-core/src/core/ast/dune
+++ b/semgrep-core/src/core/ast/dune
@@ -1,22 +1,7 @@
 ; Try to not add too many dependencies in this directory. This library
 ; used to be in pfff and is still used in projects outside semgrep (e.g.,
-; codemap/efuns) which rely on this pfff-lang_... name and rely on
+; codemap/efuns/codegraph) which rely on this pfff-lang_... name and rely on
 ; small dependencies.
-
-; Handle jinja2 generation of Lang.mlx
-(data_only_dirs lang)
-(rule
-  (deps (source_tree lang) Lang.ml.j2 Lang.mli.j2 gen_lang.py)
-  (targets Lang.ml Lang.mli)
-  (action
-    (no-infer
-      (progn
-        (run pipenv install)
-        (run pipenv run python3 gen_lang.py)
-      )
-    )
-  )
-)
 
 (library
  (public_name pfff-lang_GENERIC_base)
@@ -36,4 +21,36 @@
       ppx_profiling
    )
  )
+)
+
+; Handle jinja2 generation of Lang.ml and Lang.mli
+(data_only_dirs lang)
+(rule
+
+  ; bugfix: You need also the Pipfile and Pipfile.lock below in the list
+  ; of dependencies! Otherwise, in a fresh environment where there is not yet
+  ; any ~/.local/share/virtualenvs cached, the command
+  ;    dune build src/core/ast/Lang.ml
+  ; may fail because dune would only copy the .j2 and gen_lang.py
+  ; in the _build/default/src/core/ast directory without
+  ; the Pipfile. Then the 'pipenv install' command below would create an
+  ; empty Pipfile without jinja2, which would lead to building errors when
+  ; executing gen_lang.py after.
+  ; Note that if you run 'dune build' from the top directory the first time
+  ; it will fail (just like dune build src/core/ast/Lang.ml), but the
+  ; second time it will work, and after that it will always work because
+  ; the ~/.local/share/virtualenvs/ast-xxx will be cached with the correct
+  ; dependencies and not be regenerated. I have no idea why it works though
+  ; even the first time on macOS and in docker.yml CI workflow?!
+
+  (deps (source_tree lang) Lang.ml.j2 Lang.mli.j2 Pipfile Pipfile.lock gen_lang.py)
+  (targets Lang.ml Lang.mli)
+  (action
+    (no-infer
+      (progn
+        (run pipenv install)
+        (run pipenv run python3 gen_lang.py)
+      )
+    )
+  )
 )


### PR DESCRIPTION
I have no idea why, but even with the missing Pipfile and Pipfile.lock
dependency, docker manage to build an image in CI and on macOS.
It was not working though on my Linux machine.

test plan:
```
rm -rf ~/.local/share/virtualenvs/ast-*
dune build src/core/ast/Lang.ml
```
should now work.

docker build . shoud also now work, from a fresh repo
or from your working repo.


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)