### PR TITLE
Add `focus-metavariable:` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Fixed
+### Added
+
+- New `focus-metavariable:` operator that allows to focus matching on a particular
+  metavariable within a `patterns:` operator (#4453)
+
+## [0.83.0](https://github.com/returntocorp/semgrep/releases/tag/v0.83.0) - 2022-02-24
 
 - Show correct findings count when using `--config auto` (#4674)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ## Unreleased
 
 ### Fixed
-### Added
-
-- New `focus-metavariable:` operator that allows to focus matching on a particular
-  metavariable within a `patterns:` operator (#4453)
-
-## [0.83.0](https://github.com/returntocorp/semgrep/releases/tag/v0.83.0) - 2022-02-24
 
 - Show correct findings count when using `--config auto` (#4674)
 

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -27,6 +27,7 @@ and sformula_and = {
   positives : sformula list;
   negatives : sformula list;
   conditionals : R.metavar_cond list;
+  focus : MV.mvar list;
 }
 [@@deriving show]
 
@@ -90,10 +91,10 @@ let formula_to_sformula formula =
     (* Visit formula and convert *)
     match formula with
     | R.P (p, inside) -> Leaf (p, inside)
-    | R.And (_, fs, conds) -> And (convert_and_formulas fs conds)
+    | R.And (_, fs, conds, focus) -> And (convert_and_formulas fs conds focus)
     | R.Or (_, fs) -> Or (List.map formula_to_sformula fs)
     | R.Not (_, f) -> Not (formula_to_sformula f)
-  and convert_and_formulas fs cond =
+  and convert_and_formulas fs cond focus =
     let pos, neg = split_and fs in
     let pos = List.map formula_to_sformula pos in
     let neg = List.map formula_to_sformula neg in
@@ -108,6 +109,7 @@ let formula_to_sformula formula =
       positives = pos;
       negatives = neg;
       conditionals = cond |> List.map snd;
+      focus = focus |> List.map snd;
     }
   in
   formula_to_sformula formula

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -91,7 +91,8 @@ let formula_to_sformula formula =
     (* Visit formula and convert *)
     match formula with
     | R.P (p, inside) -> Leaf (p, inside)
-    | R.And (_, fs, conds, focus) -> And (convert_and_formulas fs conds focus)
+    | R.And { tok = _; conjuncts = fs; conditions = conds; focus } ->
+        And (convert_and_formulas fs conds focus)
     | R.Or (_, fs) -> Or (List.map formula_to_sformula fs)
     | R.Not (_, f) -> Not (formula_to_sformula f)
   and convert_and_formulas fs cond focus =

--- a/semgrep-core/src/engine/Specialize_formula.mli
+++ b/semgrep-core/src/engine/Specialize_formula.mli
@@ -25,6 +25,7 @@ and sformula_and = {
   positives : sformula list;
   negatives : sformula list;
   conditionals : Rule.metavar_cond list;
+  focus : Metavariable.mvar list;
 }
 [@@deriving show]
 

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -99,7 +99,7 @@ let check_formula env (lang : Xlang.t) f =
     | P _ -> ()
     | Not (_, f) -> find_dupe f
     | Or (t, xs)
-    | And (t, xs, _) ->
+    | And (t, xs, _, _) ->
         let rec aux xs =
           match xs with
           | [] -> ()

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -99,7 +99,7 @@ let check_formula env (lang : Xlang.t) f =
     | P _ -> ()
     | Not (_, f) -> find_dupe f
     | Or (t, xs)
-    | And (t, xs, _, _) ->
+    | And { tok = t; conjuncts = xs; _ } ->
         let rec aux xs =
           match xs with
           | [] -> ()

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -134,12 +134,12 @@ let option_map f xs =
 let rec (remove_not : Rule.formula -> Rule.formula option) =
  fun f ->
   match f with
-  | R.And (t, xs, conds, focus) ->
+  | R.And { tok = t; conjuncts = xs; conditions = conds; focus } ->
       let ys = Common.map_filter remove_not xs in
       if null ys then (
         logger#warning "null And after remove_not";
         None)
-      else Some (R.And (t, ys, conds, focus))
+      else Some (R.And { tok = t; conjuncts = ys; conditions = conds; focus })
   | R.Or (t, xs) ->
       (* See NOTE "AND vs OR and map_filter". *)
       let* ys = option_map remove_not xs in
@@ -156,7 +156,7 @@ let rec (remove_not : Rule.formula -> Rule.formula option) =
       | R.Or (_, _xs) ->
           logger#warning "Not Or";
           None
-      | R.And (_, _xs, _conds, _focus) ->
+      | R.And _ ->
           logger#warning "Not And";
           None)
   | R.P (pat, inside) -> Some (P (pat, inside))
@@ -195,7 +195,7 @@ let rec (cnf : Rule.formula -> cnf_step0) =
    * | R.And _xs -> failwith "Not And"
    * )
    *)
