### PR TITLE
refactor(metrics): Rewrite as class with TypedDict payload

### DIFF
--- a/semgrep-core/src/reporting/Unit_reporting.ml
+++ b/semgrep-core/src/reporting/Unit_reporting.ml
@@ -55,20 +55,16 @@ let semgrep_cli_output =
      let files =
        Common2.glob (spf "%s/*.json" dir)
        @ (Common.files_of_dir_or_files_no_vcs_nofilter [ e2e_path ]
-         |> List.filter (fun file -> file =~ ".*\\.json")
+         |> List.filter (fun file -> file =~ ".*/results[.]json")
          |> Common.exclude (fun file ->
-                (* just toplevel 'scanned:' and 'skipped:', no 'results:' *)
-                file =~ ".*test_semgrepignore_ignore_log_json_report"
                 (* empty JSON (because of timeout probably) *)
-                || file =~ ".*/test_spacegrep_timeout/"
+                file =~ ".*/test_spacegrep_timeout/"
                 (* weird JSON, results but not match results *)
                 || file =~ ".*/test_cli_test/"
                 (* missing offset *)
                 || file =~ ".*/test_max_target_bytes/"
                 (* different API *)
                 || file =~ ".*/test_dump_ast/"
-                (* different JSON, for findings API *)
-                || file =~ ".*/test_ci/"
                 (* too long filename exn in alcotest, and no fingerprint *)
                 || file =~ ".*/test_join_rules/"
                 || false))

--- a/semgrep/Pipfile
+++ b/semgrep/Pipfile
@@ -21,6 +21,7 @@ types-setuptools = "*"
 types-colorama = "~=0.4.0"
 types-jsonschema = "~=3.2"
 pytest-mock = "*"
+pytest-freezegun = "*"
 
 [packages]
 semgrep = {editable = true,path = "."}

--- a/semgrep/Pipfile.lock
+++ b/semgrep/Pipfile.lock
@@ -238,6 +238,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==4.64.0"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708",
+                "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.2.0"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",

--- a/semgrep/Pipfile.lock
+++ b/semgrep/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b4c37447ae2935a47134113af07e65f270a00796b0b8761058da94305de7ae3d"
+            "sha256": "71178fb91836c94f76944ea6811b4f4d02704080de77e4b6e215bd46b80a4b9f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -295,6 +295,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.7.0"
         },
