### PR TITLE
get rid of semgrep.types.RuleId

### DIFF
--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -68,7 +68,7 @@ class CoreError:
     """
 
     error_type: str
-    rule_id: Optional[str]  # TODO: Optional[core.RuleId]
+    rule_id: Optional[core.RuleId]
     path: Path
     start: core.Position
     end: core.Position
@@ -80,8 +80,7 @@ class CoreError:
     @classmethod
     def make(cls, error: core.Error) -> "CoreError":
         error_type = error.error_type
-        # TODO: core.RuleId(...)
-        rule_id = error.rule_id.value if error.rule_id else None
+        rule_id = error.rule_id
         path = Path(error.location.path)
         start = error.location.start
         end = error.location.end

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -31,7 +31,6 @@ from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 from semgrep.rule_match import RuleMatchSet
 from semgrep.types import JsonObject
-from semgrep.types import RuleId
 from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
@@ -69,7 +68,7 @@ class CoreError:
     """
 
     error_type: str
-    rule_id: Optional[RuleId]
+    rule_id: Optional[str]  # TODO: Optional[core.RuleId]
     path: Path
     start: core.Position
     end: core.Position
@@ -81,7 +80,8 @@ class CoreError:
     @classmethod
     def make(cls, error: core.Error) -> "CoreError":
         error_type = error.error_type
-        rule_id = RuleId(error.rule_id.value) if error.rule_id else None
+        # TODO: core.RuleId(...)
+        rule_id = error.rule_id.value if error.rule_id else None
         path = Path(error.location.path)
         start = error.location.start
         end = error.location.end

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -30,7 +30,6 @@ from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.constants import USER_DATA_FOLDER
 from semgrep.core_output import CoreOutput
 from semgrep.core_output import CoreTiming
-from semgrep.core_output import RuleId
 from semgrep.error import _UnknownLanguageError
 from semgrep.error import SemgrepCoreError
 from semgrep.error import SemgrepError
@@ -509,7 +508,7 @@ class CoreRunner:
         Note: this is a list because a target can appear twice (e.g. Java + Generic)
         """
         target_info: Dict[
-            Tuple[Path, Language], List[RuleId]
+            Tuple[Path, Language], List[str]  # TODO: List[core.RuleId]
         ] = collections.defaultdict(list)
 
         for rule in rules:
@@ -518,7 +517,7 @@ class CoreRunner:
 
                 for target in targets:
                     all_targets.add(target)
-                    target_info[target, language].append(RuleId(rule.id))
+                    target_info[target, language].append(rule.id)  # TODO: core.RuleId
 
         return Plan(
             [

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -16,7 +16,6 @@ from semgrep.constants import Colors
 from semgrep.rule_lang import Position
 from semgrep.rule_lang import SourceTracker
 from semgrep.rule_lang import Span
-from semgrep.types import RuleId
 from semgrep.util import with_color
 
 OK_EXIT_CODE = 0
@@ -99,7 +98,7 @@ class SemgrepCoreError(SemgrepError):
     code: int
     level: Level
     error_type: str
-    rule_id: Optional[RuleId]
+    rule_id: Optional[str]  # TODO: Optional[RuleId]
     path: Path
     start: core.Position
     end: core.Position

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -98,7 +98,7 @@ class SemgrepCoreError(SemgrepError):
     code: int
     level: Level
     error_type: str
-    rule_id: Optional[str]  # TODO: Optional[RuleId]
+    rule_id: Optional[core.RuleId]
     path: Path
     start: core.Position
     end: core.Position
@@ -109,7 +109,7 @@ class SemgrepCoreError(SemgrepError):
     def to_dict_base(self) -> Dict[str, Any]:
         base: Dict[str, Any] = {"type": self.error_type, "message": str(self)}
         if self.rule_id:
-            base["rule_id"] = self.rule_id
+            base["rule_id"] = self.rule_id.value
 
         # For rule errors path is a temp file so for now will just be confusing to add
         if (
@@ -143,9 +143,9 @@ class SemgrepCoreError(SemgrepError):
                 self.error_type == "Rule parse error"
                 or self.error_type == "Pattern parse error"
             ):
-                error_context = f"in rule {self.rule_id}"
+                error_context = f"in rule {self.rule_id.value}"
             else:
-                error_context = f"when running {self.rule_id} on {self.path}"
+                error_context = f"when running {self.rule_id.value} on {self.path}"
         else:
             error_context = f"at line {self.path}:{self.start.line}"
 

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -207,7 +207,7 @@ class OutputHandler:
                 if not err.rule_id:
                     timeout_errors[err.path].append("<unknown rule_id>")
                 else:
-                    timeout_errors[err.path].append(err.rule_id)
+                    timeout_errors[err.path].append(err.rule_id.value)
             else:
                 self._handle_semgrep_error(err)
 

--- a/semgrep/semgrep/types.py
+++ b/semgrep/semgrep/types.py
@@ -4,14 +4,11 @@ from pathlib import Path
 from typing import Any
 from typing import FrozenSet
 from typing import Mapping
-from typing import NewType
 
 from attrs import field
 from attrs import frozen
 
 JsonObject = Mapping[str, Any]
-
-RuleId = NewType("RuleId", str)
 
 Targets = FrozenSet[Path]
 


### PR DESCRIPTION
This is redundant with the one provided by output_from_core.py

This is part of a my work to reduce core_output.py

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)