### PR TITLE
fix: pin git to 2.34.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,11 +84,13 @@ COPY --from=build-semgrep-core /semgrep/semgrep /semgrep
 
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
-     apk add --no-cache --virtual=.run-deps bash git=2.34.1-r0 git-lfs openssh && \
+     apk add --no-cache --virtual=.run-deps bash git git-lfs openssh && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
      semgrep --version && \
      apk del .build-deps && \
      mkdir -p /tmp/.cache
+
+RUN git config --global --add safe.directory="*"
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,6 @@ RUN apk add --no-cache --virtual=.build-deps build-base && \
      apk del .build-deps && \
      mkdir -p /tmp/.cache
 
-RUN git config --global --add safe.directory="*"
-
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY --from=build-semgrep-core /semgrep/semgrep /semgrep
 
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
-     apk add --no-cache --virtual=.run-deps bash git=2.35.1 git-lfs openssh && \
+     apk add --no-cache --virtual=.run-deps bash git=2.35.1-r2 git-lfs openssh && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
      semgrep --version && \
      apk del .build-deps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,8 @@ COPY --from=build-semgrep-core /semgrep/semgrep /semgrep
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
      apk add --no-cache --virtual=.run-deps bash git git-lfs openssh && \
+     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main git=2.34.1 && \
+     apk add --no-cache git-lfs && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
      semgrep --version && \
      apk del .build-deps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,8 @@ COPY --from=build-semgrep-core /semgrep/semgrep /semgrep
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
      apk add --no-cache --virtual=.run-deps bash git git-lfs openssh && \
-     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main git=2.34.1 git-lfs && \
+     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main git=2.34.1 && \
+     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/community git-lfs && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
      semgrep --version && \
      apk del .build-deps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,7 @@ COPY --from=build-semgrep-core /semgrep/semgrep /semgrep
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
      apk add --no-cache --virtual=.run-deps bash git git-lfs openssh && \
-     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main git=2.34.1 && \
-     apk add --no-cache git-lfs && \
+     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main git=2.34.1 git-lfs && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
      semgrep --version && \
      apk del .build-deps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY --from=build-semgrep-core /semgrep/semgrep /semgrep
 
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
-     apk add --no-cache --virtual=.run-deps bash git=2.35.1-r2 git-lfs openssh && \
+     apk add --no-cache --virtual=.run-deps bash git=2.34.1-r0 git-lfs openssh && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
      semgrep --version && \
      apk del .build-deps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY --from=build-semgrep-core /semgrep/semgrep /semgrep
 
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
-     apk add --no-cache --virtual=.run-deps bash git git-lfs openssh && \
+     apk add --no-cache --virtual=.run-deps bash git=2.35.1 git-lfs openssh && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
      semgrep --version && \
      apk del .build-deps && \


### PR DESCRIPTION
With latest git release https://github.blog/2022-04-12-git-security-vulnerability-announced/ , docker semgrep running in CI pipelines will fail because of how CI providers put code into the docker image (https://github.com/actions/checkout/issues/760) 

This PR pins the git version in the docker image to 2.35.1. The vulnerability fixed in 2.35.2 is not relevant to the use case of running docker in semgrep and any usage is either a user copying files into a volume or a CI provider putting code inside the docker image.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
