### PR TITLE
core(error): Do not crash when only one rule is malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Changed
 
+- Semgrep should now be more tolerant to rules using futur extensions by
+  skipping those rules instead of just crashing (#4835)
 - Removed `tests` from published python wheel
 - Findings are now considered identical between baseline and current scans
   based on the same logic as Semgrep CI uses, which means:

--- a/interfaces/Output_from_core.atd
+++ b/interfaces/Output_from_core.atd
@@ -41,7 +41,9 @@ type position = {
 type match_results = {
   matches: match_ list;
   errors: error list;
-  skipped: skipped_target list;
+  skipped_targets <json name="skipped">: skipped_target list;
+  (* skipped_rules was introduced  in semgrep 0.86 *)
+  ?skipped_rules: skipped_rule list option;
   stats: stats;
   ?time: time option;
 }
@@ -174,6 +176,13 @@ type skip_reason = [
   | Irrelevant_rule <json name="irrelevant_rule">
   | Too_many_matches <json name="too_many_matches">
 ] <ocaml repr="classic">
+
+type skipped_rule = {
+  rule_id: rule_id;
+  details: string;
+  (* position of the error in the rule file *)
+  position: position;
+}
 
 (*****************************************************************************)
 (* Profiling information *)

--- a/semgrep-core/src/core/Report.mli
+++ b/semgrep-core/src/core/Report.mli
@@ -26,7 +26,7 @@ type file_profiling = {
 type 'a match_result = {
   matches : Pattern_match.t list;
   errors : Semgrep_error_code.error list;
-  skipped : Output_from_core_t.skipped_target list;
+  skipped_targets : Output_from_core_t.skipped_target list;
   profiling : 'a;
 }
 
@@ -41,7 +41,8 @@ type final_profiling = {
 type final_result = {
   matches : Pattern_match.t list;
   errors : Semgrep_error_code.error list;
-  skipped : Output_from_core_t.skipped_target list;
+  skipped_targets : Output_from_core_t.skipped_target list;
+  skipped_rules : Rule.invalid_rule_error list;
   final_profiling : final_profiling option;
 }
 
@@ -50,6 +51,8 @@ val empty_partial_profiling : Common.filename -> partial_profiling
 val empty_rule_profiling : Rule.t -> rule_profiling
 
 val empty_semgrep_result : times match_result
+
+val empty_final_result : final_result
 
 val add_run_time :
   float -> partial_profiling match_result -> file_profiling match_result

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2019-2021 r2c
+ * Copyright (C) 2019-2022 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -12,6 +12,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
  *)
+open Common
 module G = AST_generic
 module MV = Metavariable
 
@@ -276,23 +277,38 @@ type rules = rule list [@@deriving show]
  *)
 let (last_matched_rule : rule_id option ref) = ref None
 
-exception InvalidLanguage of rule_id * string * Parse_info.t
+(* Those are recoverable errors; We can just skip the rules containing
+ * those errors.
+ * less: use a record
+ * alt: put in Output_from_core.atd?
+ *)
+type invalid_rule_error = invalid_rule_error_kind * rule_id * Parse_info.t
 
-(* TODO: the Parse_info.t is not precise for now, it corresponds to the
- * start of the pattern *)
-exception
-  InvalidPattern of
-    rule_id * string * Xlang.t * string (* exn *) * Parse_info.t * string list
+and invalid_rule_error_kind =
+  | InvalidLanguage of string (* the language string *)
+  (* TODO: the Parse_info.t for InvalidPattern is not precise for now;
+   * it corresponds to the start of the pattern *)
+  | InvalidPattern of
+      string (* pattern *) * Xlang.t * string (* exn *) * string list (* yaml path *)
+  | InvalidRegexp of string (* PCRE error message *)
+  | InvalidOther of string
 
-exception InvalidRegexp of rule_id * string * Parse_info.t
+let string_of_invalid_rule_error_kind = function
+  | InvalidLanguage language -> spf "invalid language %s" language
+  | InvalidRegexp message -> spf "invalid regex %s" message
+  (* coupling: this is actually intercepted in
+   * Semgrep_error_code.exn_to_error to generate a PatternParseError instead
+   * of a RuleParseError *)
+  | InvalidPattern (_pattern, xlang, _message, _yaml_path) ->
+      spf "Invalid pattern for %s" (Xlang.to_string xlang)
+  | InvalidOther s -> s
+
+exception InvalidRule of invalid_rule_error
 
 (* general errors *)
 exception InvalidYaml of string * Parse_info.t
 
 exception DuplicateYamlKey of string * Parse_info.t
-
-(* less: could be merged with InvalidYaml *)
-exception InvalidRule of rule_id * string * Parse_info.t
 
 exception UnparsableYamlException of string
 

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -71,17 +71,9 @@ let exn_to_error ?(rule_id = None) file exn =
       mk_error_tok tok msg ParseError
   | Parse_info.Other_error (s, tok) ->
       mk_error_tok ~rule_id tok s SpecifiedParseError
-  | Rule.InvalidRule (rule_id, s, pos) ->
-      mk_error_tok ~rule_id:(Some rule_id) pos s RuleParseError
-  | Rule.InvalidLanguage (rule_id, language, pos) ->
-      mk_error_tok ~rule_id:(Some rule_id) pos
-        (spf "invalid language %s" language)
-        RuleParseError
-  | Rule.InvalidRegexp (rule_id, message, pos) ->
-      mk_error_tok ~rule_id:(Some rule_id) pos
-        (spf "invalid regex %s" message)
-        RuleParseError
-  | Rule.InvalidPattern (rule_id, _pattern, xlang, _message, pos, yaml_path) ->
+  | Rule.InvalidRule
+      (Rule.InvalidPattern (_pattern, xlang, _message, yaml_path), rule_id, pos)
+    ->
       {
         rule_id = Some rule_id;
         typ = PatternParseError;
@@ -92,6 +84,9 @@ let exn_to_error ?(rule_id = None) file exn =
         details = None;
         yaml_path = Some yaml_path;
       }
+  | Rule.InvalidRule (kind, rule_id, pos) ->
+      let str = Rule.string_of_invalid_rule_error_kind kind in
+      mk_error_tok ~rule_id:(Some rule_id) pos str RuleParseError
   | Rule.InvalidYaml (msg, pos) -> mk_error_tok ~rule_id pos msg InvalidYaml
   | Rule.DuplicateYamlKey (s, pos) -> mk_error_tok ~rule_id pos s InvalidYaml
   | Common.Timeout timeout_info ->

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -130,10 +130,10 @@ let check ~match_hook ~timeout ~timeout_threshold default_config rules xtarget =
                            [
                              E.mk_error ~rule_id:(Some rule_id) loc "" E.Timeout;
                            ];
-                         skipped = [];
+                         skipped_targets = [];
                          profiling = RP.empty_rule_profiling r;
                        }))
   in
   let skipped = Common.map (skipped_target_of_rule xtarget) skipped_rules in
   let res = RP.collate_rule_results xtarget.Xtarget.file res_rules in
