### PR TITLE
Switch to RuleId instead of Rule for profiling.py

### DIFF
--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -468,14 +468,15 @@ class CoreRunner:
         timing: CoreTiming,
     ) -> None:
         rules = timing.rules
+        ruleids = [r.id2 for r in rules]
         targets = [t.target for t in timing.target_timings]
 
-        profiling_data.init_empty(rules, targets)
+        profiling_data.init_empty(ruleids, targets)
         profiling_data.set_rules_parse_time(timing.rules_parse_time)
 
         for t in timing.target_timings:
             rule_timings = {
-                rt.rule: Times(rt.parse_time, rt.match_time)
+                rt.rule.id2: Times(rt.parse_time, rt.match_time)
                 for rt in t.per_rule_timings
             }
             profiling_data.set_file_times(t.target, rule_timings, t.run_time)

--- a/semgrep/semgrep/profiling.py
+++ b/semgrep/semgrep/profiling.py
@@ -4,11 +4,12 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 
+import semgrep.output_from_core as core
 from semgrep.rule import Rule
 
 
 class Semgrep_run(NamedTuple):
-    rule: Rule
+    rule: core.RuleId
     target: Path
 
 
@@ -24,12 +25,12 @@ class ProfilingData:
         self._file_run_time: Dict[Path, float] = {}
         self._match_time_matrix: Dict[Semgrep_run, Times] = {}
 
-        self._rule_match_times: Dict[Rule, float] = {}
-        self._rule_bytes_scanned: Dict[Rule, int] = {}
+        self._rule_match_times: Dict[core.RuleId, float] = {}
+        self._rule_bytes_scanned: Dict[core.RuleId, int] = {}
         self._file_match_times: Dict[Path, float] = {}
         self._file_num_times_scanned: Dict[Path, int] = {}
 
-    def init_empty(self, rules: List[Rule], targets: List[Path]) -> None:
+    def init_empty(self, rules: List[core.RuleId], targets: List[Path]) -> None:
         self._rules_parse_time = 0.0
         self._file_parse_time = {target: 0.0 for target in targets}
         self._file_run_time = {target: 0.0 for target in targets}
@@ -47,7 +48,7 @@ class ProfilingData:
 
     def get_run_times(self, rule: Rule, target: Path) -> Times:
         return self._match_time_matrix.get(
-            Semgrep_run(rule=rule, target=target),
+            Semgrep_run(rule=rule.id2, target=target),
             Times(parse_time=0.0, match_time=0.0),
         )
 
@@ -68,13 +69,13 @@ class ProfilingData:
 
         Return None if RULE has no timing information saved
         """
-        return self._rule_match_times.get(rule)
+        return self._rule_match_times.get(rule.id2)
 
     def get_rule_bytes_scanned(self, rule: Rule) -> int:
         """
         Return total number of bytes scanned by a given rule
         """
-        return self._rule_bytes_scanned.get(rule, 0)
+        return self._rule_bytes_scanned.get(rule.id2, 0)
 
     def get_file_match_time(self, target: Path) -> Optional[float]:
         """
@@ -103,7 +104,7 @@ class ProfilingData:
         return self._file_num_times_scanned.get(target, 0)
 
     def set_file_times(
-        self, target: Path, times: Dict[Rule, Times], run_time: float
+        self, target: Path, times: Dict[core.RuleId, Times], run_time: float
     ) -> None:
         num_bytes = target.stat().st_size
 

--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -10,6 +10,7 @@ from typing import Sequence
 from typing import Set
 from typing import Union
 
+import semgrep.output_from_core as core
 from semgrep.constants import RuleSeverity
 from semgrep.error import InvalidRuleSchemaError
 from semgrep.rule_lang import EmptySpan
@@ -127,8 +128,12 @@ class Rule:
         return self._excludes
 
     @property
-    def id(self) -> str:
+    def id(self) -> str:  # TODO: return a core.RuleId
         return self._id
+
+    @property
+    def id2(self) -> core.RuleId:  # TODO: merge with id
+        return core.RuleId(self._id)
 
     @property
     def message(self) -> str:

--- a/semgrep/tests/unit/test_metric_manager.py
+++ b/semgrep/tests/unit/test_metric_manager.py
@@ -147,10 +147,10 @@ def test_timings(snapshot) -> None:
         profiling_data = ProfilingData()
 
         target_a_time = {
-            rule1: Times(match_time=0.2, parse_time=0.3),
+            rule1.id2: Times(match_time=0.2, parse_time=0.3),
         }
         target_b_time = {
-            rule2: Times(match_time=1.2, parse_time=0.2),
+            rule2.id2: Times(match_time=1.2, parse_time=0.2),
         }
         profiling_data.set_file_times(targets[0], target_a_time, 0.4)
         profiling_data.set_file_times(targets[1], target_b_time, 1.4)


### PR DESCRIPTION
This is part of the work to reduce core_output.py
by using directly types from output_from_core.py

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)