### PR TITLE
Update to latest semgrep-interfaces

### DIFF
--- a/semgrep-core/dev/dev.opam
+++ b/semgrep-core/dev/dev.opam
@@ -13,5 +13,4 @@ depends: [
   # https://github.com/returntocorp/ocaml-layer/blob/master/common-config.sh
   # and also scripts/lint-ocaml
   "ocamlformat" {= "0.21.0" }  # used by the pre-commit hook
-  "atdpy" {>= "2.4.1"}  # used to generate python code
 ]

--- a/semgrep/semgrep/formatter/json.py
+++ b/semgrep/semgrep/formatter/json.py
@@ -23,7 +23,7 @@ class JsonFormatter(BaseFormatter):
     def _rule_match_to_CliMatch(rule_match: RuleMatch) -> out.CliMatch:
         extra = out.CliMatchExtra(
             message=rule_match.message,
-            metadata=out.RawJson(out._Identity(rule_match.metadata)),
+            metadata=out.RawJson(rule_match.metadata),
             severity=rule_match.severity.value,
             fingerprint=rule_match.syntactic_id,
             # 'lines' already contains '\n' at the end of each line
@@ -33,7 +33,7 @@ class JsonFormatter(BaseFormatter):
 
         if rule_match.extra.get("dependency_matches"):
             extra.dependency_matches = out.RawJson(
-                out._Identity(rule_match.extra.get("dependency_matches"))
+                rule_match.extra.get("dependency_matches")
             )
             extra.dependency_match_only = rule_match.extra.get("dependency_match_only")
         if rule_match.extra.get("fixed_lines"):

--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -287,7 +287,7 @@ class RuleMatch:
             index=self.index,
             commit_date=commit_date_app_format,
             syntactic_id=self.syntactic_id,
-            metadata=out.RawJson(out._Identity(self.metadata)),
+            metadata=out.RawJson(self.metadata),
             is_blocking=self.is_blocking,
         )
 


### PR DESCRIPTION
We now use atdpy 2.7.0 which has better support for 'abstract'
The relevant changes are really in the semgrep-interfaces submodule

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)