### PR TITLE
Run tests from quick to slow, in parallel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,7 @@ jobs:
           unset CI
           unset "${!GITHUB_@}"
 
+          make check-markers
           pipenv run pytest --ignore=tests/qa/test_public_repos.py -n auto -vv --tb=short --durations=0 --snapshot-update tests/
       - name: Generate cheatsheets for semgrep.dev
         run: ./scripts/generate-cheatsheet

--- a/semgrep/Makefile
+++ b/semgrep/Makefile
@@ -1,8 +1,34 @@
+# Typecheck + run all the tests in arbitrary order.
+# See also 'all-tests'
+.PHONY: test
 test:
-	pipenv run pytest -v --tb=short tests/
+	$(MAKE) check
+	pipenv run pytest -v --tb=short --durations=10 tests
+
+# Run only the tests marked as quick (@pytest.mark.quick)
+# We have also 'kinda_slow' and 'slow'. See 'tox.ini', section 'pytest'.
+.PHONY: quick-tests
+quick-tests:
+	$(MAKE) check
+	pipenv run pytest -v --tb=short --durations=10 -m quick tests
+
+.PHONY: kinda-quick-tests
+kinda-quick-tests:
+	$(MAKE) quick-tests
+	pipenv run pytest -v --tb=short --durations=10 -m kinda_slow tests
+
+# Run all tests from quickest to slowest.
+# Warning: this won't run the tests that are not marked with @pytest.mark.XXX
+.PHONY: all-tests
+all-tests:
+	$(MAKE) kinda-quick-tests
+	pipenv run pytest -v --tb=short --durations=10 -m slow tests
+
+.PHONY:
 regenerate-tests:
 	pipenv run pytest tests/ --snapshot-update --ignore=tests/qa/test_public_repos.py
 
+.PHONY:
 setup:
 	pipenv install --dev
 

--- a/semgrep/Makefile
+++ b/semgrep/Makefile
@@ -6,6 +6,16 @@ test:
 	$(MAKE) kinda-quick-tests
 	$(PYTEST) -n auto -m 'not quick and not kinda_slow' tests
 
+.PHONY: check
+check:
+	pre-commit run -a mypy
+	$(MAKE) check-markers
+
+# Check that all the test_* functions are categorized by duration.
+.PHONY: check-markers
+check-markers:
+	./tests/check-markers tests
+
 # Run only the tests marked as quick (@pytest.mark.quick)
 # We have also 'kinda_slow' and 'slow'. See 'tox.ini', section 'pytest'.
 #
