### PR TITLE
Convert Swift hello world to generic AST

### DIFF
--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -336,6 +336,7 @@ let lang_parsing_tests =
     pack_parsing_tests_for_lang Lang.Dockerfile "dockerfile" ".dockerfile";
     pack_parsing_tests_for_lang Lang.Lua "lua" ".lua";
     pack_parsing_tests_for_lang Lang.Rust "rust" ".rs";
+    pack_parsing_tests_for_lang Lang.Swift "swift" ".swift";
     pack_parsing_tests_for_lang Lang.Kotlin "kotlin" ".kt";
     pack_parsing_tests_for_lang Lang.Hack "hack" ".hack";
     (* here we have both a Pfff and tree-sitter parser *)

--- a/semgrep-core/tests/swift/parsing/hello-world.swift
+++ b/semgrep-core/tests/swift/parsing/hello-world.swift
@@ -1,0 +1,1 @@
+print("hello world")


### PR DESCRIPTION
I've done just the bare minimum here to convert a "hello world" program in Swift to Semgrep's generic AST. To get it building with my changes, I had to add some more todos. In places where I was unsure about best practices, I looked to other languages for examples, but I'd still appreciate any pointers if there are better ways to do things.

Test plan:

New automated test (I verified that without these changes it fails), plus the following manual test:

```
$ semgrep-core -lang swift -dump_ast hello-world.swift
Pr(
  [ExprStmt(
     Call(N(Id(("print", ()), {id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
       [Arg(L(String(("hello world", ()))))]), ())])
```

Partially addresses #2232

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
