### PR TITLE
fix: change user of benchmark image

### DIFF
--- a/dockerfiles/semgrep-dev.Dockerfile
+++ b/dockerfiles/semgrep-dev.Dockerfile
@@ -29,5 +29,4 @@ COPY dockerfiles/semgrep-dev.Dockerfile /Dockerfile
 # cd ~
 WORKDIR /home/semgrep
 
-USER semgrep
 ENTRYPOINT ["/bin/bash"]

--- a/dockerfiles/semgrep-dev.Dockerfile
+++ b/dockerfiles/semgrep-dev.Dockerfile
@@ -13,7 +13,6 @@
 # For things like benchmarks, we want a "recent version of semgrep that works".
 #
 FROM returntocorp/semgrep:develop
-USER root
 
 # Various utilities. We can always install them during the CI job but it's
 # it's nice to do it here while we're root.


### PR DESCRIPTION
We updated semgrep docker image to use root since that was necessary to run it in CI/CD

This PR updates the user used in an internally used docker image

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
