### PR TITLE
fix: Include fixed_lines field in JSON output when --autofix --dryrun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - Kotlin: support for ellispis in class parameters, e.g.. `class Foo(...) {}` (#5180)
+- `fixed_lines` is once again included in JSON output when running with `--autofix --dryrun`
 
 ## [0.92.0](https://github.com/returntocorp/semgrep/releases/tag/v0.92.0) - 2022-05-11
 

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -36,6 +36,8 @@ class JsonFormatter(BaseFormatter):
                 out._Identity(rule_match.extra.get("dependency_matches"))
             )
             extra.dependency_match_only = rule_match.extra.get("dependency_match_only")
+        if rule_match.extra.get("fixed_lines"):
+            extra.fixed_lines = rule_match.extra.get("fixed_lines")
         if rule_match.fix:
             extra.fix = rule_match.fix
         if rule_match.fix_regex:

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "52e9b86a1b3404140fcaedeed3274639",
         "fix": "inputs.get(x)",
+        "fixed_lines": [
+          "  inputs.get(x) = 1"
+        ],
         "is_ignored": false,
         "lines": "  inputs[x] = 1",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
@@ -76,6 +79,9 @@
       "extra": {
         "fingerprint": "2c58f67c769a8e675e9a74ca1ed3c096",
         "fix": "inputs.get(x + 1)",
+        "fixed_lines": [
+          "  if inputs.get(x + 1) == True:"
+        ],
         "is_ignored": false,
         "lines": "  if inputs[x + 1] == True:",
         "message": "Use `.get()` method to avoid a KeyNotFound error",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-not-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "52e9b86a1b3404140fcaedeed3274639",
         "fix": "inputs.get(x)",
+        "fixed_lines": [
+          "  inputs.get(x) = 1"
+        ],
         "is_ignored": false,
         "lines": "  inputs[x] = 1",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
@@ -76,6 +79,9 @@
       "extra": {
         "fingerprint": "2c58f67c769a8e675e9a74ca1ed3c096",
         "fix": "inputs.get(x + 1)",
+        "fixed_lines": [
+          "  if inputs.get(x + 1) == True:"
+        ],
         "is_ignored": false,
         "lines": "  if inputs[x + 1] == True:",
         "message": "Use `.get()` method to avoid a KeyNotFound error",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py-dryrun/results.json
@@ -20,6 +20,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
+        "fixed_lines": [
+          "csv.writer(csvfile, delimiter=',', quotechar='\"', quoting=csv.QUOTE_ALL)"
+        ],
         "is_ignored": false,
         "lines": "csv.writer(csvfile, delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",
@@ -53,6 +56,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
+        "fixed_lines": [
+          "csv.writer(get_file(), delimiter=',', quotechar='\"', quoting=csv.QUOTE_ALL)"
+        ],
         "is_ignored": false,
         "lines": "csv.writer(get_file(), delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py-not-dryrun/results.json
@@ -20,6 +20,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
+        "fixed_lines": [
+          "csv.writer(csvfile, delimiter=',', quotechar='\"', quoting=csv.QUOTE_ALL)"
+        ],
         "is_ignored": false,
         "lines": "csv.writer(csvfile, delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",
@@ -53,6 +56,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
+        "fixed_lines": [
+          "csv.writer(get_file(), delimiter=',', quotechar='\"', quoting=csv.QUOTE_ALL)"
+        ],
         "is_ignored": false,
         "lines": "csv.writer(get_file(), delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java-dryrun/results.json
@@ -20,6 +20,9 @@
           "regex": "DefaultHttpClient\\(",
           "replacement": "SystemDefaultHttpClient("
         },
+        "fixed_lines": [
+          "\t\tHttpClient client = new SystemDefaultHttpClient();"
+        ],
         "is_ignored": false,
         "lines": "\t\tHttpClient client = new DefaultHttpClient();",
         "message": "DefaultHttpClient is deprecated. Further, it does not support connections\nusing TLS1.2, which makes using DefaultHttpClient a security hazard.\nUse SystemDefaultHttpClient instead, which supports TLS1.2.\n",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java-not-dryrun/results.json
@@ -20,6 +20,9 @@
           "regex": "DefaultHttpClient\\(",
           "replacement": "SystemDefaultHttpClient("
         },
