### PR TITLE
fix(swift): Unwrap a single-element tuple

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -2714,7 +2714,19 @@ and map_tuple_expression (env : env)
       v4
   in
   let v5 = (* ")" *) token env v5 in
-  G.Container (G.Tuple, (v1, v3 :: v4, v5)) |> G.e
+  let exprs = v3 :: v4 in
+  match exprs with
+  (* The grammar doesn't differentiate, but according to the Swift spec:
+   *
+   * "A single expression inside parentheses is a parenthesized expression."
+   *
+   * https://docs.swift.org/swift-book/ReferenceManual/Expressions.html#ID552
+   *
+   * See also
+   * https://docs.swift.org/swift-book/ReferenceManual/Expressions.html#ID395
+   *)
+  | [ e ] -> e
+  | _ -> G.Container (G.Tuple, (v1, exprs, v5)) |> G.e
 
 and map_tuple_type (env : env) ((v1, v2, v3) : CST.tuple_type) =
   let v1 = (* "(" *) token env v1 in


### PR DESCRIPTION
See comment for explanation.

Test plan:

`$ semgrep-core -lang swift -dump_ast test.swift`

where `test.swift` contains `(foo)`:

```
Pr(
  [ExprStmt(
     N(
       Id(("foo", ()), {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
     ())])
```

Also checked `(foo, bar)` and made sure it was still considered a tuple

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
