### PR TITLE
project-depends-on: create dependency only matches even without a pattern match

### DIFF
--- a/semgrep/dependencyparser/models.py
+++ b/semgrep/dependencyparser/models.py
@@ -23,7 +23,7 @@ class PackageManagers(str, Enum):
     MAVEN = "maven"
 
 
-@dataclass(eq=True, order=True)
+@dataclass(eq=True, order=True, frozen=True)
 class LockfileDependency:
     name: str
     version: str

--- a/semgrep/dependencyparser/models.py
+++ b/semgrep/dependencyparser/models.py
@@ -1,10 +1,9 @@
+from dataclasses import dataclass
 from enum import Enum
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Set
-
-from attrs import frozen
 
 KNOWN_HASH_ALGORITHMS: Set[str] = {
     "sha256",
@@ -15,7 +14,7 @@ KNOWN_HASH_ALGORITHMS: Set[str] = {
 }
 
 
-class PackageManagers(Enum):
+class PackageManagers(str, Enum):
     NPM = "npm"
     PYPI = "pypi"
     GEM = "gem"
@@ -24,7 +23,7 @@ class PackageManagers(Enum):
     MAVEN = "maven"
 
 
-@frozen(eq=True, order=True)
+@dataclass(eq=True, order=True)
 class LockfileDependency:
     name: str
     version: str

--- a/semgrep/dependencyparser/package_restrictions.py
+++ b/semgrep/dependencyparser/package_restrictions.py
@@ -28,7 +28,7 @@ def find_and_parse_lockfiles(current_dir: Path) -> Dict[Path, List[LockfileDepen
     return dependencies
 
 
-@dataclass(eq=True, order=True)
+@dataclass(eq=True, order=True, frozen=True)
 class ProjectDependsOnEntry:
     namespace: PackageManagers
     package_name: str

--- a/semgrep/dependencyparser/package_restrictions.py
+++ b/semgrep/dependencyparser/package_restrictions.py
@@ -1,4 +1,5 @@
 import functools
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict
 from typing import Generator
@@ -6,7 +7,6 @@ from typing import List
 from typing import Tuple
 
 import packaging.version
-from attrs import frozen
 from dependencyparser.find_lockfiles import find_lockfiles
 from dependencyparser.models import LockfileDependency
 from dependencyparser.models import PackageManagers
@@ -28,7 +28,7 @@ def find_and_parse_lockfiles(current_dir: Path) -> Dict[Path, List[LockfileDepen
     return dependencies
 
 
-@frozen(eq=True, order=True)
+@dataclass(eq=True, order=True)
 class ProjectDependsOnEntry:
     namespace: PackageManagers
     package_name: str

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi.js/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi.js/results.json
@@ -6,5 +6,60 @@
       "targets/dependency_aware/ansi.js"
     ]
   },
-  "results": []
+  "results": [
+    {
+      "check_id": "rules.dependency_aware.ansi-html-redos",
+      "end": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      },
+      "extra": {
+        "dependency_match_only": true,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "npm",
+              "package_name": "ansi-html",
+              "semver_range": "< 0.0.8"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "name": "ansi-html",
+              "namespace": "npm",
+              "resolved_url": [
+                "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz"
+              ],
+              "version": "0.0.7"
+            },
+            "lockfile": "yarn.lock"
+          }
+        ],
+        "fingerprint": "34dbc50eb98e00ba192ad6f3e9716450",
+        "is_ignored": false,
+        "lines": "",
+        "message": "This affects all versions of package ansi-html. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time. There is no upgrade fix at this time (the package is no longer being maintained), but you can change to use the 'ansi-html-community@0.0.8' package instead.\n",
+        "metadata": {
+          "category": "security",
+          "references": [
+            "https://github.com/advisories/GHSA-whgm-jr23-g3j9",
+            "https://nvd.nist.gov/vuln/detail/CVE-2021-23424",
+            "https://github.com/Tjatse/ansi-html/issues/19",
+            "https://github.com/mahdyar/ansi-html-community"
+          ],
+          "technology": [
+            "js",
+            "ts"
+          ]
+        },
+        "severity": "ERROR"
+      },
+      "path": ".",
+      "start": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      }
+    }
+  ]
 }

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli_vuln.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli_vuln.py/results.json
@@ -15,6 +15,29 @@
         "offset": 537
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": "== 1.11.82"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
         "fingerprint": "c3281feb0f4821f2e7ae791684266776",
         "is_ignored": false,
         "lines": "            s3_client = boto3.client(\"s3\")",
