### PR TITLE
fix(playground): always report start and end of error

### DIFF
--- a/semgrep-core/tests/OTHER/semgrep_output/cli_output/rule_id_and_spans.json
+++ b/semgrep-core/tests/OTHER/semgrep_output/cli_output/rule_id_and_spans.json
@@ -7,6 +7,17 @@
       "rule_id": "rules.invalid-rules.print",
       "spans": [
         {
+          "end": {
+            "col": 21,
+            "line": 9,
+            "offset": 180
+          },
+          "file": "rules/invalid_rules/print",
+          "start": {
+            "col": 12,
+            "line": 9,
+            "offset": 171
+          },
           "config_end": {
             "col": 21,
             "line": 9,

--- a/semgrep/semgrep/core_output.py
+++ b/semgrep/semgrep/core_output.py
@@ -40,14 +40,22 @@ def core_error_to_semgrep_error(err: core.CoreError) -> SemgrepCoreError:
     spans: Optional[List[out.ErrorSpan]] = None
     if err.yaml_path:
         yaml_path = err.yaml_path[::-1]
+        start = out.PositionBis(
+            line=err.location.start.line, col=err.location.start.col
+        )
+        end = out.PositionBis(line=err.location.end.line, col=err.location.end.col)
+        config_start = out.PositionBis(line=0, col=1)
+        config_end = out.PositionBis(
+            line=err.location.end.line - err.location.start.line,
+            col=err.location.end.col - err.location.start.col + 1,
+        )
         spans = [
             out.ErrorSpan(
-                config_start=out.PositionBis(
-                    line=err.location.start.line, col=err.location.start.col
-                ),
-                config_end=out.PositionBis(
-                    line=err.location.end.line, col=err.location.end.col
-                ),
+                file=err.location.path,
+                start=start,
+                end=end,
+                config_start=config_start,
+                config_end=config_end,
                 config_path=yaml_path,
             )
         ]

--- a/semgrep/semgrep/rule_lang.py
+++ b/semgrep/semgrep/rule_lang.py
@@ -136,12 +136,6 @@ class Span:
     config_end: Optional[Position] = None
 
     def to_ErrorSpan(self) -> out.ErrorSpan:
-        config_start = None
-        if self.config_start:
-            config_start = self.config_start.to_PositionBis()
-        config_end = None
-        if self.config_end:
-            config_end = self.config_end.to_PositionBis()
         context_start = None
         if self.context_start:
             context_start = self.context_start.to_PositionBis()
@@ -150,12 +144,10 @@ class Span:
             context_end = self.context_end.to_PositionBis()
 
         return out.ErrorSpan(
-            config_start=config_start,
-            config_end=config_end,
             config_path=self.config_path,
             context_start=context_start,
             context_end=context_end,
-            file=self.file,
+            file=self.file if self.file else "<No file>",
             start=self.start.to_PositionBis(),
             end=self.end.to_PositionBis(),
             source_hash=self.source_hash,
@@ -176,32 +168,6 @@ class Span:
         lines = s.splitlines()
         end = Position(line=len(lines), col=len(lines[-1]))
         return Span(start=start, end=end, file=filename, source_hash=src_hash)
-
-    @classmethod
-    def from_string_token(
-        cls,
-        s: str,
-        line: int,
-        col: int,
-        # path: List[Dict[str, Union[int, str]]], # TODO
-        path: List[str],
-        filename: Optional[str] = None,
-    ) -> "Span":
-        src_hash = SourceTracker.add_source(s)
-        start = Position(line + 1, col + 1)  # 1-index instead of 0
-        lines = s.splitlines()
-        row_diff = len(lines)
-        col_diff = len(lines[-1])
-        end = Position(line=(row_diff + line - 1), col=(col_diff + col + 1))
-        return Span(
-            start=start,
-            end=end,
-            file=filename,
-            source_hash=src_hash,
-            config_path=path,
-            config_start=Position(0, 1),
-            config_end=Position(row_diff - 1, col_diff + 1),
-        )
 
     def fix(self) -> "Span":
         # some issues in ruamel lead to bad spans

--- a/semgrep/tests/conftest.py
+++ b/semgrep/tests/conftest.py
@@ -56,6 +56,16 @@ def _clean_stdout(out):
     json_output = json.loads(out)
     if json_output.get("version"):
         json_output["version"] = "0.42"
+
+    # Necessary because some tests produce temp files
+    if json_output.get("errors"):
+        for error in json_output.get("errors"):
+            if error.get("spans"):
+                for span in error.get("spans"):
+                    if span.get("file"):
+                        file = span.get("file")
+                        span["file"] = file if "tmp" not in file else "tmp/masked/path"
+
     return json.dumps(json_output)
 
 

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad-three-layers/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad-three-layers/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 8
           },
-          "file": "no file",
+          "file": "rules/syntax/bad-three-layers.yaml",
           "source_hash": "230ae0cfd32c4a669eb5edbc9f5a3574609dfe147a7440bfcb85c35e1828ac54",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad-three-layers/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad-three-layers/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 8

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad-three-layers/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad-three-layers/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 8
           },
-          "file": "rules/syntax/bad-three-layers.yaml",
+          "file": "no file",
           "source_hash": "230ae0cfd32c4a669eb5edbc9f5a3574609dfe147a7440bfcb85c35e1828ac54",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
@@ -11,7 +11,7 @@
             "col": 7,
             "line": 12
           },
-          "file": "rules/syntax/bad1.yaml",
+          "file": "no file",
           "source_hash": "58787bea35443f02072f84af73a97dc567e47abfd67214fe739bebf7cf138c2f",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
@@ -11,7 +11,7 @@
             "col": 7,
             "line": 12
           },
