### PR TITLE
fix(rule): language order sent to core is deterministic

### DIFF
--- a/semgrep/semgrep/rule.py
+++ b/semgrep/semgrep/rule.py
@@ -61,7 +61,7 @@ class Rule:
             language == LANGUAGE.resolve("javascript") for language in rule_languages
         ):
             rule_languages.add(LANGUAGE.resolve("typescript"))
-            self._raw["languages"] = [str(l) for l in rule_languages]
+            self._raw["languages"] = sorted(str(l) for l in rule_languages)
 
         self._languages = sorted(rule_languages)
 


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/5106

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
