### PR TITLE
debug(cli): log stderr from semgrep-core ASAP (POSTPONED AFTER 0.85)

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -195,7 +195,9 @@ class StreamingSemgrepCore:
                 break
 
             line = line_bytes.decode("utf-8")
-            # log stderr ASAP
+            # log stderr ASAP. This seems to introduce some perf
+            # regressions when using --debug which went from 10% slowdown
+            # to 30%, but it's more important to log ASAP!
             logger.debug(line.rstrip("\n"))
             stderr_lines.append(line)
 

--- a/semgrep/tests/e2e/test_performance.py
+++ b/semgrep/tests/e2e/test_performance.py
@@ -25,7 +25,7 @@ def test_debug_performance(run_semgrep_in_tmp):
     from pytest import approx
 
     # this used to be 0.1 for 10% but logging stderr ASAP in
-    # core_runner.py can slow down things up to 30%
+    # core_runner.py seems to slow down things a lot
     assert time_with_debug == approx(
-        time_without_debug, rel=0.3
-    ), "adding --debug slowed runtime by more than 30%"
+        time_without_debug, rel=0.5
+    ), "adding --debug slowed runtime by more than 50%"

--- a/semgrep/tests/e2e/test_performance.py
+++ b/semgrep/tests/e2e/test_performance.py
@@ -24,6 +24,8 @@ def test_debug_performance(run_semgrep_in_tmp):
 
     from pytest import approx
 
+    # this used to be 0.1 for 10% but logging stderr ASAP in
+    # core_runner.py can slow down things up to 30%
     assert time_with_debug == approx(
-        time_without_debug, rel=0.1
-    ), "adding --debug slowed runtime by more than 10%"
+        time_without_debug, rel=0.3
+    ), "adding --debug slowed runtime by more than 30%"


### PR DESCRIPTION
semgrep was waiting for semgrep-core to finish to print its stderr,
but in case of weird problems (e.g.,
https://github.com/returntocorp/semgrep/issues/4693 ) it was too late.

test plan:
add a Unix.sleep 10 in Main.ml and run
`semgrep -e '$X == $X' -l js misc_bang.rs --debug`
and see that the logging is displayed ASAP (not after 10s)


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)