### PR TITLE
Add construct to save resolved names

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -280,6 +280,7 @@ and resolved_name_kind =
   (* used for C *)
   | Macro
   | EnumConstant
+  | ResolvedName of dotted_ident (* for deep semgrep *)
 [@@deriving show { with_path = false }, eq, hash]
 
 (* Start of big mutually recursive types because of the use of 'any'

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -113,6 +113,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | Macro -> Macro
     | EnumConstant -> EnumConstant
     | TypeName -> TypeName
+    | ResolvedName v1 ->
+        let v1 = map_dotted_ident v1 in
+        ResolvedName v1
   and map_name_info
       {
         name_last = v1;

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -56,6 +56,9 @@ and vof_resolved_name_kind = function
   | Macro -> OCaml.VSum ("Macro", [])
   | EnumConstant -> OCaml.VSum ("EnumConstant", [])
   | TypeName -> OCaml.VSum ("TypeName", [])
+  | ResolvedName v1 ->
+      let v1 = vof_dotted_ident v1 in
+      OCaml.VSum ("ResolvedName", [ v1 ])
 
 let rec vof_qualifier = function
   | QDots v1 ->

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -174,6 +174,9 @@ let (mk_visitor :
     | Macro -> ()
     | EnumConstant -> ()
     | TypeName -> ()
+    | ResolvedName v1 ->
+        let v1 = v_dotted_ident v1 in
+        ()
   and v_name_info
       { name_middle = v4; name_top = v3; name_last = v1; name_info = v2 } =
     let v1 = v_ident_and_targs v1 in

--- a/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
@@ -112,6 +112,7 @@ and map_resolved_name_kind = function
   | Macro -> `Macro
   | EnumConstant -> `EnumConstant
   | TypeName -> `TypeName
+  | ResolvedName _v1 -> failwith "TODO"
 
 and map_id_info x =
   match x with

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -367,7 +367,8 @@ let rec m_name a b =
                 contents =
                   Some
                     ( ( B.ImportedEntity dotted
-                      | B.ImportedModule (B.DottedName dotted) ),
+                      | B.ImportedModule (B.DottedName dotted)
+                      | B.ResolvedName dotted ),
                       _sid );
               };
             _;
@@ -2706,7 +2707,6 @@ and m_class_parent a b =
       let xs =
         match !id_resolved with
         | Some (B.ImportedEntity xs, _sid) -> xs
-        | Some (B.ResolvedName xs, _sid) -> xs
         | _ -> [ id ]
       in
       (* deep: *)

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -302,7 +302,8 @@ let m_resolved_name_kind a b =
   | G.EnumConstant, _
   | G.TypeName, _
   | G.ImportedEntity _, _
-  | G.ImportedModule _, _ ->
+  | G.ImportedModule _, _
+  | G.ResolvedName _, _ ->
       fail ()
 
 let _m_resolved_name (a1, a2) (b1, b2) =
@@ -2701,20 +2702,13 @@ and m_class_parent a b =
                            fun () ->
   match (a, b) with
   (* less: this could be generalized, but let's go simple first *)
-  | ( (a1, None),
-      ( {
-          t =
-            B.TyN
-              (B.Id
-                ( _id,
-                  {
-                    id_resolved =
-                      { contents = Some (B.ImportedEntity xs, _sid) };
-                    _;
-                  } ));
-          _;
-        },
-        None ) ) ->
+  | (a1, None), ({ t = B.TyN (B.Id (id, { id_resolved; _ })); _ }, None) ->
+      let xs =
+        match !id_resolved with
+        | Some (B.ImportedEntity xs, _sid) -> xs
+        | Some (B.ResolvedName xs, _sid) -> xs
+        | _ -> [ id ]
+      in
       (* deep: *)
       let candidates =
         match !hook_find_possible_parents with


### PR DESCRIPTION
This enables name resolution in deep semgrep

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
