### PR TITLE
tainting: Analyze lambdas in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `r2c-internal-project-depends-on`:
   - pretty printing for SCA results
   - support for poetry and gradle lockfiles
+- taint-mode: Taint tracking will now analyze lambdas in their surrounding context.
+  Previously, if a variable became tainted outside a lanbda, and this variable was
+  used inside the lambda causing the taint to reach a sink, this was not being
+  detected because any nested lambdas were "opaque" to the analysis. (Taint tracking
+  looked at lambdas but as isolated functions.) Now lambas are simply analyzed as if
+  they were statement blocks. Taint tracking still does not follow the flow of taint
+  through the lambda's arguments!
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Scala: correctly handle `return` for taint analysis (#4975)
 - PHP: correctly handle namespace use declarations when they don't rename
   the imported name (#3964)
+- Constant propagation is now faster and memory efficient when analyzing
+  large functions with lots of variables.
 
 ## [0.94.0](https://github.com/returntocorp/semgrep/releases/tag/v0.94.0) - 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   - pretty printing for SCA results
   - support for poetry and gradle lockfiles
 - taint-mode: Taint tracking will now analyze lambdas in their surrounding context.
-  Previously, if a variable became tainted outside a lanbda, and this variable was
+  Previously, if a variable became tainted outside a lambda, and this variable was
   used inside the lambda causing the taint to reach a sink, this was not being
   detected because any nested lambdas were "opaque" to the analysis. (Taint tracking
   looked at lambdas but as isolated functions.) Now lambas are simply analyzed as if
-  they were statement blocks. Taint tracking still does not follow the flow of taint
-  through the lambda's arguments!
+  they were statement blocks. However, taint tracking still does not follow the flow
+  of taint through the lambda's arguments!
 
 ### Changed
 

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -583,11 +583,12 @@ and expr_aux env ?(void = false) e_gen =
       mk_e (Composite (kind, xs)) eorig
   | G.Comprehension _ -> todo (G.E e_gen)
   | G.Record fields -> record env fields
-  | G.Lambda def ->
+  | G.Lambda fdef ->
       (* TODO: we should have a use def.f_tok *)
       let tok = G.fake "lambda" in
       let lval = fresh_lval env tok in
-      add_instr env (mk_i (AssignAnon (lval, Lambda def)) eorig);
+      let fdef = function_definition env fdef in
+      add_instr env (mk_i (AssignAnon (lval, Lambda fdef)) eorig);
       mk_e (Fetch lval) eorig
   | G.AnonClass def ->
       (* TODO: should use def.ckind *)
@@ -1376,6 +1377,15 @@ and python_with_stmt env manager opt_pat body =
     ss_exit
   in
   pre_try_stmts @ [ mk_s (Try (try_body, try_catches, try_finally)) ]
+
+(*****************************************************************************)
+(* Defs *)
+(*****************************************************************************)
+
+and function_definition env fdef =
+  let foarams = parameters env fdef.G.fparams in
+  let fbody = function_body env fdef.G.fbody in
+  { foarams; frettype = fdef.G.frettype; fbody }
 
 (*****************************************************************************)
 (* Entry points *)

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -273,14 +273,14 @@ and call_special =
    | StringAccess of string (* for records/hashes *)
 *)
 and anonymous_entity =
-  | Lambda of G.function_definition
+  | Lambda of function_definition
   | AnonClass of G.class_definition
 [@@deriving show { with_path = false }]
 
 (*****************************************************************************)
 (* Statement *)
 (*****************************************************************************)
-type stmt = { s : stmt_kind (* sorig: G.stmt; ?*) }
+and stmt = { s : stmt_kind (* sorig: G.stmt; ?*) }
 
 and stmt_kind =
   | Instr of instr
@@ -316,6 +316,11 @@ and label = ident * G.sid [@@deriving show { with_path = false }]
 (* Defs *)
 (*****************************************************************************)
 (* See AST_generic.ml *)
+and function_definition = {
+  foarams : name list;
+  frettype : G.type_ option;
+  fbody : stmt list;
+}
 
 (*****************************************************************************)
 (* Control-flow graph (CFG) *)

--- a/semgrep-core/tests/OTHER/rules/taint_lambda.js
+++ b/semgrep-core/tests/OTHER/rules/taint_lambda.js
@@ -1,0 +1,9 @@
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
+
+const numbers = [ 1, 2, 3 ];
+
+function test () {
+  var x = source;
+  //ruleid: test
+  console.log(numbers.map(i => sink(i + x)));
+}

--- a/semgrep-core/tests/OTHER/rules/taint_lambda.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_lambda.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    message: Test
+    languages:
+      - javascript
+    severity: WARNING
+    mode: taint
+    pattern-sinks:
+    - pattern: sink(...)
+    pattern-sources:
+    - pattern: source

--- a/semgrep-core/tests/OTHER/rules/taint_lambda1.java
+++ b/semgrep-core/tests/OTHER/rules/taint_lambda1.java
@@ -1,0 +1,296 @@
+package org.sasanlabs.service.vulnerability.sqlInjection;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.internal.utility.JSONSerializationUtils;
+import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
+import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.sasanlabs.vulnerability.utils.Constants;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseEntity.BodyBuilder;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * Error Based SQLInjection is the easiest way for extracting data and a very dangerous way which
+ * can lead to serious impacts and can compromise the entire system.
+ *
+ * @author preetkaran20@gmail.com KSASAN
+ */
+@VulnerableAppRestController(
+        descriptionLabel = "SQL_INJECTION_VULNERABILITY",
+        value = "ErrorBasedSQLInjectionVulnerability")
+public class ErrorBasedSQLInjectionVulnerability {
+
+    private JdbcTemplate applicationJdbcTemplate;
+
+    private static final transient Logger LOGGER =
+            LogManager.getLogger(ErrorBasedSQLInjectionVulnerability.class);
+
+    private static final Function<Exception, String> GENERIC_EXCEPTION_RESPONSE_FUNCTION =
+            (ex) -> "{ \"isCarPresent\": false, \"moreInfo\": " + ex.getMessage() + "}";
+    static final String CAR_IS_NOT_PRESENT_RESPONSE = "{ \"isCarPresent\": false}";
+    static final Function<String, String> CAR_IS_PRESENT_RESPONSE =
+            (carInformation) ->
+                    "{ \"isCarPresent\": true, \"carInformation\":" + carInformation + "}";
+
+    public ErrorBasedSQLInjectionVulnerability(
+            @Qualifier("applicationJdbcTemplate") JdbcTemplate applicationJdbcTemplate) {
+        this.applicationJdbcTemplate = applicationJdbcTemplate;
+    }
+
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
+            description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_DIRECTLY_TO_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_1")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_1,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> doesCarInformationExistsLevel1(
+            @RequestParam Map<String, String> queryParams) {
+        String id = queryParams.get(Constants.ID);
+        BodyBuilder bodyBuilder = ResponseEntity.status(HttpStatus.OK);
+        try {
+            ResponseEntity<String> response =
+                    applicationJdbcTemplate.query(
+                            // ruleid: jdbc
+                            "select * from cars where id=" + id,
+                            (rs) -> {
+                                if (rs.next()) {
+                                    CarInformation carInformation = new CarInformation();
+                                    carInformation.setId(rs.getInt(1));
+                                    carInformation.setName(rs.getString(2));
+                                    carInformation.setImagePath(rs.getString(3));
+                                    try {
+                                        return bodyBuilder.body(
+                                                CAR_IS_PRESENT_RESPONSE.apply(
+                                                        JSONSerializationUtils.serialize(
+                                                                carInformation)));
+                                    } catch (JsonProcessingException e) {
+                                        LOGGER.error("Following error occurred", e);
+                                        return bodyBuilder.body(
+                                                GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(e));
+                                    }
+                                } else {
+                                    return bodyBuilder.body(
+                                            ErrorBasedSQLInjectionVulnerability
+                                                    .CAR_IS_NOT_PRESENT_RESPONSE);
+                                }
+                            });
+            return response;
+        } catch (Exception ex) {
+            LOGGER.error("Following error occurred", ex);
+            return bodyBuilder.body(GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(ex));
+        }
+    }
+
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
+            description =
+                    "ERROR_SQL_INJECTION_URL_PARAM_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_2")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_2,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> doesCarInformationExistsLevel2(
+            @RequestParam Map<String, String> queryParams) {
+        String id = queryParams.get(Constants.ID);
+        BodyBuilder bodyBuilder = ResponseEntity.status(HttpStatus.OK);
+        try {
+            ResponseEntity<String> response =
+                    applicationJdbcTemplate.query(
+                            // ruleid: jdbc
+                            "select * from cars where id='" + id + "'",
+                            (rs) -> {
+                                if (rs.next()) {
+                                    CarInformation carInformation = new CarInformation();
+                                    carInformation.setId(rs.getInt(1));
+                                    carInformation.setName(rs.getString(2));
+                                    carInformation.setImagePath(rs.getString(3));
+                                    try {
+                                        return bodyBuilder.body(
+                                                CAR_IS_PRESENT_RESPONSE.apply(
+                                                        JSONSerializationUtils.serialize(
+                                                                carInformation)));
+                                    } catch (JsonProcessingException e) {
+                                        LOGGER.error("Following error occurred", e);
+                                        return bodyBuilder.body(
+                                                GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(e));
+                                    }
+                                } else {
+                                    return bodyBuilder.body(
+                                            ErrorBasedSQLInjectionVulnerability
+                                                    .CAR_IS_NOT_PRESENT_RESPONSE);
+                                }
+                            });
+            return response;
+        } catch (Exception ex) {
+            LOGGER.error("Following error occurred", ex);
+            return bodyBuilder.body(GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(ex));
+        }
+    }
+
+    // https://stackoverflow.com/questions/15537368/how-can-sanitation-that-escapes-single-quotes-be-defeated-by-sql-injection-in-sq
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
+            description =
+                    "ERROR_SQL_INJECTION_URL_PARAM_REMOVES_SINGLE_QUOTE_WRAPPED_WITH_SINGLE_QUOTE_APPENDED_TO_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_3")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_3,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> doesCarInformationExistsLevel3(
+            @RequestParam Map<String, String> queryParams) {
+        String id = queryParams.get(Constants.ID);
+        id = id.replaceAll("'", "");
+        BodyBuilder bodyBuilder = ResponseEntity.status(HttpStatus.OK);
+        bodyBuilder.body(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        try {
+            ResponseEntity<String> response =
+                    applicationJdbcTemplate.query(
+                            // ruleid: jdbc
+                            "select * from cars where id='" + id + "'",
+                            (rs) -> {
+                                if (rs.next()) {
+                                    CarInformation carInformation = new CarInformation();
+
+                                    carInformation.setId(rs.getInt(1));
+                                    carInformation.setName(rs.getString(2));
+                                    carInformation.setImagePath(rs.getString(3));
+                                    try {
+                                        return bodyBuilder.body(
+                                                CAR_IS_PRESENT_RESPONSE.apply(
+                                                        JSONSerializationUtils.serialize(
+                                                                carInformation)));
+                                    } catch (JsonProcessingException e) {
+                                        LOGGER.error("Following error occurred", e);
+                                        return bodyBuilder.body(
+                                                GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(e));
+                                    }
+                                } else {
+                                    return bodyBuilder.body(
+                                            ErrorBasedSQLInjectionVulnerability
+                                                    .CAR_IS_NOT_PRESENT_RESPONSE);
+                                }
+                            });
+
+            return response;
+        } catch (Exception ex) {
+            LOGGER.error("Following error occurred", ex);
+            return bodyBuilder.body(GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(ex));
+        }
+    }
+
+    // Assumption that only creating PreparedStatement object can save is wrong. You
+    // need to use the parameterized query properly.
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.ERROR_BASED_SQL_INJECTION,
+            description = "ERROR_SQL_INJECTION_URL_PARAM_APPENDED_TO_PARAMETERIZED_QUERY",
+            payload = "ERROR_BASED_SQL_INJECTION_PAYLOAD_LEVEL_4")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_4,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> doesCarInformationExistsLevel4(
+            @RequestParam Map<String, String> queryParams) {
+        final String id = queryParams.get(Constants.ID).replaceAll("'", "");
+        BodyBuilder bodyBuilder = ResponseEntity.status(HttpStatus.OK);
+        bodyBuilder.body(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        try {
+            ResponseEntity<String> response =
+                    applicationJdbcTemplate.query(
+                            // ruleid: jdbc
+                            (conn) ->
+                                    conn.prepareStatement(
+                                            "select * from cars where id='" + id + "'"),
+                            (ps) -> {},
+                            (rs) -> {
+                                if (rs.next()) {
+                                    CarInformation carInformation = new CarInformation();
+
+                                    carInformation.setId(rs.getInt(1));
+                                    carInformation.setName(rs.getString(2));
+                                    carInformation.setImagePath(rs.getString(3));
+                                    try {
+                                        return bodyBuilder.body(
+                                                CAR_IS_PRESENT_RESPONSE.apply(
+                                                        JSONSerializationUtils.serialize(
+                                                                carInformation)));
+                                    } catch (JsonProcessingException e) {
+                                        LOGGER.error("Following error occurred", e);
+                                        return bodyBuilder.body(
+                                                GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(e));
+                                    }
+                                } else {
+                                    return bodyBuilder.body(
+                                            ErrorBasedSQLInjectionVulnerability
+                                                    .CAR_IS_NOT_PRESENT_RESPONSE);
+                                }
+                            });
+
+            return response;
+        } catch (Exception ex) {
+            LOGGER.error("Following error occurred", ex);
+            return bodyBuilder.body(GENERIC_EXCEPTION_RESPONSE_FUNCTION.apply(ex));
+        }
+    }
+
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_5,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/SQLInjection_Level1")
+    public ResponseEntity<String> doesCarInformationExistsLevel5(
+            @RequestParam Map<String, String> queryParams) {
+        final String id = queryParams.get(Constants.ID);
+        BodyBuilder bodyBuilder = ResponseEntity.status(HttpStatus.OK);
+        bodyBuilder.body(ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        try {
+            ResponseEntity<String> responseEntity =
+                    applicationJdbcTemplate.query(
+                            (conn) -> conn.prepareStatement("select * from cars where id=?"),
+                            // ok: jdbc
+                            (prepareStatement) -> {
+                                prepareStatement.setString(1, id);
+                            },
+                            (rs) -> {
+                                CarInformation carInformation = new CarInformation();
+                                if (rs.next()) {
+                                    carInformation.setId(rs.getInt(1));
+                                    carInformation.setName(rs.getString(2));
+                                    carInformation.setImagePath(rs.getString(3));
+
+                                    try {
+                                        return bodyBuilder.body(
+                                                CAR_IS_PRESENT_RESPONSE.apply(
+                                                        JSONSerializationUtils.serialize(
+                                                                carInformation)));
+                                    } catch (JsonProcessingException e) {
+                                        LOGGER.error("Following error occurred", e);
+                                        return bodyBuilder.body(
+                                                ErrorBasedSQLInjectionVulnerability
+                                                        .CAR_IS_NOT_PRESENT_RESPONSE);
+                                    }
+                                } else {
+                                    return bodyBuilder.body(
+                                            ErrorBasedSQLInjectionVulnerability
+                                                    .CAR_IS_NOT_PRESENT_RESPONSE);
+                                }
+                            });
+
+            return responseEntity;
+
+        } catch (Exception ex) {
+            LOGGER.error("Following error occurred", ex);
+            return bodyBuilder.body(
+                    ErrorBasedSQLInjectionVulnerability.CAR_IS_NOT_PRESENT_RESPONSE);
+        }
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/taint_lambda1.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_lambda1.yaml
@@ -1,0 +1,47 @@
+rules:
+- id: jdbc
+  languages:
+    - java
+  severity: ERROR
+  message: User data flows into this manually-constructed SQL string. User data
+    can be safely inserted into SQL strings using prepared statements or an
+    object-relational mapper (ORM). Manually-constructed SQL strings is a possible
+    indicator of SQL injection, which could let an attacker steal or manipulate
+    data from the database. Instead, use prepared statements
+    (`connection.PreparedStatement`) or a safe library.
+  metadata:
+    cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      ('SQL Injection')"
+    owasp:
+      - A03:2021
+      - A01:2017
+    references:
+      - https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html
+    category: security
+    technology:
+      - spring
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+  mode: taint
+  pattern-sources:
+    - patterns:
+        - pattern-inside: |
+            public ResponseEntity<String> $FUNC(...,
+            @RequestParam Map<$TYPE, $TYPE> $VALUE,...) {
+            ...
+            }
+        - pattern-either:
+            - pattern: $VALUE.get(...)
+  pattern-sinks:
+    - patterns:
+        - pattern-either:
+            - pattern: |
+                applicationJdbcTemplate.query($QUERY,...)          
+        - pattern: $QUERY
+    - patterns:
+        - pattern-inside: |
+            applicationJdbcTemplate.query(...)
+        - pattern-either:
+            - pattern-inside: |
+                conn.prepareStatement($QUERY,...)          
+        - pattern: $QUERY
+


### PR DESCRIPTION
Lambdas were already analyzed in isolation, as they are function
definitions, but they were not being analyzed in the context surrounding
them. So if e.g. some variable was tainted outside a lambda, and reached
a sink inside the lambda, this was not being detected.

Helps PA-1224
Closes PA-1308
Closes #5239

test plan:
make test # added two tests

PR checklist:

- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
