### PR TITLE
feat(swift): Handle conversion of many statements to generic AST

### DIFF
--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -1,0 +1,71 @@
+// -----------------------------------------------------------------------------
+// Global Declarations
+// -----------------------------------------------------------------------------
+
+// Import
+
+// TODO include modifiers
+import foo;
+import foo.bar;
+import typealias foo.bar;
+import struct foo;
+import class foo;
+import enum foo;
+import protocol foo;
+import let foo;
+import var foo;
+import func foo;
+
+// Constant
+
+// TODO this is quite incomplete, add more cases as needed
+
+let foo = 3;
+let (foo) = 3;
+let foo: Int = 4;
+let (foo, bar) = (1, 2);
+// TODO
+// let (foo: baz, bar) = (1, 2);
+let foo: Int = 1, bar = 2;
+
+// Variable
+
+// TODO this is quite incomplete, add more cases as needed
+
+var foo = 1;
+var bar: Int = 2;
+var baz: Int;
+
+// TODO computed variables
+// var computed: Int {
+//     get { 4 }
+//     set { }
+// }
+
+// Typealias
+
+// TODO include modifiers
+typealias foo = bar;
+typealias foo<baz> = bar;
+typealias foo<baz: Int> = bar;
+
+// Function
+
+// TODO include modifiers
+func foo() { }
+func foo() -> Int { return 5; }
+func foo(x: Int, y: Int) { }
+func foo(_: Int) { }
+func foo(_ x: Int) { }
+func foo(x y: Int) { }
+// TODO
+// func foo(x: inout Int) { }
+func foo(x: Int = 5) { }
+func foo(x: Int...) { }
+// TODO
+// func foo() throws { }
+// func foo() throws -> Int { }
+// func foo(f: () throws -> void) rethrows { }
+// func foo() async { }
+// func foo() async -> Int { return 5; }
+// func foo() async throws { }


### PR DESCRIPTION
Test plan:

Automated tests

Manual inspection of the ASTs created, for example:

`$ semgrep-core -lang swift -dump_ast test.swift` on:

`func foo(x: Int = 5) { }`:

```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("foo", ()),
                {id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[]; tparams=[]; },
      FuncDef(
        {fkind=(Function, ());
         fparams=[Param(
                    {pname=Some(("x", ())); pdefault=Some(L(Int((Some(5), ()))));
                     ptype=Some({t_attrs=[];
                                 t=TyN(
                                     Id(("Int", ()),
                                       {id_info_id=1; id_hidden=false; id_resolved=Ref(
                                        None); id_type=Ref(None); id_svalue=Ref(
                                        None); }));
                                 });
                     pattrs=[];
                     pinfo={id_info_id=2; id_hidden=false; id_resolved=Ref(
                            Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                            None); };
                     })];
         frettype=None; fbody=FBStmt(Block([])); })))])
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
