### PR TITLE
Handle utf-8 decoding errors gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   - Generic mode rules work again
   - Semgrep will not fail on targets that contain no relevant lockfiles
 - Go: parse multiline string literals
+- Handle utf-8 decoding errors without crashing (#5023)
 
 ## [0.87.0](https://github.com/returntocorp/semgrep/releases/tag/v0.87.0) - 2022-04-07
 

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -175,7 +175,7 @@ class StreamingSemgrepCore:
 
             # read returns empty when EOF
             if not line_bytes:
-                self._stdout = b"".join(stdout_lines).decode("utf-8")
+                self._stdout = b"".join(stdout_lines).decode("utf-8", "replace")
                 break
 
             if line_bytes == b".\n":
@@ -210,7 +210,7 @@ class StreamingSemgrepCore:
                 self._stderr = "".join(stderr_lines)
                 break
 
-            line = line_bytes.decode("utf-8")
+            line = line_bytes.decode("utf-8", "replace")
             stderr_lines.append(line)
 
     async def _stream_subprocess(self) -> int:


### PR DESCRIPTION
Replace unicode characters instead of crashing when decoding semgrep-core output

Test plan: `semgrep -l java -e '$X == $X' stress-test-monorepo/repos/intellij-community/java/java-tests/testData/psi/formatter/commandLine/encoding`

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
