### PR TITLE
taint-mode: Propagate metavariables correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   constant will also be considered constant (#4301)
 - Constant propagation now recognizes operators `++` and `--` as side-effectful
   (#4667)
+- Taint mode now propagates metavariables that are bound by a `pattern-inside`.
+  In particular, these metavariables are now available to the rule message. (#4464)
 
 ## [0.85.0](https://github.com/returntocorp/semgrep/releases/tag/v0.85.0) - 2022-03-16
 

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -165,22 +165,6 @@ let (group_matches_per_pattern_id : Pattern_match.t list -> id_to_match_results)
          Hashtbl.add h id m);
   h
 
-let (range_to_pattern_match_adjusted : Rule.t -> RM.t -> Pattern_match.t) =
- fun r range ->
-  let m = range.origin in
-  let rule_id = m.rule_id in
-  (* adjust the rule id *)
-  let rule_id =
-    {
-      rule_id with
-      Pattern_match.id = fst r.R.id;
-      message = r.R.message (* keep pattern_str which can be useful to debug *);
-    }
-  in
-  (* Need env to be the result of evaluate_formula, which propagates metavariables *)
-  (* rather than the original metavariables for the match                          *)
-  { m with rule_id; env = range.mvars }
-
 let error_with_rule_id rule_id (error : E.error) =
   { error with rule_id = Some rule_id }
 
@@ -1070,7 +1054,7 @@ let check_rule r hook (default_config, equivs) pformula xtarget =
   {
     RP.matches =
       final_ranges
-      |> List.map (range_to_pattern_match_adjusted r)
+      |> List.map (RM.range_to_pattern_match_adjusted r)
       (* dedup similar findings (we do that also in Match_patterns.ml,
        * but different mini-rules matches can now become the same match)
        *)

--- a/semgrep-core/src/engine/Range_with_metavars.ml
+++ b/semgrep-core/src/engine/Range_with_metavars.ml
@@ -32,6 +32,23 @@ let (match_result_to_range : Pattern_match.t -> t) =
   let r = Range.range_of_token_locations start_loc end_loc in
   { r; mvars; origin = m; kind = Plain }
 
+let (range_to_pattern_match_adjusted : Rule.t -> t -> Pattern_match.t) =
+ fun r range ->
+  let m = range.origin in
+  let rule_id = m.rule_id in
+  (* adjust the rule id *)
+  let rule_id =
+    {
+      rule_id with
+      Pattern_match.id = fst r.Rule.id;
+      message =
+        r.Rule.message (* keep pattern_str which can be useful to debug *);
+    }
+  in
+  (* Need env to be the result of evaluate_formula, which propagates metavariables *)
+  (* rather than the original metavariables for the match                          *)
+  { m with rule_id; env = range.mvars }
+
 (*****************************************************************************)
 (* Set operations *)
 (*****************************************************************************)

--- a/semgrep-core/src/engine/Range_with_metavars.mli
+++ b/semgrep-core/src/engine/Range_with_metavars.mli
@@ -19,6 +19,7 @@ type ranges = t list [@@deriving show]
 (* Functions *)
 
 val match_result_to_range : Pattern_match.t -> t
+val range_to_pattern_match_adjusted : Rule.rule -> t -> Pattern_match.t
 
 (* Set functions *)
 

--- a/semgrep-core/tests/OTHER/rules/taint_match_mvars.js
+++ b/semgrep-core/tests/OTHER/rules/taint_match_mvars.js
@@ -1,0 +1,15 @@
+function foo() {
+    x = source()
+    //ruleid: test
+    foo(x)
+    //ok: test
+    bar(x)
+}
+
+function bar() {
+    x = source()
+    //ok: test
+    foo(x)
+    //ruleid: test
+    bar(x)
+}

--- a/semgrep-core/tests/OTHER/rules/taint_match_mvars.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_match_mvars.yaml
@@ -1,0 +1,19 @@
+# https://github.com/returntocorp/semgrep/issues/4464
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+      - patterns:
+        - pattern-inside: function $FUNC(...) { ... }
+        - pattern: source(...)
+    pattern-sinks:
+      # Note that the $FUNC here must be unifiable with the $FUNC coming
+      # from the pattern-sources match! We want to test that this works
+      # even when $FUNC is bound by a pattern-inside.
+      - patterns:
+        - pattern-inside: $FUNC($TAINT)
+        - pattern: $TAINT
+    message: Test
+    languages:
+      - js
+    severity: WARNING


### PR DESCRIPTION
Even when they are bound by a pattern-inside!

Closes #4464

test plan:
make test # test included

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
