### PR TITLE
Better error message for patterns with only negative terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - The dot access ellipsis now matches field accesses in addition to method
   calls.
 - Made error message for resource exhausion (exit code -11/-9) more actionable
+- Made error message for rules with patterns missing positive terms
+  more actionable (#5234)
 - In this version, we have made several performance improvements
   to the code that surrounds our source parsing and matching core.
   This includes file targeting, rule fetching, and similar parts of the codebase.

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -109,15 +109,19 @@ type formula =
    * (see tests/OTHER/rules/negation_exact.yaml)
    *)
   | P of xpattern (* a leaf pattern *) * inside option
-  (* see Specialize_formula.split_and() *)
   | And of conjunction
   | Or of tok * formula list
   (* There are currently restrictions on where a Not can appear in a formula.
    * It must be inside an And to be intersected with "positive" formula.
-   * But this could change? If we were moving to a different range semantic?
+   * TODO? Could this change if we were moving to a different range semantic?
    *)
   | Not of tok * formula
 
+(* The conjuncts must contain at least
+ * one positive "term" (unless it's inside a CondNestedFormula, in which
+ * case there is not such a restriction).
+ * See also split_and().
+ *)
 and conjunction = {
   tok : tok;
   (* pattern-inside:'s and pattern:'s *)
@@ -293,6 +297,7 @@ and invalid_rule_error_kind =
       * string list (* yaml path *)
   | InvalidRegexp of string (* PCRE error message *)
   | InvalidOther of string
+  | MissingPositiveTermInAnd
 
 let string_of_invalid_rule_error_kind = function
   | InvalidLanguage language -> spf "invalid language %s" language
@@ -302,6 +307,8 @@ let string_of_invalid_rule_error_kind = function
    * of a RuleParseError *)
   | InvalidPattern (_pattern, xlang, _message, _yaml_path) ->
       spf "Invalid pattern for %s" (Xlang.to_string xlang)
+  | MissingPositiveTermInAnd ->
+      "you need at least one positive term (not just negations or conditions)"
   | InvalidOther s -> s
 
 exception InvalidRule of invalid_rule_error
@@ -393,8 +400,26 @@ let remove_noop (e : formula_old) : formula_old =
   in
   aux e
 
-let rec (convert_formula_old : formula_old -> formula) =
- fun e ->
+(* return list of "positive" x list of Not *)
+let split_and : formula list -> formula list * formula list =
+ fun xs ->
+  xs
+  |> Common.partition_either (fun e ->
+         match e with
+         (* positives *)
+         | P _
+         | And _
+         | Or _ ->
+             Left e
+         (* negatives *)
+         | Not (_, f) -> Right f)
+
+let rec (convert_formula_old :
+          ?in_metavariable_pattern:bool ->
+          rule_id:rule_id ->
+          formula_old ->
+          formula) =
+ fun ?(in_metavariable_pattern = false) ~rule_id e ->
   let rec aux e =
     match e with
     | Pat x -> P (x, None)
@@ -406,6 +431,9 @@ let rec (convert_formula_old : formula_old -> formula) =
         Or (t, xs)
     | Patterns (t, xs) ->
         let fs, conds, focus = Common.partition_either3 aux_and xs in
+        let pos, _ = split_and fs in
+        if pos = [] && not in_metavariable_pattern then
+          raise (InvalidRule (MissingPositiveTermInAnd, rule_id, t));
         And { tok = t; conjuncts = fs; conditions = conds; focus }
     | PatExtra (t, _) ->
         raise
@@ -418,18 +446,20 @@ let rec (convert_formula_old : formula_old -> formula) =
   and aux_and e =
     match e with
     | PatExtra (t, x) ->
-        let e = convert_extra x in
+        let e = convert_extra ~rule_id x in
         Middle3 (t, e)
     | PatFocus (t, mvar) -> Right3 (t, mvar)
     | _ -> Left3 (aux e)
   in
   aux (remove_noop e)
 
-and convert_extra x =
+and convert_extra ~rule_id x =
   match x with
   | MetavarRegexp (mvar, re) -> CondRegexp (mvar, re)
   | MetavarPattern (mvar, opt_xlang, formula_old) ->
-      let formula = convert_formula_old formula_old in
+      let formula =
+        convert_formula_old ~in_metavariable_pattern:true ~rule_id formula_old
+      in
       CondNestedFormula (mvar, opt_xlang, formula)
   | MetavarComparison comp -> (
       match comp with
@@ -458,9 +488,9 @@ and convert_extra x =
 *)
       failwith (Common.spf "convert_extra: TODO: %s" (show_extra x))
 
-let formula_of_pformula = function
+let formula_of_pformula ?in_metavariable_pattern ~rule_id = function
   | New f -> f
-  | Old oldf -> convert_formula_old oldf
+  | Old oldf -> convert_formula_old ?in_metavariable_pattern ~rule_id oldf
 
 let partition_rules rules =
   rules

