### PR TITLE
taint-mode: Stop unifying source-sink metavariables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,28 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Changed
+
+- taint-mode: We no longer force the unification of metavariables between
+  sources and sinks by default. It is not clear that this is the most natural
+  behavior; and we realized that, in fact, it was confusing even for experienced
+  Semgrep users. Instead, each set of metavariables is now considered independent.
+  The metavariables available to the rule message are all metavariables bound by
+  `pattern-sinks`, plus the subset of metavariables bound by `pattern-sources`
+  that do not collide with the ones bound by `pattern-sinks`. We do not expect
+  this change to break many taint rules because source-sink metavariable
+  unification had a bug (see #4464) that prevented metavariables bound by a
+  `pattern-inside` to be unified, thus limiting the usefulness of the feature.
+  Nonetheless, it is still possible to force metavariable unification by setting
+  `taint_unify_mvars: true` in the rule's `options`.
+
 ### Fixed
 
 - `-` is now parsed as a valid identifier in Scala
 - `new $OBJECT(...)` will now work properly as a taint sink (#4858)
 - JS/TS: `...{$X}...` will no longer match `str`
+- taint-mode: Metavariables bound by a `pattern-inside` are now available to the
+  rule message. (#4464)
 
 ## [0.86.5](https://github.com/returntocorp/semgrep/releases/tag/v0.86.5) - 2022-03-28
 

--- a/interfaces/Config_semgrep.atd
+++ b/interfaces/Config_semgrep.atd
@@ -21,6 +21,8 @@ type t = {
   ~constant_propagation <ocaml default="true"> : bool;
   (* symbolic_propagation requires constant_propagation to have effect *)
   ~symbolic_propagation <ocaml default="false"> : bool;
+  (* metavariables common to a source and sink will be unified *)
+  ~taint_unify_mvars <ocaml default="false"> : bool;
   (* 'ac' stands for associative-commutative matching *)
   ~ac_matching <ocaml default="true"> : bool;
   (* pretend && and || are commutative *)

--- a/semgrep-core/src/engine/Dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Dataflow_tainting.ml
@@ -211,17 +211,18 @@ let sink_biased_union_mvars source_mvars sink_mvars =
   in
   Some (source_mvars' @ sink_mvars)
 
-let merge_source_sink_mvars env =
+(* Merge source's and sink's bound metavariables. *)
+let merge_source_sink_mvars env source_mvars sink_mvars =
   if env.config.unify_mvars then
     (* This used to be the default, but it turned out to be confusing even for
      * r2c's security team! Typically you think of `pattern-sources` and
      * `pattern-sinks` as independent. We keep this option mainly for
      * backwards compatibility, it may be removed later on if no real use
      * is found. *)
-    unify_mvars_sets
+    unify_mvars_sets source_mvars sink_mvars
   else
     (* The union of both sets, but taking the sink mvars in case of collision. *)
-    sink_biased_union_mvars
+    sink_biased_union_mvars source_mvars sink_mvars
 
 let union_map f xs = xs |> List.map f |> List.fold_left Taint.union Taint.empty
 

--- a/semgrep-core/src/engine/Dataflow_tainting.mli
+++ b/semgrep-core/src/engine/Dataflow_tainting.mli
@@ -58,6 +58,7 @@ type config = {
   is_sanitizer : AST_generic.any -> Pattern_match.t list;
       (** Test whether 'any' is a sanitizer, this corresponds to
       * 'pattern-sanitizers:' in taint-mode. *)
+  unify_mvars : bool;  (** Unify metavariables in sources and sinks? *)
   handle_findings :
     var option (** function name ('None' if anonymous) *) ->
     finding list ->
@@ -80,12 +81,6 @@ type fun_env = (var, Pattern_match.Set.t) Hashtbl.t
   * interprocedural taint tracking. TO BE DEPRECATED. *)
 
 val pm_of_dm : deep_match -> Pattern_match.t
-
-val unify_meta_envs :
-  Metavariable.bindings -> Metavariable.bindings -> Metavariable.bindings option
-(** [unify_meta_envs env1 env2] returns [Some (env1 U env2)] if
-  * [env1] and [env2] contain no conflicting metavariable assignments,
-  * otherwise [None]. *)
 
 val hook_function_taint_signature :
   (config -> AST_generic.expr -> finding list option) option ref

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -165,22 +165,6 @@ let (group_matches_per_pattern_id : Pattern_match.t list -> id_to_match_results)
          Hashtbl.add h id m);
   h
 
-let (range_to_pattern_match_adjusted : Rule.t -> RM.t -> Pattern_match.t) =
- fun r range ->
-  let m = range.origin in
-  let rule_id = m.rule_id in
-  (* adjust the rule id *)
-  let rule_id =
-    {
-      rule_id with
-      Pattern_match.id = fst r.R.id;
-      message = r.R.message (* keep pattern_str which can be useful to debug *);
-    }
-  in
-  (* Need env to be the result of evaluate_formula, which propagates metavariables *)
-  (* rather than the original metavariables for the match                          *)
-  { m with rule_id; env = range.mvars }
-
 let error_with_rule_id rule_id (error : E.error) =
   { error with rule_id = Some rule_id }
 
@@ -1070,7 +1054,7 @@ let check_rule r hook (default_config, equivs) pformula xtarget =
   {
     RP.matches =
       final_ranges
-      |> List.map (range_to_pattern_match_adjusted r)
+      |> List.map (RM.range_to_pattern_match_adjusted r)
       (* dedup similar findings (we do that also in Match_patterns.ml,
        * but different mini-rules matches can now become the same match)
        *)

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -155,18 +155,20 @@ let taint_config_of_rule default_config equivs file ast_and_errors
      * to assume that any other function will handle tainted data safely.
      * Without this, `$F(...)` will automatically sanitize any other function
      * call acting as a sink or a source. *)
-    |> List.filter_map (fun (not_conflicting, rng) ->
+    |> List.filter_map (fun (not_conflicting, range) ->
            (* TODO: Warn user when we filter out a sanitizer? *)
            if not_conflicting then
              if
                not
-                 (List.exists (fun rng' -> rng'.RM.r = rng.RM.r) sinks_ranges
+                 (List.exists
+                    (fun range' -> range'.RM.r = range.RM.r)
+                    sinks_ranges
                  || List.exists
-                      (fun rng' -> rng'.RM.r = rng.RM.r)
+                      (fun range' -> range'.RM.r = range.RM.r)
                       sources_ranges)
-             then Some rng
+             then Some range
              else None
-           else Some rng)
+           else Some range)
   in
   ( {
       Dataflow_tainting.filepath = file;

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -18,6 +18,7 @@ module H = AST_generic_helpers
 module V = Visitor_AST
 module R = Rule
 module PM = Pattern_match
+module RM = Range_with_metavars
 module RP = Report
 
 let logger = Logging.get_logger [ __MODULE__ ]
@@ -71,9 +72,9 @@ let logger = Logging.get_logger [ __MODULE__ ]
  *)
 
 type debug_taint = {
-  sources : Range_with_metavars.ranges;
-  sanitizers : Range_with_metavars.ranges;
-  sinks : Range_with_metavars.ranges;
+  sources : RM.ranges;
+  sanitizers : RM.ranges;
+  sinks : RM.ranges;
 }
 
 (*****************************************************************************)
@@ -92,7 +93,7 @@ end)
 
 let convert_rule_id (id, _tok) = { PM.id; message = ""; pattern_string = id }
 
-let any_in_ranges any rwms =
+let any_in_ranges rule any rwms =
   (* This is potentially slow. We may need to store range position in
    * the AST at some point. *)
   match Visitor_AST.range_of_any_opt any with
@@ -103,8 +104,8 @@ let any_in_ranges any rwms =
       []
   | Some (tok1, tok2) ->
       let r = Range.range_of_token_locations tok1 tok2 in
-      List.filter (fun rwm -> Range.( $<=$ ) r rwm.Range_with_metavars.r) rwms
-      |> List.map (fun rwm -> rwm.Range_with_metavars.origin)
+      List.filter (fun rwm -> Range.( $<=$ ) r rwm.RM.r) rwms
+      |> List.map (RM.range_to_pattern_match_adjusted rule)
 
 let range_w_metas_of_pformula config equivs file_and_more rule_id pformula =
   let formula = Rule.formula_of_pformula pformula in
@@ -159,13 +160,9 @@ let taint_config_of_rule default_config equivs file ast_and_errors
            if not_conflicting then
              if
                not
-                 (List.exists
-                    (fun rng' ->
-                      rng'.Range_with_metavars.r = rng.Range_with_metavars.r)
-                    sinks_ranges
+                 (List.exists (fun rng' -> rng'.RM.r = rng.RM.r) sinks_ranges
                  || List.exists
-                      (fun rng' ->
-                        rng'.Range_with_metavars.r = rng.Range_with_metavars.r)
+                      (fun rng' -> rng'.RM.r = rng.RM.r)
                       sources_ranges)
              then Some rng
              else None
@@ -174,9 +171,10 @@ let taint_config_of_rule default_config equivs file ast_and_errors
   ( {
       Dataflow_tainting.filepath = file;
       rule_id = fst rule.R.id;
-      is_source = (fun x -> any_in_ranges x sources_ranges);
-      is_sanitizer = (fun x -> any_in_ranges x sanitizers_ranges);
-      is_sink = (fun x -> any_in_ranges x sinks_ranges);
+      is_source = (fun x -> any_in_ranges rule x sources_ranges);
+      is_sanitizer = (fun x -> any_in_ranges rule x sanitizers_ranges);
+      is_sink = (fun x -> any_in_ranges rule x sinks_ranges);
+      unify_mvars = config.taint_unify_mvars;
       handle_findings;
     },
     {

--- a/semgrep-core/src/engine/Range_with_metavars.ml
+++ b/semgrep-core/src/engine/Range_with_metavars.ml
@@ -32,6 +32,23 @@ let (match_result_to_range : Pattern_match.t -> t) =
   let r = Range.range_of_token_locations start_loc end_loc in
   { r; mvars; origin = m; kind = Plain }
 
+let (range_to_pattern_match_adjusted : Rule.t -> t -> Pattern_match.t) =
+ fun r range ->
+  let m = range.origin in
+  let rule_id = m.rule_id in
+  (* adjust the rule id *)
+  let rule_id =
+    {
+      rule_id with
+      Pattern_match.id = fst r.Rule.id;
+      message =
+        r.Rule.message (* keep pattern_str which can be useful to debug *);
+    }
+  in
+  (* Need env to be the result of evaluate_formula, which propagates metavariables *)
+  (* rather than the original metavariables for the match                          *)
+  { m with rule_id; env = range.mvars }
+
 (*****************************************************************************)
 (* Set operations *)
 (*****************************************************************************)

--- a/semgrep-core/src/engine/Range_with_metavars.mli
+++ b/semgrep-core/src/engine/Range_with_metavars.mli
@@ -19,6 +19,7 @@ type ranges = t list [@@deriving show]
 (* Functions *)
 
 val match_result_to_range : Pattern_match.t -> t
+val range_to_pattern_match_adjusted : Rule.rule -> t -> Pattern_match.t
 
 (* Set functions *)
 

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -29,6 +29,7 @@ let test_dfg_tainting file =
                  is_source = (fun _ -> []);
                  is_sink = (fun _ -> []);
                  is_sanitizer = (fun _ -> []);
+                 unify_mvars = false;
                  handle_findings = (fun _ _ _ -> ());
                }
              in

--- a/semgrep-core/tests/OTHER/rules/taint_unify_mvars.js
+++ b/semgrep-core/tests/OTHER/rules/taint_unify_mvars.js
@@ -1,0 +1,15 @@
+function foo() {
+    x = source()
+    //ruleid: test
+    foo(x)
+    //ok: test
+    bar(x)
+}
+
+function bar() {
+    x = source()
+    //ok: test
+    foo(x)
+    //ruleid: test
+    bar(x)
+}

--- a/semgrep-core/tests/OTHER/rules/taint_unify_mvars.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_unify_mvars.yaml
@@ -1,0 +1,21 @@
+# https://github.com/returntocorp/semgrep/issues/4464
+rules:
+  - id: test
+    options:
+      taint_unify_mvars: true
+    mode: taint
+    pattern-sources:
+      - patterns:
+        - pattern-inside: function $FUNC(...) { ... }
+        - pattern: source(...)
+    pattern-sinks:
+      # Note that the $FUNC here must be unifiable with the $FUNC coming
+      # from the pattern-sources match! We want to test that this works
+      # even when $FUNC is bound by a pattern-inside.
+      - patterns:
+        - pattern-inside: $FUNC($TAINT)
+        - pattern: $TAINT
+    message: Test
+    languages:
+      - js
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/taint_union_mvars.js
+++ b/semgrep-core/tests/OTHER/rules/taint_union_mvars.js
@@ -1,0 +1,15 @@
+function foo() {
+    x = source()
+    //ruleid: test
+    foo(x)
+    //ruleid: test
+    bar(x)
+}
+
+function bar() {
+    x = source()
+    //ruleid: test
+    foo(x)
+    //ruleid: test
+    bar(x)
+}

--- a/semgrep-core/tests/OTHER/rules/taint_union_mvars.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_union_mvars.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+      - patterns:
+        - pattern-inside: function $FUNC(...) { ... }
+        - pattern: source(...)
+    pattern-sinks:
+      - patterns:
+        # This $FUNC is independent of the $FUNC used in
+        # pattern-sources!
+        - pattern-inside: $FUNC($TAINT)
+        - pattern: $TAINT
+    message: Test
+    languages:
+      - js
+    severity: WARNING

--- a/semgrep-core/tests/tainting_rules/js/metavar_eq_simple.yaml
+++ b/semgrep-core/tests/tainting_rules/js/metavar_eq_simple.yaml
@@ -3,6 +3,8 @@ rules:
     languages:
       - javascript
     message: Matched on $X!
+    options:
+      taint_unify_mvars: true
     mode: taint
     pattern-sinks:
       - pattern: sink($X,...)


### PR DESCRIPTION
At least it will not be the default. Forcing unification of source-sink
metavariables turned out to be confusing even for r2c's security team!
But we never had a real use for it, we just wanted to expose the
metavariables to the rule message, which we can achieve in other ways.
Here we chose to do the union of both metavariable sets, but prefer
the sink ones in case of collision.

And restore most of "taint-mode: Propagate metavariables correctly (#4877)"
We still have to propagate metavariables correctly!

Closes #4464

test plan:
make test # test included

PR checklist:

- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
