### PR TITLE
fix(deep): Don't attempt metavariable matches against parent classes

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -405,12 +405,18 @@ let rec m_name a b =
                       _sid );
               };
             _;
-          } ) ) ->
+          } ) ) -> (
       m_name a (B.Id (idb, B.empty_id_info ()))
       >||> (* try this time a match with the resolved entity *)
       m_name a (H.name_of_ids dotted)
-      >||> (* Try the parents *)
-      try_parents dotted
+      >||>
+      (* Try the parents *)
+      match a with
+      (* If we're matching against a metavariable, don't bother checking
+       * parents. It will only cause duplicate matches that can't be deduped,
+       * since the captured metavariable will be different. *)
+      | G.Id ((str, _tok), _info) when MV.is_metavar_name str -> fail ()
+      | _ -> try_parents dotted)
   | G.Id (a1, a2), B.Id (b1, b2) ->
       (* this will handle metavariables in Id *)
       m_ident_and_id_info (a1, a2) (b1, b2)


### PR DESCRIPTION
Test plan:

Automated tests

`test.rb`:

```
class Bar < Foo::Baz
end
```

`test.sgrep`:

```
class $CLS < Foo::Baz
  ...
end
```

`$ deep-semgrep --lang ruby -f test.sgrep .`

Before, it printed three matches at the same location. Now, it prints
only one. The existing automated test runner doesn't fail on duplicate
matches, so it wouldn't be straightforward to write an automated test
for this.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