+        "freezegun": {
+            "hashes": [
+                "sha256:15103a67dfa868ad809a8f508146e396be2995172d25f927e48ce51c0bf5cb09",
+                "sha256:b4c64efb275e6bc68dc6e771b17ffe0ff0f90b81a2a5189043550b6519926ba4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.2.1"
+        },
         "iniconfig": {
             "hashes": [
                 "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
@@ -391,6 +399,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==1.4.0"
         },
+        "pytest-freezegun": {
+            "hashes": [
+                "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949",
+                "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"
+            ],
+            "index": "pypi",
+            "version": "==0.4.2"
+        },
         "pytest-mock": {
             "hashes": [
                 "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534",
@@ -414,6 +430,14 @@
             ],
             "index": "pypi",
             "version": "==2.5.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
         },
         "six": {
             "hashes": [

--- a/semgrep/semgrep/app/session.py
+++ b/semgrep/semgrep/app/session.py
@@ -127,7 +127,7 @@ class AppSession(requests.Session):
         self.token = auth.get_token()
 
         metrics = get_state().metrics
-        metrics.add_sanitized_token(self.token)
+        metrics.add_token(self.token)
 
     def request(self, *args: Any, **kwargs: Any) -> requests.Response:
         kwargs.setdefault("timeout", 30)

--- a/semgrep/semgrep/app/session.py
+++ b/semgrep/semgrep/app/session.py
@@ -126,8 +126,7 @@ class AppSession(requests.Session):
 
         self.token = auth.get_token()
 
-        metrics = get_state().metrics
-        metrics.set_is_authenticated(bool(self.token))
+        get_state().metrics.payload["environment"]["isAuthenticated"] = bool(self.token)
 
     def request(self, *args: Any, **kwargs: Any) -> requests.Response:
         kwargs.setdefault("timeout", 30)

--- a/semgrep/semgrep/app/session.py
+++ b/semgrep/semgrep/app/session.py
@@ -126,7 +126,8 @@ class AppSession(requests.Session):
 
         self.token = auth.get_token()
 
-        get_state().metrics.payload["environment"]["isAuthenticated"] = bool(self.token)
+        metrics = get_state().metrics
+        metrics.add_sanitized_token(self.token)
 
     def request(self, *args: Any, **kwargs: Any) -> requests.Response:
         kwargs.setdefault("timeout", 30)

--- a/semgrep/semgrep/commands/wrapper.py
+++ b/semgrep/semgrep/commands/wrapper.py
@@ -2,8 +2,8 @@ import sys
 from functools import wraps
 from typing import Any
 from typing import Callable
+from typing import NoReturn
 
-from semgrep import __VERSION__
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import OK_EXIT_CODE
 from semgrep.error import SemgrepError
@@ -25,30 +25,27 @@ def handle_command_errors(func: Callable) -> Callable:
     """
 
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> None:
+    def wrapper(*args: Any, **kwargs: Any) -> NoReturn:
         # When running semgrep as a command line tool
         # silence root level logger otherwise logs higher
         # than warning are handled twice
         logger = getLogger("semgrep")
         logger.propagate = False
 
-        metrics = get_state().metrics
-        metrics.payload["environment"]["version"] = __VERSION__
+        exit_code = OK_EXIT_CODE
 
         try:
             func(*args, **kwargs)
         # Catch custom exception, output the right message and exit
         except SemgrepError as e:
-            metrics.payload["errors"]["returnCode"] = e.code
-            sys.exit(e.code)
+            exit_code = e.code
         except Exception as e:
             logger.exception(e)
-            metrics.payload["errors"]["returnCode"] = FATAL_EXIT_CODE
-            sys.exit(FATAL_EXIT_CODE)
-        else:
-            metrics.payload["errors"]["returnCode"] = OK_EXIT_CODE
-            sys.exit(OK_EXIT_CODE)
+            exit_code = FATAL_EXIT_CODE
         finally:
+            metrics = get_state().metrics
+            metrics.add_sanitized_exit_code(exit_code)
             metrics.send()
+            sys.exit(exit_code)
 
     return wrapper

--- a/semgrep/semgrep/commands/wrapper.py
+++ b/semgrep/semgrep/commands/wrapper.py
@@ -44,7 +44,7 @@ def handle_command_errors(func: Callable) -> Callable:
             exit_code = FATAL_EXIT_CODE
         finally:
             metrics = get_state().metrics
-            metrics.add_sanitized_exit_code(exit_code)
+            metrics.add_exit_code(exit_code)
             metrics.send()
             sys.exit(exit_code)
 

--- a/semgrep/semgrep/commands/wrapper.py
+++ b/semgrep/semgrep/commands/wrapper.py
@@ -33,20 +33,20 @@ def handle_command_errors(func: Callable) -> Callable:
         logger.propagate = False
 
         metrics = get_state().metrics
-        metrics.set_version(__VERSION__)
+        metrics.payload["environment"]["version"] = __VERSION__
 
         try:
             func(*args, **kwargs)
         # Catch custom exception, output the right message and exit
         except SemgrepError as e:
-            metrics.set_return_code(e.code)
+            metrics.payload["errors"]["returnCode"] = e.code
             sys.exit(e.code)
         except Exception as e:
             logger.exception(e)
-            metrics.set_return_code(FATAL_EXIT_CODE)
+            metrics.payload["errors"]["returnCode"] = FATAL_EXIT_CODE
             sys.exit(FATAL_EXIT_CODE)
         else:
-            metrics.set_return_code(OK_EXIT_CODE)
+            metrics.payload["errors"]["returnCode"] = OK_EXIT_CODE
             sys.exit(OK_EXIT_CODE)
         finally:
             metrics.send()

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -110,7 +110,7 @@ class ConfigPath:
             self._config_path = str(Path(config_str).expanduser())
 
         if self.is_registry_url():
-            state.metrics.set_using_server_true()
+            state.metrics.is_using_registry = True
 
     def resolve_config(self) -> Mapping[str, YamlTree]:
         """resolves if config arg is a registry entry, a url, or a file, folder, or loads from defaults if None"""

--- a/semgrep/semgrep/metrics.py
+++ b/semgrep/semgrep/metrics.py
@@ -224,7 +224,7 @@ class Metrics:
 
     def add_rules(self, rules: Sequence[Rule], profiling_data: ProfilingData) -> None:
         m = cast(Sha256Hash, hashlib.sha256())
-        rule_hashes = sorted(r.full_hash for r in rules)
+        rule_hashes = list(sorted(r.full_hash for r in rules))
         for rule_hash in rule_hashes:
             m.update(rule_hash.encode())
         self.payload["environment"]["rulesHash"] = m

--- a/semgrep/semgrep/metrics.py
+++ b/semgrep/semgrep/metrics.py
@@ -220,7 +220,7 @@ class Metrics:
         m = cast(Sha256Hash, hashlib.sha256())
         for c in configs:
             m.update(c.encode())
-        self._configs_hash = m
+        self.payload["environment"]["configNamesHash"] = m
 
     def add_rules(self, rules: Sequence[Rule], profiling_data: ProfilingData) -> None:
         m = cast(Sha256Hash, hashlib.sha256())

--- a/semgrep/semgrep/metrics.py
+++ b/semgrep/semgrep/metrics.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+from _hashlib import HASH as HashType  # type: ignore
 from datetime import datetime
 from enum import auto
 from enum import Enum
@@ -13,6 +14,7 @@ from typing import NewType
 from typing import Optional
 from typing import Sequence
 from typing import Set
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -29,6 +31,9 @@ from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
 from semgrep.types import FilteredMatches
 from semgrep.verbose_logging import getLogger
+
+if TYPE_CHECKING:
+    from hashlib import _Hash as HashType
 
 logger = getLogger(__name__)
 
@@ -49,7 +54,7 @@ class MetricsState(Enum):
     AUTO = auto()
 
 
-Sha256Hash = NewType("Sha256Hash", hashlib._Hash)
+Sha256Hash = NewType("Sha256Hash", HashType)  # type: ignore
 
 
 class RuleStats(TypedDict, total=False):
@@ -112,7 +117,7 @@ class MetricsJsonEncoder(json.JSONEncoder):
         if isinstance(obj, datetime):
             return obj.astimezone().isoformat()
 
-        if isinstance(obj, hashlib._Hash):
+        if isinstance(obj, HashType):
             return obj.hexdigest()
 
         if isinstance(obj, UUID):

--- a/semgrep/semgrep/metrics.py
+++ b/semgrep/semgrep/metrics.py
@@ -1,19 +1,27 @@
 import hashlib
+import json
 import os
 from datetime import datetime
 from enum import auto
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from typing import cast
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Mapping
+from typing import NewType
 from typing import Optional
 from typing import Sequence
 from urllib.parse import urlparse
+from uuid import UUID
 
 import click
 import requests
+from attr import define
+from attr import Factory
+from typing_extensions import TypedDict
 
 from semgrep.profiling import ProfilingData
 from semgrep.rule import Rule
@@ -39,39 +47,100 @@ class MetricsState(Enum):
     AUTO = auto()
 
 
+Sha256Hash = NewType("Sha256Hash", hashlib._Hash)
+
+
+class RuleStats(TypedDict, total=False):
+    ruleHash: str
+    bytesScanned: int
+    matchTime: Optional[float]
+
+
+class FileStats(TypedDict, total=False):
+    size: int
+    numTimesScanned: int
+    parseTime: Optional[float]
+    matchTime: Optional[float]
+    runTime: Optional[float]
+
+
+class EnvironmentSchema(TypedDict, total=False):
+    version: str
+    projectHash: Optional[Sha256Hash]
+    configNamesHash: Sha256Hash
+    rulesHash: Sha256Hash
+    ci: Optional[str]
+    isAuthenticated: bool
+
+
+class PerformanceSchema(TypedDict, total=False):
+    fileStats: List[FileStats]
+    ruleStats: List[RuleStats]
+    profilingTimes: Dict[str, float]
+    numRules: Optional[int]
+    numTargets: Optional[int]
+    totalBytesScanned: Optional[int]
+
+
+class ErrorsSchema(TypedDict, total=False):
+    returnCode: Optional[int]
+    errors: List[str]
+
+
+class ValueSchema(TypedDict, total=False):
+    numFindings: int
+    numIgnored: int
+    ruleHashesWithFindings: Dict[str, int]
+
+
+class TopLevelSchema(TypedDict, total=False):
+    started_at: datetime
+    sent_at: datetime
+
+
+class PayloadSchema(TopLevelSchema):
+    environment: EnvironmentSchema
+    performance: PerformanceSchema
+    errors: ErrorsSchema
+    value: ValueSchema
+
+
+class MetricsJsonEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, datetime):
+            return obj.astimezone().isoformat()
+
+        if isinstance(obj, hashlib._Hash):
+            return obj.hexdigest()
+
+        if isinstance(obj, UUID):
+            return str(obj)
+
+        return super().default(obj)
+
+
+@define
 class Metrics:
     """
     To prevent sending unintended metrics, be sure that any data
     stored on this object is sanitized of anything that we don't
     want sent (i.e. sanitize before saving not before sending)
-
-    Made explicit decision to be verbose in setting metrics instead
-    of something more dynamic (and thus less boiler plate code) to
-    be very explicit in what metrics are being collected
     """
 
-    def __init__(self) -> None:
-        self._project_hash: Optional[str] = None
-        self._configs_hash = ""
-        self._rules_hash = ""
-        self._return_code: Optional[int] = None
-        self._version: Optional[str] = None
-        self._num_rules: Optional[int] = None
-        self._num_targets: Optional[int] = None
-        self._num_findings: Optional[int] = None
-        self._num_ignored: Optional[int] = None
-        self._profiling_times: Dict[str, float] = {}
-        self._total_bytes_scanned: Optional[int] = None
-        self._errors: List[str] = []
-        self._file_stats: List[Dict[str, Any]] = []
-        self._rule_stats: List[Dict[str, Any]] = []
-        self._rules_with_findings: Mapping[str, int] = {}
-        self._is_authenticated: Optional[bool] = None
-        self._started_at: str = datetime.now().astimezone().isoformat()
-        self._sent_at: Optional[str] = None
+    _is_using_registry: bool = False
+    metrics_state: MetricsState = MetricsState.OFF
+    payload: PayloadSchema = Factory(
+        lambda: PayloadSchema(
+            environment=EnvironmentSchema(),
+            errors=ErrorsSchema(),
+            performance=PerformanceSchema(),
+            value=ValueSchema(),
+        )
+    )
 
-        self._send_metrics: MetricsState = MetricsState.OFF
-        self._using_server = False
+    def __attrs_post_init__(self) -> None:
+        self.payload["started_at"] = datetime.now()
+        self.payload["environment"]["ci"] = os.getenv("CI")
 
     def configure(
         self,
@@ -96,170 +165,106 @@ class Metrics:
             raise click.BadParameter(
                 "--enable-metrics/--disable-metrics can not be used with either --metrics or SEMGREP_SEND_METRICS"
             )
-        self._send_metrics = metrics_state or legacy_state or MetricsState.AUTO
-        self._using_server = False
+        self.metrics_state = metrics_state or legacy_state or MetricsState.AUTO
 
-    def get_is_using_server(self) -> bool:
-        return self._using_server
+    @property
+    def is_using_registry(self) -> bool:
+        return self._is_using_registry
 
-    def set_using_server_true(self) -> None:
-        if not self._using_server:
+    @is_using_registry.setter
+    def is_using_registry(self, value: bool) -> None:
+        if self.is_using_registry is False and value is True:
             logger.info("Fetching rules from https://semgrep.dev/registry.")
 
-        self._using_server = True
+        self._is_using_registry = value
 
-    def set_project_hash(self, project_url: Optional[str]) -> None:
+    def add_sanitized_project_url(self, project_url: Optional[str]) -> None:
         """
         Standardizes url then hashes
         """
         if project_url is None:
-            self._project_hash = None
-        else:
-            try:
-                parsed_url = urlparse(project_url)
-                if parsed_url.scheme == "https":
-                    # Remove optional username/password from project_url
-                    sanitized_url = f"{parsed_url.hostname}{parsed_url.path}"
-                else:
-                    # For now don't do anything special with other git-url formats
-                    sanitized_url = project_url
-            except ValueError:
-                logger.debug(f"Failed to parse url {project_url}")
+            self.payload["environment"]["projectHash"] = None
+            return
+
+        try:
+            parsed_url = urlparse(project_url)
+            if parsed_url.scheme == "https":
+                # Remove optional username/password from project_url
+                sanitized_url = f"{parsed_url.hostname}{parsed_url.path}"
+            else:
+                # For now don't do anything special with other git-url formats
                 sanitized_url = project_url
+        except ValueError:
+            logger.debug(f"Failed to parse url {project_url}")
+            sanitized_url = project_url
 
-            project_hash = hashlib.sha256(sanitized_url.encode()).hexdigest()
-            self._project_hash = project_hash
+        project_hash = cast(Sha256Hash, hashlib.sha256(sanitized_url.encode()))
+        self.payload["environment"]["projectHash"] = project_hash
 
-    def set_configs_hash(self, configs: Sequence[str]) -> None:
+    def add_sanitized_configs(self, configs: Sequence[str]) -> None:
         """
         Assumes configs is list of arguments passed to semgrep using --config
         """
-        m = hashlib.sha256()
+        m = cast(Sha256Hash, hashlib.sha256())
         for c in configs:
             m.update(c.encode())
-        self._configs_hash = m.hexdigest()
+        self._configs_hash = m
 
-    def set_rules_hash(self, rules: Sequence[Rule]) -> None:
-        m = hashlib.sha256()
-        rule_hashes = [r.full_hash for r in rules]
-        rule_hashes.sort()  # sort hashes to have a stable rules_hash
+    def add_sanitized_rules(
+        self, rules: Iterable[Rule], profiling_data: ProfilingData
+    ) -> None:
+        m = cast(Sha256Hash, hashlib.sha256())
+        rule_hashes = sorted(r.full_hash for r in rules)
         for rule_hash in rule_hashes:
             m.update(rule_hash.encode())
-        self._rules_hash = m.hexdigest()
+        self.payload["environment"]["rulesHash"] = m
 
-    def set_return_code(self, return_code: int) -> None:
-        self._return_code = return_code
+        self.payload["performance"]["ruleStats"] = [
+            {
+                "ruleHash": rule.full_hash,
+                "matchTime": profiling_data.get_rule_match_time(rule),
+                "bytesScanned": profiling_data.get_rule_bytes_scanned(rule),
+            }
+            for rule in rules
+        ]
 
-    def set_version(self, version: str) -> None:
-        self._version = version
-
-    def set_num_rules(self, num_rules: int) -> None:
-        self._num_rules = num_rules
-
-    def set_num_targets(self, num_targets: int) -> None:
-        self._num_targets = num_targets
-
-    def set_num_findings(self, num_findings: int) -> None:
-        self._num_findings = num_findings
-
-    def set_num_ignored(self, num_ignored: int) -> None:
-        self._num_ignored = num_ignored
-
-    def set_profiling_times(self, profiling_times: Dict[str, float]) -> None:
-        self._profiling_times = profiling_times
-
-    def set_total_bytes_scanned(self, total_bytes_scanned: int) -> None:
-        self._total_bytes_scanned = total_bytes_scanned
-
-    def set_errors(self, error_types: List[str]) -> None:
-        self._errors = error_types
-
-    def set_rules_with_findings(
+    def add_sanitized_findings(
         self, findings: Mapping[Rule, Sequence[RuleMatch]]
     ) -> None:
         self._rules_with_findings = {r.full_hash: len(f) for r, f in findings.items()}
 
-    def set_is_authenticated(self, is_authenticated: bool) -> None:
-        self._is_authenticated = is_authenticated
-
-    def set_run_timings(
-        self, profiling_data: ProfilingData, targets: List[Path], rules: List[Rule]
+    def add_sanitized_targets(
+        self, targets: Iterable[Path], profiling_data: ProfilingData
     ) -> None:
-        """
-        Store rule hashes, rule parse times, and file-stats
-        """
-        rule_stats = []
-        for rule in rules:
-            rule_stats.append(
-                {
-                    "ruleHash": rule.full_hash,
-                    "matchTime": profiling_data.get_rule_match_time(rule),
-                    "bytesScanned": profiling_data.get_rule_bytes_scanned(rule),
-                }
-            )
-        self._rule_stats = rule_stats
+        self.payload["performance"]["fileStats"] = [
+            {
+                "size": target.stat().st_size,
+                "numTimesScanned": profiling_data.get_file_num_times_scanned(target),
+                "parseTime": profiling_data.get_file_parse_time(target),
+                "matchTime": profiling_data.get_file_match_time(target),
+                "runTime": profiling_data.get_file_run_time(target),
+            }
+            for target in targets
+        ]
 
-        file_stats = []
-        for target in targets:
-            file_stats.append(
-                {
-                    "size": target.stat().st_size,
-                    "numTimesScanned": profiling_data.get_file_num_times_scanned(
-                        target
-                    ),
-                    "parseTime": profiling_data.get_file_parse_time(target),
-                    "matchTime": profiling_data.get_file_match_time(target),
-                    "runTime": profiling_data.get_file_run_time(target),
-                }
-            )
-        self._file_stats = file_stats
+    def as_json(self) -> str:
+        return json.dumps(
+            self.payload, indent=2, sort_keys=True, cls=MetricsJsonEncoder
+        )
 
-    def as_dict(self) -> Dict[str, Any]:
-        return {
-            "started_at": self._started_at,
-            "sent_at": self._sent_at,
-            "environment": {
-                "version": self._version,
-                "projectHash": self._project_hash,
-                "configNamesHash": self._configs_hash,
-                "rulesHash": self._rules_hash,
-                "ci": os.environ.get("CI"),
-                "isAuthenticated": self._is_authenticated,
-            },
-            "performance": {
-                "fileStats": self._file_stats,
-                "ruleStats": self._rule_stats,
-                "profilingTimes": self._profiling_times,
-                "numRules": self._num_rules,
-                "numTargets": self._num_targets,
-                "totalBytesScanned": self._total_bytes_scanned,
-            },
-            "errors": {
-                "returnCode": self._return_code,
-                "errors": self._errors,
-            },
-            "value": {
-                "numFindings": self._num_findings,
-                "numIgnored": self._num_ignored,
-                "ruleHashesWithFindings": self._rules_with_findings,
-            },
-        }
-
+    @property
     def is_enabled(self) -> bool:
         """
         Returns whether metrics should be sent.
 
-        If _send_metrics is:
-          - auto, sends if using_server
+        If metrics_state is:
+          - auto, sends if using_registry
           - on, sends
           - off, doesn't send
         """
-        res = (
-            self._using_server
-            if self._send_metrics == MetricsState.AUTO
-            else self._send_metrics == MetricsState.ON
-        )
-        return res
+        if self.metrics_state == MetricsState.AUTO:
+            return self.is_using_registry
+        return self.metrics_state == MetricsState.ON
 
     def send(self) -> None:
         """
@@ -271,19 +276,22 @@ class Metrics:
 
         user_agent = get_state().app_session.user_agent
         logger.verbose(
-            f"{'Sending' if self.is_enabled() else 'Not sending'} pseudonymous metrics since metrics are configured to {self._send_metrics.name} and server usage is {self._using_server}"
+            f"{'Sending' if self.is_enabled else 'Not sending'} pseudonymous metrics since metrics are configured to {self.metrics_state.name} and registry usage is {self.is_using_registry}"
         )
 
-        if not self.is_enabled():
+        if not self.is_enabled:
             return
 
-        self._sent_at = datetime.now().astimezone().isoformat()
+        self.payload["sent_at"] = datetime.now()
 
         try:
             r = requests.post(
                 METRICS_ENDPOINT,
-                json=self.as_dict(),
-                headers={"User-Agent": str(user_agent)},
+                data=self.as_json(),
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": str(user_agent),
+                },
                 timeout=3,
             )
             r.raise_for_status()

--- a/semgrep/semgrep/output.py
+++ b/semgrep/semgrep/output.py
@@ -344,7 +344,7 @@ class OutputHandler:
                 num_findings == 0
                 and num_targets > 0
                 and num_rules > 0
-                and state.metrics.get_is_using_server()
+                and state.metrics.is_using_registry
                 and state.app_session.token is None
             ):
                 suggestion_line = "(need more rules? `semgrep login` for additional free Semgrep Registry rules)\n"

--- a/semgrep/semgrep/semgrep_main.py
+++ b/semgrep/semgrep/semgrep_main.py
@@ -432,13 +432,13 @@ def main(
 
     metrics = get_state().metrics
     if metrics.is_enabled:
-        metrics.add_sanitized_project_url(project_url)
-        metrics.add_sanitized_configs(configs)
-        metrics.add_sanitized_rules(filtered_rules, profiling_data)
-        metrics.add_sanitized_targets(all_targets, profiling_data)
-        metrics.add_sanitized_findings(filtered_matches_by_rule)
-        metrics.add_sanitized_errors(semgrep_errors)
-        metrics.add_sanitized_profiling(profiler)
+        metrics.add_project_url(project_url)
+        metrics.add_configs(configs)
+        metrics.add_rules(filtered_rules, profiling_data)
+        metrics.add_targets(all_targets, profiling_data)
+        metrics.add_findings(filtered_matches_by_rule)
+        metrics.add_errors(semgrep_errors)
+        metrics.add_profiling(profiler)
 
     if autofix:
         apply_fixes(filtered_matches_by_rule.kept, dryrun)

--- a/semgrep/semgrep/types.py
+++ b/semgrep/semgrep/types.py
@@ -1,10 +1,15 @@
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 from typing import FrozenSet
 from typing import Mapping
+from typing import TYPE_CHECKING
 
 from attrs import field
 from attrs import frozen
+
+if TYPE_CHECKING:
+    from semgrep.rule_match import RuleMatchMap
 
 JsonObject = Mapping[str, Any]
 
@@ -19,3 +24,13 @@ class FilteredFiles:
 
     kept: Targets
     removed: Targets = field(factory=frozenset)
+
+
+@frozen
+class FilteredMatches:
+    """
+    The return value of functions that filter matches files.
+    """
+
+    kept: "RuleMatchMap"
+    removed: "RuleMatchMap" = field(factory=lambda: defaultdict(list))

--- a/semgrep/setup.py
+++ b/semgrep/setup.py
@@ -130,6 +130,7 @@ install_requires = [
     "peewee~=3.14",
     "defusedxml~=0.7.1",
     "urllib3~=1.26",
+    "typing-extensions~=4.2",
 ]
 
 setuptools.setup(

--- a/semgrep/tests/e2e/snapshots/test_check/test_max_memory/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_max_memory/error.txt
@@ -45,4 +45,4 @@ Some files were skipped or only partially analyzed.
   Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
 
 Ran 1 rule on 1 file: 0 findings.
-Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False
+Not sending pseudonymous metrics since metrics are configured to AUTO and registry usage is False

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
@@ -52,4 +52,4 @@ Some files were skipped or only partially analyzed.
   Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
 
 Ran 3 rules on 1 file: 0 findings.
-Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False
+Not sending pseudonymous metrics since metrics are configured to AUTO and registry usage is False

--- a/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
+++ b/semgrep/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
@@ -50,4 +50,4 @@ Some files were skipped or only partially analyzed.
   Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
 
 Ran 3 rules on 1 file: 0 findings.
-Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False
+Not sending pseudonymous metrics since metrics are configured to AUTO and registry usage is False

--- a/semgrep/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
+++ b/semgrep/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
@@ -49,4 +49,4 @@ Some files were skipped or only partially analyzed.
   Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
 
 Ran 2 rules on 1 file: 3 findings.
-Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False
+Not sending pseudonymous metrics since metrics are configured to AUTO and registry usage is False

--- a/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
+++ b/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
@@ -2,10 +2,10 @@
   "environment": {
     "ci": null,
     "configNamesHash": "4a34b75810eab9dcfb56fa43b7b25391b28ac07a285dca56d979a9e0111ab23a",
-    "isAuthenticated": true,
+    "isAuthenticated": false,
     "projectHash": "c26d8842e4e91153327987e1ec630cb08ca9b6320a9c0c1290626c5ad659f14e",
     "rulesHash": "a501bbc393322a2b45518dc554d25894c0a4babdfd2860f820e6758b8f1ba4c0",
-    "version": "0.94.0"
+    "version": "x.x.x"
   },
   "errors": {
     "errors": [],

--- a/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
+++ b/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
@@ -1,10 +1,10 @@
 {
   "environment": {
     "ci": null,
-    "configNamesHash": "4a34b75810eab9dcfb56fa43b7b25391b28ac07a285dca56d979a9e0111ab23a",
+    "configNamesHash": "d3e03c9938537c0a0668cec7204f37f1e9da87d03e18e8cc444dd7454b36c4d5",
     "isAuthenticated": false,
-    "projectHash": "c26d8842e4e91153327987e1ec630cb08ca9b6320a9c0c1290626c5ad659f14e",
-    "rulesHash": "a501bbc393322a2b45518dc554d25894c0a4babdfd2860f820e6758b8f1ba4c0",
+    "projectHash": null,
+    "rulesHash": "35cecb4773928947459818858bc1c19bb125fc2e4ffa7e900bb55aa5f817ce67",
     "version": "x.x.x"
   },
   "errors": {
@@ -33,36 +33,36 @@
       {
         "bytesScanned": 0,
         "matchTime": 0.0,
-        "ruleHash": "c9f743a8a0b82e972d39e27742dc338edd19b8b8b5290cbc7648ab935ffe92ee"
+        "ruleHash": "0c9be123b69d289f1b0fa65faefade9c76479bae63006869f3ecacd8ffe8b0a8"
       },
       {
         "bytesScanned": 0,
         "matchTime": 0.0,
-        "ruleHash": "4a5729225fd6db9727a30a543782843b680b51628ea87f5d9e2c6e45603d9735"
+        "ruleHash": "a8cd926ebff78f194e33fbd7e53578c3b035e25000a5c2e8248ff9a8ef152783"
       },
       {
         "bytesScanned": 0,
         "matchTime": 0.0,
-        "ruleHash": "c5dbaccc321ef86dfd875201de8887ad2d5b8a9c5cf5861d6184f5e7859ddd47"
+        "ruleHash": "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731"
       },
       {
         "bytesScanned": 0,
         "matchTime": 0.0,
-        "ruleHash": "a3eadb7df30dbd3e2e7f0ffff0afafc3e97026ef1d8423ce1f6f7e169e4d4098"
+        "ruleHash": "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089"
       }
     ],
     "totalBytesScanned": 6
   },
-  "sent_at": "2017-03-03T00:00:00-08:00",
-  "started_at": "2017-03-03T00:00:00-08:00",
+  "sent_at": "2017-03-03T17:00:00+09:00",
+  "started_at": "2017-03-03T17:00:00+09:00",
   "value": {
     "numFindings": 1,
     "numIgnored": 0,
     "ruleHashesWithFindings": {
-      "4a5729225fd6db9727a30a543782843b680b51628ea87f5d9e2c6e45603d9735": 1,
-      "a3eadb7df30dbd3e2e7f0ffff0afafc3e97026ef1d8423ce1f6f7e169e4d4098": 0,
-      "c5dbaccc321ef86dfd875201de8887ad2d5b8a9c5cf5861d6184f5e7859ddd47": 0,
-      "c9f743a8a0b82e972d39e27742dc338edd19b8b8b5290cbc7648ab935ffe92ee": 0
+      "0c9be123b69d289f1b0fa65faefade9c76479bae63006869f3ecacd8ffe8b0a8": 0,
+      "a8cd926ebff78f194e33fbd7e53578c3b035e25000a5c2e8248ff9a8ef152783": 1,
+      "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089": 0,
+      "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731": 0
     }
   }
 }

--- a/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
+++ b/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
@@ -1,15 +1,68 @@
 {
   "environment": {
     "ci": null,
+    "configNamesHash": "4a34b75810eab9dcfb56fa43b7b25391b28ac07a285dca56d979a9e0111ab23a",
     "isAuthenticated": true,
     "projectHash": "c26d8842e4e91153327987e1ec630cb08ca9b6320a9c0c1290626c5ad659f14e",
+    "rulesHash": "a501bbc393322a2b45518dc554d25894c0a4babdfd2860f820e6758b8f1ba4c0",
     "version": "0.94.0"
   },
   "errors": {
-    "returnCode": 2
+    "errors": [],
+    "returnCode": 0
   },
-  "performance": {},
+  "performance": {
+    "fileStats": [
+      {
+        "matchTime": 0.0,
+        "numTimesScanned": 0,
+        "parseTime": 0.0,
+        "runTime": 0.0,
+        "size": 6
+      }
+    ],
+    "numRules": 4,
+    "numTargets": 1,
+    "profilingTimes": {
+      "config_time": 0.0,
+      "core_time": 0.0,
+      "ignores_time": 0.0,
+      "total_time": 0.0
+    },
+    "ruleStats": [
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "c9f743a8a0b82e972d39e27742dc338edd19b8b8b5290cbc7648ab935ffe92ee"
+      },
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "4a5729225fd6db9727a30a543782843b680b51628ea87f5d9e2c6e45603d9735"
+      },
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "c5dbaccc321ef86dfd875201de8887ad2d5b8a9c5cf5861d6184f5e7859ddd47"
+      },
+      {
+        "bytesScanned": 0,
+        "matchTime": 0.0,
+        "ruleHash": "a3eadb7df30dbd3e2e7f0ffff0afafc3e97026ef1d8423ce1f6f7e169e4d4098"
+      }
+    ],
+    "totalBytesScanned": 6
+  },
   "sent_at": "2017-03-03T00:00:00-08:00",
   "started_at": "2017-03-03T00:00:00-08:00",
-  "value": {}
+  "value": {
+    "numFindings": 1,
+    "numIgnored": 0,
+    "ruleHashesWithFindings": {
+      "4a5729225fd6db9727a30a543782843b680b51628ea87f5d9e2c6e45603d9735": 1,
+      "a3eadb7df30dbd3e2e7f0ffff0afafc3e97026ef1d8423ce1f6f7e169e4d4098": 0,
+      "c5dbaccc321ef86dfd875201de8887ad2d5b8a9c5cf5861d6184f5e7859ddd47": 0,
+      "c9f743a8a0b82e972d39e27742dc338edd19b8b8b5290cbc7648ab935ffe92ee": 0
+    }
+  }
 }

--- a/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
+++ b/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
@@ -1,0 +1,15 @@
+{
+  "environment": {
+    "ci": null,
+    "isAuthenticated": true,
+    "projectHash": "c26d8842e4e91153327987e1ec630cb08ca9b6320a9c0c1290626c5ad659f14e",
+    "version": "0.94.0"
+  },
+  "errors": {
+    "returnCode": 2
+  },
+  "performance": {},
+  "sent_at": "2017-03-03T00:00:00-08:00",
+  "started_at": "2017-03-03T00:00:00-08:00",
+  "value": {}
+}

--- a/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
+++ b/semgrep/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
@@ -43,18 +43,18 @@
       {
         "bytesScanned": 0,
         "matchTime": 0.0,
-        "ruleHash": "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731"
+        "ruleHash": "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089"
       },
       {
         "bytesScanned": 0,
         "matchTime": 0.0,
-        "ruleHash": "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089"
+        "ruleHash": "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731"
       }
     ],
     "totalBytesScanned": 6
   },
