### PR TITLE
Make throw an expression in PHP

### DIFF
--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -143,9 +143,6 @@ let rec stmt_aux = function
       let v1 = stmt v1 in
       [ G.Label (ident id, v1) |> G.s ]
   | Goto (t, id) -> [ G.Goto (t, ident id, G.sc) |> G.s ]
-  | Throw (t, v1) ->
-      let v1 = expr v1 in
-      [ G.Throw (t, v1, G.sc) |> G.s ]
   | Try (t, v1, v2, v3) ->
       let v1 = stmt v1 and v2 = list catch v2 and v3 = finally v3 in
       [ G.Try (t, v1, v2, v3) |> G.s ]
@@ -325,6 +322,10 @@ and expr e : G.expr =
   | Call (v1, v2) ->
       let v1 = expr v1 and v2 = bracket (list argument) v2 in
       G.Call (v1, v2)
+  | Throw (t, v1) ->
+      let v1 = expr v1 in
+      let st = G.Throw (t, v1, G.sc) |> G.s in
+      G.StmtExpr st
   | Infix ((v1, t), v2) ->
       let v1 = fixOp v1 and v2 = expr v2 in
       G.Call (G.IdSpecial (G.IncrDecr (v1, G.Prefix), t) |> G.e, fb [ G.Arg v2 ])

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -1689,8 +1689,7 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : A.expr =
   | `Throw_exp (v1, v2) ->
       let v1 = (* pattern [tT][hH][rR][oO][wW] *) token env v1 in
       let v2 = map_expression env v2 in
-      todo env (v1, v2)
-(* TODO A.Throw is a stmt, when it should be an expr *)
+      A.Throw (v1, v2)
 
 and map_property_element (env : env) ((v1, v2) : CST.property_element) =
   let v1 = map_variable_name env v1 in


### PR DESCRIPTION
As of PHP 8.0.0, the throw keyword is an expression and may be used in any expression context. In prior versions it was a statement and was required to be on its own line.

[Corresponding pfff pull request](https://github.com/returntocorp/pfff/pull/522)

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
