### PR TITLE
[refactor] reduce distance between core.Match and RuleMatch

### DIFF
--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -109,14 +109,14 @@ def core_matches_to_rule_matches(
         fix = interpolate(rule.fix, metavariables) if rule.fix else None
 
         return RuleMatch(
-            match.rule_id.value,
+            rule_id_=match.rule_id,
+            location=match.location,
+            extra=match.extra.to_json(),
             message=message,
             metadata=rule.metadata,
             severity=rule.severity,
             fix=fix,
             fix_regex=rule.fix_regex,
-            location=match.location,
-            extra=match.extra.to_json(),
         )
 
     # TODO: Dict[core.RuleId, RuleMatchSet]

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -6,7 +6,6 @@ The precise type of the response from semgrep-core is specified in
 https://github.com/returntocorp/semgrep/blob/develop/interfaces/Output_from_core.atd
 """
 from dataclasses import replace
-from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -116,9 +115,7 @@ def core_matches_to_rule_matches(
             severity=rule.severity,
             fix=fix,
             fix_regex=rule.fix_regex,
-            path=Path(match.location.path),
-            start=match.location.start,
-            end=match.location.end,
+            location=match.location,
             extra=match.extra.to_json(),
         )
 

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -109,8 +109,7 @@ def core_matches_to_rule_matches(
         fix = interpolate(rule.fix, metavariables) if rule.fix else None
 
         return RuleMatch(
-            rule_id_=match.rule_id,
-            location=match.location,
+            match=match,
             extra=match.extra.to_json(),
             message=message,
             metadata=rule.metadata,

--- a/semgrep/semgrep/dependency_aware_rule.py
+++ b/semgrep/semgrep/dependency_aware_rule.py
@@ -4,6 +4,7 @@ from typing import Generator
 from typing import List
 from typing import Tuple
 
+import semgrep.output_from_core as core
 from dependencyparser.find_lockfiles import DependencyTrie
 from dependencyparser.models import languages_to_namespaces
 from dependencyparser.models import LockfileDependency
@@ -11,7 +12,6 @@ from dependencyparser.models import PackageManagers
 from dependencyparser.package_restrictions import dependencies_range_match_any
 from dependencyparser.package_restrictions import ProjectDependsOnEntry
 from semgrep.error import SemgrepError
-from semgrep.output_from_core import Position
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
 
@@ -113,11 +113,13 @@ def run_dependency_aware_rule(
                     message=rule.message,
                     metadata=rule.metadata,
                     severity=rule.severity,
-                    path=lockfile_path,
                     fix=None,
                     fix_regex=None,
-                    start=Position(0, 0, 0),
-                    end=Position(0, 0, 0),
+                    location=core.Location(
+                        path=str(lockfile_path),
+                        start=core.Position(0, 0, 0),
+                        end=core.Position(0, 0, 0),
+                    ),
                     extra={
                         "dependency_match_only": True,
                         "dependency_matches": output_for_json,

--- a/semgrep/semgrep/dependency_aware_rule.py
+++ b/semgrep/semgrep/dependency_aware_rule.py
@@ -109,12 +109,12 @@ def run_dependency_aware_rule(
             matches = matches_remaining
             if not reachable:
                 dependency_only_match = RuleMatch(
-                    rule_id=rule.id,
                     message=rule.message,
                     metadata=rule.metadata,
                     severity=rule.severity,
                     fix=None,
                     fix_regex=None,
+                    rule_id_=core.RuleId(rule.id),
                     location=core.Location(
                         path=str(lockfile_path),
                         start=core.Position(0, 0, 0),

--- a/semgrep/semgrep/dependency_aware_rule.py
+++ b/semgrep/semgrep/dependency_aware_rule.py
@@ -114,11 +114,16 @@ def run_dependency_aware_rule(
                     severity=rule.severity,
                     fix=None,
                     fix_regex=None,
-                    rule_id_=core.RuleId(rule.id),
-                    location=core.Location(
-                        path=str(lockfile_path),
-                        start=core.Position(0, 0, 0),
-                        end=core.Position(0, 0, 0),
+                    match=core.Match(
+                        rule_id=core.RuleId(rule.id),
+                        location=core.Location(
+                            path=str(lockfile_path),
+                            start=core.Position(0, 0, 0),
+                            end=core.Position(0, 0, 0),
+                        ),
+                        # TODO: we need to define the fields below in
+                        # Output_from_core.atd so we can reuse core.MatchExtra
+                        extra=core.MatchExtra(metavars={}),
                     ),
                     extra={
                         "dependency_match_only": True,

--- a/semgrep/semgrep/join_rule.py
+++ b/semgrep/semgrep/join_rule.py
@@ -535,7 +535,7 @@ def run_join_rule(
 
     rule_matches = [
         RuleMatch(
-            rule_id=join_rule.get("id", match.get("check_id", "[empty]")),
+            rule_id_=join_rule.get("id", match.get("check_id", "[empty]")),
             message=join_rule.get(
                 "message", match.get("extra", {}).get("message", "[empty]")
             ),

--- a/semgrep/semgrep/join_rule.py
+++ b/semgrep/semgrep/join_rule.py
@@ -535,7 +535,6 @@ def run_join_rule(
 
     rule_matches = [
         RuleMatch(
-            rule_id_=join_rule.get("id", match.get("check_id", "[empty]")),
             message=join_rule.get(
                 "message", match.get("extra", {}).get("message", "[empty]")
             ),
@@ -547,10 +546,17 @@ def run_join_rule(
                     "severity", match.get("severity", RuleSeverity.INFO.value)
                 )
             ),
-            location=core.Location(
-                path=match.get("path", "[empty]"),
-                start=core.Position.from_json(match["start"]),
-                end=core.Position.from_json(match["end"]),
+            match=core.Match(
+                rule_id=core.RuleId(
+                    join_rule.get("id", match.get("check_id", "[empty]"))
+                ),
+                location=core.Location(
+                    path=match.get("path", "[empty]"),
+                    start=core.Position.from_json(match["start"]),
+                    end=core.Position.from_json(match["end"]),
+                ),
+                # TODO? extra=core.MatchExtra.from_json(match.get("extra", {})),
+                extra=core.MatchExtra(metavars={}),
             ),
             extra=match.get("extra", {}),
             fix=None,

--- a/semgrep/semgrep/join_rule.py
+++ b/semgrep/semgrep/join_rule.py
@@ -547,9 +547,11 @@ def run_join_rule(
                     "severity", match.get("severity", RuleSeverity.INFO.value)
                 )
             ),
-            path=Path(match.get("path", "[empty]")),
-            start=core.Position.from_json(match["start"]),
-            end=core.Position.from_json(match["end"]),
+            location=core.Location(
+                path=match.get("path", "[empty]"),
+                start=core.Position.from_json(match["start"]),
+                end=core.Position.from_json(match["end"]),
+            ),
             extra=match.get("extra", {}),
             fix=None,
             fix_regex=None,

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -43,11 +43,11 @@ class RuleMatch:
     TODO: Rename this class to Finding?
     """
 
-    rule_id: str  # TODO: core.RuleId
+    rule_id_: core.RuleId
+    location: core.Location
+
     message: str = field(repr=False)
     severity: RuleSeverity
-
-    location: core.Location
 
     metadata: Dict[str, Any] = field(repr=False, factory=dict)
     extra: Dict[str, Any] = field(repr=False, factory=dict)
@@ -70,6 +70,10 @@ class RuleMatch:
     ci_unique_key: Tuple = field(init=False, repr=False)
     ordering_key: Tuple = field(init=False, repr=False)
     syntactic_id: str = field(init=False, repr=False)
+
+    @property
+    def rule_id(self) -> str:
+        return self.rule_id_.value
 
     @property
     def path(self) -> Path:

--- a/semgrep/tests/unit/test_rule_match.py
+++ b/semgrep/tests/unit/test_rule_match.py
@@ -21,7 +21,7 @@ def test_rule_match_attributes():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match = RuleMatch(
-            rule_id="long.rule.id",
+            rule_id_=core.RuleId("long.rule.id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -54,7 +54,7 @@ def test_rule_match_sorting():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         line3 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -64,7 +64,7 @@ def test_rule_match_sorting():
             ),
         )
         line4 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -91,7 +91,7 @@ def test_rule_match_hashing():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -116,7 +116,7 @@ def test_rule_match_is_nosemgrep_agnostic():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match_1 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -136,7 +136,7 @@ def test_rule_match_is_nosemgrep_agnostic():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match_2 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -157,7 +157,7 @@ def test_rule_match_is_nosemgrep_agnostic():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match_3 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -188,7 +188,7 @@ def test_rule_match_set_indexes():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         line3 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -198,7 +198,7 @@ def test_rule_match_set_indexes():
             ),
         )
         line4 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -208,7 +208,7 @@ def test_rule_match_set_indexes():
             ),
         )
         line5 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(
@@ -218,7 +218,7 @@ def test_rule_match_set_indexes():
             ),
         )
         line6 = RuleMatch(
-            rule_id="rule_id",
+            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
             location=core.Location(

--- a/semgrep/tests/unit/test_rule_match.py
+++ b/semgrep/tests/unit/test_rule_match.py
@@ -24,9 +24,11 @@ def test_rule_match_attributes():
             rule_id="long.rule.id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("relative/path/to/foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
+            location=core.Location(
+                path="relative/path/to/foo.py",
+                start=core.Position(3, 1, 24),
+                end=core.Position(3, 15, 38),
+            ),
         )
     assert match.lines == ["    5 == 5 # nosem\n"], "wrong line was read from file"
     assert (
@@ -55,17 +57,21 @@ def test_rule_match_sorting():
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(3, 1, 24),
+                end=core.Position(3, 15, 38),
+            ),
         )
         line4 = RuleMatch(
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(4, 1, 36),
-            end=core.Position(4, 15, 50),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(4, 1, 36),
+                end=core.Position(4, 15, 50),
+            ),
         )
     # fmt: off
     assert (
@@ -88,9 +94,11 @@ def test_rule_match_hashing():
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(3, 1, 24),
+                end=core.Position(3, 15, 38),
+            ),
         )
     assert {match, match} == {match}, "matches must deduplicate when added to a set"
 
