### PR TITLE
chore(tail-recursion): Assert efficient tail-recursion in List ops

### DIFF
--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -245,7 +245,7 @@ let rec eval env x : svalue option =
 
 and eval_args env args =
   args |> unbracket
-  |> List.map (function
+  |> Common.map (function
        | Arg e -> eval env e
        | _ -> None)
 
@@ -504,7 +504,7 @@ let terraform_sid = 0
 
 let add_special_constants env lang prog =
   if lang = Lang.Hcl then
-    let vars = prog |> List.map terraform_stmt_to_vardefs |> List.flatten in
+    let vars = prog |> Common.map terraform_stmt_to_vardefs |> List.flatten in
     vars
     |> List.iter (fun (id, v) ->
            match v.e with

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -259,7 +259,7 @@ and eval_lval env lval =
 
 and eval_op env wop args =
   let op, tok = wop in
-  let cs = List.map (eval env) args in
+  let cs = Common.map (eval env) args in
   match (op, cs) with
   | G.Plus, [ c1 ] -> c1
   | op, [ G.Lit (G.Bool (b, _)) ] -> eval_unop_bool op b
@@ -279,7 +279,7 @@ and eval_op env wop args =
   | ___else___ -> G.NotCst
 
 and eval_concat env args =
-  match List.map (eval env) args with
+  match Common.map (eval env) args with
   | [] -> G.Lit (literal_of_string "")
   | G.Lit (G.String (r, tok)) :: args' ->
       List.fold_left
@@ -417,7 +417,7 @@ let transfer :
             let cexp = eval_or_sym_prop inp' exp in
             D.VarMap.add (str_of_name var) cexp inp'
         | Call (Some { base = Var var; offset = NoOffset }, func, args) -> (
-            let args_val = List.map (eval inp') args in
+            let args_val = Common.map (eval inp') args in
             match (lang, func, args_val) with
             (* Built-in knowledge, we know these functions return constants when
              * given constant arguments. *)

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -187,19 +187,19 @@ let json_of_v (v : OCaml.v) =
     | OCaml.VChar v1 -> J.String (spf "'%c'" v1)
     | OCaml.VString v1 -> J.String v1
     | OCaml.VInt i -> J.Int i
-    | OCaml.VTuple xs -> J.Array (List.map aux xs)
-    | OCaml.VDict xs -> J.Object (List.map (fun (k, v) -> (k, aux v)) xs)
+    | OCaml.VTuple xs -> J.Array (Common.map aux xs)
+    | OCaml.VDict xs -> J.Object (Common.map (fun (k, v) -> (k, aux v)) xs)
     | OCaml.VSum (s, xs) -> (
         match xs with
         | [] -> J.String (spf "%s" s)
         | [ one_element ] -> J.Object [ (s, aux one_element) ]
-        | _ -> J.Object [ (s, J.Array (List.map aux xs)) ])
+        | _ -> J.Object [ (s, J.Array (Common.map aux xs)) ])
     | OCaml.VVar (s, i64) -> J.String (spf "%s_%d" s (Int64.to_int i64))
     | OCaml.VArrow _ -> failwith "Arrow TODO"
     | OCaml.VNone -> J.Null
     | OCaml.VSome v -> J.Object [ ("some", aux v) ]
     | OCaml.VRef v -> J.Object [ ("ref@", aux v) ]
-    | OCaml.VList xs -> J.Array (List.map aux xs)
+    | OCaml.VList xs -> J.Array (Common.map aux xs)
     | OCaml.VTODO _ -> J.String "VTODO"
   in
   aux v
@@ -255,7 +255,7 @@ let dump_v1_json file =
 let dump_ext_of_lang () =
   let lang_to_exts =
     Lang.keys
-    |> List.map (fun lang_str ->
+    |> Common.map (fun lang_str ->
            match Lang.lang_of_string_opt lang_str with
            | Some lang ->
                lang_str ^ "->" ^ String.concat ", " (Lang.ext_of_lang lang)

--- a/semgrep-core/src/core/Report.ml
+++ b/semgrep-core/src/core/Report.ml
@@ -170,12 +170,12 @@ let collate_rule_results :
   }
 
 let make_final_result results rules ~report_time ~rules_parse_time =
-  let matches = results |> List.map (fun x -> x.matches) |> List.flatten in
-  let errors = results |> List.map (fun x -> x.errors) |> List.flatten in
+  let matches = results |> Common.map (fun x -> x.matches) |> List.flatten in
+  let errors = results |> Common.map (fun x -> x.errors) |> List.flatten in
   let skipped_targets =
-    results |> List.map (fun x -> x.skipped_targets) |> List.flatten
+    results |> Common.map (fun x -> x.skipped_targets) |> List.flatten
   in
-  let file_times = results |> List.map (fun x -> x.profiling) in
+  let file_times = results |> Common.map (fun x -> x.profiling) in
   let final_profiling =
     if report_time then Some { rules; rules_parse_time; file_times } else None
   in

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -406,10 +406,10 @@ let remove_noop (e : formula_old) : formula_old =
   let rec aux e =
     match e with
     | PatEither (t, xs) ->
-        let xs = List.map aux (List.filter valid_formula xs) in
+        let xs = Common.map aux (List.filter valid_formula xs) in
         PatEither (t, xs)
     | Patterns (t, xs) -> (
-        let xs' = List.map aux (List.filter valid_formula xs) in
+        let xs' = Common.map aux (List.filter valid_formula xs) in
         (* If the only thing in Patterns is a PatFilteredInPythonTodo key,
            after this filter it will be an empty And. To prevent
            an error, check for that *)
@@ -434,7 +434,7 @@ let (convert_formula_old : formula_old -> formula) =
     | PatNot (t, x) -> Not (t, P (x, None))
     | PatNotInside (t, x) -> Not (t, P (x, Some Inside))
     | PatEither (t, xs) ->
-        let xs = List.map aux xs in
+        let xs = Common.map aux xs in
         Or (t, xs)
     | Patterns (t, xs) ->
         let fs, conds, focus = Common.partition_either3 aux_and xs in

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -213,7 +213,7 @@ let (expected_error_lines_of_files :
       (Common.filename * int) (* line *) list) =
  fun ?(regexp = default_error_regexp) test_files ->
   test_files
-  |> List.map (fun file ->
+  |> Common.map (fun file ->
          Common.cat file |> Common.index_list_1
          |> Common.map_filter (fun (s, idx) ->
                 (* Right now we don't care about the actual error messages. We
@@ -231,7 +231,7 @@ let (expected_error_lines_of_files :
 let compare_actual_to_expected actual_errors expected_error_lines =
   let actual_error_lines =
     actual_errors
-    |> List.map (fun err ->
+    |> Common.map (fun err ->
            let loc = err.loc in
            (loc.PI.file, loc.PI.line))
   in

--- a/semgrep-core/src/core/Xlang.ml
+++ b/semgrep-core/src/core/Xlang.ml
@@ -29,7 +29,7 @@ let lang_of_opt_xlang (x : t option) : Lang.t =
   | Some xlang -> to_lang xlang
 
 let assoc : (string * t) list =
-  List.map (fun (k, v) -> (k, of_lang v)) Lang.assoc
+  Common.map (fun (k, v) -> (k, of_lang v)) Lang.assoc
   @ [ ("regex", LRegex); ("generic", LGeneric) ]
 
 let map = Common.hash_of_list assoc

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1921,7 +1921,7 @@ let arg e = Arg e
 (* Expressions *)
 (* ------------------------------------------------------------------------- *)
 let special spec es =
-  Call (IdSpecial spec |> e, fake_bracket (es |> List.map arg)) |> e
+  Call (IdSpecial spec |> e, fake_bracket (es |> Common.map arg)) |> e
 
 let opcall (op, tok) exprs : expr = special (Op op, tok) exprs
 
@@ -1938,13 +1938,13 @@ let interpolated (lquote, xs, rquote) =
         ( special,
           ( lquote,
             xs
-            |> List.map (function
+            |> Common.map (function
                  | Common.Left3 str -> Arg (L (String str) |> e)
                  | Common.Right3 (lbrace, eopt, rbrace) ->
                      let special =
                        IdSpecial (InterpolatedElement, lbrace) |> e
                      in
-                     let args = eopt |> Option.to_list |> List.map arg in
+                     let args = eopt |> Option.to_list |> Common.map arg in
                      Arg (Call (special, (lbrace, args, rbrace)) |> e)
                  | Common.Middle3 e -> Arg e),
             rquote ) )

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -118,7 +118,7 @@ let name_of_ids xs =
   | x :: xs ->
       let qualif =
         if xs = [] then None
-        else Some (QDots (xs |> List.rev |> List.map (fun id -> (id, None))))
+        else Some (QDots (xs |> List.rev |> Common.map (fun id -> (id, None))))
       in
       IdQualified
         {
@@ -154,7 +154,7 @@ let dotted_ident_of_name (n : name) : dotted_ident =
       let before =
         match name_middle with
         (* we skip the type parts in ds ... *)
-        | Some (QDots ds) -> ds |> List.map fst
+        | Some (QDots ds) -> ds |> Common.map fst
         | Some (QExpr _) ->
             logger#error "unexpected qualifier type";
             []
@@ -173,10 +173,10 @@ let rec expr_to_pattern e =
   match e.e with
   | N (Id (id, info)) -> PatId (id, info)
   | Container (Tuple, (t1, xs, t2)) ->
-      PatTuple (t1, xs |> List.map expr_to_pattern, t2)
+      PatTuple (t1, xs |> Common.map expr_to_pattern, t2)
   | L l -> PatLiteral l
   | Container (List, (t1, xs, t2)) ->
-      PatList (t1, xs |> List.map expr_to_pattern, t2)
+      PatList (t1, xs |> Common.map expr_to_pattern, t2)
   | Ellipsis t -> PatEllipsis t
   (* Todo:  PatKeyVal *)
   | _ -> OtherPat (("ExprToPattern", fake ""), [ E e ])
@@ -188,10 +188,10 @@ let rec pattern_to_expr p =
   (match p with
   | PatId (id, info) -> N (Id (id, info))
   | PatTuple (t1, xs, t2) ->
-      Container (Tuple, (t1, xs |> List.map pattern_to_expr, t2))
+      Container (Tuple, (t1, xs |> Common.map pattern_to_expr, t2))
   | PatLiteral l -> L l
   | PatList (t1, xs, t2) ->
-      Container (List, (t1, xs |> List.map pattern_to_expr, t2))
+      Container (List, (t1, xs |> Common.map pattern_to_expr, t2))
   | OtherPat (("ExprToPattern", _), [ E e ]) -> e.e
   | _ -> raise NotAnExpr)
   |> G.e
@@ -358,14 +358,14 @@ let ac_matching_nf op args =
   (* yes... here we use exceptions like a "goto" to avoid the option monad *)
   let rec nf args1 =
     args1
-    |> List.map (function
+    |> Common.map (function
          | Arg e -> e
          | ArgKwd _
          | ArgKwdOptional _
          | ArgType _
          | OtherArg _ ->
              raise_notrace Exit)
-    |> List.map nf_one |> List.flatten
+    |> Common.map nf_one |> List.flatten
   and nf_one e =
     match e.e with
     | Call ({ e = IdSpecial (Op op1, _tok1); _ }, (_, args1, _)) when op = op1

--- a/semgrep-core/src/core/ast/Pretty_print_AST.ml
+++ b/semgrep-core/src/core/ast/Pretty_print_AST.ml
@@ -427,7 +427,7 @@ and for_stmt env level (for_tok, hdr, s) =
     | ForEllipsis tok -> token "..." tok
     | ForIn (init, exprs) ->
         F.sprintf "%s %s %s" (show_init_list init) "in"
-          (String.concat "," (List.map (fun e -> expr env e) exprs))
+          (String.concat "," (Common.map (fun e -> expr env e) exprs))
   in
   let body_str = stmt env (level + 1) s in
   for_format (token "for" for_tok) hdr_str body_str
@@ -659,7 +659,7 @@ and id_qualified env { name_last = id, _toptTODO; name_middle; name_top; _ } =
   match name_middle with
   | Some (QDots dot_ids) ->
       (* TODO: do not do fst, look also at type qualification *)
-      F.sprintf "%s.%s" (dotted_access env (List.map fst dot_ids)) (ident id)
+      F.sprintf "%s.%s" (dotted_access env (Common.map fst dot_ids)) (ident id)
   | Some (QExpr (e, _t)) -> expr env e ^ "::"
   | None -> ident id
 

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -403,7 +403,7 @@ let rec lvals_of_exp e =
   | Composite (_, (_, xs, _))
   | Operator (_, xs) ->
       lvals_of_exps xs
-  | Record ys -> lvals_of_exps (ys |> List.map snd)
+  | Record ys -> lvals_of_exps (ys |> Common.map snd)
   | FixmeExp (_, _, Some e) -> lvals_of_exp e
   | FixmeExp (_, _, None) -> []
 
@@ -420,7 +420,7 @@ and lvals_in_lval lval =
   in
   base_lvals @ offset_lvals
 
-and lvals_of_exps xs = xs |> List.map lvals_of_exp |> List.flatten
+and lvals_of_exps xs = xs |> Common.map lvals_of_exp |> List.flatten
 
 (** The lvals in the RHS of the instruction. *)
 let rlvals_of_instr x =

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -97,7 +97,7 @@ let parse_json file =
             | _ -> failwith "only expressions are supported"
           in
           let metavars =
-            xs |> List.map (fun (s, json) -> (s, metavar_of_json s json))
+            xs |> Common.map (fun (s, json) -> (s, metavar_of_json s json))
           in
           let env =
             {
@@ -164,13 +164,13 @@ let rec eval env code =
   | G.Call ({ e = G.IdSpecial (G.Op op, _t); _ }, (_, args, _)) ->
       let values =
         args
-        |> List.map (function
+        |> Common.map (function
              | G.Arg e -> eval env e
              | _ -> raise (NotHandled code))
       in
       eval_op op values code
   | G.Container (G.List, (_, xs, _)) ->
-      let vs = List.map (eval env) xs in
+      let vs = Common.map (eval env) xs in
       List vs
   (* Emulate Python re.match just enough *)
   | G.Call

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -105,7 +105,7 @@ let any_in_ranges rule any rwms =
   | Some (tok1, tok2) ->
       let r = Range.range_of_token_locations tok1 tok2 in
       List.filter (fun rwm -> Range.( $<=$ ) r rwm.RM.r) rwms
-      |> List.map (RM.range_to_pattern_match_adjusted rule)
+      |> Common.map (RM.range_to_pattern_match_adjusted rule)
 
 let range_w_metas_of_pformula config equivs file_and_more rule_id pformula =
   let formula = Rule.formula_of_pformula pformula in
@@ -141,7 +141,7 @@ let taint_config_of_rule default_config equivs file ast_and_errors
   let find_range_w_metas_santizers specs =
     specs
     |> List.concat_map (fun spec ->
-           List.map
+           Common.map
              (fun pf -> (spec.Rule.not_conflicting, pf))
              (range_w_metas_of_pformula config equivs file_and_more rule
                 spec.pformula))
@@ -302,7 +302,8 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
            |> List.iter (fun (m : Pattern_match.t) ->
                   let str = Common.spf "with rule %s" m.rule_id.id in
                   match_hook str m.env m.tokens))
-    |> List.map (fun m -> { m with PM.rule_id = convert_rule_id rule.Rule.id })
+    |> Common.map (fun m ->
+           { m with PM.rule_id = convert_rule_id rule.Rule.id })
   in
   ( {
       RP.matches;

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -93,12 +93,12 @@ let formula_to_sformula formula =
     | R.P (p, inside) -> Leaf (p, inside)
     | R.And { tok = _; conjuncts = fs; conditions = conds; focus } ->
         And (convert_and_formulas fs conds focus)
-    | R.Or (_, fs) -> Or (List.map formula_to_sformula fs)
+    | R.Or (_, fs) -> Or (Common.map formula_to_sformula fs)
     | R.Not (_, f) -> Not (formula_to_sformula f)
   and convert_and_formulas fs cond focus =
     let pos, neg = split_and fs in
-    let pos = List.map formula_to_sformula pos in
-    let neg = List.map formula_to_sformula neg in
+    let pos = Common.map formula_to_sformula pos in
+    let neg = Common.map formula_to_sformula neg in
     let sel, pos =
       (* We only want a selector if there is something to select from. *)
       match remove_selectors (None, []) pos with
@@ -109,8 +109,8 @@ let formula_to_sformula formula =
       selector_opt = sel;
       positives = pos;
       negatives = neg;
-      conditionals = cond |> List.map snd;
-      focus = focus |> List.map snd;
+      conditionals = cond |> Common.map snd;
+      focus = focus |> Common.map snd;
     }
   in
   formula_to_sformula formula

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -38,7 +38,7 @@ let (lang_of_rules: Rule.t list -> Lang.t) = fun rs ->
 *)
 
 let (xlangs_of_rules : Rule.t list -> Xlang.t list) =
- fun rs -> rs |> List.map (fun r -> r.R.languages) |> List.sort_uniq compare
+ fun rs -> rs |> Common.map (fun r -> r.R.languages) |> List.sort_uniq compare
 
 let first_xlang_of_rules rs =
   match rs with

--- a/semgrep-core/src/engine/Unit_entropy.ml
+++ b/semgrep-core/src/engine/Unit_entropy.ml
@@ -117,7 +117,7 @@ let test_information_density () =
 
 let get_entropies strings =
   strings
-  |> List.map (fun s ->
+  |> Common.map (fun s ->
          print_info s;
          (s, Entropy.entropy s))
 
@@ -143,7 +143,7 @@ let test_high_entropy () =
 
 let get_densities strings =
   strings
-  |> List.map (fun s ->
+  |> Common.map (fun s ->
          print_info s;
          (s, Entropy.information_density s))
 
@@ -170,7 +170,7 @@ let test_high_density () =
 
 let get_scores strings =
   strings
-  |> List.map (fun s ->
+  |> Common.map (fun s ->
          print_info s;
          (s, Entropy.score s))
 

--- a/semgrep-core/src/experiments/datalog/Datalog_fact.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_fact.ml
@@ -157,7 +157,7 @@ let string_of_fact fact =
   let str, xs = meta_fact fact in
   spf "%s(%s)" str
     (xs
-    |> List.map (function
+    |> Common.map (function
          | V x
          | F x
          | N x

--- a/semgrep-core/src/experiments/datalog/Datalog_io.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_io.ml
@@ -38,13 +38,14 @@ let string_of_value = function
       spf "'%s'" x
   | Z i -> spf "%d" i
 
-let csv_of_tuple xs = (xs |> List.map string_of_value |> Common.join ",") ^ "\n"
+let csv_of_tuple xs =
+  (xs |> Common.map string_of_value |> Common.join ",") ^ "\n"
 
 (*****************************************************************************)
 (* Write *)
 (*****************************************************************************)
 let write_facts_for_doop facts dir =
-  let facts = facts |> List.map D.meta_fact in
+  let facts = facts |> Common.map D.meta_fact in
   let groups = facts |> Common.group_assoc_bykey_eff in
   groups
   |> List.iter (fun (table, tuples) ->

--- a/semgrep-core/src/experiments/misc/Experiments.ml
+++ b/semgrep-core/src/experiments/misc/Experiments.ml
@@ -19,9 +19,9 @@ let stat_matches file =
   pr2 (spf "matched: %d" (List.length matches));
   let per_files =
     matches
-    |> List.map (fun m -> (m.Pattern_match.file, m))
+    |> Common.map (fun m -> (m.Pattern_match.file, m))
     |> Common.group_assoc_bykey_eff
-    |> List.map (fun (file, xs) -> (file, List.length xs))
+    |> Common.map (fun (file, xs) -> (file, List.length xs))
     |> Common.sort_by_val_highfirst |> Common.take_safe 10
   in
   pr2 "biggest file offenders";
@@ -52,7 +52,7 @@ let ebnf_to_menhir file =
     let tokens = lexer chars in
     let xs = Stream.npeek 100 tokens in
     xs |> insert_space_when_needed
-    |> List.map (function
+    |> Common.map (function
          | T.Kwd s -> spf "%s" s
          | T.Ident s ->
              if s =~ "^[A-Z]" then lower s
@@ -70,7 +70,7 @@ let ebnf_to_menhir file =
   in
   let ys =
     xs
-    |> List.map (fun s ->
+    |> Common.map (fun s ->
            match s with
            | _ when s =~ "^ *\\([A-Z][a-zA-Z0-9]*\\) +::= \\(.*\\)$" ->
                let s1, s2 = Common.matched2 s in
@@ -117,7 +117,7 @@ let gen_layer ~root ~query _matching_tokens file =
   (* todo: could now use Layer_code.simple_layer_of_parse_infos *)
   let files_and_lines =
     toks
-    |> List.map (fun tok ->
+    |> Common.map (fun tok ->
            let file = PI.file_of_info tok in
            let line = PI.line_of_info tok in
            let file = Common2.relative_to_absolute file in
@@ -131,12 +131,12 @@ let gen_layer ~root ~query _matching_tokens file =
       kinds;
       files =
         group
-        |> List.map (fun (file, lines) ->
+        |> Common.map (fun (file, lines) ->
                let lines = Common2.uniq lines in
                ( file,
                  {
                    Layer_code.micro_level =
-                     lines |> List.map (fun l -> (l, "m"));
+                     lines |> Common.map (fun l -> (l, "m"));
                    macro_level = (if null lines then [] else [ ("m", 1.) ]);
                  } ));
     }

--- a/semgrep-core/src/experiments/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pattern_from_Code.ml
@@ -269,7 +269,7 @@ and generalize_exp e env =
 (* Helper functions to make it easier to add all variations *)
 (* Generalizes e, then applies the same transformation f to each *)
 and add_expr e f env =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | str, E e' -> f (str, e')
@@ -277,7 +277,7 @@ and add_expr e f env =
     (generalize_exp e env)
 
 and add_stmt s f env =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | str, S s' -> f (str, s')

--- a/semgrep-core/src/experiments/synthesizing/Pretty_print_pattern.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pretty_print_pattern.ml
@@ -31,7 +31,7 @@ let pattern_to_string lang any =
   | E e -> expr_to_string lang (*mvars*) e
   | S s -> stmt_to_string lang (*mvars*) s
   | Ss stmts ->
-      List.map (stmt_to_string lang (*mvars*)) stmts |> String.concat "\n"
+      Common.map (stmt_to_string lang (*mvars*)) stmts |> String.concat "\n"
   | Args args -> arguments_to_string (*{ lang; mvars }*) lang args
   | _ ->
       pr2 (AST_generic.show_any any);

--- a/semgrep-core/src/experiments/synthesizing/Range_to_AST.ml
+++ b/semgrep-core/src/experiments/synthesizing/Range_to_AST.ml
@@ -150,7 +150,7 @@ let join_anys (anys : AST_generic.any list) : AST_generic.any option =
   match anys with
   | [] -> None
   | [ xs ] -> Some xs
-  | G.S _ :: _ -> Some (G.Ss (List.map any_to_stmt anys))
+  | G.S _ :: _ -> Some (G.Ss (Common.map any_to_stmt anys))
   | _ ->
       failwith
         "Unable to handle ranges that contain multiple expressions. Range must \
@@ -158,7 +158,7 @@ let join_anys (anys : AST_generic.any list) : AST_generic.any option =
 
 let split_any (any : G.any) : G.any list =
   match any with
-  | G.Ss stmts -> List.map (fun s -> G.S s) stmts
+  | G.Ss stmts -> Common.map (fun s -> G.S s) stmts
   | x -> [ x ]
 
 let any_at_range_all r1 ast : AST_generic.any option =

--- a/semgrep-core/src/experiments/synthesizing/Synthesizer.ml
+++ b/semgrep-core/src/experiments/synthesizing/Synthesizer.ml
@@ -21,7 +21,7 @@ let synthesize_patterns config s file =
   let lang = Lang.langs_of_filename file |> List.hd in
   let a = range_to_ast file lang s in
   let patterns = Pattern_from_Code.from_any config a in
-  List.map
+  Common.map
     (fun (k, v) -> (k, Pretty_print_pattern.pattern_to_string lang v))
     patterns
 
@@ -30,7 +30,7 @@ let locate_patched_functions f =
 
   let d = In.diff_files_of_string f in
   let diff_files = d.In.cve_diffs in
-  let diffs = List.map Pattern_from_diff.pattern_from_diff diff_files in
+  let diffs = Common.map Pattern_from_diff.pattern_from_diff diff_files in
   Out.string_of_cve_results diffs
 
 let target_to_string lang target =
@@ -50,11 +50,11 @@ let parse_range_args s =
 let parse_targets (args : string list) : Pattern.t list * Lang.t =
   let ranges, file = parse_range_args args in
   let lang = Lang.langs_of_filename file |> List.hd in
-  let targets = List.map (range_to_ast file lang) ranges in
+  let targets = Common.map (range_to_ast file lang) ranges in
   (targets, lang)
 
 let print_pattern lang targets pattern =
-  List.map (target_to_string lang) targets
+  Common.map (target_to_string lang) targets
   @ [ Pretty_print_pattern.pattern_to_string lang pattern ]
 
 let generate_pattern_from_targets config s =

--- a/semgrep-core/src/experiments/synthesizing/Test_synthesizing.ml
+++ b/semgrep-core/src/experiments/synthesizing/Test_synthesizing.ml
@@ -31,7 +31,9 @@ let expr_at_range s file =
 let synthesize_patterns s file =
   let config = Config_semgrep.default_config in
   let options = Synthesizer.synthesize_patterns config s file in
-  let json_opts = J.Object (List.map (fun (k, v) -> (k, J.String v)) options) in
+  let json_opts =
+    J.Object (Common.map (fun (k, v) -> (k, J.String v)) options)
+  in
   let s = J.string_of_json json_opts in
   pr s
   [@@action]

--- a/semgrep-core/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/semgrep-core/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -80,7 +80,7 @@ let ranges_matched lang file pattern : Range.t list =
       (Config_semgrep.default_config, equiv)
       [ rule ] (file, lang, ast)
   in
-  List.map extract_range matches
+  Common.map extract_range matches
 
 let run_single_test file linecols expected_pattern =
   let lang, _, inferred_pattern =
@@ -92,7 +92,7 @@ let run_single_test file linecols expected_pattern =
   in
   let pattern_correct = actual_pattern = expected_pattern in
   let ranges_expected =
-    List.map (fun lcs -> Range.range_of_linecol_spec lcs file) linecols
+    Common.map (fun lcs -> Range.range_of_linecol_spec lcs file) linecols
   in
   let ranges_actual = ranges_matched lang file inferred_pattern in
   let ranges_correct =

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -426,7 +426,7 @@ let rec m_name a b =
       let new_qualifier =
         match List.rev dotted with
         | [] -> raise Impossible
-        | _x :: xs -> List.rev xs |> List.map (fun id -> (id, None))
+        | _x :: xs -> List.rev xs |> Common.map (fun id -> (id, None))
       in
       m_name a
         (B.IdQualified
@@ -657,7 +657,7 @@ and m_expr a b =
           }),
       _b ) ->
       (* TODO: double check names does not have any type_args *)
-      let full = (names |> List.map fst) @ [ alabel ] in
+      let full = (names |> Common.map fst) @ [ alabel ] in
       m_expr (make_dotted full) b
   | G.DotAccess (_, _, _), B.N b1 ->
       (* Reinterprets a DotAccess expression such as a.b.c as a name, when
@@ -1657,8 +1657,8 @@ and m_ac_op tok op aargs_ac bargs_ac =
           in
           let tout =
             m_list__m_argument
-              (List.map G.arg avars_dots)
-              (List.map B.arg bs') tin
+              (Common.map G.arg avars_dots)
+              (Common.map B.arg bs') tin
           in
           [ ([], tout) ])
       |> m_comb_flatten

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -135,7 +135,7 @@ let (( >>= ) : (tin -> tout) -> (unit -> tin -> tout) -> tin -> tout) =
    *)
   let xs = m1 tin in
   (* try m2 on each possible returned bindings *)
-  let xxs = xs |> List.map (fun binding -> m2 () binding) in
+  let xxs = xs |> Common.map (fun binding -> m2 () binding) in
   List.flatten xxs
 
 (* the disjunctive combinator *)
@@ -360,7 +360,7 @@ let rec inits_and_rest_of_list = function
   | [ e ] -> [ ([ e ], []) ]
   | e :: l ->
       ([ e ], l)
-      :: List.map (fun (l, rest) -> (e :: l, rest)) (inits_and_rest_of_list l)
+      :: Common.map (fun (l, rest) -> (e :: l, rest)) (inits_and_rest_of_list l)
 
 let _ =
   Common2.example
@@ -400,7 +400,7 @@ let rec all_splits = function
   | [] -> [ ([], []) ]
   | x :: xs ->
       all_splits xs
-      |> List.map (function ls, rs -> [ (x :: ls, rs); (ls, x :: rs) ])
+      |> Common.map (function ls, rs -> [ (x :: ls, rs); (ls, x :: rs) ])
       |> List.flatten
 
 (* let _ = Common2.example
@@ -593,14 +593,14 @@ let m_comb_bind (comb_result : _ comb_result) f : _ comb_result =
     | [] -> []
     | (bs, tout) :: comb_matches' ->
         let bs_matches =
-          tout |> List.map (fun tin -> f bs tin) |> List.flatten
+          tout |> Common.map (fun tin -> f bs tin) |> List.flatten
         in
         bs_matches @ loop comb_matches'
   in
   loop (comb_result tin)
 
 let m_comb_flatten (comb_result : _ comb_result) (tin : tin) : tout =
-  comb_result tin |> List.map snd |> List.flatten
+  comb_result tin |> Common.map snd |> List.flatten
 
 let m_comb_fold (m_comb : _ comb_matcher) (xs : _ list)
     (comb_result : _ comb_result) : _ comb_result =

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -135,7 +135,7 @@ let subexprs_of_expr with_symbolic_propagation e =
   | Comprehension (_, (_, (e, xs), _)) ->
       e
       :: (xs
-         |> List.map (function
+         |> Common.map (function
               | CompFor (_, _pat, _, e) -> e
               | CompIf (_, e) -> e))
   | New (_, _t, args) -> subexprs_of_args args
@@ -146,7 +146,7 @@ let subexprs_of_expr with_symbolic_propagation e =
       e1
       :: (e2 |> unbracket
          |> (fun (a, b, c) -> [ a; b; c ])
-         |> List.map Option.to_list |> List.flatten)
+         |> Common.map Option.to_list |> List.flatten)
   | Yield (_, eopt, _) -> Option.to_list eopt
   | StmtExpr st -> subexprs_of_stmt st
   | OtherExpr (_, anys) ->
@@ -197,13 +197,13 @@ let substmts_of_stmt st =
   | Block (_, xs, _) -> xs
   | Switch (_, _, xs) ->
       xs
-      |> List.map (function
+      |> Common.map (function
            | CasesAndBody (_, st) -> [ st ]
            | CaseEllipsis _ -> [])
       |> List.flatten
   | Try (_, st, xs, opt) -> (
       [ st ]
-      @ (xs |> List.map Common2.thd3)
+      @ (xs |> Common.map Common2.thd3)
       @
       match opt with
       | None -> []
@@ -291,9 +291,9 @@ let flatten_substmts_of_stmts xs =
     (if !go_really_deeper_stmt then
      let es = subexprs_of_stmt x in
      (* getting deeply nested lambdas stmts *)
-     let lambdas = es |> List.map lambdas_in_expr_memo |> List.flatten in
+     let lambdas = es |> Common.map lambdas_in_expr_memo |> List.flatten in
      lambdas
-     |> List.map (fun def -> H.funcbody_to_stmt def.fbody)
+     |> Common.map (fun def -> H.funcbody_to_stmt def.fbody)
      |> List.iter aux);
 
     let xs = substmts_of_stmt x in

--- a/semgrep-core/src/optimizing/Caching.ml
+++ b/semgrep-core/src/optimizing/Caching.ml
@@ -421,7 +421,7 @@ module Cache = struct
     let cached_span : Stmts_match_span.t = access.get_span_field cached_acc in
 
     let patched_full_env =
-      List.map
+      Common.map
         (fun ((k, _v) as cached_binding) ->
           if Env.has_backref k backrefs (* = is in min_env *) then
             cached_binding
@@ -482,7 +482,7 @@ module Cache = struct
             match res with
             | [] -> []
             | res ->
-                List.map
+                Common.map
                   (fun cached_acc ->
                     patch_result_from_cache ~access backrefs a acc cached_acc)
                   res)

--- a/semgrep-core/src/parsing/Parse_equivalences.ml
+++ b/semgrep-core/src/parsing/Parse_equivalences.ml
@@ -32,7 +32,7 @@ let parse file =
       match v with
       | `O [ ("equivalences", `A xs) ] ->
           xs
-          |> List.map (fun v ->
+          |> Common.map (fun v ->
                  match v with
                  | `O xs -> (
                      match Common.sort_by_key_lowfirst xs with
@@ -43,7 +43,7 @@ let parse file =
                      ] ->
                          let languages =
                            langs
-                           |> List.map (function
+                           |> Common.map (function
                                 | `String s -> (
                                     match Lang.lang_of_string_opt s with
                                     | None ->

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -105,11 +105,11 @@ let generic_to_json env (key : key) ast =
     | G.L (Float (Some f, _)) -> J.Float f
     | G.L (Int (Some i, _)) -> J.Int i
     | G.L (String (s, _)) -> J.String s
-    | G.Container (Array, (_, xs, _)) -> J.Array (xs |> List.map aux)
+    | G.Container (Array, (_, xs, _)) -> J.Array (xs |> Common.map aux)
     | G.Container (Dict, (_, xs, _)) ->
         J.Object
           (xs
-          |> List.map (fun x ->
+          |> Common.map (fun x ->
                  match x.G.e with
                  | G.Container
                      (G.Tuple, (_, [ { e = L (String (k, _)); _ }; v ], _)) ->
@@ -219,7 +219,7 @@ let parse_string_wrap_no_env (key : key) x =
 
 let parse_list_no_env (key : key) f x =
   match x.G.e with
-  | G.Container (Array, (_, xs, _)) -> List.map f xs
+  | G.Container (Array, (_, xs, _)) -> Common.map f xs
   | _ -> yaml_error_at_key key ("Expected a list for " ^ fst key)
 
 let parse_string_wrap_list_no_env (key : key) e =
@@ -245,7 +245,7 @@ let parse_string env (key : key) x = parse_string_wrap env key x |> fst
 
 let parse_list env (key : key) f x =
   match x.G.e with
-  | G.Container (Array, (_, xs, _)) -> List.map (f env) xs
+  | G.Container (Array, (_, xs, _)) -> Common.map (f env) xs
   | _ -> error_at_key env key ("Expected a list for " ^ fst key)
 
 (* TODO: delete at some point, should use parse_string_wrap_list *)
@@ -670,7 +670,7 @@ let parse_languages ~id langs : Xlang.t =
   | xs -> (
       let languages =
         xs
-        |> List.map (function s, t ->
+        |> Common.map (function s, t ->
                (match Lang.lang_of_string_opt s with
                | None -> raise (R.InvalidRule (R.InvalidLanguage s, fst id, t))
                | Some l -> l))

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -132,7 +132,7 @@ let dump_tree_sitter_cst lang file =
   | _ -> failwith "lang not supported by ocaml-tree-sitter"
 
 let test_parse_tree_sitter lang root_paths =
-  let paths = List.map Common.fullpath root_paths in
+  let paths = Common.map Common.fullpath root_paths in
   let paths, _skipped_paths =
     Find_target.files_of_dirs_or_files (Some lang) paths
   in
@@ -245,7 +245,7 @@ let parsing_common ?(verbose = true) lang files_or_dirs =
 
   let paths =
     (* = absolute paths *)
-    List.map Common.fullpath files_or_dirs
+    Common.map Common.fullpath files_or_dirs
   in
   let paths, skipped = Find_target.files_of_dirs_or_files (Some lang) paths in
   let stats =
@@ -330,7 +330,7 @@ let update_parsing_rate (acc : Parsing_stats_t.project_stats) :
 *)
 let aggregate_file_stats (results : (string * PI.parsing_stat list) list) :
     Parsing_stats_t.project_stats list =
-  List.map
+  Common.map
     (fun (project_name, file_stats) ->
       let acc =
         {
@@ -397,7 +397,7 @@ let print_json lang results =
   print_endline (Yojson.Safe.prettify s)
 
 let parse_projects ~verbose lang project_dirs =
-  List.map
+  Common.map
     (fun dir ->
       let name = dir in
       parse_project ~verbose lang name [ dir ])
@@ -407,7 +407,7 @@ let parsing_stats ?(json = false) ?(verbose = false) lang project_dirs =
   let stat_list = parse_projects ~verbose lang project_dirs in
   if json then print_json lang stat_list
   else
-    let flat_stat = List.map snd stat_list |> List.flatten in
+    let flat_stat = List.concat_map snd stat_list in
     Parse_info.print_parsing_stat_list flat_stat
 
 let parsing_regressions lang files_or_dirs =

--- a/semgrep-core/src/parsing/ast/AST_bash.ml
+++ b/semgrep-core/src/parsing/ast/AST_bash.ml
@@ -627,7 +627,7 @@ let concat_blists (x : blist list) : blist =
 
 let add_redirects_to_command (cmd_r : cmd_redir) (redirects : redirect list) :
     cmd_redir =
-  let all_locs = cmd_r.loc :: List.map redirect_loc redirects in
+  let all_locs = cmd_r.loc :: Common.map redirect_loc redirects in
   let loc = Loc.of_list (fun loc -> loc) all_locs in
   { cmd_r with loc; redirects = cmd_r.redirects @ redirects }
 

--- a/semgrep-core/src/parsing/ast/Bash_to_generic.ml
+++ b/semgrep-core/src/parsing/ast/Bash_to_generic.ml
@@ -123,7 +123,7 @@ let block : stmt_or_expr list -> stmt_or_expr = function
   | [ x ] -> x
   | several ->
       let loc = Loc.of_list stmt_or_expr_loc several in
-      let stmts = List.map as_stmt several in
+      let stmts = Common.map as_stmt several in
       Stmt (loc, G.s (G.Block (bracket loc stmts)))
 
 let mk_name (str_wrap : string wrap) : G.name =
@@ -194,7 +194,7 @@ end
    Usage: call C.cmd args
 *)
 let call loc name exprs =
-  G.Call (name loc, bracket loc (List.map (fun e -> G.Arg e) exprs)) |> G.e
+  G.Call (name loc, bracket loc (Common.map (fun e -> G.Arg e) exprs)) |> G.e
 
 let todo_tokens ((start, end_) : loc) =
   let wrap tok = (Parse_info.str_of_info tok, tok) in
@@ -227,7 +227,7 @@ let redirect_pipeline_stderr_to_stdout pip =
 let rec blist (env : env) (l : blist) : stmt_or_expr list =
   match l with
   | Seq (_loc, left, right) -> blist env left @ blist env right
-  | Pipelines (_loc, pl) -> List.map (fun x -> pipeline env x) pl
+  | Pipelines (_loc, pl) -> Common.map (fun x -> pipeline env x) pl
   | Empty _loc -> []
 
 and pipeline (env : env) (x : pipeline) : stmt_or_expr =
@@ -281,7 +281,7 @@ and command (env : env) (cmd : command) : stmt_or_expr =
       | [ (Expr_semgrep_ellipsis tok as e) ] ->
           Expr ((tok, tok), expression env e)
       | arguments ->
-          let args = List.map (expression env) arguments in
+          let args = Common.map (expression env) arguments in
           Expr (loc, call loc C.cmd args))
   | And (loc, left, and_tok, right) ->
       let left = pipeline env left |> as_expr in
@@ -301,7 +301,7 @@ and command (env : env) (cmd : command) : stmt_or_expr =
       let header =
         let values : G.expr list =
           match opt_in with
-          | Some (_in, vals) -> List.map (fun x -> expression env x) vals
+          | Some (_in, vals) -> Common.map (fun x -> expression env x) vals
           | None ->
               (*
                  Pretend there's a '"$@"', which is semantically correct
@@ -334,11 +334,11 @@ and command (env : env) (cmd : command) : stmt_or_expr =
   | Case (loc, case, subject, in_, clauses, esac) ->
       let subject = expression env subject in
       let clauses =
-        List.map
+        Common.map
           (fun (loc, patterns, paren, stmts, _opt_term) ->
             (* TODO: handle the different kinds of terminators. Insert breaks. *)
             let patterns =
-              List.map
+              Common.map
                 (fun e ->
                   let tok, _ = expression_loc e in
                   let pat =
@@ -435,7 +435,7 @@ and assignment (env : env) ass =
    is needed for matching. We can't simplify it into a single expression
    if there's only one statement. *)
 and stmt_group (env : env) (loc : loc) (l : stmt_or_expr list) : stmt_or_expr =
-  let stmts = List.map as_stmt l in
+  let stmts = Common.map as_stmt l in
   let start, end_ = loc in
   Stmt (loc, G.s (G.Block (start, stmts, end_)))
 
@@ -453,7 +453,7 @@ and expression (env : env) (e : expression) : G.expr =
           G.L (G.String wrap) |> G.e
       | _ ->
           let loc = (open_, close) in
-          List.map (string_fragment env) frags |> call loc C.quoted_concat)
+          Common.map (string_fragment env) frags |> call loc C.quoted_concat)
   | String_fragment (loc, frag) -> string_fragment env frag
   | Raw_string (* 'foo' *) (str, tok) ->
       (* normalization to enable matching of e.g. 'foo' against foo *)
@@ -467,7 +467,8 @@ and expression (env : env) (e : expression) : G.expr =
       G.L (G.String (without_quotes, tok)) |> G.e
   | Ansii_c_string str -> G.L (G.String str) |> G.e
   | Special_character str -> G.L (G.String str) |> G.e
-  | Concatenation (loc, el) -> List.map (expression env) el |> call loc C.concat
+  | Concatenation (loc, el) ->
+      Common.map (expression env) el |> call loc C.concat
   | Expr_semgrep_ellipsis tok -> G.Ellipsis tok |> G.e
   | Expr_semgrep_deep_ellipsis (_loc, (open_, e, close)) ->
       G.DeepEllipsis (open_, expression env e, close) |> G.e
@@ -475,7 +476,7 @@ and expression (env : env) (e : expression) : G.expr =
   | Equality_test (loc, _, _) -> (* don't know what this is *) todo_expr loc
   | Empty_expression loc -> G.L (G.String ("", fst loc)) |> G.e
   | Array (loc, (open_, elts, close)) ->
-      let elts = List.map (expression env) elts in
+      let elts = Common.map (expression env) elts in
       G.Container (G.Array, (open_, elts, close)) |> G.e
   | Process_substitution (loc, (open_, x, close)) ->
       let arg = blist env x |> block |> as_expr in
@@ -508,7 +509,7 @@ and expansion (env : env) (x : expansion) : G.expr =
 
 and expand loc (var_expr : G.expr) : G.expr = call loc C.expand [ var_expr ]
 
-let program (env : env) x = blist (env : env) x |> List.map as_stmt
+let program (env : env) x = blist (env : env) x |> Common.map as_stmt
 
 (*
    Unwrap the pattern tree as much as possible to maximize matches.

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -509,7 +509,7 @@ let program file =
     }
   in
   let xs = parse env in
-  List.map G.exprstmt xs
+  Common.map G.exprstmt xs
 
 let any str =
   let file = "<pattern_file>" in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
@@ -134,7 +134,7 @@ let string_literal (env : env) ((v1, v2, v3) : CST.string_literal) : string wrap
     (* "\"" *)
   in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Imm_tok_pat_c7f65b4 tok -> str env tok (* pattern "[^\\\\\"\\n]+" *)
@@ -143,8 +143,8 @@ let string_literal (env : env) ((v1, v2, v3) : CST.string_literal) : string wrap
       v2
   in
   let v3 = token env v3 (* "\"" *) in
-  let s = v2 |> List.map fst |> String.concat "" in
-  (s, PI.combine_infos v1 (List.map snd v2 @ [ v3 ]))
+  let s = v2 |> Common.map fst |> String.concat "" in
+  (s, PI.combine_infos v1 (Common.map snd v2 @ [ v3 ]))
 
 let char_literal (env : env) ((v1, v2, v3) : CST.char_literal) : string wrap =
   let v1 =
@@ -253,7 +253,7 @@ let rec preproc_argument_list (env : env)
     | Some (v1, v2) ->
         let v1 = preproc_expression env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = preproc_expression env v2 in
@@ -264,7 +264,7 @@ let rec preproc_argument_list (env : env)
     | None -> []
   in
   let v3 = token env v3 (* ")" *) in
-  (v1, v2 |> List.map (fun x -> Arg x), v3)
+  (v1, v2 |> Common.map (fun x -> Arg x), v3)
 
 and preproc_binary_expression (env : env) (x : CST.preproc_binary_expression) :
     expr =
@@ -426,7 +426,7 @@ let preproc_params (env : env) ((v1, v2, v3) : CST.preproc_params) : name list =
     | Some (v1, v2) ->
         let v1 = anon_choice_type_id_d3c4b5f env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = anon_choice_type_id_d3c4b5f env v2 in
@@ -460,7 +460,7 @@ let rec abstract_declarator (env : env) (x : CST.abstract_declarator) :
   match x with
   | `Abst_poin_decl (v1, v2, v3) ->
       let v1 = token env v1 (* "*" *) in
-      let _v2 = List.map (type_qualifier env) v2 in
+      let _v2 = Common.map (type_qualifier env) v2 in
       let v3 =
         match v3 with
         | Some x ->
@@ -480,7 +480,7 @@ let rec abstract_declarator (env : env) (x : CST.abstract_declarator) :
       v1
   | `Abst_array_decl (v1, v2, v3, v4, v5) ->
       let _v2 = token env v2 (* "[" *) in
-      let _v3 = List.map (type_qualifier env) v3 in
+      let _v3 = Common.map (type_qualifier env) v3 in
       let v4 =
         match v4 with
         | Some x -> Some (anon_choice_exp_508611b env x)
@@ -526,7 +526,7 @@ and anon_choice_init_pair_1a6981e (env : env)
   match x with
   | `Init_pair (v1, v2, v3) ->
       let v1 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Subs_desi x ->
@@ -574,13 +574,13 @@ and anon_choice_prep_else_in_field_decl_list_97ea65e (env : env)
   match x with
   | `Prep_else_in_field_decl_list (v1, v2) ->
       let _v1 = token env v1 (* pattern #[ 	]*else *) in
-      let _v2 = List.map (field_declaration_list_item env) v2 in
+      let _v2 = Common.map (field_declaration_list_item env) v2 in
       ()
   | `Prep_elif_in_field_decl_list (v1, v2, v3, v4, v5) ->
       let _v1 = token env v1 (* pattern #[ 	]*elif *) in
       let _v2 = preproc_expression env v2 in
       let _v3 = token env v3 (* "\n" *) in
-      let _v4 = List.map (field_declaration_list_item env) v4 in
+      let _v4 = Common.map (field_declaration_list_item env) v4 in
       let _v5 =
         match v5 with
         | Some x ->
@@ -628,7 +628,7 @@ and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
     | Some (v1, v2) ->
         let v1 = expression env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = expression env v2 in
@@ -639,7 +639,7 @@ and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
     | None -> []
   in
   let v3 = token env v3 (* ")" *) in
-  (v1, v2 |> List.map (fun x -> Arg x), v3)
+  (v1, v2 |> Common.map (fun x -> Arg x), v3)
 
 and assignment_left_expression (env : env) (x : CST.assignment_left_expression)
     : expr =
@@ -784,9 +784,9 @@ and call_expression (env : env) ((v1, v2) : CST.call_expression) : expr =
 
 and declaration_specifiers (env : env)
     ((v1, v2, v3) : CST.declaration_specifiers) : type_ =
-  let _v1 = List.map (anon_choice_stor_class_spec_5764fed env) v1 in
+  let _v1 = Common.map (anon_choice_stor_class_spec_5764fed env) v1 in
   let v2 = type_specifier env v2 in
-  let _v3 = List.map (anon_choice_stor_class_spec_5764fed env) v3 in
+  let _v3 = Common.map (anon_choice_stor_class_spec_5764fed env) v3 in
   v2
 
 (* return a couple (name * partial type (to be applied to return type)) *)
@@ -799,19 +799,19 @@ and declarator (env : env) (x : CST.declarator) : name * (type_ -> type_) =
         | None -> None
       in
       let v2 = token env v2 (* "*" *) in
-      let _v3 = List.map (ms_pointer_modifier env) v3 in
-      let _v4 = List.map (type_qualifier env) v4 in
+      let _v3 = Common.map (ms_pointer_modifier env) v3 in
+      let _v4 = Common.map (type_qualifier env) v4 in
       let id, f = declarator env v5 in
       (id, fun t -> TPointer (v2, t) |> f)
   | `Func_decl (v1, v2, v3) ->
       let id, f = declarator env v1 in
       let v2 = parameter_list env v2 in
-      let _v3 = List.map (attribute_specifier env) v3 in
+      let _v3 = Common.map (attribute_specifier env) v3 in
       (id, fun t -> f (TFunction (t, v2)))
   | `Array_decl (v1, v2, v3, v4, v5) ->
       let id, f = declarator env v1 in
       let _v2 = token env v2 (* "[" *) in
-      let _v3 = List.map (type_qualifier env) v3 in
+      let _v3 = Common.map (type_qualifier env) v3 in
       let v4 =
         match v4 with
         | Some x -> Some (anon_choice_exp_508611b env x)
@@ -847,7 +847,7 @@ and enumerator_list (env : env) ((v1, v2, v3, v4) : CST.enumerator_list) =
     | Some (v1, v2) ->
         let v1 = enumerator env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = enumerator env v2 in
@@ -945,7 +945,7 @@ and expression (env : env) (x : CST.expression) : expr =
       Null t
   | `Conc_str (v1, v2) ->
       let v1 = string_literal env v1 in
-      let v2 = List.map (string_literal env) v2 in
+      let v2 = Common.map (string_literal env) v2 in
       ConcatString (v1 :: v2)
   | `Char_lit x ->
       let c = char_literal env x in
@@ -955,9 +955,9 @@ and expression (env : env) (x : CST.expression) : expr =
 and field_declaration_list (env : env)
     ((v1, v2, v3) : CST.field_declaration_list) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = List.map (field_declaration_list_item env) v2 in
+  let v2 = List.concat_map (field_declaration_list_item env) v2 in
   let v3 = token env v3 (* "}" *) in
-  (v1, List.flatten v2, v3)
+  (v1, v2, v3)
 
 and field_declaration_list_item (env : env)
     (x : CST.field_declaration_list_item) : field_def list =
@@ -969,7 +969,7 @@ and field_declaration_list_item (env : env)
         | Some (v1, v2) ->
             let v1 = field_declarator env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token env v1 (* "," *) in
                   let v2 = field_declarator env v2 in
@@ -985,7 +985,7 @@ and field_declaration_list_item (env : env)
         | None -> None
       in
       let _v4 = token env v4 (* ";" *) in
-      v2 |> List.map (fun (id, f) -> { fld_name = Some id; fld_type = f v1 })
+      v2 |> Common.map (fun (id, f) -> { fld_name = Some id; fld_type = f v1 })
   | `Prep_def x ->
       let _ = preproc_def env x in
       []
@@ -1000,7 +1000,7 @@ and field_declaration_list_item (env : env)
       let _v1 = token env v1 (* pattern #[ 	]*if *) in
       let _v2 = preproc_expression env v2 in
       let _v3 = token env v3 (* "\n" *) in
-      let v4 = List.map (field_declaration_list_item env) v4 in
+      let v4 = List.concat_map (field_declaration_list_item env) v4 in
       let _v5 =
         match v5 with
         | Some x ->
@@ -1008,12 +1008,12 @@ and field_declaration_list_item (env : env)
         | None -> None
       in
       let _v6 = token env v6 (* pattern #[ 	]*endif *) in
-      v4 |> List.flatten
+      v4
   (* just taking the first branch *)
   | `Prep_ifdef_in_field_decl_list (v1, v2, v3, v4, v5) ->
       let _v1 = anon_choice_pat_25b90ba_4a37f8c env v1 in
       let _v2 = identifier env v2 (* pattern [a-zA-Z_]\w* *) in
-      let v3 = List.map (field_declaration_list_item env) v3 in
+      let v3 = List.concat_map (field_declaration_list_item env) v3 in
       let _v4 =
         match v4 with
         | Some x ->
@@ -1021,7 +1021,7 @@ and field_declaration_list_item (env : env)
         | None -> None
       in
       let _v5 = token env v5 (* pattern #[ 	]*endif *) in
-      v3 |> List.flatten
+      v3
 
 (* argh, diff with regular declarator ? *)
 and field_declarator (env : env) (x : CST.field_declarator) :
@@ -1034,8 +1034,8 @@ and field_declarator (env : env) (x : CST.field_declarator) :
         | None -> None
       in
       let v2 = token env v2 (* "*" *) in
-      let _v3 = List.map (ms_pointer_modifier env) v3 in
-      let _v4 = List.map (type_qualifier env) v4 in
+      let _v3 = Common.map (ms_pointer_modifier env) v3 in
+      let _v4 = Common.map (type_qualifier env) v4 in
       let id, f = field_declarator env v5 in
       (id, fun t -> TPointer (v2, t) |> f)
   | `Func_field_decl (v1, v2) ->
@@ -1045,7 +1045,7 @@ and field_declarator (env : env) (x : CST.field_declarator) :
   | `Array_field_decl (v1, v2, v3, v4, v5) ->
       let id, f = field_declarator env v1 in
       let _v2 = token env v2 (* "[" *) in
-      let _v3 = List.map (type_qualifier env) v3 in
+      let _v3 = Common.map (type_qualifier env) v3 in
       let v4 =
         match v4 with
         | Some x -> Some (anon_choice_exp_508611b env x)
@@ -1083,7 +1083,7 @@ and initializer_list (env : env) ((v1, v2, v3, v4) : CST.initializer_list) :
     | Some (v1, v2) ->
         let v1 = anon_choice_init_pair_1a6981e env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = anon_choice_init_pair_1a6981e env v2 in
@@ -1102,7 +1102,7 @@ and initializer_list (env : env) ((v1, v2, v3, v4) : CST.initializer_list) :
   (* TODO: can be RecordInit too! *)
   let elems =
     v2
-    |> List.map (function
+    |> Common.map (function
          | Right e -> (None, e)
          | Left (designators, _tkeq, e) -> (
              match designators with
@@ -1124,7 +1124,7 @@ and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
     | Some (v1, v2) ->
         let v1 = anon_choice_param_decl_bdc8cc9 env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = anon_choice_param_decl_bdc8cc9 env v2 in
@@ -1170,9 +1170,9 @@ and subscript_expression (env : env)
 
 and type_descriptor (env : env) ((v1, v2, v3, v4) : CST.type_descriptor) : type_
     =
-  let _v1 = List.map (type_qualifier env) v1 in
+  let _v1 = Common.map (type_qualifier env) v1 in
   let v2 = type_specifier env v2 in
-  let _v3 = List.map (type_qualifier env) v3 in
+  let _v3 = Common.map (type_qualifier env) v3 in
   let v4 =
     match v4 with
     | Some x -> (abstract_declarator env x) v2
@@ -1261,7 +1261,7 @@ and type_specifier (env : env) (x : CST.type_specifier) : type_ =
   | `Sized_type_spec (v1, v2) ->
       let v1 =
         (* repeat1 in grammar.js so at least one *)
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Signed tok -> str env tok (* "signed" *)
@@ -1280,8 +1280,8 @@ and type_specifier (env : env) (x : CST.type_specifier) : type_ =
         | None -> []
       in
       let xs = v1 @ v2 in
-      let s = xs |> List.map fst |> String.concat " " in
-      let ys = xs |> List.map snd in
+      let s = xs |> Common.map fst |> String.concat " " in
+      let ys = xs |> Common.map snd in
       (* repeat1 in grammar.js so List.hd is safe *)
       let tk = PI.combine_infos (List.hd ys) (List.tl ys) in
       TBase (s, tk)
@@ -1325,8 +1325,8 @@ let rec type_declarator (env : env) (x : CST.type_declarator) :
         | None -> None
       in
       let v2 = token env v2 (* "*" *) in
-      let _v3 = List.map (ms_pointer_modifier env) v3 in
-      let _v4 = List.map (type_qualifier env) v4 in
+      let _v3 = Common.map (ms_pointer_modifier env) v3 in
+      let _v4 = Common.map (type_qualifier env) v4 in
       let id, f = type_declarator env v5 in
       (id, fun t -> TPointer (v2, t) |> f)
   | `Func_type_decl (v1, v2) ->
@@ -1336,7 +1336,7 @@ let rec type_declarator (env : env) (x : CST.type_declarator) :
   | `Array_type_decl (v1, v2, v3, v4, v5) ->
       let id, f = type_declarator env v1 in
       let _v2 = token env v2 (* "[" *) in
-      let _v3 = List.map (type_qualifier env) v3 in
+      let _v3 = Common.map (type_qualifier env) v3 in
       let v4 =
         match v4 with
         | Some x -> Some (anon_choice_exp_508611b env x)
@@ -1378,11 +1378,11 @@ let anon_choice_decl_f8b0ff3 (env : env) (x : CST.anon_choice_decl_f8b0ff3) =
 let type_definition (env : env) ((v1, v2, v3, v4, v5, v6) : CST.type_definition)
     : type_def list =
   let _v1 = token env v1 (* "typedef" *) in
-  let _v2 = List.map (type_qualifier env) v2 in
+  let _v2 = Common.map (type_qualifier env) v2 in
   let v3 = type_specifier env v3 in
   let v4 = type_declarator env v4 in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = type_declarator env v2 in
@@ -1391,14 +1391,14 @@ let type_definition (env : env) ((v1, v2, v3, v4, v5, v6) : CST.type_definition)
   in
   let xs = v4 :: v5 in
   let _v6 = token env v6 (* ";" *) in
-  xs |> List.map (fun (id, f) -> { t_name = id; t_type = f v3 })
+  xs |> Common.map (fun (id, f) -> { t_name = id; t_type = f v3 })
 
 let declaration (env : env) ((v1, v2, v3, v4) : CST.declaration) : var_decl list
     =
   let v1 = declaration_specifiers env v1 in
   let v2 = anon_choice_decl_f8b0ff3 env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = anon_choice_decl_f8b0ff3 env v2 in
@@ -1407,7 +1407,7 @@ let declaration (env : env) ((v1, v2, v3, v4) : CST.declaration) : var_decl list
   in
   let xs = v2 :: v3 in
   let _v4 = token env v4 (* ";" *) in
-  xs |> List.map (fun f -> f v1)
+  xs |> Common.map (fun f -> f v1)
 
 let rec anon_choice_prep_else_8b52b0f (env : env)
     (x : CST.anon_choice_prep_else_8b52b0f) =
@@ -1580,7 +1580,7 @@ and statement2 (env : env) (x : CST.statement) : (case, stmt) Common.either =
   | `Case_stmt (v1, v2, v3) ->
       let _v2 = token env v2 (* ":" *) in
       let v3 =
-        List.map
+        List.concat_map
           (fun x ->
             match x with
             | `Choice_labe_stmt x -> [ non_case_statement env x ]
@@ -1589,9 +1589,8 @@ and statement2 (env : env) (x : CST.statement) : (case, stmt) Common.either =
                 [ Vars vars ]
             | `Type_defi x ->
                 let xs = type_definition env x in
-                xs |> List.map (fun t -> DefStmt (TypeDef t)))
+                xs |> Common.map (fun t -> DefStmt (TypeDef t)))
           v3
-        |> List.flatten
       in
 
       let v1 =
@@ -1621,19 +1620,19 @@ and top_level_item (env : env) (x : CST.top_level_item) : toplevel list =
         | `Func_defi x -> [ DefStmt (FuncDef (function_definition env x)) ]
         | `Decl x ->
             let vars = declaration env x in
-            vars |> List.map (fun v -> DefStmt (VarDef v))
+            vars |> Common.map (fun v -> DefStmt (VarDef v))
         | `Decl_list x -> declaration_list env x
       in
       v3
   | `Decl x ->
       let vars = declaration env x in
-      vars |> List.map (fun v -> DefStmt (VarDef v))
+      vars |> Common.map (fun v -> DefStmt (VarDef v))
   | `Choice_case_stmt x ->
       let st = statement env x in
       [ st ]
   | `Type_defi x ->
       let xs = type_definition env x in
-      xs |> List.map (fun x -> DefStmt (TypeDef x))
+      xs |> Common.map (fun x -> DefStmt (TypeDef x))
   | `Empty_decl (v1, v2) ->
       let _v1 = type_specifier env v1 in
       let _v2 = token env v2 (* ";" *) in
@@ -1688,7 +1687,7 @@ and top_level_item (env : env) (x : CST.top_level_item) : toplevel list =
   | `Prep_call x -> [ DirStmt (preproc_call env x) ]
 
 and translation_unit (env : env) (xs : CST.translation_unit) : program =
-  List.map
+  List.concat_map
     (fun x ->
       let res = top_level_item env x in
       let env = env.extra in
@@ -1699,13 +1698,12 @@ and translation_unit (env : env) (xs : CST.translation_unit) : program =
       env.struct_defs_toadd <- [];
       env.enum_defs_toadd <- [];
       env.typedefs_toadd <- [];
-      ((structs |> List.map (fun x -> StructDef x))
-       @ (enums |> List.map (fun x -> EnumDef x))
-       @ (typedefs |> List.map (fun x -> TypeDef x))
-      |> List.map (fun x -> DefStmt x))
+      ((structs |> Common.map (fun x -> StructDef x))
+       @ (enums |> Common.map (fun x -> EnumDef x))
+       @ (typedefs |> Common.map (fun x -> TypeDef x))
+      |> Common.map (fun x -> DefStmt x))
       @ res)
     xs
-  |> List.flatten
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -396,7 +396,7 @@ let map_string_literal (env : env) ((v1, v2, v3) : CST.string_literal) :
     (* "\"" *)
   in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Imm_tok_pat_c7f65b4 tok -> str env tok (* pattern "[^\\\\\"\\n]+" *)
@@ -404,8 +404,8 @@ let map_string_literal (env : env) ((v1, v2, v3) : CST.string_literal) :
         (* escape_sequence *))
       v2
   in
-  let s = v2 |> List.map fst |> String.concat "" in
-  let xs = v2 |> List.map snd in
+  let s = v2 |> Common.map fst |> String.concat "" in
+  let xs = v2 |> Common.map snd in
   let v3 = token env v3 (* "\"" *) in
   let t = PI.combine_infos v1 (xs @ [ v3 ]) in
   (s, t)
@@ -493,7 +493,7 @@ let map_anon_choice_stmt_id_d3c4b5f (env : env)
 let map_sized_type_specifier (env : env) ((v1, v2) : CST.sized_type_specifier) :
     type_ =
   let v1 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Signed tok -> (TSigned, token env tok) (* "signed" *)
@@ -538,7 +538,7 @@ let rec map_preproc_argument_list (env : env)
     | Some (v1, v2) ->
         let v1 = map_preproc_expression env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_preproc_expression env v2 in
@@ -658,7 +658,7 @@ and map_preproc_expression (env : env) (x : CST.preproc_expression) : expr =
       expr_of_id x
   | `Prep_call_exp x ->
       let id, (l, xs, r) = map_preproc_call_expression env x in
-      let args = xs |> List.map expr_to_arg in
+      let args = xs |> Common.map expr_to_arg in
       Call (expr_of_id id, (l, args, r))
   | `Num_lit tok ->
       let x = str env tok (* number_literal *) in
@@ -698,7 +698,7 @@ let map_preproc_params (env : env) ((v1, v2, v3) : CST.preproc_params) =
     | Some (v1, v2) ->
         let v1 = map_anon_choice_stmt_id_d3c4b5f env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_anon_choice_stmt_id_d3c4b5f env v2 in
@@ -724,7 +724,7 @@ let map_anon_choice_stmt_id_efddc5b (env : env)
 
 let map_concatenated_string (env : env) ((v1, v2) : CST.concatenated_string) =
   let v1 = map_anon_choice_raw_str_lit_28125b5 env v1 in
-  let v2 = List.map (map_anon_choice_raw_str_lit_28125b5 env) v2 in
+  let v2 = Common.map (map_anon_choice_raw_str_lit_28125b5 env) v2 in
   match v2 with
   | [] -> String v1
   | _ -> MultiString (v1 :: v2)
@@ -746,7 +746,7 @@ let map_preproc_include (env : env) ((v1, v2, v3) : CST.preproc_include) =
         IncOther (expr_of_id id)
     | `Prep_call_exp x ->
         let id, (l, xs, r) = map_preproc_call_expression env x in
-        let args = xs |> List.map expr_to_arg in
+        let args = xs |> Common.map expr_to_arg in
         let x = Call (expr_of_id id, (l, args, r)) in
         IncOther x
   in
@@ -778,7 +778,7 @@ let rec map_abstract_array_declarator (env : env)
     | None -> id
   in
   let v2 = token env v2 (* "[" *) in
-  let v3 = List.map (map_type_qualifier env) v3 in
+  let v3 = Common.map (map_type_qualifier env) v3 in
   let v4 =
     match v4 with
     | Some x -> Some (map_anon_choice_exp_508611b env x)
@@ -815,7 +815,7 @@ and map_abstract_function_declarator (env : env)
   in
   let v2 = map_parameter_list env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Type_qual x ->
@@ -864,7 +864,7 @@ and map_abstract_parenthesized_declarator (env : env)
 and map_abstract_pointer_declarator (env : env)
     ((v1, v2, v3) : CST.abstract_pointer_declarator) : abstract_declarator =
   let v1 = token env v1 (* "*" *) in
-  let v2 = List.map (map_type_qualifier env) v2 in
+  let v2 = Common.map (map_type_qualifier env) v2 in
   let f1 x = (v2, TPointer (v1, x, [])) in
   let v3 =
     match v3 with
@@ -925,7 +925,7 @@ and map_anon_choice_class_name_d6703e6 (env : env)
             {
               c_kind = ckey;
               c_inherit =
-                v3 |> List.map (fun clause -> { clause with i_virtual = v2 });
+                v3 |> Common.map (fun clause -> { clause with i_virtual = v2 });
               c_members = v4;
             } )
         in
@@ -955,12 +955,12 @@ and map_anon_choice_decl_f8b0ff3 (env : env) (x : CST.anon_choice_decl_f8b0ff3)
   | `Decl x ->
       let x = map_declarator env x in
       fun attrs t specs ->
-        let v_specs = List.map (fun x -> A x) attrs @ specs in
+        let v_specs = Common.map (fun x -> A x) attrs @ specs in
         make_onedecl ~v_name:x.dn ~v_type:(x.dt t) ~v_init:None ~v_specs
   | `Init_decl x ->
       let x, init = map_init_declarator env x in
       fun attrs t specs ->
-        let v_specs = List.map (fun x -> A x) attrs @ specs in
+        let v_specs = Common.map (fun x -> A x) attrs @ specs in
         make_onedecl ~v_name:x.dn ~v_type:(x.dt t) ~v_init:(Some init) ~v_specs
 
 and map_anon_choice_exp_3078596 (env : env) (x : CST.anon_choice_exp_3078596) :
@@ -998,7 +998,7 @@ and map_anon_choice_init_pair_1a6981e (env : env)
   match x with
   | `Init_pair (v1, v2, v3) ->
       let v1 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Subs_desi x -> map_subscript_designator env x
@@ -1094,21 +1094,21 @@ and map_anon_choice_prep_else_in_field_decl_list_97ea65e (env : env)
   match x with
   | `Prep_else_in_field_decl_list (v1, v2) ->
       let v1 = token env v1 (* pattern #[ 	]*else *) in
-      let v2 = List.map (map_field_declaration_list_item env) v2 in
+      let v2 = List.concat_map (map_field_declaration_list_item env) v2 in
       let dir = CppIfdef (IfdefElse v1) in
-      dir :: List.flatten v2
+      dir :: v2
   | `Prep_elif_in_field_decl_list (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* pattern #[ 	]*elif *) in
       let _v2 = map_preproc_expression env v2 in
       let _v3 = token env v3 (* "\n" *) in
-      let v4 = List.map (map_field_declaration_list_item env) v4 in
+      let v4 = List.concat_map (map_field_declaration_list_item env) v4 in
       let v5 =
         match v5 with
         | Some x -> map_anon_choice_prep_else_in_field_decl_list_97ea65e env x
         | None -> []
       in
       let dir = CppIfdef (IfdefElseif v1) in
-      (dir :: List.flatten v4) @ v5
+      (dir :: v4) @ v5
 
 (* used for field initializer in ctor/dtor *)
 and map_anon_choice_stmt_id_ae28a26 (env : env)
@@ -1209,7 +1209,7 @@ and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
     | Some (v1, v2) ->
         let v1 = map_anon_choice_exp_3078596 env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_anon_choice_exp_3078596 env v2 in
@@ -1222,7 +1222,7 @@ and map_argument_list (env : env) ((v1, v2, v3) : CST.argument_list) :
   let v3 = token env v3 (* ")" *) in
   ( v1,
     v2
-    |> List.map (function
+    |> Common.map (function
          | InitExpr e -> Arg e
          | InitList (l, xs, r) -> ArgInits (l, xs, r)
          | _ -> raise Impossible (* see map_anon_choice_exp_3078596 *)),
@@ -1232,7 +1232,7 @@ and map_array_declarator (env : env)
     ((v1, v2, v3, v4, v5) : CST.array_declarator) : declarator =
   let v1 = map_declarator env v1 in
   let v2 = token env v2 (* "[" *) in
-  let v3 = List.map (map_type_qualifier env) v3 in
+  let v3 = Common.map (map_type_qualifier env) v3 in
   let v4 =
     match v4 with
     | Some x -> Some (map_anon_choice_exp_508611b env x)
@@ -1245,7 +1245,7 @@ and map_array_field_declarator (env : env)
     ((v1, v2, v3, v4, v5) : CST.array_field_declarator) =
   let v1 = map_field_declarator env v1 in
   let v2 = token env v2 (* "[" *) in
-  let v3 = List.map (map_type_qualifier env) v3 in
+  let v3 = Common.map (map_type_qualifier env) v3 in
   let v4 =
     match v4 with
     | Some x -> Some (map_anon_choice_exp_508611b env x)
@@ -1298,7 +1298,7 @@ and map_attribute (env : env) ((v1, v2, v3, v4) : CST.attribute) : attribute =
   let v1 = token env v1 (* "[[" *) in
   let v2 = map_expression env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = map_expression env v2 in
@@ -1332,7 +1332,7 @@ and map_base_class_clause (env : env)
   in
   let base1 = { i_name = v3; i_access = v2; i_virtual = None } in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2, v3, v4) ->
         let _v1 = token env v1 (* "," *) in
         let v2 =
@@ -1482,7 +1482,7 @@ and map_case_statement (env : env) ((v1, v2, v3) : CST.case_statement) : stmt =
   in
   let v2 = token env v2 (* ":" *) in
   let v3 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Choice_labe_stmt x ->
@@ -1652,7 +1652,7 @@ and map_constructor_or_destructor_definition (env : env)
 
 and map_constructor_specifiers (env : env) (xs : CST.constructor_specifiers) :
     specifier list =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Stor_class_spec x ->
@@ -1674,11 +1674,11 @@ and map_constructor_specifiers (env : env) (xs : CST.constructor_specifiers) :
 
 and map_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.declaration) :
     vars_decl =
-  let v1 = List.map (map_attribute env) v1 in
+  let v1 = Common.map (map_attribute env) v1 in
   let t, specs = map_declaration_specifiers env v2 in
   let v3 = map_anon_choice_decl_f8b0ff3 env v3 in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = map_anon_choice_decl_f8b0ff3 env v2 in
@@ -1686,7 +1686,7 @@ and map_declaration (env : env) ((v1, v2, v3, v4, v5) : CST.declaration) :
       v4
   in
   let v5 = token env v5 (* ";" *) in
-  let xs = v3 :: v4 |> List.map (fun f -> f v1 t specs) in
+  let xs = v3 :: v4 |> Common.map (fun f -> f v1 t specs) in
   (xs, v5)
 
 and map_declaration_list (env : env) ((v1, v2, v3) : CST.declaration_list) :
@@ -1698,9 +1698,9 @@ and map_declaration_list (env : env) ((v1, v2, v3) : CST.declaration_list) :
 
 and map_declaration_specifiers (env : env)
     ((v1, v2, v3) : CST.declaration_specifiers) : type_ * specifier list =
-  let v1 = List.map (map_anon_choice_stor_class_spec_5764fed env) v1 in
+  let v1 = Common.map (map_anon_choice_stor_class_spec_5764fed env) v1 in
   let v2 = map_type_specifier env v2 in
-  let v3 = List.map (map_anon_choice_stor_class_spec_5764fed env) v3 in
+  let v3 = Common.map (map_anon_choice_stor_class_spec_5764fed env) v3 in
   (v2, v1 @ v3)
 
 and map_declarator (env : env) (x : CST.declarator) : declarator =
@@ -1742,7 +1742,7 @@ and map_declarator (env : env) (x : CST.declarator) : declarator =
       let v1 = token env v1 (* "[" *) in
       let v2 = str env v2 (* pattern [a-zA-Z_]\w* *) in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = str env v2 (* pattern [a-zA-Z_]\w* *) in
@@ -1794,7 +1794,7 @@ and map_enumerator_list (env : env) ((v1, v2, v3, v4) : CST.enumerator_list) =
     | Some (v1, v2) ->
         let v1 = map_enumerator env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_enumerator env v2 in
@@ -1964,7 +1964,7 @@ and map_expression_statement (env : env) ((v1, v2) : CST.expression_statement) :
 
 and map_field_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.field_declaration) : class_member =
-  let v1 = List.map (map_attribute env) v1 in
+  let v1 = Common.map (map_attribute env) v1 in
   let v2 =
     match v2 with
     | Some x -> [ M (map_virtual_function_specifier env x) ]
@@ -1976,7 +1976,7 @@ and map_field_declaration (env : env)
     | Some (v1, v2) ->
         let v1 = map_field_declarator env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_field_declarator env v2 in
@@ -1986,7 +1986,7 @@ and map_field_declaration (env : env)
         v1 :: v2
     | None -> []
   in
-  let specs = (v1 |> List.map (fun x -> A x)) @ v2 @ specs in
+  let specs = (v1 |> Common.map (fun x -> A x)) @ v2 @ specs in
   let v5 =
     match v5 with
     | Some x -> (
@@ -2007,7 +2007,7 @@ and map_field_declaration (env : env)
   (* TODO? v4 can be empty? *)
   let xs =
     v4
-    |> List.map (fun { dn; dt } ->
+    |> Common.map (fun { dn; dt } ->
            make_onedecl ~v_name:dn ~v_init:v5 ~v_type:(dt t) ~v_specs:specs)
   in
   F (DeclList (xs, v6))
@@ -2016,9 +2016,9 @@ and map_field_declaration_list (env : env)
     ((v1, v2, v3) : CST.field_declaration_list) :
     class_member sequencable list brace =
   let v1 = token env v1 (* "{" *) in
-  let v2 = List.map (map_field_declaration_list_item env) v2 in
+  let v2 = List.concat_map (map_field_declaration_list_item env) v2 in
   let v3 = token env v3 (* "}" *) in
-  (v1, List.flatten v2, v3)
+  (v1, v2, v3)
 
 and map_field_declaration_list_item (env : env)
     (x : CST.field_declaration_list_item) : class_member sequencable list =
@@ -2047,7 +2047,7 @@ and map_field_declaration_list_item (env : env)
       let x = map_template_declaration env x in
       [ X (F x) ]
   | `Inline_meth_defi (v1, v2, v3, v4, v5) ->
-      let v1 = List.map (map_attribute env) v1 in
+      let v1 = Common.map (map_attribute env) v1 in
       let v2 =
         match v2 with
         | Some x -> [ M (map_virtual_function_specifier env x) ]
@@ -2062,7 +2062,7 @@ and map_field_declaration_list_item (env : env)
       let fdef =
         ( {
             ent with
-            specs = ent.specs @ List.map (fun x -> A x) v1 @ v2 @ specs;
+            specs = ent.specs @ Common.map (fun x -> A x) v1 @ v2 @ specs;
           },
           def )
       in
@@ -2200,7 +2200,7 @@ and map_field_initializer_list (env : env)
   let _v1 = token env v1 (* ":" *) in
   let v2 = map_field_initializer env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = map_field_initializer env v2 in
@@ -2213,7 +2213,7 @@ and map_function_declarator (env : env)
     ((v1, v2, v3, v4) : CST.function_declarator) : declarator =
   let v1 = map_declarator env v1 in
   let v2 = map_parameter_list env v2 in
-  let _v3 = List.map (map_attribute_specifier env) v3 in
+  let _v3 = Common.map (map_attribute_specifier env) v3 in
   let ft_specs, ft_rets, ft_throw =
     Common.partition_either3 (map_anon_choice_type_qual_01506e0 env) v4
   in
@@ -2238,7 +2238,7 @@ and map_function_declarator (env : env)
 
 and map_function_definition (env : env)
     ((v1, v2, v3, v4, v5) : CST.function_definition) : func_definition =
-  let v1 = List.map (map_attribute env) v1 in
+  let v1 = Common.map (map_attribute env) v1 in
   let v2 =
     match v2 with
     | Some x ->
@@ -2252,7 +2252,8 @@ and map_function_definition (env : env)
   let n = name_of_dname_for_function dn in
   let t = dt t in
   let ent, def = HPfff.fixFunc ((n, t, []), FBDef v5) in
-  ({ ent with specs = ent.specs @ specs @ List.map (fun x -> A x) v1 @ v2 }, def)
+  ( { ent with specs = ent.specs @ specs @ Common.map (fun x -> A x) v1 @ v2 },
+    def )
 
 and map_function_field_declarator (env : env)
     ((v1, v2, v3) : CST.function_field_declarator) =
@@ -2309,7 +2310,7 @@ and map_initializer_list (env : env) ((v1, v2, v3, v4) : CST.initializer_list) :
     | Some (v1, v2) ->
         let v1 = map_anon_choice_init_pair_1a6981e env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_anon_choice_init_pair_1a6981e env v2 in
@@ -2337,28 +2338,28 @@ and map_lambda_capture_specifier (env : env)
         | Some (v1, v2) ->
             let v1 = map_expression env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token env v1 (* "," *) in
                   let v2 = map_expression env v2 in
                   v2)
                 v2
             in
-            v1 :: v2 |> List.map (fun e -> CaptureOther e)
+            v1 :: v2 |> Common.map (fun e -> CaptureOther e)
         | None -> [])
     | `Lambda_defa_capt_COMMA_exp_rep_COMMA_exp (v1, v2, v3, v4) ->
         let v1 = map_lambda_default_capture env v1 in
         let _v2 = token env v2 (* "," *) in
         let v3 = map_expression env v3 in
         let v4 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_expression env v2 in
               v2)
             v4
         in
-        v1 :: (v3 :: v4 |> List.map (fun e -> CaptureOther e))
+        v1 :: (v3 :: v4 |> Common.map (fun e -> CaptureOther e))
   in
   let v3 = token env v3 (* "]" *) in
   (v1, v2, v3)
@@ -2594,9 +2595,9 @@ and map_optional_type_parameter_declaration (env : env)
 
 and map_parameter_declaration (env : env)
     ((v1, v2, v3) : CST.parameter_declaration) : parameter_classic =
-  let v1 = List.map (map_attribute env) v1 in
+  let v1 = Common.map (map_attribute env) v1 in
   let t, specs = map_declaration_specifiers env v2 in
-  let p_specs = (v1 |> List.map (fun x -> A x)) @ specs in
+  let p_specs = (v1 |> Common.map (fun x -> A x)) @ specs in
   let v3 =
     match v3 with
     | Some x -> (
@@ -2620,7 +2621,7 @@ and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
     | Some (v1, v2) ->
         let v1 = map_anon_choice_param_decl_d9083af env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_anon_choice_param_decl_d9083af env v2 in
@@ -2662,8 +2663,8 @@ and map_pointer_declarator (env : env)
     | None -> []
   in
   let v2 = token env v2 (* "*" *) in
-  let v3 = List.map (map_ms_pointer_modifier env) v3 in
-  let v4 = List.map (map_type_qualifier env) v4 in
+  let v3 = Common.map (map_ms_pointer_modifier env) v3 in
+  let v4 = Common.map (map_type_qualifier env) v4 in
   let f1 x = (v4, TPointer (v2, x, v1 @ v3)) in
   let v5 = map_declarator env v5 in
   { dn = v5.dn; dt = (fun x -> x |> f1 |> v5.dt) }
@@ -2687,8 +2688,8 @@ and map_pointer_field_declarator (env : env)
     | None -> []
   in
   let v2 = token env v2 (* "*" *) in
-  let v3 = List.map (map_ms_pointer_modifier env) v3 in
-  let v4 = List.map (map_type_qualifier env) v4 in
+  let v3 = Common.map (map_ms_pointer_modifier env) v3 in
+  let v4 = Common.map (map_type_qualifier env) v4 in
   let f1 x = (v4, TPointer (v2, x, v1 @ v3)) in
   let v5 = map_field_declarator env v5 in
   { dn = v5.dn; dt = (fun x -> x |> f1 |> v5.dt) }
@@ -2718,7 +2719,7 @@ and map_preproc_if_in_field_declaration_list (env : env)
   let _v2TODO = map_preproc_expression env v2 in
   let _v3 = token env v3 (* "\n" *) in
   let dir1 = Ifdef v1 in
-  let v4 = List.map (map_field_declaration_list_item env) v4 in
+  let v4 = List.concat_map (map_field_declaration_list_item env) v4 in
   let v5 =
     match v5 with
     | Some x -> map_anon_choice_prep_else_in_field_decl_list_97ea65e env x
@@ -2726,7 +2727,7 @@ and map_preproc_if_in_field_declaration_list (env : env)
   in
   let v6 = token env v6 (* pattern #[ 	]*endif *) in
   let dir2 = IfdefEndif v6 in
-  (CppIfdef dir1 :: List.flatten v4) @ v5 @ [ CppIfdef dir2 ]
+  (CppIfdef dir1 :: v4) @ v5 @ [ CppIfdef dir2 ]
 
 and map_preproc_ifdef (env : env) ((v1, v2, v3, v4, v5) : CST.preproc_ifdef) :
     toplevel list =
@@ -2749,7 +2750,7 @@ and map_preproc_ifdef_in_field_declaration_list (env : env)
   let v1 = map_anon_choice_pat_25b90ba_4a37f8c env v1 in
   let dir1 = v1 in
   let _v2 = token env v2 (* pattern [a-zA-Z_]\w* *) in
-  let v3 = List.map (map_field_declaration_list_item env) v3 in
+  let v3 = List.concat_map (map_field_declaration_list_item env) v3 in
   let v4 =
     match v4 with
     | Some x -> map_anon_choice_prep_else_in_field_decl_list_97ea65e env x
@@ -2757,7 +2758,7 @@ and map_preproc_ifdef_in_field_declaration_list (env : env)
   in
   let v5 = token env v5 (* pattern #[ 	]*endif *) in
   let dir2 = IfdefEndif v5 in
-  (CppIfdef dir1 :: List.flatten v3) @ v4 @ [ CppIfdef dir2 ]
+  (CppIfdef dir1 :: v3) @ v4 @ [ CppIfdef dir2 ]
 
 and map_return_statement (env : env) (x : CST.return_statement) : stmt =
   match x with
@@ -2860,7 +2861,7 @@ and map_statement (env : env) (x : CST.statement) : stmt =
   | `Try_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "try" *) in
       let v2 = map_compound_statement env v2 in
-      let v3 = List.map (map_catch_clause env) v3 in
+      let v3 = Common.map (map_catch_clause env) v3 in
       Try (v1, v2, v3)
   | `Throw_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "throw" *) in
@@ -2924,7 +2925,7 @@ and map_template_argument_list (env : env)
     | Some (v1, v2) ->
         let v1 = map_anon_choice_type_desc_4d9cafa env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_anon_choice_type_desc_4d9cafa env v2 in
@@ -2992,7 +2993,7 @@ and map_template_parameter_list (env : env)
     | Some (v1, v2) ->
         let v1 = map_anon_choice_param_decl_13b5913 env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_anon_choice_param_decl_13b5913 env v2 in
@@ -3027,7 +3028,7 @@ and map_throw_specifier (env : env) ((v1, v2, v3, v4) : CST.throw_specifier) :
     | Some (v1, v2) ->
         let v1 = map_type_descriptor env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = map_type_descriptor env v2 in
@@ -3148,7 +3149,7 @@ and map_trailing_return_type (env : env)
   v4 v3
 
 and map_translation_unit (env : env) (xs : CST.translation_unit) : program =
-  List.map (map_top_level_item env) xs |> List.flatten
+  List.concat_map (map_top_level_item env) xs
 
 (* actually dn is an ident here, never a complex name *)
 and map_type_declarator (env : env) (x : CST.type_declarator) : declarator =
@@ -3160,8 +3161,8 @@ and map_type_declarator (env : env) (x : CST.type_declarator) : declarator =
         | None -> []
       in
       let v2 = token env v2 (* "*" *) in
-      let v3 = List.map (map_ms_pointer_modifier env) v3 in
-      let v4 = List.map (map_type_qualifier env) v4 in
+      let v3 = Common.map (map_ms_pointer_modifier env) v3 in
+      let v4 = Common.map (map_type_qualifier env) v4 in
       let f1 x = (v4, TPointer (v2, x, v1 @ v3)) in
       let v5 = map_type_declarator env v5 in
       { dn = v5.dn; dt = (fun x -> x |> f1 |> v5.dt) }
@@ -3186,7 +3187,7 @@ and map_type_declarator (env : env) (x : CST.type_declarator) : declarator =
   | `Array_type_decl (v1, v2, v3, v4, v5) ->
       let v1 = map_type_declarator env v1 in
       let v2 = token env v2 (* "[" *) in
-      let v3 = List.map (map_type_qualifier env) v3 in
+      let v3 = Common.map (map_type_qualifier env) v3 in
       let v4 =
         match v4 with
         | Some x -> Some (map_anon_choice_exp_508611b env x)
@@ -3207,11 +3208,11 @@ and map_type_declarator (env : env) (x : CST.type_declarator) : declarator =
 and map_type_definition (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.type_definition) : vars_decl =
   let v1 = token env v1 (* "typedef" *) in
-  let _v2TODO = List.map (map_type_qualifier env) v2 in
+  let _v2TODO = Common.map (map_type_qualifier env) v2 in
   let v3 = map_type_specifier env v3 in
   let v4 = map_type_declarator env v4 in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = map_type_declarator env v2 in
@@ -3222,7 +3223,7 @@ and map_type_definition (env : env)
 
   let xs =
     v4 :: v5
-    |> List.map (fun { dn; dt } ->
+    |> Common.map (fun { dn; dt } ->
            let id = HPfff.id_of_dname_for_typedef dn in
            TypedefDecl (v1, dt v3, id))
   in
@@ -3230,9 +3231,9 @@ and map_type_definition (env : env)
 
 and map_type_descriptor (env : env) ((v1, v2, v3, v4) : CST.type_descriptor) :
     type_ =
-  let v1 = List.map (map_type_qualifier env) v1 in
+  let v1 = Common.map (map_type_qualifier env) v1 in
   let qs, tc = map_type_specifier env v2 in
-  let v3 = List.map (map_type_qualifier env) v3 in
+  let v3 = Common.map (map_type_qualifier env) v3 in
   let t = (v1 @ qs @ v3, tc) in
   let v4 =
     match v4 with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_dockerfile_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_dockerfile_tree_sitter.ml
@@ -564,7 +564,7 @@ let argv_or_shell (env : env) (x : CST.anon_choice_str_array_878ad0b) =
   | `Shell_cmd (v1, v2, v3) -> (
       (* Stitch back the fragments together, then parse using the correct
          shell language. *)
-      let _comment_lines = List.map (comment_line env) v1 in
+      let _comment_lines = Common.map (comment_line env) v1 in
       let first_frag = shell_fragment env v2 in
       let more_frags =
         v3

--- a/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
@@ -178,10 +178,10 @@ let map_anon_choice_PLUS_8019319 (env : env) (x : CST.anon_choice_PLUS_8019319)
 let map_terminator (env : env) (x : CST.terminator) =
   match x with
   | `Rep_pat_509ec78_SEMI (v1, v2) ->
-      let v1 = List.map (token env (* pattern \r?\n *)) v1 in
+      let v1 = Common.map (token env (* pattern \r?\n *)) v1 in
       let v2 = (* ";" *) token env v2 in
       todo env (v1, v2)
-  | `Rep1_pat_509ec78 xs -> List.map (token env (* pattern \r?\n *)) xs
+  | `Rep1_pat_509ec78 xs -> Common.map (token env (* pattern \r?\n *)) xs
 
 let map_identifier (env : env) (x : CST.identifier) =
   match x with
@@ -193,7 +193,7 @@ let map_identifier (env : env) (x : CST.identifier) =
 let map_quoted_slash (env : env) ((v1, v2, v3) : CST.quoted_slash) =
   let v1 = (* "/" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_slash tok -> (* quoted_content_slash *) token env tok
@@ -207,7 +207,7 @@ let map_quoted_heredoc_double (env : env)
     ((v1, v2, v3) : CST.quoted_heredoc_double) =
   let v1 = (* "\"\"\"" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_here_double tok ->
@@ -221,7 +221,7 @@ let map_quoted_heredoc_double (env : env)
 let map_quoted_single (env : env) ((v1, v2, v3) : CST.quoted_single) =
   let v1 = (* "'" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_single tok ->
@@ -235,7 +235,7 @@ let map_quoted_single (env : env) ((v1, v2, v3) : CST.quoted_single) =
 let map_quoted_angle (env : env) ((v1, v2, v3) : CST.quoted_angle) =
   let v1 = (* "<" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_angle tok -> (* quoted_content_angle *) token env tok
@@ -248,7 +248,7 @@ let map_quoted_angle (env : env) ((v1, v2, v3) : CST.quoted_angle) =
 let map_quoted_double (env : env) ((v1, v2, v3) : CST.quoted_double) =
   let v1 = (* "\"" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_double tok ->
@@ -262,7 +262,7 @@ let map_quoted_double (env : env) ((v1, v2, v3) : CST.quoted_double) =
 let map_quoted_parenthesis (env : env) ((v1, v2, v3) : CST.quoted_parenthesis) =
   let v1 = (* "(" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_paren tok ->
@@ -276,7 +276,7 @@ let map_quoted_parenthesis (env : env) ((v1, v2, v3) : CST.quoted_parenthesis) =
 let map_quoted_square (env : env) ((v1, v2, v3) : CST.quoted_square) =
   let v1 = (* "[" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_square tok ->
@@ -291,7 +291,7 @@ let map_quoted_heredoc_single (env : env)
     ((v1, v2, v3) : CST.quoted_heredoc_single) =
   let v1 = (* "'''" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_here_single tok ->
@@ -305,7 +305,7 @@ let map_quoted_heredoc_single (env : env)
 let map_quoted_curly (env : env) ((v1, v2, v3) : CST.quoted_curly) =
   let v1 = (* "{" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_curl tok -> (* quoted_content_curly *) token env tok
@@ -318,7 +318,7 @@ let map_quoted_curly (env : env) ((v1, v2, v3) : CST.quoted_curly) =
 let map_quoted_bar (env : env) ((v1, v2, v3) : CST.quoted_bar) =
   let v1 = (* "|" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_bar tok -> (* quoted_content_bar *) token env tok
@@ -404,14 +404,14 @@ and map_anon_choice_choice_stab_clause_rep_term_choice_stab_clause_b295119
         match v1 with
         | `Stab_clause x -> map_stab_clause env x
       in
-      let v2 = List.map (map_anon_term_choice_stab_clause_70647b7 env) v2 in
+      let v2 = Common.map (map_anon_term_choice_stab_clause_70647b7 env) v2 in
       todo env (v1, v2)
   | `Choice_exp_rep_term_choice_exp_opt_term (v1, v2, v3) ->
       let v1 =
         match v1 with
         | `Exp x -> map_expression env x
       in
-      let v2 = List.map (map_anon_term_choice_exp_996111b env) v2 in
+      let v2 = Common.map (map_anon_term_choice_exp_996111b env) v2 in
       let v3 =
         match v3 with
         | Some x -> map_terminator env x
@@ -434,7 +434,7 @@ and map_anon_exp_rep_COMMA_exp_opt_COMMA_keywos_041d82e (env : env)
     ((v1, v2, v3) : CST.anon_exp_rep_COMMA_exp_opt_COMMA_keywos_041d82e) =
   let v1 = map_expression env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_expression env v2 in
@@ -664,7 +664,7 @@ and map_body (env : env) ((v1, v2, v3, v4) : CST.body) =
   in
   let v2 = map_expression env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = map_terminator env v1 in
         let v2 = map_expression env v2 in
@@ -711,7 +711,7 @@ and map_call_arguments_with_trailing_separator (env : env)
   | `Exp_rep_COMMA_exp_opt_COMMA_keywos_with_trai_sepa (v1, v2, v3) ->
       let v1 = map_expression env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_expression env v2 in
@@ -819,7 +819,7 @@ and map_do_block (env : env) ((v1, v2, v3, v4, v5) : CST.do_block) =
     | None -> todo env ()
   in
   let v4 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `After_blk x -> map_after_block env x
@@ -981,7 +981,7 @@ and map_expression (env : env) (x : CST.expression) =
       in
       let v3 = map_stab_clause env v3 in
       let v4 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = map_terminator env v1 in
             let v2 = map_stab_clause env v2 in
@@ -1003,7 +1003,7 @@ and map_items_with_trailing_separator (env : env)
   | `Exp_rep_COMMA_exp_opt_COMMA (v1, v2, v3) ->
       let v1 = map_expression env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_expression env v2 in
@@ -1022,7 +1022,7 @@ and map_items_with_trailing_separator (env : env)
         | Some (v1, v2, v3) ->
             let v1 = map_expression env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let v1 = (* "," *) token env v1 in
                   let v2 = map_expression env v2 in
@@ -1047,7 +1047,7 @@ and map_keyword (env : env) (x : CST.keyword) =
 and map_keywords (env : env) ((v1, v2) : CST.keywords) =
   let v1 = map_pair env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_pair env v2 in
@@ -1060,7 +1060,7 @@ and map_keywords_with_trailing_separator (env : env)
     ((v1, v2, v3) : CST.keywords_with_trailing_separator) =
   let v1 = map_pair env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_pair env v2 in
@@ -1089,7 +1089,7 @@ and map_pair (env : env) ((v1, v2) : CST.pair) =
 and map_quoted_i_angle (env : env) ((v1, v2, v3) : CST.quoted_i_angle) =
   let v1 = (* "<" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_angle tok ->
@@ -1104,7 +1104,7 @@ and map_quoted_i_angle (env : env) ((v1, v2, v3) : CST.quoted_i_angle) =
 and map_quoted_i_bar (env : env) ((v1, v2, v3) : CST.quoted_i_bar) =
   let v1 = (* "|" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_bar tok -> (* quoted_content_i_bar *) token env tok
@@ -1118,7 +1118,7 @@ and map_quoted_i_bar (env : env) ((v1, v2, v3) : CST.quoted_i_bar) =
 and map_quoted_i_curly (env : env) ((v1, v2, v3) : CST.quoted_i_curly) =
   let v1 = (* "{" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_curl tok ->
@@ -1133,7 +1133,7 @@ and map_quoted_i_curly (env : env) ((v1, v2, v3) : CST.quoted_i_curly) =
 and map_quoted_i_double (env : env) ((v1, v2, v3) : CST.quoted_i_double) =
   let v1 = (* "\"" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_double tok ->
@@ -1149,7 +1149,7 @@ and map_quoted_i_heredoc_double (env : env)
     ((v1, v2, v3) : CST.quoted_i_heredoc_double) =
   let v1 = (* "\"\"\"" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_here_double tok ->
@@ -1165,7 +1165,7 @@ and map_quoted_i_heredoc_single (env : env)
     ((v1, v2, v3) : CST.quoted_i_heredoc_single) =
   let v1 = (* "'''" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_here_single tok ->
@@ -1181,7 +1181,7 @@ and map_quoted_i_parenthesis (env : env)
     ((v1, v2, v3) : CST.quoted_i_parenthesis) =
   let v1 = (* "(" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_paren tok ->
@@ -1196,7 +1196,7 @@ and map_quoted_i_parenthesis (env : env)
 and map_quoted_i_single (env : env) ((v1, v2, v3) : CST.quoted_i_single) =
   let v1 = (* "'" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_single tok ->
@@ -1211,7 +1211,7 @@ and map_quoted_i_single (env : env) ((v1, v2, v3) : CST.quoted_i_single) =
 and map_quoted_i_slash (env : env) ((v1, v2, v3) : CST.quoted_i_slash) =
   let v1 = (* "/" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_slash tok ->
@@ -1226,7 +1226,7 @@ and map_quoted_i_slash (env : env) ((v1, v2, v3) : CST.quoted_i_slash) =
 and map_quoted_i_square (env : env) ((v1, v2, v3) : CST.quoted_i_square) =
   let v1 = (* "[" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Quoted_content_i_square tok ->
@@ -1413,7 +1413,7 @@ let map_source (env : env) ((v1, v2) : CST.source) =
     | Some (v1, v2, v3) ->
         let v1 = map_expression env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = map_terminator env v1 in
               let v2 = map_expression env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -143,7 +143,7 @@ let empty_labeled_statement (env : env) ((v1, v2) : CST.empty_labeled_statement)
 let field_name_list (env : env) ((v1, v2) : CST.field_name_list) : ident list =
   let v1 = identifier env v1 (* identifier *) in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = identifier env v1 (* "," *) in
         let _v2 = token env v2 (* identifier *) in
@@ -158,7 +158,7 @@ let string_literal (env : env) (x : CST.string_literal) =
   | `Inte_str_lit (v1, v2, v3) ->
       let v1 = token env v1 (* "\"" *) in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Inte_str_lit_basic_content tok ->
@@ -168,8 +168,8 @@ let string_literal (env : env) (x : CST.string_literal) =
           v2
       in
       let v3 = token env v3 (* "\"" *) in
-      let str = v2 |> List.map fst |> String.concat "" in
-      let toks = (v2 |> List.map snd) @ [ v3 ] in
+      let str = v2 |> Common.map fst |> String.concat "" in
+      let toks = (v2 |> Common.map snd) @ [ v3 ] in
       (str, PI.combine_infos v1 toks)
 
 let import_spec (env : env) ((v1, v2) : CST.import_spec) =
@@ -189,7 +189,7 @@ let rec type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
   let v1 = token env v1 (* "case" *) in
   let v2 = type_ env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = type_ env v2 in
@@ -203,7 +203,7 @@ let rec type_case (env : env) ((v1, v2, v3, v4, v5) : CST.type_case) =
     | None -> []
   in
   let xs = v2 :: v3 in
-  (CaseExprs (v1, xs |> List.map (fun x -> Right x)), stmt1 v4 v5)
+  (CaseExprs (v1, xs |> Common.map (fun x -> Right x)), stmt1 v4 v5)
 
 and simple_statement (env : env) (x : CST.simple_statement) : simple =
   match x with
@@ -322,7 +322,7 @@ and interface_body (env : env) (x : CST.interface_body) : interface_field =
   | `Cons_elem (v1, v2) ->
       let v1 = constraint_term env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "|" *) token env v1 in
             let v2 = constraint_term env v2 in
@@ -375,7 +375,7 @@ and field_declaration (env : env) ((v1, v2) : CST.field_declaration) :
     | `Id_rep_COMMA_id_choice_simple_type (v1, v2, v3) ->
         let v1 = identifier env v1 (* identifier *) in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = identifier env v2 (* identifier *) in
@@ -384,7 +384,7 @@ and field_declaration (env : env) ((v1, v2) : CST.field_declaration) :
         in
         let v3 = type_ env v3 in
         let xs = v1 :: v2 in
-        xs |> List.map (fun id -> Field (id, v3))
+        xs |> Common.map (fun id -> Field (id, v3))
     | `Opt_STAR_choice_id (v1, v2) ->
         let v1 =
           match v1 with
@@ -403,14 +403,14 @@ and field_declaration (env : env) ((v1, v2) : CST.field_declaration) :
     | Some x -> Some (string_literal env x)
     | None -> None
   in
-  v1 |> List.map (fun x -> (x, v2))
+  v1 |> Common.map (fun x -> (x, v2))
 
 and special_argument_list (env : env)
     ((v1, v2, v3, v4, v5) : CST.special_argument_list) =
   let v1 = token env v1 (* "(" *) in
   let v2 = type_ env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = expression env v2 in
@@ -447,7 +447,7 @@ and parameter_declaration env (v1, v2) =
   match v1 with
   | Some x ->
       field_name_list env x
-      |> List.map (fun id ->
+      |> Common.map (fun id ->
              ParamClassic { pname = Some id; ptype = v2; pdots = None })
   | None -> [ ParamClassic { pname = None; ptype = v2; pdots = None } ]
 
@@ -503,7 +503,7 @@ and simple_type (env : env) (x : CST.simple_type) : type_ =
         | Some (v1, v2, v3) ->
             let v1 = interface_body env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = anon_choice_LF_249c99f env v1 in
                   let v2 = interface_body env v2 in
@@ -539,7 +539,7 @@ and type_arguments (env : env) ((v1, v2, v3, v4, v5) : CST.type_arguments) =
   let lbra = (* "[" *) token env v1 in
   let t = type_ env v2 in
   let ts =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = type_ env v2 in
@@ -585,7 +585,7 @@ and slice_type (env : env) ((v1, v2, v3) : CST.slice_type) =
 and expression_list (env : env) ((v1, v2) : CST.expression_list) =
   let v1 = expression env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = expression env v2 in
@@ -819,7 +819,7 @@ and statement (env : env) (x : CST.statement) : stmt =
       in
       let _v4 = token env v4 (* "{" *) in
       let v5 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Exp_case x -> CaseClause (expression_case env x)
@@ -833,13 +833,13 @@ and statement (env : env) (x : CST.statement) : stmt =
       let v2 = type_switch_header env v2 in
       let _v3 = token env v3 (* "{" *) in
       let v4 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Type_case x -> type_case env x
             | `Defa_case x -> default_case env x)
           v4
-        |> List.map (fun x -> CaseClause x)
+        |> Common.map (fun x -> CaseClause x)
       in
       let a, b = v2 in
       let _v5 = token env v5 (* "}" *) in
@@ -848,13 +848,13 @@ and statement (env : env) (x : CST.statement) : stmt =
       let v1 = token env v1 (* "select" *) in
       let _v2 = token env v2 (* "{" *) in
       let v3 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Comm_case x -> communication_case env x
             | `Defa_case x -> default_case env x)
           v3
-        |> List.map (fun x -> CaseClause x)
+        |> Common.map (fun x -> CaseClause x)
       in
       let _v4 = token env v4 (* "}" *) in
       Select (v1, v3)
@@ -916,7 +916,7 @@ and field_declaration_list (env : env)
     | Some (v1, v2, v3) ->
         let v1 = field_declaration env v1 in
         let v2 =
-          List.map
+          List.concat_map
             (fun (v1, v2) ->
               let _v1 = anon_choice_LF_249c99f env v1 in
               let v2 = field_declaration env v2 in
@@ -924,7 +924,7 @@ and field_declaration_list (env : env)
             v2
         in
         let _v3 = trailing_terminator env v3 in
-        v1 @ List.flatten v2
+        v1 @ v2
     | None -> []
   in
   let v3 = token env v3 (* "}" *) in
@@ -955,7 +955,7 @@ and expression_case (env : env) ((v1, v2, v3, v4) : CST.expression_case) =
     | Some x -> statement_list env x
     | None -> []
   in
-  (CaseExprs (v1, v2 |> List.map (fun x -> Left x)), stmt1 v3 v4)
+  (CaseExprs (v1, v2 |> Common.map (fun x -> Left x)), stmt1 v3 v4)
 
 and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
   let v1 = token env v1 (* "(" *) in
@@ -964,7 +964,7 @@ and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
     | Some (v1, v2, v3) ->
         let v1 = anon_choice_exp_047b57a env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = anon_choice_exp_047b57a env v2 in
@@ -990,7 +990,7 @@ and type_ (env : env) (x : CST.type_) =
 and const_spec (env : env) ((v1, v2, v3) : CST.const_spec) =
   let v1 = identifier env v1 (* identifier *) in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = identifier env v2 (* identifier *) in
@@ -1049,7 +1049,7 @@ and type_parameter_list (env : env)
   let lbra = (* "[" *) token env v1 in
   let params = parameter_declaration env v2 in
   let paramss =
-    List.map
+    List.concat_map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = parameter_declaration env v2 in
@@ -1058,7 +1058,7 @@ and type_parameter_list (env : env)
   in
   let _v4 = trailing_comma env v4 in
   let rbra = (* "]" *) token env v5 in
-  (lbra, params @ List.flatten paramss, rbra)
+  (lbra, params @ paramss, rbra)
 
 and channel_type (env : env) (x : CST.channel_type) =
   match x with
@@ -1088,14 +1088,14 @@ and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
           | Some (v1, v2) ->
               let v1 = anon_choice_param_decl_18823e5 env v1 in
               let v2 =
-                List.map
+                List.concat_map
                   (fun (v1, v2) ->
                     let _v1 = token env v1 (* "," *) in
                     let v2 = anon_choice_param_decl_18823e5 env v2 in
                     v2)
                   v2
               in
-              v1 @ List.flatten v2
+              v1 @ v2
           | None -> []
         in
         let _v2 = trailing_comma env v2 in
@@ -1113,7 +1113,7 @@ and element (env : env) (x : CST.element) : init =
 and var_spec (env : env) ((v1, v2, v3) : CST.var_spec) =
   let v1 = identifier env v1 (* identifier *) in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = identifier env v2 (* identifier *) in
@@ -1148,7 +1148,7 @@ and declaration (env : env) (x : CST.declaration) =
         | `LPAR_rep_const_spec_choice_LF_RPAR (v1, v2, v3) ->
             let _v1 = token env v1 (* "(" *) in
             let v2 =
-              List.map
+              List.concat_map
                 (fun (v1, v2) ->
                   let v1 = const_spec env v1 in
                   let _v2 = anon_choice_LF_249c99f env v2 in
@@ -1156,7 +1156,7 @@ and declaration (env : env) (x : CST.declaration) =
                 v2
             in
             let _v3 = token env v3 (* ")" *) in
-            List.flatten v2
+            v2
       in
       v2
   | `Type_decl (v1, v2) ->
@@ -1168,7 +1168,7 @@ and declaration (env : env) (x : CST.declaration) =
         | `LPAR_rep_choice_type_spec_choice_LF_RPAR (v1, v2, v3) ->
             let _v1 = token env v1 (* "(" *) in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let v1 =
                     match v1 with
@@ -1191,7 +1191,7 @@ and declaration (env : env) (x : CST.declaration) =
         | `LPAR_rep_var_spec_choice_LF_RPAR (v1, v2, v3) ->
             let _v1 = token env v1 (* "(" *) in
             let v2 =
-              List.map
+              List.concat_map
                 (fun (v1, v2) ->
                   let v1 = var_spec env v1 in
                   let _v2 = anon_choice_LF_249c99f env v2 in
@@ -1199,7 +1199,7 @@ and declaration (env : env) (x : CST.declaration) =
                 v2
             in
             let _v3 = token env v3 (* ")" *) in
-            List.flatten v2
+            v2
       in
       v2
 
@@ -1208,7 +1208,7 @@ and statement_list (env : env) (x : CST.statement_list) : stmt list =
   | `Stmt_rep_choice_LF_stmt_opt_choice_LF_opt_empty_labe_stmt (v1, v2, v3) ->
       let v1 = statement env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = anon_choice_LF_249c99f env v1 in
             let v2 = statement env v2 in
@@ -1242,7 +1242,7 @@ and communication_case (env : env) ((v1, v2, v3, v4) : CST.communication_case) =
         match opt with
         | None -> CaseExprs (v1, [ Left e ])
         | Some (xs, (_lr, tk)) ->
-            CaseAssign (v1, xs |> List.map (fun e -> Left e), tk, e))
+            CaseAssign (v1, xs |> Common.map (fun e -> Left e), tk, e))
   in
   let v3 = token env v3 (* ":" *) in
   let v4 =
@@ -1260,7 +1260,7 @@ and literal_value (env : env) ((v1, v2, v3) : CST.literal_value) :
     | Some (v1, v2, v3) ->
         let v1 = anon_choice_elem_c42cd9b env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = anon_choice_elem_c42cd9b env v2 in
@@ -1277,7 +1277,7 @@ and literal_value (env : env) ((v1, v2, v3) : CST.literal_value) :
 let import_spec_list (env : env) ((v1, v2, v3) : CST.import_spec_list) =
   let _v1 = token env v1 (* "(" *) in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = import_spec env v1 in
         let _v2 = anon_choice_LF_249c99f env v2 in
@@ -1344,10 +1344,11 @@ let top_level_declaration (env : env) (x : CST.top_level_declaration) :
         | `Import_spec_list x -> import_spec_list env x
       in
       v2
-      |> List.map (fun (a, b) -> Import { i_tok = v1; i_path = b; i_kind = a })
+      |> Common.map (fun (a, b) ->
+             Import { i_tok = v1; i_path = b; i_kind = a })
 
 let source_file (env : env) (xs : CST.source_file) : program =
-  List.map
+  List.concat_map
     (fun x ->
       match x with
       | `Stmt_choice_LF (v1, v2) ->
@@ -1359,7 +1360,6 @@ let source_file (env : env) (xs : CST.source_file) : program =
           let _v2 = trailing_terminator env v2 in
           v1)
     xs
-  |> List.flatten
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -170,7 +170,7 @@ let xhp_category_declaration (env : env)
     (* pattern %[a-zA-Z_][a-zA-Z0-9_]*([-:][a-zA-Z0-9_]+)* *) str env v2
   in
   let _v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 =
@@ -198,7 +198,7 @@ let qualified_identifier (env : env) (x : CST.qualified_identifier) :
             | None -> []
           in
           let v2 =
-            List.map
+            Common.map
               (fun (v1, v2) ->
                 let _v1 = (* "\\" *) token env v1 in
                 let v2 =
@@ -266,7 +266,7 @@ let rec xhp_attribute_expression (env : env) (x : CST.xhp_attribute_expression)
       let v1 = (* "(" *) token env v1 in
       let v2 = xhp_attribute_expression env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = xhp_attribute_expression env v2 in
@@ -358,7 +358,7 @@ let trait_select_clause (env : env)
   let v4 = (* "insteadof" *) token env v4 in
   let v5 = qualified_identifier env v5 in
   let v6 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = qualified_identifier env v2 in
@@ -378,7 +378,7 @@ let _xhp_children_declaration (env : env)
   let _v1 = (* "children" *) token env v1 in
   let _v2TODO = xhp_attribute_expression env v2 in
   let _v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = xhp_attribute_expression env v2 in
@@ -406,7 +406,7 @@ let xhp_enum_type (env : env) ((v1, v2, v3, v4, v5, v6) : CST.xhp_enum_type)
   let _v2 = (* "{" *) token env v2 in
   let v3 = G.OrEnum (xhp_enum_key env v3, None) in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = G.OrEnum (xhp_enum_key env v2, None) in
@@ -460,7 +460,7 @@ let _anonymous_function_use_clause (env : env)
   let v2 = (* "(" *) token env v2 in
   let v3 = (* variable *) token env v3 in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = (* variable *) token env v2 in
@@ -529,7 +529,7 @@ and anon_choice_exp_rep_COMMA_choice_exp_opt_COMMA_e4364bb (env : env)
     =
   let v1 = anon_choice_exp_1701d0a env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = anon_choice_exp_1701d0a env v2 in
@@ -572,7 +572,7 @@ and anon_exp_rep_COMMA_exp_0bb260c (env : env)
     ((v1, v2) : CST.anon_exp_rep_COMMA_exp_0bb260c) =
   let v1 = expression env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         (* Q: Change tree-sitter to be less permissive in what's allowed here? *)
@@ -607,7 +607,7 @@ and arguments (env : env) ((v1, v2, v3) : CST.arguments) : G.arguments =
     | Some (v1, v2, v3) ->
         let v1 = argument env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
               let v2 = argument env v2 in
@@ -649,7 +649,7 @@ and attribute_modifier (env : env)
   let n = H2.name_of_ids v2 in
   let attr1 = G.NamedAttr (v1, n, v3) in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2, v3) ->
         let v1 = (* "," *) token env v1 in
         let v2 = qualified_identifier env v2 in
@@ -988,7 +988,7 @@ and catch_clause (env : env) ((v1, v2, v3, v4, v5, v6) : CST.catch_clause) =
 
 and class_const_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.class_const_declaration) =
-  let v1 = List.map (member_modifier env) v1 in
+  let v1 = Common.map (member_modifier env) v1 in
   let v2 = (* "const" *) [ G.KeywordAttr (Const, token env v2) ] in
   let attrs = v1 @ v2 in
   let type_ =
@@ -999,7 +999,7 @@ and class_const_declaration (env : env)
   let _v6 = (* ";" *) token env v6 in
   let v4 = G.F (class_const_declarator env v4 attrs type_) in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = G.F (class_const_declarator env v2 attrs type_) in
@@ -1027,7 +1027,7 @@ and class_const_declarator (env : env) ((v1, v2) : CST.class_const_declarator)
 and compound_statement (env : env) ((v1, v2, v3) : CST.compound_statement) :
     G.stmt =
   let v1 = (* "{" *) token env v1 in
-  let v2 = List.map (statement env) v2 in
+  let v2 = Common.map (statement env) v2 in
   let v3 = (* "}" *) token env v3 in
   G.Block (v1, v2, v3) |> G.s
 
@@ -1247,7 +1247,7 @@ and declaration (env : env) (x : CST.declaration) =
         | None -> None
       in
       let _v7 = (* "{" *) token env v7 in
-      let v8 = List.map (enumerator env) v8 in
+      let v8 = Common.map (enumerator env) v8 in
       let _v9 = (* "}" *) token env v9 in
       G.DefStmt (G.basic_entity v3 ~attrs:v1, TypeDef { tbody = G.OrType v8 })
   | `Name_decl (v1, v2) -> (
@@ -1284,7 +1284,7 @@ and declaration (env : env) (x : CST.declaration) =
       in
       let v3 = const_declarator env v3 attr type_ |> G.s in
       let v4 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = const_declarator env v2 attr type_ |> G.s in
@@ -1356,7 +1356,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
             | None -> v2
           in
           let v4 =
-            List.map
+            Common.map
               (fun x ->
                 G.Arg
                   (match x with
@@ -1413,7 +1413,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
             | Some (v1, v2, v3) ->
                 let v1 = expression env v1 in
                 let v2 =
-                  List.map
+                  Common.map
                     (fun (v1, v2) ->
                       let _v1 = (* "," *) token env v1 in
                       let v2 = expression env v2 in
@@ -1439,7 +1439,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
             | Some (v1, v2, v3) ->
                 let v1 = G.F (field_initializer env v1 |> G.s) in
                 let v2 =
-                  List.map
+                  Common.map
                     (fun (v1, v2) ->
                       let _v1 = (* "," *) token env v1 in
                       let v2 = G.F (field_initializer env v2 |> G.s) in
@@ -1666,14 +1666,14 @@ and extends_clause (env : env) ((v1, v2, v3) : CST.extends_clause) :
   let _v1 = (* "extends" *) token env v1 in
   let v2 = type_ env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = type_ env v2 in
         v2)
       v3
   in
-  v2 :: v3 |> List.map (fun ty -> (ty, None))
+  v2 :: v3 |> Common.map (fun ty -> (ty, None))
 
 and field_initializer (env : env) ((v1, v2, v3) : CST.field_initializer) =
   let v1 =
@@ -1748,7 +1748,7 @@ and implements_clause (env : env) ((v1, v2, v3) : CST.implements_clause) =
   let _v1 = (* "implements" *) token env v1 in
   let v2 = type_ env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = type_ env v2 in
@@ -1760,7 +1760,7 @@ and implements_clause (env : env) ((v1, v2, v3) : CST.implements_clause) =
 and member_declarations (env : env) ((v1, v2, v3) : CST.member_declarations) =
   let v1 = (* "{" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Class_const_decl x -> class_const_declaration env x
@@ -1794,7 +1794,7 @@ and method_declaration (env : env) ((v1, v2, v3, v4) : CST.method_declaration) =
     | Some x -> attribute_modifier env x
     | None -> []
   in
-  let v2 = List.map (member_modifier env) v2 in
+  let v2 = Common.map (member_modifier env) v2 in
   let func_def, identifier, type_args = function_declaration_header env v3 in
   let v4 = inline_compound_statement env v4 in
   let def = { func_def with fbody = G.FBStmt v4 } in
@@ -1879,7 +1879,7 @@ and parameters (env : env) ((v1, v2, v3) : CST.parameters) =
         | `Param_rep_COMMA_param_opt_COMMA (v1, v2, v3) ->
             let v1 = parameter env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = parameter env v2 in
@@ -1970,7 +1970,7 @@ and property_declaration (env : env)
     | Some x -> attribute_modifier env x
     | None -> []
   in
-  let v2 = List.map (member_modifier env) v2 in
+  let v2 = Common.map (member_modifier env) v2 in
   let attrs = v1 @ v2 in
   let type_ =
     match v3 with
@@ -1979,7 +1979,7 @@ and property_declaration (env : env)
   in
   let v4 = G.F (property_declarator env v4 attrs type_) in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = G.F (property_declarator env v2 attrs type_) in
@@ -2010,7 +2010,7 @@ and require_extends_clause (env : env)
   let v2 = (* "extends" *) [ G.TodoK (str env v2) ] in
   let v3 = [ G.T (type_ env v3) ] in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = G.T (type_ env v2) in
@@ -2026,7 +2026,7 @@ and require_implements_clause (env : env)
   let v2 = (* "implements" *) [ G.TodoK (str env v2) ] in
   let v3 = [ G.T (type_ env v3) ] in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = G.T (type_ env v2) in
@@ -2099,7 +2099,7 @@ and statement (env : env) (x : CST.statement) =
       let v1 = (* "echo" *) str env v1 in
       let v2 = G.Arg (expression env v2) in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = G.Arg (expression env v2) in
@@ -2119,7 +2119,7 @@ and statement (env : env) (x : CST.statement) =
         | Some (v1, v2) ->
             let v1 = variablish env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = variablish env v2 in
@@ -2153,7 +2153,7 @@ and statement (env : env) (x : CST.statement) =
         | `Use_clause_rep_COMMA_use_clause_opt_COMMA (v1, v2, v3) ->
             let v1 = create_directive (use_clause env v1) [] in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = use_clause env v2 in
@@ -2186,7 +2186,7 @@ and statement (env : env) (x : CST.statement) =
             let _v3 = (* "{" *) token env v3 in
             let v4 = create_directive (use_clause env v4) ident_prefix in
             let v5 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = use_clause env v2 in
@@ -2209,7 +2209,7 @@ and statement (env : env) (x : CST.statement) =
       let v3 = statement env v3 in
       (* Q: Should we be folding? Where does elif go? *)
       let v4 =
-        List.map
+        Common.map
           (fun (v1, v2, v3) ->
             let v1 =
               match v1 with
@@ -2255,7 +2255,7 @@ and statement (env : env) (x : CST.statement) =
         (* Q: Always use ForInitExpr since that is what we get back? *)
         | Some x ->
             let cast x = G.ForInitExpr x in
-            List.map cast (anon_exp_rep_COMMA_exp_0bb260c env x)
+            Common.map cast (anon_exp_rep_COMMA_exp_0bb260c env x)
         | None -> []
       in
       let _v4 = (* ";" *) token env v4 in
@@ -2281,7 +2281,7 @@ and statement (env : env) (x : CST.statement) =
       let v2 = Some (G.Cond (parenthesized_expression env v2)) in
       let _v3 = (* "{" *) token env v3 in
       let v4 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Switch_case x -> switch_case env x
@@ -2322,7 +2322,7 @@ and statement (env : env) (x : CST.statement) =
   | `Try_stmt (v1, v2, v3, v4) ->
       let v1 = (* "try" *) token env v1 in
       let v2 = compound_statement env v2 in
-      let v3 = List.map (catch_clause env) v3 in
+      let v3 = Common.map (catch_clause env) v3 in
       let v4 =
         match v4 with
         | `Catch_clause x ->
@@ -2358,7 +2358,7 @@ and statement (env : env) (x : CST.statement) =
             let v1 = (* "(" *) token env v1 in
             let v2 = G.ExprStmt (expression env v2, fk v1) |> G.s in
             let v3 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let v1 = (* "," *) token env v1 in
                   let v2 = G.ExprStmt (expression env v2, fk v1) |> G.s in
@@ -2376,7 +2376,7 @@ and switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
   let v1 = (* "case" *) token env v1 in
   let v2 = expression env v2 in
   let _v3 = (* ":" *) token env v3 in
-  let v4 = List.map (statement env) v4 in
+  let v4 = Common.map (statement env) v4 in
   (* Q: Also, this is terrible.... Make expression more specific to be pattern? How to handle? *)
   (* G.CasesAndBody([Case(v1, OtherPat(OP_Expr, [G.E(v2)]))], G.Block(G.fake_bracket v4) |> G.s) *)
   (* Well can also do this... *)
@@ -2387,7 +2387,7 @@ and switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
 and switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
   let v1 = (* "default" *) token env v1 in
   let _v2 = (* ":" *) token env v2 in
-  let v3 = List.map (statement env) v3 in
+  let v3 = Common.map (statement env) v3 in
   (* Q: Again. Is it appropriate to use Block here? *)
   G.CasesAndBody ([ G.Default v1 ], G.Block (G.fake_bracket v3) |> G.s)
 
@@ -2395,7 +2395,7 @@ and _trait_use_clause (env : env) ((v1, v2, v3, v4) : CST.trait_use_clause) =
   let v1 = (* "use" *) token env v1 in
   let v2 = type_ env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = type_ env v2 in
@@ -2407,7 +2407,7 @@ and _trait_use_clause (env : env) ((v1, v2, v3, v4) : CST.trait_use_clause) =
     | `LCURL_rep_choice_trait_select_clause_SEMI_RCURL (v1, v2, v3) ->
         let v1 = (* "{" *) token env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 =
                 match v1 with
@@ -2427,7 +2427,7 @@ and _trait_use_clause (env : env) ((v1, v2, v3, v4) : CST.trait_use_clause) =
 and type_ (env : env) (x : CST.type_) : G.type_ =
   match x with
   | `Type_spec (v1, v2, v3) ->
-      let _v1TODO = List.map (type_modifier env) v1 in
+      let _v1TODO = Common.map (type_modifier env) v1 in
       let v3 =
         match v3 with
         | Some x -> type_arguments env x
@@ -2449,11 +2449,11 @@ and type_ (env : env) (x : CST.type_) : G.type_ =
       v2
   | `Type_cst (v1, v2) ->
       (* TODO: What to do with modifier? *)
-      let _v1TODO = List.map (type_modifier env) v1 in
+      let _v1TODO = Common.map (type_modifier env) v1 in
       let v2 = type_constant_ env v2 in
       G.TyN (H2.name_of_ids v2) |> G.t
   | `Shape_type_spec (v1, v2, v3, v4, v5) ->
-      let _v1TODO = List.map (type_modifier env) v1 in
+      let _v1TODO = Common.map (type_modifier env) v1 in
       let v2 = (* "shape" *) token env v2 in
       let v3 = (* "(" *) token env v3 in
       let v4 =
@@ -2461,7 +2461,7 @@ and type_ (env : env) (x : CST.type_) : G.type_ =
         | Some (v1, v2, v3) ->
             let v1 = G.F (shape_field_specifier env v1 |> G.s) in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = G.F (shape_field_specifier env v2 |> G.s) in
@@ -2479,7 +2479,7 @@ and type_ (env : env) (x : CST.type_) : G.type_ =
       let v5 = (* ")" *) token env v5 in
       G.TyRecordAnon ((G.Class, v2), (v3, v4, v5)) |> G.t
   | `Func_type_spec (v1, v2, v3, v4, v5, v6, v7, v8) ->
-      let _v1TODO = List.map (type_modifier env) v1 in
+      let _v1TODO = Common.map (type_modifier env) v1 in
       let _v2 = (* "(" *) token env v2 in
       let _v3TODO = (* pattern function\s*\( *) token env v3 in
       let v4 =
@@ -2497,7 +2497,7 @@ and type_ (env : env) (x : CST.type_) : G.type_ =
               | None -> None
             in
             let v4 =
-              List.map
+              Common.map
                 (fun (v1, v2, v3, v4) ->
                   (* TODO: Handle `...` *)
                   let _v1 = (* "," *) token env v1 in
@@ -2533,11 +2533,11 @@ and type_ (env : env) (x : CST.type_) : G.type_ =
       let _v8 = (* ")" *) token env v8 in
       G.TyFun (v4, v7) |> G.t
   | `Tuple_type_spec (v1, v2, v3, v4, v5, v6) ->
-      let _v1TODO = List.map (type_modifier env) v1 in
+      let _v1TODO = Common.map (type_modifier env) v1 in
       let v2 = (* "(" *) token env v2 in
       let v3 = type_ env v3 in
       let v4 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = type_ env v2 in
@@ -2560,7 +2560,7 @@ and type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) :
     | Some (v1, v2, v3) ->
         let v1 = G.TA (type_ env v1) in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
               let v2 = G.TA (type_ env v2) in
@@ -2587,7 +2587,7 @@ and type_const_declaration (env : env)
     | Some x -> attribute_modifier env x
     | None -> []
   in
-  let v2 = List.map (member_modifier env) v2 in
+  let v2 = Common.map (member_modifier env) v2 in
   let v3 = (* "const" *) [ G.KeywordAttr (Const, token env v3) ] in
   let _v4 = (* "type" *) token env v4 in
   let id = semgrep_extended_identifier env v5 in
@@ -2653,7 +2653,7 @@ and type_parameter (env : env) ((v1, v2, v3, v4) : CST.type_parameter) :
     (* pattern [a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]* *) str env v3
   in
   let tp_bounds =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1TODO =
           match v1 with
@@ -2671,7 +2671,7 @@ and type_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.type_parameters) =
   let _v1 = (* "<" *) token env v1 in
   let v2 = type_parameter env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = type_parameter env v2 in
@@ -2701,7 +2701,7 @@ and variablish (env : env) (x : CST.variablish) : G.expr =
         | None -> []
       in
       let v4 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 =
@@ -2747,7 +2747,7 @@ and where_clause (env : env) ((v1, v2) : CST.where_clause) =
   (* Q: Should this become a cmixins? *)
   let twhere = (* "where" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let frst, snd, thrd = where_constraint env v1 in
         let _v2 =
@@ -2804,7 +2804,7 @@ and xhp_attribute_declaration (env : env)
   (* Q: Is this what we want to do with the keyword? *)
   let v2 = xhp_class_attribute env v2 attr_tok in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = xhp_class_attribute env v2 attr_tok in
@@ -2869,7 +2869,7 @@ and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =
   | `Xhp_open_close (v1, v2, v3, v4) ->
       let v1 = (* "<" *) token env v1 in
       let v2 = xhp_identifier_ env v2 in
-      let v3 = List.map (xhp_attribute env) v3 in
+      let v3 = Common.map (xhp_attribute env) v3 in
       let v4 = (* "/>" *) token env v4 in
       { xml_kind = G.XmlSingleton (v1, v2, v4); xml_attrs = v3; xml_body = [] }
   | `Xhp_open_rep_choice_xhp_str_xhp_close (v1, v2, v3) ->
@@ -2877,7 +2877,7 @@ and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =
         xhp_open env v1
       in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Xhp_str tok -> (* xhp_string *) G.XmlText (str env tok)
@@ -2902,7 +2902,7 @@ and xhp_expression (env : env) (x : CST.xhp_expression) : G.xml =
 and xhp_open (env : env) ((v1, v2, v3, v4) : CST.xhp_open) =
   let v1 = (* "<" *) token env v1 in
   let v2 = xhp_identifier_ env v2 in
-  let v3 = List.map (xhp_attribute env) v3 in
+  let v3 = Common.map (xhp_attribute env) v3 in
   let v4 = (* ">" *) token env v4 in
   (v1, v2, v3, v4)
 
@@ -2922,7 +2922,7 @@ let script (env : env) ((v1, v2) : CST.script) : G.program =
     | Some tok -> (* pattern <\?[hH][hH] *) token env tok |> ignore
     | None -> ()
   in
-  List.map (statement env) v2
+  Common.map (statement env) v2
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
@@ -108,14 +108,14 @@ let map_attribute (env : env) ((v1, v2) : CST.attribute) : xml_attribute =
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
   let v2 = str env v2 (* script_start_tag_name *) in
-  let v3 = List.map (map_attribute env) v3 in
+  let v3 = Common.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
   let v2 = str env v2 (* style_start_tag_name *) in
-  let v3 = List.map (map_attribute env) v3 in
+  let v3 = Common.map (map_attribute env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
@@ -125,7 +125,7 @@ let map_start_tag (env : env) (x : CST.start_tag) =
   | `LT_start_tag_name_rep_attr_GT (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "<" *) in
       let v2 = str env v2 (* start_tag_name *) in
-      let v3 = List.map (map_attribute env) v3 in
+      let v3 = Common.map (map_attribute env) v3 in
       let v4 = token env v4 (* ">" *) in
       (v1, v2, v3, v4)
 
@@ -144,12 +144,12 @@ let rec map_element (env : env) (x : CST.element) : xml =
   | `Self_clos_tag (v1, v2, v3, v4) ->
       let l = token env v1 (* "<" *) in
       let id = str env v2 (* start_tag_name *) in
-      let attrs = List.map (map_attribute env) v3 in
+      let attrs = Common.map (map_attribute env) v3 in
       let r = token env v4 (* "/>" *) in
       { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
 
 and map_fragment (env : env) (xs : CST.fragment) : xml_body list =
-  List.map (map_node env) xs
+  Common.map (map_node env) xs
 
 and map_node (env : env) (x : CST.node) : xml_body =
   match x with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -108,7 +108,7 @@ let inferred_parameters (env : env) ((v1, v2, v3, v4) : CST.inferred_parameters)
   let v1 = token env v1 (* "(" *) in
   let v2 = str env v2 (* pattern [a-zA-Z_]\w* *) in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = str env v2 (* pattern [a-zA-Z_]\w* *) in
@@ -158,7 +158,7 @@ let module_directive (env : env) ((v1, v2) : CST.module_directive) =
     match v1 with
     | `Requis_rep_requis_modi_choice_id (v1, v2, v3) ->
         let _v1 = token env v1 (* "requires" *) in
-        let _v2 = List.map (requires_modifier env) v2 in
+        let _v2 = Common.map (requires_modifier env) v2 in
         let _v3 = qualifier_extra env v3 in
         ()
     | `Exports_choice_id_opt_to_opt_choice_id_rep_COMMA_choice_id
@@ -176,7 +176,7 @@ let module_directive (env : env) ((v1, v2) : CST.module_directive) =
           | None -> None
         in
         let _v5 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = qualifier_extra env v2 in
@@ -199,7 +199,7 @@ let module_directive (env : env) ((v1, v2) : CST.module_directive) =
           | None -> None
         in
         let _v5 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = qualifier_extra env v2 in
@@ -218,7 +218,7 @@ let module_directive (env : env) ((v1, v2) : CST.module_directive) =
         let _v3 = token env v3 (* "with" *) in
         let _v4 = qualifier_extra env v4 in
         let _v5 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = qualifier_extra env v2 in
@@ -232,7 +232,7 @@ let module_directive (env : env) ((v1, v2) : CST.module_directive) =
 
 let module_body (env : env) ((v1, v2, v3) : CST.module_body) =
   let _v1 = token env v1 (* "{" *) in
-  let _v2 = List.map (module_directive env) v2 in
+  let _v2 = Common.map (module_directive env) v2 in
   let _v3 = token env v3 (* "}" *) in
   ()
 
@@ -284,7 +284,7 @@ let rec expression (env : env) (x : CST.expression) =
         | `Formal_params x -> formal_parameters env x
         | `Infe_params x ->
             let _, xs, _ = inferred_parameters env x in
-            xs |> List.map (fun id -> ParamClassic (AST.entity_of_id id))
+            xs |> Common.map (fun id -> ParamClassic (AST.entity_of_id id))
       in
       let v2 = token env v2 (* "->" *) in
       let v3 =
@@ -309,7 +309,7 @@ let rec expression (env : env) (x : CST.expression) =
       let v1 = token env v1 (* "(" *) in
       let v2 = type_ env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "&" *) in
             let v2 = type_ env v2 in
@@ -557,7 +557,7 @@ and primary_expression (env : env) (x : CST.primary_expression) =
       let exprs, dims, init =
         match v3 with
         | `Rep1_dimens_expr_opt_dimens (v1, v2) ->
-            let v1 = List.map (dimensions_expr env) v1 in
+            let v1 = Common.map (dimensions_expr env) v1 in
             let v2 =
               match v2 with
               | Some x -> dimensions env x
@@ -572,16 +572,16 @@ and primary_expression (env : env) (x : CST.primary_expression) =
       NewArray (v1, v2, exprs, List.length dims, init)
 
 and dimensions_expr (env : env) ((v1, v2, v3, v4) : CST.dimensions_expr) =
-  let _v1 = List.map (annotation env) v1 in
+  let _v1 = Common.map (annotation env) v1 in
   let _v2 = token env v2 (* "[" *) in
   let v3 = expression env v3 in
   let _v4 = token env v4 (* "]" *) in
   v3
 
 and dimensions (env : env) (xs : CST.dimensions) =
-  List.map
+  Common.map
     (fun (v1, v2, v3) ->
-      let _v1 = List.map (annotation env) v1 in
+      let _v1 = Common.map (annotation env) v1 in
       let v2 = token env v2 (* "[" *) in
       let v3 = token env v3 (* "]" *) in
       (v2, (), v3))
@@ -665,7 +665,7 @@ and argument_list (env : env) ((v1, v2, v3) : CST.argument_list) =
     | Some (v1, v2) ->
         let v1 = expression env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = expression env v2 in
@@ -689,7 +689,7 @@ and type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) =
           | `Wild x -> wildcard env x
         in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 =
@@ -707,7 +707,7 @@ and type_arguments (env : env) ((v1, v2, v3) : CST.type_arguments) =
   (v1, v2, v3)
 
 and wildcard (env : env) ((v1, v2, v3) : CST.wildcard) =
-  let _v1 = List.map (annotation env) v1 in
+  let _v1 = Common.map (annotation env) v1 in
   let v2 = token env v2 (* "?" *) in
   let v3 =
     match v3 with
@@ -779,7 +779,7 @@ and statement_aux env x : Ast_java.stmt list =
               | Some (v1, v2) ->
                   let v1 = expression env v1 in
                   let v2 =
-                    List.map
+                    Common.map
                       (fun (v1, v2) ->
                         let _v1 = token env v1 (* "," *) in
                         let v2 = expression env v2 in
@@ -803,7 +803,7 @@ and statement_aux env x : Ast_java.stmt list =
         | Some (v1, v2) ->
             let v1 = expression env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token env v1 (* "," *) in
                   let v2 = expression env v2 in
@@ -888,7 +888,7 @@ and statement_aux env x : Ast_java.stmt list =
       [ Sync (v2, v3) ]
   | `Local_var_decl x ->
       let xs = local_variable_declaration env x in
-      xs |> List.map (fun x -> LocalVar x)
+      xs |> Common.map (fun x -> LocalVar x)
   | `Throw_stmt (v1, v2, v3) ->
       let v1 = token env v1 (* "throw" *) in
       let v2 = expression env v2 in
@@ -899,9 +899,9 @@ and statement_aux env x : Ast_java.stmt list =
       let v2 = block env v2 in
       let v3 =
         match v3 with
-        | `Rep1_catch_clause xs -> (List.map (catch_clause env) xs, None)
+        | `Rep1_catch_clause xs -> (Common.map (catch_clause env) xs, None)
         | `Rep_catch_clause_fina_clause (v1, v2) ->
-            let v1 = List.map (catch_clause env) v1 in
+            let v1 = Common.map (catch_clause env) v1 in
             let v2 = finally_clause env v2 in
             (v1, Some v2)
       in
@@ -911,7 +911,7 @@ and statement_aux env x : Ast_java.stmt list =
       let v1 = token env v1 (* "try" *) in
       let v2 = resource_specification env v2 in
       let v3 = block env v3 in
-      let v4 = List.map (catch_clause env) v4 in
+      let v4 = Common.map (catch_clause env) v4 in
       let v5 =
         match v5 with
         | Some x -> Some (finally_clause env x)
@@ -921,7 +921,7 @@ and statement_aux env x : Ast_java.stmt list =
 
 and block (env : env) ((v1, v2, v3) : CST.block) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = List.map (statement env ~tok:v1) v2 in
+  let v2 = Common.map (statement env ~tok:v1) v2 in
   let v3 = token env v3 (* "}" *) in
   Block (v1, v2, v3)
 
@@ -945,13 +945,13 @@ and switch_block (env : env) ((v1, v2, v3) : CST.switch_block) =
   let v2 =
     match v2 with
     | `Rep_switch_blk_stmt_group stmt_blocks ->
-        List.map
+        Common.map
           (fun (cases, stmts) ->
-            ( List.flatten (List.map (fun (x, _) -> switch_label env x) cases),
-              List.map (statement env ~tok:v1) stmts ))
+            ( List.concat_map (fun (x, _) -> switch_label env x) cases,
+              Common.map (statement env ~tok:v1) stmts ))
           stmt_blocks
     | `Rep_switch_rule rules ->
-        List.map
+        Common.map
           (fun (label, _tok, stmt) ->
             ( switch_label env label,
               let s =
@@ -972,7 +972,7 @@ and switch_label (env : env) (x : CST.switch_label) =
       let v1 = token env v1 (* "case" *) in
       let v2 = expression env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (tok (* "," *), e) -> Case (token env tok, expression env e))
           v3
       in
@@ -1004,7 +1004,7 @@ and catch_formal_parameter (env : env)
 and catch_type (env : env) ((v1, v2) : CST.catch_type) =
   let v1 = unannotated_type env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "|" *) in
         let v2 = unannotated_type env v2 in
@@ -1023,7 +1023,7 @@ and resource_specification (env : env)
   let v1 = token env v1 (* "(" *) in
   let v2 = resource env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = resource env v2 in
@@ -1080,7 +1080,7 @@ and annotation_argument_list (env : env)
         | Some (v1, v2) ->
             let v1 = AnnotPair (element_value_pair env v1) in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token env v1 (* "," *) in
                   let v2 = AnnotPair (element_value_pair env v2) in
@@ -1110,7 +1110,7 @@ and element_value (env : env) (x : CST.element_value) =
         | Some (v1, v2) ->
             let v1 = element_value env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token env v1 (* "," *) in
                   let v2 = element_value env v2 in
@@ -1133,7 +1133,7 @@ and element_value (env : env) (x : CST.element_value) =
 and declaration (env : env) (x : CST.declaration) : AST.stmt =
   match x with
   | `Module_decl (v1, v2, v3, v4, v5) ->
-      let _v1 = List.map (annotation env) v1 in
+      let _v1 = Common.map (annotation env) v1 in
       let _v2 =
         match v2 with
         | Some tok -> Some (token env tok) (* "open" *)
@@ -1144,7 +1144,7 @@ and declaration (env : env) (x : CST.declaration) : AST.stmt =
       let _v5 = module_body env v5 in
       DirectiveStmt (ModuleTodo v3)
   | `Pack_decl (v1, v2, v3, v4) ->
-      let _v1 = List.map (annotation env) v1 in
+      let _v1 = Common.map (annotation env) v1 in
       let v2 = token env v2 (* "package" *) in
       let v3 = qualifier_extra env v3 in
       let v4 = token env v4 (* ";" *) in
@@ -1199,7 +1199,7 @@ and enum_body (env : env) ((v1, v2, v3, v4, v5) : CST.enum_body) =
     | Some (v1, v2) ->
         let v1 = enum_constant env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = enum_constant env v2 in
@@ -1261,7 +1261,7 @@ and class_body_decl env = function
 
 and enum_body_declarations (env : env) ((v1, v2) : CST.enum_body_declarations) =
   let _v1 = token env v1 (* ";" *) in
-  let v2 = List.map (fun x -> class_body_decl env x) v2 in
+  let v2 = Common.map (fun x -> class_body_decl env x) v2 in
   List.flatten v2
 
 and enum_constant (env : env) ((v1, v2, v3, v4) : CST.enum_constant) =
@@ -1320,7 +1320,7 @@ and class_declaration (env : env)
   }
 
 and modifiers (env : env) (xs : CST.modifiers) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Anno x ->
@@ -1345,7 +1345,7 @@ and type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
   let _v1 = token env v1 (* "<" *) in
   let v2 = type_parameter env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = type_parameter env v2 in
@@ -1357,7 +1357,7 @@ and type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
 
 and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) :
     type_parameter =
-  let _v1 = List.map (annotation env) v1 in
+  let _v1 = Common.map (annotation env) v1 in
   let v2 = identifier env v2 (* pattern [a-zA-Z_]\w* *) in
   let v3 =
     match v3 with
@@ -1370,7 +1370,7 @@ and type_bound (env : env) ((v1, v2, v3) : CST.type_bound) =
   let _v1 = token env v1 (* "extends" *) in
   let v2 = type_ env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "&" *) in
         let v2 = type_ env v2 in
@@ -1392,7 +1392,7 @@ and super_interfaces (env : env) ((v1, v2) : CST.super_interfaces) =
 and interface_type_list (env : env) ((v1, v2) : CST.interface_type_list) =
   let v1 = type_ env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = type_ env v2 in
@@ -1403,7 +1403,7 @@ and interface_type_list (env : env) ((v1, v2) : CST.interface_type_list) =
 
 and class_body (env : env) ((v1, v2, v3) : CST.class_body) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = List.map (fun x -> class_body_decl env x) v2 in
+  let v2 = Common.map (fun x -> class_body_decl env x) v2 in
   let v3 = token env v3 (* "}" *) in
   (v1, List.flatten v2, v3)
 
@@ -1448,7 +1448,7 @@ and constructor_body (env : env) ((v1, v2, v3, v4) : CST.constructor_body) =
     | Some x -> [ explicit_constructor_invocation env x ]
     | None -> []
   in
-  let v3 = List.map (statement env ~tok:v1) v3 in
+  let v3 = Common.map (statement env ~tok:v1) v3 in
   let v4 = token env v4 (* "}" *) in
   Block (v1, v2 @ v3, v4)
 
@@ -1514,7 +1514,7 @@ and annotation_type_declaration (env : env)
 and annotation_type_body (env : env) ((v1, v2, v3) : CST.annotation_type_body) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Anno_type_elem_decl x ->
@@ -1597,7 +1597,7 @@ and extends_interfaces (env : env) ((v1, v2) : CST.extends_interfaces) =
 and interface_body (env : env) ((v1, v2, v3) : CST.interface_body) =
   let v1 = token env v1 (* "{" *) in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Cst_decl x -> constant_declaration env x
@@ -1628,7 +1628,7 @@ and variable_declarator_list (env : env)
     ((v1, v2) : CST.variable_declarator_list) =
   let v1 = variable_declarator env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = variable_declarator env v2 in
@@ -1671,7 +1671,7 @@ and array_initializer (env : env) ((v1, v2, v3, v4) : CST.array_initializer) =
     | Some (v1, v2) ->
         let v1 = init_extra env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = init_extra env v2 in
@@ -1693,7 +1693,7 @@ and type_ (env : env) (x : CST.type_) : typ =
   match x with
   | `Unan_type x -> unannotated_type env x
   | `Anno_type (v1, v2) ->
-      let _v1 = List.map (annotation env) v1 in
+      let _v1 = Common.map (annotation env) v1 in
       let v2 = unannotated_type env v2 in
       v2
 
@@ -1716,7 +1716,7 @@ and scoped_type_identifier (env : env)
     | `Gene_type x -> generic_type env x
   in
   let _v2 = token env v2 (* "." *) in
-  let _v3 = List.map (annotation env) v3 in
+  let _v3 = Common.map (annotation env) v3 in
   let v4 = identifier env v4 (* pattern [a-zA-Z_]\w* *) in
 
   v1 @ [ (v4, None) ]
@@ -1740,7 +1740,7 @@ and method_header (env : env) ((v1, v2, v3, v4) : CST.method_header) =
     match v1 with
     | Some (v1, v2) ->
         let v1 = type_parameters env v1 in
-        let _v2 = List.map (annotation env) v2 in
+        let _v2 = Common.map (annotation env) v2 in
         v1
     | None -> []
   in
@@ -1783,7 +1783,7 @@ and formal_parameters (env : env) ((v1, v2, v3, v4) : CST.formal_parameters) =
           | `Spread_param x -> spread_parameter env x
         in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 =
@@ -1811,7 +1811,7 @@ and formal_parameter (env : env) ((v1, v2, v3) : CST.formal_parameter) =
   ParamClassic (AST.canon_var v1 (Some v2) v3)
 
 and receiver_parameter (env : env) ((v1, v2, v3, v4) : CST.receiver_parameter) =
-  let _v1 = List.map (annotation env) v1 in
+  let _v1 = Common.map (annotation env) v1 in
   let v2 = unannotated_type env v2 in
   let _v3 =
     match v3 with
@@ -1842,7 +1842,7 @@ and throws (env : env) ((v1, v2, v3) : CST.throws) : typ list =
   let _v1 = token env v1 (* "throws" *) in
   let v2 = type_ env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = type_ env v2 in
@@ -1881,7 +1881,7 @@ and method_declaration (env : env) ((v1, v2, v3) : CST.method_declaration) =
 
 let program (env : env) file (xs : CST.program) =
   let tok = PI.fake_info_loc (PI.first_loc_of_file file) "" in
-  List.map (statement env ~tok) xs
+  Common.map (statement env ~tok) xs
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -45,7 +45,7 @@ let var_to_pattern (id, ptype) =
   | None -> pat
 
 let vars_to_pattern (l, xs, r) =
-  let ys = xs |> List.map (fun (id, ptype) -> var_to_pattern (id, ptype)) in
+  let ys = xs |> Common.map (fun (id, ptype) -> var_to_pattern (id, ptype)) in
   PatTuple (l, ys, r)
 
 (*****************************************************************************)
@@ -325,7 +325,7 @@ let line_str_escaped_char (env : env) (x : CST.line_str_escaped_char) =
   | `Uni_char_lit x -> uni_character_literal env x
 
 let type_projection_modifiers (env : env) (xs : CST.type_projection_modifiers) =
-  List.map (type_projection_modifier env) xs
+  Common.map (type_projection_modifier env) xs
 
 let simple_identifier (env : env) (x : CST.simple_identifier) : ident =
   match x with
@@ -348,7 +348,7 @@ let return_at (env : env) ((v1, v2) : CST.return_at) =
 let identifier (env : env) ((v1, v2) : CST.identifier) : dotted_ident =
   let v1 = simple_identifier env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "." *) in
         let v2 = simple_identifier env v2 in
@@ -427,7 +427,7 @@ let import_header (env : env) ((v1, v2, v3, v4) : CST.import_header) : directive
   v3 |> G.d
 
 let rec annotated_lambda (env : env) ((v1, v2, v3) : CST.annotated_lambda) =
-  let _v1TODO = List.map (annotation env) v1 in
+  let _v1TODO = Common.map (annotation env) v1 in
   let _v2TODO = v2 in
   lambda_literal env v3
 
@@ -454,9 +454,9 @@ and annotation (env : env) (x : CST.annotation) : attribute list =
         | None -> None
       in
       let _v3 = token env v3 (* "[" *) in
-      let v4 = List.map (unescaped_annotation env) v4 in
+      let v4 = Common.map (unescaped_annotation env) v4 in
       let _v5 = token env v5 (* "]" *) in
-      v4 |> List.map (fun (n, args) -> NamedAttr (v1, n, args))
+      v4 |> Common.map (fun (n, args) -> NamedAttr (v1, n, args))
 
 and anon_choice_param_b77c1d8 (env : env) (x : CST.anon_choice_param_b77c1d8) =
   match x with
@@ -489,7 +489,7 @@ and directly_assignable_expression (env : env)
       N (H2.name_of_id id) |> G.e
   | `Post_un_exp (v1, v2) ->
       let v1 = primary_expression env v1 in
-      let v2 = List.map (postfix_unary_suffix env) v2 in
+      let v2 = Common.map (postfix_unary_suffix env) v2 in
       v2 |> List.fold_left (fun acc f -> f acc) v1
 
 and postfix_unary_suffix (env : env) (x : CST.postfix_unary_suffix) =
@@ -598,7 +598,7 @@ and catch_block (env : env) ((v1, v2, v3, v4, v5, v6, v7, v8) : CST.catch_block)
     =
   let v1 = token env v1 (* "catch" *) in
   let _v2 = token env v2 (* "(" *) in
-  let _v3TODO = List.map (annotation env) v3 in
+  let _v3TODO = Common.map (annotation env) v3 in
   let v4 = simple_identifier env v4 in
   let _v5 = token env v5 (* ":" *) in
   let v6 = type_ env v6 in
@@ -798,7 +798,7 @@ and class_member_declaration (env : env) (x : CST.class_member_declaration) :
 
 and class_member_declarations (env : env) (xs : CST.class_member_declarations) :
     field list =
-  List.map
+  Common.map
     (fun (v1, v2) ->
       let v1 = class_member_declaration env v1 in
       let _v2 = semi env v2 (* pattern [\r\n]+ *) in
@@ -835,7 +835,7 @@ and class_parameters (env : env) ((v1, v2, v3) : CST.class_parameters) :
     | Some (v1, v2) ->
         let v1 = class_parameter env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = class_parameter env v2 in
@@ -1078,7 +1078,7 @@ and delegation_specifiers (env : env) ((v1, v2) : CST.delegation_specifiers) :
     class_parent list =
   let v1 = delegation_specifier env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = delegation_specifier env v2 in
@@ -1112,7 +1112,7 @@ and enum_class_body (env : env) ((v1, v2, v3, v4) : CST.enum_class_body) =
 and enum_entries (env : env) ((v1, v2, v3) : CST.enum_entries) : field list =
   let v1 = enum_entry env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = enum_entry env v2 in
@@ -1180,7 +1180,7 @@ and function_literal (env : env) (x : CST.function_literal) =
         | Some (v1, v2, v3) ->
             let v1 = simple_user_type env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token env v1 (* "." *) in
                   let v2 = simple_user_type env v2 in
@@ -1226,7 +1226,7 @@ and function_type_parameters (env : env)
     | Some (v1, v2) ->
         let v1 = anon_choice_param_b77c1d8 env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = anon_choice_param_b77c1d8 env v2 in
@@ -1271,7 +1271,7 @@ and function_value_parameters (env : env)
     | Some (v1, v2) ->
         let v1 = function_value_parameter env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = function_value_parameter env v2 in
@@ -1310,7 +1310,7 @@ and indexing_suffix (env : env) ((v1, v2, v3, v4) : CST.indexing_suffix) =
   let v1 = token env v1 (* "[" *) in
   let v2 = expression env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = token env v1 (* "," *) in
         let v2 = expression env v2 in
@@ -1375,7 +1375,7 @@ and jump_expression (env : env) (x : CST.jump_expression) =
       | None -> Return (tret, v2, sc tret) |> G.s
       | Some id ->
           let n = N (H2.name_of_id id) |> G.e in
-          let any = Option.to_list v2 |> List.map (fun e -> E e) in
+          let any = Option.to_list v2 |> Common.map (fun e -> E e) in
           OtherStmt (OS_Todo, TodoK ("return@", tret) :: E n :: any) |> G.s)
   | `Cont tok ->
       let v1 = token env tok (* "continue" *) in
@@ -1432,7 +1432,7 @@ and var_or_multivar (env : env) (x : CST.lambda_parameter) =
       let v1 = (* "(" *) token env v1 in
       let v2 = variable_declaration env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = variable_declaration env v2 in
@@ -1467,7 +1467,7 @@ and lambda_parameters (env : env) ((v1, v2) : CST.lambda_parameters) :
     G.parameter list =
   let v1 = lambda_parameter env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = lambda_parameter env v2 in
@@ -1481,7 +1481,7 @@ and loop_statement (env : env) (x : CST.loop_statement) =
   | `For_stmt (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 = token env v1 (* "for" *) in
       let _v2 = token env v2 (* "(" *) in
-      let _v3TODO = List.map (annotation env) v3 in
+      let _v3TODO = Common.map (annotation env) v3 in
       let pat = lambda_parameter_for_loop env v4 in
       let v5 = token env v5 (* "in" *) in
       let v6 = expression env v6 in
@@ -1520,11 +1520,11 @@ and loop_statement (env : env) (x : CST.loop_statement) =
       DoWhile (v1, v2, v5) |> G.s
 
 and modifiers (env : env) (xs : CST.modifiers) : attribute list =
-  xs
-  |> List.map (function
-       | `Anno x -> annotation env x
-       | `Modi x -> [ modifier env x ])
-  |> List.flatten
+  List.concat_map
+    (function
+      | `Anno x -> annotation env x
+      | `Modi x -> [ modifier env x ])
+    xs
 
 and modifiers_opt env x =
   match x with
@@ -1563,7 +1563,7 @@ and nullable_type (env : env) ((v1, v2) : CST.nullable_type) =
     | `Type_ref x -> type_reference env x
     | `Paren_type x -> parenthesized_type env x
   in
-  let v2 = List.map (token env) (* "?" *) v2 in
+  let v2 = Common.map (token env) (* "?" *) v2 in
   match v2 with
   | hd :: _tl -> TyQuestion (v1, hd) |> G.t
   | [] -> raise Impossible
@@ -1576,11 +1576,11 @@ and parameter (env : env) ((v1, v2, v3) : CST.parameter) =
   (v1, v3)
 
 and parameter_modifiers (env : env) (xs : CST.parameter_modifiers) =
-  xs
-  |> List.map (function
-       | `Anno x -> annotation env x
-       | `Param_modi x -> [ parameter_modifier env x ])
-  |> List.flatten
+  List.concat_map
+    (function
+      | `Anno x -> annotation env x
+      | `Param_modi x -> [ parameter_modifier env x ])
+    xs
 
 and parameter_with_optional_type (env : env)
     ((v1, v2, v3) : CST.parameter_with_optional_type) : parameter_classic =
@@ -1690,7 +1690,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
       let v1 = token env v1 (* "[" *) in
       let v2 = expression env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = expression env v2 in
@@ -1749,7 +1749,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
         | None -> None
       in
       let _v3 = token env v3 (* "{" *) in
-      let v4 = List.map (when_entry env) v4 in
+      let v4 = Common.map (when_entry env) v4 in
       let _v5 = token env v5 (* "}" *) in
       let switch_stmt = Switch (v1, v2, v4) |> G.s in
       stmt_to_expr switch_stmt
@@ -1759,7 +1759,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
       let catch, finally =
         match v3 with
         | `Rep1_catch_blk_opt_fina_blk (v1, v2) ->
-            let v1 = List.map (catch_block env) v1 in
+            let v1 = Common.map (catch_block env) v1 in
             let v2 =
               match v2 with
               | Some x -> Some (finally_block env x)
@@ -1847,7 +1847,7 @@ and statement (env : env) (x : CST.statement) : stmt =
 and statements (env : env) ((v1, v2, v3) : CST.statements) =
   let v1 = statement env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = semi env v1 (* pattern [\r\n]+ *) in
         let v2 = statement env v2 in
@@ -1868,7 +1868,7 @@ and string_literal (env : env) (x : CST.string_literal) : expr =
   | `Line_str_lit (v1, v2, v3) ->
       let v1 = token env v1 (* "\dq" *) in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Line_str_content x -> Common.Left3 (line_string_content env x)
@@ -1882,7 +1882,7 @@ and string_literal (env : env) (x : CST.string_literal) : expr =
   | `Multi_line_str_lit (v1, v2, v3) ->
       let v1 = token env v1 (* "\"\"\dq" *) in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Multi_line_str_content x ->
@@ -1914,7 +1914,7 @@ and type_arguments (env : env) ((v1, v2, v3, v4) : CST.type_arguments) =
   let v1 = token env v1 (* "<" *) in
   let v2 = type_projection env ~tok:v1 v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = token env v1 (* "," *) in
         let v2 = type_projection env ~tok:v1 v2 in
@@ -1926,7 +1926,7 @@ and type_arguments (env : env) ((v1, v2, v3, v4) : CST.type_arguments) =
 
 and type_constraint (env : env) ((v1, v2, v3, v4) : CST.type_constraint) :
     ident * type_ =
-  let _v1TODO = List.map (annotation env) v1 in
+  let _v1TODO = Common.map (annotation env) v1 in
   let v2 = simple_identifier env v2 in
   let _v3 = token env v3 (* ":" *) in
   let v4 = type_ env v4 in
@@ -1936,7 +1936,7 @@ and type_constraints (env : env) ((v1, v2, v3) : CST.type_constraints) =
   let _v1 = token env v1 (* "where" *) in
   let v2 = type_constraint env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = type_constraint env v2 in
@@ -1953,7 +1953,7 @@ and type_modifier (env : env) (x : CST.type_modifier) : attribute list =
       [ G.unhandled_keywordattr x ]
 
 and type_modifiers (env : env) (xs : CST.type_modifiers) : attribute list =
-  List.map (type_modifier env) xs |> List.flatten
+  List.concat_map (type_modifier env) xs
 
 and type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
   let tp_modifiers =
@@ -1990,13 +1990,13 @@ and type_parameter_modifier (env : env) (x : CST.type_parameter_modifier) =
   | `Anno x -> Left (annotation env x)
 
 and type_parameter_modifiers (env : env) (xs : CST.type_parameter_modifiers) =
-  List.map (type_parameter_modifier env) xs
+  Common.map (type_parameter_modifier env) xs
 
 and type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
   let _v1 = token env v1 (* "<" *) in
   let v2 = type_parameter env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = type_parameter env v2 in
@@ -2085,7 +2085,7 @@ and unescaped_annotation (env : env) (x : CST.unescaped_annotation) :
 and user_type (env : env) ((v1, v2) : CST.user_type) : name =
   let v1 = simple_user_type env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "." *) in
         let v2 = simple_user_type env v2 in
@@ -2132,7 +2132,7 @@ and value_arguments (env : env) ((v1, v2, v3) : CST.value_arguments) : arguments
     | Some (v1, v2) ->
         let v1 = value_argument env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = value_argument env v2 in
@@ -2178,7 +2178,7 @@ and when_entry (env : env) ((v1, v2, v3, v4) : CST.when_entry) =
     | `When_cond_rep_COMMA_when_cond (v1, v2) ->
         let v1 = when_condition env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = token env v1 (* "," *) in
               let v2 = when_condition env v2 in
@@ -2209,7 +2209,7 @@ and when_subject (env : env) ((v1, v2, v3, v4) : CST.when_subject) : condition =
   let _v2TODO =
     match v2 with
     | Some (v1, v2, v3, v4) ->
-        let _v1 = List.map (annotation env) v1 in
+        let _v1 = Common.map (annotation env) v1 in
         let v2 = token env v2 (* "val" *) in
         let v3 = variable_declaration env v3 in
         let v4 = token env v4 (* "=" *) in
@@ -2229,7 +2229,7 @@ let file_annotation (env : env) ((v1, v2, v3, v4, v5) : CST.file_annotation) =
     match v4 with
     | `LBRACK_rep1_unes_anno_RBRACK (v1, v2, v3) ->
         let _v1 = token env v1 (* "[" *) in
-        let v2 = List.map (unescaped_annotation env) v2 in
+        let v2 = Common.map (unescaped_annotation env) v2 in
         let _v3 = token env v3 (* "]" *) in
         v2
     | `Unes_anno x ->
@@ -2248,22 +2248,22 @@ let source_file (env : env) (x : CST.source_file) : any =
         | Some x -> shebang_line env x
         | None -> ()
       in
-      let _v2 = List.map (file_annotation env) v2 in
+      let _v2 = Common.map (file_annotation env) v2 in
       let v3 =
         match v3 with
         | Some x -> [ package_header env x ]
         | None -> []
       in
-      let v4 = List.map (import_header env) v4 in
+      let v4 = Common.map (import_header env) v4 in
       let v5 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = statement env v1 in
             let _v2 = semi env v2 (* pattern [\r\n]+ *) in
             v1)
           v5
       in
-      let dirs = v3 @ v4 |> List.map (fun d -> DirectiveStmt d |> G.s) in
+      let dirs = v3 @ v4 |> Common.map (fun d -> DirectiveStmt d |> G.s) in
       Pr (dirs @ v5)
   | `Semg_exp (_v1, v2) ->
       let v2 = expression env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -128,7 +128,7 @@ let map_parameters (env : env) ((v1, v2, v3) : CST.parameters) : G.parameters =
           (* pattern [a-zA-Z_][a-zA-Z0-9_]* *)
         in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "," *) in
               let v2 = identifier env v2 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *) in
@@ -153,14 +153,14 @@ let map_local_variable_declarator (env : env)
     ((v1, v2) : CST.local_variable_declarator) local : G.entity list =
   let ident_first = identifier env v1 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *) in
   let ident_rest =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _comma = token env v1 (* "," *) in
         let ident = identifier env v2 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *) in
         ident)
       v2
   in
-  List.map
+  Common.map
     (fun x -> G.basic_entity x ~attrs:[ G.KeywordAttr (G.Static, local) ])
     (ident_first :: ident_rest)
 
@@ -168,7 +168,7 @@ let map_function_name_field (env : env) ((v1, v2) : CST.function_name_field)
     colon_and_ident : G.name =
   let v1 = identifier env v1 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *) in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "." *) in
         let v2 = identifier env v2 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *) in
@@ -197,7 +197,7 @@ let rec map_expression_list (env : env)
     ((v1, v2) : CST.anon_exp_rep_COMMA_exp_0bb260c) : G.expr list =
   let v1 = map_expression env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = map_expression env v2 in
@@ -214,7 +214,7 @@ and map_expression_tuple (env : env)
 and map_anon_arguments (env : env)
     ((v1, v2) : CST.anon_exp_rep_COMMA_exp_0bb260c) : G.argument list =
   let v1 = map_expression_list env (v1, v2) in
-  List.map (fun (v1 : G.expr) -> G.Arg v1) v1
+  Common.map (fun (v1 : G.expr) -> G.Arg v1) v1
 
 and map_arguments (env : env) (x : CST.arguments) : G.arguments =
   match x with
@@ -341,7 +341,7 @@ and map_binary_operation (env : env) (x : CST.binary_operation) =
       G.Call (G.IdSpecial (G.Op G.BitXor, v2) |> G.e, fb [ G.Arg v1; G.Arg v3 ])
 
 and map_statement_list (env : env) (x : CST.statement list) : G.stmt list =
-  let v1 = List.map (map_statement env) x in
+  let v1 = Common.map (map_statement env) x in
   List.flatten v1
 
 and map_statements_and_return (env : env) (v1, v2) : G.stmt list =
@@ -445,7 +445,7 @@ and map_field_sequence (env : env) ((v1, v2, v3) : CST.field_sequence) :
     G.expr list =
   let v1 = map_field env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = map_field_sep env v1 in
         let v2 = map_field env v2 in
@@ -504,7 +504,7 @@ and map_in_loop_expression (env : env)
   let var : G.variable_definition = { vinit = None; vtype = None } in
   let for_init_var = G.ForInitVar (G.basic_entity v1, var) in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = identifier env v2 (* pattern [a-zA-Z_][a-zA-Z0-9_]* *) in
@@ -516,7 +516,7 @@ and map_in_loop_expression (env : env)
   let _v3 = token env v3 (* "in" *) in
   let v4 = map_expression env v4 in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = map_expression env v2 in
@@ -582,7 +582,7 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
   | `Var_decl (v1, v2, v3, v4, v5) ->
       let ident_first = map_variable_declarator env v1 in
       let ident_rest =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = map_variable_declarator env v2 in
@@ -592,7 +592,7 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
       let equal = token env v3 (* "=" *) in
       let expr_first = map_expression env v4 in
       let expr_rest =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = map_expression env v2 in
@@ -602,7 +602,7 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
       let assigns =
         mk_assigns (ident_first :: ident_rest) (expr_first :: expr_rest) equal
       in
-      List.map (fun x -> G.ExprStmt (x, G.sc) |> G.s) assigns
+      Common.map (fun x -> G.ExprStmt (x, G.sc) |> G.s) assigns
   | `Local_var_decl (v1, v2, v3) ->
       let local = token env v1 (* "local" *) in
       let entities = map_local_variable_declarator env v2 local in
@@ -612,7 +612,7 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
             let _v1 = token env v1 (* "=" *) in
             let v2 = map_expression env v2 in
             let v3 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token env v1 (* "," *) in
                   let v2 = map_expression env v2 in
@@ -623,7 +623,7 @@ and map_statement (env : env) (x : CST.statement) : G.stmt list =
         | None -> []
       in
       let defs = mk_vars entities exprs in
-      List.map (fun x -> G.DefStmt x |> G.s) defs
+      Common.map (fun x -> G.DefStmt x |> G.s) defs
   | `Do_stmt (v1, v2, v3, v4) -> [ map_do_block env (v1, v2, v3, v4) ]
   | `If_stmt (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 = token env v1 (* "if" *) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -185,7 +185,7 @@ let map_pow_operator (env : env) (x : CST.pow_operator) =
 (* "asr" *)
 
 let map_quoted_string_content (env : env) (xs : CST.quoted_string_content) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Imm_tok_SPACE tok -> str env tok (* " " *)
@@ -252,7 +252,7 @@ let rec map_extended_module_path (env : env) (x : CST.extended_module_path) :
       v1
 
 let map_string_content (env : env) (xs : CST.string_content) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Imm_tok_SPACE tok -> str env tok (* " " *)
@@ -299,7 +299,7 @@ let map_module_type_name (env : env) (x : CST.module_type_name) : ident =
 
 let map_abstract_type (env : env) ((v1, v2) : CST.abstract_type) =
   let v1 = token env v1 (* "type" *) in
-  let v2 = List.map (str env) (* pattern "[a-z_][a-zA-Z0-9_']*" *) v2 in
+  let v2 = Common.map (str env) (* pattern "[a-z_][a-zA-Z0-9_']*" *) v2 in
   (v1, v2)
 
 let map_anon_choice_inst_var_name_cbd841f (env : env)
@@ -391,8 +391,8 @@ let map_string_ (env : env) ((v1, v2, v3) : CST.string_) : string wrap =
     | None -> []
   in
   let v3 = token env v3 (* "\"" *) in
-  let s = v2 |> List.map fst |> String.concat "" in
-  let ts = v2 |> List.map snd in
+  let s = v2 |> Common.map fst |> String.concat "" in
+  let ts = v2 |> Common.map snd in
   (s, PI.combine_infos v1 (ts @ [ v3 ]))
 
 let map_parenthesized_operator (env : env)
@@ -455,8 +455,8 @@ let map_parenthesized_operator (env : env)
           | None -> []
         in
         let xs = [ v2 ] @ v3 @ v4 in
-        let s = "." ^ (xs |> List.map fst |> String.concat "") in
-        (s, PI.combine_infos v1 (xs |> List.map snd))
+        let s = "." ^ (xs |> Common.map fst |> String.concat "") in
+        (s, PI.combine_infos v1 (xs |> Common.map snd))
     | `Let_op tok -> str env tok (* let_operator *)
     | `And_op tok -> str env tok (* and_operator *)
     | `Match_op tok -> str env tok
@@ -486,7 +486,7 @@ let map_parenthesized_abstract_type (env : env)
 let map_attribute_id (env : env) ((v1, v2) : CST.attribute_id) : dotted_ident =
   let v1 = map_anon_choice_inst_var_name_cbd841f env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "." *) in
         let v2 = map_anon_choice_inst_var_name_cbd841f env v2 in
@@ -547,8 +547,8 @@ let map_constant (env : env) (x : CST.constant) : literal =
       in
       let v4 = token env v4 (* right_quoted_string_delimiter *) in
       let v5 = token env v5 (* "}" *) in
-      let s = v3 |> List.map fst |> String.concat "" in
-      let xs = [ v2 ] @ List.map snd v3 @ [ v4; v5 ] in
+      let s = v3 |> Common.map fst |> String.concat "" in
+      let xs = [ v2 ] @ Common.map snd v3 @ [ v4; v5 ] in
       String (s, PI.combine_infos v1 xs)
   | `Bool x -> map_boolean env x
   | `Unit x -> map_unit_ env x
@@ -645,7 +645,7 @@ let map_type_params (env : env) (x : CST.type_params) : type_parameter list =
       let _v1 = token env v1 (* "(" *) in
       let v2 = map_type_param env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = map_type_param env v2 in
@@ -662,7 +662,7 @@ let map_anon_LBRACK_type_param_rep_COMMA_type_param_RBRACK_cea5434 (env : env)
   let _v1 = token env v1 (* "[" *) in
   let v2 = map_type_param env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "," *) in
         let v2 = map_type_param env v2 in
@@ -693,7 +693,7 @@ let map_toplevel_directive (env : env) ((v1, v2) : CST.toplevel_directive) :
             [ E (Name x) ]
         | `Module_path x ->
             let xs = map_module_path env x in
-            xs |> List.map (fun x -> Id x))
+            xs |> Common.map (fun x -> Id x))
     | None -> []
   in
   ItemTodo (("Directive", tsharp), []) |> mki
@@ -704,7 +704,7 @@ let rec map_anon_bind_pat_ext_rep_SEMI_bind_pat_ext_opt_SEMI_38caf30 (env : env)
     pattern list =
   let v1 = map_binding_pattern_ext env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = map_binding_pattern_ext env v2 in
@@ -730,7 +730,7 @@ and map_anon_choice_cons_type_771aabb (env : env)
       in
       let _v3 = map_type_constructor_path env v3 in
       let _v4 = map_type_equation env v4 in
-      let _v5 = List.map (map_type_constraint env) v5 in
+      let _v5 = Common.map (map_type_constraint env) v5 in
       ()
   | `Cons_module (v1, v2, v3, v4) ->
       let _v1 = token env v1 (* "module" *) in
@@ -765,7 +765,7 @@ and map_anon_choice_simple_type_ext_30dd028 (env : env)
       let _v1 = token env v1 (* "(" *) in
       let v2 = map_type_ext env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = map_type_ext env v2 in
@@ -779,7 +779,7 @@ and map_anon_cons_decl_rep_BAR_cons_decl_fc0ccc5 (env : env)
     ((v1, v2) : CST.anon_cons_decl_rep_BAR_cons_decl_fc0ccc5) =
   let v1 = map_constructor_declaration env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "|" *) in
         let v2 = map_constructor_declaration env v2 in
@@ -793,7 +793,7 @@ and map_anon_exp_ext_rep_SEMI_exp_ext_opt_SEMI_f0de170 (env : env)
     expr list =
   let v1 = map_expression_ext env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = map_expression_ext env v2 in
@@ -812,7 +812,7 @@ and map_anon_pat_ext_rep_SEMI_pat_ext_opt_SEMI_3830e8c (env : env)
     pattern list =
   let v1 = map_pattern_ext env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = map_pattern_ext env v2 in
@@ -1033,7 +1033,7 @@ and map_class_binding (env : env)
     | None -> []
   in
   let _v3 = token env v3 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
-  let _v4 = List.map (map_parameter env) v4 in
+  let _v4 = Common.map (map_parameter env) v4 in
   let _v5 =
     match v5 with
     | Some x -> Some (map_class_typed env x)
@@ -1047,7 +1047,7 @@ and map_class_binding (env : env)
         Some v2
     | None -> None
   in
-  let _v7 = List.map (map_item_attribute env) v7 in
+  let _v7 = Common.map (map_item_attribute env) v7 in
   ()
 
 and map_class_definition (env : env) ((v1, v2, v3, v4) : CST.class_definition) =
@@ -1055,7 +1055,7 @@ and map_class_definition (env : env) ((v1, v2, v3, v4) : CST.class_definition) =
   let _v2 = map_attribute_opt env v2 in
   let _v3 = map_class_binding env v3 in
   let _v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "and" *) in
         let v2 = map_class_binding env v2 in
@@ -1069,13 +1069,13 @@ and map_class_expression (env : env) (x : CST.class_expression) =
   | `Simple_class_exp x -> map_simple_class_expression env x
   | `Class_func (v1, v2, v3, v4) ->
       let _v1 = token env v1 (* "fun" *) in
-      let _v2 = List.map (map_parameter env) v2 in
+      let _v2 = Common.map (map_parameter env) v2 in
       let _v3 = token env v3 (* "->" *) in
       let _v4 = map_class_expression_ext env v4 in
       ()
   | `Class_app (v1, v2) ->
       let _v1 = map_simple_class_expression env v1 in
-      let _v2 = List.map (map_argument env) v2 in
+      let _v2 = Common.map (map_argument env) v2 in
       ()
   | `Let_class_exp (v1, v2, v3) ->
       let _v1 = map_value_definition env v1 in
@@ -1114,7 +1114,7 @@ and map_class_field (env : env) (x : CST.class_field) =
             Some v2
         | None -> None
       in
-      let _v5 = List.map (map_item_attribute env) v5 in
+      let _v5 = Common.map (map_item_attribute env) v5 in
       ()
   | `Inst_var_defi (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let _v1 = token env v1 (* "val" *) in
@@ -1123,7 +1123,7 @@ and map_class_field (env : env) (x : CST.class_field) =
         | Some tok -> Some (token env tok) (* "!" *)
         | None -> None
       in
-      let _v3 = List.map (map_anon_choice_muta_d43fe41 env) v3 in
+      let _v3 = Common.map (map_anon_choice_muta_d43fe41 env) v3 in
       let _v4 = token env v4 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
       let _v5 = map_typed_opt env v5 in
       let _v6 =
@@ -1142,7 +1142,7 @@ and map_class_field (env : env) (x : CST.class_field) =
             Some v2
         | None -> None
       in
-      let _v8 = List.map (map_item_attribute env) v8 in
+      let _v8 = Common.map (map_item_attribute env) v8 in
       ()
   | `Meth_defi (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let _v1 = token env v1 (* "method" *) in
@@ -1151,9 +1151,9 @@ and map_class_field (env : env) (x : CST.class_field) =
         | Some tok -> Some (token env tok) (* "!" *)
         | None -> None
       in
-      let _v3 = List.map (map_anon_choice_priv_c7cc539 env) v3 in
+      let _v3 = Common.map (map_anon_choice_priv_c7cc539 env) v3 in
       let _v4 = token env v4 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
-      let _v5 = List.map (map_parameter env) v5 in
+      let _v5 = Common.map (map_parameter env) v5 in
       let _v6 =
         match v6 with
         | Some x -> Some (map_polymorphic_typed env x)
@@ -1167,7 +1167,7 @@ and map_class_field (env : env) (x : CST.class_field) =
             Some v2
         | None -> None
       in
-      let _v8 = List.map (map_item_attribute env) v8 in
+      let _v8 = Common.map (map_item_attribute env) v8 in
       ()
   | `Type_param_cons x ->
       let _x = map_type_parameter_constraint env x in
@@ -1175,7 +1175,7 @@ and map_class_field (env : env) (x : CST.class_field) =
   | `Class_init (v1, v2, v3) ->
       let _v1 = token env v1 (* "initializer" *) in
       let _v2 = map_sequence_expression_ext env v2 |> seq1 in
-      let _v3 = List.map (map_item_attribute env) v3 in
+      let _v3 = Common.map (map_item_attribute env) v3 in
       ()
 
 and map_class_field_ext (env : env) (x : CST.class_field_ext) =
@@ -1191,21 +1191,21 @@ and map_class_field_specification (env : env)
   | `Inhe_spec (v1, v2, v3) ->
       let _v1 = token env v1 (* "inherit" *) in
       let _v2 = map_simple_class_type_ext env v2 in
-      let _v3 = List.map (map_item_attribute env) v3 in
+      let _v3 = Common.map (map_item_attribute env) v3 in
       ()
   | `Inst_var_spec (v1, v2, v3, v4, v5) ->
       let _v1 = token env v1 (* "val" *) in
-      let _v2 = List.map (map_anon_choice_muta_d43fe41 env) v2 in
+      let _v2 = Common.map (map_anon_choice_muta_d43fe41 env) v2 in
       let _v3 = token env v3 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
       let _v4 = map_typed env v4 in
-      let _v5 = List.map (map_item_attribute env) v5 in
+      let _v5 = Common.map (map_item_attribute env) v5 in
       ()
   | `Meth_spec (v1, v2, v3, v4, v5) ->
       let _v1 = token env v1 (* "method" *) in
-      let _v2 = List.map (map_anon_choice_priv_c7cc539 env) v2 in
+      let _v2 = Common.map (map_anon_choice_priv_c7cc539 env) v2 in
       let _v3 = token env v3 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
       let _v4 = map_polymorphic_typed env v4 in
-      let _v5 = List.map (map_item_attribute env) v5 in
+      let _v5 = Common.map (map_item_attribute env) v5 in
       ()
   | `Type_param_cons x ->
       let _v1 = map_type_parameter_constraint env x in
@@ -1259,7 +1259,7 @@ and map_class_type_binding (env : env)
   let _v3 = token env v3 (* pattern "[a-z_][a-zA-Z0-9_']*" *) in
   let _v4 = token env v4 (* "=" *) in
   let _v5 = map_simple_class_type_ext env v5 in
-  let _v6 = List.map (map_item_attribute env) v6 in
+  let _v6 = Common.map (map_item_attribute env) v6 in
   ()
 
 and map_class_type_definition (env : env)
@@ -1269,7 +1269,7 @@ and map_class_type_definition (env : env)
   let _v3 = map_attribute_opt env v3 in
   let _v4 = map_class_type_binding env v4 in
   let _v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "and" *) in
         let v2 = map_class_type_binding env v2 in
@@ -1296,7 +1296,7 @@ and map_constructor_argument (env : env) (x : CST.constructor_argument) :
   | `Choice_simple_type_rep_STAR_choice_simple_type (v1, v2) ->
       let v1 = map_simple_type_ext env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "*" *) in
             let v2 = map_simple_type_ext env v2 in
@@ -1373,7 +1373,7 @@ and map_exception_definition (env : env)
   let v1 = token env v1 (* "exception" *) in
   let _v2 = map_attribute_opt env v2 in
   let id, tys = map_constructor_declaration env v3 in
-  let v4 = List.map (map_item_attribute env) v4 in
+  let v4 = Common.map (map_item_attribute env) v4 in
   { i = Exception (v1, id, tys); iattrs = v4 }
 
 (*****************************************************************************)
@@ -1395,7 +1395,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
       Infix (v1, v2, v3)
   | `App_exp (v1, v2) ->
       let v1 = map_simple_expression_ext env v1 in
-      let v2 = List.map (map_argument env) v2 in
+      let v2 = Common.map (map_argument env) v2 in
       Call (v1, v2)
   | `Infix_exp x -> map_infix_expression env x
   | `Sign_exp (v1, v2) ->
@@ -1480,7 +1480,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
   | `Fun_exp (v1, v2, v3, v4, v5, v6) ->
       let v1 = token env v1 (* "fun" *) in
       let _v2 = map_attribute_opt env v2 in
-      let v3 = List.map (map_parameter env) v3 in
+      let v3 = Common.map (map_parameter env) v3 in
       let _v4TODO =
         match v4 with
         | Some x -> Some (map_simple_typed env x)
@@ -1540,7 +1540,7 @@ and map_expression_ext (env : env) (x : CST.expression_ext) =
 
 and map_expression_item (env : env) ((v1, v2) : CST.expression_item) =
   let v1 = map_sequence_expression_ext env v1 |> seq1 in
-  let _v2 = List.map (map_item_attribute env) v2 in
+  let _v2 = Common.map (map_item_attribute env) v2 in
   v1
 
 and map_extension (env : env) (x : CST.extension) : todo_category =
@@ -1576,8 +1576,8 @@ and map_external_ (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.external_) :
   let v3 = map_value_name env v3 in
   let _, typ = map_typed env v4 in
   let _v5 = token env v5 (* "=" *) in
-  let v6 = List.map (map_string_ env) v6 in
-  let v7 = List.map (map_item_attribute env) v7 in
+  let v6 = Common.map (map_string_ env) v6 in
+  let v7 = Common.map (map_item_attribute env) v7 in
   { i = External (v1, v3, typ, v6); iattrs = v7 }
 
 and map_field_binding_pattern (env : env)
@@ -1722,7 +1722,7 @@ and map_item_extension (env : env) (x : CST.item_extension) =
       let _v2 = map_attribute_id env v2 in
       let _v3 = map_attribute_payload_opt env v3 in
       let _v4 = token env v4 (* "]" *) in
-      let _v5 = List.map (map_item_attribute env) v5 in
+      let _v5 = Common.map (map_item_attribute env) v5 in
       ("Extension", v1)
   | `Quoted_item_exte (v1, v2, v3, v4, v5, v6, v7, v8) ->
       let v1 = token env v1 (* "{%%" *) in
@@ -1740,7 +1740,7 @@ and map_item_extension (env : env) (x : CST.item_extension) =
       in
       let _v6 = token env v6 (* right_quoted_string_delimiter *) in
       let _v7 = token env v7 (* "}" *) in
-      let _v8 = List.map (map_item_attribute env) v8 in
+      let _v8 = Common.map (map_item_attribute env) v8 in
       ("Extension", v1)
 
 and map_labeled_argument (env : env) (x : CST.labeled_argument) =
@@ -1763,7 +1763,7 @@ and map_let_binding (env : env) ((v1, v2, v3) : CST.let_binding) : let_binding =
   let v2 =
     match v2 with
     | Some (v1, v2, v3, v4, v5) -> (
-        let v1 = List.map (map_parameter env) v1 in
+        let v1 = Common.map (map_parameter env) v1 in
         let v2 =
           match v2 with
           | Some x -> Some (map_polymorphic_typed env x)
@@ -1788,7 +1788,7 @@ and map_let_binding (env : env) ((v1, v2, v3) : CST.let_binding) : let_binding =
     (* TODO: grammar.js is wrong, this can not happen *)
     | None -> raise Impossible
   in
-  let _v3 = List.map (map_item_attribute env) v3 in
+  let _v3 = Common.map (map_item_attribute env) v3 in
   v2
 
 and map_list_binding_pattern (env : env)
@@ -1850,7 +1850,7 @@ and map_match_cases (env : env) ((v1, v2, v3) : CST.match_cases) =
   in
   let v2 = map_match_case env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "|" *) in
         let v2 = map_match_case env v2 in
@@ -1861,7 +1861,7 @@ and map_match_cases (env : env) ((v1, v2, v3) : CST.match_cases) =
 
 and map_module_binding (env : env) ((v1, v2, v3, v4, v5) : CST.module_binding) =
   let v1 = map_anon_choice_module_name_7ad5569 env v1 in
-  let _v2TODO = List.map (map_module_parameter env) v2 in
+  let _v2TODO = Common.map (map_module_parameter env) v2 in
   let _v3TODO =
     match v3 with
     | Some x -> Some (map_module_typed env x)
@@ -1875,7 +1875,7 @@ and map_module_binding (env : env) ((v1, v2, v3, v4, v5) : CST.module_binding) =
         v2
     | None -> ModuleTodo (("AbstractModule", snd v1), [])
   in
-  let _v5 = List.map (map_item_attribute env) v5 in
+  let _v5 = Common.map (map_item_attribute env) v5 in
   { mname = v1; mbody = v4 }
 
 and map_module_definition (env : env)
@@ -1885,7 +1885,7 @@ and map_module_definition (env : env)
   let _v3 = rec_opt env v3 in
   let v4 = map_module_binding env v4 in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "and" *) in
         let v2 = map_module_binding env v2 in
@@ -1913,7 +1913,7 @@ and map_module_expression (env : env) (x : CST.module_expression) =
       ModuleStruct v2
   | `Func (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "functor" *) in
-      let _v2 = List.map (map_module_parameter env) v2 in
+      let _v2 = Common.map (map_module_parameter env) v2 in
       let _v3 = token env v3 (* "->" *) in
       let v4 = map_module_expression_ext env v4 in
       ModuleTodo (("Functor", v1), [ v4 ])
@@ -1968,7 +1968,7 @@ and map_module_type (env : env) (x : CST.module_type) =
       let _v2 = token env v2 (* "with" *) in
       let _v3 = map_anon_choice_cons_type_771aabb env v3 in
       let _v4 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "and" *) in
             let v2 = map_anon_choice_cons_type_771aabb env v2 in
@@ -1987,7 +1987,7 @@ and map_module_type (env : env) (x : CST.module_type) =
         match v1 with
         | `Func_rep_module_param (v1, v2) ->
             let _v1 = token env v1 (* "functor" *) in
-            let _v2 = List.map (map_module_parameter env) v2 in
+            let _v2 = Common.map (map_module_parameter env) v2 in
             ()
         | `Choice_module_type x -> map_module_type_ext env x
       in
@@ -2014,7 +2014,7 @@ and map_module_type_definition (env : env)
         Some (v1, v2)
     | None -> None
   in
-  let v6 = List.map (map_item_attribute env) v6 in
+  let v6 = Common.map (map_item_attribute env) v6 in
   { i = ItemTodo (("ModuleType", v1), []); iattrs = v6 }
 
 and map_module_type_ext (env : env) (x : CST.module_type_ext) =
@@ -2039,7 +2039,7 @@ and map_object_copy_expression (env : env)
     | Some (v1, v2) ->
         let v1 = map_instance_variable_expression env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* ";" *) in
               let v2 = map_instance_variable_expression env v2 in
@@ -2055,7 +2055,7 @@ and map_object_copy_expression (env : env)
     | None -> None
   in
   let _v4 = token env v4 (* ">}" *) in
-  ExprTodo (("ObjCopy", v1), v2 |> List.map snd)
+  ExprTodo (("ObjCopy", v1), v2 |> Common.map snd)
 
 and map_object_expression (env : env)
     ((v1, v2, v3, v4, v5) : CST.object_expression) =
@@ -2072,7 +2072,7 @@ and map_object_expression (env : env)
     | None -> ()
   in
   let _v4 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Class_field_ext x ->
@@ -2095,7 +2095,7 @@ and map_open_module (env : env) ((v1, v2, v3, v4, v5) : CST.open_module) =
   in
   let _v3 = map_attribute_opt env v3 in
   let v4 = map_module_expression_ext env v4 in
-  let v5 = List.map (map_item_attribute env) v5 in
+  let v5 = Common.map (map_item_attribute env) v5 in
   match v4 with
   | ModuleName n -> { i = Open (v1, n); iattrs = v5 }
   | _ -> { i = ItemTodo (("OpenModExpr", v1), []); iattrs = v5 }
@@ -2270,7 +2270,7 @@ and map_polymorphic_type (env : env) (x : CST.polymorphic_type) : type_ =
       let _v1 =
         match v1 with
         | `Rep1_type_var xs ->
-            let _xs = List.map (map_type_variable env) xs in
+            let _xs = Common.map (map_type_variable env) xs in
             ()
         | `Abst_type x ->
             let _x = map_abstract_type env x in
@@ -2291,7 +2291,7 @@ and map_record_binding_pattern (env : env)
   let v1 = token env v1 (* "{" *) in
   let _v2 = map_field_binding_pattern env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = map_field_binding_pattern env v2 in
@@ -2319,7 +2319,7 @@ and map_record_declaration (env : env)
   let v1 = token env v1 (* "{" *) in
   let v2 = map_field_declaration env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = map_field_declaration env v2 in
@@ -2347,7 +2347,7 @@ and map_record_expression (env : env)
   in
   let v3 = map_field_expression env v3 in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = map_field_expression env v2 in
@@ -2367,7 +2367,7 @@ and map_record_pattern (env : env)
   let v1 = token env v1 (* "{" *) in
   let v2 = map_field_pattern env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* ";" *) in
         let v2 = map_field_pattern env v2 in
@@ -2421,18 +2421,18 @@ and map_sequence_expression_ext (env : env) (x : CST.sequence_expression_ext) :
 and map_signature (env : env) (x : CST.signature) : item list =
   match x with
   | `Rep1_SEMISEMI xs ->
-      let _xs = List.map (token env) (* ";;" *) xs in
+      let _xs = Common.map (token env) (* ";;" *) xs in
       []
   | `Rep1_rep_SEMISEMI_sign_item_ext_rep_SEMISEMI (v1, v2) ->
       let v1 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
-            let _v1 = List.map (token env) (* ";;" *) v1 in
+            let _v1 = Common.map (token env) (* ";;" *) v1 in
             let v2 = map_signature_item_ext env v2 in
             v2)
           v1
       in
-      let _v2 = List.map (token env) (* ";;" *) v2 in
+      let _v2 = Common.map (token env) (* ";;" *) v2 in
       v1
 
 and map_signature_item (env : env) (x : CST.signature_item) : item =
@@ -2442,7 +2442,7 @@ and map_signature_item (env : env) (x : CST.signature_item) : item =
       let _v2 = map_attribute_opt env v2 in
       let v3 = map_value_name env v3 in
       let _, v4 = map_typed env v4 in
-      let v5 = List.map (map_item_attribute env) v5 in
+      let v5 = Common.map (map_item_attribute env) v5 in
       { i = Val (v1, v3, v4); iattrs = v5 }
   | `Exte x -> map_external_ env x
   | `Type_defi x -> map_type_definition env x
@@ -2454,7 +2454,7 @@ and map_signature_item (env : env) (x : CST.signature_item) : item =
       let v1 = token env v1 (* "include" *) in
       let _v2 = map_attribute_opt env v2 in
       let _v3 = map_module_type_ext env v3 in
-      let v4 = List.map (map_item_attribute env) v4 in
+      let v4 = Common.map (map_item_attribute env) v4 in
       { i = ItemTodo (("Include", v1), []); iattrs = v4 }
   | `Class_defi x -> map_class_definition env x
   | `Class_type_defi x -> map_class_type_definition env x
@@ -2476,7 +2476,7 @@ and map_simple_class_expression (env : env) (x : CST.simple_class_expression) =
       let _v1 = token env v1 (* "[" *) in
       let _v2 = map_type_ext env v2 in
       let _v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = map_type_ext env v2 in
@@ -2510,7 +2510,7 @@ and map_simple_class_type (env : env) (x : CST.simple_class_type) =
       let _v1 = token env v1 (* "[" *) in
       let _v2 = map_type_ext env v2 in
       let _v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token env v1 (* "," *) in
             let v2 = map_type_ext env v2 in
@@ -2528,7 +2528,7 @@ and map_simple_class_type (env : env) (x : CST.simple_class_type) =
         | None -> None
       in
       let _v3 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Class_field_spec_ext x ->
@@ -2783,7 +2783,7 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
           let _v3 = token env v3 (* "|" *) in
           let _v4 = map_tag_spec env v4 in
           let _v5 =
-            List.map
+            Common.map
               (fun (v1, v2) ->
                 let _v1 = token env v1 (* "|" *) in
                 let v2 = map_tag_spec env v2 in
@@ -2805,7 +2805,7 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
             | Some (v1, v2) ->
                 let v1 = map_tag_spec env v1 in
                 let v2 =
-                  List.map
+                  Common.map
                     (fun (v1, v2) ->
                       let _v1 = token env v1 (* "|" *) in
                       let v2 = map_tag_spec env v2 in
@@ -2827,7 +2827,7 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
           in
           let _v3 = map_tag_spec env v3 in
           let _v4 =
-            List.map
+            Common.map
               (fun (v1, v2) ->
                 let _v1 = token env v1 (* "|" *) in
                 let v2 = map_tag_spec env v2 in
@@ -2838,7 +2838,7 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
             match v5 with
             | Some (v1, v2) ->
                 let _v1 = token env v1 (* ">" *) in
-                let v2 = List.map (map_tag env) v2 in
+                let v2 = Common.map (map_tag env) v2 in
                 v2
             | None -> []
           in
@@ -2870,7 +2870,7 @@ and map_simple_type (env : env) (x : CST.simple_type) : type_ =
                 (v1, v2, v3) ->
                 let _v1 = map_anon_choice_meth_type_345b567 env v1 in
                 let _v2 =
-                  List.map
+                  Common.map
                     (fun (v1, v2) ->
                       let _v1 = token env v1 (* ";" *) in
                       let v2 = map_anon_choice_meth_type_345b567 env v2 in
@@ -2931,11 +2931,11 @@ and map_string_get_expression (env : env)
 and map_structure (env : env) (x : CST.structure) : item list =
   match x with
   | `Rep1_SEMISEMI xs ->
-      let _xs = List.map (token env) (* ";;" *) xs in
+      let _xs = Common.map (token env) (* ";;" *) xs in
       []
   | `Rep_SEMISEMI_choice_stru_item_ext_rep_choice_rep_SEMISEMI_choice_stru_item_ext_rep_SEMISEMI
       (v1, v2, v3, v4) ->
-      let _v1 = List.map (token env) (* ";;" *) v1 in
+      let _v1 = Common.map (token env) (* ";;" *) v1 in
       let v2 =
         match v2 with
         | `Stru_item_ext x -> map_structure_item_ext env x
@@ -2945,11 +2945,11 @@ and map_structure (env : env) (x : CST.structure) : item list =
             TopExpr x |> mki
       in
       let v3 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Rep_SEMISEMI_choice_stru_item_ext (v1, v2) ->
-                let _v1 = List.map (token env) (* ";;" *) v1 in
+                let _v1 = Common.map (token env) (* ";;" *) v1 in
                 let v2 =
                   match v2 with
                   | `Stru_item_ext x -> map_structure_item_ext env x
@@ -2957,12 +2957,12 @@ and map_structure (env : env) (x : CST.structure) : item list =
                 in
                 v2
             | `Rep1_SEMISEMI_exp_item (v1, v2) ->
-                let _v1 = List.map (token env) (* ";;" *) v1 in
+                let _v1 = Common.map (token env) (* ";;" *) v1 in
                 let v2 = map_expression_item env v2 in
                 TopExpr v2 |> mki)
           v3
       in
-      let _v4 = List.map (token env) (* ";;" *) v4 in
+      let _v4 = Common.map (token env) (* ";;" *) v4 in
       v2 :: v3
 
 and map_structure_item (env : env) (x : CST.structure_item) : item =
@@ -2980,7 +2980,7 @@ and map_structure_item (env : env) (x : CST.structure_item) : item =
       let v1 = token env v1 (* "include" *) in
       let _v2 = map_attribute_opt env v2 in
       let _v3 = map_module_expression_ext env v3 in
-      let v4 = List.map (map_item_attribute env) v4 in
+      let v4 = Common.map (map_item_attribute env) v4 in
       { i = ItemTodo (("Include", v1), []); iattrs = v4 }
   | `Class_defi x -> map_class_definition env x
   | `Class_type_defi x -> map_class_type_definition env x
@@ -3013,7 +3013,7 @@ and map_tag_specification (env : env) ((v1, v2) : CST.tag_specification) =
         in
         let _v3 = map_type_ext env v3 in
         let _v4 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token env v1 (* "&" *) in
               let v2 = map_type_ext env v2 in
@@ -3108,7 +3108,7 @@ and map_type_binding (env : env) ((v1, v2, v3) : CST.type_binding) :
               v3
           | None -> AbstractType
         in
-        let _v4 = List.map (map_type_constraint env) v4 in
+        let _v4 = Common.map (map_type_constraint env) v4 in
         TyDecl { tname = v1; tparams; tbody = v3 }
     | `Type_cons_path_PLUSEQ_opt_priv_vari_decl (v1, v2, v3, v4) ->
         let _v1 = map_type_constructor_path env v1 in
@@ -3117,7 +3117,7 @@ and map_type_binding (env : env) ((v1, v2, v3) : CST.type_binding) :
         let _v4 = map_variant_declaration env v4 in
         TyDeclTodo ("ExtensionType", v2)
   in
-  let _v3 = List.map (map_item_attribute env) v3 in
+  let _v3 = Common.map (map_item_attribute env) v3 in
   v2
 
 and map_type_constraint (env : env) ((v1, v2, v3, v4) : CST.type_constraint) =
@@ -3138,7 +3138,7 @@ and map_type_definition (env : env) ((v1, v2, v3, v4, v5) : CST.type_definition)
   in
   let v4 = map_type_binding env v4 in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token env v1 (* "and" *) in
         let v2 = map_type_binding env v2 in
@@ -3166,7 +3166,7 @@ and map_type_parameter_constraint (env : env)
   let _v2 = map_type_ext env v2 in
   let _v3 = token env v3 (* "=" *) in
   let _v4 = map_type_ext env v4 in
-  let _v5 = List.map (map_item_attribute env) v5 in
+  let _v5 = Common.map (map_item_attribute env) v5 in
   ()
 
 and map_typed (env : env) ((v1, v2) : CST.typed) : tok * type_ =
@@ -3211,7 +3211,7 @@ and map_value_definition (env : env) ((v1, v2, v3) : CST.value_definition) :
   in
   let v2 = map_let_binding env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 =
           match v1 with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -96,7 +96,7 @@ let map_anon_choice_COLON_5102e09 (env : env)
   | `SEMI tok -> (* ";" *) token env tok
 
 let map_text (env : env) (xs : CST.text) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `LT tok -> (* < *) token env tok
@@ -108,7 +108,7 @@ let map_namespace_name (env : env) ((v1, v2) : CST.namespace_name) =
     (* pattern [_a-zA-Z\u00A1-\u00ff][_a-zA-Z\u00A1-\u00ff\d]* *) token env v1
   in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "\\" *) token env v1 in
         let v2 =
@@ -210,7 +210,7 @@ let map_anonymous_function_use_clause (env : env)
   in
   let v4 = map_variable_name env v4 in
   let v5 =
-    List.map
+    Common.map
       (fun (v1, v2, v3) ->
         let v1 = (* "," *) token env v1 in
         let v2 =
@@ -304,7 +304,7 @@ let map_namespace_use_group (env : env)
   let v1 = (* "{" *) token env v1 in
   let v2 = map_namespace_use_group_clause env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_namespace_use_group_clause env v2 in
@@ -341,7 +341,7 @@ let map_anon_choice_name_062e4f2 (env : env) (x : CST.anon_choice_name_062e4f2)
 let map_type_list (env : env) ((v1, v2) : CST.type_list) =
   let v1 = map_named_type env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "|" *) token env v1 in
         let v2 = map_named_type env v2 in
@@ -354,7 +354,7 @@ let map_base_clause (env : env) ((v1, v2, v3) : CST.base_clause) =
   let v1 = (* pattern [eE][xX][tT][eE][nN][dD][sS] *) token env v1 in
   let v2 = map_anon_choice_name_062e4f2 env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_name_062e4f2 env v2 in
@@ -370,7 +370,7 @@ let map_class_interface_clause (env : env)
   in
   let v2 = map_anon_choice_name_062e4f2 env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_name_062e4f2 env v2 in
@@ -404,7 +404,7 @@ let map_types (env : env) (x : CST.types) =
 let map_union_type (env : env) ((v1, v2) : CST.union_type) =
   let v1 = map_types env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "|" *) token env v1 in
         let v2 = map_types env v2 in
@@ -424,7 +424,7 @@ let rec map_anon_array_elem_init_rep_COMMA_array_elem_init_1dad3d4 (env : env)
     ((v1, v2) : CST.anon_array_elem_init_rep_COMMA_array_elem_init_1dad3d4) =
   let v1 = map_array_element_initializer env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_array_element_initializer env v2 in
@@ -446,12 +446,12 @@ and map_anon_choice_case_stmt_f1b35bc (env : env)
       let v1 = (* pattern [cC][aA][sS][eE] *) token env v1 in
       let v2 = map_expression env v2 in
       let v3 = map_anon_choice_COLON_5102e09 env v3 in
-      let v4 = List.map (map_statement env) v4 in
+      let v4 = Common.map (map_statement env) v4 in
       todo env (v1, v2, v3, v4)
   | `Defa_stmt (v1, v2, v3) ->
       let v1 = (* pattern [dD][eE][fF][aA][uU][lL][tT] *) token env v1 in
       let v2 = map_anon_choice_COLON_5102e09 env v2 in
-      let v3 = List.map (map_statement env) v3 in
+      let v3 = Common.map (map_statement env) v3 in
       todo env (v1, v2, v3)
 
 and map_anon_choice_choice_array_dest_abfb170 (env : env)
@@ -582,7 +582,7 @@ and map_arguments (env : env) ((v1, v2, v3, v4) : CST.arguments) =
     | Some (v1, v2) ->
         let v1 = map_argument env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 = map_argument env v2 in
@@ -646,7 +646,7 @@ and map_array_destructing (env : env) ((v1, v2, v3, v4) : CST.array_destructing)
     | None -> todo env ()
   in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 =
@@ -693,12 +693,12 @@ and map_attribute (env : env) ((v1, v2) : CST.attribute) =
   todo env (v1, v2)
 
 and map_attribute_list (env : env) (xs : CST.attribute_list) =
-  List.map
+  Common.map
     (fun (v1, v2, v3, v4) ->
       let v1 = (* "#[" *) token env v1 in
       let v2 = map_attribute env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_attribute env v2 in
@@ -936,12 +936,12 @@ and map_clone_expression (env : env) ((v1, v2) : CST.clone_expression) =
 
 and map_colon_block (env : env) ((v1, v2) : CST.colon_block) =
   let v1 = (* ":" *) token env v1 in
-  let v2 = List.map (map_statement env) v2 in
+  let v2 = Common.map (map_statement env) v2 in
   todo env (v1, v2)
 
 and map_compound_statement (env : env) ((v1, v2, v3) : CST.compound_statement) =
   let v1 = (* "{" *) token env v1 in
-  let v2 = List.map (map_statement env) v2 in
+  let v2 = Common.map (map_statement env) v2 in
   let v3 = (* "}" *) token env v3 in
   todo env (v1, v2, v3)
 
@@ -958,7 +958,7 @@ and map_const_declaration_ (env : env)
   let v2 = (* pattern [cC][oO][nN][sS][tT] *) token env v2 in
   let v3 = map_const_element env v3 in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_const_element env v2 in
@@ -976,7 +976,7 @@ and map_const_element (env : env) ((v1, v2, v3) : CST.const_element) =
 
 and map_declaration_list (env : env) ((v1, v2, v3) : CST.declaration_list) =
   let v1 = (* "{" *) token env v1 in
-  let v2 = List.map (map_member_declaration env) v2 in
+  let v2 = Common.map (map_member_declaration env) v2 in
   let v3 = (* "}" *) token env v3 in
   todo env (v1, v2, v3)
 
@@ -1032,7 +1032,7 @@ and map_else_if_clause_2 (env : env) ((v1, v2, v3) : CST.else_if_clause_2) =
 and map_enum_declaration_list (env : env)
     ((v1, v2, v3) : CST.enum_declaration_list) =
   let v1 = (* "{" *) token env v1 in
-  let v2 = List.map (map_enum_member_declaration env) v2 in
+  let v2 = Common.map (map_enum_member_declaration env) v2 in
   let v3 = (* "}" *) token env v3 in
   todo env (v1, v2, v3)
 
@@ -1209,7 +1209,7 @@ and map_formal_parameters (env : env) ((v1, v2, v3, v4) : CST.formal_parameters)
     | Some (v1, v2) ->
         let v1 = map_anon_choice_simple_param_5af5eb3 env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 = map_anon_choice_simple_param_5af5eb3 env v2 in
@@ -1254,7 +1254,7 @@ and map_list_destructing (env : env)
     | None -> todo env ()
   in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 =
@@ -1277,7 +1277,7 @@ and map_match_block (env : env) ((v1, v2, v3, v4, v5) : CST.match_block) =
   let v1 = (* "{" *) token env v1 in
   let v2 = map_anon_choice_match_cond_exp_d891119 env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_match_cond_exp_d891119 env v2 in
@@ -1295,7 +1295,7 @@ and map_match_block (env : env) ((v1, v2, v3, v4, v5) : CST.match_block) =
 and map_match_condition_list (env : env) ((v1, v2) : CST.match_condition_list) =
   let v1 = map_expression env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_expression env v2 in
@@ -1332,7 +1332,7 @@ and map_member_declaration (env : env) (x : CST.member_declaration) =
         | Some x -> map_attribute_list env x
         | None -> todo env ()
       in
-      let v2 = List.map (map_modifier env) v2 in
+      let v2 = Common.map (map_modifier env) v2 in
       let v3 =
         match v3 with
         | Some x -> map_type_ env x
@@ -1340,7 +1340,7 @@ and map_member_declaration (env : env) (x : CST.member_declaration) =
       in
       let v4 = map_property_element env v4 in
       let v5 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_property_element env v2 in
@@ -1374,7 +1374,7 @@ and map_method_declaration (env : env)
     | Some x -> map_attribute_list env x
     | None -> todo env ()
   in
-  let v2 = List.map (map_modifier env) v2 in
+  let v2 = Common.map (map_modifier env) v2 in
   let v3 = map_function_definition_header env v3 in
   let v4 =
     match v4 with
@@ -1559,7 +1559,7 @@ and map_statement (env : env) (x : CST.statement) =
         match v3 with
         | `Choice_empty_stmt_rep_else_if_clause_opt_else_clause (v1, v2, v3) ->
             let v1 = map_statement env v1 in
-            let v2 = List.map (map_else_if_clause env) v2 in
+            let v2 = Common.map (map_else_if_clause env) v2 in
             let v3 =
               match v3 with
               | Some x -> map_else_clause env x
@@ -1569,7 +1569,7 @@ and map_statement (env : env) (x : CST.statement) =
         | `Colon_blk_rep_else_if_clause_2_opt_else_clause_2_pat_b10beb6_choice_auto_semi
             (v1, v2, v3, v4, v5) ->
             let v1 = map_colon_block env v1 in
-            let v2 = List.map (map_else_if_clause_2 env) v2 in
+            let v2 = Common.map (map_else_if_clause_2 env) v2 in
             let v3 =
               match v3 with
               | Some x -> map_else_clause_2 env x
@@ -1635,7 +1635,7 @@ and map_statement (env : env) (x : CST.statement) =
         | `COLON_rep_choice_empty_stmt_pat_1d5f5b3_choice_auto_semi
             (v1, v2, v3, v4) ->
             let v1 = (* ":" *) token env v1 in
-            let v2 = List.map (map_statement env) v2 in
+            let v2 = Common.map (map_statement env) v2 in
             let v3 = (* pattern [eE][nN][dD][fF][oO][rR] *) token env v3 in
             let v4 = map_semicolon env v4 in
             todo env (v1, v2, v3, v4)
@@ -1705,7 +1705,7 @@ and map_statement (env : env) (x : CST.statement) =
       let v1 = (* pattern [tT][rR][yY] *) token env v1 in
       let v2 = map_compound_statement env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Catch_clause x -> map_catch_clause env x
@@ -1724,7 +1724,7 @@ and map_statement (env : env) (x : CST.statement) =
         | `COLON_rep_choice_empty_stmt_pat_bb9603f_choice_auto_semi
             (v1, v2, v3, v4) ->
             let v1 = (* ":" *) token env v1 in
-            let v2 = List.map (map_statement env) v2 in
+            let v2 = Common.map (map_statement env) v2 in
             let v3 =
               (* pattern [eE][nN][dD][dD][eE][cC][lL][aA][rR][eE] *)
               token env v3
@@ -1744,7 +1744,7 @@ and map_statement (env : env) (x : CST.statement) =
       let v2 = (* "(" *) token env v2 in
       let v3 = map_variable env v3 in
       let v4 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_variable env v2 in
@@ -1880,7 +1880,7 @@ and map_statement (env : env) (x : CST.statement) =
         | `Name_use_clause_rep_COMMA_name_use_clause (v1, v2) ->
             let v1 = map_namespace_use_clause env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let v1 = (* "," *) token env v1 in
                   let v2 = map_namespace_use_clause env v2 in
@@ -1905,7 +1905,7 @@ and map_statement (env : env) (x : CST.statement) =
       let v1 = (* pattern [gG][lL][oO][bB][aA][lL] *) token env v1 in
       let v2 = map_variable_name_ env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_variable_name_ env v2 in
@@ -1918,7 +1918,7 @@ and map_statement (env : env) (x : CST.statement) =
       let v1 = (* pattern [sS][tT][aA][tT][iI][cC] *) token env v1 in
       let v2 = map_static_variable_declaration env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_static_variable_declaration env v2 in
@@ -1963,12 +1963,12 @@ and map_switch_block (env : env) (x : CST.switch_block) =
   match x with
   | `LCURL_rep_choice_case_stmt_RCURL (v1, v2, v3) ->
       let v1 = (* "{" *) token env v1 in
-      let v2 = List.map (map_anon_choice_case_stmt_f1b35bc env) v2 in
+      let v2 = Common.map (map_anon_choice_case_stmt_f1b35bc env) v2 in
       let v3 = (* "}" *) token env v3 in
       todo env (v1, v2, v3)
   | `COLON_rep_choice_case_stmt_pat_0b47e00_choice_auto_semi (v1, v2, v3, v4) ->
       let v1 = (* ":" *) token env v1 in
-      let v2 = List.map (map_anon_choice_case_stmt_f1b35bc env) v2 in
+      let v2 = Common.map (map_anon_choice_case_stmt_f1b35bc env) v2 in
       let v3 =
         (* pattern [eE][nN][dD][sS][wW][iI][tT][cC][hH] *) token env v3
       in
@@ -2057,7 +2057,7 @@ and map_use_declaration (env : env) ((v1, v2, v3, v4) : CST.use_declaration) =
   let v1 = (* pattern [uU][sS][eE] *) token env v1 in
   let v2 = map_anon_choice_name_062e4f2 env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_name_062e4f2 env v2 in
@@ -2083,7 +2083,7 @@ and map_use_instead_of_clause (env : env)
 and map_use_list (env : env) ((v1, v2, v3) : CST.use_list) =
   let v1 = (* "{" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 =
           match v1 with
@@ -2130,7 +2130,7 @@ let map_program (env : env) ((v1, v2) : CST.program) =
     match v2 with
     | Some (v1, v2) ->
         let v1 = (* pattern <\?([pP][hH][pP]|=)? *) token env v1 in
-        let v2 = List.map (map_statement env) v2 in
+        let v2 = Common.map (map_statement env) v2 in
         todo env (v1, v2)
     | None -> todo env ()
   in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
@@ -82,12 +82,12 @@ let map_escape_interpolation (env : env) (x : CST.escape_interpolation) =
   | `RCURLRCURL tok -> (* "}}" *) str env tok
 
 let map_import_prefix (env : env) (xs : CST.import_prefix) : tok list =
-  List.map (token env (* "." *)) xs
+  Common.map (token env (* "." *)) xs
 
 let map_dotted_name (env : env) ((v1, v2) : CST.dotted_name) : dotted_name =
   let v1 = (* pattern [_\p{XID_Start}][_\p{XID_Continue}]* *) str env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "." *) token env v1 in
         let v2 =
@@ -194,7 +194,7 @@ and map_argument_list (env : env) ((v1, v2, v3, v4) : CST.argument_list) =
     | Some (v1, v2) ->
         let arg = map_anon_choice_type_aad5b2d env v1 in
         let args =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _tcomma = (* "," *) token env v1 in
               let arg = map_anon_choice_type_aad5b2d env v2 in
@@ -299,7 +299,7 @@ and map_collection_elements (env : env) ((v1, v2, v3) : CST.collection_elements)
     : expr list =
   let v1 = map_anon_choice_type_03d361f env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_type_03d361f env v2 in
@@ -313,7 +313,7 @@ and map_comprehension_clauses (env : env) ((v1, v2) : CST.comprehension_clauses)
     : for_if list =
   let v1 = map_for_in_clause env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `For_in_clause x -> map_for_in_clause env x
@@ -338,7 +338,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
   | `Comp_op (v1, v2) ->
       let e = map_primary_expression env v1 in
       let xs =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 =
               match v1 with
@@ -366,7 +366,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
             (v1, v2))
           v2
       in
-      Compare (e, xs |> List.map fst, xs |> List.map snd)
+      Compare (e, xs |> Common.map fst, xs |> Common.map snd)
   | `Not_op (v1, v2) ->
       let v1 = (* "not" *) token env v1 in
       let v2 = map_type_ env v2 in
@@ -411,7 +411,7 @@ and map_expression_list (env : env) ((v1, v2) : CST.expression_list) : expr list
         []
     | `Rep1_COMMA_exp_opt_COMMA (v1, v2) ->
         let v1 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
               let v2 = map_type_ env v2 in
@@ -460,7 +460,7 @@ and map_for_in_clause (env : env)
   let _tin = (* "in" *) token env v4 in
   let e = map_expression_within_for_in_clause env v5 in
   let xs =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_expression_within_for_in_clause env v2 in
@@ -487,7 +487,7 @@ and map_format_specifier (env : env) ((v1, v2) : CST.format_specifier) :
     expr list =
   let _tcolon = (* ":" *) token env v1 in
   let xs =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `LBRA tok ->
@@ -544,7 +544,7 @@ and map_left_hand_side (env : env) (x : CST.left_hand_side) : pattern =
             []
         | `Rep1_COMMA_pat_opt_COMMA (v1, v2) ->
             let v1 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = map_pattern env v2 in
@@ -623,7 +623,7 @@ and map_parameter (env : env) (x : CST.parameter) : parameter =
 and map_parameters_ (env : env) ((v1, v2, v3) : CST.parameters_) =
   let v1 = map_parameter env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_parameter env v2 in
@@ -678,7 +678,7 @@ and map_pattern (env : env) (x : CST.pattern) : pattern =
 and map_patterns (env : env) ((v1, v2, v3) : CST.patterns) : pattern list =
   let v1 = map_pattern env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_pattern env v2 in
@@ -703,7 +703,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
       todo env x
   | `Conc_str (v1, v2) ->
       let v1 = map_string_ env v1 in
-      let v2 = List.map (map_string_ env) v2 in
+      let v2 = Common.map (map_string_ env) v2 in
       todo env (v1, v2)
   | `Int tok ->
       let s, tk = (* integer *) str env tok in
@@ -765,7 +765,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
         | Some (v1, v2) ->
             let v1 = map_anon_choice_pair_002ffed env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = map_anon_choice_pair_002ffed env v2 in
@@ -789,7 +789,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
       let l = (* "{" *) token env v1 in
       let xs = map_collection_elements env v2 in
       let r = (* "}" *) token env v3 in
-      let ys = xs |> List.map (fun e -> Key e) in
+      let ys = xs |> Common.map (fun e -> Key e) in
       DictOrSet (CompList (l, ys, r))
   | `Set_comp (v1, v2, v3, v4) ->
       let l = (* "{" *) token env v1 in
@@ -828,7 +828,7 @@ and map_string_ (env : env) ((v1, v2, v3) : CST.string_) :
     interpolated list bracket =
   let str_start = (* string_start *) token env v1 in
   let xs =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Interp x ->
@@ -856,7 +856,7 @@ and map_subscript (env : env) ((v1, v2, v3, v4, v5, v6) : CST.subscript) =
   let l = (* "[" *) token env v2 in
   let slice = map_anon_choice_type_a577897 env v3 in
   let slices =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_type_a577897 env v2 in
@@ -1012,7 +1012,7 @@ let map_with_clause (env : env) (x : CST.with_clause) : with_clause =
   | `With_item_rep_COMMA_with_item (v1, v2) ->
       let v1 = map_with_item env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = map_with_item env v2 in
@@ -1024,7 +1024,7 @@ let map_with_clause (env : env) (x : CST.with_clause) : with_clause =
       let _l = (* "(" *) token env v1 in
       let v2 = map_with_item env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = map_with_item env v2 in
@@ -1040,7 +1040,7 @@ let map_expression_statement (env : env) (x : CST.expression_statement) : expr =
   | `Exp_rep_COMMA_exp_opt_COMMA (v1, v2, v3) ->
       let v1 = map_type_ env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = map_type_ env v2 in
@@ -1059,7 +1059,7 @@ let map_print_statement (env : env) (x : CST.print_statement) =
       let v1 = (* "print" *) token env v1 in
       let v2 = map_chevron env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = map_type_ env v2 in
@@ -1072,7 +1072,7 @@ let map_print_statement (env : env) (x : CST.print_statement) =
       let v1 = (* "print" *) token env v1 in
       let v2 = map_type_ env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = map_type_ env v2 in
@@ -1085,7 +1085,7 @@ let map_print_statement (env : env) (x : CST.print_statement) =
 let map_import_list (env : env) ((v1, v2, v3) : CST.import_list) =
   let v1 = map_anon_choice_dotted_name_c5c573a env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_dotted_name_c5c573a env v2 in
@@ -1144,7 +1144,7 @@ let map_simple_statement (env : env) (x : CST.simple_statement) : stmt =
       let tassert = (* "assert" *) token env v1 in
       let test = map_type_ env v2 in
       let _extraTODO =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_type_ env v2 in
@@ -1196,7 +1196,7 @@ let map_simple_statement (env : env) (x : CST.simple_statement) : stmt =
       let tglobal = (* "global" *) token env v1 in
       let id = (* pattern [_\p{XID_Start}][_\p{XID_Continue}]* *) str env v2 in
       let ids =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 =
@@ -1210,7 +1210,7 @@ let map_simple_statement (env : env) (x : CST.simple_statement) : stmt =
       let tnonlocal = (* "nonlocal" *) token env v1 in
       let id = (* pattern [_\p{XID_Start}][_\p{XID_Continue}]* *) str env v2 in
       let ids =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 =
@@ -1229,7 +1229,7 @@ let map_simple_statement (env : env) (x : CST.simple_statement) : stmt =
             let v1 = (* "in" *) token env v1 in
             let v2 = map_type_ env v2 in
             let v3 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = map_type_ env v2 in
@@ -1245,7 +1245,7 @@ let map_simple_statements (env : env) ((v1, v2, v3, v4) : CST.simple_statements)
     : stmt list =
   let v1 = map_simple_statement env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* ";" *) token env v1 in
         let v2 = map_simple_statement env v2 in
@@ -1293,7 +1293,7 @@ and map_compound_statement (env : env) (x : CST.compound_statement) : stmt =
       let cond = map_type_ env v2 in
       let _tcolon = (* ":" *) token env v3 in
       let then_ = map_suite env v4 in
-      let elseifs = List.map (map_elif_clause env) v5 in
+      let elseifs = Common.map (map_elif_clause env) v5 in
       let else_ =
         match v6 with
         | Some x -> map_else_clause env x
@@ -1325,7 +1325,7 @@ and map_compound_statement (env : env) (x : CST.compound_statement) : stmt =
       let res =
         match v4 with
         | `Rep1_except_clause_opt_else_clause_opt_fina_clause (v1, v2, v3) ->
-            let excepts = List.map (map_except_clause env) v1 in
+            let excepts = Common.map (map_except_clause env) v1 in
             let orelse = map_or_else_as_list env v2 in
             let _finallyTODO =
               match v3 with
@@ -1354,7 +1354,7 @@ and map_compound_statement (env : env) (x : CST.compound_statement) : stmt =
       let def = map_class_definition env x in
       ClassDef def
   | `Deco_defi (v1, v2) ->
-      let decorators = List.map (map_decorator env) v1 in
+      let decorators = Common.map (map_decorator env) v1 in
       let def =
         match v2 with
         | `Class_defi x ->
@@ -1432,7 +1432,7 @@ and map_function_definition (env : env)
   (tdef, id, params, topt, body, [])
 
 and map_module_ (env : env) (xs : CST.module_) : stmt list =
-  List.map (map_statement env) xs |> List.flatten
+  List.concat_map (map_statement env) xs
 
 and map_statement (env : env) (x : CST.statement) : stmt list =
   match x with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
@@ -83,7 +83,7 @@ let map_pat_3e57880 (env : env) (tok : CST.pat_3e57880) = token env tok
 let map_special (env : env) ((v1, v2, v3) : CST.special) =
   let v1 = token env v1 (* "%" *) in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Pat_5e7ac5f tok -> token env tok (* pattern [^%\\\n]+|\\\r?\n *)
@@ -100,7 +100,7 @@ let map_identifier (env : env) (x : CST.identifier) =
   | `BQUOT_rep_choice_pat_4ad362e_BQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "`" *) in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Pat_4ad362e tok -> token env tok (* pattern [^`\\\n]+|\\\r?\n *)
@@ -116,7 +116,7 @@ let map_string_ (env : env) (x : CST.string_) =
   | `DQUOT_rep_choice_pat_de5d470_DQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "\"" *) in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Pat_de5d470 tok ->
@@ -130,7 +130,7 @@ let map_string_ (env : env) (x : CST.string_) =
   | `SQUOT_rep_choice_pat_3e57880_SQUOT (v1, v2, v3) ->
       let v1 = token env v1 (* "'" *) in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Pat_3e57880 tok ->
@@ -164,7 +164,7 @@ let rec map_argument (env : env) (x : CST.argument) =
       todo env (v1, v2, v3)
 
 and map_arguments (env : env) (xs : CST.arguments) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Arg x -> map_argument env x
@@ -322,7 +322,7 @@ and map_expression (env : env) (x : CST.expression) =
       todo env (v1, v2, v3)
   | `Paren_list (v1, v2, v3) ->
       let v1 = token env v1 (* "(" *) in
-      let v2 = List.map (map_expression env) v2 in
+      let v2 = Common.map (map_expression env) v2 in
       let v3 = token env v3 (* ")" *) in
       todo env (v1, v2, v3)
   | `Bin x -> map_binary env x
@@ -444,7 +444,7 @@ and map_formal_parameters (env : env) ((v1, v2, v3) : CST.formal_parameters) =
     | Some (v1, v2, v3) ->
         let v1 = map_formal_parameter env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = token env v1 (* "," *) in
               let v2 = map_formal_parameter env v2 in
@@ -470,7 +470,7 @@ and map_function_definition (env : env) ((v1, v2, v3) : CST.function_definition)
   todo env (v1, v2, v3)
 
 and map_program (env : env) (xs : CST.program) =
-  List.map
+  Common.map
     (fun (v1, v2) ->
       let v1 = map_expression env v1 in
       let v2 =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -132,16 +132,16 @@ let rec statements (env : env) (x : CST.statements) : AST.stmts =
   match x with
   | `Rep1_choice_stmt_term_opt_stmt (v1, v2) ->
       let v1 =
-        v1
-        |> List.map (fun x ->
-               match x with
-               | `Stmt_term (v1, v2) ->
-                   let v1 = statement env v1 in
-                   let _v2 = terminator env v2 in
-                   [ v1 ]
-               (* TODO? use EmptyStmt in generic AST? *)
-               | `Empty_stmt _tok -> [])
-        |> List.flatten
+        List.concat_map
+          (fun x ->
+            match x with
+            | `Stmt_term (v1, v2) ->
+                let v1 = statement env v1 in
+                let _v2 = terminator env v2 in
+                [ v1 ]
+            (* TODO? use EmptyStmt in generic AST? *)
+            | `Empty_stmt _tok -> [])
+          v1
       in
       let v2 =
         match v2 with
@@ -158,7 +158,7 @@ and statement (env : env) (x : CST.statement) :
       let v1 = token2 env v1 in
       let v2 = method_name env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = token2 env v1 in
             let v2 = method_name env v2 in
@@ -258,7 +258,7 @@ and parameters (env : env) ((v1, v2, v3) : CST.parameters) :
     | Some (v1, v2) ->
         let v1 = formal_parameter env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token2 env v1 in
               let v2 = formal_parameter env v2 in
@@ -275,7 +275,7 @@ and bare_parameters (env : env) ((v1, v2) : CST.bare_parameters) :
     AST.formal_param list =
   let v1 = simple_formal_parameter env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token2 env v1 in
         let v2 = formal_parameter env v2 in
@@ -292,7 +292,7 @@ and block_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.block_parameters) :
     | Some (v1, v2) ->
         let v1 = formal_parameter env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token2 env v1 in
               let v2 = formal_parameter env v2 in
@@ -313,7 +313,7 @@ and block_parameters (env : env) ((v1, v2, v3, v4, v5) : CST.block_parameters) :
         let _v1 = token2 env v1 in
         let v2 = str env v2 in
         let v3 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = token2 env v1 in
               let v2 = str env v2 in
@@ -387,7 +387,7 @@ and when_ (env : env) ((v1, v2, v3, v4) : CST.when_) =
   let twhen = token2 env v1 in
   let v2 = pattern env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _tcomma = token2 env v1 in
         let v2 = pattern env v2 in
@@ -502,7 +502,7 @@ and exceptions (env : env) ((v1, v2) : CST.exceptions) : AST.expr list =
     | `Splat_arg x -> splat_argument env x
   in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token2 env v1 in
         let v2 =
@@ -659,7 +659,7 @@ and anon_lit_content_rep_pat_3d340f6_lit_content_3d2b44e (env : env)
     ((v1, v2) : CST.anon_lit_content_rep_pat_3d340f6_lit_content_3d2b44e) =
   let v1 = literal_contents env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token2 env v1 (* pattern \s+ *) in
         let v2 = literal_contents env v2 in
@@ -733,7 +733,7 @@ and primary (env : env) (x : CST.primary) : AST.expr =
               | `Hash_splat_arg x -> hash_splat_argument env x
             in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = token2 env v1 in
                   let v2 =
@@ -778,12 +778,11 @@ and primary (env : env) (x : CST.primary) : AST.expr =
   | `Chai_str (v1, v2) ->
       let l, v1, r = string_ env v1 in
       let v2 =
-        List.map
+        List.concat_map
           (fun x ->
             let _lp, x, _ = string_ env x in
             x)
           v2
-        |> List.flatten
       in
       Literal (String (Double (l, v1 @ v2, r)))
   | `Regex (v1, v2, v3) ->
@@ -964,7 +963,7 @@ and primary (env : env) (x : CST.primary) : AST.expr =
         | Some x -> Some (terminator env x)
         | None -> None
       in
-      let v5 = List.map (when_ env) v5 in
+      let v5 = Common.map (when_ env) v5 in
       let v6 =
         match v6 with
         | Some x -> Some (else_ env x)
@@ -1157,7 +1156,7 @@ and command_argument_list (env : env) ((v1, v2) : CST.command_argument_list) :
     AST.argument list =
   let v1 = argument env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _t = token2 env v1 in
         let v2 = argument env v2 in
@@ -1181,7 +1180,7 @@ and argument_list_with_trailing_comma (env : env)
     ((v1, v2, v3) : CST.argument_list_with_trailing_comma) : AST.argument list =
   let v1 = argument env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _ = token2 env v1 in
         let v2 = argument env v2 in
@@ -1476,7 +1475,7 @@ and right_assignment_list (env : env) ((v1, v2) : CST.right_assignment_list) :
     | `Splat_arg x -> splat_argument env x
   in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token2 env v1 in
         let v2 =
@@ -1611,7 +1610,7 @@ and literal_contents (env : env) (xs : CST.literal_contents) : AST.interp list =
 and mlhs (env : env) ((v1, v2, v3) : CST.mlhs) : AST.expr list =
   let v1 = anon_choice_lhs_3a98eae env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = token2 env v1 in
         let v2 = anon_choice_lhs_3a98eae env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.ml
@@ -305,7 +305,7 @@ let map_int_ (env : env) (x : CST.int_) =
 let map_yul_path (env : env) ((v1, v2) : CST.yul_path) : name =
   let v1 = (* pattern [a-zA-Z$_]+ *) str env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "." *) token env v1 in
         let v2 = (* pattern [a-zA-Z$_]+ *) str env v2 in
@@ -319,7 +319,7 @@ let map_anon_yul_id_rep_COMMA_yul_id_opt_COMMA_477546e (env : env)
     ident list =
   let v1 = (* pattern [a-zA-Z$_]+ *) str env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = (* pattern [a-zA-Z$_]+ *) str env v2 in
@@ -333,7 +333,7 @@ let map_anon_id_rep_COMMA_id_opt_COMMA_e9ba3f8 (env : env)
     ((v1, v2, v3) : CST.anon_id_rep_COMMA_id_opt_COMMA_e9ba3f8) : ident list =
   let v1 = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
@@ -351,7 +351,7 @@ let map_user_defined_type (env : env) ((v1, v2) : CST.user_defined_type) : name
     =
   let v1 = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "." *) token env v1 in
         let v2 = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
@@ -405,7 +405,7 @@ let map_fixed (env : env) (x : CST.fixed) =
 
 let map_anon_rep_opt___hex_digit_c87bea1 (env : env)
     (xs : CST.anon_rep_opt___hex_digit_c87bea1) : string wrap list =
-  List.map
+  Common.map
     (fun (v1, v2) ->
       let _v1 =
         match v1 with
@@ -438,7 +438,7 @@ let map_string_ (env : env) (x : CST.string_) : string wrap =
   | `DQUOT_rep_choice_str_imme_elt_inside_double_quote_DQUOT (v1, v2, v3) ->
       let v1 = (* "\"" *) token env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Str_imme_elt_inside_double_quote tok ->
@@ -447,13 +447,13 @@ let map_string_ (env : env) (x : CST.string_) : string wrap =
           v2
       in
       let v3 = (* "\"" *) token env v3 in
-      let str = v2 |> List.map fst |> String.concat "" in
-      let toks = (v2 |> List.map snd) @ [ v3 ] in
+      let str = v2 |> Common.map fst |> String.concat "" in
+      let toks = (v2 |> Common.map snd) @ [ v3 ] in
       (str, PI.combine_infos v1 toks)
   | `SQUOT_rep_choice_str_imme_elt_inside_quote_SQUOT (v1, v2, v3) ->
       let v1 = (* "'" *) token env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Str_imme_elt_inside_quote tok ->
@@ -462,8 +462,8 @@ let map_string_ (env : env) (x : CST.string_) : string wrap =
           v2
       in
       let v3 = (* "'" *) token env v3 in
-      let str = v2 |> List.map fst |> String.concat "" in
-      let toks = (v2 |> List.map snd) @ [ v3 ] in
+      let str = v2 |> Common.map fst |> String.concat "" in
+      let toks = (v2 |> Common.map snd) @ [ v3 ] in
       (str, PI.combine_infos v1 toks)
 
 let map_enum_declaration (env : env)
@@ -478,7 +478,7 @@ let map_enum_declaration (env : env)
   in
   let _rb = (* "}" *) token env v5 in
   let ent = G.basic_entity id in
-  let ors = elems |> List.map (fun id -> OrEnum (id, None)) in
+  let ors = elems |> Common.map (fun id -> OrEnum (id, None)) in
   let def = { tbody = OrType ors } in
   (ent, TypeDef def)
 
@@ -490,7 +490,7 @@ let map_override_specifier (env : env) ((v1, v2) : CST.override_specifier) =
         let lp = (* "(" *) token env v1 in
         let n = map_user_defined_type env v2 in
         let xs =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _tcomma = (* "," *) token env v1 in
               let n = map_user_defined_type env v2 in
@@ -507,7 +507,7 @@ let map_override_specifier (env : env) ((v1, v2) : CST.override_specifier) =
   | Some (_l, xs, _r) ->
       OtherAttribute
         ( ("OverrideWithNames", toverride),
-          xs |> List.map (fun x -> E (N x |> G.e)) )
+          xs |> Common.map (fun x -> E (N x |> G.e)) )
 
 let map_hex_number (env : env) ((v1, v2) : CST.hex_number) =
   let start, t1 = (* pattern 0[xX] *) str env v1 in
@@ -519,12 +519,12 @@ let map_hex_number (env : env) ((v1, v2) : CST.hex_number) =
         v1 :: v2
     | None -> []
   in
-  let str = start ^ (v2 |> List.map fst |> String.concat "") in
-  let toks = v2 |> List.map snd in
+  let str = start ^ (v2 |> Common.map fst |> String.concat "") in
+  let toks = v2 |> Common.map snd in
   (int_of_string_opt str, PI.combine_infos t1 toks)
 
 let map_hex_string_literal (env : env) (xs : CST.hex_string_literal) =
-  List.map
+  Common.map
     (fun (v1, v2) ->
       let v1 = (* "hex" *) token env v1 in
       let v2 =
@@ -540,8 +540,8 @@ let map_hex_string_literal (env : env) (xs : CST.hex_string_literal) =
               | None -> []
             in
             let v3 = (* "\"" *) token env v3 in
-            let str = v2 |> List.map fst |> String.concat "" in
-            let toks = (v2 |> List.map snd) @ [ v3 ] in
+            let str = v2 |> Common.map fst |> String.concat "" in
+            let toks = (v2 |> Common.map snd) @ [ v3 ] in
             (str, PI.combine_infos v1 toks)
         | `SQUOT_opt_hex_digit_rep_opt___hex_digit_SQUOT (v1, v2, v3) ->
             let v1 = (* "'" *) token env v1 in
@@ -554,8 +554,8 @@ let map_hex_string_literal (env : env) (xs : CST.hex_string_literal) =
               | None -> []
             in
             let v3 = (* "'" *) token env v3 in
-            let str = v2 |> List.map fst |> String.concat "" in
-            let toks = (v2 |> List.map snd) @ [ v3 ] in
+            let str = v2 |> Common.map fst |> String.concat "" in
+            let toks = (v2 |> Common.map snd) @ [ v3 ] in
             (str, PI.combine_infos v1 toks)
       in
       (v1, v2))
@@ -598,24 +598,24 @@ let map_primitive_type (env : env) (x : CST.primitive_type) : type_ =
       G.ty_builtin x
 
 let map_unicode_string_literal (env : env) (xs : CST.unicode_string_literal) =
-  List.map
+  Common.map
     (fun (v1, v2) ->
       let v1 = (* "unicode" *) token env v1 in
       let v2 =
         match v2 with
         | `DQUOT_rep_double_quoted_unic_char_DQUOT (v1, v2, v3) ->
             let v1 = (* "\"" *) token env v1 in
-            let v2 = List.map (map_double_quoted_unicode_char env) v2 in
+            let v2 = Common.map (map_double_quoted_unicode_char env) v2 in
             let v3 = (* "\"" *) token env v3 in
-            let str = v2 |> List.map fst |> String.concat "" in
-            let toks = (v2 |> List.map snd) @ [ v3 ] in
+            let str = v2 |> Common.map fst |> String.concat "" in
+            let toks = (v2 |> Common.map snd) @ [ v3 ] in
             (str, PI.combine_infos v1 toks)
         | `SQUOT_rep_single_quoted_unic_char_SQUOT (v1, v2, v3) ->
             let v1 = (* "'" *) token env v1 in
-            let v2 = List.map (map_single_quoted_unicode_char env) v2 in
+            let v2 = Common.map (map_single_quoted_unicode_char env) v2 in
             let v3 = (* "'" *) token env v3 in
-            let str = v2 |> List.map fst |> String.concat "" in
-            let toks = (v2 |> List.map snd) @ [ v3 ] in
+            let str = v2 |> Common.map fst |> String.concat "" in
+            let toks = (v2 |> Common.map snd) @ [ v3 ] in
             (str, PI.combine_infos v1 toks)
       in
       (v1, v2))
@@ -650,7 +650,7 @@ let map_import_clause (env : env) (x : CST.import_clause) =
         | Some (v1, v2, v3) ->
             let v1 = map_import_declaration env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = map_import_declaration env v2 in
@@ -664,7 +664,7 @@ let map_import_clause (env : env) (x : CST.import_clause) =
       let _rb = (* "}" *) token env v3 in
       fun timport modname ->
         xs
-        |> List.map (fun (id, aliasopt) ->
+        |> Common.map (fun (id, aliasopt) ->
                ImportFrom (timport, modname, id, aliasopt) |> G.d)
 
 let map_mapping_key (env : env) (x : CST.mapping_key) : type_ =
@@ -709,7 +709,7 @@ let map_source_import (env : env) ((v1, v2) : CST.source_import) =
   (v1, v2)
 
 let map_string_literal (env : env) (xs : CST.string_literal) =
-  List.map (map_yul_string_literal env) xs
+  Common.map (map_yul_string_literal env) xs
 
 let rec map_yul_expression (env : env) (x : CST.yul_expression) : expr =
   match x with
@@ -739,7 +739,7 @@ and map_yul_function_call (env : env) ((v1, v2, v3, v4) : CST.yul_function_call)
     | Some (v1, v2, v3) ->
         let v1 = map_yul_expression env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
               let v2 = map_yul_expression env v2 in
@@ -751,7 +751,7 @@ and map_yul_function_call (env : env) ((v1, v2, v3, v4) : CST.yul_function_call)
     | None -> []
   in
   let rp = (* ")" *) token env v4 in
-  let args = args |> List.map G.arg in
+  let args = args |> Common.map G.arg in
   Call (operand, (lp, args, rp)) |> G.e
 
 let map_literal (env : env) (x : CST.literal) : expr =
@@ -771,7 +771,8 @@ let map_literal (env : env) (x : CST.literal) : expr =
           in
           G.Call
             ( operand,
-              fb (xs |> List.map (fun x -> G.Arg (G.L (G.String x) |> G.e))) )
+              fb (xs |> Common.map (fun x -> G.Arg (G.L (G.String x) |> G.e)))
+            )
           |> G.e)
   | `Num_lit (v1, v2) ->
       let lit =
@@ -803,7 +804,7 @@ let map_literal (env : env) (x : CST.literal) : expr =
           OtherExpr
             ( ("HexString", tok_hex),
               xs
-              |> List.map (fun (thex, str) -> [ Tk thex; Str str ])
+              |> Common.map (fun (thex, str) -> [ Tk thex; Str str ])
               |> List.flatten )
           |> G.e)
   | `Unic_str_lit x -> (
@@ -814,7 +815,7 @@ let map_literal (env : env) (x : CST.literal) : expr =
           OtherExpr
             ( ("UnicodeString", tok_unicode),
               xs
-              |> List.map (fun (tk, str) -> [ Tk tk; Str str ])
+              |> Common.map (fun (tk, str) -> [ Tk tk; Str str ])
               |> List.flatten )
           |> G.e)
 
@@ -846,7 +847,7 @@ let map_yul_variable_declaration (env : env) (x : CST.yul_variable_declaration)
             let lp = (* "(" *) token env v1 in
             let v2 = (* pattern [a-zA-Z$_]+ *) str env v2 in
             let v3 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = (* pattern [a-zA-Z$_]+ *) str env v2 in
@@ -868,7 +869,7 @@ let map_yul_variable_declaration (env : env) (x : CST.yul_variable_declaration)
       (* TODO: if eopt is None we could return a list of defs *)
       let pat =
         PatTuple
-          (lp, ids |> List.map (fun id -> PatId (id, G.empty_id_info ())), rp)
+          (lp, ids |> Common.map (fun id -> PatId (id, G.empty_id_info ())), rp)
         |> G.p
       in
       let ent = { name = EPattern pat; attrs = []; tparams = [] } in
@@ -886,7 +887,7 @@ let map_yul_assignment (env : env) (x : CST.yul_assignment) : expr =
       (v1, v2, v3, v4) ->
       let v1 = map_yul_path env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let _v1 = (* "," *) token env v1 in
             let v2 = map_yul_path env v2 in
@@ -900,7 +901,8 @@ let map_yul_assignment (env : env) (x : CST.yul_assignment) : expr =
         | [] -> raise Impossible
         | [ x ] -> N x |> G.e
         | xs ->
-            Container (Tuple, fb (xs |> List.map (fun n -> N n |> G.e))) |> G.e
+            Container (Tuple, fb (xs |> Common.map (fun n -> N n |> G.e)))
+            |> G.e
       in
       let res =
         match v4 with
@@ -919,7 +921,7 @@ let map_directive (env : env) (x : CST.directive) : directive list =
   | `Pragma_dire (v1, v2, v3, v4) ->
       let tpragma = (* "pragma" *) token env v1 in
       let id = (* "solidity" *) str env v2 in
-      let anys = List.map (map_pragma_version_constraint env) v3 in
+      let anys = Common.map (map_pragma_version_constraint env) v3 in
       let sc = (* ";" *) token env v4 in
       [ Pragma (id, [ Tk tpragma ] @ List.flatten anys @ [ Tk sc ]) |> G.d ]
   | `Import_dire (v1, v2, v3) ->
@@ -950,7 +952,7 @@ let rec map_anon_choice_exp_e762ef6 (env : env)
         | None -> []
       in
       let _rb = (* "}" *) token env v3 in
-      OtherArg (("ArgIds", lb), ids |> List.map (fun id -> I id))
+      OtherArg (("ArgIds", lb), ids |> Common.map (fun id -> I id))
 
 and map_array_access (env : env) ((v1, v2, v3, v4) : CST.array_access) : expr =
   let e = map_expression env v1 in
@@ -1076,7 +1078,7 @@ and map_call_arguments (env : env) ((v1, v2, v3) : CST.call_arguments) :
     | Some (v1, v2, v3) ->
         let v1 = map_anon_choice_exp_e762ef6 env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
               let v2 = map_anon_choice_exp_e762ef6 env v2 in
@@ -1128,7 +1130,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
                 let _tcolon = (* ":" *) token env v2 in
                 let e = map_expression env v3 in
                 let xs =
-                  List.map
+                  Common.map
                     (fun (v1, v2, v3, v4) ->
                       let _v1 = (* "," *) token env v1 in
                       let fld_id =
@@ -1147,7 +1149,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
           (* TODO? kind of New? or a With? *)
           let flds_any =
             flds
-            |> List.map (fun (fld_id, e) -> [ I fld_id; E e ])
+            |> Common.map (fun (fld_id, e) -> [ I fld_id; E e ])
             |> List.flatten
           in
           OtherExpr (("StructExpr", lb), [ E e; Tk lb ] @ flds_any @ [ Tk rb ])
@@ -1234,7 +1236,7 @@ and map_parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
     | Some (v1, v2, v3) ->
         let v1 = map_parameter env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
               let v2 = map_parameter env v2 in
@@ -1313,7 +1315,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
         | Some (v1, v2, v3) ->
             let v1 = map_expression env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = map_expression env v2 in
@@ -1327,7 +1329,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : expr =
       let rb = (* "]" *) token env v3 in
       OtherExpr
         ( ("InlineArray", lb),
-          [ Tk lb ] @ (es |> List.map (fun e -> E e)) @ [ Tk rb ] )
+          [ Tk lb ] @ (es |> Common.map (fun e -> E e)) @ [ Tk rb ] )
       |> G.e
   | `Id tok ->
       let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env tok in
@@ -1350,7 +1352,7 @@ and map_return_parameters (env : env)
   let lp = (* "(" *) token env v1 in
   let v2 = map_nameless_parameter env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_nameless_parameter env v2 in
@@ -1370,7 +1372,7 @@ and map_tuple_expression (env : env) ((v1, v2, v3, v4) : CST.tuple_expression) :
     | None -> tuple_hole_expr env lp
   in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let tcomma = (* "," *) token env v1 in
         let e =
@@ -1398,7 +1400,7 @@ and map_type_name (env : env) (x : CST.type_name) : type_ =
       let tval = map_type_name env v5 in
       let rp = (* ")" *) token env v6 in
       let n = H2.name_of_id idmap in
-      let targs = [ tkey; tval ] |> List.map (fun t -> TA t) in
+      let targs = [ tkey; tval ] |> Common.map (fun t -> TA t) in
       TyApply (TyN n |> G.t, (lp, targs, rp)) |> G.t
   | `Array_type (v1, v2, v3, v4) ->
       let t = map_type_name env v1 in
@@ -1456,7 +1458,7 @@ and map_update_expression (env : env) (x : CST.update_expression) =
 
 let rec map_yul_block (env : env) ((v1, v2, v3) : CST.yul_block) =
   let lb = (* "{" *) token env v1 in
-  let xs = List.map (map_yul_statement env) v2 in
+  let xs = Common.map (map_yul_statement env) v2 in
   let rb = (* "}" *) token env v3 in
   Block (lb, xs, rb) |> G.s
 
@@ -1498,7 +1500,7 @@ and map_yul_statement (env : env) (x : CST.yul_statement) : stmt =
             [ CasesAndBody ([ Default tdefault ], st) ]
         | `Rep1_case_yul_lit_yul_blk_opt_defa_yul_blk (v1, v2) ->
             let v1 =
-              List.map
+              Common.map
                 (fun (v1, v2, v3) ->
                   let tcase = (* "case" *) token env v1 in
                   let lit = map_yul_literal env v2 in
@@ -1542,7 +1544,7 @@ and map_yul_statement (env : env) (x : CST.yul_statement) : stmt =
             let _tarrow = (* "->" *) token env v1 in
             let v2 = (* pattern [a-zA-Z$_]+ *) str env v2 in
             let v3 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = (* pattern [a-zA-Z$_]+ *) str env v2 in
@@ -1558,13 +1560,14 @@ and map_yul_statement (env : env) (x : CST.yul_statement) : stmt =
                   (TyTuple
                      (fb
                         (xs
-                        |> List.map (fun id -> TyN (H2.name_of_id id) |> G.t)))
+                        |> Common.map (fun id -> TyN (H2.name_of_id id) |> G.t)
+                        ))
                   |> G.t))
         | None -> None
       in
       let body = map_yul_block env v7 in
       let ent = G.basic_entity id in
-      let params = ids |> List.map (fun id -> Param (G.param_of_id id)) in
+      let params = ids |> Common.map (fun id -> Param (G.param_of_id id)) in
       let def =
         {
           fkind = (Function, tfunc);
@@ -1579,7 +1582,7 @@ let map_state_variable_declaration (env : env)
     ((v1, v2, v3, v4, v5) : CST.state_variable_declaration) : definition =
   let ty = map_type_name env v1 in
   let attrs =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Visi x -> map_visibility env x
@@ -1705,7 +1708,7 @@ let map_struct_declaration (env : env)
   let tstruct = (* "struct" *) token env v1 in
   let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
   let lb = (* "{" *) token env v3 in
-  let flds = List.map (map_struct_member env) v4 in
+  let flds = Common.map (map_struct_member env) v4 in
   let rb = (* "}" *) token env v5 in
   let ent = G.basic_entity id in
   let def =
@@ -1725,7 +1728,7 @@ let map_class_heritage (env : env) ((v1, v2, v3, v4) : CST.class_heritage) :
   let _tis = (* "is" *) token env v1 in
   let v2 = map_inheritance_specifier env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         let v2 = map_inheritance_specifier env v2 in
@@ -1743,7 +1746,7 @@ let map_event_parameter_list (env : env)
     | Some (v1, v2, v3) ->
         let v1 = map_event_paramater env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = (* "," *) token env v1 in
               let v2 = map_event_paramater env v2 in
@@ -1767,7 +1770,7 @@ let map_variable_declaration_tuple (env : env)
         | Some (v1, v2, v3) ->
             let v1 = map_variable_declaration env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   let v2 = map_variable_declaration env v2 in
@@ -1776,7 +1779,7 @@ let map_variable_declaration_tuple (env : env)
             in
             let _v3 = map_trailing_comma env v3 in
             v1 :: v2
-            |> List.map (fun (ty, _attrsTODO, id) ->
+            |> Common.map (fun (ty, _attrsTODO, id) ->
                    PatTyped (PatId (id, G.empty_id_info ()) |> G.p, ty) |> G.p)
         | None -> []
       in
@@ -1793,7 +1796,7 @@ let map_variable_declaration_tuple (env : env)
         | None -> tuple_hole_pat env lp
       in
       let ps =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let tcomma = (* "," *) token env v1 in
             let pat =
@@ -1821,7 +1824,7 @@ let map_event_definition (env : env)
   in
   let _sc = (* ";" *) token env v5 in
   let ent = G.basic_entity id ~attrs in
-  let anys = params |> List.map (fun pclassic -> Pa (Param pclassic)) in
+  let anys = params |> Common.map (fun pclassic -> Pa (Param pclassic)) in
   (ent, OtherDef (("Event", tevent), anys))
 
 let map_variable_declaration_statement (env : env)
@@ -1855,7 +1858,7 @@ let map_variable_declaration_statement (env : env)
 
 let rec map_block_statement (env : env) ((v1, v2, v3) : CST.block_statement) =
   let lb = (* "{" *) token env v1 in
-  let xs = List.map (map_statement env) v2 in
+  let xs = Common.map (map_statement env) v2 in
   let rb = (* "}" *) token env v3 in
   Block (lb, xs, rb) |> G.s
 
@@ -1871,7 +1874,7 @@ and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) : catch =
           | None -> []
         in
         let params = map_parameter_list env v2 in
-        let anys = idopt @ (params |> List.map (fun p -> Pa p)) in
+        let anys = idopt @ (params |> Common.map (fun p -> Pa p)) in
         OtherCatch (("CatchParams", tcatch), anys)
     | None -> OtherCatch (("CatchEmpty", tcatch), [])
   in
@@ -1936,7 +1939,7 @@ and map_statement (env : env) (x : CST.statement) : stmt =
         | None -> None
       in
       let st = map_block_statement env v4 in
-      let catches = List.map (map_catch_clause env) v5 in
+      let catches = Common.map (map_catch_clause env) v5 in
       Try (ttry, st, catches, None) |> G.s
   | `Ret_stmt (v1, v2, v3) ->
       let tret = (* "return" *) token env v1 in
@@ -1962,7 +1965,7 @@ and map_statement (env : env) (x : CST.statement) : stmt =
         | None -> None
       in
       let lb = (* "{" *) token env v3 in
-      let xs = List.map (map_yul_statement env) v4 in
+      let xs = Common.map (map_yul_statement env) v4 in
       let rb = (* "}" *) token env v5 in
       let st = Block (lb, xs, rb) |> G.s in
       OtherStmtWithStmt (OSWS_Todo, [ TodoK ("Assembly", tassembly) ], st)
@@ -2015,7 +2018,7 @@ and map_for_statement env v =
 let map_function_body (env : env) ((v1, v2, v3) : CST.function_body) :
     function_body =
   let lb = (* "{" *) token env v1 in
-  let xs = List.map (map_statement env) v2 in
+  let xs = Common.map (map_statement env) v2 in
   let rb = (* "}" *) token env v3 in
   FBStmt (Block (lb, xs, rb) |> G.s)
 
@@ -2024,7 +2027,7 @@ let map_constructor_definition (env : env)
   let tctor = (* "constructor" *) token env v1 in
   let params = map_parameter_list env v2 in
   let attrs =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Modi_invo x ->
@@ -2099,7 +2102,7 @@ let map_fallback_receive_definition (env : env)
   in
   let _lp = (* "(" *) token env v2 in
   let _rp = (* ")" *) token env v3 in
-  let attrs = List.map (fun x -> visi_and_co env x) v4 in
+  let attrs = Common.map (fun x -> visi_and_co env x) v4 in
   let ent = { ent with attrs = ent.attrs @ attrs } in
   let fbody = map_anon_choice_semi_f2fe6be env v5 in
   let def = { fkind = (Function, tk); fparams = []; frettype = None; fbody } in
@@ -2110,7 +2113,7 @@ let map_function_definition (env : env)
   let tfunc = (* "function" *) token env v1 in
   let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
   let params = map_parameter_list env v3 in
-  let attrs = List.map (fun x -> visi_and_co env x) v4 in
+  let attrs = Common.map (fun x -> visi_and_co env x) v4 in
   let _ret_type_TODO =
     match v5 with
     | Some x -> Some (map_return_type_definition env x)
@@ -2134,7 +2137,7 @@ let map_modifier_definition (env : env)
     | None -> []
   in
   let attrs =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Virt tok ->
@@ -2176,7 +2179,7 @@ let map_contract_member (env : env) (x : CST.contract_member) =
 let map_contract_body (env : env) ((v1, v2, v3) : CST.contract_body) :
     (definition, tok, directive) either3 list bracket =
   let lb = (* "{" *) token env v1 in
-  let xs = List.map (map_contract_member env) v2 in
+  let xs = Common.map (map_contract_member env) v2 in
   let rb = (* "}" *) token env v3 in
   (lb, xs, rb)
 
@@ -2196,7 +2199,9 @@ let map_declaration (env : env) (x : CST.declaration) : definition =
         | None -> []
       in
       let l, defs_or_dirs, r = map_contract_body env v5 in
-      let flds = defs_or_dirs |> List.map (fun x -> F (stmt_of_def_or_dir x)) in
+      let flds =
+        defs_or_dirs |> Common.map (fun x -> F (stmt_of_def_or_dir x))
+      in
       let ent = G.basic_entity id ~attrs in
       let def =
         {
@@ -2220,7 +2225,9 @@ let map_declaration (env : env) (x : CST.declaration) : definition =
         | None -> []
       in
       let l, defs_or_dirs, r = map_contract_body env v4 in
-      let flds = defs_or_dirs |> List.map (fun x -> F (stmt_of_def_or_dir x)) in
+      let flds =
+        defs_or_dirs |> Common.map (fun x -> F (stmt_of_def_or_dir x))
+      in
       let ent = G.basic_entity id in
       let def =
         {
@@ -2238,7 +2245,7 @@ let map_declaration (env : env) (x : CST.declaration) : definition =
       let id = (* pattern [a-zA-Z$_][a-zA-Z0-9$_]* *) str env v2 in
       let _l, defs_or_dirs, _r = map_contract_body env v3 in
       let ent = G.basic_entity id in
-      let items = defs_or_dirs |> List.map stmt_of_def_or_dir in
+      let items = defs_or_dirs |> Common.map stmt_of_def_or_dir in
       (* TODO: kinda of namespace/module? *)
       let def = { mbody = ModuleStruct (Some [ id ], items) } in
       (ent, ModuleDef def)
@@ -2261,7 +2268,7 @@ let map_source_unit (env : env) (x : CST.source_unit) : item list =
   match x with
   | `Dire x ->
       let xs = map_directive env x in
-      xs |> List.map (fun dir -> DirectiveStmt dir |> G.s)
+      xs |> Common.map (fun dir -> DirectiveStmt dir |> G.s)
   | `Decl x ->
       let def = map_declaration env x in
       [ DefStmt def |> G.s ]
@@ -2269,10 +2276,10 @@ let map_source_unit (env : env) (x : CST.source_unit) : item list =
 let map_source_file (env : env) (x : CST.source_file) : any =
   match x with
   | `Rep_source_unit v1 ->
-      let xxs = List.map (map_source_unit env) v1 in
+      let xxs = Common.map (map_source_unit env) v1 in
       Pr (List.flatten xxs)
   | `Rep1_stmt xs ->
-      let xs = List.map (map_statement env) xs in
+      let xs = Common.map (map_statement env) xs in
       Ss xs
   | `Exp x ->
       let e = map_expression env x in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -387,7 +387,7 @@ let map_non_local_scope_modifier (env : env) (x : CST.non_local_scope_modifier)
   | `Param_modi x -> map_parameter_modifier env x
 
 let map_parameter_modifiers (env : env) (xs : CST.parameter_modifiers) =
-  List.map (map_parameter_modifier env) xs
+  Common.map (map_parameter_modifier env) xs
 
 let map_simple_identifier (env : env) (x : CST.simple_identifier) : G.ident =
   match x with
@@ -461,7 +461,7 @@ let map_operator_declaration (env : env)
 let map_identifier (env : env) ((v1, v2) : CST.identifier) =
   let v1 = map_simple_identifier env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* dot_custom *) token env v1 in
         let v2 = map_simple_identifier env v2 in
@@ -526,7 +526,7 @@ let map_line_string_content (env : env) (x : CST.line_string_content) =
   | `Str_esca_char x -> map_str_escaped_char env x |> todo env
 
 let map_getter_effects (env : env) (xs : CST.getter_effects) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Async_kw tok -> (* async_keyword_custom *) token env tok
@@ -535,7 +535,7 @@ let map_getter_effects (env : env) (xs : CST.getter_effects) =
 
 let map_precedence_group_attributes (env : env)
     (xs : CST.precedence_group_attributes) =
-  List.map (map_precedence_group_attribute env) xs
+  Common.map (map_precedence_group_attribute env) xs
 
 let map_non_constructor_function_decl (env : env)
     ((v1, v2) : CST.non_constructor_function_decl) =
@@ -569,7 +569,7 @@ let map_anon_choice_avai_arg_450e260 (env : env)
       let v1 = map_identifier env v1 in
       let v2 = (* integer_literal *) token env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "." *) token env v1 in
             let v2 = (* integer_literal *) token env v2 in
@@ -596,7 +596,7 @@ let map_protocol_property_requirements (env : env)
     ((v1, v2, v3) : CST.protocol_property_requirements) =
   let v1 = (* "{" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Getter_spec x -> map_getter_specifier env x
@@ -608,7 +608,7 @@ let map_protocol_property_requirements (env : env)
 
 let rec map_annotated_inheritance_specifier (env : env)
     ((v1, v2) : CST.annotated_inheritance_specifier) =
-  let v1 = List.map (map_attribute env) v1 in
+  let v1 = Common.map (map_attribute env) v1 in
   let v2 = map_inheritance_specifier env v2 in
   todo env (v1, v2)
 
@@ -621,7 +621,7 @@ and map_anon_LPAR_choice_simple_id_COLON_bind_pat_rep_COMMA_choice_simple_id_COL
   let v1 = (* "(" *) token env v1 in
   let v2 = map_anon_choice_simple_id_COLON_bind_pat_ff3f05b env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_simple_id_COLON_bind_pat_ff3f05b env v2 in
@@ -647,7 +647,7 @@ and map_anon_LPAR_choice_simple_id_COLON_non_bind_pat_with_expr_rep_COMMA_choice
     map_anon_choice_simple_id_COLON_non_bind_pat_with_expr_64db5e0 env v2
   in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 =
@@ -673,7 +673,7 @@ and map_anon_LPAR_choice_simple_id_COLON_switch_pat_rep_COMMA_choice_simple_id_C
   let v1 = (* "(" *) token env v1 in
   let v2 = map_anon_choice_simple_id_COLON_switch_pat_19a0585 env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_anon_choice_simple_id_COLON_switch_pat_19a0585 env v2 in
@@ -692,7 +692,7 @@ and map_anon_choice_comp_getter_566f67d (env : env)
     (x : CST.anon_choice_comp_getter_566f67d) =
   match x with
   | `Comp_getter (v1, v2, v3) ->
-      let v1 = List.map (map_attribute env) v1 in
+      let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_getter_specifier env v2 in
       let v3 =
         match v3 with
@@ -701,7 +701,7 @@ and map_anon_choice_comp_getter_566f67d (env : env)
       in
       todo env (v1, v2, v3)
   | `Comp_setter (v1, v2, v3, v4) ->
-      let v1 = List.map (map_attribute env) v1 in
+      let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_setter_specifier env v2 in
       let v3 =
         match v3 with
@@ -719,7 +719,7 @@ and map_anon_choice_comp_getter_566f67d (env : env)
       in
       todo env (v1, v2, v3, v4)
   | `Comp_modify (v1, v2, v3) ->
-      let v1 = List.map (map_attribute env) v1 in
+      let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_modify_specifier env v2 in
       let v3 =
         match v3 with
@@ -751,7 +751,7 @@ and map_anon_choice_enum_type_params_396c460 (env : env)
               | None -> todo env ()
             in
             let v4 =
-              List.map
+              Common.map
                 (fun (v1, v2, v3, v4) ->
                   let v1 = (* "," *) token env v1 in
                   let v2 =
@@ -834,7 +834,7 @@ and map_anon_choice_opt_stmts_a5b6d26 (env : env)
       | Some x -> map_statements env x
       | None -> todo env ())
   | `Rep_choice_comp_getter xs ->
-      List.map (map_anon_choice_comp_getter_566f67d env) xs
+      Common.map (map_anon_choice_comp_getter_566f67d env) xs
 
 and map_anon_choice_simple_id_COLON_bind_pat_ff3f05b (env : env)
     (x : CST.anon_choice_simple_id_COLON_bind_pat_ff3f05b) =
@@ -856,7 +856,7 @@ and map_anon_choice_simple_id_COLON_exp_9957b83 (env : env)
       todo env (v1, v2, v3)
   | `Exp x -> map_expression env x
   | `Rep1_simple_id_COLON xs ->
-      List.map
+      Common.map
         (fun (v1, v2) ->
           let v1 = map_simple_identifier env v1 in
           let v2 = (* ":" *) token env v2 in
@@ -864,10 +864,10 @@ and map_anon_choice_simple_id_COLON_exp_9957b83 (env : env)
         xs
       |> todo env
   | `Rep1_simple_id_int_lit_rep_DOT_int_lit (v1, v2, v3) ->
-      let v1 = List.map (map_simple_identifier env) v1 in
+      let v1 = Common.map (map_simple_identifier env) v1 in
       let v2 = (* integer_literal *) token env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "." *) token env v1 in
             let v2 = (* integer_literal *) token env v2 in
@@ -1009,7 +1009,7 @@ and map_attribute (env : env) (x : CST.attribute) =
             let v1 = (* "(" *) token env v1 in
             let v2 = map_anon_choice_simple_id_COLON_exp_9957b83 env v2 in
             let v3 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let v1 = (* "," *) token env v1 in
                   let v2 = map_anon_choice_simple_id_COLON_exp_9957b83 env v2 in
@@ -1196,7 +1196,7 @@ and map_call_suffix (env : env) (v1 : CST.call_suffix) : G.arguments =
        * former. *)
       let anon_arg = G.Arg (map_lambda_literal env v1) in
       let labeled_args =
-        List.map
+        Common.map
           (fun (v1, v2, v3) ->
             let name = map_simple_identifier env v1 in
             let _colon = (* ":" *) token env v2 in
@@ -1207,11 +1207,11 @@ and map_call_suffix (env : env) (v1 : CST.call_suffix) : G.arguments =
       anon_arg :: labeled_args |> G.fake_bracket
 
 and map_capture_list (env : env) ((v1, v2, v3, v4, v5) : CST.capture_list) =
-  let v1 = List.map (map_attribute env) v1 in
+  let v1 = Common.map (map_attribute env) v1 in
   let v2 = (* "[" *) token env v2 in
   let v3 = map_capture_list_item env v3 in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_capture_list_item env v2 in
@@ -1279,7 +1279,7 @@ and map_class_member_declarations (env : env)
     ((v1, v2, v3) : CST.class_member_declarations) =
   let v1 = map_type_level_declaration env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* semi *) token env v1 in
         let v2 = map_type_level_declaration env v2 in
@@ -1377,7 +1377,7 @@ and map_directly_assignable_expression (env : env)
 and map_do_statement (env : env) ((v1, v2, v3) : CST.do_statement) =
   let v1 = (* "do" *) token env v1 in
   let v2 = map_function_body env v2 in
-  let v3 = List.map (map_catch_block env) v3 in
+  let v3 = Common.map (map_catch_block env) v3 in
   todo env (v1, v2, v3)
 
 and map_else_options (env : env) (x : CST.else_options) =
@@ -1388,7 +1388,7 @@ and map_else_options (env : env) (x : CST.else_options) =
 and map_enum_class_body (env : env) ((v1, v2, v3) : CST.enum_class_body) =
   let v1 = (* "{" *) token env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Enum_entry x -> map_enum_entry env x
@@ -1417,7 +1417,7 @@ and map_enum_entry (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.enum_entry) =
     | None -> todo env ()
   in
   let v6 =
-    List.map
+    Common.map
       (fun (v1, v2, v3) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_simple_identifier env v2 in
@@ -1590,7 +1590,7 @@ and map_function_value_parameters (env : env)
     | Some (v1, v2) ->
         let v1 = map_function_value_parameter env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 = map_function_value_parameter env v2 in
@@ -1608,7 +1608,7 @@ and map_guard_statement (env : env) ((v1, v2, v3, v4, v5) : CST.guard_statement)
   let v1 = (* "guard" *) token env v1 in
   let v2 = map_if_condition_sequence_item env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_if_condition_sequence_item env v2 in
@@ -1633,7 +1633,7 @@ and map_if_condition_sequence_item (env : env)
       let v2 = (* "(" *) token env v2 in
       let v3 = map_anon_choice_avai_arg_450e260 env v3 in
       let v4 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_anon_choice_avai_arg_450e260 env v2 in
@@ -1647,7 +1647,7 @@ and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
   let v1 = (* "if" *) token env v1 in
   let v2 = map_if_condition_sequence_item env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_if_condition_sequence_item env v2 in
@@ -1690,7 +1690,7 @@ and map_inheritance_specifiers (env : env)
     ((v1, v2) : CST.inheritance_specifiers) =
   let v1 = map_annotated_inheritance_specifier env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 =
           match v1 with
@@ -1725,9 +1725,9 @@ and map_key_path_component (env : env) (x : CST.key_path_component) =
   match x with
   | `Simple_id_rep_key_path_postfs (v1, v2) ->
       let v1 = map_simple_identifier env v1 in
-      let v2 = List.map (map_key_path_postfixes env) v2 in
+      let v2 = Common.map (map_key_path_postfixes env) v2 in
       todo env (v1, v2)
-  | `Rep1_key_path_postfs xs -> List.map (map_key_path_postfixes env) xs
+  | `Rep1_key_path_postfs xs -> Common.map (map_key_path_postfixes env) xs
 
 and map_key_path_postfixes (env : env) (x : CST.key_path_postfixes) =
   match x with
@@ -1802,7 +1802,7 @@ and map_lambda_function_type_parameters (env : env)
     ((v1, v2) : CST.lambda_function_type_parameters) : G.parameter list =
   let v1 = map_lambda_parameter env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
         map_lambda_parameter env v2)
@@ -1937,7 +1937,7 @@ and map_local_statement (env : env) (x : CST.local_statement)
 
 and map_locally_permitted_modifiers (env : env)
     (xs : CST.locally_permitted_modifiers) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Attr x -> map_attribute env x
@@ -2105,7 +2105,7 @@ and map_modifierless_property_declaration (env : env)
     | None -> todo env ()
   in
   let v6 =
-    List.map
+    Common.map
       (fun (v1, v2, v3, v4, v5) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_property_binding_pattern env v2 in
@@ -2143,7 +2143,7 @@ and map_modifierless_typealias_declaration (env : env)
   todo env (v1, v2, v3, v4, v5)
 
 and map_modifiers (env : env) (xs : CST.modifiers) =
-  List.map
+  Common.map
     (fun x ->
       match x with
       | `Non_local_scope_modi x -> map_non_local_scope_modifier env x
@@ -2176,7 +2176,7 @@ and map_non_binding_pattern (env : env) ((v1, v2) : CST.non_binding_pattern) =
         let v1 = (* "(" *) token env v1 in
         let v2 = map_anon_choice_simple_id_COLON_prop_bind_pat_37a24c0 env v2 in
         let v3 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 =
@@ -2278,7 +2278,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) =
       let v4 = (* ":" *) token env v4 in
       let v5 = map_expression env v5 in
       let v6 =
-        List.map
+        Common.map
           (fun (v1, v2, v3, v4) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_simple_identifier env v2 in
@@ -2296,7 +2296,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) =
         | Some (v1, v2) ->
             let v1 = map_expression env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let v1 = (* "," *) token env v1 in
                   let v2 = map_expression env v2 in
@@ -2321,7 +2321,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) =
         | `Dict_lit_item_rep_COMMA_dict_lit_item (v1, v2) ->
             let v1 = map_dictionary_literal_item env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let v1 = (* "," *) token env v1 in
                   let v2 = map_dictionary_literal_item env v2 in
@@ -2360,7 +2360,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) =
         | None -> todo env ()
       in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "." *) token env v1 in
             let v2 = map_key_path_component env v2 in
@@ -2469,7 +2469,7 @@ and map_protocol_member_declarations (env : env)
     ((v1, v2, v3) : CST.protocol_member_declarations) =
   let v1 = map_protocol_member_declaration env v1 in
   let v2 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* semi *) token env v1 in
         let v2 = map_protocol_member_declaration env v2 in
@@ -2503,7 +2503,7 @@ and map_repeat_while_statement (env : env)
   let v5 = (* "while" *) token env v5 in
   let v6 = map_if_condition_sequence_item env v6 in
   let v7 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_if_condition_sequence_item env v2 in
@@ -2540,14 +2540,14 @@ and associate_statement_semis (fst_stmt : 'a) (stmts : ('b * 'a) list)
 
 and map_statements (env : env) ((v1, v2, v3) : CST.statements) =
   let stmts = associate_statement_semis v1 v2 v3 in
-  List.map (fun (stmt, semi) -> map_local_statement env stmt semi) stmts
+  Common.map (fun (stmt, semi) -> map_local_statement env stmt semi) stmts
 
 and map_string_literal (env : env) (x : CST.string_literal) : G.expr =
   match x with
   | `Line_str_lit (v1, v2, v3) ->
       let v1 = (* "\"" *) token env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Line_str_content x ->
@@ -2560,7 +2560,7 @@ and map_string_literal (env : env) (x : CST.string_literal) : G.expr =
   | `Multi_line_str_lit (v1, v2, v3) ->
       let v1 = (* "\"\"\"" *) token env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Multi_line_str_content x -> map_multi_line_string_content env x
@@ -2571,7 +2571,7 @@ and map_string_literal (env : env) (x : CST.string_literal) : G.expr =
       todo env (v1, v2, v3)
   | `Raw_str_lit (v1, v2) ->
       let v1 =
-        List.map
+        Common.map
           (fun (v1, v2, v3) ->
             let v1 = (* raw_str_part *) token env v1 in
             let v2 = map_raw_str_interpolation env v2 in
@@ -2635,7 +2635,7 @@ and map_switch_entry (env : env) ((v1, v2, v3, v4, v5) : CST.switch_entry) =
           | None -> todo env ()
         in
         let v4 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 = map_switch_pattern env v2 in
@@ -2662,7 +2662,7 @@ and map_switch_statement (env : env)
   let v1 = (* "switch" *) token env v1 in
   let v2 = map_expression env v2 in
   let v3 = (* "{" *) token env v3 in
-  let v4 = List.map (map_switch_entry env) v4 in
+  let v4 = Common.map (map_switch_entry env) v4 in
   let v5 = (* "}" *) token env v5 in
   todo env (v1, v2, v3, v4, v5)
 
@@ -2697,7 +2697,7 @@ and map_tuple_expression (env : env)
   in
   let v3 = map_expression env v3 in
   let v4 =
-    List.map
+    Common.map
       (fun (v1, v2, v3) ->
         let v1 = (* "," *) token env v1 in
         let v2 =
@@ -2722,7 +2722,7 @@ and map_tuple_type (env : env) ((v1, v2, v3) : CST.tuple_type) =
     | Some (v1, v2) ->
         let v1 = map_tuple_type_item env v1 in
         let v2 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 = map_tuple_type_item env v2 in
@@ -2771,7 +2771,7 @@ and map_type_arguments (env : env) (x : CST.type_arguments) =
       let v1 = (* "<" *) token env v1 in
       let v2 = map_type_ env v2 in
       let v3 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_type_ env v2 in
@@ -2784,13 +2784,13 @@ and map_type_arguments (env : env) (x : CST.type_arguments) =
 and map_type_constraint (env : env) (x : CST.type_constraint) =
   match x with
   | `Inhe_cons (v1, v2, v3, v4) ->
-      let v1 = List.map (map_attribute env) v1 in
+      let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_identifier env v2 in
       let v3 = (* ":" *) token env v3 in
       let v4 = map_possibly_implicitly_unwrapped_type env v4 in
       todo env (v1, v2, v3, v4)
   | `Equa_cons (v1, v2, v3, v4) ->
-      let v1 = List.map (map_attribute env) v1 in
+      let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_identifier env v2 in
       let v3 =
         match v3 with
@@ -2804,7 +2804,7 @@ and map_type_constraints (env : env) ((v1, v2, v3) : CST.type_constraints) =
   let v1 = (* where_keyword *) token env v1 in
   let v2 = map_type_constraint env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_type_constraint env v2 in
@@ -2850,13 +2850,13 @@ and map_type_parameter (env : env) ((v1, v2, v3) : CST.type_parameter) =
 
 and map_type_parameter_modifiers (env : env) (xs : CST.type_parameter_modifiers)
     =
-  List.map (map_attribute env) xs
+  Common.map (map_attribute env) xs
 
 and map_type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
   let v1 = (* "<" *) token env v1 in
   let v2 = map_type_parameter env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_type_parameter env v2 in
@@ -2891,7 +2891,7 @@ and map_unannotated_type (env : env) (x : CST.unannotated_type) =
         | `Array_type x -> map_array_type env x
         | `Dict_type x -> map_dictionary_type env x
       in
-      let v2 = List.map (token env (* "?" *)) v2 in
+      let v2 = Common.map (token env (* "?" *)) v2 in
       todo env (v1, v2)
   | `Meta (v1, v2, v3) ->
       let v1 = map_unannotated_type env v1 in
@@ -2909,7 +2909,7 @@ and map_unannotated_type (env : env) (x : CST.unannotated_type) =
   | `Prot_comp_type (v1, v2) ->
       let v1 = map_unannotated_type env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* "&" *) token env v1 in
             let v2 = map_unannotated_type env v2 in
@@ -2971,7 +2971,7 @@ and map_user_type (env : env) (x : CST.user_type) =
   | `Rectype (v1, v2) ->
       let v1 = map_simple_user_type env v1 in
       let v2 =
-        List.map
+        Common.map
           (fun (v1, v2) ->
             let v1 = (* dot_custom *) token env v1 in
             let v2 = map_simple_user_type env v2 in
@@ -2994,7 +2994,7 @@ and map_value_argument (env : env) ((v1, v2) : CST.value_argument) :
          * the arguments creates a new function that can be called without later
          * providing labels for the actual arguments, but it does not call the
          * function in question. *)
-        List.map
+        Common.map
           (fun (id, colon) ->
             let id = map_simple_identifier env id in
             let _colon = (* ":" *) token env colon in
@@ -3059,7 +3059,7 @@ and map_while_statement (env : env)
   let v1 = (* "while" *) token env v1 in
   let v2 = map_if_condition_sequence_item env v2 in
   let v3 =
-    List.map
+    Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_if_condition_sequence_item env v2 in
@@ -3100,7 +3100,7 @@ let map_top_level_statement (env : env) (x : CST.top_level_statement)
 
 let map_source_file (env : env) ((_shebang, stmts) : CST.source_file) : G.any =
   let stmts =
-    List.map (fun (stmt, semi) -> map_top_level_statement env stmt semi) stmts
+    Common.map (fun (stmt, semi) -> map_top_level_statement env stmt semi) stmts
   in
   G.Pr stmts
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -75,7 +75,7 @@ let map_sep_list (env : env) (head : 'a) (tail : (_ * 'a) list)
     (f : env -> 'a -> 'b) : 'b list =
   let head = f env head in
   let tail =
-    List.map (fun ((_sep : Tree_sitter_run.Token.t), elt) -> f env elt) tail
+    Common.map (fun ((_sep : Tree_sitter_run.Token.t), elt) -> f env elt) tail
   in
   head :: tail
 
@@ -128,7 +128,7 @@ let string_ (env : env) (x : CST.string_) : string wrap =
   | `DQUOT_rep_choice_unes_double_str_frag_DQUOT (v1, v2, v3) ->
       let open_ = token env v1 (* "\"" *) in
       let contents =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Unes_double_str_frag tok ->
@@ -137,13 +137,13 @@ let string_ (env : env) (x : CST.string_) : string wrap =
           v2
       in
       let close = token env v3 (* "\"" *) in
-      let str = contents |> List.map fst |> String.concat "" in
-      let toks = (contents |> List.map snd) @ [ close ] in
+      let str = contents |> Common.map fst |> String.concat "" in
+      let toks = (contents |> Common.map snd) @ [ close ] in
       (str, PI.combine_infos open_ toks)
   | `SQUOT_rep_choice_unes_single_str_frag_SQUOT (v1, v2, v3) ->
       let open_ = token env v1 (* "'" *) in
       let v2 =
-        List.map
+        Common.map
           (fun x ->
             match x with
             | `Unes_single_str_frag tok -> str env tok (* pattern "[^'\\\\]+" *)
@@ -152,8 +152,8 @@ let string_ (env : env) (x : CST.string_) : string wrap =
           v2
       in
       let close = token env v3 (* "'" *) in
-      let str = v2 |> List.map fst |> String.concat "" in
-      let toks = (v2 |> List.map snd) @ [ close ] in
+      let str = v2 |> Common.map fst |> String.concat "" in
+      let toks = (v2 |> Common.map snd) @ [ close ] in
       (str, PI.combine_infos open_ toks)
 
 let namespace_import (env : env) ((v1, v2, v3) : CST.namespace_import) =
@@ -199,13 +199,13 @@ let jsx_element_name (env : env) (x : CST.jsx_element_name) : a_ident =
   | `Choice_jsx_id x -> jsx_identifier_ env x
   | `Nested_id x ->
       let xs = nested_identifier env x in
-      let str = xs |> List.map fst |> String.concat "." in
+      let str = xs |> Common.map fst |> String.concat "." in
       let hd, tl =
         match xs with
         | [] -> raise Impossible
         | x :: xs -> (x, xs)
       in
-      (str, PI.combine_infos (snd hd) (tl |> List.map snd))
+      (str, PI.combine_infos (snd hd) (tl |> Common.map snd))
   | `Jsx_name_name x ->
       let id1, id2 = jsx_namespace_name env x in
       let str = fst id1 ^ ":" ^ fst id2 in
@@ -309,8 +309,8 @@ let import_export_specifier (env : env)
       Some (expr_id, opt_as_id)
 
 let concat_nested_identifier (idents : a_ident list) : a_ident =
-  let str = idents |> List.map fst |> String.concat "." in
-  let tokens = List.map snd idents in
+  let str = idents |> Common.map fst |> String.concat "." in
+  let tokens = Common.map snd idents in
   let x, xs =
     match tokens with
     | [] -> assert false
@@ -411,7 +411,7 @@ let named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   let _close = token env v4 (* "}" *) in
   fun (import_tok : tok) (from_path : a_filename) ->
     imports
-    |> List.map (fun (name, opt_as_name) ->
+    |> Common.map (fun (name, opt_as_name) ->
            Import (import_tok, name, opt_as_name, from_path))
 
 let import_clause (env : env) (x : CST.import_clause) =
@@ -486,7 +486,7 @@ and jsx_opening_element (env : env) ((v1, v2, v3, v4) : CST.jsx_opening_element)
         in
         id
   in
-  let v3 = List.map (jsx_attribute_ env) v3 in
+  let v3 = Common.map (jsx_attribute_ env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
@@ -506,7 +506,7 @@ and jsx_self_clos_elem (env : env)
         in
         id
   in
-  let v3 = List.map (jsx_attribute_ env) v3 in
+  let v3 = Common.map (jsx_attribute_ env) v3 in
   let v4 = token env v4 (* "/" *) in
   let v5 = token env v5 (* ">" *) in
   let t2 = PI.combine_infos v4 [ v5 ] in
@@ -516,7 +516,7 @@ and jsx_fragment (env : env) ((v1, v2, v3, v4, v5, v6) : CST.jsx_fragment) : xml
     =
   let v1 = token env v1 (* "<" *) in
   let v2 = token env v2 (* ">" *) in
-  let v3 = List.map (jsx_child env) v3 in
+  let v3 = Common.map (jsx_child env) v3 in
   let v4 = token env v4 (* "<" *) in
   let v5 = token env v5 (* "/" *) in
   let v6 = token env v6 (* ">" *) in
@@ -603,7 +603,7 @@ and jsx_element_ (env : env) (x : CST.jsx_element_) : xml =
   match x with
   | `Jsx_elem (v1, v2, v3) ->
       let t0, tag, attrs, closing = jsx_opening_element env v1 in
-      let v2 = List.map (jsx_child env) v2 in
+      let v2 = Common.map (jsx_child env) v2 in
       let v3 = jsx_closing_element env v3 in
       {
         xml_kind = XmlClassic (t0, tag, closing, snd v3);
@@ -760,7 +760,7 @@ and anon_choice_exp_9818c1b (env : env) (x : CST.anon_choice_exp_9818c1b) =
 and switch_default (env : env) ((v1, v2, v3) : CST.switch_default) =
   let v1 = token env v1 (* "default" *) in
   let v2 = token env v2 (* ":" *) in
-  let v3 = List.map (statement env) v3 |> List.flatten in
+  let v3 = List.concat_map (statement env) v3 in
   Default (v1, stmt1 v2 v3)
 
 and binary_expression (env : env) (x : CST.binary_expression) : expr =
@@ -1196,7 +1196,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           in
           let _tparams, (v5, tret) = call_signature env v5 in
           let v6 = statement_block env v6 in
-          let attrs = v1 @ v3 |> List.map attr in
+          let attrs = v1 @ v3 |> Common.map attr in
           let f_kind = (G.LambdaKind, v2) in
           let f =
             {
@@ -1209,7 +1209,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           in
           Fun (f, v4)
       | `Class (v1, v2, v3, v4, v5, v6) ->
-          let v1 = List.map (decorator env) v1 in
+          let v1 = Common.map (decorator env) v1 in
           let v2 = token env v2 (* "class" *) in
           let v3 =
             match v3 with
@@ -1366,7 +1366,7 @@ and object_type (env : env) ((v1, v2, v3) : CST.object_type) =
         in
         let v2 = anon_choice_export_stmt_f90d83f env v2 in
         let v3 =
-          List.map
+          Common.map
             (fun (v1, v2) ->
               let _v1 = anon_choice_COMMA_5194cb4 env v1 in
               let v2 = anon_choice_export_stmt_f90d83f env v2 in
@@ -1393,7 +1393,7 @@ and template_string (env : env) ((v1, v2, v3) : CST.template_string) :
     expr list bracket =
   let v1 = token env v1 (* "`" *) in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Temp_chars tok -> L (String (str env tok)) (* template_chars *)
@@ -1871,7 +1871,7 @@ and default_type (env : env) ((v1, v2) : CST.default_type) =
 and switch_body (env : env) ((v1, v2, v3) : CST.switch_body) =
   let _v1 = token env v1 (* "{" *) in
   let v2 =
-    List.map
+    Common.map
       (fun x ->
         match x with
         | `Switch_case x -> switch_case env x
@@ -1915,7 +1915,7 @@ and statement (env : env) (x : CST.statement) : stmt list =
             [ ImportFile (import_tok, file) ]
       in
       let _v4 = semicolon env v4 in
-      v3 |> List.map (fun m -> M m)
+      v3 |> Common.map (fun m -> M m)
   | `Debu_stmt (v1, v2) ->
       let v1 = identifier env v1 (* "debugger" *) in
       let v2 = semicolon env v2 in
@@ -1925,7 +1925,7 @@ and statement (env : env) (x : CST.statement) : stmt list =
       [ ExprStmt (e, t) ]
   | `Decl x ->
       let vars = declaration env x in
-      vars |> List.map (fun x -> DefStmt x)
+      vars |> Common.map (fun x -> DefStmt x)
   | `Stmt_blk x -> [ statement_block env x ]
   | `If_stmt (v1, v2, v3, v4) ->
       let v1 = token env v1 (* "if" *) in
@@ -2096,7 +2096,7 @@ and method_definition (env : env)
   in
   let _tparams, (v8, tret) = call_signature env v8 in
   let v9 = statement_block env v9 in
-  let attrs = v1 @ v2 @ v3 @ v4 @ v5 @ v7 |> List.map attr in
+  let attrs = v1 @ v2 @ v3 @ v4 @ v5 @ v7 |> Common.map attr in
   let f_kind = (G.Method, fake) in
   let f =
     { f_attrs = []; f_params = v8; f_body = v9; f_rettype = tret; f_kind }
@@ -2107,7 +2107,7 @@ and method_definition (env : env)
 
 and class_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6, v7) : CST.class_declaration) : definition =
-  let v1 = List.map (decorator env) v1 in
+  let v1 = Common.map (decorator env) v1 in
   let v2 = token env v2 (* "class" *) in
   let v3 = identifier env v3 (* identifier *) in
   (* TODO types: type_parameters *)
@@ -2173,7 +2173,7 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
                 let tok2, path = from_clause env v2 in
                 let _v3 = semicolon env v3 in
                 v1
-                |> List.map (fun (n1, n2opt) ->
+                |> List.concat_map (fun (n1, n2opt) ->
                        let tmpname = ("!tmp_" ^ fst n1, snd n1) in
                        let import = Import (tok2, n1, Some tmpname, path) in
                        let e = idexp tmpname in
@@ -2184,42 +2184,39 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
                        | Some n2 ->
                            let v = Ast_js.mk_const_var n2 e in
                            [ M import; DefStmt v; M (Export (export_tok, n2)) ])
-                |> List.flatten
             | `Export_clause_choice_auto_semi (v1, v2) ->
                 (* export { import1 as name1, import2 as name2, nameN } from 'foo'; *)
                 let v1 = export_clause env v1 in
                 let _v2 = semicolon env v2 in
                 v1
-                |> List.map (fun (n1, n2opt) ->
+                |> List.concat_map (fun (n1, n2opt) ->
                        match n2opt with
                        | None -> [ M (Export (export_tok, n1)) ]
                        | Some n2 ->
                            let v = Ast_js.mk_const_var n2 (idexp n1) in
                            [ DefStmt v; M (Export (export_tok, n2)) ])
-                |> List.flatten
           in
           v2
       | `Rep_deco_export_choice_decl (v1, v2, v3) ->
-          let decorators = List.map (decorator env) v1 in
+          let decorators = Common.map (decorator env) v1 in
           let export_tok = token env v2 (* "export" *) in
           let v3 =
             match v3 with
             | `Decl x ->
                 let defs = declaration env x in
                 defs
-                |> List.map (fun def ->
+                |> List.concat_map (fun def ->
                        let ent, defkind = def in
                        let n = ent.name in
                        let ent = { ent with attrs = ent.attrs @ decorators } in
                        [ DefStmt (ent, defkind); M (Export (export_tok, n)) ])
-                |> List.flatten
             | `Defa_choice_decl (v1, v2) -> (
                 let tok_default (* TODO *) = token env v1 (* "default" *) in
                 match v2 with
                 | `Decl x ->
                     let defs = declaration env x in
                     defs
-                    |> List.map (fun def ->
+                    |> List.concat_map (fun def ->
                            let ent, defkind = def in
                            let ent =
                              { ent with attrs = ent.attrs @ decorators }
@@ -2247,7 +2244,6 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
                              DefStmt default_decl;
                              M (Export (export_tok, default_name));
                            ])
-                    |> List.flatten
                 | `Exp_choice_auto_semi (v1, v2) ->
                     let e = expression env v1 in
                     let _semi = semicolon env v2 in
@@ -2345,7 +2341,7 @@ and anon_choice_export_stmt_f90d83f (env : env)
         | Some x -> Some (type_annotation env x |> snd)
         | None -> None
       in
-      let attrs = v1 @ v2 @ v3 @ v5 |> List.map attr in
+      let attrs = v1 @ v2 @ v3 @ v5 |> Common.map attr in
       let fld =
         { fld_name = v4; fld_attrs = attrs; fld_type = v6; fld_body = None }
       in
@@ -2443,7 +2439,7 @@ and public_field_definition (env : env)
     | Some x -> Some (initializer_ env x)
     | None -> None
   in
-  let attrs = attributes |> List.map attr in
+  let attrs = attributes |> Common.map attr in
   Field
     {
       fld_name = prop_name;
@@ -2535,7 +2531,7 @@ and switch_case (env : env) ((v1, v2, v3, v4) : CST.switch_case) =
   let v1 = token env v1 (* "case" *) in
   let v2 = expressions env v2 in
   let v3 = token env v3 (* ":" *) in
-  let v4 = List.map (statement env) v4 |> List.flatten in
+  let v4 = List.concat_map (statement env) v4 in
   Case (v1, v2, stmt1 v3 v4)
 
 and spread_element (env : env) ((v1, v2) : CST.spread_element) =
@@ -2567,7 +2563,7 @@ and abstract_method_signature (env : env)
     | Some tok -> [ (Optional, token env tok) ] (* "?" *)
     | None -> []
   in
-  let attrs = v1 @ v2 @ v3 @ v5 |> List.map attr in
+  let attrs = v1 @ v2 @ v3 @ v5 |> Common.map attr in
   let _tparams, x = call_signature env v6 in
   let t = mk_functype x in
   { fld_name = v4; fld_attrs = attrs; fld_type = Some t; fld_body = None }
@@ -2746,7 +2742,7 @@ and constraint_ (env : env) ((v1, v2) : CST.constraint_) :
 
 and parameter_name (env : env) ((v1, v2, v3, v4) : CST.parameter_name) :
     (a_ident, a_pattern) Common.either =
-  let _decorators = List.map (decorator env) v1 in
+  let _decorators = Common.map (decorator env) v1 in
   let _accessibility =
     match v2 with
     | Some x -> [ accessibility_modifier env x ]
@@ -2780,7 +2776,7 @@ and lhs_expression (env : env) (x : CST.lhs_expression) : expr =
 
 and statement_block (env : env) ((v1, v2, v3, v4) : CST.statement_block) =
   let v1 = token env v1 (* "{" *) in
-  let v2 = List.map (statement env) v2 |> List.flatten in
+  let v2 = List.concat_map (statement env) v2 in
   let v3 = token env v3 (* "}" *) in
   let _v4 =
     match v4 with
@@ -2903,7 +2899,7 @@ and method_signature (env : env)
     | Some tok -> [ (Optional, token env tok) ] (* "?" *)
     | None -> []
   in
-  let attrs = v1 @ v2 @ v3 @ v4 @ v5 @ v7 |> List.map attr in
+  let attrs = v1 @ v2 @ v3 @ v4 @ v5 @ v7 |> Common.map attr in
   let _tparams, x = call_signature env v8 in
   let t = mk_functype x in
   { fld_name = v6; fld_attrs = attrs; fld_type = Some t; fld_body = None }
@@ -2941,7 +2937,7 @@ and declaration (env : env) (x : CST.declaration) : definition list =
           VarDef { v_kind = (Const, v2); v_init = None; v_type = Some ty } );
       ]
   | `Abst_class_decl (v1, v2, v3, v4, v5, v6, v7) ->
-      let _v1_TODO = List.map (decorator env) v1 in
+      let _v1_TODO = Common.map (decorator env) v1 in
       let v2 = attr (Abstract, token env v2) (* "abstract" *) in
       let v3 = token env v3 (* "class" *) in
       let v4 = identifier env v4 (* identifier *) in
@@ -3098,7 +3094,7 @@ let program (env : env) ((v1, v2) : CST.program) : a_program =
     | Some tok -> Some (token env tok) (* pattern #!.* *)
     | None -> None
   in
-  let v2 = List.map (toplevel env) v2 |> List.flatten in
+  let v2 = List.concat_map (toplevel env) v2 in
   v2
 
 (*****************************************************************************)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -93,7 +93,7 @@ let map_quoted_attribute_value (env : env) (x : CST.quoted_attribute_value) :
       (s, PI.combine_infos v1 (ts @ [ v3 ]))
 
 let map_directive_modifiers (env : env) (xs : CST.directive_modifiers) =
-  List.map
+  Common.map
     (fun (v1, v2) ->
       let v1 = token env v1 (* "." *) in
       let v2 = str env v2 (* pattern "[^<>\"'/=\\s.]+" *) in
@@ -188,7 +188,7 @@ let map_anon_choice_attr_a1991da (env : env) (x : CST.anon_choice_attr_a1991da)
 let map_start_tag (env : env) ((v1, v2, v3, v4) : CST.start_tag) =
   let v1 = token env v1 (* "<" *) in
   let v2 = str env v2 (* start_tag_name *) in
-  let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
+  let v3 = Common.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
@@ -196,21 +196,21 @@ let map_template_start_tag (env : env)
     ((v1, v2, v3, v4) : CST.template_start_tag) =
   let v1 = token env v1 (* "<" *) in
   let v2 = str env v2 (* template_start_tag_name *) in
-  let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
+  let v3 = Common.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_style_start_tag (env : env) ((v1, v2, v3, v4) : CST.style_start_tag) =
   let v1 = token env v1 (* "<" *) in
   let v2 = str env v2 (* style_start_tag_name *) in
-  let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
+  let v3 = Common.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
 let map_script_start_tag (env : env) ((v1, v2, v3, v4) : CST.script_start_tag) =
   let v1 = token env v1 (* "<" *) in
   let v2 = str env v2 (* script_start_tag_name *) in
-  let v3 = List.map (map_anon_choice_attr_a1991da env) v3 in
+  let v3 = Common.map (map_anon_choice_attr_a1991da env) v3 in
   let v4 = token env v4 (* ">" *) in
   (v1, v2, v3, v4)
 
@@ -242,7 +242,7 @@ let rec map_element (env : env) (x : CST.element) : xml =
   match x with
   | `Start_tag_rep_node_choice_end_tag (v1, v2, v3) ->
       let l, id, attrs, r = map_start_tag env v1 in
-      let v2 = List.map (map_node env) v2 |> List.flatten in
+      let v2 = List.concat_map (map_node env) v2 in
       let v3 =
         match v3 with
         | `End_tag x -> map_end_tag env x
@@ -253,7 +253,7 @@ let rec map_element (env : env) (x : CST.element) : xml =
   | `Self_clos_tag (v1, v2, v3, v4) ->
       let l = token env v1 (* "<" *) in
       let id = str env v2 (* start_tag_name *) in
-      let attrs = List.map (map_anon_choice_attr_a1991da env) v3 in
+      let attrs = Common.map (map_anon_choice_attr_a1991da env) v3 in
       let r = token env v4 (* "/>" *) in
       { xml_kind = XmlSingleton (l, id, r); xml_attrs = attrs; xml_body = [] }
 
@@ -312,12 +312,12 @@ and map_node (env : env) (x : CST.node) : xml_body list =
 and map_template_element (env : env) ((v1, v2, v3) : CST.template_element) : xml
     =
   let l, id, attrs, r = map_template_start_tag env v1 in
-  let v2 = List.map (map_node env) v2 |> List.flatten in
+  let v2 = List.concat_map (map_node env) v2 in
   let v3 = map_end_tag env v3 in
   { xml_kind = XmlClassic (l, id, r, v3); xml_attrs = attrs; xml_body = v2 }
 
 let map_component (env : env) (xs : CST.component) : stmt list =
-  List.map
+  List.concat_map
     (fun x ->
       match x with
       | `Comm tok ->
@@ -348,7 +348,6 @@ let map_component (env : env) (xs : CST.component) : stmt list =
           let xml = map_style_element env x in
           [ G.exprstmt (Xml xml |> G.e) ])
     xs
-  |> List.flatten
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -118,7 +118,7 @@ let metavars startp_of_match_range (s, mval) =
             any |> V.ii_of_any
             |> List.filter PI.is_origintok
             |> List.sort Parse_info.compare_pos
-            |> List.map PI.str_of_info
+            |> Common.map PI.str_of_info
             |> Matching_report.join_with_space_if_needed;
           unique_id = unique_id any;
         } )
@@ -140,7 +140,7 @@ let match_to_match x =
          extra =
            {
              message = Some x.rule_id.message;
-             metavars = x.env |> List.map (metavars startp);
+             metavars = x.env |> Common.map (metavars startp);
            };
        }
         : ST.match_)
@@ -201,19 +201,19 @@ let error_to_error err =
 let json_time_of_profiling_data profiling_data =
   let json_time_of_rule_times rule_times =
     rule_times
-    |> List.map (fun { RP.rule_id; parse_time; match_time } ->
+    |> Common.map (fun { RP.rule_id; parse_time; match_time } ->
            { ST.rule_id; parse_time; match_time })
   in
   {
     ST.targets =
       profiling_data.RP.file_times
-      |> List.map (fun { RP.file = target; rule_times; run_time } ->
+      |> Common.map (fun { RP.file = target; rule_times; run_time } ->
              {
                ST.path = target;
                rule_times = json_time_of_rule_times rule_times;
                run_time;
              });
-    rules = List.map (fun rule -> fst rule.Rule.id) profiling_data.RP.rules;
+    rules = Common.map (fun rule -> fst rule.Rule.id) profiling_data.RP.rules;
     rules_parse_time = Some profiling_data.RP.rules_parse_time;
   }
 
@@ -231,7 +231,7 @@ let match_results_of_matches_and_errors files res =
   let count_ok = List.length files - count_errors in
   {
     ST.matches;
-    errors = errs |> List.map error_to_error;
+    errors = errs |> Common.map error_to_error;
     skipped_targets = res.RP.skipped_targets;
     skipped_rules =
       (match res.RP.skipped_rules with
@@ -239,7 +239,7 @@ let match_results_of_matches_and_errors files res =
       | xs ->
           Some
             (xs
-            |> List.map (fun (kind, rule_id, tk) ->
+            |> Common.map (fun (kind, rule_id, tk) ->
                    let loc = PI.unsafe_token_location_of_info tk in
                    {
                      ST.rule_id;

--- a/semgrep-core/src/reporting/Matching_report.ml
+++ b/semgrep-core/src/reporting/Matching_report.ml
@@ -72,14 +72,14 @@ let print_match ?(format = Normal) ?(str = "") ii =
         pr prefix;
         (* todo? some context too ? *)
         lines
-        |> List.map (fun i -> arr.(i))
+        |> Common.map (fun i -> arr.(i))
         |> List.iter (fun s -> pr (" " ^ s))
     (* bugfix: do not add extra space after ':', otherwise M-x wgrep will not work *)
     | Emacs -> pr (prefix ^ ":" ^ arr.(List.hd lines))
     | OneLine ->
         pr
           (prefix ^ ": "
-          ^ (ii |> List.map PI.str_of_info |> join_with_space_if_needed))
+          ^ (ii |> Common.map PI.str_of_info |> join_with_space_if_needed))
   with
   | Failure "get_pos: Ab or FakeTok" ->
       pr "<could not locate match, FakeTok or AbstractTok>"

--- a/semgrep-core/src/reporting/Statistics_report.ml
+++ b/semgrep-core/src/reporting/Statistics_report.ml
@@ -117,21 +117,21 @@ let stat file =
   (* parsing *)
   let xs = Common.cat file in
   let ys = xs |> Common2.split_list_regexp "^Running rule" in
-  let runs = ys |> List.map parse_run in
+  let runs = ys |> Common.map parse_run in
 
   if !debug then runs |> List.iter (fun r -> pr2 (show_run r));
 
   (* reporting *)
   pr2 (spf "TIMEOUT FILES (timeout = %.1f" !timeout);
   let timeout_files =
-    runs |> List.map (fun x -> x.timeout) |> List.flatten |> Common2.uniq
+    runs |> Common.map (fun x -> x.timeout) |> List.flatten |> Common2.uniq
   in
   timeout_files |> List.iter pr2_gen;
 
   pr2 "SLOW FILES";
   let problematic_files =
     runs
-    |> List.map (fun x -> x.files)
+    |> Common.map (fun x -> x.files)
     |> List.flatten
     |> Common.exclude (fun (file, _) -> List.mem file timeout_files)
     |> Common.sort_by_val_highfirst |> Common.take_safe 30
@@ -140,9 +140,9 @@ let stat file =
 
   let problematic_rules =
     runs
-    |> List.map (fun x ->
+    |> Common.map (fun x ->
            ( (x.rule, List.length x.files, x.lang),
-             x.files |> List.map snd |> Common2.sum_float ))
+             x.files |> Common.map snd |> Common2.sum_float ))
     |> Common.sort_by_val_highfirst |> Common.take_safe 30
   in
   pr2 "PROBLEMATIC RULES";
@@ -152,21 +152,21 @@ let stat file =
   let groups = runs |> Common.group_by (fun x -> x.lang) in
   let stats =
     groups
-    |> List.map (fun (xlang, xs) ->
+    |> Common.map (fun (xlang, xs) ->
            let total_rules = List.length xs in
            let total_time =
              xs
-             |> List.map (fun x -> x.files)
-             |> List.flatten |> List.map snd |> Common2.sum_float
+             |> Common.map (fun x -> x.files)
+             |> List.flatten |> Common.map snd |> Common2.sum_float
            in
            let total_files =
-             xs |> List.map (fun x -> List.length x.files) |> Common2.sum
+             xs |> Common.map (fun x -> List.length x.files) |> Common2.sum
            in
            { xlang; total_rules; total_time; total_files })
   in
 
   stats
-  |> List.map (fun stat -> (stat, stat.total_time))
+  |> Common.map (fun stat -> (stat, stat.total_time))
   |> Common.sort_by_val_highfirst
   |> List.iter (fun (stat, _) -> report_stat_per_lang stat);
 

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -75,12 +75,12 @@ let print_match ?str match_format mvars mvar_binding ii_of_any
 
     let strings_metavars =
       mvars
-      |> List.map (fun x ->
+      |> Common.map (fun x ->
              match Common2.assoc_opt x mvar_binding with
              | Some any ->
                  any |> ii_of_any
                  |> List.filter PI.is_origintok
-                 |> List.map PI.str_of_info
+                 |> Common.map PI.str_of_info
                  |> Matching_report.join_with_space_if_needed
              | None -> failwith (spf "the metavariable '%s' was not binded" x))
     in
@@ -178,19 +178,19 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
   in
   let new_errors, new_skipped =
     offending_file_list
-    |> List.map (fun file ->
+    |> Common.map (fun file ->
            (* logging useful info for rule writers *)
            logger#info "too many matches on %s, generating exn for it" file;
            let sorted_offending_rules =
              let matches = List.assoc file per_files in
              matches
-             |> List.map (fun m ->
+             |> Common.map (fun m ->
                     let rule_id = m.Pattern_match.rule_id in
                     ( ( rule_id.Pattern_match.id,
                         rule_id.Pattern_match.pattern_string ),
                       m ))
              |> Common.group_assoc_bykey_eff
-             |> List.map (fun (k, xs) -> (k, List.length xs))
+             |> Common.map (fun (k, xs) -> (k, List.length xs))
              |> Common.sort_by_val_highfirst
              (* nosemgrep *)
            in
@@ -217,7 +217,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
            in
            let skipped =
              sorted_offending_rules
-             |> List.map (fun ((rule_id, _pat), n) ->
+             |> Common.map (fun ((rule_id, _pat), n) ->
                     let details =
                       spf
                         "found %i matches for rule %s, which exceeds the \
@@ -370,7 +370,7 @@ let rules_for_xlang xlang rules =
          | (Xlang.LRegex | Xlang.LGeneric | Xlang.L _), _ -> false)
 
 let mk_rule_table rules =
-  let rule_pairs = List.map (fun r -> (fst r.R.id, r)) rules in
+  let rule_pairs = Common.map (fun r -> (fst r.R.id, r)) rules in
   Common.hash_of_list rule_pairs
 
 let xtarget_of_file _config xlang file =
@@ -420,7 +420,7 @@ let targets_of_config (config : Runner_config.t)
       let files, skipped = Find_target.files_of_dirs_or_files lang_opt roots in
       let targets =
         files
-        |> List.map (fun file ->
+        |> Common.map (fun file ->
                {
                  In.path = file;
                  language = Xlang.to_string xlang;
@@ -461,7 +461,7 @@ let semgrep_with_rules config ((rules, skipped_rules), rules_parse_time) =
 
   let rule_table = mk_rule_table rules in
   let targets, skipped =
-    targets_of_config config (List.map (fun r -> fst r.R.id) rules)
+    targets_of_config config (Common.map (fun r -> fst r.R.id) rules)
   in
   logger#info "processing %d files, skipping %d files" (List.length targets)
     (List.length skipped);
@@ -471,7 +471,7 @@ let semgrep_with_rules config ((rules, skipped_rules), rules_parse_time) =
            let file = target.In.path in
            let xlang = Xlang.of_string target.In.language in
            let rules =
-             List.map
+             Common.map
                (fun r_id -> Hashtbl.find rule_table r_id)
                target.In.rule_ids
            in
@@ -518,7 +518,7 @@ let semgrep_with_rules config ((rules, skipped_rules), rules_parse_time) =
       skipped_rules;
       final_profiling = res.RP.final_profiling;
     },
-    targets |> List.map (fun x -> x.In.path) )
+    targets |> Common.map (fun x -> x.In.path) )
 
 let semgrep_with_raw_results_and_exn_handler config =
   let rules_file = config.rules_file in
@@ -653,9 +653,9 @@ let semgrep_with_one_pattern config =
       in
       (* simpler code path than in semgrep_with_rules *)
       let targets, _skipped =
-        targets_of_config config (List.map (fun r -> r.MR.id) minirule)
+        targets_of_config config (Common.map (fun r -> r.MR.id) minirule)
       in
-      let files = targets |> List.map (fun t -> t.In.path) in
+      let files = targets |> Common.map (fun t -> t.In.path) in
       files
       |> List.iter (fun file ->
              logger#info "processing: %s" file;

--- a/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
+++ b/semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml
@@ -177,8 +177,8 @@ let run config =
     (match config.pattern with
     | None -> []
     | Some pat_str -> [ Src_file.of_string pat_str ])
-    @ List.map Src_file.of_file pattern_files
-    |> List.map (fun pat_src ->
+    @ Common.map Src_file.of_file pattern_files
+    |> Common.map (fun pat_src ->
            (pat_src, parse_pattern config.comment_style pat_src))
   in
   let patterns, errors =
@@ -202,7 +202,9 @@ let run config =
         ]
     | roots ->
         let files = Find_files.list roots in
-        List.map (fun file ?max_len () -> Src_file.of_file ?max_len file) files
+        Common.map
+          (fun file ?max_len () -> Src_file.of_file ?max_len file)
+          files
   in
   let debug = config.debug in
   if debug then Match.debug := true;

--- a/semgrep-core/src/spacegrep/src/lib/Find_files.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Find_files.ml
@@ -76,7 +76,7 @@ let fold_one ~accept_file_name ~accept_dir_name visit_tracker f acc root =
                  and overall minimize surprises. *)
               Array.sort compare_filenames a;
               Array.to_list a
-              |> List.map (fun name -> Filename.concat path name)
+              |> Common.map (fun name -> Filename.concat path name)
             in
             List.fold_left fold acc children
       | Some Unix.S_REG -> if accept_file_name name then f acc path else acc

--- a/semgrep-core/src/spacegrep/src/lib/Match.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Match.ml
@@ -392,7 +392,7 @@ let starts_with_dots (pat : Pattern_AST.node list) =
 
 let convert_named_captures env =
   Env.bindings env
-  |> List.map (fun (name, (loc, value)) -> (name, { value; loc }))
+  |> Common.map (fun (name, (loc, value)) -> (name, { value; loc }))
 
 (*
 let to_string src match_ =

--- a/semgrep-core/src/spacegrep/src/lib/Parse_pattern.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Parse_pattern.ml
@@ -120,7 +120,7 @@ let parse_doc_line tokens : Pattern_AST.node list =
 
 (* Interpret braces as regular punctuation. This is intended for patterns. *)
 let parse_pattern_line (tokens : Lexer.token list) : Pattern_AST.node list =
-  List.map
+  Common.map
     (fun (token : Lexer.token) ->
       match token with
       | Atom (loc, atom) -> Atom (loc, atom)

--- a/semgrep-core/src/spacegrep/src/test/Comment.ml
+++ b/semgrep-core/src/spacegrep/src/test/Comment.ml
@@ -81,7 +81,7 @@ bye
 
 let test =
   "Comment",
-  tests |> List.map (fun (name, style, input, expected_output) ->
+  tests |> Common.map (fun (name, style, input, expected_output) ->
     let run () =
       let output = C.remove_comments_from_string style input in
       Alcotest.(check string "equal" expected_output output)

--- a/semgrep-core/src/spacegrep/src/test/File_type.ml
+++ b/semgrep-core/src/spacegrep/src/test/File_type.ml
@@ -30,7 +30,7 @@ let run_one expected_class data =
 
 let test =
   let suite =
-    List.map
+    Common.map
       (fun (name, expected_class, data) ->
         (name, `Quick, fun () -> run_one expected_class data))
       corpus

--- a/semgrep-core/src/spacegrep/src/test/Matcher.ml
+++ b/semgrep-core/src/spacegrep/src/test/Matcher.ml
@@ -45,7 +45,7 @@ let doc_eq doc1_str doc2_str =
 
 let matches_eq expected_doc_strings matches =
   let doc_strings =
-    List.map (fun (x : Match.match_) -> x.capture.value) matches
+    Common.map (fun (x : Match.match_) -> x.capture.value) matches
   in
   printf "=== expected matches ===\n";
   List.iter (fun s -> printf "%s\n--\n" s) expected_doc_strings;
@@ -210,7 +210,7 @@ let matcher_corpus_case_insensitive =
   [ ("case-insensitive", Matches [ "Foo"; "foo" ], "foo", "Foo or foo") ]
 
 let matcher_suite =
-  List.map
+  Common.map
     (fun (name, expectation, pat_str, doc_str) ->
       ( name,
         `Quick,
@@ -219,7 +219,7 @@ let matcher_suite =
     matcher_corpus
 
 let matcher_suite_case_insensitive =
-  List.map
+  Common.map
     (fun (name, expectation, pat_str, doc_str) ->
       ( name,
         `Quick,

--- a/semgrep-core/src/spacegrep/src/test/Parser.ml
+++ b/semgrep-core/src/spacegrep/src/test/Parser.ml
@@ -116,11 +116,11 @@ let pretty_corpus =
 
 let test =
   let suite =
-    List.map
+    Common.map
       (fun (name, input, expected_output) ->
         (name, `Quick, fun () -> run_debug input expected_output))
       debug_corpus
-    @ List.map
+    @ Common.map
         (fun (name, input, expected_output) ->
           (name, `Quick, fun () -> run_pretty input expected_output))
         pretty_corpus

--- a/semgrep-core/src/spacegrep/src/test/Src_file.ml
+++ b/semgrep-core/src/spacegrep/src/test/Src_file.ml
@@ -22,7 +22,7 @@ let highlight_corpus =
   ]
 
 let rec find_word_locations word (ast : Doc_AST.node list) =
-  List.map (find_word_locations_in_node word) ast |> List.flatten
+  List.concat_map (find_word_locations_in_node word) ast
 
 and find_word_locations_in_node word node =
   match node with
@@ -60,11 +60,11 @@ let lines_of_range_corpus =
 
 let test =
   let suite =
-    List.map
+    Common.map
       (fun (name, input, start, end_, expected_output) ->
         (name, `Quick, fun () -> test_highlight input start end_ expected_output))
       highlight_corpus
-    @ List.map
+    @ Common.map
         (fun (name, input, start_word, end_word, expected_output) ->
           ( name,
             `Quick,

--- a/semgrep-core/src/targeting/Guess_lang.ml
+++ b/semgrep-core/src/targeting/Guess_lang.ml
@@ -63,7 +63,7 @@ let prepend_period_if_needed s =
    Both '.d.ts' and '.ts' are considered extensions of 'hello.d.ts'.
 *)
 let has_extension extensions =
-  has_suffix (List.map prepend_period_if_needed extensions)
+  has_suffix (Common.map prepend_period_if_needed extensions)
 
 let has_lang_extension lang = has_extension (Lang.ext_of_lang lang)
 

--- a/semgrep-core/src/targeting/Unit_guess_lang.ml
+++ b/semgrep-core/src/targeting/Unit_guess_lang.ml
@@ -107,11 +107,11 @@ let fix_path s =
   | _ -> s
 
 let test_inspect_file =
-  List.map
+  Common.map
     (fun (test_name, lang, path, expectation) ->
       (test_name, fun () -> test_name_only lang (fix_path path) expectation))
     name_tests
-  @ List.map
+  @ Common.map
       (fun (test_name, lang, file_name, contents, exec, expectation) ->
         ( test_name,
           fun () -> test_with_contents lang file_name contents exec expectation

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -46,6 +46,37 @@ rules:
     paths:
       exclude:
         - SPcre.ml
+
+  - id: no-list-map
+    pattern: List.map
+    message: >-
+      `List.map` creates O(N) stack depth, and can lead to a
+      stack overflow. Use `Common.map` instead.
+    fix: Common.map
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - semgrep-core/src/*
+
+  - id: use-concat-map
+    pattern-either:
+      - pattern: List.map ... |> List.flatten
+      - pattern: Common.map ... |> List.flatten
+      - pattern: List.map ... |> List.concat
+      - pattern: Common.map ... |> List.concat
+      - pattern: List.flatten ( List.map ... )
+      - pattern: List.flatten ( Common.map ... )
+      - pattern: List.concat ( List.map ... )
+      - pattern: List.concat ( Common.map ... )
+    message: >-
+      `List.concat_map` is more efficient and more readable than a `map` followed
+      by `concat`.
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - semgrep-core/src/*
 # not ready yet
 #  - id: no-exit-in-semgrep
 #    pattern: |


### PR DESCRIPTION
This commit:
- Updates semgrep.yml to check for use of List.map (which is not
  tail-recursive), and map operations piped to List.flatten
- Fixes all such occurrences in our code base

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
