### PR TITLE
[refactor] Use more classes from semgrep_scan_output_v1.py

### DIFF
--- a/semgrep/semgrep/formatter/base.py
+++ b/semgrep/semgrep/formatter/base.py
@@ -6,6 +6,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
 from semgrep.rule import Rule
@@ -18,13 +19,18 @@ class BaseFormatter(abc.ABC):
         rules: FrozenSet[Rule],
         rule_matches: Sequence[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
         shown_severities: Collection[RuleSeverity],
     ) -> str:
         filtered_rules = (r for r in rules if r.severity in shown_severities)
         filtered_matches = (m for m in rule_matches if m.severity in shown_severities)
         return self.format(
-            filtered_rules, filtered_matches, semgrep_structured_errors, extra
+            filtered_rules,
+            filtered_matches,
+            semgrep_structured_errors,
+            cli_output_extra,
+            extra,
         )
 
     @abc.abstractmethod
@@ -33,6 +39,7 @@ class BaseFormatter(abc.ABC):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         raise NotImplementedError

--- a/semgrep/semgrep/formatter/emacs.py
+++ b/semgrep/semgrep/formatter/emacs.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep.constants import CLI_RULE_ID
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
@@ -34,6 +35,7 @@ class EmacsFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         sorted_matches = sorted(rule_matches, key=lambda r: (r.path, r.rule_id))

--- a/semgrep/semgrep/formatter/gitlab_sast.py
+++ b/semgrep/semgrep/formatter/gitlab_sast.py
@@ -6,6 +6,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
@@ -84,6 +85,7 @@ class GitlabSastFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         """

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
 from semgrep.rule import Rule
@@ -48,6 +49,7 @@ class JsonFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         output_dict = {
@@ -55,6 +57,7 @@ class JsonFormatter(BaseFormatter):
                 self._rule_match_to_json(rule_match) for rule_match in rule_matches
             ],
             "errors": [error.to_dict() for error in semgrep_structured_errors],
+            **(cli_output_extra.to_json()),
             **extra,
         }
         # Sort keys for predictable output. This helps with snapshot tests, etc.

--- a/semgrep/semgrep/formatter/junit_xml.py
+++ b/semgrep/semgrep/formatter/junit_xml.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep.error import SemgrepError
 from semgrep.external.junit_xml import TestCase  # type: ignore[attr-defined]
 from semgrep.external.junit_xml import TestSuite  # type: ignore[attr-defined]
@@ -34,6 +35,7 @@ class JunitXmlFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         test_cases = [

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep import __VERSION__
 from semgrep.constants import RuleSeverity
 from semgrep.error import Level
@@ -137,6 +138,7 @@ class SarifFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         """

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -169,30 +169,30 @@ class TextFormatter(BaseFormatter):
 
     @staticmethod
     def _build_summary(
-        time_data: Mapping[str, Any],
+        time_data: v1.CliTiming,
         error_output: Sequence[SemgrepError],
         color_output: bool,
     ) -> Iterator[str]:
         items_to_show = 5
         col_lim = 50
 
-        targets = time_data["targets"]
+        targets = time_data.targets
 
         # Compute summary timings
