### PR TITLE
[TS] support for template literal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `r2c-internal-project-depends-on`: support for Gradle and Poetry lockfiles
 
+### Fixed
+
+- TS: support for template literal types after upgrading to a more recent
+  tree-sitter-typescript (Oct 2021)
+
 ## [0.93.0](https://github.com/returntocorp/semgrep/releases/tag/v0.93.0) - 2022-05-17
 
 ### Changed

--- a/semgrep-core/tests/ts/parsing/template_literal_types.ts
+++ b/semgrep-core/tests/ts/parsing/template_literal_types.ts
@@ -1,0 +1,9 @@
+type MakeUpdateCellContentsOperationArgs<
+  ACTION_TYPE extends `UPDATE_${string}_CELL`,
+  ENTITY_NAME extends `${string}Cell`,
+  FIELD_NAME extends `${Uncapitalize<ENTITY_NAME>}Id`,
+> = {
+  type: ACTION_TYPE;
+  entityName: ENTITY_NAME;
+  fieldName: FIELD_NAME;
+};


### PR DESCRIPTION
This comes for free after updating to a more recent
tree-sitter-typescript in the previous PR.

test plan:
test file included


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)