### PR TITLE
chore: Update pytest snapshots

### DIFF
--- a/semgrep/tests/e2e/snapshots/test_ci/test_config_run/autofix/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_config_run/autofix/output.txt
@@ -39,5 +39,3 @@ Ran 4 rules on 1 file: 6 findings.
 Ran 2 blocking rules, 1 audit rules, and 1 internal rules used for rule recommendations.
 Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_config_run/noautofix/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_config_run/noautofix/output.txt
@@ -39,5 +39,3 @@ Ran 4 rules on 1 file: 6 findings.
 Ran 2 blocking rules, 1 audit rules, and 1 internal rules used for rule recommendations.
 Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_dryrun/autofix/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_dryrun/autofix/output.txt
@@ -268,5 +268,3 @@ Would have sent complete blob: {
 }
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_dryrun/noautofix/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_dryrun/noautofix/output.txt
@@ -262,5 +262,3 @@ Would have sent complete blob: {
 }
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/output.txt
@@ -51,5 +51,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/output.txt
@@ -49,5 +49,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/output.txt
@@ -51,5 +51,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/output.txt
@@ -49,5 +49,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/output.txt
@@ -42,5 +42,3 @@ Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Reporting findings to semgrep.dev ...
 Success.
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_outputs/autofix/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_outputs/autofix/output.txt
@@ -15,5 +15,3 @@ Ran 4 rules on 1 file: 6 findings.
 Ran 2 blocking rules, 1 audit rules, and 1 internal rules used for rule recommendations.
 Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading

--- a/semgrep/tests/e2e/snapshots/test_ci/test_outputs/noautofix/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_outputs/noautofix/output.txt
@@ -15,5 +15,3 @@ Ran 4 rules on 1 file: 6 findings.
 Ran 2 blocking rules, 1 audit rules, and 1 internal rules used for rule recommendations.
 Found 5 findings from blocking rules and 1 findings from non-blocking rules
 Has findings for blocking rules so exiting with code 1
-
-A new version of Semgrep is available. See https://semgrep.dev/docs/upgrading


### PR DESCRIPTION
I think these changes were erroneously committed. We shouldn't be getting this notice in tests, and #5241 is failing tests due to this problem.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
