### PR TITLE
[Swift] Handle binary expressions

### DIFF
--- a/semgrep-core/tests/swift/parsing/expressions.swift
+++ b/semgrep-core/tests/swift/parsing/expressions.swift
@@ -113,3 +113,65 @@ Thing<Int, String>.foo;
 // Open end range expressions:
 
 5...;
+
+// -----------------------------------------------------------------------------
+// Binary expressions:
+// -----------------------------------------------------------------------------
+
+// Multiplicative expressions:
+
+5 * 5;
+5 / 2;
+5 % 2;
+
+// Additive expressions:
+
+5 + 2;
+5 - 2;
+
+// Range expressions:
+
+1...5;
+1..<5;
+
+// Infix expressions:
+
+5 /. 5;
+
+// Nil coalescing expressions:
+
+nil ?? nil;
+
+// Check expressions:
+
+5 is Int;
+
+// Equality expressions:
+
+5 != 5;
+5 !== 5;
+5 == 5;
+5 === 5;
+
+// Comparison expressions:
+
+5 < 5;
+5 > 5;
+5 <= 5;
+5 >= 5;
+
+// Conjunction expressions:
+
+true && false;
+
+// Disjunction expressions:
+
+true || false;
+
+// Bitwise expression:
+
+5 & 5;
+5 | 5;
+5 ^ 5;
+5 << 1;
+5 >> 1;


### PR DESCRIPTION
Note that this adds another `OtherExpr` for `is`. See below.

Test plan:

Automated tests

Manual inspection of the generated AST for the new constructs, for
example, for `5 is Int;`:

```
$ semgrep-core -lang swift -dump_ast test.swift
Pr(
  [ExprStmt(
     Call(IdSpecial((Instanceof, ())),
       [Arg(L(Int((Some(5), ()))));
        Arg(
          OtherExpr(("TypeExpr", ()),
            [T(
               {t_attrs=[];
                t=TyN(
                    Id(("Int", ()),
                      {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
                })]))]), ())])
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
