### PR TITLE
[Go] add support for generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Semgrep can now output findings in GitLab's SAST report and secret scanning
   report formats with `--gitlab-sast` and `--gitlab-secrets`.
-- Terraform: basic support for constant propagation of locals (#1147)
-  and variables (#4816)
 - JSON output now includes a fingerprint of each finding.
   This fingerprint remains consistent when matching code is just moved around
   or reindented.
-- HTML: you can now use metavariable ellipsis (#4841)
+- Go: use latest tree-sitter-go with support for Go 1.18 generics (#4823)
+- Terraform: basic support for constant propagation of locals (#1147)
+  and variables (#4816)
+- HTML: you can now use metavariable ellipsis inside <script> (#4841)
   (e.g., `<script>$...JS</script>`)
 
 ### Changed

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1147,7 +1147,7 @@ and type_kind =
    * note: the type_ should always be a TyN, so really it's a TyNameApply
    * but it's simpler to not repeat TyN to factorize code in semgrep regarding
    * aliasing.
-   * TODO: could merge with TyN when name has proper qualifiers?
+   * TODO: could merge with TyN now that qualified_info has type_arguments
    *)
   | TyApply of type_ * type_arguments
   (* old: was 'TyFun of type_ list * type*' , but languages such as C and
@@ -1374,7 +1374,7 @@ and type_parameter =
   (* sgrep-ext: *)
   | TParamEllipsis of tok
   (* e.g., Lifetime in Rust, complex types in OCaml, HasConstructor in C#,
-   * regular Param in C++, AnonTypeParam/TPRest/TPNested in C++
+   * regular Param in C++/Go, AnonTypeParam/TPRest/TPNested in C++
    *)
   | OtherTypeParam of todo_kind * any list
 


### PR DESCRIPTION
This closes #4823

There are still constructs which are not represented accurately
in the generic AST, but it's probably good enough to start
running semgrep on Go code using generics

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)