### PR TITLE
fix(C#): update to latest tree-sitter-c-sharp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 
+- C#: use latest tree-sitter-c-sharp with support for most C# 10.0 features
+
 ### Fixed
 
 - JSX: ellipsis in JSX body (e.g., `<div>...</div>`) now matches any

--- a/semgrep-core/tests/csharp/parsing/namespace_file_level.cs
+++ b/semgrep-core/tests/csharp/parsing/namespace_file_level.cs
@@ -1,0 +1,3 @@
+using Com.Auth0.FGA.Exceptions;
+
+namespace Com.Auth0.FGA.Client;


### PR DESCRIPTION
This closes PA-945
This will now parse 'namespace' directives at the toplevel.

test plan:
```
/home/pad/yy/_build/default/src/cli/Main.exe -l csharp -dump_ast namespace_file_level.cs
Pr(
  [DirectiveStmt(
     {d_attrs=[]; d=ImportAll((), DottedName([("Com", ()); ("Auth0", ()); ("FGA", ()); ("Exceptions", ())]), ()); });
   DirectiveStmt({d_attrs=[]; d=Package((), [("Com", ()); ("Auth0", ()); ("FGA", ()); ("Client", ())]); })])

```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)