### PR TITLE
taint-mode: Enable deep taint analysis

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.mli
+++ b/semgrep-core/src/analyzing/AST_to_IL.mli
@@ -4,3 +4,5 @@ val function_definition :
 val stmt : Lang.t -> AST_generic.stmt -> IL.stmt list
 
 val name_of_entity : AST_generic.entity -> IL.name option
+
+val var_of_id_info : AST_generic.ident -> AST_generic.id_info -> IL.name

--- a/semgrep-core/src/engine/Dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Dataflow_tainting.ml
@@ -20,41 +20,23 @@ module D = Dataflow_core
 module VarMap = Dataflow_core.VarMap
 module PM = Pattern_match
 
+let logger = Logging.get_logger [ __MODULE__ ]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
 (* Tainting dataflow analysis.
  *
- * This is a very rudimentary tainting analysis. Just intraprocedural,
- * very coarse grained (taint whole array/object).
+ * This is a very rudimentary tainting analysis.
+ * It is a MAY analysis, it finds *potential* bugs (the tainted path could not
+ * be feasible in practice).
+ * Very coarse grained (taint whole array/object).
  * This is step1 for taint tracking support in semgrep.
  * This was originally in semgrep-core/src/analyze, but it now depends on Pattern_match,
  * so it was moved to semgrep-core/src/engine
  *)
 
