### PR TITLE
fix Circle CI parsing-stats job for Scala

### DIFF
--- a/parsing-stats/lang/scala/projects.txt
+++ b/parsing-stats/lang/scala/projects.txt
@@ -23,7 +23,6 @@ https://github.com/polynote/polynote
 https://github.com/mesosphere/marathon
 https://github.com/zio/zio
 https://github.com/microsoft/SynapseML
-https://github.com/yahoo/CMAK
 https://github.com/delta-io/delta
 https://github.com/lichess-org/scalachess
 https://github.com/outworkers/phantom


### PR DESCRIPTION
the CMAK repo was already present in the projects.txt,
leading to duplicates triggering a git error during the
CI job

test plan:
cd parsing-stats
./run-lang scala


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)