-          "file": "no file",
+          "file": "rules/syntax/bad1.yaml",
           "source_hash": "58787bea35443f02072f84af73a97dc567e47abfd67214fe739bebf7cf138c2f",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 7,
             "line": 12

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad10/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad10/error.json
@@ -7,9 +7,6 @@
       "short_msg": "null values prohibited",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "context_end": {
             "col": 0,
             "line": 9

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad10/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad10/error.json
@@ -19,7 +19,7 @@
             "col": 21,
             "line": 8
           },
-          "file": "no file",
+          "file": "rules/syntax/bad10.yaml",
           "source_hash": "9bf69aa52b0a57d7f67b6200f2434646c150331285aa0e3903c2a92d4dc9bbb3",
           "start": {
             "col": 20,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad10/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad10/error.json
@@ -19,7 +19,7 @@
             "col": 21,
             "line": 8
           },
-          "file": "rules/syntax/bad10.yaml",
+          "file": "no file",
           "source_hash": "9bf69aa52b0a57d7f67b6200f2434646c150331285aa0e3903c2a92d4dc9bbb3",
           "start": {
             "col": 20,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad11/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad11/error.json
@@ -19,7 +19,7 @@
             "col": 9,
             "line": 2
           },
-          "file": "no file",
+          "file": "rules/syntax/bad11.yaml",
           "source_hash": "7a019471428f78e4d02c4c06c76fd7195445c3ccb10b555af042346e63d8c3de",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad11/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad11/error.json
@@ -19,7 +19,7 @@
             "col": 9,
             "line": 2
           },
-          "file": "rules/syntax/bad11.yaml",
+          "file": "no file",
           "source_hash": "7a019471428f78e4d02c4c06c76fd7195445c3ccb10b555af042346e63d8c3de",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad11/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad11/error.json
@@ -7,9 +7,6 @@
       "short_msg": "null values prohibited",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "context_end": {
             "col": 0,
             "line": 3

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad12/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad12/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 6
           },
-          "file": "rules/syntax/bad12.yaml",
+          "file": "no file",
           "source_hash": "69c490071ff3af369ac30c61b12bad8f0ee8092440ea9d5b4fcdf3ee924c78ae",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad12/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad12/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 6
           },
-          "file": "no file",
+          "file": "rules/syntax/bad12.yaml",
           "source_hash": "69c490071ff3af369ac30c61b12bad8f0ee8092440ea9d5b4fcdf3ee924c78ae",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad12/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad12/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 5,
             "line": 6

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad13/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad13/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 9

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad13/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad13/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 9
           },