-  { res with skipped = skipped @ res.skipped }
+  { res with skipped_targets = skipped @ res.skipped_targets }

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -284,7 +284,7 @@ let matches_of_patterns ?range_filter config file_and_more patterns =
       {
         RP.matches;
         errors;
-        skipped = [];
+        skipped_targets = [];
         profiling = { RP.parse_time; match_time };
       }
   | _ -> RP.empty_semgrep_result
@@ -356,7 +356,7 @@ let (matches_of_matcher :
         {
           RP.matches = res;
           errors = [];
-          skipped = [];
+          skipped_targets = [];
           profiling = { RP.parse_time; match_time };
         }
 
@@ -1066,6 +1066,6 @@ let check_rule r hook (default_config, equivs) pformula xtarget =
                     let str = spf "with rule %s" rule_id in
                     hook str m.env m.tokens));
     errors = res.errors |> List.map (error_with_rule_id rule_id);
-    skipped = res.skipped;
+    skipped_targets = res.skipped_targets;
     profiling = res.profiling;
   }

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -278,6 +278,6 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
   {
     RP.matches;
     errors;
-    skipped = [];
+    skipped_targets = [];
     profiling = { RP.rule_id = fst rule.Rule.id; parse_time; match_time };
   }

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -75,7 +75,6 @@ let make_tests ?(unit_testing = false) xs =
            let test () =
              logger#info "processing rule file %s" file;
              let rules = Parse_rule.parse file in