@@ -111,9 +119,11 @@ def test_rule_match_is_nosemgrep_agnostic():
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(3, 1, 28),
-            end=core.Position(5, 2, 48),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(3, 1, 28),
+                end=core.Position(5, 2, 48),
+            ),
         )
     file_content = dedent(
         """
@@ -129,9 +139,11 @@ def test_rule_match_is_nosemgrep_agnostic():
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(3, 1, 28),
-            end=core.Position(5, 2, 72),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(3, 1, 28),
+                end=core.Position(5, 2, 72),
+            ),
         )
     file_content = dedent(
         """
@@ -148,9 +160,11 @@ def test_rule_match_is_nosemgrep_agnostic():
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(4, 1, 55),
-            end=core.Position(6, 2, 75),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(4, 1, 55),
+                end=core.Position(6, 2, 75),
+            ),
         )
     assert (
         match_1.ci_unique_key == match_2.ci_unique_key
@@ -177,33 +191,41 @@ def test_rule_match_set_indexes():
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(3, 1, 24),
-            end=core.Position(3, 15, 38),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(3, 1, 24),
+                end=core.Position(3, 15, 38),
+            ),
         )
         line4 = RuleMatch(
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(4, 1, 36),
-            end=core.Position(4, 15, 50),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(4, 1, 36),
+                end=core.Position(4, 15, 50),
+            ),
         )
         line5 = RuleMatch(
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(5, 1, 48),
-            end=core.Position(5, 15, 62),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(5, 1, 48),
+                end=core.Position(5, 15, 62),
+            ),
         )
         line6 = RuleMatch(
             rule_id="rule_id",
             message="message",
             severity=RuleSeverity.ERROR,
-            path=Path("foo.py"),
-            start=core.Position(6, 1, 60),
-            end=core.Position(6, 15, 74),
+            location=core.Location(
+                path="foo.py",
+                start=core.Position(6, 1, 60),
+                end=core.Position(6, 15, 74),
+            ),
         )
         matches = RuleMatchSet()
         matches.update(

--- a/semgrep/tests/unit/test_rule_match.py
+++ b/semgrep/tests/unit/test_rule_match.py
@@ -21,13 +21,16 @@ def test_rule_match_attributes():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match = RuleMatch(
-            rule_id_=core.RuleId("long.rule.id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="relative/path/to/foo.py",
-                start=core.Position(3, 1, 24),
-                end=core.Position(3, 15, 38),
+            match=core.Match(
+                rule_id=core.RuleId("long.rule.id"),
+                location=core.Location(
+                    path="relative/path/to/foo.py",
+                    start=core.Position(3, 1, 24),
+                    end=core.Position(3, 15, 38),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
     assert match.lines == ["    5 == 5 # nosem\n"], "wrong line was read from file"
@@ -54,23 +57,29 @@ def test_rule_match_sorting():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         line3 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(3, 1, 24),
-                end=core.Position(3, 15, 38),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(3, 1, 24),
+                    end=core.Position(3, 15, 38),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
         line4 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(4, 1, 36),
-                end=core.Position(4, 15, 50),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(4, 1, 36),
+                    end=core.Position(4, 15, 50),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
     # fmt: off
@@ -91,13 +100,16 @@ def test_rule_match_hashing():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(3, 1, 24),
-                end=core.Position(3, 15, 38),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(3, 1, 24),
+                    end=core.Position(3, 15, 38),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
     assert {match, match} == {match}, "matches must deduplicate when added to a set"
@@ -116,13 +128,16 @@ def test_rule_match_is_nosemgrep_agnostic():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match_1 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(3, 1, 28),
-                end=core.Position(5, 2, 48),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(3, 1, 28),
+                    end=core.Position(5, 2, 48),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
     file_content = dedent(
@@ -136,13 +151,16 @@ def test_rule_match_is_nosemgrep_agnostic():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match_2 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(3, 1, 28),
-                end=core.Position(5, 2, 72),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(3, 1, 28),
+                    end=core.Position(5, 2, 72),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
     file_content = dedent(
@@ -157,13 +175,16 @@ def test_rule_match_is_nosemgrep_agnostic():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         match_3 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(4, 1, 55),
-                end=core.Position(6, 2, 75),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(4, 1, 55),
+                    end=core.Position(6, 2, 75),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
     assert (
@@ -188,43 +209,55 @@ def test_rule_match_set_indexes():
     ).lstrip()
     with mock.patch.object(Path, "open", mock.mock_open(read_data=file_content)):
         line3 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(3, 1, 24),
-                end=core.Position(3, 15, 38),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(3, 1, 24),
+                    end=core.Position(3, 15, 38),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
         line4 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(4, 1, 36),
-                end=core.Position(4, 15, 50),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(4, 1, 36),
+                    end=core.Position(4, 15, 50),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
         line5 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(5, 1, 48),
-                end=core.Position(5, 15, 62),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(5, 1, 48),
+                    end=core.Position(5, 15, 62),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
         line6 = RuleMatch(
-            rule_id_=core.RuleId("rule_id"),
             message="message",
             severity=RuleSeverity.ERROR,
-            location=core.Location(
-                path="foo.py",
-                start=core.Position(6, 1, 60),
-                end=core.Position(6, 15, 74),
+            match=core.Match(
+                rule_id=core.RuleId("rule_id"),
+                location=core.Location(
+                    path="foo.py",
+                    start=core.Position(6, 1, 60),
+                    end=core.Position(6, 15, 74),
+                ),
+                extra=core.MatchExtra(metavars={}),
             ),
         )
         matches = RuleMatchSet()


### PR DESCRIPTION
This is similar to https://github.com/returntocorp/semgrep/pull/5112

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)