### PR TITLE
put back fingerprint: and path: in results.json

### DIFF
--- a/interfaces/notes.txt
+++ b/interfaces/notes.txt
@@ -9,8 +9,6 @@ See https://github.com/ahrefs/atd for more information on atdgen.
 We're also using jsonschema for rule_schema.yaml (JSON schemas
 can also be specified using a YAML syntax, and they can also
 be used to check the schema of YAML files).
-WARNING: This file is a symbolic link because it can't be moved from its
-original location in semgrep/semgrep/ because its part of the installed
+WARNING: This rule_schema.yaml file is a symbolic link because it can't be moved
+from its original location in semgrep/semgrep/ because its part of the installed
 semgrep Python package and used at runtime.
-
-TODO: we should have lang.json there too

--- a/semgrep-core/src/reporting/Unit_reporting.ml
+++ b/semgrep-core/src/reporting/Unit_reporting.ml
@@ -52,9 +52,9 @@ let semgrep_cli_output =
      let files =
        Common2.glob (spf "%s/*.json" dir)
        @ (Common.files_of_dir_or_files_no_vcs_nofilter [ e2e_path ]
-         |> List.filter (fun file -> file =~ "*\\.json")
+         |> List.filter (fun file -> file =~ ".*\\.json")
          |> Common.exclude (fun file ->
-                (* just toplevel 'scanned:' and 'skipped:', no match 'results:' *)
+                (* just toplevel 'scanned:' and 'skipped:', no 'results:' *)
                 file =~ ".*test_semgrepignore_ignore_log_json_report"
                 (* empty JSON (because of timeout probably) *)
                 || file =~ ".*/test_spacegrep_timeout/"
@@ -62,20 +62,12 @@ let semgrep_cli_output =
                 || file =~ ".*/test_cli_test/"
                 (* missing offset *)
                 || file =~ ".*/test_max_target_bytes/"
-                || file =~ ".*/test_equivalence/"
-                (* missing offset and extra debug: field *)
-                || file =~ ".*/test_debugging_json/"
                 (* different API *)
                 || file =~ ".*/test_dump_ast/"
                 (* different JSON, for findings API *)
                 || file =~ ".*/test_ci/"
                 (* too long filename exn in alcotest, and no fingerprint *)
                 || file =~ ".*/test_join_rules/"
-                (* no fingerprint *)
-                || file =~ ".*/test_subshell_input"
-                || file =~ ".*/test_multi_subshell_input"
-                || file =~ ".*/test_stdin_input"
-                || file =~ ".*/test_file_not_relative_to_base_path/"
                 || false))
      in
      files

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -64,7 +64,8 @@ def _clean_output_json(output_json: str) -> str:
             p = r.get("path")
             if p and "/tmp" in p:
                 del r["path"]
-                del r["extra"]["fingerprint"]  # the fingerprint contains the path too
+                # the fingerprint contains the path too
+                r["extra"]["fingerprint"] = "0x42"
 
     paths = output.get("paths", {})
     if paths.get("scanned"):

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -63,7 +63,7 @@ def _clean_output_json(output_json: str) -> str:
         for r in results:
             p = r.get("path")
             if p and "/tmp" in p:
-                del r["path"]
+                r["path"] = "/tmp/masked/path"
                 # the fingerprint contains the path too
                 r["extra"]["fingerprint"] = "0x42"
 

--- a/semgrep/tests/e2e/snapshots/test_check/test_multi_subshell_input/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multi_subshell_input/results.json
@@ -16,6 +16,7 @@
         "offset": 5
       },
       "extra": {
+        "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "b + a",
         "message": "a",
@@ -37,6 +38,7 @@
         "offset": 1
       },
       "extra": {
+        "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "a",
         "message": "a",

--- a/semgrep/tests/e2e/snapshots/test_check/test_multi_subshell_input/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_multi_subshell_input/results.json
@@ -24,6 +24,7 @@
         "metavars": {},
         "severity": "ERROR"
       },
+      "path": "/tmp/masked/path",
       "start": {
         "col": 5,
         "line": 1,
@@ -46,6 +47,7 @@
         "metavars": {},
         "severity": "ERROR"
       },
+      "path": "/tmp/masked/path",
       "start": {
         "col": 1,
         "line": 1,

--- a/semgrep/tests/e2e/snapshots/test_check/test_stdin_input/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_stdin_input/results.json
@@ -23,6 +23,7 @@
         "metavars": {},
         "severity": "ERROR"
       },
+      "path": "/tmp/masked/path",
       "start": {
         "col": 1,
         "line": 1,

--- a/semgrep/tests/e2e/snapshots/test_check/test_stdin_input/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_stdin_input/results.json
@@ -15,6 +15,7 @@
         "offset": 1
       },
       "extra": {
+        "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "a",
         "message": "a",

--- a/semgrep/tests/e2e/snapshots/test_check/test_subshell_input/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_subshell_input/results.json
@@ -23,6 +23,7 @@
         "metavars": {},
         "severity": "ERROR"
       },
