### PR TITLE
Automate PR opening/templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
@@ -1,0 +1,12 @@
+# Release Checklist
+
+- [ ] Updated CHANGELOG with latest changes
+- [ ] Updated latest release and release date in `CHANGELOG.md`
+- [ ] Tests/CI passes on this Pull Request
+- [ ] Announce on community slack that release is in progress
+- [ ] Build Release Candidate finished successfully (`release` workflow)
+- [ ] Publish Github Release Page
+- [ ] Update semgrep.dev
+- [ ] Update semgrep action
+- [ ] Update semgrep-docs
+- [ ] Merge this PR without squashing the commits

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -53,10 +53,41 @@ jobs:
         run: make release
       - name: Push release branch
         id: push-release-branch
+        env:
+          SEMGREP_RELEASE_NEXT_VERSION: ${{ steps.next-version.outputs.next-version }}
         run: |
-          export SEMGREP_RELEASE_NEXT_VERSION=${{ steps.next-version.outputs.next-version }}
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git add --all
           git commit -m "chore: Bump version to ${SEMGREP_RELEASE_NEXT_VERSION}"
           git push --set-upstream origin ${{ steps.release-branch.outputs.release-branch }}
+      - name: Create PR
+        id: open-pr
+        env:
+          AUTH_HEADER: "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+          HEADER: "Accept: application/vnd.github.v3+json"
+          URL: "${{ github.event.repository.url }}/pulls"
+          SOURCE: "${{ steps.release-branch.outputs.release-branch }}"
+          TARGET: "${{ github.event.repository.default_branch }}"
+          TITLE: "Release Version ${{ steps.next-version.outputs.next-version }}"
+        run: |
+          # check if the branch already has a pull request open
+          DATA="{\"base\":\"${TARGET}\", \"head\":\"${SOURCE}\"}";
+          RESPONSE=$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X GET --data "${DATA}" $URL);
+          echo "${RESPONSE}"
+          PR=$(echo "${RESPONSE}" | jq --raw-output '.[] | .head.ref');
+
+          # GitHub REST API doesn't allow you to pass a template, so here we go
+          BODY=$(cat ./.github/PULL_REQUEST_TEMPLATE/release_pr_template.md)
+
+          if [[ "${PR}" == "${SOURCE}" ]]; then
+              # pull request already open
+              echo "pull request from SOURCE ${SOURCE} to TARGET ${TARGET} is already open";
+              echo "cancelling release"
+              exit 1
+          else
+              # open new pull request with the body of from the local template.
+              # Use a bash parameter expansion with replacement on BODY since it contains newlines.
+              DATA="{\"title\":\"${TITLE}\", \"body\":\"${BODY//$'\n'/'\n'}\", \"base\":\"${TARGET}\", \"head\":\"${SOURCE}\"}";
+              curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X POST --data "${DATA}" $URL;
+          fi

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -74,7 +74,6 @@ jobs:
           # check if the branch already has a pull request open
           DATA="{\"base\":\"${TARGET}\", \"head\":\"${SOURCE}\"}";
           RESPONSE=$(curl -sSL -H "${AUTH_HEADER}" -H "${HEADER}" -X GET --data "${DATA}" $URL);
-          echo "${RESPONSE}"
           PR=$(echo "${RESPONSE}" | jq --raw-output '.[] | .head.ref');
 
           # GitHub REST API doesn't allow you to pass a template, so here we go


### PR DESCRIPTION
This allows auto-creation of the release branch PR, plus automatically creates the template. 

NOTE: The PR templating here gets really weird due to limitations on GitHub's REST API. You can't set a default template, so we left the original template where it is. Additionally, the REST API doesn't let you specify templates, so instead we have to read the file, serialize it as JSON, and send it as the body of the PR. 

PR checklist:

- [ ] Documentation is up-to-date
    - will be updated once changes are live
- [x] Changelog is up-to-date - N/A
- [x] Change has no security implications (otherwise, ping security team)
