### PR TITLE
fix(ci): dont docker push when building dependabot PR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
         # said PRs do not have access to secrets so will fail anyway but
         # nicer to not have a "failing" CI job in the PR so don't even
         # try if we can detect is coming from a fork
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         run: |
           tag=returntocorp/semgrep:${{ github.sha }}
           docker build -t "$tag" .


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
