### PR TITLE
Guard unix-only module load in unix check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Moved description of parse/internal errors to the "skipped" section of output
 
+### Fixed
+
+- Fixed issue that caused Semgrep to always fail on Windows (#4947); NOTE:
+  memory protection will not work on Windows
+
 ## [0.87.0](https://github.com/returntocorp/semgrep/releases/tag/v0.87.0) - 2022-04-07
 
 ### Added


### PR DESCRIPTION
This was causing us to hard-fail on Windows 100% of the time.

(Probably) fixes #4947.

Test-plan: just automated CI; we don't have any Windows test environments.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
