### PR TITLE
[refactor] reduce distance between SemgrepCoreError and core.Error

### DIFF
--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -5,6 +5,7 @@ json output into a typed object
 The precise type of the response from semgrep-core is specified in
 https://github.com/returntocorp/semgrep/blob/develop/interfaces/Output_from_core.atd
 """
+from dataclasses import replace
 from pathlib import Path
 from typing import Dict
 from typing import List
@@ -50,16 +51,7 @@ def core_error_to_semgrep_error(err: core.Error) -> SemgrepCoreError:
         code = 2
 
     return SemgrepCoreError(
-        code,
-        level,
-        err.error_type,
-        reported_rule_id,
-        Path(err.location.path),
-        err.location.start,
-        err.location.end,
-        err.message,
-        spans,
-        err.details,
+        code, level, reported_rule_id, spans, replace(err, rule_id=reported_rule_id)
     )
 
 

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -27,7 +27,7 @@ logger = getLogger(__name__)
 
 
 def core_error_to_semgrep_error(err: core.Error) -> SemgrepCoreError:
-    reported_rule_id = err.rule_id
+    final_rule_id = err.rule_id
 
     # Hackily convert the level string to Semgrep expectations
     level_str = err.severity.kind
@@ -46,13 +46,11 @@ def core_error_to_semgrep_error(err: core.Error) -> SemgrepCoreError:
     # See https://semgrep.dev/docs/cli-usage/ for meaning of codes
     if err.error_type == "Syntax error" or err.error_type == "Lexical error":
         code = 3
-        reported_rule_id = None  # Rule id not important for parse errors
+        final_rule_id = None  # Rule id not important for parse errors
     else:
         code = 2
 
-    return SemgrepCoreError(
-        code, level, reported_rule_id, spans, replace(err, rule_id=reported_rule_id)
-    )
+    return SemgrepCoreError(code, level, spans, replace(err, rule_id=final_rule_id))
 
 
 def parse_core_output(raw_json: JsonObject) -> core.MatchResults:

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -106,6 +106,8 @@ def setrlimits_preexec_fn() -> None:
     logger.info("Failed to change stack limits")
 
 
+# This is used only to dedup errors from validate_configs(). For dedupping errors
+# from _invoke_semgrep(), see output.py and the management of self.error_set
 def dedup_errors(errors: List[SemgrepCoreError]) -> List[SemgrepCoreError]:
     return list({uniq_error_id(e): e for e in errors}.values())
 
@@ -113,7 +115,13 @@ def dedup_errors(errors: List[SemgrepCoreError]) -> List[SemgrepCoreError]:
 def uniq_error_id(
     error: SemgrepCoreError,
 ) -> Tuple[int, Path, core.Position, core.Position, str]:
-    return (error.code, error.path, error.start, error.end, error.message)
+    return (
+        error.code,
+        Path(error.core.location.path),
+        error.core.location.start,
+        error.core.location.end,
+        error.core.message,
+    )
 
 
 class StreamingSemgrepCore:

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -206,7 +206,9 @@ class TextFormatter(BaseFormatter):
             for err in error_output
             if SemgrepError.semgrep_error_type(err) == "SemgrepCoreError"
         ]
-        errors = {(err.path, err.error_type) for err in semgrep_core_errors}
+        errors = {
+            (err.core.location.path, err.core.error_type) for err in semgrep_core_errors
+        }
 
         error_types = {k: len(list(v)) for k, v in groupby(errors, lambda x: x[1])}
         num_errors = len(errors)

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -205,9 +205,13 @@ class OutputHandler:
                 self.error_set.add(err)
 
                 if not err.rule_id:
-                    timeout_errors[err.path].append("<unknown rule_id>")
+                    timeout_errors[Path(err.core.location.path)].append(
+                        "<unknown rule_id>"
+                    )
                 else:
-                    timeout_errors[err.path].append(err.rule_id.value)
+                    timeout_errors[Path(err.core.location.path)].append(
+                        err.rule_id.value
+                    )
             else:
                 self._handle_semgrep_error(err)
 
@@ -314,7 +318,7 @@ class OutputHandler:
                 for err in self.semgrep_structured_errors
                 if SemgrepError.semgrep_error_type(err) == "SemgrepCoreError"
             ]
-            paths = {err.path for err in semgrep_core_errors}
+            paths = {Path(err.core.location.path) for err in semgrep_core_errors}
             final_error = self.semgrep_structured_errors[-1]
             self.ignore_log.failed_to_analyze.update(paths)
 

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -204,13 +204,13 @@ class OutputHandler:
                 self.semgrep_structured_errors.append(err)
                 self.error_set.add(err)
 
-                if not err.rule_id:
+                if not err.core.rule_id:
                     timeout_errors[Path(err.core.location.path)].append(
                         "<unknown rule_id>"
                     )
                 else:
                     timeout_errors[Path(err.core.location.path)].append(
-                        err.rule_id.value
+                        err.core.rule_id.value
                     )
             else:
                 self._handle_semgrep_error(err)


### PR DESCRIPTION
This will enable at some point the PA team to extend the error type
and get the extra information sent out by the CLI, without having
to modift the python code

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)