### PR TITLE
Rules with invalid patterns fail fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - JS/TS: `...{$X}...` will no longer match `str`
 - taint-mode: Metavariables bound by a `pattern-inside` are now available to the
   rule message. (#4464)
+- parsing: fail fast on in semgrep-core if rules fail to validate (broken since 0.86.5)
 
 ## [0.86.5](https://github.com/returntocorp/semgrep/releases/tag/v0.86.5) - 2022-03-28
 

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -522,7 +522,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
       RP.matches;
       errors;
       skipped_targets;
-      invalid_rules;
+      skipped_rules = invalid_rules;
       final_profiling = res.RP.final_profiling;
     },
     targets |> List.map (fun x -> x.In.path) )

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -452,11 +452,16 @@ let targets_of_config (config : Runner_config.t)
  * It takes a set of rules and a set of targets and
  * recursively process those targets.
  *)
-let semgrep_with_rules config ((rules, skipped_rules), rules_parse_time) =
-  (* if there are no rules but just skipped rules, better to return an exn *)
-  (match (rules, skipped_rules) with
+let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
+  (* Return an exception
+     - always, if there are no rules but just invalid rules
+     - when users want to fail fast, if there are valid and invalid rules *)
+  (* TODO right now there is no option to not fail fast *)
+  (match (rules, invalid_rules) with
   | [], [] -> ()
   | [], err :: _ -> raise (Rule.InvalidRule err)
+  | _, err :: _ (* TODO fail fast when only when strict? *) ->
+      raise (Rule.InvalidRule err)
   | _ -> ());
 
   let rule_table = mk_rule_table rules in
@@ -471,8 +476,10 @@ let semgrep_with_rules config ((rules, skipped_rules), rules_parse_time) =
            let file = target.In.path in
            let xlang = Xlang.of_string target.In.language in
            let rules =
-             List.map
-               (fun r_id -> Hashtbl.find rule_table r_id)
+             (* Assumption: find_opt will return None iff a r_id
+                 is in skipped_rules *)
+             List.filter_map
+               (fun r_id -> Hashtbl.find_opt rule_table r_id)
                target.In.rule_ids
            in
 
@@ -515,7 +522,7 @@ let semgrep_with_rules config ((rules, skipped_rules), rules_parse_time) =
       RP.matches;
       errors;
       skipped_targets;
-      skipped_rules;
+      invalid_rules;
       final_profiling = res.RP.final_profiling;
     },
     targets |> List.map (fun x -> x.In.path) )

--- a/semgrep/tests/e2e/rules/invalid-rules/invalid-pattern.yaml
+++ b/semgrep/tests/e2e/rules/invalid-rules/invalid-pattern.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: eqeq
+  pattern: $X == $X
+  message: Useless comparison
+  languages: [js]
+  severity: WARNING
+- id: console_log
+  pattern: console.l..);
+  message: Using console.log
+  languages: [js]
+  severity: WARNING

--- a/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.js/results.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.js/results.json
@@ -1,0 +1,35 @@
+{
+  "errors": [
+    {
+      "code": 2,
+      "level": "error",
+      "message": "[ERROR] Semgrep Core \u2014 Pattern parse error\nAn error occurred while invoking the Semgrep engine. Please help us fix this by creating an issue at https://github.com/returntocorp/semgrep\n\nIn rule rules.invalid-rules.console_log: Invalid pattern for TypeScript\n",
+      "rule_id": "rules.invalid-rules.console_log",
+      "spans": [
+        {
+          "config_end": {
+            "col": 25,
+            "line": 10,
+            "offset": 197
+          },
+          "config_path": [
+            "rules",
+            "1",
+            "pattern"
+          ],
+          "config_start": {
+            "col": 12,
+            "line": 10,
+            "offset": 184
+          }
+        }
+      ],
+      "type": "Pattern parse error"
+    }
+  ],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": []
+  },
+  "results": []
+}

--- a/semgrep/tests/e2e/test_rule_validation.py
+++ b/semgrep/tests/e2e/test_rule_validation.py
@@ -11,6 +11,7 @@ import pytest
         ("rules/invalid-rules/invalid-metavariable-regex.yaml", "basic/stupid.py"),
         ("rules/invalid-rules/invalid-pattern-child.yaml", "basic/stupid.py"),
         ("rules/invalid-rules/invalid-missing-top-item.yaml", "basic/stupid.py"),
+        ("rules/invalid-rules/invalid-pattern.yaml", "basic/stupid.js"),
     ],
 )
 def test_validation_of_invalid_rules(run_semgrep_in_tmp, snapshot, rule, target):


### PR DESCRIPTION
In 0.86.5, semgrep-core started collecting the invalid rules to send at the end. This is nice if we want to fail open, but we haven't implemented that in semgrep yet. This means that rules with bad patterns are getting skipped and then later causing Not_found to be raised when the target looks for the rule. For now, just throw the exception but leave the infrastructure to fail open.

Also changes the code that gets the rules for each target to expect that some might not be found. This assumes that any rule that is not in the table is invalid.

Test plan:

rule_file.yaml
```
rules:
- id: println
  pattern: System.out.println(...);
  message: Using println
  languages: [java]
  severity: WARNING
- id: console_log
  pattern: console.l..);
  message: Using console.log
  languages: [js]
  severity: WARNING
```

Run `semgrep --config rule_file.yaml .`, expect a crash

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
