### PR TITLE
AST_to_IL: Translate if-then-else as expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Added
+
+- Datafow: The dataflow engine now handles if-then-else expressions as in OCaml,
+  Ruby, etc. Previously it only handled if-then-else statements. (#4965)
+
 ### Fixed
 
 - Kotlin: support for ellispis in class parameters, e.g.. `class Foo(...) {}` (#5180)

--- a/semgrep-core/tests/OTHER/rules/taint_ruby_if_expr.rb
+++ b/semgrep-core/tests/OTHER/rules/taint_ruby_if_expr.rb
@@ -1,0 +1,12 @@
+# https://github.com/returntocorp/semgrep/issues/4965
+
+def awesome
+  something = if params[:thang]
+                params[:thang]
+              elsif somevar = "monkeypanda"
+                somevar
+              end
+  #ruleid: check-symbol-dos
+  something.to_sym
+  return true
+end

--- a/semgrep-core/tests/OTHER/rules/taint_ruby_if_expr.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_ruby_if_expr.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: check-symbol-dos
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        params[...]
+  pattern-sinks:
+    - patterns:
+        - pattern-inside: |
+            $X.to_sym
+        - pattern: $X
+  message: Found potential denial of service via unsafe symbol conversion of a
+    string. Do not call symbol conversion on user-controllable input.
+  languages:
+    - ruby
+  severity: ERROR


### PR DESCRIPTION
We supported if-then-else statements, but not expressions as in OCaml,
Ruby, etc.

Closes #PA-1118
Closes #4965

test plan:
make test # test included

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
