### PR TITLE
use XDG_CONFIG_HOME for USER_DATA_FOLDER if set

### DIFF
--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -19,7 +19,11 @@ DEFAULT_CONFIG_FOLDER = f".{DEFAULT_SEMGREP_CONFIG_NAME}"
 
 DEFAULT_TIMEOUT = 30  # seconds
 
-USER_DATA_FOLDER = Path.home() / ".semgrep"
+if "XDG_CONFIG_HOME" in os.environ and Path(ox.environ["XDG_CONFIG_HOME"]).is_dir():
+    USER_DATA_FOLDER = Path(os.environ["XDG_CONFIG_HOME"]) / "semgrep"
+else:
+    USER_DATA_FOLDER = Path.home() / ".semgrep"
+
 USER_LOG_FILE = Path(os.environ.get("SEMGREP_LOG_FILE", USER_DATA_FOLDER / "last.log"))
 SETTINGS_FILE = "settings.yml"
 SEMGREP_SETTING_ENVVAR_NAME = "SEMGREP_SETTINGS_FILE"

--- a/semgrep/semgrep/constants.py
+++ b/semgrep/semgrep/constants.py
@@ -19,7 +19,7 @@ DEFAULT_CONFIG_FOLDER = f".{DEFAULT_SEMGREP_CONFIG_NAME}"
 
 DEFAULT_TIMEOUT = 30  # seconds
 
-if "XDG_CONFIG_HOME" in os.environ and Path(ox.environ["XDG_CONFIG_HOME"]).is_dir():
+if "XDG_CONFIG_HOME" in os.environ and Path(os.environ["XDG_CONFIG_HOME"]).is_dir():
     USER_DATA_FOLDER = Path(os.environ["XDG_CONFIG_HOME"]) / "semgrep"
 else:
     USER_DATA_FOLDER = Path.home() / ".semgrep"

--- a/semgrep/semgrep/settings.py
+++ b/semgrep/semgrep/settings.py
@@ -53,7 +53,7 @@ class Settings:
     @staticmethod
     def get_path_to_settings() -> Path:
         """
-        Uses ~/.semgrep/settings.yaml unless SEMGREP_SETTINGS_FILE is set
+        Uses {$XDG_CONFIG_HOME/semgrep || ~/.semgrep}/settings.yaml unless SEMGREP_SETTINGS_FILE is set
         """
         if SEMGREP_SETTINGS_FILE:
             return Path(SEMGREP_SETTINGS_FILE)


### PR DESCRIPTION
This PR updates `semgrep` to use `$XDG_CONFIG_HOME` from the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) as its user data folder if the env var is set. (re: https://github.com/returntocorp/semgrep/issues/4465)

PR checklist:

- [x] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
