### PR TITLE
Print parse errors in dump_ast

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -236,6 +236,9 @@ let dump_ast ?(naming = false) lang file =
       pr s;
       if errors <> [] then (
         pr2 (spf "WARNING: fail to fully parse %s" file);
+        pr2
+          (Common.map (fun e -> "  " ^ E.string_of_error e) errors
+          |> String.concat "\n");
         Runner_exit.(exit_semgrep False)))
 
 let dump_v1_json file =


### PR DESCRIPTION
In addition to printing the warning that the file failed to fully parse,
print the parse errors that actually led to that warning. This is useful
when investigating parse errors.

Test plan:

`$ semgrep-core -tree_sitter_only -lang php -dump_ast filewitherrors.php`

See the parse errors reported on the CLI

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
