### PR TITLE
[refactor] use proper variant for semgrep-core error kind

### DIFF
--- a/semgrep-core/src/core/Semgrep_error_code.mli
+++ b/semgrep-core/src/core/Semgrep_error_code.mli
@@ -1,33 +1,11 @@
 type error = {
   rule_id : Rule.rule_id option;
-  typ : error_kind;
+  typ : Output_from_core_t.core_error_kind;
   loc : Parse_info.token_location;
   msg : string;
   details : string option;
   yaml_path : string list option;
 }
-
-and error_kind =
-  (* File parsing related errors.
-   * See also try_with_exn_to_errors(), try_with_error_loc_and_reraise(), and
-   * filter_maybe_parse_and_fatal_errors
-   *)
-  | LexicalError
-  | ParseError (* aka SyntaxError *)
-  | SpecifiedParseError
-  | AstBuilderError
-  (* pattern parsing related errors *)
-  | RuleParseError
-  | PatternParseError
-  | InvalidYaml
-  (* matching (semgrep) related *)
-  | MatchingError (* internal error, e.g., NoTokenLocation *)
-  | SemgrepMatchFound of string (* check_id TODO: what is this for? *)
-  | TooManyMatches
-  (* other *)
-  | FatalError (* missing file, OCaml errors, etc. *)
-  | Timeout
-  | OutOfMemory
 
 type severity = Error | Warning
 
@@ -42,11 +20,15 @@ val mk_error :
   ?rule_id:Rule.rule_id option ->
   Parse_info.token_location ->
   string ->
-  error_kind ->
+  Output_from_core_t.core_error_kind ->
   error
 
 val error :
-  Rule.rule_id -> Parse_info.token_location -> string -> error_kind -> unit
+  Rule.rule_id ->
+  Parse_info.token_location ->
+  string ->
+  Output_from_core_t.core_error_kind ->
+  unit
 
 val exn_to_error :
   ?rule_id:Rule.rule_id option -> Common.filename -> exn -> error
@@ -69,8 +51,7 @@ val try_with_print_exn_and_exit_fast : Common.filename -> (unit -> unit) -> unit
 (*****************************************************************************)
 
 val string_of_error : error -> string
-val string_of_error_kind : error_kind -> string
-val severity_of_error : error_kind -> severity
+val severity_of_error : Output_from_core_t.core_error_kind -> severity
 
 (*****************************************************************************)
 (* Helpers for unit testing *)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -18,6 +18,7 @@ module R = Rule
 module RP = Report
 module Resp = Output_from_core_t
 module E = Semgrep_error_code
+module Out = Output_from_core_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -136,7 +137,8 @@ let check ~match_hook ~timeout ~timeout_threshold default_config rules xtarget =
                          RP.matches = [];
                          errors =
                            [
-                             E.mk_error ~rule_id:(Some rule_id) loc "" E.Timeout;
+                             E.mk_error ~rule_id:(Some rule_id) loc ""
+                               Out.Timeout;
                            ];
                          skipped_targets = [];
                          profiling = RP.empty_rule_profiling r;

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -24,6 +24,7 @@ module S = Specialize_formula
 module RM = Range_with_metavars
 module E = Semgrep_error_code
 module Resp = Output_from_core_t
+module Out = Output_from_core_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 let debug_timeout = ref false
@@ -129,7 +130,7 @@ let error env msg =
   let loc = PI.first_loc_of_file env.file_and_more.Xtarget.file in
   (* TODO: warning or error? MatchingError or ... ? *)
   let err =
-    E.mk_error ~rule_id:(Some (fst env.rule.Rule.id)) loc msg E.MatchingError
+    E.mk_error ~rule_id:(Some (fst env.rule.Rule.id)) loc msg Out.MatchingError
   in
   Common.push err env.errors
 

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -4,6 +4,7 @@ module R = Rule
 module MR = Mini_rule
 module P = Pattern_match
 module E = Semgrep_error_code
+module Out = Output_from_core_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -293,8 +294,7 @@ let regression_tests_for_lang ~with_caching files lang =
                      let minii_loc =
                        Parse_info.unsafe_token_location_of_info minii
                      in
