### PR TITLE
tainting: Allow variables to be sanitized by side-effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,18 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   safe data, this was not recognized by the taint engine. Also, if `taint(x)`
   occurred inside e.g. an `if` block, any occurrence of `x` outside that block
   was not considered tainted. Now, if you specify that the code variable itself
-  is a taint source, the taint engine will handle this as expected and it will
-  not suffer from the aforementioned limitations. We believe that this change
-  should not break existing taint rules, but please report any regressions that
-  you may find.
+  is a taint source (using `focus-metavaraible`), the taint engine will handle
+  this as expected, and it will not suffer from the aforementioned limitations.
+  We believe that this change should not break existing taint rules, but please
+  report any regressions that you may find.
 - taint-mode: Let's say that e.g. `sanitize(x)` sanitizes `x` by side-effect.
   Previously, we had to rely on a trick that declared that _any_ occurrence of
   `x` inside `sanitize(x); ...` was sanitized. If `x` later overwritten with
   tainted data, the taint engine would still regard `x` as safe. Now, if you
-  specify that the code variable itself is sanitized, the taint engine will
-  handle this as expected and it will not suffer from such limitation. We
-  believe that this change should not break existing taint rules, but please
-  report any regressions that you may find.
+  specify that the code variable itself is sanitized (using `focus-metavaraible`),
+  the taint engine will handle this as expected and it will not suffer from such
+  limitation. We believe that this change should not break existing taint rules,
+  but please report any regressions that you may find.
 - Processing large rule files is now 30% faster.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   not suffer from the aforementioned limitations. We believe that this change
   should not break existing taint rules, but please report any regressions that
   you may find.
+- taint-mode: Let's say that e.g. `sanitize(x)` sanitizes `x` by side-effect.
+  Previously, we had to rely on a trick that declared that _any_ occurrence of
+  `x` inside `sanitize(x); ...` was sanitized. If `x` later overwritten with
+  tainted data, the taint engine would still regard `x` as safe. Now, if you
+  specify that the code variable itself is sanitized, the taint engine will
+  handle this as expected and it will not suffer from such limitation. We
+  believe that this change should not break existing taint rules, but please
+  report any regressions that you may find.
 - Processing large rule files is now 30% faster.
 
 ### Fixed

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -194,8 +194,7 @@ let taint_config_of_rule default_config equivs file ast_and_errors
       Dataflow_tainting.filepath = file;
       rule_id = fst rule.R.id;
       is_source = (fun x -> any_in_ranges rule x sources_ranges);
-      is_sanitizer =
-        (fun x -> any_in_ranges_no_overlap rule x sanitizers_ranges);
+      is_sanitizer = (fun x -> any_in_ranges rule x sanitizers_ranges);
       is_sink = (fun x -> any_in_ranges_no_overlap rule x sinks_ranges);
       unify_mvars = config.taint_unify_mvars;
       handle_findings;

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -16,7 +16,7 @@ type config = {
   is_sink : AST_generic.any -> Pattern_match.t list;
       (** Test whether 'any' is a sink, this corresponds to 'pattern-sinks:'
       * in taint-mode. *)
-  is_sanitizer : AST_generic.any -> Pattern_match.t list;
+  is_sanitizer : AST_generic.any -> (Pattern_match.t * overlap) list;
       (** Test whether 'any' is a sanitizer, this corresponds to
       * 'pattern-sanitizers:' in taint-mode. *)
   unify_mvars : bool;  (** Unify metavariables in sources and sinks? *)

--- a/semgrep-core/tests/OTHER/rules/taint_sanitizer_var.py
+++ b/semgrep-core/tests/OTHER/rules/taint_sanitizer_var.py
@@ -1,0 +1,11 @@
+def ok():
+    x = source
+    # `x` is sanitized by side effect!
+    sanitize(x)
+    #ok: test
+    sink(x)
+
+def bad():
+    x = source
+    #ruleid: test
+    sink(x)

--- a/semgrep-core/tests/OTHER/rules/taint_sanitizer_var.py
+++ b/semgrep-core/tests/OTHER/rules/taint_sanitizer_var.py
@@ -9,3 +9,10 @@ def bad():
     x = source
     #ruleid: test
     sink(x)
+
+def also_bad():
+    x = source
+    sanitize(x)
+    x = source
+    #ruleid: test
+    sink(x)

--- a/semgrep-core/tests/OTHER/rules/taint_sanitizer_var.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_sanitizer_var.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Test
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source
+    pattern-sanitizers:
+      - patterns:
+        - pattern-inside: sanitize($X)
+        - focus-metavariable: $X
+    pattern-sinks:
+      - pattern: sink(...)

--- a/semgrep-core/tests/OTHER/rules/taint_source_var.py
+++ b/semgrep-core/tests/OTHER/rules/taint_source_var.py
@@ -1,7 +1,15 @@
-def test():
+def bad():
     x = set([])
     # `x` becomes tainted by side effect
     taint(x)
     y = x
     #ruleid: test
+    sink(y)
+
+def ok():
+    x = set([])
+    taint(x)
+    # remotes taint
+    x = set([])
+    #ok: test
     sink(y)


### PR DESCRIPTION
Closes PA-1360

test plan:
make test # one test added

PR checklist:

- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
