### PR TITLE
fix(core_runner): performance regression with --debug 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Report parse errors even when invoked with `--strict`
 - Show correct findings count when using `--config auto` (#4674)
 - Autofix: Semgrep no longer errors during `--dry-run`s where one fix changes the line numbers in a file that also has a second autofix.
+- Performance regression when running with --debug (#4761)
 
 ## [0.83.0](https://github.com/returntocorp/semgrep/releases/tag/v0.83.0) - 2022-02-24
 

--- a/semgrep/tests/e2e/targets/simple.yaml
+++ b/semgrep/tests/e2e/targets/simple.yaml
@@ -1,0 +1,20 @@
+name: Linters
+
+on:
+  pull_request:
+  push:
+    branches: [production, develop]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          extra_args: --hook-stage manual --all-files

--- a/semgrep/tests/e2e/test_performance.py
+++ b/semgrep/tests/e2e/test_performance.py
@@ -10,9 +10,9 @@ def test_debug_performance(run_semgrep_in_tmp):
     run_semgrep_in_tmp("rules/long_message.yaml", target_name="simple.yaml")
     time_without_debug = time.time() - start_without_debug
 
-    assert time_without_debug > 2, (
-        "runtime was suspiciously low, was the rule optimized out?"
-    )
+    assert (
+        time_without_debug > 2
+    ), "runtime was suspiciously low, was the rule optimized out?"
 
     start_with_debug = time.time()
     run_semgrep_in_tmp(
@@ -23,6 +23,7 @@ def test_debug_performance(run_semgrep_in_tmp):
     time_with_debug = time.time() - start_with_debug
 
     from pytest import approx
-    assert time_with_debug == approx(time_without_debug, rel=0.1), (
-        "adding --debug slowed runtime by more than 10%"
-    )
+
+    assert time_with_debug == approx(
+        time_without_debug, rel=0.1
+    ), "adding --debug slowed runtime by more than 10%"

--- a/semgrep/tests/e2e/test_performance.py
+++ b/semgrep/tests/e2e/test_performance.py
@@ -1,0 +1,26 @@
+import time
+
+
+def test_debug_performance(run_semgrep_in_tmp):
+    """
+    Verify that running semgrep with --debug does not result in
+    performance slowdown wrt running without --debug
+    """
+    start_without_debug = time.time()
+    run_semgrep_in_tmp("rules/long_message.yaml", target_name="simple.yaml")
+    time_without_debug = time.time() - start_without_debug
+
+    # If this fails the rule was probably optimized out
+    assert time_without_debug > 2
+
+    start_with_debug = time.time()
+    run_semgrep_in_tmp(
+        "rules/long_message.yaml",
+        target_name="simple.yaml",
+        options=["--debug", "--time"],
+    )
+    time_with_debug = time.time() - start_with_debug
+
+    # There was a slowdown of more than 10% in reality the time should be basically the same
+    # but we account for variablity in runtime here
+    assert time_with_debug - time_without_debug < 0.1 * time_without_debug

--- a/semgrep/tests/e2e/test_performance.py
+++ b/semgrep/tests/e2e/test_performance.py
@@ -10,8 +10,9 @@ def test_debug_performance(run_semgrep_in_tmp):
     run_semgrep_in_tmp("rules/long_message.yaml", target_name="simple.yaml")
     time_without_debug = time.time() - start_without_debug
 
-    # If this fails the rule was probably optimized out
-    assert time_without_debug > 2
+    assert time_without_debug > 2, (
+        "runtime was suspiciously low, was the rule optimized out?"
+    )
 
     start_with_debug = time.time()
     run_semgrep_in_tmp(
@@ -21,6 +22,7 @@ def test_debug_performance(run_semgrep_in_tmp):
     )
     time_with_debug = time.time() - start_with_debug
 
-    # There was a slowdown of more than 10% in reality the time should be basically the same
-    # but we account for variablity in runtime here
-    assert time_with_debug - time_without_debug < 0.1 * time_without_debug
+    from pytest import approx
+    assert time_with_debug == approx(time_without_debug, rel=0.1), (
+        "adding --debug slowed runtime by more than 10%"
+    )


### PR DESCRIPTION
When semgrep was run with --debug we were seeing a significant performance
regression than without. The root cause was in core_runner we were appending
stdout and stderr to a string which was running in O(n^3) for n line length.

With this PR we append to a list O(1) and do a single join at the end
removing the perf regression

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
