### PR TITLE
fix(php): Ignore use list

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -2353,8 +2353,15 @@ and map_use_declaration (env : env) ((v1, v2, v3, v4) : CST.use_declaration) :
   in
   let v4 =
     match v4 with
-    | `Use_list x -> map_use_list env x
-    | `Choice_auto_semi x -> map_semicolon env x
+    (* The use list is ignored by the pfff parser. For now, for consistency
+     * let's ignore it here too. But at some point it could be worthwhile to
+     * find a way to represent this in the generic AST. *)
+    | `Use_list x ->
+        let _ = map_use_list in
+        ()
+    | `Choice_auto_semi x ->
+        let _ = map_semicolon env x in
+        ()
   in
   let uses = v2 :: v3 in
   Common.map (fun u -> UseTrait u) uses


### PR DESCRIPTION
Test plan:

`test.php`:

```
<?php

class Foo {
  use Bar1, Bar2 { f as g; }
}
```

Observe differences only with IDs when running:
`semgrep-core -lang php -diff_pfff_tree_sitter test.php`

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
