### PR TITLE
Print failed files when running parsing stats

### DIFF
--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -278,6 +278,8 @@ let parsing_common ?(verbose = true) lang files_or_dirs =
                  *)
                  PI.bad_stat file
            in
+           if verbose && stat.PI.error_line_count > 0 then
+             pr2 (spf "FAILED TO FULLY PARSE: %s" stat.PI.filename);
            stat)
   in
   (stats, skipped)


### PR DESCRIPTION
This makes it into `stats.log` when running parsing stats. It's useful
to know which files failed parsing when investigating parse errors.

Test plan:

From the parsing-stats directory: `./run-lang php`. Then inspect
`parsing-stats/lang/php/stats.log` for the new lines.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