-(*****************************************************************************)
-(* Types *)
-(*****************************************************************************)
-
-type mapping = PM.Set.t Dataflow_core.mapping
-(** Map for each node/var of all the pattern matches that originated its taint.
-    Anything not included in the map is not tainted. Currently we only strictly need
-    the metavariable environment in these pattern matches, but we plan to make use of
-    the full pattern match information eventually.
-*)
-
-(* Tracks tainted functions. *)
-type fun_env = (Dataflow_core.var, PM.Set.t) Hashtbl.t
-
-(* is_source/sink/sanitizer returns a list of ways that some piece of code can be matched as a source/sink/sanitizer *)
-type config = {
-  is_source : G.any -> PM.t list;
-  is_sink : G.any -> PM.t list;
-  is_sanitizer : G.any -> PM.t list;
-  found_tainted_sink : PM.Set.t -> PM.Set.t Dataflow_core.env -> unit;
-}
-(** This can use semgrep patterns under the hood. Note that a source can be an
-  * instruction but also an expression. *)
+let ( let* ) = Option.bind
 
 module DataflowX = Dataflow_core.Make (struct
   type node = F.node
@@ -67,8 +49,120 @@ module DataflowX = Dataflow_core.Make (struct
 end)
 
 (*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+type var = Dataflow_core.var
+
+type deep_match = PM of Pattern_match.t | Call of G.expr * deep_match
+
+type source = deep_match
+
+type sink = deep_match
+
+type arg_pos = int
+
+type finding =
+  | SrcToSink of source * sink * Metavariable.bindings
+  | SrcToReturn of source
+  | ArgToSink of arg_pos * sink
+  | ArgToReturn of arg_pos
+
+(* TODO: Add tracing info, e.g. what intermediate variables have been tainted. *)
+type taint = Src of source | Arg of arg_pos
+
+(* We use a set simply to avoid duplicate findings.
+ * THINK: Should we just let them pass here and be filtered out later on? *)
+module Taint = Set.Make (struct
+  type t = taint
+
+  let compare_pm pm1 pm2 =
+    (* If the pattern matches are obviously different (have different ranges),
+     * we are done. If their ranges are the same, we compare their metavariable
+     * environments. This is not robust to reordering metavariable environments,
+     * e.g.: [("$A",e1);("$B",e2)] is not equal to [("$B",e2);("$A",e1)]. This
+     * is a potential source of duplicate findings, but that is OK.
+     *)
+    match compare pm1.PM.range_loc pm2.PM.range_loc with
+    | 0 -> compare pm1.PM.env pm2.PM.env
+    | c -> c
+
+  let rec compare_dm dm1 dm2 =
+    match (dm1, dm2) with
+    | PM p, PM q -> compare_pm p q
+    | PM _, Call _ -> -1
+    | Call _, PM _ -> 1
+    | Call (c1, d1), Call (c2, d2) ->
+        let c_cmp = Int.compare c1.e_id c2.e_id in
+        if c_cmp <> 0 then c_cmp else compare_dm d1 d2
+
+  (* TODO: Rely on ppx_deriving.ord ? *)
+  let compare t1 t2 =
+    match (t1, t2) with
+    | Arg i, Arg j -> Int.compare i j
+    | Src p, Src q -> compare_dm p q
+    | Arg _, Src _ -> -1
+    | Src _, Arg _ -> 1
+end)
+
+type config = {
+  filepath : Common.filename;
+  rule_id : string;
+  is_source : G.any -> PM.t list;
+  is_sink : G.any -> PM.t list;
+  is_sanitizer : G.any -> PM.t list;
+  handle_findings :
+    var option -> finding list -> Taint.t Dataflow_core.env -> unit;
+}
+
+type mapping = Taint.t Dataflow_core.mapping
+
+(* HACK: Tracks tainted functions intrafile. *)
+type fun_env = (var, PM.Set.t) Hashtbl.t
+
+type env = {
+  config : config;
+  fun_name : var option;
+  fun_env : fun_env;
+  var_env : Taint.t VarMap.t;
+}
+
+(*****************************************************************************)
+(* Hooks *)
+(*****************************************************************************)
+
+let hook_function_taint_signature = ref None
+
+(*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+
+let rec pm_of_dm = function
+  | PM pm -> pm
+  | Call (_, dm) -> pm_of_dm dm
+
+let dm_of_pm pm = PM pm
+
+let src_of_pm pm = Src (PM pm)
+
+let taint_of_pms pms = pms |> List.map src_of_pm |> Taint.of_list
+
+(* Debug *)
+let show_tainted tainted =
+  tainted |> Taint.elements
+  |> List.map (function
+       | Src _ -> "PM"
+       | Arg i -> "Arg " ^ string_of_int i)
+  |> String.concat ", "
+  |> fun str -> "{ " ^ str ^ " }"
+
+(* Debug *)
+let _show_env =
+  let (env_to_str : ('a -> string) -> 'a VarMap.t -> string) =
+   fun val2str env ->
+    VarMap.fold (fun dn v s -> s ^ dn ^ ":" ^ val2str v ^ " ") env ""
+  in
+  env_to_str show_tainted
 
 let str_of_name name = spf "%s:%d" (fst name.ident) name.sid
 
@@ -78,13 +172,11 @@ let orig_is_sanitized config orig = config.is_sanitizer (any_of_orig orig)
 
 let orig_is_sink config orig = config.is_sink (any_of_orig orig)
 
-let set_opt_to_set = function
-  | None -> PM.Set.empty
-  | Some x -> x
+let report_findings env findings =
+  if findings <> [] then
+    env.config.handle_findings env.fun_name findings env.var_env
 
-(* [unify_meta_envs env1 env1] returns [Some (union env1 env2)] if [env1] and [env2] contain no conflicting metavariable assignments, otherwise [None]. *)
 let unify_meta_envs env1 env2 =
-  let ( let* ) = Option.bind in
   let xs =
     List.fold_left
       (fun xs (mvar, mval) ->
@@ -102,188 +194,284 @@ let unify_meta_envs env1 env2 =
   in
   Option.map (fun xs -> xs @ ys) xs
 
-let set_concat_map f xs =
-  xs |> List.map f |> List.fold_left PM.Set.union PM.Set.empty
+let union_map f xs = xs |> List.map f |> List.fold_left Taint.union Taint.empty
 
-let set_filter_map f pm_set =
-  PM.Set.fold
-    (fun pm pm_set ->
-      match f pm with
-      | Some pm' -> PM.Set.add pm' pm_set
-      | None -> pm_set)
-    pm_set PM.Set.empty
-
-(* @param sink_pm Pattern match of a sink.
-   @param src_pms Set of pattern matches corresponding to sources.
-   @returns PM.Set.t containing a copy [sink_pm] with an updated metavariable environment for each PM in [src_pms] whose env unifies with [sink_pm]s. *)
-let update_meta_envs sink_pm src_pms =
+(* Produces a finding for every taint source that is unifiable with the sink. *)
+let findings_of_tainted_sink (taint : Taint.t) (sink : sink) : finding list =
   let ( let* ) = Option.bind in
-  set_filter_map
-    (fun src_pm ->
-      let* env = unify_meta_envs sink_pm.PM.env src_pm.PM.env in
-      Some { sink_pm with env })
-    src_pms
+  taint |> Taint.elements
+  |> List.filter_map (fun taint ->
+         match taint with
+         | Arg i ->
+             (* We need to check unifiability at the call site. *)
+             Some (ArgToSink (i, sink))
+         | Src src ->
+             let src_pm = pm_of_dm src in
+             let sink_pm = pm_of_dm sink in
+             let* env = unify_meta_envs sink_pm.PM.env src_pm.PM.env in
+             Some (SrcToSink (src, sink, env)))
 
-(* @param sink_pms List of sink pattern matches.
-   @param src_pms Set of source pattern matches.
-   @returns PM.Set.t of all the possible tainted sink pattern matches with their metavariable environments updated
-   to include the bindings from the source whose environment unified with it.
- *)
-let make_tainted_sink_matches sink_pms src_pms =
-  sink_pms
-  |> List.map (fun pm -> update_meta_envs pm src_pms)
-  |> List.fold_left PM.Set.union PM.Set.empty
+(* Produces a finding for every unifiable source-sink pair. *)
+let findings_of_tainted_sinks (taint : Taint.t) (sinks : sink list) :
+    finding list =
+  sinks |> List.concat_map (findings_of_tainted_sink taint)
+
+let findings_of_tainted_return (taint : Taint.t) : finding list =
+  taint |> Taint.elements
+  |> List.map (fun taint ->
+         match taint with
+         | Arg i -> ArgToReturn i
+         | Src src -> SrcToReturn src)
 
 (*****************************************************************************)
 (* Tainted *)
 (*****************************************************************************)
 
-let check_tainted_var config (fun_env : fun_env) (env : PM.Set.t VarMap.t) var =
-  let source_pms, sanitize_pms, sink_pms =
+(* Test whether a variable occurrence is tainted, and if it is also a sink,
+ * report the finding too (by side effect). *)
+let check_tainted_var env (var : IL.name) : Taint.t =
+  let source_pms, sanitizer_pms, sink_pms =
     let _, tok = var.ident in
     if Parse_info.is_origintok tok then
-      ( config.is_source (G.Tk tok),
-        config.is_sanitizer (G.Tk tok),
-        config.is_sink (G.Tk tok) )
+      ( env.config.is_source (G.Tk tok),
+        env.config.is_sanitizer (G.Tk tok),
+        env.config.is_sink (G.Tk tok) )
     else ([], [], [])
   in
-  let tainted_pms =
-    PM.Set.of_list source_pms
-    |> PM.Set.union (set_opt_to_set (VarMap.find_opt (str_of_name var) env))
-    |> PM.Set.union
-         (set_opt_to_set (Hashtbl.find_opt fun_env (str_of_name var)))
+  let taint_sources = source_pms |> taint_of_pms
+  and taint_var_env =
+    VarMap.find_opt (str_of_name var) env.var_env
+    |> Option.value ~default:Taint.empty
+  and taint_fun_env =
+    (* TODO: Move this to check_tainted_instr ? *)
+    Hashtbl.find_opt env.fun_env (str_of_name var)
+    |> Option.value ~default:PM.Set.empty
+    |> PM.Set.elements |> taint_of_pms
   in
-  match sanitize_pms with
-  | _ :: _ -> PM.Set.empty
+  let taint : Taint.t =
+    taint_sources |> Taint.union taint_var_env |> Taint.union taint_fun_env
+    (* |> PM.Set.union (is_tainted_function_hook config ((G.Id (var.ident, var.id_info)))) *)
+  in
+  match sanitizer_pms with
+  (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
+  | _ :: _ -> Taint.empty
   | [] ->
-      let found = make_tainted_sink_matches sink_pms tainted_pms in
-      if not (PM.Set.is_empty found) then config.found_tainted_sink found env;
-      tainted_pms
+      let sinks = sink_pms |> List.map dm_of_pm in
+      let findings = findings_of_tainted_sinks taint sinks in
+      report_findings env findings;
+      taint
 
 (* Test whether an expression is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)
-let rec check_tainted_expr config (fun_env : fun_env) (env : PM.Set.t VarMap.t)
-    exp =
-  let check = check_tainted_expr config fun_env env in
-  let sink_pms = orig_is_sink config exp.eorig in
+let rec check_tainted_expr env exp =
+  let check = check_tainted_expr env in
   let check_base = function
-    | Var var -> check_tainted_var config fun_env env var
-    | VarSpecial _ -> PM.Set.empty
+    | Var var -> check_tainted_var env var
+    | VarSpecial _ -> Taint.empty
     | Mem e -> check e
   in
   let check_offset = function
     | Index e -> check e
     | NoOffset
     | Dot _ ->
-        PM.Set.empty
+        Taint.empty
   in
-  let check_subexpr = function
+  let check_subexpr exp =
+    match exp.e with
     | Fetch { base = VarSpecial (This, _); offset = Dot fld; _ } ->
-        set_opt_to_set (Hashtbl.find_opt fun_env (str_of_name fld))
+        (* TODO: Move this to check_tainted_instr ? *)
+        Hashtbl.find_opt env.fun_env (str_of_name fld)
+        |> Option.value ~default:PM.Set.empty
+        |> PM.Set.elements |> taint_of_pms
     | Fetch { base; offset; _ } ->
-        PM.Set.union (check_base base) (check_offset offset)
+        Taint.union (check_base base) (check_offset offset)
     | FixmeExp (_, _, Some e) -> check e
     | Literal _
     | FixmeExp (_, _, None) ->
-        PM.Set.empty
+        Taint.empty
     | Composite (_, (_, es, _))
     | Operator (_, es) ->
-        set_concat_map check es
-    | Record fields -> set_concat_map (fun (_, e) -> check e) fields
+        union_map check es
+    | Record fields -> union_map (fun (_, e) -> check e) fields
     | Cast (_, e) -> check e
   in
-  let sanitized_pms = orig_is_sanitized config exp.eorig in
-  match sanitized_pms with
-  | _ :: _ -> PM.Set.empty
+  let sanitizer_pms = orig_is_sanitized env.config exp.eorig in
+  match sanitizer_pms with
+  | _ :: _ ->
+      (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
+      Taint.empty
   | [] ->
-      let tainted_pms =
-        PM.Set.union (check_subexpr exp.e)
-          (PM.Set.of_list (orig_is_source config exp.eorig))
-      in
-      let found = make_tainted_sink_matches sink_pms tainted_pms in
-      if not (PM.Set.is_empty found) then config.found_tainted_sink found env;
-      tainted_pms
+      let sinks = orig_is_sink env.config exp.eorig |> List.map dm_of_pm in
+      let taint_sources = orig_is_source env.config exp.eorig |> taint_of_pms in
+      let taint = taint_sources |> Taint.union (check_subexpr exp) in
+      let findings = findings_of_tainted_sinks taint sinks in
+      report_findings env findings;
+      taint
+
+let check_function_signature env fun_exp args_taint =
+  let taint_of_arg i =
+    let taint_opt = List.nth_opt args_taint i in
+    if Option.is_none taint_opt then
+      logger#error "cannot match taint variable with function arguments";
+    taint_opt
+  in
+  match (!hook_function_taint_signature, fun_exp) with
+  | ( Some hook,
+      {
+        e =
+          Fetch
+            {
+              base =
+                Var
+                  {
+                    id_info =
+                      {
+                        G.id_resolved =
+                          { contents = Some (G.ImportedEntity _, _) };
+                        _;
+                      };
+                    _;
+                  };
+              offset = Dot _;
+              _;
+            };
+        eorig = SameAs eorig;
+        _;
+      } ) ->
+      let fun_sig = hook env.config eorig in
+      fun_sig
+      |> List.filter_map (function
+           | SrcToReturn dm ->
+               let dm = Call (eorig, dm) in
+               Some (Taint.singleton (Src dm))
+           | ArgToReturn i -> taint_of_arg i
+           | ArgToSink (i, sink) ->
+               let* arg_taint = taint_of_arg i in
+               arg_taint
+               |> Taint.iter (fun t ->
+                      findings_of_tainted_sink (Taint.singleton t) sink
+                      |> report_findings env);
+               None
+           | _ -> None)
+      |> List.fold_left Taint.union Taint.empty
+  | None, _
+  | Some _, _ ->
+      Taint.empty
 
 (* Test whether an instruction is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)
-let check_tainted_instr config fun_env env instr : PM.Set.t =
-  let sink_pms = orig_is_sink config instr.iorig in
-  let check_expr = check_tainted_expr config fun_env env in
-  let tainted_args = function
+(* TODO: This should return a new var_env rather than just taint, it
+ * makes more sense given that an instruction may have side-effects.
+ * It Also makes simpler to handle sanitization by side-effect. *)
+let check_tainted_instr env instr : Taint.t =
+  let check_expr = check_tainted_expr env in
+  let check_instr = function
     | Assign (_, e) -> check_expr e
-    | AssignAnon _ -> PM.Set.empty (* TODO *)
+    | AssignAnon _ -> Taint.empty (* TODO *)
     | Call (_, e, args) ->
-        let e_tainted_pms = check_expr e in
-        let args_tainted_pms = set_concat_map check_expr args in
-        PM.Set.union e_tainted_pms args_tainted_pms
-    | CallSpecial (_, _, args) -> set_concat_map check_expr args
-    | FixmeInstr _ -> PM.Set.empty
+        let e_taint = check_expr e in
+        let args_taint = List.map check_expr args in
+        List.fold_left Taint.union Taint.empty args_taint
+        |> Taint.union e_taint
+        |> Taint.union (check_function_signature env e args_taint)
+    | CallSpecial (_, _, args) -> union_map check_expr args
+    | FixmeInstr _ -> Taint.empty
   in
-  let sanitized_pm_opt = orig_is_sanitized config instr.iorig in
-  match sanitized_pm_opt with
-  | _ :: _ -> PM.Set.empty
+  let sanitizer_pms = orig_is_sanitized env.config instr.iorig in
+  match sanitizer_pms with
+  | _ :: _ ->
+      (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
+      Taint.empty
   | [] ->
-      let tainted_pms =
-        PM.Set.union (tainted_args instr.i)
-          (PM.Set.of_list (orig_is_source config instr.iorig))
+      let sinks = orig_is_sink env.config instr.iorig |> List.map dm_of_pm in
+      let taint_sources =
+        orig_is_source env.config instr.iorig |> taint_of_pms
       in
-      let found = make_tainted_sink_matches sink_pms tainted_pms in
-      if not (PM.Set.is_empty found) then config.found_tainted_sink found env;
-      tainted_pms
+      let taint = taint_sources |> Taint.union (check_instr instr.i) in
+      let findings = findings_of_tainted_sinks taint sinks in
+      report_findings env findings;
+      taint
 
 (* Test whether a `return' is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)
-let check_tainted_return config fun_env env tok e =
-  let sink_pms = config.is_sink (G.Tk tok) @ orig_is_sink config e.eorig in
-  let e_tainted_pms = check_tainted_expr config fun_env env e in
-  let found = make_tainted_sink_matches sink_pms e_tainted_pms in
-  if not (PM.Set.is_empty found) then config.found_tainted_sink found env;
-  e_tainted_pms
+let check_tainted_return env tok e =
+  let sinks =
+    env.config.is_sink (G.Tk tok) @ orig_is_sink env.config e.eorig
+    |> List.map dm_of_pm
+  in
+  let taint = check_tainted_expr env e in
+  let findings = findings_of_tainted_sinks taint sinks in
+  report_findings env findings;
+  taint
 
 (*****************************************************************************)
 (* Transfer *)
 (*****************************************************************************)
 
-let union = Dataflow_core.varmap_union PM.Set.union
+let union_env = Dataflow_core.varmap_union Taint.union
+
+let input_env ~enter_env ~(flow : F.cfg) mapping ni =
+  let node = flow.graph#nodes#assoc ni in
+  match node.F.n with
+  | Enter -> enter_env
+  | _else -> (
+      let pred_envs =
+        CFG.predecessors flow ni
+        |> Common.map (fun (pi, _) -> mapping.(pi).D.out_env)
+      in
+      match pred_envs with
+      | [] -> VarMap.empty
+      | [ penv ] -> penv
+      | penv1 :: penvs -> List.fold_left union_env penv1 penvs)
 
 let (transfer :
       config ->
       fun_env ->
-      IL.name option ->
+      Taint.t Dataflow_core.env ->
+      string option ->
       flow:F.cfg ->
-      PM.Set.t Dataflow_core.transfn) =
- fun config fun_env opt_name ~flow
+      Taint.t Dataflow_core.transfn) =
+ fun config fun_env enter_env opt_name ~flow
      (* the transfer function to update the mapping at node index ni *)
        mapping ni ->
-  let in' =
-    CFG.predecessors flow ni
-    |> List.fold_left
-         (fun acc (ni_pred, _) -> union acc mapping.(ni_pred).D.out_env)
-         VarMap.empty
-  in
+  (* DataflowX.display_mapping flow mapping show_tainted; *)
+  let in' : Taint.t VarMap.t = input_env ~enter_env ~flow mapping ni in
   let node = flow.graph#nodes#assoc ni in
-  let out' =
+  let out' : Taint.t VarMap.t =
+    let env = { config; fun_name = opt_name; fun_env; var_env = in' } in
     match node.F.n with
     | NInstr x -> (
-        let tainted = check_tainted_instr config fun_env in' x in
-        match (PM.Set.is_empty tainted, IL.lvar_of_instr_opt x) with
+        let tainted = check_tainted_instr env x in
+        match (Taint.is_empty tainted, IL.lvar_of_instr_opt x) with
         | true, Some var -> VarMap.remove (str_of_name var) in'
         | false, Some var ->
             VarMap.update (str_of_name var)
               (function
                 | None -> Some tainted
-                | Some tainted' -> Some (PM.Set.union tainted tainted'))
+                | Some tainted' -> Some (Taint.union tainted tainted'))
               in'
         | _, None -> in')
     | NReturn (tok, e) -> (
-        let tainted = check_tainted_return config fun_env in' tok e in
+        (* TODO: Move most of this to check_tainted_return. *)
+        let taint = check_tainted_return env tok e in
+        let findings = findings_of_tainted_return taint in
+        report_findings env findings;
+        let pmatches =
+          taint |> Taint.elements
+          |> List.filter_map (function
+               | Src src -> Some (pm_of_dm src)
+               | Arg _ -> None)
+          |> PM.Set.of_list
+        in
         match opt_name with
         | Some var ->
-            (let str = str_of_name var in
+            (let str = var in
              match Hashtbl.find_opt fun_env str with
-             | None -> Hashtbl.add fun_env str tainted
+             | None ->
+                 if not (PM.Set.is_empty pmatches) then
+                   Hashtbl.add fun_env str pmatches
              | Some tained' ->
-                 Hashtbl.replace fun_env str (PM.Set.union tainted tained'));
+                 Hashtbl.replace fun_env str (PM.Set.union pmatches tained'));
             in'
         | None -> in')
     | _ -> in'
@@ -294,11 +482,26 @@ let (transfer :
 (* Entry point *)
 (*****************************************************************************)
 
-let (fixpoint : config -> fun_env -> IL.name option -> F.cfg -> mapping) =
- fun config fun_env opt_name flow ->
-  DataflowX.fixpoint ~eq:PM.Set.equal
-    ~init:(DataflowX.new_node_array flow (Dataflow_core.empty_inout ()))
+let (fixpoint :
+      ?in_env:Taint.t Dataflow_core.VarMap.t ->
+      ?name:Dataflow_core.var ->
+      ?fun_env:fun_env ->
+      config ->
+      F.cfg ->
+      mapping) =
+ fun ?in_env ?name:opt_name ?(fun_env = Hashtbl.create 1) config flow ->
+  let init_mapping =
+    DataflowX.new_node_array flow (Dataflow_core.empty_inout ())
+  in
+  let enter_env =
+    match in_env with
+    | None -> VarMap.empty
+    | Some in_env -> in_env
+  in
+  (* THINK: Why I cannot just update mapping here ? if I do, the mapping gets overwritten later on! *)
+  (* DataflowX.display_mapping flow init_mapping show_tainted; *)
+  DataflowX.fixpoint ~eq:Taint.equal ~init:init_mapping
     ~trans:
-      (transfer config fun_env opt_name ~flow)
+      (transfer config fun_env enter_env opt_name ~flow)
       (* tainting is a forward analysis! *)
     ~forward:true ~flow

--- a/semgrep-core/src/engine/Dataflow_tainting.mli
+++ b/semgrep-core/src/engine/Dataflow_tainting.mli
@@ -1,30 +1,98 @@
-type mapping = Pattern_match.Set.t Dataflow_core.mapping
-(** Map for each node/var whether a variable is "tainted" *)
+type var = Dataflow_core.var
+(** A string of the form "<source name>:<sid>". *)
 
-type fun_env = (Dataflow_core.var, Pattern_match.Set.t) Hashtbl.t
-(** Set of "tainted" functions in the overall program.
-  * Note that here [Dataflow.var] is a string of the form "<source name>:<sid>". *)
+(** A match that spans multiple functions (aka "deep").
+  * E.g. Call('foo(a)', PM('sink(x)')) is an indirect match for 'sink(x)'
+  * through the function call 'foo(a)'. *)
+type deep_match =
+  | PM of Pattern_match.t  (** A direct match.  *)
+  | Call of AST_generic.expr * deep_match
+      (** An indirect match through a function call. *)
+
+type source = deep_match
+
+type sink = deep_match
+
+type arg_pos = int
+
+type taint =
+  | Src of source  (** An actual taint source (`pattern-sources:` match). *)
+  | Arg of arg_pos
+      (** A taint variable (potential taint coming through an argument). *)
+
+(** Function-level finding (not necessarily a Semgrep finding). These may
+  * depend on taint variables so they must be interpreted on a specific
+  * context. *)
+type finding =
+  | SrcToSink of source * sink * Metavariable.bindings
+  | SrcToReturn of source
+  | ArgToSink of arg_pos * sink
+  | ArgToReturn of arg_pos
+
+module Taint : Set.S with type elt = taint
+(** A set of taint sources. *)
 
 type config = {
+  filepath : Common.filename;  (** File under analysis, for Deep Semgrep. *)
+  rule_id : string;  (** Taint rule id, for Deep Semgrep. *)
   is_source : AST_generic.any -> Pattern_match.t list;
+      (** Test whether 'any' is a taint source, this corresponds to
+      * 'pattern-sources:' in taint-mode. *)
   is_sink : AST_generic.any -> Pattern_match.t list;
+      (** Test whether 'any' is a sink, this corresponds to 'pattern-sinks:'
+      * in taint-mode. *)
   is_sanitizer : AST_generic.any -> Pattern_match.t list;
-  found_tainted_sink :
-    Pattern_match.Set.t -> Pattern_match.Set.t Dataflow_core.env -> unit;
+      (** Test whether 'any' is a sanitizer, this corresponds to
+      * 'pattern-sanitizers:' in taint-mode. *)
+  handle_findings :
+    var option (** function name ('None' if anonymous) *) ->
+    finding list ->
+    Taint.t Dataflow_core.env ->
+    unit;
+      (** Callback to report findings. *)
 }
-(** This can use semgrep patterns under the hood. Note that a source can be an
-  * instruction but also an expression. *)
+(** Taint rule instantiated for a given file.
+  *
+  * For a source to taint a sink, the bindings of both source and sink must be
+  * unifiable. See 'unify_meta_envs'. *)
 
-val fixpoint : config -> fun_env -> IL.name option -> IL.cfg -> mapping
-(** Main entry point, [fixpoint config fun_env opt_name cfg] returns a mapping
-  * (effectively a set) containing all the tainted variables in [cfg]. Besides,
-  * if it finds an instruction that consumes tainted data, then it will invoke
-  * [config.found_tainted_sink] which can perform any side-effectful action.
+type mapping = Taint.t Dataflow_core.mapping
+(** Mapping from variables to taint sources (if the variable is tainted).
+  * If a variable is not in the map, then it's not tainted. *)
+
+type fun_env = (var, Pattern_match.Set.t) Hashtbl.t
+(** Set of functions known to act as taint sources (their output is
+  * tainted). This is used for a HACK to do some poor-man's intrafile
+  * interprocedural taint tracking. TO BE DEPRECATED. *)
+
+val pm_of_dm : deep_match -> Pattern_match.t
+
+val unify_meta_envs :
+  Metavariable.bindings -> Metavariable.bindings -> Metavariable.bindings option
+(** [unify_meta_envs env1 env2] returns [Some (env1 U env2)] if
+  * [env1] and [env2] contain no conflicting metavariable assignments,
+  * otherwise [None]. *)
+
+val hook_function_taint_signature :
+  (config -> AST_generic.expr -> finding list) option ref
+(** Deep Semgrep *)
+
+val fixpoint :
+  ?in_env:Taint.t Dataflow_core.VarMap.t ->
+  ?name:var ->
+  ?fun_env:fun_env (** Poor-man's interprocedural HACK (TO BE DEPRECATED) *) ->
+  config ->
+  IL.cfg ->
+  mapping
+(** Main entry point, [fixpoint config cfg] returns a mapping (effectively a set)
+  * containing all the tainted variables in [cfg]. Besides, if it infers any taint
+  * 'findings', it will invoke [config.handle_findings] which can perform any
+  * side-effectful action.
   *
-  * Parameter [fun_env] is a set of tainted functions in the overall program;
-  * it provides basic interprocedural capabilities.
-  *
-  * Parameter [opt_name] is the name of the function being analyzed, if it has
-  * a name. When [Some name] is given, and there is a tainted return statement in
-  * [cfg], the function [name] itself will be added to [fun_env] by side-effect.
-*)
+  * @param in_env are the assumptions made on the function's parameters.
+  * @param name is the name of the function being analyzed, if it has a name.
+  * @param fun_env is a set of tainted functions in the same file, it is a HACK
+  *    to provide some poor-man's interprocedural capabilities. If the function
+  *    being analyzed has a name, and taint reaches a `return` statement, the
+  *    function name will be added to this environment by side-effect.
+  * *)

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -108,8 +108,14 @@ let range_w_metas_of_pformula config equivs file_and_more rule_id pformula =
     formula None
   |> snd
 
+let lazy_force x = Lazy.force x [@@profiling]
+
+(*****************************************************************************)
+(* Main entry points *)
+(*****************************************************************************)
+
 let taint_config_of_rule default_config equivs file ast_and_errors
-    (rule : R.rule) (spec : R.taint_spec) found_tainted_sink =
+    (rule : R.rule) (spec : R.taint_spec) handle_findings =
   let config = Common.( ||| ) rule.options default_config in
   let lazy_ast_and_errors = lazy ast_and_errors in
   let file_and_more =
@@ -162,22 +168,17 @@ let taint_config_of_rule default_config equivs file ast_and_errors
            else Some rng)
   in
   {
-    Dataflow_tainting.is_source = (fun x -> any_in_ranges x sources_ranges);
+    Dataflow_tainting.filepath = file;
+    rule_id = fst rule.R.id;
+    is_source = (fun x -> any_in_ranges x sources_ranges);
     is_sanitizer = (fun x -> any_in_ranges x sanitizers_ranges);
     is_sink = (fun x -> any_in_ranges x sinks_ranges);
-    found_tainted_sink;
+    handle_findings;
   }
 
-let lazy_force x = Lazy.force x [@@profiling]
-
-(*****************************************************************************)
-(* Main entry point *)
-(*****************************************************************************)
-
 let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
-  (* @Iago I went and modified this to work one rule at a time *)
-  (* Let me know if this interferes with anything; it shouldn't because
-     semgrep has always passed one rule at a time *)
+  (* TODO: Pass a hashtable to cache the CFG of each def, otherwise we are
+   * recomputing the CFG for each taint rule. *)
   let matches = ref [] in
 
   let { Xtarget.file; xlang; lazy_ast_and_errors; _ } = xtarget in
@@ -192,11 +193,24 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
     Common.with_time (fun () -> lazy_force lazy_ast_and_errors)
   in
   let taint_config =
-    let found_tainted_sink pms _env =
-      PM.Set.iter (fun pm -> Common.push pm matches) pms
+    let handle_findings _ findings _env =
+      findings
+      |> List.iter
+           Dataflow_tainting.(
+             function
+             | SrcToSink (_, sink, src_sink_bindings) ->
+                 let sink_pm = Dataflow_tainting.pm_of_dm sink in
+                 let pm = { sink_pm with env = src_sink_bindings } in
+                 Common.push pm matches
+             | SrcToReturn _
+             (* TODO: We might want to report functions that let input taint
+              * go into a sink (?) *)
+             | ArgToSink _
+             | ArgToReturn _ ->
+                 ())
     in
     taint_config_of_rule default_config equivs file (ast, []) rule taint_spec
-      found_tainted_sink
+      handle_findings
   in
 
   let fun_env = Hashtbl.create 8 in
@@ -206,7 +220,7 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
     let flow = CFG_build.cfg_of_stmts xs in
 
     let mapping =
-      Dataflow_tainting.fixpoint taint_config fun_env opt_name flow
+      Dataflow_tainting.fixpoint ?name:opt_name ~fun_env taint_config flow
     in
     ignore mapping
     (* TODO
@@ -223,7 +237,11 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
           (fun (k, _v) ((ent, def_kind) as def) ->
             match def_kind with
             | G.FuncDef fdef ->
-                let opt_name = AST_to_IL.name_of_entity ent in
+                let opt_name =
+                  AST_to_IL.name_of_entity ent
+                  |> Option.map (fun name ->
+                         Common.spf "%s:%d" (fst name.IL.ident) name.IL.sid)
+                in
                 check_stmt opt_name (H.funcbody_to_stmt fdef.G.fbody);
                 (* go into nested functions *)
                 k def
@@ -263,3 +281,34 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
     skipped = [];
     profiling = { RP.rule_id = fst rule.Rule.id; parse_time; match_time };
   }
+
+(* Used by DeepSemgrep. *)
+let check_def_with_rules lang taint_configs ent_name fdef =
+  let str_of_name name = Common.spf "%s:%d" (fst name.IL.ident) name.IL.sid in
+
+  (* Input environment where formal parameters are given taint variables. *)
+  let in_env =
+    List.fold_left
+      (fun (i, env) par ->
+        match par with
+        | G.Param { pname = Some id; pinfo; _ } ->
+            let var = str_of_name (AST_to_IL.var_of_id_info id pinfo) in
+            let env =
+              Dataflow_core.VarMap.add var
+                (Dataflow_tainting.Arg i |> Dataflow_tainting.Taint.singleton)
+                env
+            in
+            (i + 1, env)
+        | _ -> (i + 1, env))
+      (0, Dataflow_core.VarMap.empty)
+      fdef.G.fparams
+    |> snd
+  in
+
+  (* We run all taint rules at once to avoid re-building the CFG. *)
+  let def_body = H.funcbody_to_stmt fdef.G.fbody in
+  let flow = def_body |> AST_to_IL.stmt lang |> CFG_build.cfg_of_stmts in
+  taint_configs
+  |> List.iter (fun taint_config ->
+         Dataflow_tainting.fixpoint ~in_env ~name:ent_name taint_config flow
+         |> ignore)

--- a/semgrep-core/src/engine/Match_tainting_rules.mli
+++ b/semgrep-core/src/engine/Match_tainting_rules.mli
@@ -6,15 +6,7 @@ val check_rule :
   Xtarget.t ->
   Report.rule_profiling Report.match_result
 
-(* Deep Semgrep *)
-val check_def_with_rules :
-  Lang.t ->
-  Dataflow_tainting.config list ->
-  string ->
-  AST_generic.function_definition ->
-  unit
-
-(* Deep Semgrep *)
+(* It could be a private function, but it is also used by Deep Semgrep *)
 val taint_config_of_rule :
   Config_semgrep_t.t ->
   Equivalence.equivalences ->

--- a/semgrep-core/src/engine/Match_tainting_rules.mli
+++ b/semgrep-core/src/engine/Match_tainting_rules.mli
@@ -5,3 +5,25 @@ val check_rule :
   Rule.taint_spec ->
   Xtarget.t ->
   Report.rule_profiling Report.match_result
+
+(* Deep Semgrep *)
+val check_def_with_rules :
+  Lang.t ->
+  Dataflow_tainting.config list ->
+  string ->
+  AST_generic.function_definition ->
+  unit
+
+(* Deep Semgrep *)
+val taint_config_of_rule :
+  Config_semgrep_t.t ->
+  Equivalence.equivalences ->
+  Common.filename ->
+  AST_generic.program * Semgrep_error_code.error list ->
+  Rule.rule ->
+  Rule.taint_spec ->
+  (Dataflow_tainting.var option ->
+  Dataflow_tainting.finding list ->
+  Dataflow_tainting.Taint.t Dataflow_core.env ->
+  unit) ->
+  Dataflow_tainting.config

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -13,29 +13,28 @@ module DataflowX = Dataflow_core.Make (struct
 end)
 
 let test_dfg_tainting file =
+  (* TODO: Run an actual taint rule! *)
   let ast = Parse_target.parse_program file in
   let lang = List.hd (Lang.langs_of_filename file) in
   Naming_AST.resolve lang ast;
-  let fun_env = Hashtbl.create 8 in
   ast
   |> List.iter (fun item ->
          match item.s with
-         | DefStmt (ent, FuncDef def) ->
+         | DefStmt (_ent, FuncDef def) ->
              let xs = AST_to_IL.stmt lang (H.funcbody_to_stmt def.fbody) in
              let flow = CFG_build.cfg_of_stmts xs in
              pr2 "Tainting";
              let config =
                {
-                 Dataflow_tainting.is_source = (fun _ -> []);
+                 Dataflow_tainting.filepath = file;
+                 rule_id = "test_dfg_tainting";
+                 is_source = (fun _ -> []);
                  is_sink = (fun _ -> []);
                  is_sanitizer = (fun _ -> []);
-                 found_tainted_sink = (fun _ _ -> ());
+                 handle_findings = (fun _ _ _ -> ());
                }
              in
-             let opt_name = AST_to_IL.name_of_entity ent in
-             let mapping =
-               Dataflow_tainting.fixpoint config fun_env opt_name flow
-             in
+             let mapping = Dataflow_tainting.fixpoint config flow in
              DataflowX.display_mapping flow mapping (fun _ ->
                  "<pattern matches>")
          | _ -> ())

--- a/semgrep-core/tests/OTHER/rules/taint_imported_func.py
+++ b/semgrep-core/tests/OTHER/rules/taint_imported_func.py
@@ -1,0 +1,6 @@
+from cryptography.hazmat.primitives import hashes
+
+def ex2(user, pwtext):
+    md5 = hashes.MD5()
+    # ruleid: md5-used-as-password
+    user.setPassword(md5)

--- a/semgrep-core/tests/OTHER/rules/taint_imported_func.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_imported_func.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: md5-used-as-password
+    severity: WARNING
+    message: Test
+    languages: [python]
+    mode: taint
+    pattern-sources:
+      - pattern: cryptography.hazmat.primitives.hashes.MD5
+    pattern-sinks:
+      - patterns:
+          - pattern: $FUNCTION(...)
+          - metavariable-regex:
+              metavariable: $FUNCTION
+              regex: (?i)(.*password.*)


### PR DESCRIPTION
This makes possible to implement deep (i.e., interfile interprocedural)
taint analysis. But it does *NOT* implement it! Deep taint-mode is a
feature reserved for Deep Semgrep.

Helps PA-899

test plan:
make test

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
