### PR TITLE
core: Make more noise when memory usage keeps going up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 - Moved description of parse/internal errors to the "skipped" section of output
+- Since 0.77.0 semgrep-core logs a warning when a worker process is consuming above
+  400 MiB of memory. Now, it will also log an extra warning every time memory usage
+  doubles. Again, this is meant to help diagnosing OOM-related crashes.
 
 ### Fixed
 


### PR DESCRIPTION
Previously we only warned once when a worker process went beyond a
certain amount of memory (400M by default), and there were no further
warnings regardless of how much memory usage grew. Now we will keep
issuing warnings every time memory usage doubles, this makes easier
to spot when a worker is going to crash by OOM.

Helps PA-705

test plan:
```
% cat oom.sgrep
<... $A ...>;
...
<... $B ...>;
...
<... $C ...>;
% semgrep-core -lang js -f oom.sgrep perf/input/l1000.js -json -debug
...
[0.955  Warning    Main.Memory_limit    ] large heap size: 492 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
[2.493  Warning    Main.Memory_limit    ] large heap size: 919 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
[6.614  Warning    Main.Memory_limit    ] large heap size: 1652 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
[16.939 Warning    Main.Memory_limit    ] large heap size: 3422 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
...
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