--- a/semgrep-core/src/engine/Match_search_rules.ml
+++ b/semgrep-core/src/engine/Match_search_rules.ml
@@ -1048,8 +1048,8 @@ and matches_of_formula config rule file_and_more formula opt_context :
 
 let check_rule r hook (default_config, equivs) pformula xtarget =
   let config = r.R.options ||| default_config in
-  let formula = R.formula_of_pformula pformula in
   let rule_id = fst r.id in
+  let formula = R.formula_of_pformula ~rule_id pformula in
   let res, final_ranges =
     matches_of_formula (config, equivs) r xtarget formula None
   in

--- a/semgrep-core/src/engine/Match_tainting_rules.ml
+++ b/semgrep-core/src/engine/Match_tainting_rules.ml
@@ -126,9 +126,10 @@ let any_in_ranges rule any rwms =
 let any_in_ranges_no_overlap rule any rwms =
   any_in_ranges rule any rwms |> Common.map fst
 
-let range_w_metas_of_pformula config equivs file_and_more rule_id pformula =
-  let formula = Rule.formula_of_pformula pformula in
-  Match_search_rules.matches_of_formula (config, equivs) rule_id file_and_more
+let range_w_metas_of_pformula config equivs file_and_more rule pformula =
+  let rule_id = fst rule.R.id in
+  let formula = Rule.formula_of_pformula ~rule_id pformula in
+  Match_search_rules.matches_of_formula (config, equivs) rule file_and_more
     formula None
   |> snd
 
@@ -298,20 +299,20 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
   check_stmt ?name ~in_env lang fun_env taint_config
     (H.funcbody_to_stmt fdef.G.fbody)
 
+module PMtbl = Hashtbl.Make (struct
+  type t = PM.t
+
+  let hash (pm : PM.t) = Hashtbl.hash (pm.rule_id, pm.file, pm.range_loc, pm.env)
+
+  (* TODO: Shouldn't be the PM.equal that does the right thing? Instead of
+   * deriving `equal` for `Metavariable.bindings` via ppx_deriving, perhaps
+   * we need to have a custom definition that relies on AST_utils there. *)
+  let equal = AST_utils.with_structural_equal PM.equal
+end)
+
 let check_rule rule match_hook (default_config, equivs) taint_spec xtarget =
   (* TODO: Pass a hashtable to cache the CFG of each def, otherwise we are
    * recomputing the CFG for each taint rule. *)
-  let module PMtbl = Hashtbl.Make (struct
-    type t = PM.t
-
-    let hash (pm : PM.t) =
-      Hashtbl.hash (pm.rule_id, pm.file, pm.range_loc, pm.env)
-
-    (* TODO: Shouldn't be the PM.equal that does the right thing? Instead of
-     * deriving `equal` for `Metavariable.bindings` via ppx_deriving, perhaps
-     * we need to have a custom definition that relies on AST_utils there. *)
-    let equal = AST_utils.with_structural_equal PM.equal
-  end) in
   let matches = ref [] in
   let pm2finding = PMtbl.create 10 in
 

--- a/semgrep-core/src/engine/Specialize_formula.ml
+++ b/semgrep-core/src/engine/Specialize_formula.ml
@@ -41,20 +41,6 @@ let selector_equal s1 s2 = s1.mvar = s2.mvar
 (* Converter *)
 (*****************************************************************************)
 