-          "file": "no file",
+          "file": "rules/syntax/bad13.yaml",
           "source_hash": "358a5e8907bbb75166d11a3e3347b3750abde97709ce141a6f5d67f82879822a",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad13/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad13/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 9
           },
-          "file": "rules/syntax/bad13.yaml",
+          "file": "no file",
           "source_hash": "358a5e8907bbb75166d11a3e3347b3750abde97709ce141a6f5d67f82879822a",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad14/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad14/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 13
           },
-          "file": "no file",
+          "file": "rules/syntax/bad14.yaml",
           "source_hash": "3288d50ef917f40d8e5d0bec082d910a53ea93465167f5b2efbaac7ed68efcb2",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad14/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad14/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 13

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad14/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad14/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 13
           },
-          "file": "rules/syntax/bad14.yaml",
+          "file": "no file",
           "source_hash": "3288d50ef917f40d8e5d0bec082d910a53ea93465167f5b2efbaac7ed68efcb2",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad15/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad15/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 10
           },
-          "file": "rules/syntax/bad15.yaml",
+          "file": "no file",
           "source_hash": "21e9affa6ddbf82df21c7daf4b11db6a72fe061d06794ab28f208f20461d666a",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad15/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad15/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 10
           },
-          "file": "no file",
+          "file": "rules/syntax/bad15.yaml",
           "source_hash": "21e9affa6ddbf82df21c7daf4b11db6a72fe061d06794ab28f208f20461d666a",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad15/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad15/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 10

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad16/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad16/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 6

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad16/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad16/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 6
           },
-          "file": "rules/syntax/bad16.yaml",
+          "file": "no file",
           "source_hash": "1ce0f2de3de6530b53d80ba25a34ed2b84cbb056bb75faadf85d715ce2349709",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad16/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad16/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 6
           },
-          "file": "no file",
+          "file": "rules/syntax/bad16.yaml",
           "source_hash": "1ce0f2de3de6530b53d80ba25a34ed2b84cbb056bb75faadf85d715ce2349709",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 8
           },
-          "file": "rules/syntax/bad2.yaml",
+          "file": "no file",
           "source_hash": "8861f46f4219927c24d0ba57521a2b46d60f7367eca308fa7efb623c5a8b17bc",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 8
           },
-          "file": "no file",
+          "file": "rules/syntax/bad2.yaml",
           "source_hash": "8861f46f4219927c24d0ba57521a2b46d60f7367eca308fa7efb623c5a8b17bc",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad2/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 8

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 5,
             "line": 5

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 5
           },
-          "file": "no file",
+          "file": "rules/syntax/bad3.yaml",
           "source_hash": "97733e185fa4cbd70969a362e968e43dd266202401e7a68a23b52c8d1cf3e547",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad3/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 5
           },
-          "file": "rules/syntax/bad3.yaml",
+          "file": "no file",
           "source_hash": "97733e185fa4cbd70969a362e968e43dd266202401e7a68a23b52c8d1cf3e547",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 8
           },
-          "file": "no file",
+          "file": "rules/syntax/bad4.yaml",
           "source_hash": "df19d059fbcde7ca517f3dcbd6d58733d738f332467bc02d1d11051ab62e2549",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 5,
             "line": 8

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad4/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 8
           },
-          "file": "rules/syntax/bad4.yaml",
+          "file": "no file",
           "source_hash": "df19d059fbcde7ca517f3dcbd6d58733d738f332467bc02d1d11051ab62e2549",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 12,
             "line": 5

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
@@ -11,7 +11,7 @@
             "col": 12,
             "line": 5
           },
-          "file": "rules/syntax/bad5.yaml",
+          "file": "no file",
           "source_hash": "5c4f00f11940b0b9526ec7832ba2b1b539877e705bc7d73a4421db5a7006eba9",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad5/error.json
@@ -11,7 +11,7 @@
             "col": 12,
             "line": 5
           },
-          "file": "no file",
+          "file": "rules/syntax/bad5.yaml",
           "source_hash": "5c4f00f11940b0b9526ec7832ba2b1b539877e705bc7d73a4421db5a7006eba9",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 6
           },