-
              (* just a sanity check *)
              (* rules |> List.iter Check_rule.check; *)
              let xlangs = xlangs_of_rules rules in

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -248,9 +248,7 @@ let check_files mk_config fparser input =
   match config.output_format with
   | Text -> List.iter (fun err -> pr2 (E.string_of_error err)) errors
   | Json ->
-      let res =
-        { RP.matches = []; errors; skipped = []; final_profiling = None }
-      in
+      let res = { RP.empty_final_result with errors } in
       let json = JSON_report.match_results_of_matches_and_errors [] res in
       pr (SJ.string_of_match_results json)
 

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -83,7 +83,7 @@ let yaml_error_at_expr (e : G.expr) s =
 
 let yaml_error_at_key (key : key) s = yaml_error (snd key) s
 
-let error env t s = raise (R.InvalidRule (env.id, s, t))
+let error env t s = raise (R.InvalidRule (R.InvalidOther s, env.id, t))
 
 let error_at_key env (key : key) s = error env (snd key) s
 
@@ -324,7 +324,8 @@ let parse_metavar_cond env key s =
 let parse_regexp env (s, t) =
   try (s, SPcre.regexp s)
   with Pcre.Error exn ->
-    raise (R.InvalidRegexp (env.id, pcre_error_to_string s exn, t))
+    raise
+      (R.InvalidRule (R.InvalidRegexp (pcre_error_to_string s exn), env.id, t))
 
 let parse_fix_regex (env : env) (key : key) fields =
   let fix_regex_dict = yaml_to_dict env key fields in
@@ -443,8 +444,10 @@ let parse_xpattern_expr env e =
   (* TODO: capture and adjust pos of parsing error exns instead of using [t] *)
   | exn ->
       raise
-        (R.InvalidPattern
-           (env.id, s, env.languages, Common.exn_to_s exn, t, env.path))
+        (R.InvalidRule
+           ( R.InvalidPattern (s, env.languages, Common.exn_to_s exn, env.path),
+             env.id,
+             t ))
 
 let find_formula_old env (rule_dict : dict) : key * G.expr =
   let find key_str = Hashtbl.find_opt rule_dict.h key_str in
@@ -624,9 +627,7 @@ and parse_extra (env : env) (key : key) (value : G.expr) : Rule.extra =
       let mv_regex_dict =
         try yaml_to_dict env key value
         with R.DuplicateYamlKey (msg, t) ->
-          raise
-            (R.InvalidRule
-               (env.id, msg ^ ". You should use multiple metavariable-regex", t))
+          error env t (msg ^ ". You should use multiple metavariable-regex")
       in
       let metavar, regexp =
         ( take mv_regex_dict env parse_string "metavariable",
@@ -675,16 +676,14 @@ let parse_languages ~id langs : Xlang.t =
         xs
         |> List.map (function s, t ->
                (match Lang.lang_of_string_opt s with
-               | None ->
-                   raise
-                     (R.InvalidLanguage
-                        (fst id, spf "unsupported language: %s" s, t))
+               | None -> raise (R.InvalidRule (R.InvalidLanguage s, fst id, t))
                | Some l -> l))
       in
       match languages with
       | [] ->
           raise
-            (R.InvalidRule (fst id, "we need at least one language", snd id))
+            (R.InvalidRule
+               (R.InvalidOther "we need at least one language", fst id, snd id))
       | x :: xs -> L (x, xs))
 
 let parse_severity ~id (s, t) =
