### PR TITLE
Convert Swift postfix and call expressions to Generic AST

### DIFF
--- a/semgrep-core/tests/swift/parsing/expressions.swift
+++ b/semgrep-core/tests/swift/parsing/expressions.swift
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------------
+// Identifiers:
+// -----------------------------------------------------------------------------
+foo;
+
+// -----------------------------------------------------------------------------
+// Unary expressions:
+// -----------------------------------------------------------------------------
+
+// Postfix expressions:
+5++;
+5--;
+bar!;
+
+// Call expressions:
+foo(bar, baz);
+foo();
+isthis[obj, c];
+bar[];
+
+named(foo: 3);
+named(foo: 3, bar: 4);
+// An argument named "async" is special-cased in the parser
+named(async: 3);
+// Not actually a function call, but parsed as one
+named(bar: baz:);
+// TODO figure out the type modifier part of a value argument
+
+closure { x in x };
+
+// TODO this leads the parser into an infinite loop in our CI environment. I
+// (nmote) have replicated it locally using the docker container that the
+// build-tests GitHub action uses, but it does not reproduce on my machine
+// otherwise. I verified by stepping through with gdb that the parser is indeed
+// in an infinite loop in scanner.c. Here's a backtrace from attaching to
+// semgrep-core while it's in the loop:
+// https://gist.github.com/nmote/0bddd68b30f925e71a60086eeff9fe23
+//
+// Reproduced using the command:
+//
+// $ semgrep-core -lang swift -dump_tree_sitter_cst expressions.swift
+//
+// doubleclosure { x in x } more: { y in y };
+
+// TODO tree-sitter-swift parses this incorrectly. The closure should be
+// considered the final argument to the function call as above, but instead this
+// is parsed as two separate call expressions where the lambda is the argument
+// to the return value of the single-argument function call.
+mixedargs(foo: 3) { x in x };


### PR DESCRIPTION
This updates `Parse_swift_tree_sitter.ml` to handle postfix expressions and call expressions, as well as a few miscellaneous 
other constructs to the extent needed to support the examples that I've written.

I would specifically appreciate reviewer feedback on my `associate_statement_semis` function and my use of `G.OtherArg`.

Test plan:

I inspected the output of `semgrep-core -lang swift -dump_ast expressions.swift` for each construct as I was implementing it.

The added parsing test ensures at least that Semgrep doesn't crash when converting the included constructs to generic AST.

Here is an example of the AST generated for the following program:

`doubleclosure { x in x } more: { y in y };`

```
Pr(
  [ExprStmt(
     Call(
       N(
         Id(("doubleclosure", ()),
           {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
       [Arg(
          Lambda(
            {fkind=(LambdaKind, ()); 
             fparams=[Param(
                        {pname=Some(("x", ())); pdefault=None; ptype=None; pattrs=[
                         ]; 
                         pinfo={id_info_id=2; id_hidden=false; id_resolved=Ref(
                                Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                                None); };
                         })];
             frettype=None; 
             fbody=FBStmt(
                     Block(
                       [ExprStmt(
                          N(
                            Id(("x", ()),
                              {id_info_id=3; id_hidden=false; id_resolved=Ref(
                               None); id_type=Ref(None); id_svalue=Ref(
                               None); })), ())]));
             }));
        ArgKwd(("more", ()),
          Lambda(
            {fkind=(LambdaKind, ()); 
             fparams=[Param(
                        {pname=Some(("y", ())); pdefault=None; ptype=None; pattrs=[
                         ]; 
                         pinfo={id_info_id=4; id_hidden=false; id_resolved=Ref(
                                Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                                None); };
                         })];
             frettype=None; 
             fbody=FBStmt(
                     Block(
                       [ExprStmt(
                          N(
                            Id(("y", ()),
                              {id_info_id=5; id_hidden=false; id_resolved=Ref(
                               None); id_type=Ref(None); id_svalue=Ref(
                               None); })), ())]));
             }))]), ())])
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