-  "sent_at": "2017-03-03T17:00:00+09:00",
-  "started_at": "2017-03-03T17:00:00+09:00",
+  "sent_at": "2017-03-03T00:00:00+09:00",
+  "started_at": "2017-03-03T00:00:00+09:00",
   "value": {
     "numFindings": 1,
     "numIgnored": 0,

--- a/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
+++ b/semgrep/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/invalid_python.py/error.txt
@@ -50,4 +50,4 @@ Some files were skipped or only partially analyzed.
   Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
 
 Ran 2 rules on 1 file: 0 findings.
-Not sending pseudonymous metrics since metrics are configured to AUTO and server usage is False
+Not sending pseudonymous metrics since metrics are configured to AUTO and registry usage is False

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -3,6 +3,7 @@ Tests for semgrep.metrics and associated command-line arguments.
 """
 import json
 import re
+from datetime import datetime
 from typing import Iterator
 
 import dateutil.tz
@@ -228,7 +229,9 @@ def _mask_version(value: str) -> str:
 
 
 @pytest.mark.quick
-@pytest.mark.freeze_time("2017-03-03")
+@pytest.mark.freeze_time(
+    datetime(2017, 3, 3, tzinfo=dateutil.tz.gettz("Asia/Tokyo")), tz_offset=9
+)
 def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch):
     # make the formatted timestamp strings deterministic
     mocker.patch.object(

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -6,6 +6,7 @@ import re
 from typing import Iterator
 
 import dateutil.tz
+import freezegun.api
 import pytest
 from click.testing import CliRunner
 from pytest import mark
@@ -229,9 +230,13 @@ def _mask_version(value: str) -> str:
 @pytest.mark.quick
 @pytest.mark.freeze_time("2017-03-03")
 def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch):
-    # this mock makes the formatted timestamp string deterministic
-    mocker.patch("freezegun.api.tzlocal", return_value=dateutil.tz.gettz("Asia/Tokyo"))
-    # these mocks make the rule and file timings deterministic
+    # make the formatted timestamp strings deterministic
+    mocker.patch.object(
+        freezegun.api, "tzlocal", return_value=dateutil.tz.gettz("Asia/Tokyo")
+    )
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+
+    # make the rule and file timings deterministic
     mocker.patch.object(ProfilingData, "set_file_times")
     mocker.patch.object(ProfilingData, "set_rules_parse_time")
 

--- a/semgrep/tests/e2e/test_metrics.py
+++ b/semgrep/tests/e2e/test_metrics.py
@@ -4,6 +4,7 @@ Tests for semgrep.metrics and associated command-line arguments.
 import json
 import os
 import re
+import sys
 import time
 from typing import Iterator
 
@@ -231,6 +232,10 @@ def _mask_version(value: str) -> str:
 
 @pytest.mark.quick
 @pytest.mark.freeze_time("2017-03-03")
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="snapshotting mock call kwargs doesn't work on py3.7",
+)
 def test_metrics_payload(tmp_path, snapshot, mocker, monkeypatch):
     # make the formatted timestamp strings deterministic
     mocker.patch.object(

--- a/semgrep/tests/unit/test_metric_manager.py
+++ b/semgrep/tests/unit/test_metric_manager.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
 
@@ -8,7 +7,8 @@ from semgrep.config_resolver import Config
 from semgrep.metrics import Metrics
 from semgrep.metrics import MetricsState
 from semgrep.profiling import ProfilingData
-from semgrep.profiling import Times
+
+pytestmark = pytest.mark.freeze_time("2017-03-03")
 
 
 @pytest.fixture
@@ -17,24 +17,40 @@ def metrics() -> Metrics:
 
 
 @pytest.mark.quick
-def test_configs_hash(metrics) -> None:
-    metrics.set_configs_hash(["p/r2c"])
-    old = metrics._configs_hash
-    metrics.set_configs_hash(["p/r2c"])
-    assert metrics._configs_hash == old
-    metrics.set_configs_hash(["not"])
-    assert metrics._configs_hash != old
+@pytest.mark.parametrize(
+    "first, second, is_equal",
+    [
+        (["p/r2c"], ["p/r2c"], True),
+        (["p/r2c"], ["p/ci"], False),
+        (["a", "b"], ["a", "b"], True),
+        (["a", "b"], ["b", "a"], False),
+    ],
+)
+def test_configs_hash(metrics, first, second, is_equal) -> None:
+    first_metrics = Metrics()
+    first_metrics.add_configs(first)
+    second_metrics = Metrics()
+    second_metrics.add_configs(second)
 
-    metrics.set_configs_hash(["a", "b"])
-    old = metrics._configs_hash
-    metrics.set_configs_hash(["a", "b"])
-    assert metrics._configs_hash == old
-    metrics.set_configs_hash(["b", "a"])
-    assert metrics._configs_hash != old
+    # this provides better error messages than `(first_metrics == second_metrics) == is_equal`
+    if is_equal:
+        assert first_metrics == second_metrics
+    else:
+        assert first_metrics != second_metrics
 
 
 @pytest.mark.quick
-def test_rules_hash(metrics) -> None:
+@pytest.mark.parametrize(
+    "first, second, is_equal",
+    [
+        ([0], [0], True),
+        ([0], [1], False),
+        ([0, 1, 2], [0, 1, 2], True),
+        ([0, 1, 2], [2, 1, 0], True),
+        ([0, 1, 2], [1], False),
+    ],
+)
+def test_rules_hash(metrics, first, second, is_equal) -> None:
     config1 = dedent(
         """
         rules:
@@ -63,19 +79,20 @@ def test_rules_hash(metrics) -> None:
         assert not errors
         rules = config.get_rules(True)
         assert len(rules) == 3
-        rule1, rule2, rule3 = rules
 
-    metrics.set_rules_hash([rule1])
-    old_hash = metrics._rules_hash
-    metrics.set_rules_hash([rule1])
-    assert old_hash == metrics._rules_hash
+    first_rules = [rules[i] for i in first]
+    second_rules = [rules[i] for i in second]
 
-    metrics.set_rules_hash(rules)
-    old_hash_2 = metrics._rules_hash
-    metrics.set_rules_hash(rules)
-    assert old_hash_2 == metrics._rules_hash
+    first_metrics = Metrics()
+    first_metrics.add_rules(first_rules, ProfilingData())
+    second_metrics = Metrics()
+    second_metrics.add_rules(second_rules, ProfilingData())
 
-    assert old_hash != old_hash_2
+    # this provides better error messages than `(first_metrics == second_metrics) == is_equal`
+    if is_equal:
+        assert first_metrics == second_metrics
+    else:
+        assert first_metrics != second_metrics
 
 
 @pytest.mark.quick
@@ -94,113 +111,19 @@ def test_send(metrics) -> None:
 
     # test that network is blocked
     with pytest.raises(Exception):
-        _ = requests.get(
-            "https://semgrep.dev",
-            timeout=2,
-        )
+        _ = requests.get("https://semgrep.dev", timeout=2)
 
     metrics.configure(MetricsState.ON, None)
     metrics.send()
 
 
 @pytest.mark.quick
-def test_timings(metrics, mocker) -> None:
-    config1 = dedent(
-        """
-        rules:
-        - id: rule1
-          pattern: $X == $X
-          languages: [python]
-          severity: INFO
-          message: bad
-        - id: rule2
-          pattern: $X == $Y
-          languages: [python]
-          severity: INFO
-          message: good
-        - id: rule3
-          pattern: $X < $Y
-          languages: [c]
-          severity: INFO
-          message: doog
-        """
-    )
-    # Load rules
-    with NamedTemporaryFile() as tf1:
-        tf1.write(config1.encode("utf-8"))
-        tf1.flush()
-        config, errors = Config.from_config_list([tf1.name], None)
-        assert not errors
-        rules = config.get_rules(True)
-        assert len(rules) == 3
-        rule1, rule2, rule3 = rules
-
-    # Mock Path().stat().st_size
-    mock_stat_result = mocker.MagicMock()
-    type(mock_stat_result).st_size = mocker.PropertyMock(side_effect=[1, 2, 1, 2])
-    mocker.patch.object(Path, "stat", return_value=mock_stat_result)
-    # Note this mock is a little fragile and assumes st_size is called twice
-    # once in set_file_times then once in set_run_timings and assumes that
-    # it will be called for target[0] then target[1] then target[0] then target[1]
-
-    targets = [Path("a"), Path("b")]
-
-    profiling_data = ProfilingData()
-
-    target_a_time = {
-        rule1.id2: Times(match_time=0.2, parse_time=0.3),
-    }
-    target_b_time = {
-        rule2.id2: Times(match_time=1.2, parse_time=0.2),
-    }
-    profiling_data.set_file_times(targets[0], target_a_time, 0.4)
-    profiling_data.set_file_times(targets[1], target_b_time, 1.4)
-    profiling_data.set_rules_parse_time(0.09)
-
-    metrics.set_run_timings(profiling_data, targets, rules)
-
-    assert metrics._rule_stats == [
-        {
-            "ruleHash": "720c14cd416c021bc45d6db0689dd0eb54d1d062bf9f446f85dae0cb5d1438c0",
-            "matchTime": 0.2,
-            "bytesScanned": 1,
-        },
-        {
-            "ruleHash": "a5360bb56a3b0a3c33c1bb2b6e7d6465e9a246ccb8940bc05710bc5b35a43e30",
-            "matchTime": 1.2,
-            "bytesScanned": 2,
-        },
-        {
-            "ruleHash": "2cc5dbc0cae3a8b6af0d8792079251c4d861b5e16815c1b1cdba676d1c96c5a5",
-            "matchTime": 0.0,
-            "bytesScanned": 0,
-        },
-    ]
-    assert metrics._file_stats == [
-        {
-            "size": 1,
-            "numTimesScanned": 1,
-            "parseTime": 0.3,
-            "matchTime": 0.2,
-            "runTime": 0.4,
-        },
-        {
-            "size": 2,
-            "numTimesScanned": 1,
-            "parseTime": 0.2,
-            "matchTime": 1.2,
-            "runTime": 1.4,
-        },
-    ]
-
-
-@pytest.mark.quick
 def test_project_hash(metrics):
-    metrics.set_project_hash("https://foo.bar.com/org/project.git")
-    no_username_password = metrics._project_hash
-    metrics.set_project_hash("https://username:password@foo.bar.com/org/project.git")
-    with_username_password_1 = metrics._project_hash
-    metrics.set_project_hash("https://username1:password2@foo.bar.com/org/project.git")
-    with_username_password_2 = metrics._project_hash
+    metrics.add_project_url("https://foo.bar.com/org/project.git")
+    no_username_password = metrics.payload
+    metrics.add_project_url("https://username:password@foo.bar.com/org/project.git")
+    with_username_password_1 = metrics.payload
+    metrics.add_project_url("https://username1:password2@foo.bar.com/org/project.git")
+    with_username_password_2 = metrics.payload
     assert no_username_password == with_username_password_1
     assert with_username_password_1 == with_username_password_2

--- a/semgrep/tests/unit/test_shouldafound.py
+++ b/semgrep/tests/unit/test_shouldafound.py
@@ -138,21 +138,12 @@ def test_read_line_args(tmp_path, mocker):
 @pytest.mark.quick
 def test_handle_api_error(tmp_path, mocker):
 
-    runner = CliRunner(
-        env={
-            SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path),
-        }
-    )
+    runner = CliRunner(env={SEMGREP_SETTING_ENVVAR_NAME: str(tmp_path)})
 
     mocker.patch.object(Path, "open", mocker.mock_open(read_data=FILE_CONTENT))
 