+        "fixed_lines": [
+          "\t\tHttpClient client = new SystemDefaultHttpClient();"
+        ],
         "is_ignored": false,
         "lines": "\t\tHttpClient client = new DefaultHttpClient();",
         "message": "DefaultHttpClient is deprecated. Further, it does not support connections\nusing TLS1.2, which makes using DefaultHttpClient a security hazard.\nUse SystemDefaultHttpClient instead, which supports TLS1.2.\n",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-dryrun/results.json
@@ -20,6 +20,12 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
+        "fixed_lines": [
+          "        new_password = request.data.get(\"password\", None)",
+          "        validate_password(new_password, user=user)",
+          "        user.set_password(new_password)",
+          "        user.save()"
+        ],
         "is_ignored": false,
         "lines": "        new_password = request.data.get(\"password\", \"\")\n        validate_password(new_password, user=user)\n        user.set_password(new_password)\n        user.save()",
         "message": "'new_password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
@@ -122,6 +128,19 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
+        "fixed_lines": [
+          "    def create_user(self, email, password=None):",
+          "        \"\"\"",
+          "        Creates and saves a Poster with the given email and password.",
+          "        \"\"\"",
+          "        if not email:",
+          "            raise ValueError('Users must have an email address')",
+          "",
+          "        user = self.model(email=self.normalize_email(email))",
+          "        user.set_password(password)",
+          "        user.save(using=self._db)",
+          "        return user"
+        ],
         "is_ignored": false,
         "lines": "    def create_user(self, email, password=\"\"):\n        \"\"\"\n        Creates and saves a Poster with the given email and password.\n        \"\"\"\n        if not email:\n            raise ValueError('Users must have an email address')\n\n        user = self.model(email=self.normalize_email(email))\n        user.set_password(password)\n        user.save(using=self._db)\n        return user",
         "message": "'password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-not-dryrun/results.json
@@ -20,6 +20,12 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
+        "fixed_lines": [
+          "        new_password = request.data.get(\"password\", None)",
+          "        validate_password(new_password, user=user)",
+          "        user.set_password(new_password)",
+          "        user.save()"
+        ],
         "is_ignored": false,
         "lines": "        new_password = request.data.get(\"password\", \"\")\n        validate_password(new_password, user=user)\n        user.set_password(new_password)\n        user.save()",
         "message": "'new_password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
@@ -122,6 +128,19 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
+        "fixed_lines": [
+          "    def create_user(self, email, password=None):",
+          "        \"\"\"",
+          "        Creates and saves a Poster with the given email and password.",
+          "        \"\"\"",
+          "        if not email:",
+          "            raise ValueError('Users must have an email address')",
+          "",
+          "        user = self.model(email=self.normalize_email(email))",
+          "        user.set_password(password)",
+          "        user.save(using=self._db)",
+          "        return user"
+        ],
         "is_ignored": false,
         "lines": "    def create_user(self, email, password=\"\"):\n        \"\"\"\n        Creates and saves a Poster with the given email and password.\n        \"\"\"\n        if not email:\n            raise ValueError('Users must have an email address')\n\n        user = self.model(email=self.normalize_email(email))\n        user.set_password(password)\n        user.save(using=self._db)\n        return user",
         "message": "'password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-dryrun/results.json
@@ -21,6 +21,9 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
+        "fixed_lines": [
+          "    return flask.jsonify(user_dict)"
+        ],
         "is_ignored": false,
         "lines": "    return json.dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",
@@ -67,6 +70,9 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
+        "fixed_lines": [
+          "    return flask.jsonify(user_dict)"
+        ],
         "is_ignored": false,
         "lines": "    return dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-not-dryrun/results.json
@@ -21,6 +21,9 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
+        "fixed_lines": [
+          "    return flask.jsonify(user_dict)"
+        ],
         "is_ignored": false,
         "lines": "    return json.dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",
