### PR TITLE
add(env): accept SEMGREP_BASELINE_REF as SEMGREP_BASELINE_COMMIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Sarif output format now includes `fixes` section
 - Rust: added support for method chaining patterns.
 - `r2c-internal-project-depends-on`: support for poetry and gradle lockfiles
+- Accept `SEMGREP_BASELINE_REF` as alias for `SEMGREP_BASELINE_COMMIT`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Sarif output format now includes `fixes` section
 - Rust: added support for method chaining patterns.
-- `r2c-internal-project-depends-on`: support for poetry and gradle lockfiles
 - Accept `SEMGREP_BASELINE_REF` as alias for `SEMGREP_BASELINE_COMMIT`
 - `r2c-internal-project-depends-on`:
   - pretty printing for SCA results

--- a/semgrep/semgrep/commands/scan.py
+++ b/semgrep/semgrep/commands/scan.py
@@ -187,7 +187,7 @@ _scan_options = [
             Only show results that are not found in this commit hash. Aborts run if not currently
             in a git directory, there are unstaged changes, or given baseline hash doesn't exist
         """,
-        envvar="SEMGREP_BASELINE_COMMIT",
+        envvar=["SEMGREP_BASELINE_COMMIT", "SEMGREP_BASELINE_REF"],
     ),
     click.option(
         "--metrics",


### PR DESCRIPTION
We used SEMGREP_BASELINE_REF in semgrep-action and docs are still recommending people use REF

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
