### PR TITLE
Parse Scala files that contain plain blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Add r2c-internal-project-depends on support for Java, Go, Ruby, and Rust
 - PHP: .tpl files are now considered PHP files (#4763)
 - Support for Scala's custom string interpolators (#4655)
+- Support parsing Scala scripting files that contain plain definitions outside an Object or Class
 
 ### Fixed
 


### PR DESCRIPTION
This PR adds parsing for Scala scripting files that contain definitions outside of `Class` or `Object` declarations.
See pfff PR: [Parse Scala files that contain plain blocks](https://github.com/returntocorp/pfff/pull/507)

test plan: make test (added test in pfff)

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
