### PR TITLE
[refactor] collateral evolutions when rename Semgrep_output_v1.atd

### DIFF
--- a/semgrep-core/src/core/Output_from_core_j.ml
+++ b/semgrep-core/src/core/Output_from_core_j.ml
@@ -1,2 +1,2 @@
 (* TODO: when ATD will gets its module system we will not need this anymore *)
-include Semgrep_output_v1_j
+include Semgrep_output_v0_j

--- a/semgrep-core/src/core/Output_from_core_t.ml
+++ b/semgrep-core/src/core/Output_from_core_t.ml
@@ -1,2 +1,2 @@
 (* TODO: when ATD will gets its module system we will not need this anymore *)
-include Semgrep_output_v1_t
+include Semgrep_output_v0_t

--- a/semgrep-core/src/core/Semgrep_output_v0.atd
+++ b/semgrep-core/src/core/Semgrep_output_v0.atd
@@ -1,0 +1,1 @@
+../../../interfaces/semgrep_interfaces/Semgrep_output_v0.atd

--- a/semgrep-core/src/core/Semgrep_output_v1.atd
+++ b/semgrep-core/src/core/Semgrep_output_v1.atd
@@ -1,1 +1,0 @@
-../../../interfaces/semgrep_interfaces/Semgrep_output_v1.atd

--- a/semgrep-core/src/core/dune
+++ b/semgrep-core/src/core/dune
@@ -58,10 +58,10 @@
 
 ; this is just used in Unit_reporting.ml
 (rule
- (targets Semgrep_output_v1_j.ml Semgrep_output_v1_j.mli)
- (deps    Semgrep_output_v1.atd)
+ (targets Semgrep_output_v0_j.ml Semgrep_output_v0_j.mli)
+ (deps    Semgrep_output_v0.atd)
  (action  (run atdgen -j -j-std %{deps})))
 (rule
- (targets Semgrep_output_v1_t.ml Semgrep_output_v1_t.mli)
- (deps    Semgrep_output_v1.atd)
+ (targets Semgrep_output_v0_t.ml Semgrep_output_v0_t.mli)
+ (deps    Semgrep_output_v0.atd)
  (action  (run atdgen -t %{deps})))

--- a/semgrep-core/src/reporting/Unit_reporting.ml
+++ b/semgrep-core/src/reporting/Unit_reporting.ml
@@ -79,7 +79,7 @@ let semgrep_cli_output =
               fun () ->
                 pr2 (spf "processing %s" file);
                 let s = Common.read_file file in
-                let _res = Semgrep_output_v1_j.cli_output_of_string s in
+                let _res = Semgrep_output_v0_j.cli_output_of_string s in
                 () )))
 
 let semgrep_scans_output =
@@ -97,7 +97,7 @@ let semgrep_scans_output =
               fun () ->
                 pr2 (spf "processing %s" file);
                 let s = Common.read_file file in
-                let _res = Semgrep_output_v1_j.api_scans_findings_of_string s in
+                let _res = Semgrep_output_v0_j.api_scans_findings_of_string s in
                 () )))
 
 (*****************************************************************************)

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -13,7 +13,7 @@ from typing import Set
 from typing import Tuple
 
 import semgrep.output_from_core as core
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.error import Level
 from semgrep.error import SemgrepCoreError
 from semgrep.error import SemgrepError
@@ -37,15 +37,15 @@ def core_error_to_semgrep_error(err: core.CoreError) -> SemgrepCoreError:
         level_str = "ERROR"
     level = Level[level_str.upper()]
 
