### PR TITLE
Fix mypy error with most recent requests version

### DIFF
--- a/semgrep/semgrep/app/metrics.py
+++ b/semgrep/semgrep/app/metrics.py
@@ -10,6 +10,7 @@ from typing import Sequence
 from urllib.parse import urlparse
 
 import click
+import requests
 
 from semgrep.app import app_session
 from semgrep.profiling import ProfilingData
@@ -250,11 +251,10 @@ class MetricManager:
             return
 
         try:
-            r = app_session.post(
+            r = requests.post(
                 METRICS_ENDPOINT,
                 json=self.as_dict(),
-                # metrics ingestion shouldn't see auth tokens
-                headers={"Authorization": None},
+                headers={"User-Agent": app_session.user_agent},
                 timeout=2,
             )
             r.raise_for_status()

--- a/semgrep/semgrep/app/session.py
+++ b/semgrep/semgrep/app/session.py
@@ -58,14 +58,8 @@ class AppSession(requests.Session):
     >>> from semgrep.app import app_session
     >>> app_session.get(url)
 
-    Disable custom user agent for a request:
-    >>> app_session.get(url, headers={"User-Agent": None}))
-
     Disable timeout for a request:
     >>> app_session.get(url, timeout=None)
-
-    Disable authentication for a request:
-    >>> app_session.get(url, headers={"Authorization": None})
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
The latest requests typings don't allow setting a header to None
(even though the functionality still works).
This commit removes the only usage of this feature.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
