### PR TITLE
tainting: Add another test for object destructuring

### DIFF
--- a/semgrep-core/tests/OTHER/rules/taint_assign_record2.js
+++ b/semgrep-core/tests/OTHER/rules/taint_assign_record2.js
@@ -1,0 +1,15 @@
+// https://github.com/returntocorp/semgrep/issues/5040
+
+function test1(input) {
+    const param = input.body.param
+
+    //ruleid: test
+    sink(param)
+  }
+
+  function test2(input) {
+    const { param }  = input.body
+
+    //ruleid: test
+    sink(param)
+  }

--- a/semgrep-core/tests/OTHER/rules/taint_assign_record2.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_assign_record2.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: test
+  mode: taint
+  message: Test
+  pattern-sources:
+    - patterns:
+        - pattern: input
+  pattern-sinks:
+    - patterns:
+        - pattern: sink(...)
+  severity: ERROR
+  languages:
+    - javascript
+    - typescript


### PR DESCRIPTION
This issue was fixed in PR #5192.

Closes #5040
Closes PA-1183

Follows: 825af92bc86 "AST_to_IL: Add basic support for object destructuring (#5192)"

test plan:
make test # one test added

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
