### PR TITLE
Remove string quotes

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -209,7 +209,11 @@ let map_visibility_modifier (env : env) (x : CST.visibility_modifier) =
 
 let map_string__ (env : env) (x : CST.string__) =
   match x with
-  | `Str tok -> (* string *) A.String (_str env tok)
+  | `Str tok ->
+      (* string *)
+      let value, tok = _str env tok in
+      let value = String.sub value 1 (String.length value - 2) in
+      A.String (value, tok)
   | `Here tok -> (* heredoc *) A.String (_str env tok)
 
 let map_anon_choice_pat_174c3a5_81b85de (env : env)


### PR DESCRIPTION
E.g. in `$a = "hello"`, put `hello` in A.String instead of `"hello"`. This
conforms to how the pfff parser does it.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
