### PR TITLE
[Elixir] added support for -l elixir in -dump_tree_sitter_cst

### DIFF
--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -131,6 +131,9 @@ let dump_tree_sitter_cst lang file =
   | Lang.Hcl ->
       Tree_sitter_hcl.Parse.file file
       |> dump_and_print_errors Tree_sitter_hcl.CST.dump_tree
+  | Lang.Elixir ->
+      Tree_sitter_elixir.Parse.file file
+      |> dump_and_print_errors Tree_sitter_elixir.CST.dump_tree
   | _ -> failwith "lang not supported by ocaml-tree-sitter"
 
 let test_parse_tree_sitter lang root_paths =


### PR DESCRIPTION
test plan:
```
$ semgrep-core -l elixir -dump_tree_sitter_cst hello_world.ex
+ /home/pad/yy/_build/default/src/cli/Main.exe -l elixir -dump_tree_sitter_cst hello_world.ex
|   |   Call
|   |   | Call_with_parens_b98484c
|   |   |   Local_call_with_parens
|   |   |   |   Pat_cf9c6c3
|   |   |   |   defmodule
|   |   |   |   Exp_rep_COMMA_exp_opt_COMMA_keywos
|   |   |   |   |   Alias
|   |   |   |   |   Hello
|   |   |   |   |   do
|   |   |   |   |   |   Rep1_pat_509ec78
|   |   |   |   |   |   | "\n"
|   |   |   |   |   |   Choice_exp_rep_term_choice_exp_opt_term
|   |   |   |   |   |   |   Exp
|   |   |   |   |   |   |   | Un_op
|   |   |   |   |   |   |   |   Opt_before_un_op_AT_exp
|   |   |   |   |   |   |   |   | "@"
|   |   |   |   |   |   |   |   |   Call
|   |   |   |   |   |   |   |   |   | Call_with_parens_b98484c
|   |   |   |   |   |   |   |   |   |   Local_call_with_parens
|   |   |   |   |   |   |   |   |   |   |   Pat_cf9c6c3
|   |   |   |   |   |   |   |   |   |   |   moduledoc
|   |   |   |   |   |   |   |   |   |   |   Exp_rep_COMMA_exp_opt_COMMA_keywos
|   |   |   |   |   |   |   |   |   |   |   |   Str
|   |   |   |   |   |   |   |   |   |   |   |   | Quoted_i_here_double
|   |   |   |   |   |   |   |   |   |   |   |   |   "\"\"\""
|   |   |   |   |   |   |   |   |   |   |   |   |   |   Quoted_content_i_here_double
|   |   |   |   |   |   |   |   |   |   |   |   |   |   "\n  Documentation for `Hello`.\n  "
|   |   |   |   |   |   |   |   |   |   |   |   |   "\"\"\""
|   |   |   |   |   |   |   |   Rep1_pat_509ec78
|   |   |   |   |   |   |   |   | "\n\n"
|   |   |   |   |   |   |   |   Exp
|   |   |   |   |   |   |   |   | Un_op
|   |   |   |   |   |   |   |   |   Opt_before_un_op_AT_exp
|   |   |   |   |   |   |   |   |   | "@"
|   |   |   |   |   |   |   |   |   |   Call
|   |   |   |   |   |   |   |   |   |   | Call_with_parens_b98484c
|   |   |   |   |   |   |   |   |   |   |   Local_call_with_parens
|   |   |   |   |   |   |   |   |   |   |   |   Pat_cf9c6c3
|   |   |   |   |   |   |   |   |   |   |   |   doc
|   |   |   |   |   |   |   |   |   |   |   |   Exp_rep_COMMA_exp_opt_COMMA_keywos
|   |   |   |   |   |   |   |   |   |   |   |   |   Str
|   |   |   |   |   |   |   |   |   |   |   |   |   | Quoted_i_here_double
|   |   |   |   |   |   |   |   |   |   |   |   |   |   "\"\"\""
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   Quoted_content_i_here_double
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   "\n  Hello world.\n\n  ## Examples\n\n      iex> Hello.hello()\n      :world\n\n  "
|   |   |   |   |   |   |   |   |   |   |   |   |   |   "\"\"\""
|   |   |   |   |   |   |   |   Rep1_pat_509ec78
|   |   |   |   |   |   |   |   | "\n"
|   |   |   |   |   |   |   |   Exp
|   |   |   |   |   |   |   |   | Call
|   |   |   |   |   |   |   |   |   Call_with_parens_b98484c
|   |   |   |   |   |   |   |   |   | Local_call_with_parens
|   |   |   |   |   |   |   |   |   |   | Pat_cf9c6c3
|   |   |   |   |   |   |   |   |   |   | def
|   |   |   |   |   |   |   |   |   |   | Exp_rep_COMMA_exp_opt_COMMA_keywos
|   |   |   |   |   |   |   |   |   |   |   | Id
|   |   |   |   |   |   |   |   |   |   |   |   Pat_cf9c6c3
|   |   |   |   |   |   |   |   |   |   |   |   hello
|   |   |   |   |   |   |   |   |   |   |   | do
|   |   |   |   |   |   |   |   |   |   |   |   | Rep1_pat_509ec78
|   |   |   |   |   |   |   |   |   |   |   |   |   "\n"
|   |   |   |   |   |   |   |   |   |   |   |   | Choice_exp_rep_term_choice_exp_opt_term
|   |   |   |   |   |   |   |   |   |   |   |   |   | Exp
|   |   |   |   |   |   |   |   |   |   |   |   |   |   Call
|   |   |   |   |   |   |   |   |   |   |   |   |   |   | Call_with_parens_b98484c
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   Remote_call_with_parens
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | Alias
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | IO
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   "."
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | Id
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   Pat_cf9c6c3
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   puts
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | Exp_rep_COMMA_exp_opt_COMMA_keywos
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | Str
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   Quoted_i_double
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | "\""
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | Quoted_content_i_double
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | "Hello world!!"
|   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   | "\""
|   |   |   |   |   |   |   |   |   |   |   |   |   |   Rep1_pat_509ec78
|   |   |   |   |   |   |   |   |   |   |   |   |   |   | "\n"
|   |   |   |   |   |   |   |   |   |   |   | end
|   |   |   |   |   |   |   | Rep1_pat_509ec78
|   |   |   |   |   |   |   |   "\n"
|   |   |   |   |   end
|   |   | Rep1_pat_509ec78
|   |   |   "\n\n"
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)