@@ -696,7 +695,10 @@ let parse_severity ~id (s, t) =
   | s ->
       raise
         (R.InvalidRule
-           (id, spf "Bad severity: %s (expected ERROR, WARNING or INFO)" s, t))
+           ( R.InvalidOther
+               (spf "Bad severity: %s (expected ERROR, WARNING or INFO)" s),
+             id,
+             t ))
 
 (*****************************************************************************)
 (* Sub parsers taint *)
@@ -743,96 +745,115 @@ let parse_mode env mode_opt (rule_dict : dict) : R.mode =
         (spf "Unexpected value for mode, should be 'search' or 'taint', not %s"
            (fst key))
 
-let parse_generic file ast =
-  let rules_block =
-    match ast with
-    | [
-     {
-       G.s =
-         G.ExprStmt
-           ( {
-               e =
-                 Container
-                   ( Dict,
-                     ( _,
-                       [
-                         {
-                           e =
-                             Container
-                               ( Tuple,
-                                 ( _,
-                                   [ { e = L (String ("rules", _)); _ }; rules ],
-                                   _ ) );
-                           _;
-                         };
-                       ],
-                       _ ) );
-               _;
-             },
-             _ );
-       _;
-     };
-    ] ->
-        rules
-    | _ ->
-        let loc = PI.first_loc_of_file file in
-        yaml_error (PI.mk_info_of_loc loc)
-          "missing rules entry as top-level key"
-  in
-  let t, rules =
-    match rules_block.G.e with
-    | Container (Array, (l, rules, _r)) -> (l, rules)
-    | _ ->
-        yaml_error_at_expr rules_block
-          "expected a list of rules following `rules:`"
-  in
-  rules
-  |> List.mapi (fun i rule ->
-         let rd = yaml_to_dict_no_env ("rules", t) rule in
-         let id, languages =
-           ( take_no_env rd parse_string_wrap_no_env "id",
-             take_no_env rd parse_string_wrap_list_no_env "languages" )
-         in
-         let languages = parse_languages ~id languages in
-         let env =
-           { id = fst id; languages; path = [ string_of_int i; "rules" ] }
-         in
-         let ( message,
-               severity,
-               mode_opt,
-               metadata_opt,
-               fix_opt,
-               fix_regex_opt,
-               paths_opt,
-               equivs_opt,
-               options_opt ) =
-           ( take rd env parse_string "message",
-             take rd env parse_string_wrap "severity",
-             take_opt rd env parse_string_wrap "mode",
-             take_opt rd env generic_to_json "metadata",
-             take_opt rd env parse_string "fix",
-             take_opt rd env parse_fix_regex "fix-regex",
-             take_opt rd env parse_paths "paths",
-             take_opt rd env parse_equivalences "equivalences",
-             take_opt rd env parse_options "options" )
-         in
-         let mode = parse_mode env mode_opt rd in
-         {
-           R.id;
-           message;
-           languages;
-           severity = parse_severity ~id:env.id severity;
-           mode;
-           (* optional fields *)
-           metadata = metadata_opt;
-           fix = fix_opt;
-           fix_regexp = fix_regex_opt;
-           paths = paths_opt;
-           equivalences = equivs_opt;
-           options = options_opt;
-         })
+(* sanity check there are no remaining fields in rd *)
+let report_unparsed_fields rd =
+  (* those were not "consumed" *)
+  Hashtbl.remove rd.h "pattern";
+  Hashtbl.remove rd.h "patterns";
+  match Common.hash_to_list rd.h with
+  | [] -> ()
+  | xs ->
+      (* less: we could return an error, but better to be fault-tolerant
+       * to futur extensions to the rule format
+       *)
+      xs
+      |> List.iter (fun (k, _v) ->
+             logger#warning "skipping unknown field: %s" k)
 
-let parse file =
+let parse_one_rule t i rule =
+  let rd = yaml_to_dict_no_env ("rules", t) rule in
+  let id, languages =
+    ( take_no_env rd parse_string_wrap_no_env "id",
+      take_no_env rd parse_string_wrap_list_no_env "languages" )
+  in
+  let languages = parse_languages ~id languages in
+  let env = { id = fst id; languages; path = [ string_of_int i; "rules" ] } in
+  let ( message,
+        severity,
+        mode_opt,
+        metadata_opt,
+        fix_opt,
+        fix_regex_opt,
+        paths_opt,
+        equivs_opt,
+        options_opt ) =
+    ( take rd env parse_string "message",
+      take rd env parse_string_wrap "severity",
+      take_opt rd env parse_string_wrap "mode",
+      take_opt rd env generic_to_json "metadata",
+      take_opt rd env parse_string "fix",
+      take_opt rd env parse_fix_regex "fix-regex",
+      take_opt rd env parse_paths "paths",
+      take_opt rd env parse_equivalences "equivalences",
+      take_opt rd env parse_options "options" )
+  in
+  let mode = parse_mode env mode_opt rd in
+  report_unparsed_fields rd;
+  {
+    R.id;
+    message;
+    languages;
+    severity = parse_severity ~id:env.id severity;
+    mode;
+    (* optional fields *)
+    metadata = metadata_opt;
+    fix = fix_opt;
+    fix_regexp = fix_regex_opt;
+    paths = paths_opt;
+    equivalences = equivs_opt;
+    options = options_opt;
+  }
+
+let parse_generic ?(error_recovery = false) file ast =
+  ignore error_recovery;
+  let t, rules =
+    match ast with
+    | [ { G.s = G.ExprStmt (e, _); _ } ] -> (
+        match e.G.e with
+        | Container
+            ( Dict,
+              ( _,
+                [
+                  {
+                    e =
+                      Container
+                        ( Tuple,
+                          (_, [ { e = L (String ("rules", _)); _ }; rules ], _)
+                        );
+                    _;
+                  };
+                ],
+                _ ) ) -> (
+            match rules.G.e with
+            | G.Container (G.Array, (l, rules, _r)) -> (l, rules)
+            | _ ->
+                yaml_error_at_expr rules
+                  "expected a list of rules following `rules:`")
+        (* it's also ok to not have the toplevel rules:, anyway we never
+         * used another toplevel key
+         *)
+        | G.Container (G.Array, (l, rules, _r)) -> (l, rules)
+        | _ ->
+            let loc = PI.first_loc_of_file file in
+            yaml_error (PI.mk_info_of_loc loc)
+              "missing rules entry as top-level key")
+    | _ -> assert false
+    (* yaml_to_generic should always return a ExprStmt *)
+  in
+  let xs =
+    rules
+    |> List.mapi (fun i rule ->
+           if error_recovery then (
+             try Left (parse_one_rule t i rule)
+             with R.InvalidRule ((kind, ruleid, _) as err) ->
+               let s = Rule.string_of_invalid_rule_error_kind kind in
+               logger#warning "skipping rule %s, error = %s" ruleid s;
+               Right err)
+           else Left (parse_one_rule t i rule))
+  in
+  Common.partition_either (fun x -> x) xs
+
+let parse_bis ?error_recovery file =
   let ast =
     match FT.file_type_of_file file with
     | FT.Config FT.Json ->
@@ -849,4 +870,11 @@ let parse file =
         logger#info "trying to parse %s as YAML" file;
         Yaml_to_generic.program file
   in
-  parse_generic file ast
+  parse_generic ?error_recovery file ast
+
+let parse file =
+  let xs, skipped = parse_bis ~error_recovery:false file in
+  assert (skipped = []);
+  xs
+
+let parse_and_filter_invalid_rules file = parse_bis ~error_recovery:true file

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -1,4 +1,18 @@
-(* may raise all the exns in Rule *)
+(* Parse a rule file.
+ *
+ * The parser accepts invalid rules, skip them, and return them in
+ * the list of errors.
+ * This will not raise Rule.InvalidRule exceptions.
+ *
+ * This function may also raise the other exns in Rule (e.g., InvalidYaml).
+ *)
+val parse_and_filter_invalid_rules :
+  Common.filename -> Rule.rules * Rule.invalid_rule_error list
+
+(* This should be used in testing code. Otherwise you should
+ * use parse_and_filter_invalid_rules.
+ * This function may raise the exns in Rule (e.g., InvalidRule).
+ *)
 val parse : Common.filename -> Rule.rules
 
 (* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml *)

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -274,13 +274,11 @@ let parse_pattern lang_pattern str =
   try Parse_pattern.parse_pattern lang_pattern ~print_errors:false str
   with exn ->
     raise
-      (Rule.InvalidPattern
-         ( "no-id",
-           str,
-           Xlang.of_lang lang_pattern,
-           Common.exn_to_s exn,
-           Parse_info.unsafe_fake_info "no loc",
-           [] ))
+      (Rule.InvalidRule
+         ( Rule.InvalidPattern
+             (str, Xlang.of_lang lang_pattern, Common.exn_to_s exn, []),
+           "no-id",
+           Parse_info.unsafe_fake_info "no loc" ))
   [@@profiling]
 
 (*****************************************************************************)
@@ -342,7 +340,7 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
                                E.OutOfMemory
                            | _ -> raise Impossible);
                        ];
