### PR TITLE
Use name_of_id helper function

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -1432,7 +1432,7 @@ and map_expression (env : env) (x : CST.expression) : G.expr =
   match x with
   | `Simple_id x ->
       let id = map_simple_identifier env x in
-      G.N (G.Id (id, G.empty_id_info ())) |> G.e
+      G.N (H2.name_of_id id) |> G.e
   | `Un_exp x -> map_unary_expression env x
   | `Bin_exp x -> map_binary_expression env x
   | `Tern_exp x -> map_ternary_expression env x


### PR DESCRIPTION
As noted in code review for #4902, this is a more concise way of creating name from an identifier:

https://github.com/returntocorp/semgrep/pull/4902#discussion_r837180519

Test plan: CI

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
