### PR TITLE
tainting: Restore -dfg_tainting and make it more useful

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -418,6 +418,7 @@ let all_actions () =
     ("-test_eval", " <JSON file>", Common.mk_action_1_arg Eval_generic.test_eval);
   ]
   @ Test_analyze_generic.actions ~parse_program:Parse_target.parse_program
+  @ Test_dataflow_tainting.actions ()
   @ Test_naming_generic.actions ~parse_program:Parse_target.parse_program
 
 let options () =

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -1,6 +1,7 @@
 open Common
 open AST_generic
 module H = AST_generic_helpers
+module RM = Range_with_metavars
 
 module DataflowX = Dataflow_core.Make (struct
   type node = IL.node
@@ -10,11 +11,35 @@ module DataflowX = Dataflow_core.Make (struct
   let short_string_of_node n = Display_IL.short_string_of_node_kind n.IL.n
 end)
 
-let test_dfg_tainting file =
-  (* TODO: Run an actual taint rule! *)
-  let ast = Parse_target.parse_program file in
+let test_dfg_tainting rules_file file =
   let lang = List.hd (Lang.langs_of_filename file) in
-  Naming_AST.resolve lang ast;
+  let rules =
+    try Parse_rule.parse rules_file with
+    | exn ->
+        failwith
+          (spf "fail to parse tainting rules %s (exn = %s)" rules_file
+             (Common.exn_to_s exn))
+  in
+  let ast =
+    try
+      let { Parse_target.ast; errors; _ } =
+        Parse_target.parse_and_resolve_name_use_pfff_or_treesitter lang file
+      in
+      if errors <> [] then pr2 (spf "WARNING: fail to fully parse %s" file);
+      ast
+    with
+    | exn ->
+        failwith (spf "fail to parse %s (exn = %s)" file (Common.exn_to_s exn))
+  in
+  let rules =
+    rules
+    |> List.filter (fun r ->
+           match r.Rule.languages with
+           | Xlang.L (x, xs) -> List.mem lang (x :: xs)
+           | _ -> false)
+  in
+  let _search_rules, taint_rules = Rule.partition_rules rules in
+  let rule, taint_spec = List.hd taint_rules in
   ast
   |> List.iter (fun item ->
          match item.s with
@@ -22,21 +47,49 @@ let test_dfg_tainting file =
              let xs = AST_to_IL.stmt lang (H.funcbody_to_stmt def.fbody) in
              let flow = CFG_build.cfg_of_stmts xs in
              pr2 "Tainting";
-             let config =
-               {
-                 Dataflow_tainting.filepath = file;
-                 rule_id = "test_dfg_tainting";
-                 is_source = (fun _ -> []);
-                 is_sink = (fun _ -> []);
-                 is_sanitizer = (fun _ -> []);
-                 unify_mvars = false;
-                 handle_findings = (fun _ _ _ -> ());
-               }
+             pr2 "========";
+             let handle_findings _ _ _ = () in
+             let config, debug_taint =
+               Match_tainting_rules.taint_config_of_rule
+                 Config_semgrep.default_config [] file (ast, []) rule taint_spec
+                 handle_findings
              in
+             Common.pr2 "\nSources";
+             Common.pr2 "-------";
+             debug_taint.sources
+             |> List.iter (fun rwm ->
+                    Common.pr2 (Range.content_at_range file rwm.RM.r));
+             Common.pr2 "\nSanitizers";
+             Common.pr2 "----------";
+             debug_taint.sanitizers
+             |> List.iter (fun rwm ->
+                    Common.pr2 (Range.content_at_range file rwm.RM.r));
+             Common.pr2 "\nSinks";
+             Common.pr2 "-----";
+             debug_taint.sinks
+             |> List.iter (fun rwm ->
+                    Common.pr2 (Range.content_at_range file rwm.RM.r));
+             Common.pr2 "\nDataflow";
+             Common.pr2 "--------";
              let mapping = Dataflow_tainting.fixpoint config flow in
-             DataflowX.display_mapping flow mapping (fun _ ->
-                 "<pattern matches>")
+             DataflowX.display_mapping flow mapping (fun taint ->
+                 let open Dataflow_tainting in
+                 let show_taint t =
+                   match t.orig with
+                   | Src src ->
+                       let tok1, tok2 = (pm_of_dm src).range_loc in
+                       let r = Range.range_of_token_locations tok1 tok2 in
+                       Range.content_at_range file r
+                   | Arg i -> spf "arg %d" i
+                 in
+                 taint |> Taint.elements |> Common.map show_taint
+                 |> String.concat ", "
+                 |> fun str -> "{ " ^ str ^ " }")
          | _ -> ())
 
 let actions () =
-  [ ("-dfg_tainting", " <file>", Common.mk_action_1_arg test_dfg_tainting) ]
+  [
+    ( "-dfg_tainting",
+      "<rules> <target>",
+      Common.mk_action_2_arg test_dfg_tainting );
+  ]


### PR DESCRIPTION
It takes a taint rule and a target file, and shows how the taint flows
through the instructions. It also shows what fragments of code correspond
to sources, sanitizers, and sinks.

test plan:
semgrep-core -dfg_tainting tests/tainting_rules/python/tainting.yaml tests/tainting_rules/python/tainting.py

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
