### PR TITLE
[Swift] Handle most remaining unary expressions

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -2988,9 +2988,10 @@ and map_unary_expression (env : env) (x : CST.unary_expression) : G.expr =
       map_prefix_unary_operator env v1 e
   | `As_exp (v1, v2, v3) ->
       let v1 = map_expression env v1 in
+      (* TODO differentiate between the `as` kinds *)
       let v2 = map_as_operator env v2 in
       let v3 = map_type_ env v3 in
-      todo env (v1, v2, v3)
+      G.Cast (v3, v2, v1) |> G.e
   | `Sele_exp (v1, v2, v3, v4, v5) ->
       let v1 = (* "#selector" *) token env v1 in
       let v2 = (* "(" *) token env v2 in
@@ -3008,11 +3009,15 @@ and map_unary_expression (env : env) (x : CST.unary_expression) : G.expr =
   | `Open_start_range_exp (v1, v2) ->
       let v1 = map_range_operator env v1 in
       let v2 = map_expression env v2 in
-      todo env (v1, v2)
+      let op = (G.Range, v1) in
+      (* TODO differentiate between different range operators? Ruby currently
+       * does not. *)
+      G.opcall op [ G.L (G.Null v1) |> G.e; v2 ]
   | `Open_end_range_exp (v1, v2) ->
       let v1 = map_expression env v1 in
       let v2 = (* three_dot_operator_custom *) token env v2 in
-      todo env (v1, v2)
+      let op = (G.Range, v2) in
+      G.opcall op [ v1; G.L (G.Null v2) |> G.e ]
 
 and map_user_type (env : env) (x : CST.user_type) : G.type_ =
   match x with

--- a/semgrep-core/tests/swift/parsing/expressions.swift
+++ b/semgrep-core/tests/swift/parsing/expressions.swift
@@ -91,3 +91,25 @@ Thing<Int, String>.foo;
 // Custom operators
 /!5;
 /!<5;
+
+// As expressions:
+
+"5" as Int;
+"5" as? Int;
+"5" as! Int;
+
+// Selector expressions:
+
+// TODO handle selector expressions
+// #selector(5);
+// #selector(getter: 4);
+// #selector(setter: 4);
+
+// Open start range expressions:
+
+...5;
+..<5;
+
+// Open end range expressions:
+
+5...;


### PR DESCRIPTION
I'll fill in `selector` later when/if it becomes clear that it is
frequently used in the real world. For now I'm going to start to speed
things up by focusing on the most basic constructs first.

Test plan:

Automated tests ensure these constructs at least don't lead to a crash

Manually inspect the output of each new construct. For example:

`$ semgrep-core -lang swift -dump_ast test.swift` on `...5;` results in:

`Pr([ExprStmt(Call(IdSpecial((Op(Range), ())), [Arg(L(Null(()))); Arg(L(Int((Some(5), ()))))]), ())])`

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