-  | R.And (_, xs, conds, _focus) ->
+  | R.And { conjuncts = xs; conditions = conds; _ } ->
       let ys = Common.map cnf xs in
       let zs = Common.map (fun (_t, cond) -> And [ Or [ LCond cond ] ]) conds in
       And (ys @ zs |> Common.map (function And ors -> ors) |> List.flatten)
@@ -519,7 +519,12 @@ let regexp_prefilter_of_taint_rule rule_tok taint_spec =
      * if executed by search-mode, but it works for the purpose of this
      * analysis! *)
     R.And
-      (rule_tok, [ R.Or (rule_tok, sources); R.Or (rule_tok, sinks) ], [], [])
+      {
+        tok = rule_tok;
+        conjuncts = [ R.Or (rule_tok, sources); R.Or (rule_tok, sinks) ];
+        conditions = [];
+        focus = [];
+      }
   in
   regexp_prefilter_of_formula f
 

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -499,6 +499,7 @@ and parse_formula_old env ((key, value) : key * G.expr) : R.formula_old =
   match s with
   | "pattern" -> R.Pat (get_pattern value)
   | "pattern-not" -> R.PatNot (t, get_pattern value)
+  | "focus-metavariable" -> R.PatFocus (t, parse_string env key value)
   | "pattern-inside" -> R.PatInside (get_pattern value)
   | "pattern-not-inside" -> R.PatNotInside (t, get_pattern value)
   | "pattern-either" ->
@@ -553,7 +554,7 @@ and parse_formula_new env (x : G.expr) : R.formula =
       | "and" ->
           let xs = parse_list env key parse_formula_and_new value in
           let fs, conds = Common.partition_either (fun x -> x) xs in
-          R.And (t, fs, conds)
+          R.And (t, fs, conds, (* TODO: 'focus-metavariable:' *) [])
       | "or" -> R.Or (t, parse_list env key parse_formula_new value)
       | "not" -> R.Not (t, parse_formula_new env value)
       | "inside" -> R.P (parse_xpattern_expr env value, Some Inside)

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -554,7 +554,14 @@ and parse_formula_new env (x : G.expr) : R.formula =
       | "and" ->
           let xs = parse_list env key parse_formula_and_new value in
           let fs, conds = Common.partition_either (fun x -> x) xs in
-          R.And (t, fs, conds, (* TODO: 'focus-metavariable:' *) [])
+          R.And
+            {
+              tok = t;
+              conjuncts = fs;
+              conditions = conds;
+              (* TODO: 'focus-metavariable:' *)
+              focus = [];
+            }
       | "or" -> R.Or (t, parse_list env key parse_formula_new value)
       | "not" -> R.Not (t, parse_formula_new env value)
       | "inside" -> R.P (parse_xpattern_expr env value, Some Inside)

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable.py
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable.py
@@ -1,0 +1,5 @@
+# ruleid: test
+foo (1 + 2,
+	1)
+foo (2 + 1,
+	1)

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable.py
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable.py
@@ -1,5 +1,4 @@
 # ruleid: test
-foo (1 + 2,
-	1)
-foo (2 + 1,
+foo (1,
+# OK: test
 	1)

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable.yaml
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test
+    patterns:
+      - pattern-inside: foo($X, ...)
+      - focus-metavariable: $X
+      - pattern: $Y + ...
+      - focus-metavariable: $Y
+      - pattern: "1"
+    message: Test
+    languages:
+      - py
+    severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable1.py
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable1.py
@@ -1,0 +1,8 @@
+# ruleid: test
+foo (1 + 2,
+# OK: test
+	1)
+# OK: test
+foo (2 + 1,
+# OK: test
+	1)

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable1.yaml
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable1.yaml
@@ -3,6 +3,9 @@ rules:
     patterns:
       - pattern-inside: foo($X, ...)
       - focus-metavariable: $X
+      - pattern: $Y + ...
+      - focus-metavariable: $Y
+      - pattern: "1"
     message: Test
     languages:
       - py

--- a/semgrep/semgrep/rule_schema.yaml
+++ b/semgrep/semgrep/rule_schema.yaml
@@ -9,6 +9,7 @@ definitions:
       anyOf:
         - $ref: "#/definitions/patterns"
         - $ref: "#/definitions/pattern-either"
+        - $ref: "#/definitions/focus-metavariable"
         - $ref: "#/definitions/pattern-inside"
         - $ref: "#/definitions/pattern-not-inside"
         - $ref: "#/definitions/pattern-not"
@@ -306,6 +307,15 @@ definitions:
         $ref: "#/definitions/pattern-either-content"
     required:
       - pattern-either
+    additionalProperties: false
+  focus-metavariable:
+    type: object
+    properties:
+      focus-metavariable:
+        title: Focus on what a given metavariable is matching
+        type: string
+    required:
+      - focus-metavariable
     additionalProperties: false
   pattern-inside:
     type: object


### PR DESCRIPTION
This operator allows to focus matching on a given metavariable, within a
`patterns:` operator.

Closes #4453

test plan:
make test # test included

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
