### PR TITLE
Go: parse multiline raw string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `r2c-internal-project-depends-on`:
   - Generic mode rules work again
   - Semgrep will not fail on targets that contain no relevant lockfiles
+- Go: parse multiline string literals
 
 ## [0.87.0](https://github.com/returntocorp/semgrep/releases/tag/v0.87.0) - 2022-04-07
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -65,7 +65,12 @@ let raw_string_literal env tok =
   (* Remove leading and trailing backticks. The grammar guarantees that raw
    * string literals will always have leading and trailing backticks, so this
    * String.sub call should be safe. Let's check just to be sure. *)
-  if not (String.get s 0 = '`' && String.get s (String.length s - 1) = '`') then
+  if
+    not
+      (String.length s >= 2
+      && String.get s 0 = '`'
+      && String.get s (String.length s - 1) = '`')
+  then
     failwith @@ "Found unexpected raw string literal without delimiters: " ^ s;
   let s = String.sub s 1 (String.length s - 2) in
   let tok = (loc, s) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -65,9 +65,9 @@ let raw_string_literal env tok =
   (* Remove leading and trailing backticks. The grammar guarantees that raw
    * string literals will always have leading and trailing backticks, so this
    * String.sub call should be safe. Let's check just to be sure. *)
-  if not Common.(s =~ "^`\\(.*\\)`$") then
-    failwith "Found unexpected raw string literal without delimiters";
-  let s = Common.matched1 s in
+  if not (String.get s 0 = '`' && String.get s (String.length s - 1) = '`') then
+    failwith @@ "Found unexpected raw string literal without delimiters: " ^ s;
+  let s = String.sub s 1 (String.length s - 2) in
   let tok = (loc, s) in
   str env tok
 

--- a/semgrep-core/tests/go/parsing/weird_raw_string.go
+++ b/semgrep-core/tests/go/parsing/weird_raw_string.go
@@ -1,0 +1,50 @@
+func f () {
+	x := `type Mutation {
+			userLifeApp(input: User!): UserCreationResponse!
+		}
+		
+		type UserCreationResponse {
+			statusCode: Int!
+		}
+		
+		input PolicyPreference {
+			carrier: String!
+			carrierName: String!
+			monthlyPremium: Float!
+			annualPremium: Float!
+			name: String!
+			returnOfPremium: Boolean!
+			underwritingClass: String!
+			isTobacco: Boolean!
+			healthCategory: String!
+			tableRating: Int!
+			issueType: String!
+			issueAge: Int!
+			planIdentifierName: String!
+			productType: String!
+			useNearestAge: Boolean!
+		}
+		
+		input AgentInfo {
+			code: String!
+			email: String!
+		}
+		
+		input User {
+			gender: Gender!
+			dateOfBirth: String!
+			state: String!
+			tobaccoUse: Boolean
+			firstName: String!
+			lastName: String!
+			phone: String!
+			email: String!
+			agentInfo: AgentInfo!
+			policyPreference: PolicyPreference
+			coverageAmount: Int
+			termInYears: Int
+			notes: String
+			paymentMode: String
+		}
+		`
+}


### PR DESCRIPTION
We were using a faulty regex to remove the backticks from raw string literals. The faulty regex did not match multiline strings.

test plan: make test (see added test)

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
