### PR TITLE
[PHP] consider also .tpl files as PHP files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `--validate` will check that metavariable-x doesn't use an invalid
   metavariable
+- PHP: .tpl files are now considered PHP files (#4763)
 
 ### Fixed
 

--- a/semgrep-core/test
+++ b/semgrep-core/test
@@ -3,8 +3,13 @@
 # Run the semgrep-core test program from the correct folder.
 # This is meant for manual use, when we want to select which tests to run.
 #
+# Example of use:
+#  ./test Maturity
+#  ./test Scala | grep OK
+#  ./test "full rule"
+#  ./test "full rule" | grep "full rule"
 
 # TODO: merge spacegrep tests into one test executable
 
 cd _build/default/tests
-./test.exe "$@"
+./test.exe test "$@"

--- a/semgrep-core/tests/OTHER/rules/misc_tpl_is_php.tpl
+++ b/semgrep-core/tests/OTHER/rules/misc_tpl_is_php.tpl
@@ -1,0 +1,6 @@
+<?php
+
+#ruleid:
+foo();
+bar();
+

--- a/semgrep-core/tests/OTHER/rules/misc_tpl_is_php.yaml
+++ b/semgrep-core/tests/OTHER/rules/misc_tpl_is_php.yaml
@@ -1,0 +1,7 @@
+rules:
+- id: tpl_is_php
+  languages:
+  - php
+  pattern: foo(...)
+  message: found a match
+  severity: ERROR


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/4762

test plan:
test file included
also
cd semgrep-core/tests/OTHER/rules
```
semgrep --config misc_tpl_is_php.yaml .
Running 1 rules...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████|3/3 files

 misc_tpl_is_php.tpl
     tpl_is_php
        found a match

          4┆ foo();

skipped: all .gitignored files
for a detailed list of skipped files, run semgrep with the --verbose flag

ran 1 rules on 3 files: 1 findings
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)