### PR TITLE
A parameter pattern without a default val can now match one with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - The `ci` CLI command will now include ignored matches in output formats
   that dictate they should always be included
+- A parameter pattern without a default value can now match a parameter
+  with a default value (#5021)
 
 ### Fixed
 

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -2559,7 +2559,7 @@ and m_parameter_classic a b =
       { B.pname = Some b1; pdefault = b2; ptype = b3; pattrs = b4; pinfo = b5 }
     ) ->
       m_ident_and_id_info (a1, a5) (b1, b5) >>= fun () ->
-      (m_option m_expr) a2 b2 >>= fun () ->
+      (m_option_none_can_match_some m_expr) a2 b2 >>= fun () ->
       (m_type_option_with_hook b1) a3 b3 >>= fun () ->
       m_list_in_any_order ~less_is_ok:true m_attribute a4 b4
   (* boilerplate *)

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -440,6 +440,7 @@ let regexp_matcher_of_regexp_string s =
 (* ---------------------------------------------------------------------- *)
 (* stdlib: option *)
 (* ---------------------------------------------------------------------- *)
+(* you should probably use m_option_none_can_match_some instead *)
 let (m_option : 'a matcher -> 'a option matcher) =
  fun f a b ->
   match (a, b) with

--- a/semgrep-core/tests/php/misc_param_default.php
+++ b/semgrep-core/tests/php/misc_param_default.php
@@ -1,0 +1,17 @@
+<?php    
+
+class TestCasePHPSQL
+{
+    //public static function testWorking($aaa, $shortName): array
+    //{
+    //    return $shortName;
+    //}
+
+    //ERROR: match
+    public static function testNotWorking($aaa, $shortName = 'public'): array
+    {
+        return $shortName;
+    }
+
+}
+?>

--- a/semgrep-core/tests/php/misc_param_default.sgrep
+++ b/semgrep-core/tests/php/misc_param_default.sgrep
@@ -1,0 +1,3 @@
+function $FUNC(...,$PAR,...) {
+  return $PAR;
+}


### PR DESCRIPTION
This closes #5021

test plan:
test file included for PHP
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)