### PR TITLE
Enable the latest cmdliner (>= 1.1.0)

### DIFF
--- a/semgrep-core/spacegrep.opam
+++ b/semgrep-core/spacegrep.opam
@@ -14,7 +14,7 @@ depends: [
   "alcotest"
   "atdgen"
   "ANSITerminal"
-  "cmdliner" {= "1.0.4"}
+  "cmdliner"
   "dune" {>= "2.1"}
 ]
 

--- a/semgrep-core/src/spacegrep/src/bin/Spacecat_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacecat_main.ml
@@ -2,6 +2,9 @@
    Entrypoint for the 'spacecat' command.
 *)
 
+(* for cmdliner >= 1.1.0 *)
+[@@@alert "-deprecated"]
+
 open Cmdliner
 open Spacegrep
 

--- a/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
@@ -39,6 +39,7 @@ type config = {
  * semgrep-core.
  *)
 type skip_reason = Minified | Binary
+
 type skipped_target = { path : string; reason : skip_reason; details : string }
 
 type matches = {

--- a/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
@@ -2,6 +2,9 @@
    Entrypoint for the 'spacegrep' command.
 *)
 
+(* for cmdliner >= 1.1.0 *)
+[@@@alert "-deprecated"]
+
 open Printf
 open Cmdliner
 open Spacegrep
@@ -36,7 +39,6 @@ type config = {
  * semgrep-core.
  *)
 type skip_reason = Minified | Binary
-
 type skipped_target = { path : string; reason : skip_reason; details : string }
 
 type matches = {


### PR DESCRIPTION
This silences the deprecation alert for code that uses cmdliner in semgrep-core and in the ocaml-tree-sitter-core submodule.

Uses https://github.com/returntocorp/ocaml-tree-sitter-core/pull/28

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
