### PR TITLE
When matching a class, also try its parents

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -374,6 +374,21 @@ let rec m_name a b =
       m_name a (B.Id (idb, B.empty_id_info ()))
       >||> (* try this time a match with the resolved entity *)
       m_name a (H.name_of_ids dotted)
+      >||>
+      (* Try the parents *)
+      let parents =
+        match !hook_find_possible_parents with
+        | None -> []
+        | Some f -> f dotted
+      in
+      (* less: use a fold *)
+      let rec aux xs =
+        match xs with
+        | [] -> fail ()
+        | x :: xs ->
+            m_name a x >||> aux xs
+      in
+      aux parents
   | G.Id (a1, a2), B.Id (b1, b2) ->
       (* this will handle metavariables in Id *)
       m_ident_and_id_info (a1, a2) (b1, b2)

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -385,8 +385,7 @@ let rec m_name a b =
       let rec aux xs =
         match xs with
         | [] -> fail ()
-        | x :: xs ->
-            m_name a x >||> aux xs
+        | x :: xs -> m_name a x >||> aux xs
       in
       aux parents
   | G.Id (a1, a2), B.Id (b1, b2) ->


### PR DESCRIPTION
Test plan: see https://github.com/returntocorp/deep-semgrep/pull/22

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
