### PR TITLE
deep: taint-mode: Record call chain to reach sink

### DIFF
--- a/semgrep-core/src/engine/Dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Dataflow_tainting.ml
@@ -350,6 +350,7 @@ let check_function_signature env fun_exp args_taint =
                  Some (Taint.singleton (Src dm))
              | ArgToReturn i -> taint_of_arg i
              | ArgToSink (i, sink) ->
+                 let sink = Call (eorig, sink) in
                  let* arg_taint = taint_of_arg i in
                  arg_taint
                  |> Taint.iter (fun t ->


### PR DESCRIPTION
We want to report tainted-sink matches on the function under analysis,
even if the sink is deep in a call chain. (Later we will have to add
some additional context to the match so that users can follow
Deep Semgrep's reasoning.)

Fixes: abc9a4d7070 ("taint-mode: Fix deep taint analysis (#4834)")

test plan:
make test # should not affect Semgrep at all

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
