### PR TITLE
[AST_generic] add a new id_info_id field

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -373,7 +373,11 @@ and id_info = {
      exist in the source of the target.
   *)
   id_hidden : bool;
+  (* this is used by Naming_X in deep-semgrep *)
+  id_info_id : id_info_id;
 }
+
+and id_info_id = int
 
 (*****************************************************************************)
 (* Expression *)
@@ -1863,6 +1867,16 @@ let p x = x
 (* Ident and names *)
 (* ------------------------------------------------------------------------- *)
 
+(* For Naming_X.ml in deep-semgrep.
+ * This can be reseted to 0 before parsing each file, or not. It does
+ * not matter as the couple (filename, id_info_id) is unique.
+ *)
+let id_info_id_counter = ref 0
+
+let id_info_id () : id_info_id =
+  incr id_info_id_counter;
+  !id_info_id_counter
+
 (* before Naming_AST.resolve can do its job *)
 let sid_TODO = -1
 let empty_var = { vinit = None; vtype = None }
@@ -1873,6 +1887,7 @@ let empty_id_info ?(hidden = false) () =
     id_type = ref None;
     id_svalue = ref None;
     id_hidden = hidden;
+    id_info_id = id_info_id ();
   }
 
 let basic_id_info ?(hidden = false) resolved =
@@ -1881,6 +1896,7 @@ let basic_id_info ?(hidden = false) resolved =
     id_type = ref None;
     id_svalue = ref None;
     id_hidden = hidden;
+    id_info_id = id_info_id ();
   }
 
 (* TODO: move AST_generic_helpers.name_of_id and ids here *)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -374,7 +374,7 @@ and id_info = {
   *)
   id_hidden : bool;
   (* this is used by Naming_X in deep-semgrep *)
-  id_info_id : id_info_id;
+  id_info_id : id_info_id; [@equal fun _a _b -> true]
 }
 
 and id_info_id = int

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -141,6 +141,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
        id_type = v_id_type;
        id_svalue = v3;
        id_hidden;
+       id_info_id;
       } ->
           let v3 = map_of_ref (map_of_option map_svalue) v3 in
           let v_id_type = map_of_ref (map_of_option map_type_) v_id_type in
@@ -153,6 +154,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
             id_type = v_id_type;
             id_svalue = v3;
             id_hidden;
+            id_info_id;
           }
     in
     vin.kidinfo (k, all_functions) v

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -100,6 +100,7 @@ and vof_id_info
       id_type = v_id_type;
       id_svalue = v3;
       id_hidden;
+      id_info_id;
     } =
   let bnds = [] in
   let arg = OCaml.vof_ref (OCaml.vof_option vof_svalue) v3 in
@@ -113,6 +114,9 @@ and vof_id_info
   let bnds = bnd :: bnds in
   let arg = OCaml.vof_bool id_hidden in
   let bnd = ("id_hidden", arg) in
+  let bnds = bnd :: bnds in
+  let arg = OCaml.vof_int id_info_id in
+  let bnd = ("id_info_id", arg) in
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
 

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -84,6 +84,7 @@ let default_visitor =
           id_type = v_id_type;
           id_svalue = _IGNORED;
           id_hidden = _IGNORED2;
+          id_info_id = _IGNORED3;
         } =
           x
         in
@@ -191,6 +192,7 @@ let (mk_visitor :
         id_type = v_id_type;
         id_svalue = v_id_svalue;
         id_hidden = v_id_hidden;
+        id_info_id = _IGNORED;
       } =
         x
       in

--- a/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
@@ -118,6 +118,7 @@ and map_id_info x =
    id_type = v_id_type;
    id_svalue = v3;
    id_hidden = _not_available_in_v1;
+   id_info_id = _IGNORED;
   } ->
       let v3 = map_of_ref (map_of_option map_svalue) v3 in
       let v_id_type = map_of_ref (map_of_option map_type_) v_id_type in

