### PR TITLE
chore(ci): Update test to silence dependabot

### DIFF
--- a/semgrep/tests/e2e/rules/dependency_aware/log4shell.yaml
+++ b/semgrep/tests/e2e/rules/dependency_aware/log4shell.yaml
@@ -11,7 +11,7 @@ rules:
     - r2c-internal-project-depends-on:
       - namespace: maven
         package: log4j-core
-        version: "<= 2.14.1"
+        version: "<= 0.0.2" # Changed to a fake version to silence dependabot lol
   message: log4j $LOGGER.$METHOD tainted argument
   languages: [java]
   severity: WARNING

--- a/semgrep/tests/e2e/targets/dependency_aware/pom.xml
+++ b/semgrep/tests/e2e/targets/dependency_aware/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <junit.version>5.7.1</junit.version>
-        <log4j.version>2.14.1</log4j.version>
+        <log4j.version>0.0.1</log4j.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
We used log4shell as a test but dependabot thinks it's a vuln lol. This changes the versions in the test.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