@@ -38,6 +61,29 @@
         "offset": 670
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": "== 1.11.82"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
         "fingerprint": "ef682f6bc12cdbd85c49a606c32993a4",
         "is_ignored": false,
         "lines": "            s3_client = boto3.client(\"s3\", region_name=region)",
@@ -54,6 +100,51 @@
       }
     },
     {
+      "check_id": "rules.dependency_aware.vulnerable-awscli-apr-2017-wrong-pattern",
+      "end": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      },
+      "extra": {
+        "dependency_match_only": true,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": "== 1.11.82"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
+        "fingerprint": "ca5cdc2e103577cd4498783ce4ed8b08",
+        "is_ignored": false,
+        "lines": "",
+        "message": "this version of awscli is subject to a directory traversal vulnerability in the s3 module 1",
+        "metadata": {},
+        "severity": "WARNING"
+      },
+      "path": ".",
+      "start": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      }
+    },
+    {
       "check_id": "rules.dependency_aware.version-ge",
       "end": {
         "col": 43,
@@ -61,6 +152,29 @@
         "offset": 537
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": ">= 0.0.1"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
         "fingerprint": "dedcd224bb4ca1f44d2d715aa5f76c4e",
         "is_ignored": false,
         "lines": "            s3_client = boto3.client(\"s3\")",
@@ -84,6 +198,29 @@
         "offset": 670
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": ">= 0.0.1"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
         "fingerprint": "1eb50fa7a4176e5d4b926f1909272008",
         "is_ignored": false,
         "lines": "            s3_client = boto3.client(\"s3\", region_name=region)",
@@ -107,6 +244,29 @@
         "offset": 537
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": "<= 1.11.82"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
         "fingerprint": "9e5f5095ba7cf122624d0dd92024baa0",
         "is_ignored": false,
         "lines": "            s3_client = boto3.client(\"s3\")",
@@ -130,6 +290,29 @@
         "offset": 670
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": "<= 1.11.82"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
         "fingerprint": "516830f4f7443db4f84e28fc557fb881",
         "is_ignored": false,
         "lines": "            s3_client = boto3.client(\"s3\", region_name=region)",
@@ -153,6 +336,29 @@
         "offset": 0
       },
       "extra": {
+        "dependency_match_only": true,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "pypi",
+              "package_name": "awscli",
+              "semver_range": "== 1.11.82"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                  "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                ]
+              },
+              "name": "awscli",
+              "namespace": "pypi",
+              "resolved_url": null,
+              "version": "1.11.82"
+            },
+            "lockfile": "Pipfile.lock"
+          }
+        ],
         "fingerprint": "aff1d5db7585f1a20463e0e73435132c",
         "is_ignored": false,
         "lines": "",

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awaresca.go/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awaresca.go/results.json
@@ -15,6 +15,51 @@
         "offset": 24
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "gomod",
+              "package_name": "github.com/cheekybits/genny",
+              "semver_range": "== 1.0.0"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "gomod": [
+                  "uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE"
+                ]
+              },
+              "name": "github.com/cheekybits/genny",
+              "namespace": "gomod",
+              "resolved_url": [
+                "github.com/cheekybits/genny"
+              ],
+              "version": "1.0.0"
+            },
+            "lockfile": "go.sum"
+          },
+          {
+            "dependency_pattern": {
+              "namespace": "gomod",
+              "package_name": "github.com/cheekybits/genny",
+              "semver_range": "== 1.0.0"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "gomod": [
+                  "+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ"
+                ]
+              },
+              "name": "github.com/cheekybits/genny",
+              "namespace": "gomod",
+              "resolved_url": [
+                "github.com/cheekybits/genny"
+              ],
+              "version": "1.0.0"
+            },
+            "lockfile": "go.sum"
+          }
+        ],
         "fingerprint": "5c136ae7599499d8a4779d6ddbe0a3cf",
         "is_ignored": false,
         "lines": "\treturn bad()",

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awaresca.js/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awaresca.js/results.json
@@ -15,6 +15,30 @@
         "offset": 9
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "npm",
+              "package_name": "@types/jquery",
+              "semver_range": "== 3.3.22"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha512": [
+                  "6b8243708849847627a160a41b7c53d826715d9780f7625e444112a2b8340cc43766c8ee285e3c87b5cae25e469761916bf22d191a4a313d29c8af3cc9182a5d"
+                ]
+              },
+              "name": "@types/jquery",
+              "namespace": "npm",
+              "resolved_url": [
+                "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz"
+              ],
+              "version": "3.3.22"
+            },
+            "lockfile": "package-lock.json"
+          }
+        ],
         "fingerprint": "bf2f0ae7b018eead68370e2ae6ab31c6",
         "is_ignored": false,
         "lines": "x = bad()",

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4shell.java/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4shell.java/results.json
@@ -15,6 +15,24 @@
         "offset": 1037
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "maven",
+              "package_name": "log4j-core",
+              "semver_range": "<= 0.0.2"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "name": "log4j-core",
+              "namespace": "maven",
+              "resolved_url": null,
+              "version": "0.0.1"
+            },
+            "lockfile": "pom.xml"
+          }
+        ],
         "fingerprint": "2dad36618046aba1c66784346119c366",
         "is_ignored": false,
         "lines": "            logger.error(userName);",

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareruby-sca.yaml-dependency_awaresca.rb/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareruby-sca.yaml-dependency_awaresca.rb/results.json
@@ -15,6 +15,24 @@
         "offset": 9
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "gem",
+              "package_name": "parallel",
+              "semver_range": "== 1.21.0"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "name": "parallel",
+              "namespace": "gem",
+              "resolved_url": null,
+              "version": "1.21.0"
+            },
+            "lockfile": "Gemfile.lock"
+          }
+        ],
         "fingerprint": "c61fb1ce8248b3d7e7d5200726fadbcf",
         "is_ignored": false,
         "lines": "x = bad()",

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarerust-sca.yaml-dependency_awaresca.rs/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarerust-sca.yaml-dependency_awaresca.rs/results.json
@@ -15,6 +15,28 @@
         "offset": 13
       },
       "extra": {
+        "dependency_match_only": false,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "cargo",
+              "package_name": "adler",
+              "semver_range": "<= 1.0.3"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha256": [
+                  "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+                ]
+              },
+              "name": "adler",
+              "namespace": "cargo",
+              "resolved_url": null,
+              "version": "1.0.2"
+            },
+            "lockfile": "cargo.lock"
+          }
+        ],
         "fingerprint": "3af766253c433df522d5b6e84d4f5f8b",
         "is_ignored": false,
         "lines": "let x = bad()",

