### PR TITLE
Specify required packages argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,5 @@ setup(
     name="semgrep_pre_commit_package",
     version="0.0.0",
     install_requires=["semgrep==0.86.5"],
+    packages=[],
 )


### PR DESCRIPTION
The latest setuptools requires this, even though it is empty. Otherwise
it won't install with a `error: Multiple top-level packages discovered
in a flat-layout` exception.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
