### PR TITLE
fix(ruby): Use QDots in IDQualified when possible

### DIFF
--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -261,7 +261,24 @@ and scope_resolution x : G.name =
        * in which case we could generate a QDots instead of a QEXpr
        *)
       let e = expr e in
-      let qualif = G.QExpr (e, t) in
+      let qualif =
+        match e with
+        | { G.e = G.N (G.Id (id, _info)); _ } -> G.QDots [ (id, None) ]
+        | {
+         G.e =
+           G.N
+             (G.IdQualified
+               {
+                 name_last;
+                 name_middle = Some (G.QDots middle);
+                 name_top = None;
+                 _;
+               });
+         _;
+        } ->
+            G.QDots (middle @ [ name_last ])
+        | _ -> G.QExpr (e, t)
+      in
       IdQualified
         {
           G.name_last = (id, None);


### PR DESCRIPTION
When resolved names go through the matching infrastructure in
`Generic_vs_generic.m_name`, they are transformed into AST nodes via the
`name_of_ids` helper function. This transformation is lossy, and in
particular, it turnes a series of multiple identifiers into an
`IdQualified` node using `QDots` as the qualifier.

Unfortunately, in Ruby, `QDots` never appears in the AST. Instead, even
a plain qualified name is represented using `QExpr`. This means that the
pattern `Foo::Bar` is represented with `QExpr`, and can be compared
against AST constructed from a resolved name using `QDots`. This causes
a match failure in every case.

We could add a case to `m_qualifier` to extract names from the
special-case of `QExpr` that contains only a name, but I've already had
to do this in one other place in DeepSemgrep and I suspect that
continuing down that path would lead to numerous places where we would
need to handle this special case.

Instead, let's handle the special case once, when we construct the
generic AST. For the common case, where the qualifier is in fact a
series of identifiers, this will make downstream code behave similarly
for Ruby as it does for other languages that use `QDots` exclusively. In
particular, this allows DeepSemgrep to match a pattern `Foo::Bar`
against something that is not exactly `Foo::Bar` but resolves to it.

Test plan:

Automated tests

`semgrep-core -lang ruby -dump_ast test.rb` where `test.rb` is
`Foo::Bar::Baz`

Before:

```
Pr(
  [ExprStmt(
     N(
       IdQualified(
         {name_last=(("Baz", ()), None); name_top=None;
          name_middle=Some(QExpr(
                             N(
                               IdQualified(
                                 {name_last=(("Bar", ()), None); name_top=None;
                                  name_middle=Some(QExpr(
                                                     N(
                                                       Id(("Foo", ()),
                                                         {id_info_id=1; id_hidden=false; id_resolved=Ref(
                                                          None); id_type=Ref(
                                                          None); id_svalue=Ref(
                                                          None); })), ()));
                                  name_info={id_info_id=2; id_hidden=false; id_resolved=Ref(
                                             None); id_type=Ref(None); id_svalue=Ref(
                                             None); };
                                  })), ()));
          name_info={id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }; })),
     ())])
```

After:

```
Pr(
  [ExprStmt(
     N(
       IdQualified(
         {name_last=(("Baz", ()), None); name_top=None;
          name_middle=Some(QDots([(("Foo", ()), None); (("Bar", ()), None)]));
          name_info={id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }; })),
     ())])
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
