### PR TITLE
Turn off garbage collector tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - YAML parsing is more tolerant of `{}` appearing when it expects a scalar,
   allowing extensions of YAML that use `{}` to be parsed (#4849)
+- Turn off optimization that trades off memory for performance because
+  the effect is minor (with current parameters)
 
 ### Fixed
 

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -653,7 +653,12 @@ let main () =
       (* main entry *)
       (* --------------------------------------------------------- *)
       | roots ->
-          if !Flag.gc_tuning && config.max_memory_mb = 0 then set_gc ();
+          (* TODO: We used to tune the garbage collector but from profiling
+             we found that the effect was small. Meanwhile, the memory
+             consumption causes some machines to freeze. We may want to
+             tune these parameters in the future/do more testing, but
+             for now just turn it off *)
+          (* if !Flag.gc_tuning && config.max_memory_mb = 0 then set_gc (); *)
           let config = { config with roots } in
           Run_semgrep.semgrep_dispatch config)
 


### PR DESCRIPTION
We use `set_gc` to tweak our garbage collection parameters to optimize for our
use case. It uses memory more aggressively to improve performance. However,
on very large repos, consuming more memory will cause us to reach the system
limit, thus making computers run more slowly or crash. Additionally, after profiling, it doesn't seem that our current parameters make a significant difference. Therefore, let's turn this off for now

Test plan: in perf, run

```
./run-benchmarks --config configs/ci_small_repos.yaml --filter-variant "std|no-gc-tuning" --plot-benchmarks
```

with `configs/ci_small_repos.yaml` and `configs/ci_medium_repos.yaml` to see the difference between std (before this PR) and without gc-tuning.

Also, run without gc tuning on repos `stress-test-monorepo` (e.g. `repos/intellij`) and the entire `repos` folder to see the effect of this on a large repo.

After this PR is released we probably will need to update benchmarks.

PR checklist:

- [x] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