-                     skipped = [];
+                     skipped_targets = [];
                      profiling = RP.empty_partial_profiling file;
                    }
                (* those were converted in Main_timeout in timeout_function()*)
@@ -351,7 +349,7 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
                    {
                      RP.matches = [];
                      errors = [ exn_to_error file exn ];
-                     skipped = [];
+                     skipped_targets = [];
                      profiling = RP.empty_partial_profiling file;
                    })
          in
@@ -454,7 +452,13 @@ let targets_of_config (config : Runner_config.t)
  * It takes a set of rules and a set of targets and
  * recursively process those targets.
  *)
-let semgrep_with_rules config (rules, rules_parse_time) =
+let semgrep_with_rules config ((rules, skipped_rules), rules_parse_time) =
+  (* if there are no rules but just skipped rules, better to return an exn *)
+  (match (rules, skipped_rules) with
+  | [], [] -> ()
+  | [], err :: _ -> raise (Rule.InvalidRule err)
+  | _ -> ());
+
   let rule_table = mk_rule_table rules in
   let targets, skipped =
     targets_of_config config (List.map (fun r -> fst r.R.id) rules)
@@ -493,9 +497,10 @@ let semgrep_with_rules config (rules, rules_parse_time) =
   let res =
     RP.make_final_result file_results rules config.report_time rules_parse_time
   in