--- a/semgrep-core/src/experiments/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pattern_from_Code.ml
@@ -72,6 +72,7 @@ let default_id str =
            id_type = ref None;
            id_svalue = ref None;
            id_hidden = false;
+           id_info_id = 0;
          } ))
   |> G.e
 

--- a/semgrep-core/src/experiments/synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pattern_from_Targets.ml
@@ -131,6 +131,7 @@ let default_id str =
            id_type = ref None;
            id_svalue = ref None;
            id_hidden = false;
+           id_info_id = 0;
          } ))
   |> G.e
 

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -532,9 +532,20 @@ and m_ident_and_empty_id_info a1 b1 =
  *)
 and m_id_info a b =
   match (a, b) with
-  | ( { G.id_resolved = _a1; id_type = _a2; id_svalue = _a3; id_hidden = _a4 },
-      { B.id_resolved = _b1; id_type = _b2; id_svalue = _b3; id_hidden = _b4 } )
-    ->
+  | ( {
+        G.id_resolved = _a1;
+        id_type = _a2;
+        id_svalue = _a3;
+        id_hidden = _a4;
+        id_info_id = _a5;
+      },
+      {
+        B.id_resolved = _b1;
+        id_type = _b2;
+        id_svalue = _b3;
+        id_hidden = _b4;
+        id_info_id = _b5;
+      } ) ->
       (* old: (m_ref m_resolved_name) a3 b3  >>= (fun () ->
        * but doing import flask in a source file means every reference
        * to flask.xxx will be tagged with a ImportedEntity, but

--- a/semgrep/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dump_ast/test_dump_ast/results.json
@@ -13,6 +13,7 @@
                 ],
                 {
                   "id_hidden": "false",
+                  "id_info_id": 7,
                   "id_resolved": {
                     "ref@": null
                   },
@@ -70,6 +71,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
+                                                "id_info_id": 3,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -94,6 +96,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
+                                                "id_info_id": 4,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -134,6 +137,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
+                                                "id_info_id": 5,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -158,6 +162,7 @@
                                               ],
                                               {
                                                 "id_hidden": "false",
+                                                "id_info_id": 6,
                                                 "id_resolved": {
                                                   "ref@": null
                                                 },
@@ -197,6 +202,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
+                    "id_info_id": 1,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -227,6 +233,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
+                    "id_info_id": 2,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -270,6 +277,7 @@
                 ],
                 {
                   "id_hidden": "false",
+                  "id_info_id": 12,
                   "id_resolved": {
                     "ref@": null
                   },
@@ -313,6 +321,7 @@
                                     ],
                                     {
                                       "id_hidden": "false",
+                                      "id_info_id": 10,
                                       "id_resolved": {
                                         "ref@": null
                                       },
@@ -337,6 +346,7 @@
                                     ],
                                     {
                                       "id_hidden": "false",
+                                      "id_info_id": 11,
                                       "id_resolved": {
                                         "ref@": null
                                       },
@@ -371,6 +381,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
+                    "id_info_id": 8,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -401,6 +412,7 @@
                   "pdefault": null,
                   "pinfo": {
                     "id_hidden": "false",
+                    "id_info_id": 9,
                     "id_resolved": {
                       "ref@": {
                         "some": [
@@ -444,6 +456,7 @@
                   ],
                   {
                     "id_hidden": "false",
+                    "id_info_id": 13,
                     "id_resolved": {
                       "ref@": null
                     },
@@ -480,6 +493,7 @@
                               ],
                               {
                                 "id_hidden": "false",
+                                "id_info_id": 14,
                                 "id_resolved": {
                                   "ref@": null
                                 },
@@ -504,6 +518,7 @@
                               ],
                               {
                                 "id_hidden": "false",
+                                "id_info_id": 15,
                                 "id_resolved": {
                                   "ref@": null
                                 },


### PR DESCRIPTION
This will make it possible to perform naming on transformed
version of AST_generic (e.g., X.ml in deep-semgrep) and backpropagate
any resolved information to the original AST, by using those
id_info_id "pointers"

test plan:
make


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)