### PR TITLE
tainting: Pass taint findings to the match hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   safe data, this was not recognized by the taint engine. Also, if `taint(x)`
   occurred inside e.g. an `if` block, any occurrence of `x` outside that block
   was not considered tainted. Now, if you specify that the code variable itself
-  is a taint source (using `focus-metavaraible`), the taint engine will handle
+  is a taint source (using `focus-metavariable`), the taint engine will handle
   this as expected, and it will not suffer from the aforementioned limitations.
   We believe that this change should not break existing taint rules, but please
   report any regressions that you may find.
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   Previously, we had to rely on a trick that declared that _any_ occurrence of
   `x` inside `sanitize(x); ...` was sanitized. If `x` later overwritten with
   tainted data, the taint engine would still regard `x` as safe. Now, if you
-  specify that the code variable itself is sanitized (using `focus-metavaraible`),
+  specify that the code variable itself is sanitized (using `focus-metavariable`),
   the taint engine will handle this as expected and it will not suffer from such
   limitation. We believe that this change should not break existing taint rules,
   but please report any regressions that you may find.

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -74,8 +74,6 @@ and rule_id = {
 }
 [@@deriving show, eq]
 
-let hash pm = Hashtbl.hash (pm.rule_id, pm.file, pm.range_loc, pm.env)
-
 let uniq pms =
   let eq = AST_utils.with_structural_equal equal in
   let tbl = Hashtbl.create 1_024 in

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -74,6 +74,8 @@ and rule_id = {
 }
 [@@deriving show, eq]
 
+let hash pm = Hashtbl.hash (pm.rule_id, pm.file, pm.range_loc, pm.env)
+
 let uniq pms =
   let eq = AST_utils.with_structural_equal equal in
   let tbl = Hashtbl.create 1_024 in

--- a/semgrep-core/src/engine/Match_rules.mli
+++ b/semgrep-core/src/engine/Match_rules.mli
@@ -9,7 +9,11 @@ exception File_timeout
 *)
 val check :
   match_hook:
-    (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
+    (string ->
+    Metavariable.bindings ->
+    Parse_info.t list Lazy.t ->
+    Taint.finding option ->
+    unit) ->
   timeout:float ->
   timeout_threshold:int ->
   Config_semgrep.t * Equivalence.equivalences ->

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -1065,7 +1065,7 @@ let check_rule r hook (default_config, equivs) pformula xtarget =
              v
              |> List.iter (fun (m : Pattern_match.t) ->
                     let str = spf "with rule %s" rule_id in
-                    hook str m.env m.tokens));
+                    hook str m.env m.tokens None));
     errors = res.errors |> Common.map (error_with_rule_id rule_id);
     skipped_targets = res.skipped_targets;
     profiling = res.profiling;

--- a/semgrep-core/src/engine/Match_search_rules.mli
+++ b/semgrep-core/src/engine/Match_search_rules.mli
@@ -1,6 +1,10 @@
 val check_rule :
   Rule.t ->
-  (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
+  (string ->
+  Metavariable.bindings ->
+  Parse_info.t list Lazy.t ->
+  _ option ->
+  unit) ->
   Config_semgrep.t * Equivalence.equivalences ->
   Rule.pformula ->
   Xtarget.t ->

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -301,7 +301,9 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
 let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
   (* TODO: Pass a hashtable to cache the CFG of each def, otherwise we are
    * recomputing the CFG for each taint rule. *)
+  let module Pmtbl = Hashtbl.Make (Pattern_match) in
   let matches = ref [] in
+  let pm2finding = Pmtbl.create 10 in
 
   let { Xtarget.file; xlang; lazy_ast_and_errors; _ } = xtarget in
   let lang =
@@ -319,7 +321,9 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
       findings
       |> List.iter (fun finding ->
              pm_of_finding file finding
-             |> Option.iter (fun pm -> Common.push pm matches))
+             |> Option.iter (fun pm ->
+                    Common.push pm matches;
+                    Pmtbl.add pm2finding pm finding))
     in
     taint_config_of_rule default_config equivs file (ast, []) rule taint_spec
       handle_findings
