### PR TITLE
Display supported languages in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2376,7 +2376,7 @@ def fetch_global_const():
 
 ### Added
 
-- Constant propagation for some langauges. Golang example:
+- Constant propagation for some languages. Golang example:
 
 ```
 pattern: dangerous1("...")

--- a/semgrep-core/src/naming/Typing.ml
+++ b/semgrep-core/src/naming/Typing.ml
@@ -22,7 +22,7 @@ let get_resolved_type lang (vinit, vtype) =
       in
       (* Currently these vary between languages *)
       (* Alternative is to define a TyInt, TyBool, etc in the generic AST *)
-      (* so this is more portable across langauges *)
+      (* so this is more portable across languages *)
       match vinit with
       | Some { e = L (Bool (_, tok)); _ } -> make_type "bool" tok
       | Some { e = L (Int (_, tok)); _ } -> make_type "int" tok

--- a/semgrep/semgrep/commands/scan.py
+++ b/semgrep/semgrep/commands/scan.py
@@ -234,6 +234,11 @@ CONTEXT_SETTINGS = {"max_content_width": 90}
     shell_complete=__get_severity_options,
 )
 @click.option(
+    "--show-supported-languages",
+    is_flag=True,
+    help=("Print a list of languages that are currently supported by Semgrep."),
+)
+@click.option(
     "--strict/--no-strict",
     is_flag=True,
     default=False,
@@ -512,7 +517,6 @@ CONTEXT_SETTINGS = {"max_content_width": 90}
         "Only works with the --autofix flag. Otherwise does nothing."
     ),
 )
-
 # These flags are deprecated or experimental - users should not
 # rely on their existence, or their output being stable
 @click.option(
@@ -603,6 +607,7 @@ def scan(
     save_test_output_tar: bool,
     scan_unknown_extensions: bool,
     severity: Optional[Tuple[str, ...]],
+    show_supported_languages: bool,
     strict: bool,
     synthesize_patterns: str,
     target: Tuple[str, ...],
@@ -646,6 +651,10 @@ def scan(
         from semgrep.job_postings import print_job_postings
 
         print_job_postings()
+        return
+
+    if show_supported_languages:
+        click.echo(LANGUAGE.show_suppported_langauges_message())
         return
 
     # To keep version runtime fast, we defer non-version imports until here

--- a/semgrep/semgrep/commands/scan.py
+++ b/semgrep/semgrep/commands/scan.py
@@ -654,7 +654,7 @@ def scan(
         return
 
     if show_supported_languages:
-        click.echo(LANGUAGE.show_suppported_langauges_message())
+        click.echo(LANGUAGE.show_suppported_languages_message())
         return
 
     # To keep version runtime fast, we defer non-version imports until here

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -396,7 +396,7 @@ class CoreRunner:
         except _UnknownLanguageError as ex:
             raise UnknownLanguageError(
                 short_msg=f"invalid language: {language}",
-                long_msg=f"unsupported language: {language}. {LANGUAGE.show_suppported_langauges_message()}",
+                long_msg=f"unsupported language: {language}. {LANGUAGE.show_suppported_languages_message()}",
                 spans=[rule.languages_span.with_context(before=1, after=1)],
             ) from ex
         return list(targets)

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -396,7 +396,7 @@ class CoreRunner:
         except _UnknownLanguageError as ex:
             raise UnknownLanguageError(
                 short_msg=f"invalid language: {language}",
-                long_msg=f"unsupported language: {language}. supported languages are: {', '.join(LANGUAGE.all_language_keys)}",
+                long_msg=f"unsupported language: {language}. {LANGUAGE.show_suppported_langauges_message()}",
                 spans=[rule.languages_span.with_context(before=1, after=1)],
             ) from ex
         return list(targets)

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -80,9 +80,12 @@ class _LanguageData:
             spans = [span.with_context(before=1, after=1)] if span else []
             raise UnknownLanguageError(
                 short_msg=f"invalid language: {normalized}",
-                long_msg=f"unsupported language: {normalized}. supported languages are: {', '.join(self.all_language_keys)}",
+                long_msg=f"unsupported language: {normalized}. {self.show_suppported_langauges_message()}",
                 spans=spans,
             )
+
+    def show_suppported_langauges_message(self) -> str:
+        return f"supported languages are: {', '.join(self.all_language_keys)}"
 
 
 LANGUAGE = _LanguageData()

--- a/semgrep/semgrep/semgrep_types.py
+++ b/semgrep/semgrep/semgrep_types.py
@@ -80,11 +80,11 @@ class _LanguageData:
             spans = [span.with_context(before=1, after=1)] if span else []
             raise UnknownLanguageError(
                 short_msg=f"invalid language: {normalized}",
-                long_msg=f"unsupported language: {normalized}. {self.show_suppported_langauges_message()}",
+                long_msg=f"unsupported language: {normalized}. {self.show_suppported_languages_message()}",
                 spans=spans,
             )
 
-    def show_suppported_langauges_message(self) -> str:
+    def show_suppported_languages_message(self) -> str:
         return f"supported languages are: {', '.join(self.all_language_keys)}"
 
 

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_show_supported_languages/results.json
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_cli_test_show_supported_languages/results.json
@@ -1,0 +1,1 @@
+supported languages are: bash, c, c#, c++, cpp, csharp, docker, dockerfile, elixir, ex, generic, go, golang, hack, hcl, html, java, javascript, js, json, kotlin, kt, lua, none, ocaml, php, py, python, python2, python3, r, regex, ruby, rust, scala, sh, sol, solidity, terraform, tf, ts, typescript, vue, yaml

--- a/semgrep/tests/e2e/test_cli_test.py
+++ b/semgrep/tests/e2e/test_cli_test.py
@@ -73,6 +73,20 @@ def test_cli_test_yaml_language(run_semgrep_in_tmp, snapshot):
     )
 
 
+def test_cli_test_show_supported_languages(run_semgrep_in_tmp, snapshot):
+    results, _ = run_semgrep_in_tmp(
+        "rules/cli_test/basic/",
+        options=["--show-supported-languages"],
+        target_name="cli_test/basic/",
+        output_format=OutputFormat.TEXT,
+    )
+
+    snapshot.assert_match(
+        results,
+        "results.json",
+    )
+
+
 def test_cli_test_suffixes(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/suffixes/",


### PR DESCRIPTION
- Display implementation is inspired by the clever hack that @clintgibler discussed in the issue, https://github.com/returntocorp/semgrep/issues/4747

- You can simply run the following to see supported languages

```
semgrep --show-supported-languages
```

Output is the following:

```
supported languages are: bash, c, c#, c++, cpp, csharp, docker, dockerfile, elixir, ex, generic, go, golang, hack, hcl, html, java, javascript, js, json, kotlin, kt, lua, none, ocaml, php, py, python, python2, python3, r, regex, ruby, rust, scala, sh, sol, solidity, terraform, tf, ts, typescript, vue, yaml
```

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [X] Change has no security implications (otherwise, ping security team)
