### PR TITLE
tainting: Allow variables to be taint sources by side-effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `r2c-internal-project-depends-on`: support for Gradle and Poetry lockfiles
 
+### Changed
+
+- taint-mode: Let's say that e.g. `taint(x)` makes `x` tainted by side-effect.
+  Previously, we had to rely on a trick that declared that _any_ occurrence of
+  `x` inside `taint(x); ...` was as taint source. If `x` was overwritten with
+  safe data, this was not recognized by the taint engine. Also, if `taint(x)`
+  occurred inside e.g. an `if` block, any occurrence of `x` outside that block
+  was not considered tainted. Now, if you specify that the code variable itself
+  is a taint source, the taint engine will handle this as expected and it will
+  not suffer from the aforementioned limitations. We believe that this change
+  should not break existing taint rules, but please report any regressions that
+  you may find.
+
 ### Fixed
 
 - TS: support for template literal types after upgrading to a more recent
@@ -58,7 +71,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   version of Semgrep used to generate the match results.
 - taint-mode: Previously, to declare a function parameteter as a taint source,
   we had to rely on a trick that declared that _any_ occurence of the parameter
-  was a taint source. If the parameter was overwriten with safe data, this was
+  was a taint source. If the parameter was overwritten with safe data, this was
   not recognized by the taint engine. Now, `focus-metavariable` can be used to
   precisely specify that a function parameter is a source of taint, and the taint
   engine will handle this as expected.

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -14,6 +14,9 @@ let string_of_lval x =
 let string_of_exp e =
   match e.e with
   | Fetch l -> string_of_lval l
+  | Literal _ -> "<LIT>"
+  | Operator _ -> "<OP>"
+  | FixmeExp _ -> "<FIXME-EXP>"
   | _ -> "<EXP>"
 
 let short_string_of_node_kind nkind =
@@ -31,7 +34,7 @@ let short_string_of_node_kind nkind =
   | NOther _ -> "<other>"
   | NInstr x -> (
       match x.i with
-      | Assign (lval, _) -> string_of_lval lval ^ " = ..."
+      | Assign (lval, exp) -> string_of_lval lval ^ " = " ^ string_of_exp exp
       | AssignAnon _ -> " ... = <lambda|class>"
       | Call (_lopt, exp, _) -> string_of_exp exp ^ "(...)"
       | CallSpecial _ -> "<special>"

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -1,10 +1,16 @@
 type var = Dataflow_core.var
 (** A string of the form "<source name>:<sid>". *)
 
+type overlap = float
+(** Overlap ratio, only applies to AST nodes that fall in the range of a
+ * source/sanitizer/sink annotation. It is a number in [0.0, 1.0], where
+ * 1.0 means that the AST node matches the annotation perfectly. For
+ * practical purposes we can interpret >0.99 as being the same as 1.0. *)
+
 type config = {
   filepath : Common.filename;  (** File under analysis, for Deep Semgrep. *)
   rule_id : string;  (** Taint rule id, for Deep Semgrep. *)
-  is_source : AST_generic.any -> Pattern_match.t list;
+  is_source : AST_generic.any -> (Pattern_match.t * overlap) list;
       (** Test whether 'any' is a taint source, this corresponds to
       * 'pattern-sources:' in taint-mode. *)
   is_sink : AST_generic.any -> Pattern_match.t list;

--- a/semgrep-core/tests/OTHER/rules/taint_source_var.py
+++ b/semgrep-core/tests/OTHER/rules/taint_source_var.py
@@ -1,0 +1,7 @@
+def test():
+    x = set([])
+    # `x` becomes tainted by side effect
+    taint(x)
+    y = x
+    #ruleid: test
+    sink(y)

--- a/semgrep-core/tests/OTHER/rules/taint_source_var.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_source_var.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Test
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+        # if $X is a variable, it will become tainted by side effect
+        - pattern: taint($X)
+        - focus-metavariable: $X
+    pattern-sinks:
+      - pattern: sink(...)

--- a/semgrep-core/tests/OTHER/rules/taint_source_var1.py
+++ b/semgrep-core/tests/OTHER/rules/taint_source_var1.py
@@ -1,0 +1,10 @@
+def test():
+    x = set([])
+    # `x` becomes tainted by side effect, even when `taint(x)` is nested
+    # inside an if conditional! This is because we no longer rely on
+    # `...` which traverses a sub-AST rather than the CFG.
+    if cond:
+        taint(x)
+    y = x
+    #ruleid: test
+    sink(y)

--- a/semgrep-core/tests/OTHER/rules/taint_source_var1.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_source_var1.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Test
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+        # if $X is a variable, it will become tainted by side effect
+        - pattern: taint($X)
+        - focus-metavariable: $X
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
Closes PA-1283

test plan:
make test # two tests added

PR checklist:

- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