-                     E.error "test pattern" minii_loc ""
-                       (E.SemgrepMatchFound ""))
+                     E.error "test pattern" minii_loc "" Out.SemgrepMatchFound)
                    (Config_semgrep.default_config, equiv)
                    [ rule ] (file, lang, ast)
                  |> ignore;
@@ -486,7 +486,7 @@ let tainting_test lang rules_file file =
     |> Common.map (fun m ->
            {
              rule_id = Some m.P.rule_id.id;
-             E.typ = SemgrepMatchFound m.P.rule_id.id;
+             E.typ = Out.SemgrepMatchFound;
              loc = fst m.range_loc;
              msg = m.P.rule_id.message;
              details = None;

--- a/semgrep-core/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/semgrep-core/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -2,6 +2,7 @@
 open Common
 module R = Rule
 module E = Semgrep_error_code
+module Out = Output_from_core_t
 
 let test_path = "../../../tests/OTHER/synthesizing/targets/"
 
@@ -76,7 +77,7 @@ let ranges_matched lang file pattern : Range.t list =
         let toks = xs |> List.filter Parse_info.is_origintok in
         let minii, _maxii = Parse_info.min_max_ii_by_pos toks in
         let minii_loc = Parse_info.unsafe_token_location_of_info minii in
-        E.error "Synthesizier tests" minii_loc "" (E.SemgrepMatchFound ""))
+        E.error "Synthesizier tests" minii_loc "" Out.SemgrepMatchFound)
       (Config_semgrep.default_config, equiv)
       [ rule ] (file, lang, ast)
   in

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -23,6 +23,7 @@ module RP = Report
 module SJ = Output_from_core_j
 module Set = Set_
 module V = Visitor_AST
+module Out = Output_from_core_t
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -70,11 +71,9 @@ type env = { r : Rule.t; errors : E.error list ref }
 
 let error env t s =
   let loc = Parse_info.unsafe_token_location_of_info t in
-  let check_id = "semgrep-metacheck-builtin" in
+  let _check_idTODO = "semgrep-metacheck-builtin" in
   let rule_id, _ = env.r.id in
-  let err =
-    E.mk_error ~rule_id:(Some rule_id) loc s (E.SemgrepMatchFound check_id)
-  in
+  let err = E.mk_error ~rule_id:(Some rule_id) loc s Out.SemgrepMatchFound in
   Common.push err env.errors
 
 (*****************************************************************************)
@@ -184,8 +183,9 @@ let semgrep_check config metachecks rules =
     let loc, _ = m.P.range_loc in
     (* TODO use the end location in errors *)
     let s = m.rule_id.message in
