### PR TITLE
Add missing semicolons to java test

### DIFF
--- a/semgrep-core/tests/java/typed_metavar_foreach.java
+++ b/semgrep-core/tests/java/typed_metavar_foreach.java
@@ -5,8 +5,8 @@ public class OtherObj {
       obj.persistObj(arg0, arg1);
     }
 
-    MyObj obj = new MyObj()
+    MyObj obj = new MyObj();
     //ERROR:match   
-    obj.persistObj(arg0, arg1)
+    obj.persistObj(arg0, arg1);
   }
 }


### PR DESCRIPTION
Adds semicolons to the Java typed metavariable test.

For whatever reason this seems to be passing on CI (and for some people locally) despite the fact that it should fail to parse (and does in fact fail for others locally). Instead of tracking down whatever is causing this, let's just fix it.

PR checklist:

- [x] Documentation is up-to-date
- [x] ~~Changelog is up-to-date~~
- [x] Change has no security implications (otherwise, ping security team)