-          "file": "rules/syntax/bad6.yaml",
+          "file": "no file",
           "source_hash": "ebcad6ecc6d2264e00fcdeeee54e8997c92b2862d3fb66a0066b2bbdde796b2e",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 6
           },
-          "file": "no file",
+          "file": "rules/syntax/bad6.yaml",
           "source_hash": "ebcad6ecc6d2264e00fcdeeee54e8997c92b2862d3fb66a0066b2bbdde796b2e",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad6/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 5,
             "line": 6

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
@@ -11,7 +11,7 @@
             "col": 12,
             "line": 3
           },
-          "file": "rules/syntax/bad7.yaml",
+          "file": "no file",
           "source_hash": "99c414681ffa893e6d96ca71e262787fd058d3da094abe7425e470a21879205c",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
@@ -11,7 +11,7 @@
             "col": 12,
             "line": 3
           },
-          "file": "no file",
+          "file": "rules/syntax/bad7.yaml",
           "source_hash": "99c414681ffa893e6d96ca71e262787fd058d3da094abe7425e470a21879205c",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad7/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 12,
             "line": 3

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 7

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 7
           },
-          "file": "rules/syntax/bad8.yaml",
+          "file": "no file",
           "source_hash": "f821234ba9175efc8d66b3226996144ba05bdc0aea35a50321cbb9c6f349f6a0",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 7
           },
-          "file": "no file",
+          "file": "rules/syntax/bad8.yaml",
           "source_hash": "f821234ba9175efc8d66b3226996144ba05bdc0aea35a50321cbb9c6f349f6a0",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
@@ -11,7 +11,7 @@
             "col": 7,
             "line": 5
           },
-          "file": "rules/syntax/bad9.yaml",
+          "file": "no file",
           "source_hash": "22b38817e2ddc7b6ad25b80aaf6a01451159c7a0233eaef3ed58642355a05379",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 7,
             "line": 5

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad9/error.json
@@ -11,7 +11,7 @@
             "col": 7,
             "line": 5
           },
-          "file": "no file",
+          "file": "rules/syntax/bad9.yaml",
           "source_hash": "22b38817e2ddc7b6ad25b80aaf6a01451159c7a0233eaef3ed58642355a05379",
           "start": {
             "col": 9,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -19,7 +19,7 @@
             "col": 26,
             "line": 7
           },
-          "file": "rules/syntax/badlanguage.yaml",
+          "file": "no file",
           "source_hash": "a586ed585e5f1676161a6663c037292f13a97ff02aeb7fa9c62517732cc00766",
           "start": {
             "col": 16,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -19,7 +19,7 @@
             "col": 26,
             "line": 7
           },
-          "file": "no file",
+          "file": "rules/syntax/badlanguage.yaml",
           "source_hash": "a586ed585e5f1676161a6663c037292f13a97ff02aeb7fa9c62517732cc00766",
           "start": {
             "col": 16,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badlanguage/error.json
@@ -7,9 +7,6 @@
       "short_msg": "invalid language: intercal",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "context_end": {
             "col": 0,
             "line": 8

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 5,
             "line": 10

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 10
           },
-          "file": "rules/syntax/badpaths1.yaml",
+          "file": "no file",
           "source_hash": "5f729ef631099eaddf81dca6b10c2e399989ff7c923ac53ab0e4e51b6124d1a1",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths1/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 10
           },
-          "file": "no file",
+          "file": "rules/syntax/badpaths1.yaml",
           "source_hash": "5f729ef631099eaddf81dca6b10c2e399989ff7c923ac53ab0e4e51b6124d1a1",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 9
           },
-          "file": "no file",
+          "file": "rules/syntax/badpaths2.yaml",
           "source_hash": "e8a29e15677c634a77353a6099e2c0acf18909672c87d06292a1caece7cd4d3c",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
@@ -11,7 +11,7 @@
             "col": 5,
             "line": 9
           },
-          "file": "rules/syntax/badpaths2.yaml",
+          "file": "no file",
           "source_hash": "e8a29e15677c634a77353a6099e2c0acf18909672c87d06292a1caece7cd4d3c",
           "start": {
             "col": 7,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpaths2/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 5,
             "line": 9

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -26,7 +26,7 @@
             "col": 24,
             "line": 4
           },
