### PR TITLE
add(error_handling): tell users to upgrade on rule parse fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - JS/TS: allow ellipsis in imports (e.g., `import {..., Foo, ...} from 'Bar'`) (#5012)
 - `fixed_lines` is once again included in JSON output when running with `--autofix --dryrun`
 
+### Changed
+
+- When a rule from the registry fails to parse, suggest user upgrade to
+  latest version of semgrep
+
 ## [0.92.0](https://github.com/returntocorp/semgrep/releases/tag/v0.92.0) - 2022-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   of the heavy lifting work
   (#3941, #2648, #2650, #3590, #3588, #3587, #3576, #3848, #3978, #4589)
 - TS: support number and boolean typed metavariables (#5350)
+- When a rule from the registry fails to parse, suggest user upgrade to
+  latest version of semgrep
 
 ## [0.94.0](https://github.com/returntocorp/semgrep/releases/tag/v0.94.0) - 2022-05-25
 
@@ -122,11 +124,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - JS/TS: allow ellipsis in binding_pattern (e.g., in arrow parameters) (#5230)
 - JS/TS: allow ellipsis in imports (e.g., `import {..., Foo, ...} from 'Bar'`) (#5012)
 - `fixed_lines` is once again included in JSON output when running with `--autofix --dryrun`
-
-### Changed
-
-- When a rule from the registry fails to parse, suggest user upgrade to
-  latest version of semgrep
 
 ## [0.92.0](https://github.com/returntocorp/semgrep/releases/tag/v0.92.0) - 2022-05-11
 

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -19,6 +19,7 @@ from ruamel.yaml import YAMLError
 
 from semgrep.app import auth
 from semgrep.constants import CLI_RULE_ID
+from semgrep.constants import Colors
 from semgrep.constants import DEFAULT_CONFIG_FILE
 from semgrep.constants import DEFAULT_CONFIG_FOLDER
 from semgrep.constants import DEFAULT_SEMGREP_CONFIG_NAME
@@ -43,6 +44,7 @@ from semgrep.state import get_state
 from semgrep.util import is_config_suffix
 from semgrep.util import is_url
 from semgrep.util import terminal_wrap
+from semgrep.util import with_color
 from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
@@ -140,6 +142,9 @@ class ConfigPath:
         return url
 
     def _download_config(self) -> Mapping[str, YamlTree]:
+        """
+        Download a configuration from semgrep.dev
+        """
         config_url = self._config_path
         logger.debug(f"trying to download from {self._nice_semgrep_url(config_url)}")
         try:
@@ -150,6 +155,11 @@ class ConfigPath:
             )
             logger.debug(f"finished downloading from {config_url}")
             return config
+        except InvalidRuleSchemaError as e:
+            notice = f"\nRules downloaded from {config_url} failed to parse.\nThis is likely because rules have been added that use functionality introduced in later versions of semgrep.\nPlease upgrade to latest version of semgrep and try again.\n"
+            notice_color = with_color(Colors.red, notice, bold=True)
+            logger.error(notice_color)
+            raise SemgrepError(terminal_wrap(f"Parse error details: {str(e)}"))
         except Exception as e:
             raise SemgrepError(
                 terminal_wrap(f"Failed to download config from {config_url}: {str(e)}")

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -156,7 +156,7 @@ class ConfigPath:
             logger.debug(f"finished downloading from {config_url}")
             return config
         except InvalidRuleSchemaError as e:
-            notice = f"\nRules downloaded from {config_url} failed to parse.\nThis is likely because rules have been added that use functionality introduced in later versions of semgrep.\nPlease upgrade to latest version of semgrep and try again.\n"
+            notice = f"\nRules downloaded from {config_url} failed to parse.\nThis is likely because rules have been added that use functionality introduced in later versions of semgrep.\nPlease upgrade to latest version of semgrep (see https://semgrep.dev/docs/upgrading/) and try again.\n"
             notice_color = with_color(Colors.red, notice, bold=True)
             logger.error(notice_color)
             raise SemgrepError(terminal_wrap(f"Parse error details: {str(e)}"))

--- a/semgrep/tests/e2e/snapshots/test_config_resolver/test_new_feature_registry_config/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_config_resolver/test_new_feature_registry_config/output.txt
@@ -2,7 +2,7 @@ Fetching rules from https://semgrep.dev/registry.
 
 Rules downloaded from https://semgrep.dev/p/ci failed to parse.
 This is likely because rules have been added that use functionality introduced in later versions of semgrep.
-Please upgrade to latest version of semgrep and try again.
+Please upgrade to latest version of semgrep (see https://semgrep.dev/docs/upgrading/) and try again.
 
 Parse error details: semgrep error: Invalid rule schema
   --> https://semgrep.dev/...:2

--- a/semgrep/tests/e2e/snapshots/test_config_resolver/test_new_feature_registry_config/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_config_resolver/test_new_feature_registry_config/output.txt
@@ -1,3 +1,9 @@
+METRICS: Using configs from the Registry (like --config=p/ci) reports pseudonymous rule metrics to semgrep.dev.
+To disable Registry rule metrics, use "--metrics=off".
+Using configs only from local files (like --config=xyz.yml) does not enable metrics.
+
+More information: https://semgrep.dev/docs/metrics
+
 Fetching rules from https://semgrep.dev/registry.
 
 Rules downloaded from https://semgrep.dev/p/ci failed to parse.

--- a/semgrep/tests/e2e/snapshots/test_config_resolver/test_new_feature_registry_config/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_config_resolver/test_new_feature_registry_config/output.txt
@@ -1,0 +1,17 @@
+Fetching rules from https://semgrep.dev/registry.
+
+Rules downloaded from https://semgrep.dev/p/ci failed to parse.
+This is likely because rules have been added that use functionality introduced in later versions of semgrep.
+Please upgrade to latest version of semgrep and try again.
+
+Parse error details: semgrep error: Invalid rule schema
+  --> https://semgrep.dev/...:2
+2 | - id: eqeq-bad
+3 |   pattern-new-feature: $X == $X
+4 |   message: "useless comparison"
+5 |   languages: [python]
+6 |   severity: ERROR
+
+Additional properties are not allowed ('pattern-new-feature' was unexpected)
+
+invalid configuration file found (1 configs were invalid)

--- a/semgrep/tests/e2e/test_config_resolver.py
+++ b/semgrep/tests/e2e/test_config_resolver.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 
+import pytest
 from click.testing import CliRunner
 
 from semgrep.app import auth
@@ -8,6 +9,7 @@ from semgrep.config_resolver import ConfigPath
 from semgrep.constants import SEMGREP_SETTING_ENVVAR_NAME
 
 
+@pytest.mark.quick
 def test_new_feature_registry_config(monkeypatch, snapshot, mocker, tmp_path):
     file_content = dedent(
         """

--- a/semgrep/tests/e2e/test_config_resolver.py
+++ b/semgrep/tests/e2e/test_config_resolver.py
@@ -1,9 +1,12 @@
 from textwrap import dedent
-from semgrep.app import auth
+
 from click.testing import CliRunner
+
+from semgrep.app import auth
 from semgrep.cli import cli
 from semgrep.config_resolver import ConfigPath
 from semgrep.constants import SEMGREP_SETTING_ENVVAR_NAME
+
 
 def test_new_feature_registry_config(monkeypatch, snapshot, mocker, tmp_path):
     file_content = dedent(

--- a/semgrep/tests/e2e/test_config_resolver.py
+++ b/semgrep/tests/e2e/test_config_resolver.py
@@ -1,0 +1,28 @@
+from textwrap import dedent
+from semgrep.app import auth
+from click.testing import CliRunner
+from semgrep.cli import cli
+from semgrep.config_resolver import ConfigPath
+from semgrep.constants import SEMGREP_SETTING_ENVVAR_NAME
+
+def test_new_feature_registry_config(monkeypatch, snapshot, mocker, tmp_path):
+    file_content = dedent(
+        """
+        rules:
+        - id: eqeq-bad
+          pattern-new-feature: $X == $X
+          message: "useless comparison"
+          languages: [python]
+          severity: ERROR
+        """
+    ).lstrip()
+    mocker.patch.object(ConfigPath, "_make_config_request", return_value=file_content)
+
+    runner = CliRunner(
+        env={
+            SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path),
+            auth.SEMGREP_LOGIN_TOKEN_ENVVAR_NAME: "",
+        }
+    )
+    result = runner.invoke(cli, ["scan", "--config", "p/ci"], env={})
+    snapshot.assert_match(result.output, "output.txt")


### PR DESCRIPTION
When pulling rules from registry, a parse failure is likely due to
a rule using features in newer versions of semgrep. Add a note in
the error message telling users to upgrade and try again.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
