### PR TITLE
core: Log rule and file affected by a memory warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 
+### Changed
+
+- Semgrep-core now logs the rule and file affected by a memory warning.
+
+### Fixed
+
+### Added
+
 - Scala support is now officially GA
   - Ellipsis method chaining is now supported
   - Type metavariables are now supported

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -293,7 +293,12 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
          let res, run_time =
            Common.with_time (fun () ->
                try
-                 Memory_limit.run_with_memory_limit
+                 let get_context () =
+                   match !Rule.last_matched_rule with
+                   | None -> file
+                   | Some rule_id -> spf "%s on %s" rule_id file
+                 in
+                 Memory_limit.run_with_memory_limit ~get_context
                    ~mem_limit_mb:config.max_memory_mb (fun () ->
                      (* we used to call timeout_function() here, but this
                       * is now done in Match_rules because we now

--- a/semgrep-core/src/system/Memory_limit.ml
+++ b/semgrep-core/src/system/Memory_limit.ml
@@ -18,7 +18,8 @@ let default_heap_warning_mb = 400
    for detailed explanations.
 
 *)
-let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
+let run_with_memory_limit ?get_context
+    ?(stack_warning_kb = default_stack_warning_kb)
     ?(heap_warning_mb = default_heap_warning_mb) ~mem_limit_mb f =
   if stack_warning_kb < 0 then
     invalid_arg
@@ -29,6 +30,13 @@ let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
       (spf "run_with_memory_limit: negative argument mem_limit_mb %i"
          mem_limit_mb);
 
+  let context () =
+    match get_context with
+    | None -> ""
+    | Some get_context ->
+        let context_str = get_context () in
+        spf "[%s] " context_str
+  in
   let mb = 1024 * 1024 in
   let mem_limit = mem_limit_mb * mb in
   let stack_warning = stack_warning_kb * 1024 in
@@ -49,14 +57,14 @@ let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
     let mem_bytes = heap_bytes + stack_bytes in
     if mem_limit > 0 && mem_bytes > mem_limit then (
       logger#info
-        "exceeded heap+stack memory limit: %d bytes (stack=%d, heap=%d)"
-        mem_bytes stack_bytes heap_bytes;
+        "%sexceeded heap+stack memory limit: %d bytes (stack=%d, heap=%d)"
+        (context ()) mem_bytes stack_bytes heap_bytes;
       raise (ExceededMemoryLimit "Exceeded memory limit"))
     else if !heap_warning > 0 && heap_bytes > !heap_warning then (
       logger#warning
-        "large heap size: %d MiB (memory limit is %d MiB). If a crash follows, \
-         you could suspect OOM."
-        (heap_bytes / mb) mem_limit_mb;
+        "%slarge heap size: %d MiB (memory limit is %d MiB). If a crash \
+         follows, you could suspect OOM."
+        (context ()) (heap_bytes / mb) mem_limit_mb;
       heap_warning := max (2 * !heap_warning) !heap_warning)
     else if
       stack_warning > 0
@@ -64,11 +72,11 @@ let run_with_memory_limit ?(stack_warning_kb = default_stack_warning_kb)
       && not !stack_already_warned
     then (
       logger#warning
-        "large stack size: %d bytes. If a crash follows, you should suspect a \
-         stack overflow. Make sure the maximum stack size is set to \
+        "%slarge stack size: %d bytes. If a crash follows, you should suspect \
+         a stack overflow. Make sure the maximum stack size is set to \
          'unlimited' or to a value greater than %d bytes so as to obtain an \
          exception rather than a segfault."
-        stack_bytes mem_limit;
+        (context ()) stack_bytes mem_limit;
       stack_already_warned := true)
   in
   let alarm = Gc.create_alarm limit_memory in

--- a/semgrep-core/src/system/Memory_limit.mli
+++ b/semgrep-core/src/system/Memory_limit.mli
@@ -65,6 +65,7 @@
    - default heap_warning_mb: 500 MiB
 *)
 val run_with_memory_limit :
+  ?get_context:(unit -> string) ->
   ?stack_warning_kb:int ->
   ?heap_warning_mb:int ->
   mem_limit_mb:int ->


### PR DESCRIPTION
Helps PA-705

test plan:
```
% cat oom.sgrep
<... $A ...>;
...
<... $B ...>;
...
<... $C ...>;
% semgrep-core -lang js -f oom.sgrep perf/input/l1000.js -json -debug
...
[0.133  Warning    Main.Memory_limit    ] [-e/-f on l1000.js] large stack size: 356408 bytes. If a crash follows, you should suspect a stack overflow. Make sure the maximum stack size is set to 'unlimited' or to a value greater than 0 bytes so as to obtain an exception rather than a segfault.
[0.979  Warning    Main.Memory_limit    ] [-e/-f on l1000.js] large heap size: 553 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
[2.724  Warning    Main.Memory_limit    ] [-e/-f on l1000.js] large heap size: 1164 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
[6.302  Warning    Main.Memory_limit    ] [-e/-f on l1000.js] large heap size: 1652 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
[16.315 Warning    Main.Memory_limit    ] [-e/-f on l1000.js] large heap size: 3361 MiB (memory limit is 0 MiB). If a crash follows, you could suspect OOM.
...
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
