### PR TITLE
tainting: Optimize the test that checks for taint labels

### DIFF
--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1455,5 +1455,10 @@ let range_of_any_opt any =
   match any with
   | G.E e when Option.is_some e.e_range -> e.e_range
   | G.S s when Option.is_some s.s_range -> s.s_range
+  | G.Tk tok -> (
+      match Parse_info.token_location_of_info tok with
+      | Ok tok_loc -> Some (tok_loc, tok_loc)
+      | Error _ -> None)
+  | G.Anys [] -> None
   | _ -> extract_ranges (fun visitor -> visitor any)
   [@@profiling]

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -98,9 +98,10 @@ let any_in_ranges rule any rwms =
    * the AST at some point. *)
   match Visitor_AST.range_of_any_opt any with
   | None ->
-      logger#debug
-        "Cannot compute range, there are no real tokens in this AST: %s"
-        (G.show_any any);
+      if any <> G.Anys [] then
+        logger#info
+          "Cannot compute range, there are no real tokens in this AST: %s"
+          (G.show_any any);
       []
   | Some (tok1, tok2) ->
       let r = Range.range_of_token_locations tok1 tok2 in

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -98,8 +98,12 @@ let any_in_ranges rule any rwms =
    * the AST at some point. *)
   match Visitor_AST.range_of_any_opt any with
   | None ->
+      (* IL.any_of_orig will return `G.Anys []` for `NoOrig`, and there is
+       * no point in issuing this warning in that case.
+       * TODO: Perhaps we should avoid the call to `any_in_ranges` in the
+       * first place? *)
       if any <> G.Anys [] then
-        logger#info
+        logger#warning
           "Cannot compute range, there are no real tokens in this AST: %s"
           (G.show_any any);
       []


### PR DESCRIPTION
To know that e.g. an expression is a source of taint, we check whether
its range is in a list of pre-computed source ranges. This test may be
performned millions of times for each taint rule, so any small cost ends
up slowing things down noticeably.

test plan
% make test
% semgrep-core -lang java -rules taint.yaml stress-test-monorepo/repos/intellij-community
    ^ at least ~30s or 1.2x faster after this change, and running N taint
    ^ rules would multiply the cost by N!
    ^ where taint.yaml is just a dummy taint rule:
```
rules:
  - id: test-rule
    languages:
      - java
    message: Test
    mode: taint
    pattern-sources:
      - pattern: user_input
    pattern-sinks:
      - pattern: sink(...)
    severity: WARNING
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
