### PR TITLE
fix(deep): Check parent classes in more cases

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -466,26 +466,30 @@ let rec m_name a b =
           (* m_name a n *)
           return ())
   (* boilerplate *)
-  | G.IdQualified a1, B.IdQualified b1 -> m_name_info a1 b1
-  | ( G.Id _,
+  | ( _,
       G.IdQualified
-        {
-          name_info =
-            {
-              B.id_resolved =
-                {
-                  contents =
-                    Some
-                      ( ( B.ImportedEntity dotted
-                        | B.ImportedModule (B.DottedName dotted)
-                        | B.ResolvedName dotted ),
-                        _sid );
-                };
-              _;
-            };
-          _;
-        } ) ->
+        ({
+           name_info =
+             {
+               B.id_resolved =
+                 {
+                   contents =
+                     Some
+                       ( ( B.ImportedEntity dotted
+                         | B.ImportedModule (B.DottedName dotted)
+                         | B.ResolvedName dotted ),
+                         _sid );
+                 };
+               _;
+             };
+           _;
+         } as b1) ) -> (
       try_parents dotted
+      >||>
+      match a with
+      | IdQualified a1 -> m_name_info a1 b1
+      | Id _ -> fail ())
+  | G.IdQualified a1, B.IdQualified b1 -> m_name_info a1 b1
   | G.Id _, _
   | G.IdQualified _, _ ->
       fail ()


### PR DESCRIPTION
This allows Semgrep to attempt a match against parent classes when both
the pattern and the source is an `IdQualified`.

Test plan:

Automated tests. No change in Semgrep behavior. DeepSemgrep finds an
additional match in its test suite with this change.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
