### PR TITLE
fix(ci): Prefer GITHUB_HEAD_REF over GITHUB_REF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 
+- `semgrep ci` used to incorrectly report the base branch as a CI job's branch
+  when running on a `pull_request_target` event in GitHub Actions.
+  By fixing this, Semgrep App can now track issue status history with `on: pull_request_target` jobs.
 - Metrics events were missing timestamps even though `PRIVACY.md` had already documented a timestamp field.
 
 ## [0.92.1](https://github.com/returntocorp/semgrep/releases/tag/v0.92.1) - 2022-05-13

--- a/semgrep/semgrep/meta.py
+++ b/semgrep/semgrep/meta.py
@@ -340,8 +340,8 @@ class GithubMeta(GitMeta):
         Event name            GITHUB_HEAD_REF -> GITHUB_REF
         ---------------------------------------------------
         pull_request        - johnny-patch-1  -> refs/pulls/123/merge
-        pull_request_target - johnny-patch-1  -> main
-        push/schedule/etc.  - <unset>         -> main
+        pull_request_target - johnny-patch-1  -> refs/heads/main
+        push/schedule/etc.  - <unset>         -> refs/heads/main
 
         This code originally always sent GITHUB_REF.
         This caused obvious breakage for pull_request_target,


### PR DESCRIPTION
For pull_request_target events, GITHUB_REF is the base branch name.
What's useful for us is the PR ref that triggered the job though.
See https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables

PR checklist:

- [x] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