-(* return list of "positive" x list of Not *)
-let split_and : R.formula list -> R.formula list * R.formula list =
- fun xs ->
-  xs
-  |> Common.partition_either (fun e ->
-         match e with
-         (* positives *)
-         | R.P _
-         | R.And _
-         | R.Or _ ->
-             Left e
-         (* negatives *)
-         | R.Not (_, f) -> Right f)
-
 let selector_from_formula f =
   match f with
   | Leaf ({ pat = Sem (pattern, _); pid; pstr }, None) -> (
@@ -96,7 +82,7 @@ let formula_to_sformula formula =
     | R.Or (_, fs) -> Or (Common.map formula_to_sformula fs)
     | R.Not (_, f) -> Not (formula_to_sformula f)
   and convert_and_formulas fs cond focus =
-    let pos, neg = split_and fs in
+    let pos, neg = Rule.split_and fs in
     let pos = Common.map formula_to_sformula pos in
     let neg = Common.map formula_to_sformula neg in
     let sel, pos =

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -171,10 +171,11 @@ let check_formula env (lang : Xlang.t) f =
 (*****************************************************************************)
 
 let check r =
+  let rule_id = fst r.id in
   (* less: maybe we could also have formula_old specific checks *)
   match r.mode with
   | Rule.Search pf ->
-      let f = Rule.formula_of_pformula pf in
+      let f = Rule.formula_of_pformula ~rule_id pf in
       check_formula { r; errors = ref [] } r.languages f
   | Taint _ -> (* TODO *) []
 

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -508,10 +508,14 @@ let regexp_prefilter_of_formula f =
   with
   | GeneralPattern -> None
 
-let regexp_prefilter_of_taint_rule rule_tok taint_spec =
+let regexp_prefilter_of_taint_rule (rule_id, rule_tok) taint_spec =
   (* We must be able to match some source _and_ some sink. *)
-  let sources = taint_spec.R.sources |> Common.map R.formula_of_pformula in
-  let sinks = taint_spec.R.sinks |> Common.map R.formula_of_pformula in
+  let sources =
+    taint_spec.R.sources |> Common.map (R.formula_of_pformula ~rule_id)
+  in
+  let sinks =
+    taint_spec.R.sinks |> Common.map (R.formula_of_pformula ~rule_id)
+  in
   let f =
     (* Note that this formula would likely not yield any meaningful result
      * if executed by search-mode, but it works for the purpose of this
@@ -529,20 +533,20 @@ let regexp_prefilter_of_taint_rule rule_tok taint_spec =
 let hmemo = Hashtbl.create 101
 
 let regexp_prefilter_of_rule r =
-  let id, t = r.R.id in
-  let k = PI.file_of_info t ^ "." ^ id in
+  let rule_id, t = r.R.id in
+  let k = PI.file_of_info t ^ "." ^ rule_id in
   Common.memoized hmemo k (fun () ->
       try
         match r.mode with
         | R.Search pf ->
-            let f = R.formula_of_pformula pf in
+            let f = R.formula_of_pformula ~rule_id pf in
             regexp_prefilter_of_formula f
-        | R.Taint spec -> regexp_prefilter_of_taint_rule t spec
+        | R.Taint spec -> regexp_prefilter_of_taint_rule r.R.id spec
       with
       (* TODO: see tests/OTHER/rules/tainted-filename.yaml *)
       | CNF_exploded ->
-          logger#error "CNF size exploded on rule id %s" id;
+          logger#error "CNF size exploded on rule id %s" rule_id;
           None
       | Stack_overflow ->
-          logger#error "Stack overflow on rule id %s" id;
+          logger#error "Stack overflow on rule id %s" rule_id;
           None)

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau, Emma Jin
  *
- * Copyright (C) 2019-2021 r2c
+ * Copyright (C) 2019-2022 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -533,8 +533,11 @@ let rec parse_formula_old env ((key, value) : key * G.expr) : R.formula_old =
   | "r2c-internal-patterns-from" -> R.PatFilteredInPythonTodo t
   | _ -> error_at_key env key (spf "unexpected key %s" (fst key))
 
-(* let extra = parse_extra env x in
-   R.PatExtra extra *)
+(* NOTE: this is mostly deadcode! None of our rules are using
+ * this new formula syntax directly (internally we do convert
+ * old style formula to new formula, but we always use the old
+ * syntax formula in yaml files).
+ *)
 and parse_formula_new env (x : G.expr) : R.formula =
   match x.G.e with
   | G.Container
@@ -553,6 +556,10 @@ and parse_formula_new env (x : G.expr) : R.formula =
       | "and" ->
           let xs = parse_list env key parse_formula_and_new value in
           let fs, conds = Common.partition_either (fun x -> x) xs in
+          (* sanity check fs *)
+          let pos, _negs = R.split_and fs in
+          if pos = [] then
+            raise (R.InvalidRule (R.MissingPositiveTermInAnd, env.id, t));
           R.And
             {
               tok = t;
@@ -704,7 +711,11 @@ let parse_severity ~id (s, t) =
 let parse_formula (env : env) (rule_dict : dict) : R.pformula =
   match Hashtbl.find_opt rule_dict.h "match" with
   | Some (_matchkey, v) -> R.New (parse_formula_new env v)
-  | None -> R.Old (parse_formula_old env (find_formula_old env rule_dict))
+  | None ->
+      let old = parse_formula_old env (find_formula_old env rule_dict) in
+      (* sanity check *)
+      let _new = Rule.convert_formula_old ~rule_id:env.id old in
+      R.Old old
 
 let parse_sanitizer env (key : key) (value : G.expr) =
   let sanitizer_dict = yaml_to_dict env key value in
@@ -807,7 +818,6 @@ let parse_one_rule t i rule =
   }
 
 let parse_generic ?(error_recovery = false) file ast =
-  ignore error_recovery;
   let t, rules =
     match ast with
     | [ { G.s = G.ExprStmt (e, _); _ } ] -> (

--- a/semgrep-core/tests/OTHER/errors/only_negative_terms.yaml
+++ b/semgrep-core/tests/OTHER/errors/only_negative_terms.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: empty-test
+  patterns:
+  - pattern-not-regex: |
+      function
+  - pattern-not-regex:
+      class
+  message: test
+  languages:
+  - java
+  severity: INFO
+  


### PR DESCRIPTION
This closes #5234

test plan:
```
$ semgrep-core -l regex -rules tests/OTHER/errors/only_negative_terms.yaml tests/java/
tests/OTHER/errors/only_negative_terms.yaml:3:2: "Rule parse error": you need at least one positive term (not just negations or conditions)
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)