### PR TITLE
fix: Set all directories as safe for Git in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - OCaml: Parenthesis in autofixed code will no longer leave dangling closing-paren.
   Thanks to Elliott Cable for his contribution (#5087)
+- When running the Semgrep Docker image, we now mark all directories as safe for use by Git,
+  which prevents a crash when the current user does not own the source code directory.
 
 ## [0.91.0](https://github.com/returntocorp/semgrep/releases/tag/v0.91.0) - 2022-05-03
 

--- a/semgrep/semgrep/cli.py
+++ b/semgrep/semgrep/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import subprocess
 
 import click
@@ -11,11 +10,41 @@ from semgrep.commands.login import login
 from semgrep.commands.login import logout
 from semgrep.commands.publish import publish
 from semgrep.commands.scan import scan
+from semgrep.constants import IN_DOCKER
 from semgrep.default_group import DefaultGroup
 from semgrep.git import GIT_SH_TIMEOUT
 from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
+
+
+def maybe_set_git_safe_directories() -> None:
+    """
+    Configure Git to be willing to run in any directory when we're in Docker.
+
+    In docker, every path is trusted:
+    - the user explicitly mounts their trusted code directory
+    - r2c provides every other path
+
+    More info:
+    - https://github.blog/2022-04-12-git-security-vulnerability-announced/
+    - https://github.com/actions/checkout/issues/766
+    """
+    if not IN_DOCKER:
+        return
+
+    try:
+        subprocess.run(
+            # "*" is used over Path.cwd() in case the user targets an absolute path instead of setting --workdir
+            ["git", "config", "--global", "--add", "safe.directory", "*"],
+            check=True,
+            encoding="utf-8",
+            timeout=GIT_SH_TIMEOUT,
+        )
+    except Exception as e:
+        logger.info(
+            f"Semgrep failed to set the safe.directory Git config option. Git commands might fail: {e}"
+        )
 
 
 @click.group(cls=DefaultGroup, default_command="scan", name="semgrep")
@@ -32,20 +61,7 @@ def cli(ctx: click.Context) -> None:
         else "command/unset"
     )
 
-    workspace = os.getenv("GITHUB_WORKSPACE")
-    if workspace:
-        try:
-            output = subprocess.run(
-                ["git", "config", "--global", "--add", "safe.directory", workspace],
-                check=True,
-                encoding="utf-8",
-                capture_output=True,
-                timeout=GIT_SH_TIMEOUT,
-            )
-        except Exception as e:
-            logger.info(
-                f"Git safe directory workaround failed. Git commands might fail: {e}"
-            )
+    maybe_set_git_safe_directories()
 
 
 cli.add_command(ci)


### PR DESCRIPTION
This fixes crashes that happen when running Semgrep in Git on a
directory that is not owned by the current user.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