@@ -366,7 +370,8 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
            v
            |> List.iter (fun (m : Pattern_match.t) ->
                   let str = Common.spf "with rule %s" m.rule_id.id in
-                  match_hook str m.env m.tokens))
+                  let opt_finding = Pmtbl.find_opt pm2finding m in
+                  match_hook str m.env m.tokens opt_finding))
     |> Common.map (fun m ->
            { m with PM.rule_id = convert_rule_id rule.Rule.id })
   in

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -301,9 +301,19 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
 let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
   (* TODO: Pass a hashtable to cache the CFG of each def, otherwise we are
    * recomputing the CFG for each taint rule. *)
-  let module Pmtbl = Hashtbl.Make (Pattern_match) in
+  let module PMtbl = Hashtbl.Make (struct
+    type t = PM.t
+
+    let hash (pm : PM.t) =
+      Hashtbl.hash (pm.rule_id, pm.file, pm.range_loc, pm.env)
+
+    (* TODO: Shouldn't be the PM.equal that does the right thing? Instead of
+     * deriving `equal` for `Metavariable.bindings` via ppx_deriving, perhaps
+     * we need to have a custom definition that relies on AST_utils there. *)
+    let equal = AST_utils.with_structural_equal PM.equal
+  end) in
   let matches = ref [] in
-  let pm2finding = Pmtbl.create 10 in
+  let pm2finding = PMtbl.create 10 in
 
   let { Xtarget.file; xlang; lazy_ast_and_errors; _ } = xtarget in
   let lang =
@@ -323,7 +333,7 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
              pm_of_finding file finding
              |> Option.iter (fun pm ->
                     Common.push pm matches;
-                    Pmtbl.add pm2finding pm finding))
+                    PMtbl.add pm2finding pm finding))
     in
     taint_config_of_rule default_config equivs file (ast, []) rule taint_spec
       handle_findings
@@ -370,7 +380,7 @@ let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
            v
            |> List.iter (fun (m : Pattern_match.t) ->
                   let str = Common.spf "with rule %s" m.rule_id.id in
-                  let opt_finding = Pmtbl.find_opt pm2finding m in
+                  let opt_finding = PMtbl.find_opt pm2finding m in
                   match_hook str m.env m.tokens opt_finding))
     |> Common.map (fun m ->
            { m with PM.rule_id = convert_rule_id rule.Rule.id })

--- a/semgrep-core/src/engine/Match_tainting_rules.mli
+++ b/semgrep-core/src/engine/Match_tainting_rules.mli
@@ -23,7 +23,11 @@ val taint_config_of_rule :
 
 val check_rule :
   Rule.t ->
-  (string -> Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
+  (string ->
+  Metavariable.bindings ->
+  Parse_info.t list Lazy.t ->
+  Taint.finding option ->
+  unit) ->
   Config_semgrep.t * Equivalence.equivalences ->
   Rule.taint_spec ->
   Xtarget.t ->

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -165,7 +165,7 @@ let make_tests ?(unit_testing = false) xs =
              let res =
                try
                  Match_rules.check
-                   ~match_hook:(fun _ _ _ -> ())
+                   ~match_hook:(fun _ _ _ _ -> ())
                    ~timeout:0. ~timeout_threshold:0 (config, []) rules xtarget
                with
                | exn ->

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -468,7 +468,7 @@ let tainting_test lang rules_file file =
            in
            let res, _debug =
              Match_tainting_rules.check_rule rule
-               (fun _ _ _ -> ())
+               (fun _ _ _ _ -> ())
                (Config_semgrep.default_config, equivs)
                taint_spec xtarget
            in

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -490,7 +490,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
            in
 
            let xtarget = xtarget_of_file config xlang file in
-           let match_hook str env matched_tokens =
+           let match_hook str env matched_tokens _opt_taint_finding =
              if config.output_format = Text then
                let xs = Lazy.force matched_tokens in
                print_match ~str config.match_format config.mvars env


### PR DESCRIPTION
This will at least facilitate debugging taint findings in DeepSemgrep.

Helps PA-1310

Also, fixed a couple of typos in the changelog.

test plan:
make test

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