-    let check_id = m.rule_id.id in
-    E.mk_error ~rule_id:None loc s (E.SemgrepMatchFound check_id)
+    let _check_id = m.rule_id.id in
+    (* TODO: why not set ~rule_id here?? bug? *)
+    E.mk_error ~rule_id:None loc s Out.SemgrepMatchFound
   in
   let config =
     {

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -22,8 +22,8 @@ module J = JSON
 module MV = Metavariable
 module RP = Report
 open Pattern_match
-module ST = Output_from_core_t (* atdgen definitions *)
 module SJ = Output_from_core_j (* JSON conversions *)
+module Out = Output_from_core_t (* atdgen definitions *)
 
 (*****************************************************************************)
 (* Unique ID *)
@@ -39,7 +39,7 @@ let unique_id any =
   match any with
   | E { e = N (Id (_, { id_resolved = { contents = Some (_, sid) }; _ })); _ }
     ->
-      { ST.type_ = `ID; md5sum = None; sid = Some sid }
+      { Out.type_ = `ID; md5sum = None; sid = Some sid }
   (* not an Id, return a md5sum of its AST as a "single unique id" *)
   | _ ->
       (* todo? note that if the any use a parameter, or a local,
@@ -54,7 +54,7 @@ let unique_id any =
        *)
       let s = Marshal.to_string any [] in
       let md5 = Digest.string s in
-      { ST.type_ = `AST; md5sum = Some (Digest.to_hex md5); sid = None }
+      { Out.type_ = `AST; md5sum = Some (Digest.to_hex md5); sid = None }
 
 (*****************************************************************************)
 (* JSON *)
@@ -65,7 +65,7 @@ let adjust_column x = x + 1
 
 let position_of_token_location loc =
   {
-    ST.line = loc.PI.line;
+    Out.line = loc.PI.line;
     col = adjust_column loc.PI.column;
     offset = loc.PI.charpos;
   }
@@ -74,12 +74,12 @@ let position_range min_loc max_loc =
   let len_max = String.length max_loc.PI.str in
   (* alt: could call position_of_token_location but more symetric like that*)
   ( {
-      ST.line = min_loc.PI.line;
+      Out.line = min_loc.PI.line;
       col = adjust_column min_loc.PI.column;
       offset = min_loc.PI.charpos;
     },
     {
-      ST.line = max_loc.PI.line;
+      Out.line = max_loc.PI.line;
       col = adjust_column (max_loc.PI.column + len_max);
       offset = max_loc.PI.charpos + len_max;
     } )
@@ -119,14 +119,14 @@ let get_propagated_value default_start mvalue =
     | Some (start, end_) ->
         Some
           {
-            ST.svalue_start = Some start;
+            Out.svalue_start = Some start;
             svalue_end = Some end_;
             svalue_abstract_content = metavar_string_of_any any;
           }
     | None ->
         Some
           {
-            ST.svalue_start = None;
+            Out.svalue_start = None;
             svalue_end = None;
             svalue_abstract_content = metavar_string_of_any any;
           }
@@ -154,7 +154,7 @@ let metavars startp_of_match_range (s, mval) =
   | Some (startp, endp) ->
       ( s,
         {
-          ST.start = startp;
+          Out.start = startp;
           end_ = endp;
           abstract_content = metavar_string_of_any any;
           propagated_value = get_propagated_value startp_of_match_range any;
@@ -167,7 +167,7 @@ let match_to_match x =
     let startp, endp = position_range min_loc max_loc in
     Left
       ({
-         ST.rule_id = x.rule_id.id;
+         Out.rule_id = x.rule_id.id;
          location = { path = x.file; start = startp; end_ = endp };
          extra =
            {
@@ -175,7 +175,7 @@ let match_to_match x =
              metavars = x.env |> Common.map (metavars startp);
            };
        }
-        : ST.core_match)
+        : Out.core_match)
     (* raised by min_max_ii_by_pos in range_of_any when the AST of the
      * pattern in x.code or the metavar does not contain any token
      *)
@@ -185,12 +185,14 @@ let match_to_match x =
       let s =
         spf "NoTokenLocation with pattern %s, %s" x.rule_id.pattern_string s
       in
-      let err = E.mk_error ~rule_id:(Some x.rule_id.id) loc s E.MatchingError in
+      let err =
+        E.mk_error ~rule_id:(Some x.rule_id.id) loc s Out.MatchingError
+      in
       Right err
   [@@profiling]
 
-(* TODO: Semgrep_error_code should be defined in Output_from_core.atd
- * directly, so we don't need those conversions
+(* less: Semgrep_error_code should be defined fully Output_from_core.atd
+ * so we would not need those conversions
  *)
 let error_to_error err =
   let severity_of_severity = function
@@ -200,13 +202,13 @@ let error_to_error err =
   let file = err.E.loc.PI.file in
   let startp, endp = position_range err.E.loc err.E.loc in
   let rule_id = err.E.rule_id in
-  let error_type = E.string_of_error_kind err.E.typ in
+  let error_type = err.E.typ in
   let severity = severity_of_severity (E.severity_of_error err.E.typ) in
   let message = err.E.msg in
   let details = err.E.details in
   let yaml_path = err.E.yaml_path in
   {
-    ST.error_type;
+    Out.error_type;
     rule_id;
     severity;
     location = { path = file; start = startp; end_ = endp };
@@ -219,14 +221,14 @@ let json_time_of_profiling_data profiling_data =
   let json_time_of_rule_times rule_times =
     rule_times
     |> Common.map (fun { RP.rule_id; parse_time; match_time } ->
-           { ST.rule_id; parse_time; match_time })
+           { Out.rule_id; parse_time; match_time })
   in
   {
-    ST.targets =
+    Out.targets =
       profiling_data.RP.file_times
       |> Common.map (fun { RP.file = target; rule_times; run_time } ->
              {
-               ST.path = target;
+               Out.path = target;
                rule_times = json_time_of_rule_times rule_times;
                run_time;
              });
@@ -247,7 +249,7 @@ let match_results_of_matches_and_errors files res =
   let count_errors = StrSet.cardinal files_with_errors in
   let count_ok = List.length files - count_errors in
   {
-    ST.matches;
+    Out.matches;
     errors = errs |> Common.map error_to_error;
     skipped_targets = res.RP.skipped_targets;
     skipped_rules =
@@ -259,7 +261,7 @@ let match_results_of_matches_and_errors files res =
             |> Common.map (fun (kind, rule_id, tk) ->
                    let loc = PI.unsafe_token_location_of_info tk in
                    {
-                     ST.rule_id;
+                     Out.rule_id;
                      details = Rule.string_of_invalid_rule_error_kind kind;
                      position = position_of_token_location loc;
                    })));
@@ -277,7 +279,7 @@ let match_results_of_matches_and_errors files res =
  * Semgrep_error_code.compare_actual_to_expected
  *)
 let error loc (rule : Pattern_match.rule_id) =
-  E.error rule.id loc rule.message (E.SemgrepMatchFound rule.id)
+  E.error rule.id loc rule.message Out.SemgrepMatchFound
 
 let match_to_error x =
   let min_loc, _max_loc = x.range_loc in

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -96,7 +96,7 @@ let timeout_function file timeout f =
   | Some res -> res
   | None ->
       let loc = PI.first_loc_of_file file in
-      let err = E.mk_error loc "" E.Timeout in
+      let err = E.mk_error loc "" Out.Timeout in
       Common.push err E.g_errors
 
 (*****************************************************************************)
@@ -213,7 +213,7 @@ let filter_files_with_too_many_matches_and_transform_as_timeout
                   "%d rules result in too many matches, most offending rule \
                    has %d: %s"
                   offending_rules cnt pat)
-               E.TooManyMatches
+               Out.TooManyMatches
            in
            let skipped =
              sorted_offending_rules
@@ -339,10 +339,10 @@ let iter_targets_and_get_matches_and_exn_to_errors config f targets =
                            (match exn with
                            | Match_rules.File_timeout ->
                                logger#info "Timeout on %s" file;
-                               E.Timeout
+                               Out.Timeout
                            | Out_of_memory ->
                                logger#info "OutOfMemory on %s" file;
-                               E.OutOfMemory
+                               Out.OutOfMemory
                            | _ -> raise Impossible);
                        ];
                      skipped_targets = [];

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -54,7 +54,9 @@ def core_error_to_semgrep_error(err: core.CoreError) -> SemgrepCoreError:
 
     # TODO benchmarking code relies on error code value right now
     # See https://semgrep.dev/docs/cli-usage/ for meaning of codes
