### PR TITLE
SCA: add --sca option to CI command (experimental)

### DIFF
--- a/semgrep/semgrep/commands/ci.py
+++ b/semgrep/semgrep/commands/ci.py
@@ -164,6 +164,11 @@ def fix_head_if_github_action(metadata: GitMeta) -> Iterator[None]:
         Instead will print out json objects it would have sent.
     """,
 )
+@click.option(
+    "--sca",
+    is_flag=True,
+    hidden=True,
+)
 @handle_command_errors
 def ci(
     ctx: click.Context,
@@ -197,6 +202,7 @@ def ci(
     sarif: bool,
     quiet: bool,
     rewrite_rule_ids: bool,
+    sca: bool,
     scan_unknown_extensions: bool,
     time_flag: bool,
     timeout_threshold: int,
@@ -288,6 +294,8 @@ def ci(
         logger.info(
             f"  semgrep.dev - authenticated{to_server} as {scan_handler.deployment_name}"
         )
+    if sca:
+        logger.info("  running an SCA scan")
     logger.info("")
 
     try:
@@ -297,7 +305,9 @@ def ci(
                 # Note this needs to happen within fix_head_if_github_action
                 # so that metadata of current commit is correct
                 if scan_handler:
-                    scan_handler.start_scan(metadata.to_dict())
+                    metadata_dict = metadata.to_dict()
+                    metadata_dict["is_sca_scan"] = sca
+                    scan_handler.start_scan(metadata_dict)
                     config = (scan_handler.scan_rules_url,)
             except Exception as e:
                 import traceback

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "github-actions",
-        "is_full_scan": true
+        "is_full_scan": true,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "github-actions",
-        "is_full_scan": false
+        "is_full_scan": false,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "github-actions",
-        "is_full_scan": true
+        "is_full_scan": true,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
@@ -19,6 +19,7 @@
         "scan_environment": "gitlab-ci",
         "is_full_scan": true,
         "base_sha": "sanitized",
-        "start_sha": null
+        "start_sha": null,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
@@ -19,6 +19,7 @@
         "scan_environment": "gitlab-ci",
         "is_full_scan": false,
         "base_sha": "sanitized",
-        "start_sha": "unused-commit-test-placeholder"
+        "start_sha": "unused-commit-test-placeholder",
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "git",
-        "is_full_scan": true
+        "is_full_scan": true,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "github-actions",
-        "is_full_scan": true
+        "is_full_scan": true,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "github-actions",
-        "is_full_scan": false
+        "is_full_scan": false,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "github-actions",
-        "is_full_scan": true
+        "is_full_scan": true,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
@@ -19,6 +19,7 @@
         "scan_environment": "gitlab-ci",
         "is_full_scan": true,
         "base_sha": "sanitized",
-        "start_sha": null
+        "start_sha": null,
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
@@ -19,6 +19,7 @@
         "scan_environment": "gitlab-ci",
         "is_full_scan": false,
         "base_sha": "sanitized",
-        "start_sha": "unused-commit-test-placeholder"
+        "start_sha": "unused-commit-test-placeholder",
+        "is_sca_scan": false
     }
 }

--- a/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/semgrep/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -17,6 +17,7 @@
         "pull_request_id": null,
         "pull_request_title": null,
         "scan_environment": "git",
-        "is_full_scan": true
+        "is_full_scan": true,
+        "is_sca_scan": false
     }
 }


### PR DESCRIPTION
This commit adds an experimental --sca flag to the semgrep ci command.
This tells the backend that the scan is an SCA scan, so the backend can
do some magic to serve the right rules.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