--- a/semgrep/tests/e2e/targets/dependency_aware/ansi.js
+++ b/semgrep/tests/e2e/targets/dependency_aware/ansi.js
@@ -1,2 +1,2 @@
-// We want the rule not to fire, because our code does not match the pattern even though our dependency has a bad version
+// The rule should still fire without the pattern match, but should specify this is the case in the `extra` field of output
 const x = 0


### PR DESCRIPTION
This PR changes the behavior of the `r2c-internal-project-depends-on` key in the following ways:
1. Given a rule with both some `pattern` key and an `r2c-internal-project-depends-on` key, if a dependency match is found, but the pattern does _not_ match (the vuln is not reachable), semgrep _will_ report a match, imitating the behavior that would occur if there had been no pattern at all. The fact that this was a dependency match but not a pattern match will be reported, see next point. This behavior has been requested by customers.
2. All matches from rules with the `r2c-internal-project-depends-on` key will include two new keys in the `extra` field of semgrep's JSON output:
    * `dependency_match_only`: will be `true` if the scenario in (1) occurs, and `false` otherwise (there was a pattern match _and_ a dependency match)
    * `dependency_matches`: will be a list of dependency matches of the following form:
        ```
        [
                  {
                    "dependency_pattern": {
                      "namespace": "cargo",
                      "package_name": "adler",
                      "semver_range": "<= 1.0.3"
                    },
                    "found_dependency": {
                      "allowed_hashes": {
                        "sha256": [
                          "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
                        ]
                      },
                      "name": "adler",
                      "namespace": "cargo",
                      "resolved_url": null,
                      "version": "1.0.2"
                    },
                    "lockfile": "cargo.lock"
                  }
         ]
        ```

Ideally the reported file in the case of (1) would be the offending lockfile. This is currently not possible because of the poor lockfile targeting situation, but should be doable soon, once that's implemented.

test plan: make test

A test that previously did not fire now (correctly) fires, and a comment has been updated to reflect this, so this functionality is now tested by existing tests.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