@@ -37,8 +47,3 @@ clean:
 	rm -rf .pytest_cache/ .benchmarks/
 	rm -f semgrep/bin/semgrep-core
 	rm -rf semgrep/__pycache__ semgrep/*/__pycache__
-
-.PHONY: check
-check:
-	pre-commit run -a mypy
-	#semgrep -pycheck .

--- a/semgrep/Makefile
+++ b/semgrep/Makefile
@@ -1,28 +1,22 @@
-# Typecheck + run all the tests in arbitrary order.
-# See also 'all-tests'
+PYTEST ?= pipenv run pytest -v --tb=short --durations=10
+
+# Typecheck and run all tests from quickest to slowest.
 .PHONY: test
 test:
-	$(MAKE) check
-	pipenv run pytest -v --tb=short --durations=10 tests
+	$(MAKE) kinda-quick-tests
+	$(PYTEST) -m 'not quick and not kinda_slow' tests
 
 # Run only the tests marked as quick (@pytest.mark.quick)
 # We have also 'kinda_slow' and 'slow'. See 'tox.ini', section 'pytest'.
 .PHONY: quick-tests
 quick-tests:
 	$(MAKE) check
-	pipenv run pytest -v --tb=short --durations=10 -m quick tests
+	$(PYTEST) -m quick tests
 
 .PHONY: kinda-quick-tests
 kinda-quick-tests:
 	$(MAKE) quick-tests
-	pipenv run pytest -v --tb=short --durations=10 -m kinda_slow tests
-
-# Run all tests from quickest to slowest.
-# Warning: this won't run the tests that are not marked with @pytest.mark.XXX
-.PHONY: all-tests
-all-tests:
-	$(MAKE) kinda-quick-tests
-	pipenv run pytest -v --tb=short --durations=10 -m slow tests
+	$(PYTEST) -m kinda_slow tests
 
 .PHONY:
 regenerate-tests:

--- a/semgrep/Makefile
+++ b/semgrep/Makefile
@@ -4,10 +4,13 @@ PYTEST ?= pipenv run pytest -v --tb=short --durations=10
 .PHONY: test
 test:
 	$(MAKE) kinda-quick-tests
-	$(PYTEST) -m 'not quick and not kinda_slow' tests
+	$(PYTEST) -n auto -m 'not quick and not kinda_slow' tests
 
 # Run only the tests marked as quick (@pytest.mark.quick)
 # We have also 'kinda_slow' and 'slow'. See 'tox.ini', section 'pytest'.
+#
+# '-n auto' parallelizes with too much overhead for the quick tests.
+#
 .PHONY: quick-tests
 quick-tests:
 	$(MAKE) check
@@ -16,11 +19,13 @@ quick-tests:
 .PHONY: kinda-quick-tests
 kinda-quick-tests:
 	$(MAKE) quick-tests
-	$(PYTEST) -m kinda_slow tests
+	$(PYTEST) -n auto -m kinda_slow tests
 
 .PHONY:
 regenerate-tests:
-	pipenv run pytest tests/ --snapshot-update --ignore=tests/qa/test_public_repos.py
+	pipenv run pytest -n auto \
+	  --snapshot-update --ignore=tests/qa/test_public_repos.py \
+	  tests
 
 .PHONY:
 setup:

--- a/semgrep/tests/check-markers
+++ b/semgrep/tests/check-markers
@@ -1,0 +1,26 @@
+#! /usr/bin/env bash
+#
+# Check that all the pytest tests are categorized by duration.
+#
+# Arguments (optional): pytest search root
+#
+set -eu
+
+echo "Checking that all tests are categorized by duration."
+
+# The pipenv command should select 0 tests.
+if pipenv run pytest --collect-only \
+   -m 'not quick and not kinda_slow and not slow' "$@"; \
+   [[ $? != 5 ]]; then
+  cat<<EOF
+*** The tests reported above are uncategorized.
+    Please apply one of the following decorators to the test_* functions:
+
+      @pytest.mark.quick       # test takes less than 100 ms
+      @pytest.mark.kinda_slow  # test takes up to 1 or 2 s
+      @pytest.mark.slow        # test takes more than 1 or 2 s
+EOF
+  exit 1
+else
+  echo "Nice."
+fi

--- a/semgrep/tests/consistency/test_lang_consistency.py
+++ b/semgrep/tests/consistency/test_lang_consistency.py
@@ -1,6 +1,8 @@
+import pytest
 from semgrep.semgrep_types import LANGUAGE
 
 
+@pytest.mark.quick
 def test_no_duplicate_keys() -> None:
     """
     Ensures one-to-one assumption of mapping from keys to language in lang.json
@@ -13,6 +15,7 @@ def test_no_duplicate_keys() -> None:
             keys.add(k)
 
 
+@pytest.mark.quick
 def test_no_duplicate_reverse_exts() -> None:
     """
     Ensures one-to-one assumption of mapping from reverse file extensions to language in lang.json

--- a/semgrep/tests/consistency/test_lang_consistency.py
+++ b/semgrep/tests/consistency/test_lang_consistency.py
@@ -1,4 +1,5 @@
 import pytest
+
 from semgrep.semgrep_types import LANGUAGE
 
 

--- a/semgrep/tests/e2e/test_api.py
+++ b/semgrep/tests/e2e/test_api.py
@@ -2,9 +2,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from semgrep.semgrep_main import invoke_semgrep
 
-
+@pytest.mark.slow
 def test_api(capsys, run_semgrep_in_tmp):
     # Test that exposed python API works and prints out nothing to stderr or stdout
     output = invoke_semgrep(

--- a/semgrep/tests/e2e/test_api.py
+++ b/semgrep/tests/e2e/test_api.py
@@ -6,6 +6,7 @@ import pytest
 
 from semgrep.semgrep_main import invoke_semgrep
 
+
 @pytest.mark.slow
 def test_api(capsys, run_semgrep_in_tmp):
     # Test that exposed python API works and prints out nothing to stderr or stdout

--- a/semgrep/tests/e2e/test_autofix.py
+++ b/semgrep/tests/e2e/test_autofix.py
@@ -64,8 +64,6 @@ def test_autofix(run_semgrep_in_tmp, snapshot, dryrun):
         ("rules/autofix/two-autofixes.yaml", "autofix/two-autofixes.txt"),
     ],
 )
-
-
 @pytest.mark.kinda_slow
 def test_regex_autofix(run_semgrep_in_tmp, snapshot, rule, target, dryrun):
     # Yes, this is fugly. I apologize. T_T

--- a/semgrep/tests/e2e/test_autofix.py
+++ b/semgrep/tests/e2e/test_autofix.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("dryrun", [True, False], ids=["dryrun", "not-dryrun"])
 def test_autofix(run_semgrep_in_tmp, snapshot, dryrun):
     snapshot.assert_match(
@@ -38,6 +39,7 @@ def test_autofix(run_semgrep_in_tmp, snapshot, dryrun):
         )
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("dryrun", [True, False], ids=["dryrun", "not-dryrun"])
 @pytest.mark.parametrize(
     "rule,target",
@@ -62,6 +64,9 @@ def test_autofix(run_semgrep_in_tmp, snapshot, dryrun):
         ("rules/autofix/two-autofixes.yaml", "autofix/two-autofixes.txt"),
     ],
 )
+
+
+@pytest.mark.kinda_slow
 def test_regex_autofix(run_semgrep_in_tmp, snapshot, rule, target, dryrun):
     # Yes, this is fugly. I apologize. T_T
     snapshot.assert_match(

--- a/semgrep/tests/e2e/test_baseline.py
+++ b/semgrep/tests/e2e/test_baseline.py
@@ -83,6 +83,7 @@ def run_sentinel_scan(check: bool = True, base_commit: Optional[str] = None):
         raise e
 
 
+@pytest.mark.kinda_slow
 def test_one_commit_with_baseline(git_tmp_path, snapshot):
     # Test that head having no change to base (git commit --allow-empty)
     # doesnt break semgrep
@@ -118,10 +119,12 @@ def test_one_commit_with_baseline(git_tmp_path, snapshot):
     )
 
 
+@pytest.mark.quick
 def test_symlink(git_tmp_path, snapshot):
     pass
 
 
+@pytest.mark.kinda_slow
 def test_no_findings_both(git_tmp_path, snapshot):
     # Test if no findings in head or base semgrep doesnt explode
     foo = git_tmp_path / "foo.py"
@@ -162,6 +165,7 @@ def test_no_findings_both(git_tmp_path, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_no_findings_head(git_tmp_path, snapshot):
     # Test that no findings in head reports no findings even if
     # findings in baseline
@@ -205,6 +209,7 @@ def test_no_findings_head(git_tmp_path, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_no_findings_baseline(git_tmp_path, snapshot):
     # Test when head contains all findings and baseline doesnt contain any
     foo = git_tmp_path / "foo.py"
@@ -246,6 +251,7 @@ def test_no_findings_baseline(git_tmp_path, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_some_intersection(git_tmp_path, snapshot):
     # Test when baseline contains some findings of head
     foo = git_tmp_path / "foo.py"
@@ -286,6 +292,7 @@ def test_some_intersection(git_tmp_path, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_all_intersect(git_tmp_path, snapshot):
     # Test when baseline and head contain same findings none are reported
     foo = git_tmp_path / "foo.py"
@@ -326,6 +333,7 @@ def test_all_intersect(git_tmp_path, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_no_intersection(git_tmp_path, snapshot):
     # If no intersection of baseline and head finding should still report head finding
     foo = git_tmp_path / "foo.py"
@@ -366,6 +374,7 @@ def test_no_intersection(git_tmp_path, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "new_name",
     [
@@ -411,14 +420,17 @@ def test_renamed_file(git_tmp_path, snapshot, new_name):
     }, "the old path should be gone now"
 
 
+@pytest.mark.quick
 def test_multiple_on_same_line(git_tmp_path, snapshot):
     pass
 
 
+@pytest.mark.quick
 def test_run_in_subdirectory(git_tmp_path, snapshot):
     pass
 
 
+@pytest.mark.kinda_slow
 def test_unstaged_changes(git_tmp_path, snapshot):
     # Should abort if have unstaged changes
     foo = git_tmp_path / "foo"
@@ -439,10 +451,12 @@ def test_unstaged_changes(git_tmp_path, snapshot):
     snapshot.assert_match(output.stderr, "error.txt")
 
 
+@pytest.mark.quick
 def test_baseline_has_head_untracked(git_tmp_path, snapshot):
     pass
 
 
+@pytest.mark.kinda_slow
 def test_not_git_directory(monkeypatch, tmp_path, snapshot):
     # Should abort baseline scan if not a git directory
     monkeypatch.chdir(tmp_path)
@@ -456,6 +470,7 @@ def test_not_git_directory(monkeypatch, tmp_path, snapshot):
     snapshot.assert_match(output.stderr, "error.txt")
 
 
+@pytest.mark.kinda_slow
 def test_commit_doesnt_exist(git_tmp_path, snapshot):
     # Should abort baseline scan if baseline is not valid commit
     foo = git_tmp_path / "foo"
@@ -472,6 +487,7 @@ def test_commit_doesnt_exist(git_tmp_path, snapshot):
     snapshot.assert_match(output.stderr, "error.txt")
 
 
+@pytest.mark.quick
 @pytest.fixture
 def git_tmp_path(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)

--- a/semgrep/tests/e2e/test_check.py
+++ b/semgrep/tests/e2e/test_check.py
@@ -15,10 +15,12 @@ GITHUB_TEST_GIST_URL = (
 )
 
 
+@pytest.mark.kinda_slow
 def test_basic_rule__local(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/eqeq.yaml")[0], "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_basic_rule__relative(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/../rules/eqeq.yaml")[0],
@@ -26,6 +28,7 @@ def test_basic_rule__relative(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_deduplication(run_semgrep_in_tmp, snapshot):
     """
     Check that semgrep runs a rule only once even when different in the metadata
@@ -38,6 +41,7 @@ def test_deduplication(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_noextension_filtering(run_semgrep_in_tmp, snapshot):
     """
     Check that semgrep does not filter out files without extensions when
@@ -51,6 +55,7 @@ def test_noextension_filtering(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_noextension_filtering_optimizations(run_semgrep_in_tmp, snapshot):
     """
     Check that semgrep does not filter out files without extensions when
@@ -66,6 +71,7 @@ def test_noextension_filtering_optimizations(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_script(run_semgrep_in_tmp, snapshot):
     """
     Validates that Semgrep scans scripts with matching shebangs
@@ -79,6 +85,7 @@ def test_script(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_basic_rule__absolute(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(Path.cwd() / "rules" / "eqeq.yaml")[0],
@@ -86,6 +93,7 @@ def test_basic_rule__absolute(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.slow
 def test_terminal_output(run_semgrep_in_tmp, snapshot):
     # Have shared settings file to test second run doesnt show metric output
     settings_file = tempfile.NamedTemporaryFile().name
@@ -110,6 +118,7 @@ def test_terminal_output(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(text_output[1], "error_second.txt")
 
 
+@pytest.mark.kinda_slow
 def test_terminal_output_quiet(run_semgrep_in_tmp, snapshot):
     """
     Quiet output should just have finding output
@@ -127,6 +136,7 @@ def test_terminal_output_quiet(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(text_output[1], "error.txt")
 
 
+@pytest.mark.kinda_slow
 def test_stdin_input(snapshot):
     process = subprocess.Popen(
         [
@@ -151,6 +161,7 @@ def test_stdin_input(snapshot):
     snapshot.assert_match(_clean_output_json(stdout), "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_subshell_input(snapshot):
     stdout = subprocess.check_output(
         [
@@ -163,6 +174,7 @@ def test_subshell_input(snapshot):
     snapshot.assert_match(_clean_output_json(stdout), "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_multi_subshell_input(snapshot):
     stdout = subprocess.check_output(
         [
@@ -175,6 +187,7 @@ def test_multi_subshell_input(snapshot):
     snapshot.assert_match(_clean_output_json(stdout), "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_multiline(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/eqeq.yaml", target_name="multiline")[0],
@@ -182,6 +195,7 @@ def test_multiline(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.slow
 def test_url_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(GITHUB_TEST_GIST_URL)[0],
@@ -189,6 +203,7 @@ def test_url_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.slow
 def test_registry_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("r2c")[0],
@@ -196,6 +211,7 @@ def test_registry_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.slow
 def test_auto_config(run_semgrep_in_tmp):
     # --config auto will change over time, so lets just make sure this doesn't error out
     # TODO: Mock config response for more detailed testing
@@ -204,10 +220,12 @@ def test_auto_config(run_semgrep_in_tmp):
     assert True
 
 
+@pytest.mark.kinda_slow
 def test_hidden_rule__explicit(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/hidden/.hidden")[0], "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_hidden_rule__implicit(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/hidden")[0]
@@ -220,11 +238,13 @@ def test_hidden_rule__implicit(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(excinfo.value.stderr, "error.txt")
 
 
+@pytest.mark.kinda_slow
 def test_default_rule__file(run_semgrep_in_tmp, snapshot):
     Path(".semgrep.yml").symlink_to(Path("rules/eqeq.yaml").resolve())
     snapshot.assert_match(run_semgrep_in_tmp()[0], "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_default_rule__folder(run_semgrep_in_tmp, snapshot):
     Path(".semgrep").mkdir()
     Path(".semgrep/.semgrep.yml").symlink_to(Path("rules/eqeq.yaml").resolve())
@@ -232,10 +252,12 @@ def test_default_rule__folder(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp()[0], "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__top(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/regex-top.yaml")[0], "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__utf8(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/regex-utf8.yaml", target_name="basic/regex-utf8.txt")[
@@ -245,6 +267,7 @@ def test_regex_rule__utf8(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__utf8_on_image(run_semgrep_in_tmp, snapshot):
     # https://github.com/returntocorp/semgrep/issues/4258
     snapshot.assert_match(
@@ -253,12 +276,14 @@ def test_regex_rule__utf8_on_image(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__child(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/regex-child.yaml")[0], "results.json"
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__not(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -268,6 +293,7 @@ def test_regex_rule__not(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__not2(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -278,6 +304,7 @@ def test_regex_rule__not2(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__pattern_regex_and_pattern_not_regex(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -288,6 +315,7 @@ def test_regex_rule__pattern_regex_and_pattern_not_regex(run_semgrep_in_tmp, sna
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__issue2465(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -298,6 +326,7 @@ def test_regex_rule__issue2465(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__invalid_expression(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/regex-invalid.yaml")[0]
@@ -306,24 +335,28 @@ def test_regex_rule__invalid_expression(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(excinfo.value.stdout, "error.json")
 
 
+@pytest.mark.kinda_slow
 def test_nested_patterns_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/nested-patterns.yaml")[0], "results.json"
     )
 
 
+@pytest.mark.kinda_slow
 def test_nested_pattern_either_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/nested-pattern-either.yaml")[0], "results.json"
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_regex_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-regex.yaml")[0], "results.json"
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_regex_multi_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-regex-multi-rule.yaml")[0],
@@ -331,6 +364,7 @@ def test_metavariable_regex_multi_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_multi_regex_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-regex-multi-regex.yaml")[0],
@@ -338,6 +372,7 @@ def test_metavariable_multi_regex_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_with_any_language_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -347,6 +382,7 @@ def test_regex_with_any_language_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_with_any_language_multiple_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -357,6 +393,7 @@ def test_regex_with_any_language_multiple_rule(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_invalid_regex_with_any_language_rule(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp(
@@ -368,6 +405,7 @@ def test_invalid_regex_with_any_language_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(excinfo.value.stdout, "error.json")
 
 
+@pytest.mark.kinda_slow
 def test_regex_with_any_language_rule_none_alias(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -378,6 +416,7 @@ def test_regex_with_any_language_rule_none_alias(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_regex_with_any_language_multiple_rule_none_alias(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -388,6 +427,7 @@ def test_regex_with_any_language_multiple_rule_none_alias(run_semgrep_in_tmp, sn
     )
 
 
+@pytest.mark.slow
 def test_timeout(run_semgrep_in_tmp, snapshot):
     # Check that semgrep-core timeouts are properly handled
 
@@ -402,6 +442,7 @@ def test_timeout(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.slow
 def test_spacegrep_timeout(run_semgrep_in_tmp, snapshot):
     # Check that spacegrep timeouts are handled gracefully.
     #
@@ -430,6 +471,7 @@ def test_spacegrep_timeout(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(stderr, "error.txt")
 
 
+@pytest.mark.kinda_slow
 def test_max_memory(run_semgrep_in_tmp, snapshot):
     stdout, stderr = run_semgrep_in_tmp(
         "rules/long.yaml",
@@ -441,6 +483,7 @@ def test_max_memory(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(stderr, "error.txt")
 
 
+@pytest.mark.slow
 def test_stack_size(run_semgrep_in_tmp, snapshot):
     """
     Verify that semgrep raises the soft stack limit if possible
@@ -483,6 +526,7 @@ def test_stack_size(run_semgrep_in_tmp, snapshot):
     assert "Stack overflow" not in output.stderr
 
 
+@pytest.mark.slow
 def test_timeout_threshold(run_semgrep_in_tmp, snapshot):
     results = run_semgrep_in_tmp(
         "rules/multiple-long.yaml",
@@ -520,18 +564,21 @@ def test_timeout_threshold(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_comparison_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-comparison.yaml")[0], "results.json"
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_comparison_rule_base(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-comparison-base.yaml")[0], "results.json"
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_comparison_rule_strip(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-comparison-strip.yaml")[0],
@@ -539,6 +586,7 @@ def test_metavariable_comparison_rule_strip(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_comparison_rule_bad_content(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/metavariable-comparison-bad-content.yaml")[0],
@@ -546,6 +594,7 @@ def test_metavariable_comparison_rule_bad_content(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_multiple_configs_file(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(["rules/eqeq.yaml", "rules/eqeq-python.yaml"])[0],
@@ -553,12 +602,14 @@ def test_multiple_configs_file(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.slow
 def test_multiple_configs_different_origins(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(["rules/eqeq.yaml", GITHUB_TEST_GIST_URL])[0], "results.json"
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_propagation_regex(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -569,6 +620,7 @@ def test_metavariable_propagation_regex(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_metavariable_propagation_comparison(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -579,6 +631,7 @@ def test_metavariable_propagation_comparison(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_taint_mode(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -589,6 +642,7 @@ def test_taint_mode(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_deduplication_same_message(run_semgrep_in_tmp, snapshot):
     """
     With same message, should deduplicate and only have one finding
@@ -602,6 +656,7 @@ def test_deduplication_same_message(run_semgrep_in_tmp, snapshot):
     assert len(json_output["results"]) == 1
 
 
+@pytest.mark.kinda_slow
 def test_deduplication_different_message(run_semgrep_in_tmp, snapshot):
     output, _ = run_semgrep_in_tmp(
         "rules/deduplication/duplication-different-message.yaml",
@@ -612,6 +667,7 @@ def test_deduplication_different_message(run_semgrep_in_tmp, snapshot):
     assert len(json_output["results"]) == 2
 
 
+@pytest.mark.kinda_slow
 def test_pattern_regex_empty_file(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -622,6 +678,7 @@ def test_pattern_regex_empty_file(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.slow
 def test_cdn_ruleset_resolution(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("p/ci")[0],
@@ -629,6 +686,7 @@ def test_cdn_ruleset_resolution(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_inventory_finding_output(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(

--- a/semgrep/tests/e2e/test_ci.py
+++ b/semgrep/tests/e2e/test_ci.py
@@ -168,6 +168,7 @@ def ci_mocks(base_commit, autofix):
                         yield
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("autofix", [True, False], ids=["autofix", "noautofix"])
 @pytest.mark.parametrize(
     "env",
@@ -325,6 +326,7 @@ def test_full_run(tmp_path, git_tmp_path_with_commit, snapshot, env, autofix):
             snapshot.assert_match(json.dumps(complete_json, indent=4), "complete.json")
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("autofix", [True, False], ids=["autofix", "noautofix"])
 def test_config_run(tmp_path, git_tmp_path_with_commit, snapshot, autofix):
     repo_base, base_commit, head_commit = git_tmp_path_with_commit
@@ -346,6 +348,7 @@ def test_config_run(tmp_path, git_tmp_path_with_commit, snapshot, autofix):
         snapshot.assert_match(sanitized_output, "output.txt")
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("autofix", [True, False], ids=["autofix", "noautofix"])
 def test_dryrun(tmp_path, git_tmp_path_with_commit, snapshot, autofix):
     repo_base, base_commit, head_commit = git_tmp_path_with_commit

--- a/semgrep/tests/e2e/test_cli_test.py
+++ b/semgrep/tests/e2e/test_cli_test.py
@@ -1,8 +1,10 @@
+import pytest
+
 from tests.conftest import _mask_floats
 
 from semgrep.constants import OutputFormat
 
-
+@pytest.mark.kinda_slow
 def test_cli_test_basic(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -16,7 +18,7 @@ def test_cli_test_basic(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_cli_test_verbose(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -31,7 +33,7 @@ def test_cli_test_verbose(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_cli_test_time(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -46,7 +48,7 @@ def test_cli_test_time(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_timeout(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/error/",
@@ -59,7 +61,7 @@ def test_timeout(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_cli_test_yaml_language(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/language/",
@@ -72,7 +74,7 @@ def test_cli_test_yaml_language(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_cli_test_show_supported_languages(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -86,7 +88,7 @@ def test_cli_test_show_supported_languages(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_cli_test_suffixes(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/suffixes/",
@@ -99,7 +101,7 @@ def test_cli_test_suffixes(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_cli_test_multiline_annotations(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
         "rules/cli_test/multiple_annotations/",
@@ -113,7 +115,7 @@ def test_cli_test_multiline_annotations(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
-
+@pytest.mark.kinda_slow
 def test_parse_errors(run_semgrep_in_tmp, snapshot):
     _results, errors = run_semgrep_in_tmp(
         "rules/cli_test/parse_errors/",

--- a/semgrep/tests/e2e/test_cli_test.py
+++ b/semgrep/tests/e2e/test_cli_test.py
@@ -1,8 +1,8 @@
 import pytest
-
 from tests.conftest import _mask_floats
 
 from semgrep.constants import OutputFormat
+
 
 @pytest.mark.kinda_slow
 def test_cli_test_basic(run_semgrep_in_tmp, snapshot):
@@ -17,6 +17,7 @@ def test_cli_test_basic(run_semgrep_in_tmp, snapshot):
         results,
         "results.json",
     )
+
 
 @pytest.mark.kinda_slow
 def test_cli_test_verbose(run_semgrep_in_tmp, snapshot):
@@ -33,6 +34,7 @@ def test_cli_test_verbose(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
+
 @pytest.mark.kinda_slow
 def test_cli_test_time(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
@@ -48,6 +50,7 @@ def test_cli_test_time(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
+
 @pytest.mark.kinda_slow
 def test_timeout(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
@@ -61,6 +64,7 @@ def test_timeout(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
+
 @pytest.mark.kinda_slow
 def test_cli_test_yaml_language(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
@@ -73,6 +77,7 @@ def test_cli_test_yaml_language(run_semgrep_in_tmp, snapshot):
         results,
         "results.json",
     )
+
 
 @pytest.mark.kinda_slow
 def test_cli_test_show_supported_languages(run_semgrep_in_tmp, snapshot):
@@ -88,6 +93,7 @@ def test_cli_test_show_supported_languages(run_semgrep_in_tmp, snapshot):
         "results.json",
     )
 
+
 @pytest.mark.kinda_slow
 def test_cli_test_suffixes(run_semgrep_in_tmp, snapshot):
     results, _ = run_semgrep_in_tmp(
@@ -100,6 +106,7 @@ def test_cli_test_suffixes(run_semgrep_in_tmp, snapshot):
         results,
         "results.json",
     )
+
 
 @pytest.mark.kinda_slow
 def test_cli_test_multiline_annotations(run_semgrep_in_tmp, snapshot):
@@ -114,6 +121,7 @@ def test_cli_test_multiline_annotations(run_semgrep_in_tmp, snapshot):
         results,
         "results.json",
     )
+
 
 @pytest.mark.kinda_slow
 def test_parse_errors(run_semgrep_in_tmp, snapshot):

--- a/semgrep/tests/e2e/test_dependency_aware_rules.py
+++ b/semgrep/tests/e2e/test_dependency_aware_rules.py
@@ -1,6 +1,6 @@
 import pytest
 
-
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule,target",
     [
@@ -27,6 +27,7 @@ def test_dependency_aware_rules(run_semgrep_in_tmp, snapshot, rule, target):
     )
 
 
+@pytest.mark.kinda_slow
 def test_explicit_lockfile_target(run_semgrep_in_tmp, snapshot):
     # We expect no results, because we explicitly passed a folder containing
     # a lockfile which does NOT contain the vulnerable dependency that this rule searches for

--- a/semgrep/tests/e2e/test_dependency_aware_rules.py
+++ b/semgrep/tests/e2e/test_dependency_aware_rules.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule,target",

--- a/semgrep/tests/e2e/test_dump_ast.py
+++ b/semgrep/tests/e2e/test_dump_ast.py
@@ -1,3 +1,6 @@
+import pytest
+
+@pytest.mark.kinda_slow
 def test_dump_ast(run_semgrep_in_tmp, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/eqeq.yaml",
@@ -7,6 +10,7 @@ def test_dump_ast(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(stdout, "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_dump_ast_no_lang(run_semgrep_in_tmp, snapshot):
     _, stderr = run_semgrep_in_tmp(
         "rules/eqeq.yaml",

--- a/semgrep/tests/e2e/test_dump_ast.py
+++ b/semgrep/tests/e2e/test_dump_ast.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.kinda_slow
 def test_dump_ast(run_semgrep_in_tmp, snapshot):
     stdout, _ = run_semgrep_in_tmp(

--- a/semgrep/tests/e2e/test_exclude_include.py
+++ b/semgrep/tests/e2e/test_exclude_include.py
@@ -5,6 +5,7 @@ def idfn(options):
     return "-and-".join(flag.strip("-") for flag in options if flag.startswith("--"))
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "options",
     [

--- a/semgrep/tests/e2e/test_generate_config.py
+++ b/semgrep/tests/e2e/test_generate_config.py
@@ -1,7 +1,9 @@
+import pytest
 import subprocess
 import sys
 
 
+@pytest.mark.kinda_slow
 def test_generate_config(run_semgrep_in_tmp):
     subprocess.check_output(
         [

--- a/semgrep/tests/e2e/test_generate_config.py
+++ b/semgrep/tests/e2e/test_generate_config.py
@@ -1,6 +1,7 @@
-import pytest
 import subprocess
 import sys
+
+import pytest
 
 
 @pytest.mark.kinda_slow

--- a/semgrep/tests/e2e/test_ignores.py
+++ b/semgrep/tests/e2e/test_ignores.py
@@ -1,3 +1,4 @@
+import pytest
 import subprocess
 from pathlib import Path
 
@@ -5,6 +6,7 @@ from ..conftest import _clean_output_json
 from ..conftest import TESTS_PATH
 
 
+@pytest.mark.kinda_slow
 def test_semgrepignore(run_semgrep_in_tmp, tmp_path, snapshot):
     (tmp_path / ".semgrepignore").symlink_to(
         Path(TESTS_PATH / "e2e" / "targets" / "ignores" / ".semgrepignore").resolve()
@@ -17,6 +19,7 @@ def test_semgrepignore(run_semgrep_in_tmp, tmp_path, snapshot):
 
 
 # We provide no .semgrepignore but everything except find.js should still be ignored
+@pytest.mark.kinda_slow
 def test_default_semgrepignore(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/eqeq-basic.yaml", target_name="ignores_default")[0],
@@ -25,6 +28,7 @@ def test_default_semgrepignore(run_semgrep_in_tmp, snapshot):
 
 
 # Input from stdin will not have a path that is relative to tmp_path, where we're running semgrep
+@pytest.mark.kinda_slow
 def test_file_not_relative_to_base_path(tmp_path, monkeypatch, snapshot):
     (tmp_path / ".semgrepignore").symlink_to(
         Path(TESTS_PATH / "e2e" / "targets" / "ignores" / ".semgrepignore").resolve()
@@ -53,6 +57,7 @@ def test_file_not_relative_to_base_path(tmp_path, monkeypatch, snapshot):
     snapshot.assert_match(_clean_output_json(stdout), "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_internal_explicit_semgrepignore(run_semgrep_in_tmp, tmp_path, snapshot):
 
     (tmp_path / ".semgrepignore").symlink_to(

--- a/semgrep/tests/e2e/test_ignores.py
+++ b/semgrep/tests/e2e/test_ignores.py
@@ -1,6 +1,7 @@
-import pytest
 import subprocess
 from pathlib import Path
+
+import pytest
 
 from ..conftest import _clean_output_json
 from ..conftest import TESTS_PATH

--- a/semgrep/tests/e2e/test_join_rules.py
+++ b/semgrep/tests/e2e/test_join_rules.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "rule,target",
     [
@@ -25,6 +26,7 @@ def test_join_rules(run_semgrep_in_tmp, snapshot, rule, target):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "rule,target",
     [

--- a/semgrep/tests/e2e/test_log_file.py
+++ b/semgrep/tests/e2e/test_log_file.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.kinda_slow
 def test_last_log_exists(run_semgrep_in_tmp, tmp_path, snapshot):
     log_dest = tmp_path / "foo" / "bar" / "last.log"
     run_semgrep_in_tmp("rules/eqeq.yaml", env={"SEMGREP_LOG_FILE": str(log_dest)})

--- a/semgrep/tests/e2e/test_login.py
+++ b/semgrep/tests/e2e/test_login.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -7,6 +9,7 @@ from semgrep.commands.login import Authentication
 from semgrep.constants import SEMGREP_SETTING_ENVVAR_NAME
 
 
+@pytest.mark.slow
 def test_login(tmp_path):
     runner = CliRunner(env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)})
 

--- a/semgrep/tests/e2e/test_login.py
+++ b/semgrep/tests/e2e/test_login.py
@@ -1,7 +1,6 @@
-import pytest
-
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from semgrep.cli import cli

--- a/semgrep/tests/e2e/test_max_target_bytes.py
+++ b/semgrep/tests/e2e/test_max_target_bytes.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize("max_bytes", ["1MB", "1B", "1.3R"])
 def test_max_target_bytes(run_semgrep_in_tmp, snapshot, max_bytes):

--- a/semgrep/tests/e2e/test_max_target_bytes.py
+++ b/semgrep/tests/e2e/test_max_target_bytes.py
@@ -1,6 +1,6 @@
 import pytest
 
-
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("max_bytes", ["1MB", "1B", "1.3R"])
 def test_max_target_bytes(run_semgrep_in_tmp, snapshot, max_bytes):
     stdout, stderr = run_semgrep_in_tmp(

--- a/semgrep/tests/e2e/test_message_interpolation.py
+++ b/semgrep/tests/e2e/test_message_interpolation.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule,target",
     [

--- a/semgrep/tests/e2e/test_metavariable_matching.py
+++ b/semgrep/tests/e2e/test_metavariable_matching.py
@@ -1,3 +1,6 @@
+import pytest
+
+@pytest.mark.kinda_slow
 def test_equivalence(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/inside.yaml", target_name="basic")[0],

--- a/semgrep/tests/e2e/test_metavariable_matching.py
+++ b/semgrep/tests/e2e/test_metavariable_matching.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.kinda_slow
 def test_equivalence(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -48,6 +48,7 @@ def mock_config_request(monkeypatch: MonkeyPatch) -> Iterator[None]:
     yield
 
 
+@pytest.mark.kinda_slow
 @mark.parametrize(
     "config,options,env,should_send",
     [
@@ -130,6 +131,7 @@ def test_flags(
     )
 
 
+@pytest.mark.kinda_slow
 @mark.parametrize(
     "config,options,env",
     [
@@ -152,6 +154,7 @@ def test_flags_actual_send(
     assert "Failed to send pseudonymous metrics" not in output
 
 
+@pytest.mark.slow
 def test_legacy_flags(run_semgrep_in_tmp):
     """
     Test metrics sending respects legacy flags. Flags take precedence over envvar

--- a/semgrep/tests/e2e/test_missing_file.py
+++ b/semgrep/tests/e2e/test_missing_file.py
@@ -3,6 +3,7 @@ from subprocess import CalledProcessError
 import pytest
 
 
+@pytest.mark.kinda_slow
 def test_missing_file(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/nosem.yaml", target_name="stupid-does-not-exist.p")

--- a/semgrep/tests/e2e/test_multi_config_fail.py
+++ b/semgrep/tests/e2e/test_multi_config_fail.py
@@ -1,7 +1,9 @@
+import pytest
 import subprocess
 
 
 # Running semgrep with multiple configs should fail fast if any of them have errors
+@pytest.mark.kinda_slow
 def test_multi_config_fail(run_semgrep_in_tmp):
     try:
         run_semgrep_in_tmp(

--- a/semgrep/tests/e2e/test_multi_config_fail.py
+++ b/semgrep/tests/e2e/test_multi_config_fail.py
@@ -1,5 +1,6 @@
-import pytest
 import subprocess
+
+import pytest
 
 
 # Running semgrep with multiple configs should fail fast if any of them have errors

--- a/semgrep/tests/e2e/test_nosemgrep.py
+++ b/semgrep/tests/e2e/test_nosemgrep.py
@@ -3,6 +3,7 @@ from subprocess import CalledProcessError
 import pytest
 
 
+@pytest.mark.kinda_slow
 def test_regex_rule__nosemgrep(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -12,10 +13,12 @@ def test_regex_rule__nosemgrep(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_nosem_rule(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(run_semgrep_in_tmp("rules/nosem.yaml")[0], "results.json")
 
 
+@pytest.mark.kinda_slow
 def test_nosem_rule_unicode(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(
@@ -25,6 +28,7 @@ def test_nosem_rule_unicode(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_nosem_rule__invalid_id(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/nosem.yaml", target_name="nosem_invalid_id")
@@ -33,6 +37,7 @@ def test_nosem_rule__invalid_id(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(excinfo.value.stdout, "error.json")
 
 
+@pytest.mark.kinda_slow
 def test_nosem_rule__with_disable_nosem(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/nosem.yaml", options=["--disable-nosem"])[0],

--- a/semgrep/tests/e2e/test_output.py
+++ b/semgrep/tests/e2e/test_output.py
@@ -16,6 +16,7 @@ from semgrep.constants import OutputFormat
 
 
 # https://stackoverflow.com/a/10077069
+@pytest.mark.kinda_slow
 def _etree_to_dict(t):
     """
     A simple and sufficient XML -> dict conversion function. This function is
@@ -41,6 +42,7 @@ def _etree_to_dict(t):
     return d
 
 
+@pytest.mark.kinda_slow
 def _clean_sarif_output(output):
     # Rules are logically a set so the JSON list's order doesn't matter
     # we make the order deterministic here so that snapshots match across runs
@@ -66,6 +68,7 @@ CLEANERS: Mapping[str, Callable[[str], str]] = {
 }
 
 
+@pytest.mark.kinda_slow
 def test_output_highlighting(run_semgrep_in_tmp, snapshot):
     results, _errors = run_semgrep_in_tmp(
         "rules/cli_test/basic/",
@@ -81,6 +84,7 @@ def test_output_highlighting(run_semgrep_in_tmp, snapshot):
 
 
 # junit-xml is tested in a test_junit_xml_output due to ambiguous XML attribute ordering
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "format",
     ["--json", "--gitlab-sast", "--gitlab-secrets", "--sarif", "--emacs", "--vim"],
@@ -96,6 +100,7 @@ def test_output_format(run_semgrep_in_tmp, snapshot, format):
     snapshot.assert_match(clean, "results.out")
 
 
+@pytest.mark.kinda_slow
 def test_omit_inventory(run_semgrep_in_tmp, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/inventory/invent.yaml", target_name="inventory/invent.py"
@@ -103,6 +108,7 @@ def test_omit_inventory(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(stdout, "results.out")
 
 
+@pytest.mark.kinda_slow
 def test_junit_xml_output(run_semgrep_in_tmp, snapshot):
     output, _ = run_semgrep_in_tmp(
         "rules/eqeq.yaml", output_format=OutputFormat.JUNIT_XML
@@ -117,6 +123,7 @@ def test_junit_xml_output(run_semgrep_in_tmp, snapshot):
 
 # If there are nosemgrep comments to ignore findings, SARIF output should include them
 # labeled as suppressed.
+@pytest.mark.kinda_slow
 def test_sarif_output_include_nosemgrep(run_semgrep_in_tmp, snapshot):
     sarif_output = json.loads(
         run_semgrep_in_tmp(
@@ -133,6 +140,7 @@ def test_sarif_output_include_nosemgrep(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_sarif_output_with_source(run_semgrep_in_tmp, snapshot):
     sarif_output = json.loads(
         run_semgrep_in_tmp("rules/eqeq-source.yml", output_format=OutputFormat.SARIF)[0]
@@ -149,6 +157,7 @@ def test_sarif_output_with_source(run_semgrep_in_tmp, snapshot):
         assert rule.get("helpUri", None) is not None
 
 
+@pytest.mark.kinda_slow
 def test_sarif_output_with_source_edit(run_semgrep_in_tmp, snapshot):
     sarif_output = json.loads(
         run_semgrep_in_tmp("rules/eqeq-meta.yaml", output_format=OutputFormat.SARIF)[0]
@@ -165,6 +174,7 @@ def test_sarif_output_with_source_edit(run_semgrep_in_tmp, snapshot):
         assert rule.get("help", None) is not None
 
 
+@pytest.mark.kinda_slow
 def test_sarif_output_with_nosemgrep_and_error(run_semgrep_in_tmp, snapshot):
     sarif_output = json.loads(
         run_semgrep_in_tmp(
@@ -188,6 +198,7 @@ IGNORE_LOG_REPORT_LAST_LINE = (
 )
 
 
+@pytest.mark.kinda_slow
 def test_semgrepignore_ignore_log_report(run_semgrep_in_tmp, tmp_path, snapshot):
     (tmp_path / ".semgrepignore").symlink_to(
         Path(TESTS_PATH / "e2e" / "targets" / "ignores" / ".semgrepignore").resolve()
@@ -223,6 +234,7 @@ def test_semgrepignore_ignore_log_report(run_semgrep_in_tmp, tmp_path, snapshot)
     snapshot.assert_match(report.group(), "report.txt")
 
 
+@pytest.mark.kinda_slow
 def test_semgrepignore_ignore_log_json_report(run_semgrep_in_tmp, tmp_path, snapshot):
     (tmp_path / ".semgrepignore").symlink_to(
         Path(TESTS_PATH / "e2e" / "targets" / "ignores" / ".semgrepignore").resolve()

--- a/semgrep/tests/e2e/test_paths.py
+++ b/semgrep/tests/e2e/test_paths.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.kinda_slow
 def test_paths(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp("rules/paths.yaml", target_name="exclude_include")[0],

--- a/semgrep/tests/e2e/test_performance.py
+++ b/semgrep/tests/e2e/test_performance.py
@@ -1,6 +1,8 @@
+import pytest
 import time
 
 
+@pytest.mark.slow
 def test_debug_performance(run_semgrep_in_tmp):
     """
     Verify that running semgrep with --debug does not result in

--- a/semgrep/tests/e2e/test_performance.py
+++ b/semgrep/tests/e2e/test_performance.py
@@ -1,5 +1,6 @@
-import pytest
 import time
+
+import pytest
 
 
 @pytest.mark.slow

--- a/semgrep/tests/e2e/test_publish.py
+++ b/semgrep/tests/e2e/test_publish.py
@@ -1,8 +1,7 @@
-import pytest
-
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 from tests.conftest import TESTS_PATH
 

--- a/semgrep/tests/e2e/test_publish.py
+++ b/semgrep/tests/e2e/test_publish.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,6 +11,7 @@ from semgrep.commands.login import Authentication
 from semgrep.constants import SEMGREP_SETTING_ENVVAR_NAME
 
 
+@pytest.mark.kinda_slow
 def test_publish(tmp_path):
     runner = CliRunner(env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)})
 

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -15,11 +15,13 @@ syntax_fails = [
 ]
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("filename", syntax_passes)
 def test_rule_parser__success(run_semgrep_in_tmp, snapshot, filename):
     run_semgrep_in_tmp(f"rules/syntax/{filename}.yaml")
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("filename", syntax_fails)
 def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
     with pytest.raises(CalledProcessError) as excinfo:
@@ -28,12 +30,14 @@ def test_rule_parser__failure(run_semgrep_in_tmp, snapshot, filename):
     snapshot.assert_match(str(excinfo.value.returncode), "returncode.txt")
 
 
+@pytest.mark.kinda_slow
 def test_regex_with_bad_language(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp("rules/badlanguage.yaml")
     assert excinfo.value.returncode != 0
 
 
+@pytest.mark.kinda_slow
 def test_rule_parser__empty(run_semgrep_in_tmp, snapshot):
     with pytest.raises(CalledProcessError) as excinfo:
         run_semgrep_in_tmp(f"rules/syntax/empty.yaml")
@@ -41,6 +45,7 @@ def test_rule_parser__empty(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(str(excinfo.value.returncode), "returncode.txt")
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize("filename", syntax_fails)
 def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):
     with pytest.raises(CalledProcessError) as excinfo:
@@ -67,6 +72,7 @@ def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, file
 
 
 # https://github.com/returntocorp/semgrep/issues/1095
+@pytest.mark.kinda_slow
 def test_rule_parser_cli_pattern(run_semgrep_in_tmp, snapshot):
     # Check json output
     with pytest.raises(CalledProcessError) as excinfo:

--- a/semgrep/tests/e2e/test_rule_validation.py
+++ b/semgrep/tests/e2e/test_rule_validation.py
@@ -4,6 +4,7 @@ from subprocess import CalledProcessError
 import pytest
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule,target",
     [

--- a/semgrep/tests/e2e/test_semgrep_core_parse_error.py
+++ b/semgrep/tests/e2e/test_semgrep_core_parse_error.py
@@ -3,6 +3,7 @@ import pytest
 from semgrep.constants import OutputFormat
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "filename",
     [

--- a/semgrep/tests/e2e/test_semgrep_rules_repo.py
+++ b/semgrep/tests/e2e/test_semgrep_rules_repo.py
@@ -17,6 +17,7 @@ def _fail_subprocess_on_error(cmd):
         pytest.fail(f"Failed running cmd={cmd}" + output.stdout + output.stderr)
 
 
+@pytest.mark.slow
 def test_semgrep_rules_repo(run_semgrep_in_tmp):
     subprocess.check_output(
         ["git", "clone", "--depth=1", "https://github.com/returntocorp/semgrep-rules"]

--- a/semgrep/tests/e2e/test_severity.py
+++ b/semgrep/tests/e2e/test_severity.py
@@ -1,3 +1,6 @@
+import pytest
+
+@pytest.mark.kinda_slow
 def test_severity_error(run_semgrep_in_tmp, snapshot):
     json_str = run_semgrep_in_tmp("rules/inside.yaml", options=["--severity", "ERROR"])[
         0
@@ -7,6 +10,7 @@ def test_severity_error(run_semgrep_in_tmp, snapshot):
     assert '"severity": "WARNING"' not in json_str
 
 
+@pytest.mark.kinda_slow
 def test_severity_info(run_semgrep_in_tmp, snapshot):
     # Shouldn't return errors or results, since inside.yaml has 'severity: ERROR'
     snapshot.assert_match(
@@ -15,6 +19,7 @@ def test_severity_info(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_severity_warning(run_semgrep_in_tmp, snapshot):
     # Shouldn't return errors or results, since inside.yaml has 'severity: ERROR'
     snapshot.assert_match(
@@ -23,6 +28,7 @@ def test_severity_warning(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_severity_multiple(run_semgrep_in_tmp, snapshot):
     # Shouldn't return errors or results, since inside.yaml has 'severity: ERROR'
     # Differs from the two preceding tests in that we're testing adding multiple severity strings

--- a/semgrep/tests/e2e/test_severity.py
+++ b/semgrep/tests/e2e/test_severity.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.kinda_slow
 def test_severity_error(run_semgrep_in_tmp, snapshot):
     json_str = run_semgrep_in_tmp("rules/inside.yaml", options=["--severity", "ERROR"])[

--- a/semgrep/tests/e2e/test_spacegrep.py
+++ b/semgrep/tests/e2e/test_spacegrep.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule,target",
     [
@@ -19,6 +20,7 @@ def test_spacegrep(run_semgrep_in_tmp, snapshot, rule, target):
     )
 
 
+@pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "rule,target",
     [

--- a/semgrep/tests/e2e/test_synthesize_patterns.py
+++ b/semgrep/tests/e2e/test_synthesize_patterns.py
@@ -1,7 +1,9 @@
 import json
+import pytest
 import subprocess
 
 
+@pytest.mark.kinda_slow
 def test_synthesize_patterns():
     output = subprocess.check_output(
         [

--- a/semgrep/tests/e2e/test_synthesize_patterns.py
+++ b/semgrep/tests/e2e/test_synthesize_patterns.py
@@ -1,6 +1,7 @@
 import json
-import pytest
 import subprocess
+
+import pytest
 
 
 @pytest.mark.kinda_slow

--- a/semgrep/tests/e2e/test_version.py
+++ b/semgrep/tests/e2e/test_version.py
@@ -1,7 +1,9 @@
+import pytest
 import re
 import subprocess
 
 
+@pytest.mark.kinda_slow
 def test_version():
     result = subprocess.check_output(
         ["semgrep", "--version", "--disable-version-check"], encoding="utf-8"

--- a/semgrep/tests/e2e/test_version.py
+++ b/semgrep/tests/e2e/test_version.py
@@ -1,6 +1,7 @@
-import pytest
 import re
 import subprocess
+
+import pytest
 
 
 @pytest.mark.kinda_slow

--- a/semgrep/tests/qa/test_public_repos.py
+++ b/semgrep/tests/qa/test_public_repos.py
@@ -174,6 +174,7 @@ def _github_repo(repo_url: str, sha: Optional[str], repo_destination: Path):
     return repo_destination
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("repo_object", ALL_REPOS)
 #
 # This test runs [which checks?] against one public git repo.

--- a/semgrep/tests/unit/targeting/test_exclude.py
+++ b/semgrep/tests/unit/targeting/test_exclude.py
@@ -28,6 +28,7 @@ CANDIDATE_NAMES = [
 CANDIDATES = frozenset(Path(name) for name in CANDIDATE_NAMES)
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "patterns, expected_kept",
     [
@@ -206,6 +207,7 @@ EQUIVALENT_PATTERNS = [
 ]
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize("pattern_variant", EQUIVALENT_PATTERNS)
 def test_filter_exclude__equivalent_variants(pattern_variant):
     """Test some different variations of the pattern yield the same result."""

--- a/semgrep/tests/unit/targeting/test_include.py
+++ b/semgrep/tests/unit/targeting/test_include.py
@@ -28,6 +28,7 @@ CANDIDATE_NAMES = [
 CANDIDATES = frozenset(Path(name) for name in CANDIDATE_NAMES)
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "patterns, expected_kept",
     [
@@ -144,6 +145,7 @@ EQUIVALENT_PATTERNS = [
 ]
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize("pattern_variant", EQUIVALENT_PATTERNS)
 def test_filter_include__equivalent_variants(pattern_variant):
     """Test some different variations of the pattern yield the same result."""

--- a/semgrep/tests/unit/targeting/test_size_limit.py
+++ b/semgrep/tests/unit/targeting/test_size_limit.py
@@ -6,6 +6,7 @@ import pytest
 from semgrep.target_manager import TargetManager
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "size_limit,should_skip",
     [

--- a/semgrep/tests/unit/targeting/test_target_manager.py
+++ b/semgrep/tests/unit/targeting/test_target_manager.py
@@ -13,6 +13,7 @@ from semgrep.target_manager import Target
 from semgrep.target_manager import TargetManager
 
 
+@pytest.mark.quick
 def test_nonexistent(tmp_path, monkeypatch):
     """
     Test that initializing TargetManager with targets that do not exist
@@ -33,6 +34,7 @@ def test_nonexistent(tmp_path, monkeypatch):
     assert e.value.paths == (Path("foo/doesntexist.py"),)
 
 
+@pytest.mark.quick
 def test_delete_git(tmp_path, monkeypatch):
     """
     Check that deleted files are not included in expanded targets
@@ -53,6 +55,7 @@ def test_delete_git(tmp_path, monkeypatch):
     assert_path_sets_equal(Target(".", True).files(), {bar})
 
 
+@pytest.mark.quick
 def assert_path_sets_equal(a: Collection[Path], b: Collection[Path]):
     """
     Assert that two sets of path contain the same paths
@@ -66,6 +69,7 @@ def assert_path_sets_equal(a: Collection[Path], b: Collection[Path]):
     assert a_abs == b_abs
 
 
+@pytest.mark.quick
 @pytest.fixture(
     scope="session", params=["no-repo", "git-repo", "git-repo-with-ignores"]
 )
@@ -135,6 +139,7 @@ def paths(request, tmp_path_factory):
 PY = Language("python")
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "workdir, targets, expected",
     [
@@ -175,6 +180,7 @@ def test_get_files_for_language(
     assert_path_sets_equal(actual, getattr(paths, expected))
 
 
+@pytest.mark.quick
 def test_skip_symlink(tmp_path, monkeypatch):
     foo = tmp_path / "foo"
     foo.mkdir()
@@ -194,6 +200,7 @@ def test_skip_symlink(tmp_path, monkeypatch):
         TargetManager([str(foo / "link.py")]).get_files_for_language(PY)
 
 
+@pytest.mark.quick
 def test_ignore_git_dir(tmp_path, monkeypatch):
     """
     Ignores all files in .git directory when scanning generic
@@ -209,6 +216,7 @@ def test_ignore_git_dir(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.quick
 def test_explicit_path(tmp_path, monkeypatch):
     foo = tmp_path / "foo"
     foo.mkdir()
@@ -283,6 +291,7 @@ def test_explicit_path(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.quick
 def test_ignores(tmp_path, monkeypatch):
     def ignore(ignore_pats):
         return TargetManager(

--- a/semgrep/tests/unit/test_baseline.py
+++ b/semgrep/tests/unit/test_baseline.py
@@ -5,6 +5,7 @@ import pytest
 from semgrep.git import BaselineHandler
 
 
+@pytest.mark.quick
 def test_baseline_context(monkeypatch, tmp_path):
     """
     Unit test verifies baseline_context can checkout a commit and return to

--- a/semgrep/tests/unit/test_bytesize.py
+++ b/semgrep/tests/unit/test_bytesize.py
@@ -1,3 +1,5 @@
+import pytest
+
 from semgrep.bytesize import parse_size
 
 
@@ -22,6 +24,7 @@ TESTS = [
 ]
 
 
+@pytest.mark.quick
 def test_parse_size() -> None:
     for input, expected_output in TESTS:
         assert parse_size(input) == expected_output

--- a/semgrep/tests/unit/test_formatters.py
+++ b/semgrep/tests/unit/test_formatters.py
@@ -1,5 +1,6 @@
 from io import StringIO
 
+import pytest
 from ruamel.yaml import YAML
 
 from semgrep.formatter.sarif import SarifFormatter
@@ -8,6 +9,7 @@ from semgrep.rule import Rule
 yaml = YAML(typ="rt")
 
 
+@pytest.mark.quick
 def test_rule_to_sarif_tags():
     r = """
       id: blah

--- a/semgrep/tests/unit/test_join_rule.py
+++ b/semgrep/tests/unit/test_join_rule.py
@@ -8,6 +8,7 @@ from semgrep.join_rule import JoinOperator
 from semgrep.join_rule import model_factory
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "A,propA,B,propB,op",
     [
@@ -43,6 +44,7 @@ def test_condition_parse(A, propA, B, propB, op):
     assert expected == actual
 
 
+@pytest.mark.quick
 def test_condition_parse_dot_behavior():
     A = "a.b.c.d.e"
     propA = "$FOO"
@@ -60,6 +62,7 @@ def test_condition_parse_dot_behavior():
     assert actual.operator == op
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "condition_string",
     [
@@ -76,6 +79,7 @@ def test_invalid_condition_string(condition_string):
         Condition.parse(condition_string)
 
 
+@pytest.mark.quick
 def test_model_factory():
     model = model_factory("HelloWorld", ["a", "b", "c"])
     assert model.__name__ == "HelloWorld"
@@ -86,6 +90,7 @@ def test_model_factory():
         _ = model.d
 
 
+@pytest.mark.quick
 def test_create_collection_set_from_conditions():
     conditions = [
         Condition("A", "propA1", "B", "propB", JoinOperator("==")),
@@ -97,6 +102,7 @@ def test_create_collection_set_from_conditions():
     assert expected == actual
 
 
+@pytest.mark.quick
 def test_create_model_map():
     results = [
         {

--- a/semgrep/tests/unit/test_metric_manager.py
+++ b/semgrep/tests/unit/test_metric_manager.py
@@ -14,6 +14,7 @@ from semgrep.profiling import Times
 from semgrep.types import MetricsState
 
 
+@pytest.mark.quick
 def test_configs_hash() -> None:
     metric_manager.set_configs_hash(["p/r2c"])
     old = metric_manager._configs_hash
@@ -30,6 +31,7 @@ def test_configs_hash() -> None:
     assert metric_manager._configs_hash != old
 
 
+@pytest.mark.quick
 def test_rules_hash() -> None:
     config1 = dedent(
         """
@@ -74,6 +76,7 @@ def test_rules_hash() -> None:
     assert old_hash != old_hash_2
 
 
+@pytest.mark.quick
 def test_send() -> None:
     """
     Check that no network does not cause failures
@@ -98,6 +101,7 @@ def test_send() -> None:
     metric_manager.send()
 
 
+@pytest.mark.quick
 def test_timings(snapshot) -> None:
     config1 = dedent(
         """
@@ -189,6 +193,7 @@ def test_timings(snapshot) -> None:
     ]
 
 
+@pytest.mark.quick
 def test_project_hash():
     metric_manager.set_project_hash("https://foo.bar.com/org/project.git")
     no_username_password = metric_manager._project_hash

--- a/semgrep/tests/unit/test_rule_match.py
+++ b/semgrep/tests/unit/test_rule_match.py
@@ -2,12 +2,15 @@ from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
+import pytest
+
 from semgrep.constants import RuleSeverity
 from semgrep.rule_match import CoreLocation
 from semgrep.rule_match import RuleMatch
 from semgrep.rule_match import RuleMatchSet
 
 
+@pytest.mark.quick
 def test_rule_match_attributes():
     file_content = dedent(
         """
@@ -37,6 +40,7 @@ def test_rule_match_attributes():
     ), "syntactic IDs must remain consistent to not trigger new notifications"
 
 
+@pytest.mark.quick
 def test_rule_match_sorting():
     file_content = dedent(
         """
@@ -70,6 +74,7 @@ def test_rule_match_sorting():
     # fmt: on
 
 
+@pytest.mark.quick
 def test_rule_match_hashing():
     file_content = dedent(
         """
@@ -90,6 +95,7 @@ def test_rule_match_hashing():
     assert {match, match} == {match}, "matches must deduplicate when added to a set"
 
 
+@pytest.mark.quick
 def test_rule_match_set_indexes():
     file_content = dedent(
         """

--- a/semgrep/tests/unit/test_semgrep_test.py
+++ b/semgrep/tests/unit/test_semgrep_test.py
@@ -20,6 +20,7 @@ from semgrep.test import TODOOK
 from semgrep.test import TODORULEID
 
 # cf. https://docs.python.org/3/library/itertools.html#itertools-recipes
+@pytest.mark.quick
 def powerset(iterable: Iterable) -> Iterable[Tuple[Any, ...]]:
     """powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"""
     s = list(iterable)
@@ -43,6 +44,7 @@ def _generate_normalize_rule_ids_test_cases() -> Iterator[Tuple[str, Set[str]]]:
                     )
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "test_case,expected", list(_generate_normalize_rule_ids_test_cases())
 )
@@ -56,6 +58,7 @@ def _generate_line_has_test_cases(annotation: str) -> Iterator[str]:
             yield f"{comment_begin}{space}{annotation}:{space}{RULE_IDS[-1]}{comment_end}".strip()
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "test_case,expected",
     list(product(_generate_line_has_test_cases("ruleid"), (True,)))
@@ -66,6 +69,7 @@ def test_line_has_rule(test_case, expected):
     assert line_has_rule(test_case) == expected
 
 
+@pytest.mark.quick
 @pytest.mark.parametrize(
     "test_case,expected",
     list(product(_generate_line_has_test_cases("ruleid"), (False,)))

--- a/semgrep/tests/unit/test_version.py
+++ b/semgrep/tests/unit/test_version.py
@@ -1,8 +1,11 @@
 from unittest import mock
 
+import pytest
+
 import semgrep.version
 
 
+@pytest.mark.quick
 def test_version_check_caching(tmp_path):
     tmp_cache_path = tmp_path / "semgrep_version"
 

--- a/semgrep/tests/unit/test_yaml_parsing.py
+++ b/semgrep/tests/unit/test_yaml_parsing.py
@@ -12,6 +12,7 @@ from semgrep.constants import RULES_KEY
 from semgrep.error import InvalidRuleSchemaError
 
 
+@pytest.mark.quick
 def test_parse_taint_rules():
     yaml_contents = dedent(
         """
@@ -52,6 +53,7 @@ def test_parse_taint_rules():
     assert True
 
 
+@pytest.mark.quick
 def test_multiple_configs():
     config1 = dedent(
         """
@@ -92,6 +94,7 @@ def test_multiple_configs():
         assert {"rule1", "rule2", "rule3"} == set([rule.id for rule in rules])
 
 
+@pytest.mark.quick
 def test_default_yaml_type_safe():
     s = '!!python/object/apply:os.system ["echo Hello world"]'
 
@@ -108,6 +111,7 @@ def test_default_yaml_type_safe():
     assert unsafe_yaml.load(io.StringIO(s)) == 0
 
 
+@pytest.mark.quick
 def test_invalid_metavariable_regex():
     rule = dedent(
         """
@@ -130,6 +134,7 @@ def test_invalid_metavariable_regex():
         parse_config_string("testfile", rule, None)
 
 
+@pytest.mark.quick
 def test_invalid_metavariable_comparison():
     rule = dedent(
         """
@@ -152,6 +157,7 @@ def test_invalid_metavariable_comparison():
         parse_config_string("testfile", rule, None)
 
 
+@pytest.mark.quick
 def test_invalid_metavariable_comparison2():
     rule = dedent(
         """
@@ -174,6 +180,7 @@ def test_invalid_metavariable_comparison2():
         parse_config_string("testfile", rule, None)
 
 
+@pytest.mark.quick
 def test_invalid_pattern_child():
     rule = dedent(
         """
@@ -193,6 +200,7 @@ def test_invalid_pattern_child():
         parse_config_string("testfile", rule, None)
 
 
+@pytest.mark.quick
 def test_invalid_rule_with_null():
     rule = dedent(
         """

--- a/semgrep/tox.ini
+++ b/semgrep/tox.ini
@@ -10,3 +10,11 @@ commands =
 setenv =
     # suppress a pipenv warning
     PIPENV_VERBOSITY = -1
+
+[pytest]
+# Custom tags for selecting a group of tests using e.g. 'pytest -m quick'
+# Markers are applied with a decorator: '@pytest.mark.quick'
+markers =
+    quick: test takes less than 100 ms
+    kinda_slow: test takes more than 100 ms and no more than 1-2 s
+    slow: test takes more than 1-2 s


### PR DESCRIPTION
Impact of this PR:
* faster when running locally with `make test`. Doesn't change the duration of CI.
* fails faster on average when running `make test`.

I haven't made any single test faster.

I tagged each pytest test with one of `quick`, `kinda_slow`, or `slow` markers. The makefile for running `make test` will run the tests from quick to slow so as to fail faster on average.

This makefile, which isn't used in CI, wasn't using the `-n` option to run multiple jobs in parallel. It now does, except for the quick tests that end up being slower with this option due to some startup overhead.
* `quick`: 725 tests, 7 seconds
* `kinda_slow`: 255 tests, 5 minutes
* `slow`: 164 tests, 35 minutes

I also added a check to ensure that all the `test_`* functions are categorized.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
