### PR TITLE
Update doc links + add INSTALL.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
    this file would be a symlink.
 -->
 
-[Contribution guidelines can be found in `doc/`](http://semgrep.dev/docs/contributing/contributing-code/).
+[Contribution guidelines can be found in `doc/`](https://semgrep.dev/docs/contributing/how-to-contribute/).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,59 @@
+# Build instructions for developers
+
+## Manual development
+
+Developers should consult the makefiles, which are documented.
+The steps to set up and build everything are normally:
+
+```
+$ make dev-setup   # meant to be run infrequently, may not be sufficient
+$ make             # routine build
+$ make test        # test everything
+```
+
+There's no simple installation of the development version of the
+`semgrep` command (Python wrapper + `semgrep-core` binary). To test
+`semgrep` without installing it, use `pipenv`:
+
+```
+$ cd semgrep
+$ pipenv shell
+$ semgrep --help
+```
+
+Or more conveniently, you can create a shell function that will call
+`pipenv` from the correct location. For example, if you cloned the
+`semgrep` repo in your home folder (`~`), you can place the following
+code in your `~/.bashrc` file and then use `semgrep-dev` as your
+`semgrep` command:
+
+```
+semgrep-dev() {
+  PIPENV_PIPFILE=~/semgrep/semgrep/Pipfile pipenv run semgrep "$@"
+}
+```
+
+The Semgrep project has two main parts:
+
+- The Python wrapper in the [`semgrep/`](semgrep) folder, which has its own
+  makefile needed for some preprocessing and for testing.
+  Read the makefile to see what targets are available.
+- The OCaml core in the [`semgrep-core/`](semgrep-core) folder, which
+  also has its own makefile. Read the makefile to see what's
+  available to the developer.
+
+## Reproducible and standalone build with Docker
+
+The main [`Dockerfile`](Dockerfile) serves as a reference on how to
+build Semgrep for Linux. The usual instructions for building a Docker
+image apply. It should be:
+
+```
+$ docker build -t semgrep .
+```
+
+## Contribution guidelines
+
+Contribution guidelines and developer documentation
+are [available from Semgrep's documentation
+website](https://semgrep.dev/docs/contributing/how-to-contribute/).

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To disable Registry rule metrics, use `--metrics=off`.
 ### More
 
 - [Frequently asked questions (FAQs)](https://semgrep.dev/docs/faq/)
-- [Contributing](https://semgrep.dev/docs/contributing/)
+- [Contributing](https://semgrep.dev/docs/contributing/how-to-contribute/)
 - [Ask questions in the r2c Community Slack](https://r2c.dev/slack)
 - [CLI reference and exit codes](https://semgrep.dev/docs/cli-usage)
 - [r2c YouTube channel with Semgrep presentation videos](https://www.youtube.com/channel/UC5ahcFBorwzUTqPipFhjkWg)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ To disable Registry rule metrics, use `--metrics=off`.
 
 - [Frequently asked questions (FAQs)](https://semgrep.dev/docs/faq/)
 - [Contributing](https://semgrep.dev/docs/contributing/how-to-contribute/)
+- [Build instructions for developers](INSTALL.md)
 - [Ask questions in the r2c Community Slack](https://r2c.dev/slack)
 - [CLI reference and exit codes](https://semgrep.dev/docs/cli-usage)
 - [r2c YouTube channel with Semgrep presentation videos](https://www.youtube.com/channel/UC5ahcFBorwzUTqPipFhjkWg)


### PR DESCRIPTION
This avoids landing on the outdated page https://semgrep.dev/docs/contributing/ whose source I wasn't able to locate. I assume it's cached or something. The newer version is https://semgrep.dev/docs/contributing/how-to-contribute/ whose source is https://github.com/returntocorp/semgrep-docs/blob/main/docs/contributing/contributing.md

I also created an `INSTALL.md` file meant as a quick, local reference for the developer on how to go about building the project.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