-    if err.error_type == "Syntax error" or err.error_type == "Lexical error":
+    if isinstance(err.error_type.value, core.ParseError) or isinstance(
+        err.error_type.value, core.LexicalError
+    ):
         code = 3
         final_rule_id = None  # Rule id not important for parse errors
     else:

--- a/semgrep/semgrep/core_runner.py
+++ b/semgrep/semgrep/core_runner.py
@@ -684,7 +684,7 @@ class CoreRunner:
             outputs = core_matches_to_rule_matches(rules, core_output)
             parsed_errors = [core_error_to_semgrep_error(e) for e in core_output.errors]
             for err in core_output.errors:
-                if err.error_type == "Timeout":
+                if isinstance(err.error_type.value, core.Timeout):
                     assert err.location.path is not None
 
                     file_timeouts[Path(err.location.path)] += 1

--- a/semgrep/semgrep/formatter/text.py
+++ b/semgrep/semgrep/formatter/text.py
@@ -208,7 +208,8 @@ class TextFormatter(BaseFormatter):
             if SemgrepError.semgrep_error_type(err) == "SemgrepCoreError"
         ]
         errors = {
-            (err.core.location.path, err.core.error_type) for err in semgrep_core_errors
+            (err.core.location.path, err.core.error_type.kind)
+            for err in semgrep_core_errors
         }
 
         error_types = {k: len(list(v)) for k, v in groupby(errors, lambda x: x[1])}


### PR DESCRIPTION
This will avoid (ab)using strings for error comparisons.

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)