### PR TITLE
[Swift] Convert constructor expressions to Generic AST

### DIFF
--- a/semgrep-core/tests/swift/parsing/expressions.swift
+++ b/semgrep-core/tests/swift/parsing/expressions.swift
@@ -47,3 +47,24 @@ closure { x in x };
 // is parsed as two separate call expressions where the lambda is the argument
 // to the return value of the single-argument function call.
 mixedargs(foo: 3) { x in x };
+
+// Constructor expressions:
+
+// TODO The examples here that don't involve type parameters are parsed as call
+// expressions rather than constructor expressions, due to ambiguity in the
+// grammar. It might not be possible to disambiguate in the general case without
+// resolving names, but we should make sure that these constructs are matched by
+// patterns as users expect.
+
+// array type
+[Int]();
+[Thing<Int>]();
+// dict type
+[Int: Int]();
+[Int: Thing<Int>]();
+// user type
+UserType(bar);
+UserType<Int>(bar);
+
+[Int] { x in y };
+[Thing<Int>] { x in y };


### PR DESCRIPTION
In addition to constructor expressions, I've also filled in other cases as needed to support the examples in the test. I'm going through expressions in the order they are mentioned in the source grammar, and not from simplest to most complex, so I have to fill in some simpler cases as I go.

A few notes:
* There is ambiguity in the grammar between constructor expressions and call expressions. I've noted this in the test file. This ambiguity is resolved in favor of call expressions, which means that to actually exercise the logic to convert constructor expressions, I had to include examples of types with type parameters, which are unambiguously parsed as constructor expressions. It appears that Swift addresses this ambiguity by resolving the names and figuring out whether they are types or values. We may find ourselves needing to do that as well.
* To represent dictionary literals, I build a tuple with each pair. Based on the comments in the AST, I believe this is the right way, but I'd appreciate someone double-checking me on it.
* To represent dictionary types, I desugar `[A: B]` to `Dictionary<A, B>`. Unlike for array types, there does not appear to be a dedicated dictionary type node in the AST, so I copied what is done for Go.

Test plan:

Automated tests ensure at least that the conversion of these structures does not fail outright. I also performed a manual inspection of the output for each line added to the tests here, as below:

`$ semgrep-core -lang swift -dump_ast test.swift`
Where `test.swift` contains `[Thing<Int>]();`
```
Pr(
  [ExprStmt(
     New((),
       {t_attrs=[]; 
        t=TyArray(None,
            {t_attrs=[]; 
             t=TyN(
                 IdQualified(
                   {
                    name_last=(("Thing", ()),
                               Some([TA(
                                       {t_attrs=[]; 
                                        t=TyN(
                                            Id(("Int", ()),
                                              {id_info_id=1; id_hidden=false; id_resolved=Ref(
                                               None); id_type=Ref(None); id_svalue=Ref(
                                               None); }));
                                        })]));
                    name_top=None; name_middle=None; 
                    name_info={id_info_id=2; id_hidden=false; id_resolved=Ref(
                               None); id_type=Ref(None); id_svalue=Ref(
                               None); };
                    }));
             });
        }, []), ())])
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
