### PR TITLE
Fix _split_classmembers

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -73,12 +73,15 @@ let rec _split_classmembers env members constants variables methods uses =
   match members with
   | [] -> (constants, variables, methods, uses)
   | hd :: rest -> (
+      let constants, variables, methods, uses =
+        _split_classmembers env rest constants variables methods uses
+      in
       match hd with
-      | ConstantDef c -> (constants @ [ c ], variables, methods, uses)
-      | ClassVar c -> (constants, variables @ [ c ], methods, uses)
-      | MethodDef m -> (constants, variables, methods @ [ m ], uses)
-      | UseTrait u -> (constants, variables, methods, uses @ [ u ])
-      | EnumCase c -> (constants, variables @ [ c ], methods, uses))
+      | ConstantDef c -> (c :: constants, variables, methods, uses)
+      | ClassVar c -> (constants, c :: variables, methods, uses)
+      | MethodDef m -> (constants, variables, m :: methods, uses)
+      | UseTrait u -> (constants, variables, methods, u :: uses)
+      | EnumCase c -> (constants, c :: variables, methods, uses))
 
 let split_classmembers env members = _split_classmembers env members [] [] [] []
 


### PR DESCRIPTION
Call it recursively, so we convert all class members. And put the element at the front, so we keep the same ordering of the class members.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
