### PR TITLE
fix(entrypoint): Avoid warning if semgrep is already 1st arg

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ "$*" =~ "--config" || "$*" == "--help" || "$1" == "publish" || "$1" == "ci" ]]; then
+if [[ "$1" != "semgrep" && ("$*" =~ "--config" || "$*" == "--help" || "$1" == "publish" || "$1" == "ci") ]]; then
   # 1) --config is a required semgrep scan argument,
   #    so if it's present, we assume the user meant to call semgrep.
   #

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,8 +14,8 @@ if [[ "$1" != "semgrep" && ("$*" =~ "--config" || "$*" == "--help" || "$1" == "p
   >&2 echo "======= DEPRECATION WARNING ======="
   >&2 echo "The returntocorp/semgrep Docker image's custom entrypoint will be removed by June 2022."
   >&2 echo "Please update your command to explicitly call semgrep."
-  >&2 echo "Change from:  docker run returntocorp/semgrep $*"
-  >&2 echo "Change to:    docker run returntocorp/semgrep semgrep $*"
+  >&2 echo "Change from:  docker run -v \$(pwd):/src returntocorp/semgrep $*"
+  >&2 echo "Change to:    docker run -v \$(pwd):/src returntocorp/semgrep semgrep $*"
   exec semgrep "$@"
 fi
 


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