-          "file": "/tmp/tmpgvlmgi7g.yaml",
+          "file": "no file",
           "start": {
             "col": 14,
             "line": 4

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -26,7 +26,7 @@
             "col": 24,
             "line": 4
           },
-          "file": "no file",
+          "file": "tmp/masked/path",
           "start": {
             "col": 14,
             "line": 4

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -7,6 +7,15 @@
       "rule_id": "rules.syntax.eqeq-is-bad",
       "spans": [
         {
+          "end": {
+            "col": 24,
+            "line": 4
+          },
+          "file": "rules/syntax/eqeq-is-bad",
+          "start": {
+            "col": 14,
+            "line": 4
+          },
           "config_end": {
             "col": 24,
             "line": 4

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error.json
@@ -7,18 +7,9 @@
       "rule_id": "rules.syntax.eqeq-is-bad",
       "spans": [
         {
-          "end": {
-            "col": 24,
-            "line": 4
-          },
-          "file": "rules/syntax/eqeq-is-bad",
-          "start": {
-            "col": 14,
-            "line": 4
-          },
           "config_end": {
-            "col": 24,
-            "line": 4
+            "col": 11,
+            "line": 0
           },
           "config_path": [
             "rules",
@@ -28,6 +19,15 @@
             "pattern"
           ],
           "config_start": {
+            "col": 1,
+            "line": 0
+          },
+          "end": {
+            "col": 24,
+            "line": 4
+          },
+          "file": "/tmp/tmpgvlmgi7g.yaml",
+          "start": {
             "col": 14,
             "line": 4
           }

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 15
           },
-          "file": "no file",
+          "file": "rules/syntax/missing-field.yaml",
           "source_hash": "11211df936d8dd4787be2c2be20d33fd13c465c766569eb9fc10e3e812829a02",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
@@ -11,7 +11,7 @@
             "col": 1,
             "line": 15
           },
-          "file": "rules/syntax/missing-field.yaml",
+          "file": "no file",
           "source_hash": "11211df936d8dd4787be2c2be20d33fd13c465c766569eb9fc10e3e812829a02",
           "start": {
             "col": 5,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-field/error.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 15

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
@@ -11,7 +11,7 @@
             "col": 0,
             "line": 7
           },
-          "file": "rules/syntax/missing-toplevel.yaml",
+          "file": "no file",
           "source_hash": "f1b1a7f0ef1f89134e4320d364d2e44df788d24337d22506a99c55191350d4fe",
           "start": {
             "col": 1,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
@@ -7,9 +7,6 @@
       "short_msg": "missing keys",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 0,
             "line": 7

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/missing-toplevel/error.json
@@ -11,7 +11,7 @@
             "col": 0,
             "line": 7
           },
-          "file": "no file",
+          "file": "rules/syntax/missing-toplevel.yaml",
           "source_hash": "f1b1a7f0ef1f89134e4320d364d2e44df788d24337d22506a99c55191350d4fe",
           "start": {
             "col": 1,

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -6,7 +6,16 @@
       "message": "[ERROR] Pattern parse error in rule -:\n Invalid pattern for C",
       "rule_id": "-",
       "spans": [
-        {
+      {
+        "end": {
+          "col": 35,
+          "line": 3
+        },
+        "file": "-",
+        "start": {
+          "col": 12,
+          "line": 3
+        },
           "config_end": {
             "col": 35,
             "line": 3

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -24,7 +24,7 @@
             "col": 35,
             "line": 3
           },
-          "file": "/tmp/tmphshwn7mw.yaml",
+          "file": "no file",
           "start": {
             "col": 12,
             "line": 3

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -6,19 +6,10 @@
       "message": "[ERROR] Pattern parse error in rule -:\n Invalid pattern for C",
       "rule_id": "-",
       "spans": [
-      {
-        "end": {
-          "col": 35,
-          "line": 3
-        },
-        "file": "-",
-        "start": {
-          "col": 12,
-          "line": 3
-        },
+        {
           "config_end": {
-            "col": 35,
-            "line": 3
+            "col": 24,
+            "line": 0
           },
           "config_path": [
             "rules",
@@ -26,6 +17,15 @@
             "pattern"
           ],
           "config_start": {
+            "col": 1,
+            "line": 0
+          },
+          "end": {
+            "col": 35,
+            "line": 3
+          },
+          "file": "/tmp/tmphshwn7mw.yaml",
+          "start": {
             "col": 12,
             "line": 3
           }

--- a/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.json
@@ -24,7 +24,7 @@
             "col": 35,
             "line": 3
           },
-          "file": "no file",
+          "file": "tmp/masked/path",
           "start": {
             "col": 12,
             "line": 3

--- a/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-metavariable-regex.yaml-basicstupid.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-metavariable-regex.yaml-basicstupid.py/results.json
@@ -7,9 +7,6 @@
       "short_msg": "Detected duplicate key",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "context_end": {
             "col": 0,
             "line": 11

--- a/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-missing-top-item.yaml-basicstupid.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-missing-top-item.yaml-basicstupid.py/results.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 6

--- a/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern-child.yaml-basicstupid.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern-child.yaml-basicstupid.py/results.json
@@ -7,9 +7,6 @@
       "short_msg": "Invalid rule schema",
       "spans": [
         {
-          "config_end": null,
-          "config_path": null,
-          "config_start": null,
           "end": {
             "col": 1,
             "line": 10

--- a/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.py/results.json
@@ -7,6 +7,17 @@
       "rule_id": "rules.invalid-rules.print",
       "spans": [
         {
+          "end": {
+            "col": 21,
+            "line": 9,
+            "offset": 180
+          },
+          "file": "rules/invalid_rules/print",
+          "start": {
+            "col": 12,
+            "line": 9,
+            "offset": 171
+          },
           "config_end": {
             "col": 21,
             "line": 9

--- a/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.py/results.json
@@ -7,20 +7,9 @@
       "rule_id": "rules.invalid-rules.print",
       "spans": [
         {
-          "end": {
-            "col": 21,
-            "line": 9,
-            "offset": 180
-          },
-          "file": "rules/invalid_rules/print",
-          "start": {
-            "col": 12,
-            "line": 9,
-            "offset": 171
-          },
           "config_end": {
-            "col": 21,
-            "line": 9
+            "col": 10,
+            "line": 0
           },
           "config_path": [
             "rules",
@@ -28,6 +17,15 @@
             "pattern"
           ],
           "config_start": {
+            "col": 1,
+            "line": 0
+          },
+          "end": {
+            "col": 21,
+            "line": 9
+          },
+          "file": "/tmp/tmpnxoer_oi.yaml",
+          "start": {
             "col": 12,
             "line": 9
           }

--- a/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.py/results.json
+++ b/semgrep/tests/e2e/snapshots/test_rule_validation/test_validation_of_invalid_rules/rulesinvalid-rulesinvalid-pattern.yaml-basicstupid.py/results.json
@@ -24,7 +24,7 @@
             "col": 21,
             "line": 9
           },
-          "file": "/tmp/tmpnxoer_oi.yaml",
+          "file": "tmp/masked/path",
           "start": {
             "col": 12,
             "line": 9

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -57,7 +57,8 @@ def _clean_output_json(output):
             if error.get("spans"):
                 for span in error.get("spans"):
                     if span.get("file"):
-                        span["file"] = "no file"
+                        file = span.get("file")
+                        span["file"] = file if "tmp" not in file else "tmp/masked/path"
 
 
 @pytest.mark.kinda_slow

--- a/semgrep/tests/e2e/test_rule_parser.py
+++ b/semgrep/tests/e2e/test_rule_parser.py
@@ -51,6 +51,14 @@ def _clean_output_json(output):
     if output.get("version"):
         output["version"] = "0.42"
 
+    # Necessary because some tests produce temp files
+    if output.get("errors"):
+        for error in output.get("errors"):
+            if error.get("spans"):
+                for span in error.get("spans"):
+                    if span.get("file"):
+                        span["file"] = "no file"
+
 
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize("filename", syntax_fails)


### PR DESCRIPTION
Playground requires start and end in the spans object of the error
Semgrep reports. This PR adds that back in.

Test plan:

`semgrep -e 'exec(..' . --json -l js`

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
