### PR TITLE
taint-mode: Fix deep taint analysis

### DIFF
--- a/semgrep-core/src/engine/Dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Dataflow_tainting.ml
@@ -327,36 +327,41 @@ let check_function_signature env fun_exp args_taint =
                     id_info =
                       {
                         G.id_resolved =
-                          { contents = Some (G.ImportedEntity _, _) };
+                          {
+                            contents =
+                              Some ((G.ImportedEntity _ | G.ResolvedName _), _);
+                          };
                         _;
                       };
                     _;
                   };
-              offset = Dot _;
+              offset = _;
               _;
             };
         eorig = SameAs eorig;
         _;
       } ) ->
-      let fun_sig = hook env.config eorig in
-      fun_sig
-      |> List.filter_map (function
-           | SrcToReturn dm ->
-               let dm = Call (eorig, dm) in
-               Some (Taint.singleton (Src dm))
-           | ArgToReturn i -> taint_of_arg i
-           | ArgToSink (i, sink) ->
-               let* arg_taint = taint_of_arg i in
-               arg_taint
-               |> Taint.iter (fun t ->
-                      findings_of_tainted_sink (Taint.singleton t) sink
-                      |> report_findings env);
-               None
-           | _ -> None)
-      |> List.fold_left Taint.union Taint.empty
+      let* fun_sig = hook env.config eorig in
+      Some
+        (fun_sig
+        |> List.filter_map (function
+             | SrcToReturn dm ->
+                 let dm = Call (eorig, dm) in
+                 Some (Taint.singleton (Src dm))
+             | ArgToReturn i -> taint_of_arg i
+             | ArgToSink (i, sink) ->
+                 let* arg_taint = taint_of_arg i in
+                 arg_taint
+                 |> Taint.iter (fun t ->
+                        findings_of_tainted_sink (Taint.singleton t) sink
+                        |> report_findings env);
+                 None
+             (* THINK: Should we report something here? *)
+             | SrcToSink _ -> None)
+        |> List.fold_left Taint.union Taint.empty)
   | None, _
   | Some _, _ ->
-      Taint.empty
+      None
 
 (* Test whether an instruction is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)
@@ -368,12 +373,16 @@ let check_tainted_instr env instr : Taint.t =
   let check_instr = function
     | Assign (_, e) -> check_expr e
     | AssignAnon _ -> Taint.empty (* TODO *)
-    | Call (_, e, args) ->
+    | Call (_, e, args) -> (
         let e_taint = check_expr e in
         let args_taint = List.map check_expr args in
-        List.fold_left Taint.union Taint.empty args_taint
-        |> Taint.union e_taint
-        |> Taint.union (check_function_signature env e args_taint)
+        match check_function_signature env e args_taint with
+        | Some call_taint -> call_taint
+        | None ->
+            (* Default is to assume that the function will propagate
+             * the taint of its arguments. *)
+            List.fold_left Taint.union Taint.empty args_taint
+            |> Taint.union e_taint)
     | CallSpecial (_, _, args) -> union_map check_expr args
     | FixmeInstr _ -> Taint.empty
   in

--- a/semgrep-core/src/engine/Dataflow_tainting.mli
+++ b/semgrep-core/src/engine/Dataflow_tainting.mli
@@ -74,7 +74,7 @@ val unify_meta_envs :
   * otherwise [None]. *)
 
 val hook_function_taint_signature :
-  (config -> AST_generic.expr -> finding list) option ref
+  (config -> AST_generic.expr -> finding list option) option ref
 (** Deep Semgrep *)
 
 val fixpoint :

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -176,6 +176,36 @@ let taint_config_of_rule default_config equivs file ast_and_errors
     handle_findings;
   }
 
+let pm_of_finding file finding =
+  let open Dataflow_tainting in
+  match finding with
+  | SrcToSink (_src, sink, src_sink_bindings) -> (
+      match sink with
+      | PM sink_pm -> Some { sink_pm with env = src_sink_bindings }
+      | Call (fun_call, _) -> (
+          let code = G.E fun_call in
+          match V.range_of_any_opt code with
+          | None ->
+              logger#error
+                "Cannot report taint finding because we lack range info";
+              None
+          | Some range_loc ->
+              let tokens = lazy (V.ii_of_any code) in
+              Some
+                {
+                  PM.rule_id = (pm_of_dm sink).rule_id;
+                  file;
+                  range_loc;
+                  tokens;
+                  env = src_sink_bindings;
+                }))
+  | SrcToReturn _
+  (* TODO: We might want to report functions that let input taint
+   * go into a sink (?) *)
+  | ArgToSink _
+  | ArgToReturn _ ->
+      None
+
 let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
   (* TODO: Pass a hashtable to cache the CFG of each def, otherwise we are
    * recomputing the CFG for each taint rule. *)
@@ -195,19 +225,9 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
   let taint_config =
     let handle_findings _ findings _env =
       findings
-      |> List.iter
-           Dataflow_tainting.(
-             function
-             | SrcToSink (_, sink, src_sink_bindings) ->
-                 let sink_pm = Dataflow_tainting.pm_of_dm sink in
-                 let pm = { sink_pm with env = src_sink_bindings } in
-                 Common.push pm matches
-             | SrcToReturn _
-             (* TODO: We might want to report functions that let input taint
-              * go into a sink (?) *)
-             | ArgToSink _
-             | ArgToReturn _ ->
-                 ())
+      |> List.iter (fun finding ->
+             pm_of_finding file finding
+             |> Option.iter (fun pm -> Common.push pm matches))
     in
     taint_config_of_rule default_config equivs file (ast, []) rule taint_spec
       handle_findings


### PR DESCRIPTION
1. Take intrafile global resolved names into account following
   https://github.com/returntocorp/semgrep/pull/4810 (needed for intrafile interprocedural).
2. If we have a signature for a function, do not assume that it may
   propagate taint, just trust its signature!
3. Report tainted-sink matches on the function under analysis, even
   if the sink is deep in a call chain.
4. Use latest Pfff (contains fix to Common.readable that we need in
   Deep Semgrep).

test plan:
make test # should not affect Semgrep at all

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