-    error_mock = mocker.Mock()
-    error_mock.side_effect = SemgrepError
-
     mocker.patch.object(
-        shouldafound,
-        "_make_shouldafound_request",
-        error_mock,
+        shouldafound, "_make_shouldafound_request", side_effect=SemgrepError
     )
     email = "myemail@foo.com"
     message = "some vuln here"


### PR DESCRIPTION
Why? I'll admit, this is quite experimental. Here are the reasons I
expect this to be an improvement:

- Previously, we'd have to repeat ourselves a lot to set a value:
  we would have to define and type-annotate an intermediary data
  storage attribute, and then translate the private attribute into the
  payload dict's format when sending. Now, we just type annotate the
  dict, and the setter can directly drop it in the payload.
  - This indirection, I think, led to the data schema being subideal in
    some cases, as the data-providing function was disconnected from
    what the metrics payload ended up looking like.
  - Removing the indirection also revealed that we could reorder the
    data setting method calls in semgrep_main, group them nicer, and
    change some of their function signatures to be more consistent.
- Previously, all fields we tracked were in a flat attribute structure,
  now we can namespace them without thinking about attribute names (such
  as errors.count and rules.count).
- Previously, data was serialized as early as it was added on Metrics.
  Now we keep rich data such as datetimes around as late as possible,
  and only convert them when serializing to JSON
  - This also deduplicates some code and makes sure that e.g. all our
    datetimes are in a consistent format
- Previously, you could find out the payload structure from the
  `def as_dict() -> Dict[str, Any]` method.
  Now you can find out the payload structure in the TypedDict structure.
  With the old version it was easier to see the structure of what keys
  are available, but it was harder to tell what type each field is.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