+      "path": "/tmp/masked/path",
       "start": {
         "col": 1,
         "line": 1,

--- a/semgrep/tests/e2e/snapshots/test_check/test_subshell_input/results.json
+++ b/semgrep/tests/e2e/snapshots/test_check/test_subshell_input/results.json
@@ -15,6 +15,7 @@
         "offset": 1
       },
       "extra": {
+        "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "a",
         "message": "a",

--- a/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.json
+++ b/semgrep/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.json
@@ -14,49 +14,6 @@
     {
       "check_id": "rules.dependency_aware.js-sca",
       "end": {
-        "col": 6,
-        "line": 1,
-        "offset": 5
-      },
-      "extra": {
-        "dependency_match_only": false,
-        "dependency_matches": [
-          {
-            "dependency_pattern": {
-              "namespace": "npm",
-              "package_name": "bad-lib",
-              "semver_range": "< 0.0.8"
-            },
-            "found_dependency": {
-              "allowed_hashes": {},
-              "name": "bad-lib",
-              "namespace": "npm",
-              "resolved_url": [
-                "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz"
-              ],
-              "version": "0.0.7"
-            },
-            "lockfile": "yarn.lock"
-          }
-        ],
-        "fingerprint": "f259dbe78c5afaa7d5dbc8059abb0792",
-        "is_ignored": false,
-        "lines": "bad()",
-        "message": "oh no",
-        "metadata": {},
-        "metavars": {},
-        "severity": "WARNING"
-      },
-      "path": "targets/dependency_aware/monorepo/webapp1/app.js",
-      "start": {
-        "col": 1,
-        "line": 1,
-        "offset": 0
-      }
-    },
-    {
-      "check_id": "rules.dependency_aware.js-sca",
-      "end": {
         "col": 0,
         "line": 0,
         "offset": 0
@@ -97,48 +54,45 @@
       }
     },
     {
-      "check_id": "rules.dependency_aware.go-sca",
+      "check_id": "rules.dependency_aware.js-sca",
       "end": {
-        "col": 0,
-        "line": 0,
-        "offset": 0
+        "col": 6,
+        "line": 1,
+        "offset": 5
       },
       "extra": {
-        "dependency_match_only": true,
+        "dependency_match_only": false,
         "dependency_matches": [
           {
             "dependency_pattern": {
-              "namespace": "gomod",
-              "package_name": "github.com/bad-lib",
-              "semver_range": "== 0.3.1"
+              "namespace": "npm",
+              "package_name": "bad-lib",
+              "semver_range": "< 0.0.8"
             },
             "found_dependency": {
-              "allowed_hashes": {
-                "gomod": [
-                  "xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU"
-                ]
-              },
-              "name": "github.com/bad-lib",
-              "namespace": "gomod",
+              "allowed_hashes": {},
+              "name": "bad-lib",
+              "namespace": "npm",
               "resolved_url": [
-                "github.com/bad-lib"
+                "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz"
               ],
-              "version": "0.3.1"
+              "version": "0.0.7"
             },
-            "lockfile": "go.sum"
+            "lockfile": "yarn.lock"
           }
         ],
-        "fingerprint": "322be9aa5aaeedf070e32bc5c825b878",
+        "fingerprint": "f259dbe78c5afaa7d5dbc8059abb0792",
         "is_ignored": false,
-        "lines": "",
+        "lines": "bad()",
         "message": "oh no",
         "metadata": {},
+        "metavars": {},
         "severity": "WARNING"
       },
-      "path": "targets/dependency_aware/monorepo/webapp1/experiment/go.sum",
+      "path": "targets/dependency_aware/monorepo/webapp1/app.js",
       "start": {
-        "col": 0,
-        "line": 0,
+        "col": 1,
+        "line": 1,
         "offset": 0
       }
     },
@@ -187,6 +141,52 @@
         "col": 2,
         "line": 2,
         "offset": 15
+      }
+    },
+    {
+      "check_id": "rules.dependency_aware.go-sca",
+      "end": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      },
+      "extra": {
+        "dependency_match_only": true,
+        "dependency_matches": [
+          {
+            "dependency_pattern": {
+              "namespace": "gomod",
+              "package_name": "github.com/bad-lib",
+              "semver_range": "== 0.3.1"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "gomod": [
+                  "xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU"
+                ]
+              },
+              "name": "github.com/bad-lib",
+              "namespace": "gomod",
+              "resolved_url": [
+                "github.com/bad-lib"
+              ],
+              "version": "0.3.1"
+            },
+            "lockfile": "go.sum"
+          }
+        ],
+        "fingerprint": "322be9aa5aaeedf070e32bc5c825b878",
+        "is_ignored": false,
+        "lines": "",
+        "message": "oh no",
+        "metadata": {},
+        "severity": "WARNING"
+      },
+      "path": "targets/dependency_aware/monorepo/webapp1/experiment/go.sum",
+      "start": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
       }
     }
   ]

--- a/semgrep/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.json
+++ b/semgrep/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.json
@@ -23,6 +23,7 @@
         "metavars": {},
         "severity": "ERROR"
       },
+      "path": "/tmp/masked/path",
       "start": {
         "col": 1,
         "line": 1,

--- a/semgrep/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.json
+++ b/semgrep/tests/e2e/snapshots/test_ignores/test_file_not_relative_to_base_path/results.json
@@ -15,6 +15,7 @@
         "offset": 1
       },
       "extra": {
+        "fingerprint": "0x42",
         "is_ignored": false,
         "lines": "a",
         "message": "a",


### PR DESCRIPTION
This allows to sanity check that those JSON follows the ATD spec
for semgrep JSON output

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)