-        rule_parsing_time = time_data["rules_parse_time"]
+        rule_parsing_time = time_data.rules_parse_time
         rule_match_timings = {
-            rule["id"]: sum(
-                t["match_times"][i] for t in targets if t["match_times"][i] >= 0
+            rule.id.value: sum(
+                t.match_times[i] for t in targets if t.match_times[i] >= 0
             )
-            for i, rule in enumerate(time_data["rules"])
+            for i, rule in enumerate(time_data.rules)
         }
         file_parsing_time = sum(
-            sum(t for t in target["parse_times"] if t >= 0) for target in targets
+            sum(t for t in target.parse_times if t >= 0) for target in targets
         )
         file_timings = {
-            target["path"]: (
-                sum(t for t in target["parse_times"] if t >= 0),
-                target["run_time"],
+            target.path: (
+                sum(t for t in target.parse_times if t >= 0),
+                target.run_time,
             )
             for target in targets
         }
@@ -231,8 +231,8 @@ class TextFormatter(BaseFormatter):
         ext_info = sorted(
             (
                 (
-                    lang_of_path(target["path"]),
-                    (target["num_bytes"], target["run_time"]),
+                    lang_of_path(target.path),
+                    (target.num_bytes, target.run_time),
                 )
                 for target in targets
             ),
@@ -244,15 +244,15 @@ class TextFormatter(BaseFormatter):
         lang_bytes: Mapping[str, int] = {
             lang: sum(info[1][0] for info in lang_info[lang]) for lang in langs
         }
-        lang_times: Mapping[str, int] = {
+        lang_times: Mapping[str, float] = {
             lang: sum(info[1][1] for info in lang_info[lang]) for lang in langs
         }
 
         # Output semgrep summary
-        total_time = time_data["profiling_times"].get("total_time", 0.0)
-        config_time = time_data["profiling_times"].get("config_time", 0.0)
-        core_time = time_data["profiling_times"].get("core_time", 0.0)
-        time_data["profiling_times"].get("ignores_time", 0.0)
+        total_time = time_data.profiling_times.get("total_time", 0.0)
+        config_time = time_data.profiling_times.get("config_time", 0.0)
+        core_time = time_data.profiling_times.get("core_time", 0.0)
+        # time_data.profiling_times.get("ignores_time", 0.0)
 
         yield f"\n============================[ summary ]============================"
 
@@ -404,11 +404,11 @@ class TextFormatter(BaseFormatter):
 
         timing_output = (
             self._build_summary(
-                extra.get("time", {}),  # TODO: cli_output_extra.time
+                cli_output_extra.time,
                 semgrep_structured_errors,
                 extra.get("color_output", False),
             )
-            if "time" in extra
+            if cli_output_extra.time
             else iter([])
         )
 

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -14,6 +14,7 @@ from typing import Sequence
 import click
 import colorama
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep.constants import CLI_RULE_ID
 from semgrep.constants import Colors
 from semgrep.constants import ELLIPSIS_STRING
@@ -391,6 +392,7 @@ class TextFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         output = self._build_text_output(
@@ -402,7 +404,7 @@ class TextFormatter(BaseFormatter):
 
         timing_output = (
             self._build_summary(
-                extra.get("time", {}),
+                extra.get("time", {}),  # TODO: cli_output_extra.time
                 semgrep_structured_errors,
                 extra.get("color_output", False),
             )

--- a/semgrep/semgrep/formatter/vim.py
+++ b/semgrep/semgrep/formatter/vim.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
+import semgrep.semgrep_interfaces.semgrep_scan_output_v1 as v1
 from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
@@ -32,6 +33,7 @@ class VimFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: v1.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         return "\n".join(":".join(self._get_parts(rm)) for rm in rule_matches)

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -392,6 +392,7 @@ class OutputHandler:
                 "scanned": [str(path) for path in sorted(self.all_targets)],
             }
         }
+        cli_paths: v1.CliPaths = v1.CliPaths(scanned=[], _comment=None, skipped=None)
         if self.settings.json_stats:
             extra["stats"] = {
                 "targets": make_target_stats(self.all_targets),
@@ -422,11 +423,13 @@ class OutputHandler:
                 "per_line_max_chars_limit"
             ] = self.settings.output_per_line_max_chars_limit
 
+        cli_output_extra: v1.CliOutputExtra = v1.CliOutputExtra(paths=cli_paths)
         # the rules are used only by the SARIF formatter
         return self.formatter.output(
             self.rules,
             self.rule_matches,
             self.semgrep_structured_errors,
+            cli_output_extra,
             extra,
             self.severities,
         )


### PR DESCRIPTION
The end goal is to have the full CLI JSON output specified
in ATD and generated by using autogenerated code from
semgrep_scan_output_v1.py

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)