### PR TITLE
[C++] apply const to the type, not the decl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - semgrep-core: you can use again rules stored in JSON instead of YAML (#5268)
 - Python: adds support for parentheses around `with` context expressions
   (e.g., `with (open(x) as a, open(y) as b): pass`) (#5092)
+- C++: we now parse correctly const declarations (#5300)
 
 ## [0.93.0](https://github.com/returntocorp/semgrep/releases/tag/v0.93.0) - 2022-05-17
 

--- a/semgrep-core/tests/cpp/misc_const.cpp
+++ b/semgrep-core/tests/cpp/misc_const.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+
+//ERROR: match
+const int age = 50;
+
+int age2 = 2;
+
+int main() {
+    return 0;
+}

--- a/semgrep-core/tests/cpp/misc_const.sgrep
+++ b/semgrep-core/tests/cpp/misc_const.sgrep
@@ -1,0 +1,1 @@
+const $TYPE $VARIABLE = $VALUE;


### PR DESCRIPTION
This closes #5300

test plan:
test file included
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)