### PR TITLE
Update changelog with `project-depends-on` information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   `pattern-inside` to be unified, thus limiting the usefulness of the feature.
   Nonetheless, it is still possible to force metavariable unification by setting
   `taint_unify_mvars: true` in the rule's `options`.
+- `r2c-internal-project-depends-on`: this is now a rule key, and not part of the pattern language.
+  The `depends-on-either` key can be used analgously to `pattern-either`
+- `r2c-internal-project-depends-on`: each rule with this key will now distinguish between
+  _reachable_ and _unreachable_ findings. A _reachable_ finding is one with both a dependency match
+  and a pattern match: a vulnerable dependency was found and the vulnerable part of the dependency
+  (according to the patterns in the rule) is used somewhere in code. An _unreachable_ finding
+  is one with only a dependency match. Reachable findings are reported as coming from the
+  code that was pattern matched. Unreachable findings are reported as coming from the lockfile
+  that was dependency matched. Both kinds of findings specify their kind, along with all matched
+  dependencies, in the `extra` field of semgrep's JSON output, using the `dependency_match_only`
+  and `dependency_matches` fields, respectively.
+- `r2c-internal-project-depends-on`: a finding will only be considered reachable if the file
+  containing the pattern match actually depends on the dependencies in the lockfile containing the
+  dependency match. A file depends on a lockfile if it is the nearest lockfile going up the
+  directory tree.
 
 ### Added
 


### PR DESCRIPTION
Recent changes to the behavior of `r2c-internal-project-depends-on` were not included in the changelog due to some now resolved uncertainty about how public we want to make the API. This PR updates the changelog. Documentation still needs to be updated.

PR checklist:

- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
