### PR TITLE
Run linters on push, not on pull_request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: lint
 on:
   workflow_dispatch:
-  pull_request:
+  push:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Changes this implies:
- will now also scan commits to develop, so that we can check if a failure is caused by a feature branch, or was inherited from the develop
- on PRs, we'll lint only code that was actually committed, not the result of merging the branch into develop; so the linted code won't change if the branch is behind
- on PRs, new jobs won't be triggered if the PR is closed & reopened.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