-  let res = { res with skipped = skipped @ res.skipped } in
+  let res = { res with skipped_targets = skipped @ res.skipped_targets } in
   logger#info "found %d matches, %d errors, %d skipped targets"
-    (List.length res.matches) (List.length res.errors) (List.length res.skipped);
+    (List.length res.matches) (List.length res.errors)
+    (List.length res.skipped_targets);
   let matches, new_errors, new_skipped =
     filter_files_with_too_many_matches_and_transform_as_timeout
       config.max_match_per_file res.matches
@@ -504,9 +509,15 @@ let semgrep_with_rules config (rules, rules_parse_time) =
    * to debug too-many-matches issues.
    * Common2.write_value matches "/tmp/debug_matches";
    *)
-  let skipped = new_skipped @ res.skipped in
+  let skipped_targets = new_skipped @ res.skipped_targets in
   let errors = new_errors @ res.errors in
-  ( { RP.matches; errors; skipped; final_profiling = res.RP.final_profiling },
+  ( {
+      RP.matches;
+      errors;
+      skipped_targets;
+      skipped_rules;
+      final_profiling = res.RP.final_profiling;
+    },
     targets |> List.map (fun x -> x.In.path) )
 
 let semgrep_with_raw_results_and_exn_handler config =
@@ -519,7 +530,8 @@ let semgrep_with_raw_results_and_exn_handler config =
     logger#linfo
       (lazy (spf "Parsing %s:\n%s" rules_file (read_file rules_file)));
     let timed_rules =
-      Common.with_time (fun () -> Parse_rule.parse rules_file)
+      Common.with_time (fun () ->
+          Parse_rule.parse_and_filter_invalid_rules rules_file)
     in
     let res, files = semgrep_with_rules config timed_rules in
     (None, res, files)
@@ -527,12 +539,7 @@ let semgrep_with_raw_results_and_exn_handler config =
     let trace = Printexc.get_backtrace () in
     logger#info "Uncaught exception: %s\n%s" (Common.exn_to_s exn) trace;
     let res =
-      {
-        RP.matches = [];
-        errors = [ E.exn_to_error "" exn ];
-        skipped = [];
-        final_profiling = None;
-      }
+      { RP.empty_final_result with errors = [ E.exn_to_error "" exn ] }
     in
     (Some exn, res, [])
 
@@ -630,10 +637,11 @@ let semgrep_with_one_pattern config =
   match config.output_format with
   | Json ->
       let rule, rules_parse_time =
-        Common.with_time (fun () ->
-            [ rule_of_pattern lang pattern_string pattern ])
+        Common.with_time (fun () -> rule_of_pattern lang pattern_string pattern)
       in
-      let res, files = semgrep_with_rules config (rule, rules_parse_time) in
+      let res, files =
+        semgrep_with_rules config (([ rule ], []), rules_parse_time)
+      in
       let json = JSON_report.match_results_of_matches_and_errors files res in
       let s = Out.string_of_match_results json in
       pr s

--- a/semgrep-core/tests/OTHER/errors/rules_recovery.yaml
+++ b/semgrep-core/tests/OTHER/errors/rules_recovery.yaml
@@ -1,0 +1,24 @@
+- id: Common.do_option
+  require: "> 0.84.0"
+  futur_stuff: "> 0.84.0"
+  pattern: Common.do_option
+  fix: Option.iter
+  languages: [ ocaml ]
+  message: found one
+  severity: ERROR
+- id: rule-with-some-error
+  # this actually does not generate an error (just a warning in the logs)
+  #ERROR: bad pattern, but we should warn and just skip this rule
+  pattern: Common.do_option ||
+  fix: Option.iter
+  languages: [ ocaml ]
+  message: found one
+  severity: ERROR
+- id: rule-with-error-in-formula
+  patterns:
+    - pattern: Common.do_option
+    - metavariable-unknown: bar
+  fix: Option.iter
+  languages: [ ocaml ]
+  message: found one
+  severity: ERROR

--- a/semgrep-core/tests/OTHER/errors/rules_recovery.yaml
+++ b/semgrep-core/tests/OTHER/errors/rules_recovery.yaml
@@ -1,13 +1,13 @@
 - id: Common.do_option
-  require: "> 0.84.0"
+  # this actually does not generate an error (just a warning in the logs)
   futur_stuff: "> 0.84.0"
+  require: "> 0.84.0"
   pattern: Common.do_option
   fix: Option.iter
   languages: [ ocaml ]
   message: found one
   severity: ERROR
 - id: rule-with-some-error
-  # this actually does not generate an error (just a warning in the logs)
   #ERROR: bad pattern, but we should warn and just skip this rule
   pattern: Common.do_option ||
   fix: Option.iter
@@ -17,6 +17,9 @@
 - id: rule-with-error-in-formula
   patterns:
     - pattern: Common.do_option
+    # this also generates an error, but the testing code for this directory
+    # parses strictly the rule and just stops at the first error
+    # (the ERROR above in rule-with-some-error)
     - metavariable-unknown: bar
   fix: Option.iter
   languages: [ ocaml ]


### PR DESCRIPTION
This closes #4829

This will help be more fault tolerant to futur extensions
to the rule format.
semgrep-core now skip malformed rules and return the reason
in its JSON output.

test plan:
```
pad@thinkstation yy (skip_rules_in_core)]$ yy -rules tests/OTHER/errors/rules_recovery.yaml -l ocaml tests/ocaml/regexp.ml -json
+ /home/pad/yy/_build/default/src/cli/Main.exe -rules tests/OTHER/errors/rules_recovery.yaml -l ocaml tests/ocaml/regexp.ml -json
[0.020  Info       Main.Setup_logging   ] loaded log_config.json
[0.020  Info       Main.Dune__exe__Main ] Executed as: /home/pad/yy/_build/default/src/cli/Main.exe -rules tests/OTHER/errors/rules_recovery.yaml -l ocaml tests/ocaml/regexp.ml -json
[0.020  Info       Main.Dune__exe__Main ] Version: semgrep-core version: v0.85.0-7-g733811989-dirty, pfff: 0.42
[0.020  Info       Main.Dune__exe__Main ] Gc tuning
[0.021  Info       Main.Run_semgrep     ] Parsing tests/OTHER/errors/rules_recovery.yaml:
- id: Common.do_option
  require: "> 0.84.0"
  futur_stuff: "> 0.84.0"
  pattern: Common.do_option
  fix: Option.iter
  languages: [ ocaml ]
  message: found one
  severity: ERROR
- id: rule-with-some-error
  # this actually does not generate an error (just a warning in the logs)
  #ERROR: bad pattern, but we should warn and just skip this rule
  pattern: Common.do_option ||
  fix: Option.iter
  languages: [ ocaml ]
  message: found one
  severity: ERROR
- id: rule-with-error-in-formula
  patterns:
    - pattern: Common.do_option
    - metavariable-unknown: bar
  fix: Option.iter
  languages: [ ocaml ]
  message: found one
  severity: ERROR

[0.022  Warning    Main.Parse_rule      ] skipping unknown field: futur_stuff
[0.022  Warning    Main.Parse_rule      ] skipping unknown field: require
[0.022  Warning    Main.Parse_rule      ] skipping rule rule-with-some-error, error = Invalid pattern for OCaml
[0.022  Warning    Main.Parse_rule      ] skipping rule rule-with-error-in-formula, error = unexpected key metavariable-unknown
[0.022  Info       Main.Run_semgrep     ] processing 1 files, skipping 0 files
[0.022  Info       Main.Run_semgrep     ] Analyzing tests/ocaml/regexp.ml
[0.022  Info       Main.Parse_target    ] Parse_target.parse_and_resolve_name_use_pfff_or_treesitter done
[0.022  Trace      Main.Match_patterns  ] checking tests/ocaml/regexp.ml with 1 mini rules
[0.022  Debug      Main.Match_patterns  ] skipping pattern on stmt 4
[0.022  Debug      Main.Match_patterns  ] skipping pattern on stmt 6
[0.022  Trace      Main.Match_search_rules] found 0 matches
[0.022  Trace      Main.Match_search_rules] evaluating the formula
[0.022  Trace      Main.Match_search_rules] found 0 final ranges
.
[0.022  Trace      Main.Run_semgrep     ] done with tests/ocaml/regexp.ml
[0.022  Info       Main.Run_semgrep     ] found 0 matches, 0 errors, 0 skipped targets
[0.022  Info       Main.Run_semgrep     ] size of returned JSON string: 345
{"matches":[],"errors":[],"skipped":[],"skipped_rules":[{"rule_id":"rule-with-some-error","details":"Invalid pattern for OCaml","position":{"line":12,"col":12,"offset":358}},{"rule_id":"rule-with-error-in-formula","details":"unexpected key metavariable-unknown","position":{"line":20,"col":7,"offset":542}}],"stats":{"okfiles":1,"errorfiles":0}}
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)