### PR TITLE
Use latest pfff with only LGPL code

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -4,8 +4,7 @@ Copyright (C) 2019, 2020, 2021, 2022 R2C
 
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Lesser General Public License (LGPL)
-   version 2.1 as published by the Free Software Foundation, with the
-   special exception on linking described in file LICENSE.
+   version 2.1 as published by the Free Software Foundation.
 
    This library is distributed in the hope that it will be useful, but
    WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,6 @@
 The Library is distributed under the terms of the GNU Lesser General
 Public License version 2.1 (included below).
 
-As a special exception to the GNU Lesser General Public License, you
-may link, statically or dynamically, a "work that uses the Library"
-with a publicly distributed version of the Library to produce an
-executable file containing portions of the Library, and distribute that
-executable file under terms of your choice, without any of the additional
-requirements listed in clause 6 of the GNU Lesser General Public License.
-By "a publicly distributed version of the Library", we mean either the
-unmodified Library as distributed by the authors, or a modified version
-of the Library that is distributed under the conditions defined in clause
-3 of the GNU Lesser General Public License.  This exception does not
-however invalidate any other reasons why the executable file might be
-covered by the GNU Lesser General Public License.
-
 ---------------------------------------------------------------------------
 
                   GNU LESSER GENERAL PUBLIC LICENSE


### PR DESCRIPTION
Also remove linking exception clause for now.

test plan:
git grep GPL in semgrep-core/src/pfff/ and check if
remaining GPL (vs LGPL) files


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)