@@ -67,6 +70,9 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
+        "fixed_lines": [
+          "    return flask.jsonify(user_dict)"
+        ],
         "is_ignored": false,
         "lines": "    return dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "2ca56c3f0400f7e2b8f57fc113dcdce0",
         "fix": "wrap(\"a\")",
+        "fixed_lines": [
+          "        return wrap(\"a\") + \"b\";"
+        ],
         "is_ignored": false,
         "lines": "        return \"a\" + \"b\";",
         "message": "Wrap strings",
@@ -59,6 +62,9 @@
       "extra": {
         "fingerprint": "9af220ae02bffe7a9e310af3bb6caadf",
         "fix": "wrap(\"b\")",
+        "fixed_lines": [
+          "        return \"a\" + wrap(\"b\");"
+        ],
         "is_ignored": false,
         "lines": "        return \"a\" + \"b\";",
         "message": "Wrap strings",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-not-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "2ca56c3f0400f7e2b8f57fc113dcdce0",
         "fix": "wrap(\"a\")",
+        "fixed_lines": [
+          "        return wrap(\"a\") + \"b\";"
+        ],
         "is_ignored": false,
         "lines": "        return \"a\" + \"b\";",
         "message": "Wrap strings",
@@ -59,6 +62,9 @@
       "extra": {
         "fingerprint": "9af220ae02bffe7a9e310af3bb6caadf",
         "fix": "wrap(\"b\")",
+        "fixed_lines": [
+          "        return \"a\" + wrap(\"b\");"
+        ],
         "is_ignored": false,
         "lines": "        return \"a\" + \"b\";",
         "message": "Wrap strings",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "1d361e3ba8e0886e552896d37f2b0099",
         "fix": "a_function_call (wrap (the_argument))",
+        "fixed_lines": [
+          "let one = a_function_call (wrap (the_argument))"
+        ],
         "is_ignored": false,
         "lines": "let one = a_function_call the_argument",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -59,6 +62,9 @@
       "extra": {
         "fingerprint": "e69c022a8fc6398980f399d8cff906b1",
         "fix": "a_function_call (wrap ((the_argument)))",
+        "fixed_lines": [
+          "let two = a_function_call (wrap ((the_argument)))"
+        ],
         "is_ignored": false,
         "lines": "let two = a_function_call (the_argument)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -101,6 +107,9 @@
       "extra": {
         "fingerprint": "c6acfb2704f56a50d2af4ec1ed96061e",
         "fix": "a_function_call (wrap ((another_func the_argument)))",
+        "fixed_lines": [
+          "let three = a_function_call (wrap ((another_func the_argument)))"
+        ],
         "is_ignored": false,
         "lines": "let three = a_function_call (another_func the_argument)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -143,6 +152,9 @@
       "extra": {
         "fingerprint": "1ece2ca01a0a038c3b553abf76491b42",
         "fix": "a_function_call (wrap ((tuple_member, threeple_member)))",
+        "fixed_lines": [
+          "let three = a_function_call (wrap ((tuple_member, threeple_member)))"
+        ],
         "is_ignored": false,
         "lines": "let three = a_function_call (tuple_member, threeple_member)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "1d361e3ba8e0886e552896d37f2b0099",
         "fix": "a_function_call (wrap (the_argument))",
+        "fixed_lines": [
+          "let one = a_function_call (wrap (the_argument))"
+        ],
         "is_ignored": false,
         "lines": "let one = a_function_call the_argument",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -59,6 +62,9 @@
       "extra": {
         "fingerprint": "e69c022a8fc6398980f399d8cff906b1",
         "fix": "a_function_call (wrap ((the_argument)))",
+        "fixed_lines": [
+          "let two = a_function_call (wrap ((the_argument)))"
+        ],
         "is_ignored": false,
         "lines": "let two = a_function_call (the_argument)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -101,6 +107,9 @@
       "extra": {
         "fingerprint": "c6acfb2704f56a50d2af4ec1ed96061e",
         "fix": "a_function_call (wrap ((another_func the_argument)))",
+        "fixed_lines": [
+          "let three = a_function_call (wrap ((another_func the_argument)))"
+        ],
         "is_ignored": false,
         "lines": "let three = a_function_call (another_func the_argument)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -143,6 +152,9 @@
       "extra": {
         "fingerprint": "1ece2ca01a0a038c3b553abf76491b42",
         "fix": "a_function_call (wrap ((tuple_member, threeple_member)))",
+        "fixed_lines": [
+          "let three = a_function_call (wrap ((tuple_member, threeple_member)))"
+        ],
         "is_ignored": false,
         "lines": "let three = a_function_call (tuple_member, threeple_member)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "e02fb095085d554bebaa733bb863be24",
         "fix": "assert \"a\"",
+        "fixed_lines": [
+          "assert \"a\""
+        ],
         "is_ignored": false,
         "lines": "assert_eq(\n    True, \"a\"\n)",
         "message": "Change assert_eq(True, x) to assert x",
@@ -59,6 +62,9 @@
       "extra": {
         "fingerprint": "313cb4216c39d1171f6858cea0d3fcc1",
         "fix": "assert \"b\"",
+        "fixed_lines": [
+          "assert \"b\""
+        ],
         "is_ignored": false,
         "lines": "assert_eq(\n    True, \"b\"\n)",
         "message": "Change assert_eq(True, x) to assert x",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-not-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "e02fb095085d554bebaa733bb863be24",
         "fix": "assert \"a\"",
+        "fixed_lines": [
+          "assert \"a\""
+        ],
         "is_ignored": false,
         "lines": "assert_eq(\n    True, \"a\"\n)",
         "message": "Change assert_eq(True, x) to assert x",
@@ -59,6 +62,9 @@
       "extra": {
         "fingerprint": "313cb4216c39d1171f6858cea0d3fcc1",
         "fix": "assert \"b\"",
+        "fixed_lines": [
+          "assert \"b\""
+        ],
         "is_ignored": false,
         "lines": "assert_eq(\n    True, \"b\"\n)",
         "message": "Change assert_eq(True, x) to assert x",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py-dryrun/results.json
@@ -20,6 +20,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.get(url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.get(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -47,6 +50,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.post(url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -74,6 +80,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.request(\"GET\", url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.request(\"GET\", url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -101,6 +110,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.request(\"GET\", return_url(), timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.request(\"GET\", return_url())",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -128,6 +140,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "    r = post(url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "    r = post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py-not-dryrun/results.json
@@ -20,6 +20,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.get(url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.get(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -47,6 +50,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.post(url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -74,6 +80,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.request(\"GET\", url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.request(\"GET\", url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -101,6 +110,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "r = requests.request(\"GET\", return_url(), timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "r = requests.request(\"GET\", return_url())",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -128,6 +140,9 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
+        "fixed_lines": [
+          "    r = post(url, timeout=30)"
+        ],
         "is_ignored": false,
         "lines": "    r = post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-dryrun/results.json
@@ -20,6 +20,16 @@
           "regex": "(.*)\\}",
           "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
         },
+        "fixed_lines": [
+          "resource \"aws_instance\" \"example1\" {",
+          "  ami           = \"ami-005e54dee72cc1d01\"",
+          "  instance_type = \"t2.micro\"",
+          "",
+          "  metadata_options {",
+          "    http_tokens = \"required\"",
+          "  }",
+          "}"
+        ],
         "is_ignored": false,
         "lines": "resource \"aws_instance\" \"example1\" {\n  ami           = \"ami-005e54dee72cc1d01\"\n  instance_type = \"t2.micro\"\n}",
         "message": "EC2 instance does not set metadata options",
@@ -65,6 +75,16 @@
           "regex": "(.*)\\}",
           "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
         },
+        "fixed_lines": [
+          "resource \"aws_instance\" \"example2\" {",
+          "  ami           = \"ami-005e54dee72cc1d02\"",
+          "  instance_type = \"t2.micro\"",
+          "",
+          "  metadata_options {",
+          "    http_tokens = \"required\"",
+          "  }",
+          "}"
+        ],
         "is_ignored": false,
         "lines": "resource \"aws_instance\" \"example2\" {\n  ami           = \"ami-005e54dee72cc1d02\"\n  instance_type = \"t2.micro\"\n}",
         "message": "EC2 instance does not set metadata options",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-not-dryrun/results.json
@@ -20,6 +20,16 @@
           "regex": "(.*)\\}",
           "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
         },
+        "fixed_lines": [
+          "resource \"aws_instance\" \"example1\" {",
+          "  ami           = \"ami-005e54dee72cc1d01\"",
+          "  instance_type = \"t2.micro\"",
+          "",
+          "  metadata_options {",
+          "    http_tokens = \"required\"",
+          "  }",
+          "}"
+        ],
         "is_ignored": false,
         "lines": "resource \"aws_instance\" \"example1\" {\n  ami           = \"ami-005e54dee72cc1d01\"\n  instance_type = \"t2.micro\"\n}",
         "message": "EC2 instance does not set metadata options",
@@ -65,6 +75,16 @@
           "regex": "(.*)\\}",
           "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
         },
+        "fixed_lines": [
+          "resource \"aws_instance\" \"example2\" {",
+          "  ami           = \"ami-005e54dee72cc1d02\"",
+          "  instance_type = \"t2.micro\"",
+          "",
+          "  metadata_options {",
+          "    http_tokens = \"required\"",
+          "  }",
+          "}"
+        ],
         "is_ignored": false,
         "lines": "resource \"aws_instance\" \"example2\" {\n  ami           = \"ami-005e54dee72cc1d02\"\n  instance_type = \"t2.micro\"\n}",
         "message": "EC2 instance does not set metadata options",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixtwo-autofixes.yaml-autofixtwo-autofixes.txt-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixtwo-autofixes.yaml-autofixtwo-autofixes.txt-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "8e5a82406b8572cbd604463e426661f4",
         "fix": "one",
+        "fixed_lines": [
+          "one"
+        ],
         "is_ignored": false,
         "lines": "one\ntwo",
         "message": "This rule changes the line numbers for the other rule's match",
@@ -41,6 +44,9 @@
       "extra": {
         "fingerprint": "61879a39cf14d9e5197692baf5cec91a",
         "fix": "four",
+        "fixed_lines": [
+          "four"
+        ],
         "is_ignored": false,
         "lines": "three\nfour",
         "message": "If semgrep is not smart enough, the match of this rule will be out of range",

--- a/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixtwo-autofixes.yaml-autofixtwo-autofixes.txt-not-dryrun/results.json
+++ b/semgrep/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixtwo-autofixes.yaml-autofixtwo-autofixes.txt-not-dryrun/results.json
@@ -17,6 +17,9 @@
       "extra": {
         "fingerprint": "8e5a82406b8572cbd604463e426661f4",
         "fix": "one",
+        "fixed_lines": [
+          "one"
+        ],
         "is_ignored": false,
         "lines": "one\ntwo",
         "message": "This rule changes the line numbers for the other rule's match",
@@ -41,6 +44,9 @@
       "extra": {
         "fingerprint": "61879a39cf14d9e5197692baf5cec91a",
         "fix": "four",
+        "fixed_lines": [
+          "four"
+        ],
         "is_ignored": false,
         "lines": "three\nfour",
         "message": "If semgrep is not smart enough, the match of this rule will be out of range",

--- a/semgrep/tests/e2e/test_autofix.py
+++ b/semgrep/tests/e2e/test_autofix.py
@@ -35,7 +35,10 @@ import pytest
 def test_autofix(run_semgrep_in_tmp, snapshot, rule, target, dryrun):
     # Yes, this is fugly. I apologize. T_T
     snapshot.assert_match(
-        run_semgrep_in_tmp(rule, target_name=target)[0],
+        # Need --autofix --dryrun so that the `fixed_lines` field will appear in output
+        run_semgrep_in_tmp(rule, target_name=target, options=["--autofix", "--dryrun"])[
+            0
+        ],
         "results.json",
     )
     # Make a copy of the target file b/c autofixes are inline. We


### PR DESCRIPTION
Fixes a regression where this field was being left out of the output JSON

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