-    spans: Optional[List[v1.ErrorSpan]] = None
+    spans: Optional[List[out.ErrorSpan]] = None
     if err.yaml_path:
         yaml_path = err.yaml_path[::-1]
         spans = [
-            v1.ErrorSpan(
-                config_start=v1.PositionBis(
+            out.ErrorSpan(
+                config_start=out.PositionBis(
                     line=err.location.start.line, col=err.location.start.col
                 ),
-                config_end=v1.PositionBis(
+                config_end=out.PositionBis(
                     line=err.location.end.line, col=err.location.end.col
                 ),
                 config_path=yaml_path,
@@ -140,7 +140,7 @@ def core_matches_to_rule_matches(
                         "optional 'count' value must be an integer when using 'fix-regex'"
                     )
 
-            fix_regex = v1.FixRegex(regex=regex, replacement=replacement, count=count)
+            fix_regex = out.FixRegex(regex=regex, replacement=replacement, count=count)
 
         return RuleMatch(
             match=match,

--- a/semgrep/semgrep/error.py
+++ b/semgrep/semgrep/error.py
@@ -15,7 +15,7 @@ from typing import Tuple
 import attr  # TODO: update to next-gen API with @define; difficult cause these subclass of Exception
 
 import semgrep.output_from_core as core
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import Colors
 from semgrep.rule_lang import Position
 from semgrep.rule_lang import SourceTracker
@@ -66,13 +66,13 @@ class SemgrepError(Exception):
 
         super().__init__(*args)
 
-    def to_CliError(self) -> v1.CliError:
-        err = v1.CliError(
+    def to_CliError(self) -> out.CliError:
+        err = out.CliError(
             code=self.code, type_=self.__class__.__name__, level=self.level.name.lower()
         )
         return self.adjust_CliError(err)
 
-    def adjust_CliError(self, base: v1.CliError) -> v1.CliError:
+    def adjust_CliError(self, base: out.CliError) -> out.CliError:
         """
         Default implementation. Subclasses should override to provide custom information.
         """
@@ -97,10 +97,10 @@ class SemgrepError(Exception):
 class SemgrepCoreError(SemgrepError):
     code: int
     level: Level
-    spans: Optional[List[v1.ErrorSpan]]
+    spans: Optional[List[out.ErrorSpan]]
     core: core.CoreError
 
-    def adjust_CliError(self, base: v1.CliError) -> v1.CliError:
+    def adjust_CliError(self, base: out.CliError) -> out.CliError:
         base = dataclasses.replace(base, type_=self.core.error_type, message=str(self))
         if self.core.rule_id:
             base = dataclasses.replace(base, rule_id=self.core.rule_id)
@@ -257,7 +257,7 @@ class ErrorWithSpan(SemgrepError):
         if not hasattr(self, "level"):
             raise ValueError("Inheritors of SemgrepError must define a level")
 
-    def adjust_CliError(self, base: v1.CliError) -> v1.CliError:
+    def adjust_CliError(self, base: out.CliError) -> out.CliError:
         base = dataclasses.replace(
             base,
             short_msg=self.short_msg,

--- a/semgrep/semgrep/formatter/base.py
+++ b/semgrep/semgrep/formatter/base.py
@@ -6,7 +6,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
 from semgrep.rule import Rule
@@ -19,7 +19,7 @@ class BaseFormatter(abc.ABC):
         rules: FrozenSet[Rule],
         rule_matches: Sequence[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
         shown_severities: Collection[RuleSeverity],
     ) -> str:
@@ -39,7 +39,7 @@ class BaseFormatter(abc.ABC):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         raise NotImplementedError

--- a/semgrep/semgrep/formatter/emacs.py
+++ b/semgrep/semgrep/formatter/emacs.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import CLI_RULE_ID
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
@@ -35,7 +35,7 @@ class EmacsFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         sorted_matches = sorted(rule_matches, key=lambda r: (r.path, r.rule_id))

--- a/semgrep/semgrep/formatter/gitlab_sast.py
+++ b/semgrep/semgrep/formatter/gitlab_sast.py
@@ -6,7 +6,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
@@ -85,7 +85,7 @@ class GitlabSastFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         """

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
 from semgrep.rule import Rule
@@ -19,10 +19,10 @@ def to_json(x: Any) -> Any:
 
 class JsonFormatter(BaseFormatter):
     @staticmethod
-    def _rule_match_to_CliMatch(rule_match: RuleMatch) -> v1.CliMatch:
-        extra = v1.CliMatchExtra(
+    def _rule_match_to_CliMatch(rule_match: RuleMatch) -> out.CliMatch:
+        extra = out.CliMatchExtra(
             message=rule_match.message,
-            metadata=v1.RawJson(v1._Identity(rule_match.metadata)),
+            metadata=out.RawJson(out._Identity(rule_match.metadata)),
             severity=rule_match.severity.value,
             fingerprint=rule_match.syntactic_id,
             # 'lines' already contains '\n' at the end of each line
@@ -31,8 +31,8 @@ class JsonFormatter(BaseFormatter):
         )
 
         if rule_match.extra.get("dependency_matches"):
-            extra.dependency_matches = v1.RawJson(
-                v1._Identity(rule_match.extra.get("dependency_matches"))
+            extra.dependency_matches = out.RawJson(
+                out._Identity(rule_match.extra.get("dependency_matches"))
             )
             extra.dependency_match_only = rule_match.extra.get("dependency_match_only")
         if rule_match.fix:
@@ -42,8 +42,8 @@ class JsonFormatter(BaseFormatter):
         if rule_match.is_ignored is not None:
             extra.is_ignored = rule_match.is_ignored
 
-        return v1.CliMatch(
-            check_id=v1.RuleId(rule_match.rule_id),
+        return out.CliMatch(
+            check_id=out.RuleId(rule_match.rule_id),
             path=str(rule_match.path),
             start=rule_match.start,
             end=rule_match.end,
@@ -55,12 +55,12 @@ class JsonFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         # Note that extra is not used here! Every part of the JSON output should
-        # be specified in Semgrep_output_v1.atd and be part of CliOutputExtra
-        output = v1.CliOutput(
+        # be specified in Semgrep_output_xxx.atd and be part of CliOutputExtra
+        output = out.CliOutput(
             results=[
                 self._rule_match_to_CliMatch(rule_match) for rule_match in rule_matches
             ],

--- a/semgrep/semgrep/formatter/junit_xml.py
+++ b/semgrep/semgrep/formatter/junit_xml.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.error import SemgrepError
 from semgrep.external.junit_xml import TestCase  # type: ignore[attr-defined]
 from semgrep.external.junit_xml import TestSuite  # type: ignore[attr-defined]
@@ -35,7 +35,7 @@ class JunitXmlFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         test_cases = [

--- a/semgrep/semgrep/formatter/sarif.py
+++ b/semgrep/semgrep/formatter/sarif.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep import __VERSION__
 from semgrep.constants import RuleSeverity
 from semgrep.error import Level
@@ -138,7 +138,7 @@ class SarifFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         """

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -14,7 +14,7 @@ from typing import Sequence
 import click
 import colorama
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import CLI_RULE_ID
 from semgrep.constants import Colors
 from semgrep.constants import ELLIPSIS_STRING
@@ -169,7 +169,7 @@ class TextFormatter(BaseFormatter):
 
     @staticmethod
     def _build_summary(
-        time_data: v1.CliTiming,
+        time_data: out.CliTiming,
         error_output: Sequence[SemgrepError],
         color_output: bool,
     ) -> Iterator[str]:
@@ -392,7 +392,7 @@ class TextFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         output = self._build_text_output(

--- a/semgrep/semgrep/formatter/vim.py
+++ b/semgrep/semgrep/formatter/vim.py
@@ -3,7 +3,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Sequence
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
@@ -33,7 +33,7 @@ class VimFormatter(BaseFormatter):
         rules: Iterable[Rule],
         rule_matches: Iterable[RuleMatch],
         semgrep_structured_errors: Sequence[SemgrepError],
-        cli_output_extra: v1.CliOutputExtra,
+        cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
     ) -> str:
         return "\n".join(":".join(self._get_parts(rm)) for rm in rule_matches)

--- a/semgrep/semgrep/output_from_core.py
+++ b/semgrep/semgrep/output_from_core.py
@@ -1,2 +1,2 @@
 # TODO: when ATD gets its module system, we would not need to this anymore
-from .semgrep_interfaces.semgrep_output_v1 import *  # noqa
+from .semgrep_interfaces.semgrep_output_v0 import *  # noqa

--- a/semgrep/semgrep/rule_lang.py
+++ b/semgrep/semgrep/rule_lang.py
@@ -26,7 +26,7 @@ from ruamel.yaml import Node
 from ruamel.yaml import RoundTripConstructor
 from ruamel.yaml import YAML
 
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 
 # Do not construct SourceFileHash directly, use `SpanBuilder().add_source`
@@ -81,7 +81,7 @@ class SourceTracker:
         return SourceFileHash(hashlib.sha256(contents).hexdigest())
 
 
-# TODO: use v1.PositionBis directly
+# TODO: use out.PositionBis directly
 @frozen(repr=False)
 class Position:
     """
@@ -95,8 +95,8 @@ class Position:
     line: int
     col: int
 
-    def to_PositionBis(self) -> v1.PositionBis:
-        return v1.PositionBis(line=self.line, col=self.col)
+    def to_PositionBis(self) -> out.PositionBis:
+        return out.PositionBis(line=self.line, col=self.col)
 
     def next_line(self) -> "Position":
         return evolve(self, line=self.line + 1)
@@ -111,7 +111,7 @@ class Position:
         return f"<{self.__class__.__name__} line={self.line} col={self.col}>"
 
 
-# TODO: use v1.ErrorSpan directly
+# TODO: use out.ErrorSpan directly
 @frozen(repr=False)
 class Span:
     """
@@ -135,7 +135,7 @@ class Span:
     config_start: Optional[Position] = None
     config_end: Optional[Position] = None
 
-    def to_ErrorSpan(self) -> v1.ErrorSpan:
+    def to_ErrorSpan(self) -> out.ErrorSpan:
         config_start = None
         if self.config_start:
             config_start = self.config_start.to_PositionBis()
@@ -149,7 +149,7 @@ class Span:
         if self.context_end:
             context_end = self.context_end.to_PositionBis()
 
-        return v1.ErrorSpan(
+        return out.ErrorSpan(
             config_start=config_start,
             config_end=config_end,
             config_path=self.config_path,

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -21,7 +21,7 @@ from attrs import field
 from attrs import frozen
 
 import semgrep.output_from_core as core
-import semgrep.semgrep_interfaces.semgrep_output_v1 as v1
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
 from semgrep.constants import NOSEM_INLINE_COMMENT_RE
 from semgrep.constants import RuleSeverity
 from semgrep.external.pymmh3 import hash128  # type: ignore[attr-defined]
@@ -67,7 +67,7 @@ class RuleMatch:
     # We call rstrip() for consistency with semgrep-core, which ignores whitespace
     # including newline chars at the end of multiline patterns
     fix: Optional[str] = field(converter=rstrip, default=None)
-    fix_regex: Optional[v1.FixRegex] = None
+    fix_regex: Optional[out.FixRegex] = None
 
     # ???
     index: int = 0
@@ -84,7 +84,7 @@ class RuleMatch:
     ordering_key: Tuple = field(init=False, repr=False)
     syntactic_id: str = field(init=False, repr=False)
 
-    # TODO: return a v1.RuleId
+    # TODO: return a out.RuleId
     @property
     def rule_id(self) -> str:
         return self.match.rule_id.value
@@ -260,7 +260,7 @@ class RuleMatch:
         """
         return "block" in self.metadata.get("dev.semgrep.actions", ["block"])
 
-    def to_app_finding_format(self, commit_date: str) -> v1.Finding:
+    def to_app_finding_format(self, commit_date: str) -> out.Finding:
         """
         commit_date here for legacy reasons.
         commit date of the head commit in epoch time
@@ -275,8 +275,8 @@ class RuleMatch:
         else:
             app_severity = 0
 
-        ret = v1.Finding(
-            check_id=v1.RuleId(self.rule_id),
+        ret = out.Finding(
+            check_id=out.RuleId(self.rule_id),
             path=str(self.path),
             line=self.start.line,
             column=self.start.col,
@@ -287,7 +287,7 @@ class RuleMatch:
             index=self.index,
             commit_date=commit_date_app_format,
             syntactic_id=self.syntactic_id,
-            metadata=v1.RawJson(v1._Identity(self.metadata)),
+            metadata=out.RawJson(out._Identity(self.metadata)),
             is_blocking=self.is_blocking,
         )
 


### PR DESCRIPTION
v0 is to match the semantic versioning scheme used in semgrep.
semgrep is 0.91 so the JSON format is also a 0.xxx
When we change the JSON format to not be backward compatible, then
we'll need to upgrate to a v1 and semgrep to 1.xxx

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)