### PR TITLE
Restrict scanning of tests to only one file

### DIFF
--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-11512123123/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-11512123123/output.txt
@@ -1,7 +1,8 @@
-Scanning 50 files.
+Scanning 1 file.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Scan skipped: 1 files matching .semgrepignore patterns
+  For a full list of skipped files, run semgrep with the --verbose flag.
 
-Ran 1 rule on 50 files: 0 findings.
+Ran 1 rule on 1 file: 0 findings.

--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-11512123123/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-11512123123/output.txt
@@ -2,7 +2,5 @@ Scanning 1 file.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Scan skipped: 1 files matching .semgrepignore patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
 
 Ran 1 rule on 1 file: 0 findings.

--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/output.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
 
 Findings:
 
-  /Users/sdrak/projects/semgrep/semgrep/tests/e2e/targets/basic/stupid.py 
+  stupid.py 
           3┆ return a + b == a + b
           ⋮┆----------------------------------------
           8┆ x == x
@@ -11,7 +11,5 @@ Findings:
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Scan skipped: 1 files matching .semgrepignore patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
 
 Ran 1 rule on 1 file: 3 findings.

--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/output.txt
@@ -1,57 +1,17 @@
-Scanning 50 files.
+Scanning 1 file.
 
 Findings:
 
-  targets/basic/stupid.py 
+  /Users/sdrak/projects/semgrep/semgrep/tests/e2e/targets/basic/stupid.py 
           3┆ return a + b == a + b
           ⋮┆----------------------------------------
           8┆ x == x
           ⋮┆----------------------------------------
          12┆ assertTrue(x == x)
 
-
-  targets/ci/foo.py 
-          4┆ a == a
-          ⋮┆----------------------------------------
-          5┆ a == a
-          ⋮┆----------------------------------------
-          7┆ a == a
-          ⋮┆----------------------------------------
-         11┆ y == y
-
-
-  targets/cli_test/basic/basic.py 
-          2┆ print(1 == 1)
-
-
-  targets/cli_test/multiple_annotations/multiple-annotations-bad.py 
-          2┆ 4 == 4
-          ⋮┆----------------------------------------
-          5┆ 5 == 5
-
-
-  targets/cli_test/multiple_annotations/multiple-annotations.py 
-          5┆ 5 == 5
-
-
-  targets/cli_test/suffixes/this.that.check.py 
-          2┆ print(1 == 1)
-
-
-  targets/multiline/stupid.py 
-          7┆ SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK
-          8┆ == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK
-
-
-  targets/nosemgrep/eqeq-nosemgrep.py 
-          2┆ return a + b == a + b  # nosemgrep: rules.eqeq-is-bad
-
-
-  targets/script/bad 
-          3┆ 4 == 4
-
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Scan skipped: 1 files matching .semgrepignore patterns
+  For a full list of skipped files, run semgrep with the --verbose flag.
 
-Ran 1 rule on 50 files: 15 findings.
+Ran 1 rule on 1 file: 3 findings.

--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-11512123123/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-11512123123/output.txt
@@ -1,8 +1,9 @@
-Scanning 50 files.
+Scanning 1 file.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Scan skipped: 1 files matching .semgrepignore patterns
+  For a full list of skipped files, run semgrep with the --verbose flag.
 
-Ran 1 rule on 50 files: 0 findings.
+Ran 1 rule on 1 file: 0 findings.
 foobar

--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-11512123123/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-11512123123/output.txt
@@ -2,8 +2,6 @@ Scanning 1 file.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Scan skipped: 1 files matching .semgrepignore patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
 
 Ran 1 rule on 1 file: 0 findings.
 foobar

--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/output.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
 
 Findings:
 
-  /Users/sdrak/projects/semgrep/semgrep/tests/e2e/targets/basic/stupid.py 
+  stupid.py 
           3┆ return a + b == a + b
           ⋮┆----------------------------------------
           8┆ x == x
@@ -11,7 +11,5 @@ Findings:
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Scan skipped: 1 files matching .semgrepignore patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
 
 Ran 1 rule on 1 file: 3 findings.

--- a/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/output.txt
+++ b/semgrep/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/output.txt
@@ -1,57 +1,17 @@
-Scanning 50 files.
+Scanning 1 file.
 
 Findings:
 
-  targets/basic/stupid.py 
+  /Users/sdrak/projects/semgrep/semgrep/tests/e2e/targets/basic/stupid.py 
           3┆ return a + b == a + b
           ⋮┆----------------------------------------
           8┆ x == x
           ⋮┆----------------------------------------
          12┆ assertTrue(x == x)
 
-
-  targets/ci/foo.py 
-          4┆ a == a
-          ⋮┆----------------------------------------
-          5┆ a == a
-          ⋮┆----------------------------------------
-          7┆ a == a
-          ⋮┆----------------------------------------
-         11┆ y == y
-
-
-  targets/cli_test/basic/basic.py 
-          2┆ print(1 == 1)
-
-
-  targets/cli_test/multiple_annotations/multiple-annotations-bad.py 
-          2┆ 4 == 4
-          ⋮┆----------------------------------------
-          5┆ 5 == 5
-
-
-  targets/cli_test/multiple_annotations/multiple-annotations.py 
-          5┆ 5 == 5
-
-
-  targets/cli_test/suffixes/this.that.check.py 
-          2┆ print(1 == 1)
-
-
-  targets/multiline/stupid.py 
-          7┆ SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK
-          8┆ == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK
-
-
-  targets/nosemgrep/eqeq-nosemgrep.py 
-          2┆ return a + b == a + b  # nosemgrep: rules.eqeq-is-bad
-
-
-  targets/script/bad 
-          3┆ 4 == 4
-
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+  Scan skipped: 1 files matching .semgrepignore patterns
+  For a full list of skipped files, run semgrep with the --verbose flag.
 
-Ran 1 rule on 50 files: 15 findings.
+Ran 1 rule on 1 file: 3 findings.

--- a/semgrep/tests/e2e/test_shouldafound.py
+++ b/semgrep/tests/e2e/test_shouldafound.py
@@ -112,11 +112,10 @@ def test_shouldafound_findings_output(
         }
     )
 
-    copytree(Path(TESTS_PATH / "e2e" / "targets").resolve(), tmp_path / "targets")
-    copytree(Path(TESTS_PATH / "e2e" / "rules").resolve(), tmp_path / "rules")
-    monkeypatch.chdir(tmp_path)
-
-    result = runner.invoke(cli, ["-e", pattern, "-l", "python"])
+    result = runner.invoke(
+        cli,
+        ["-e", pattern, "-l", "python", f"{TESTS_PATH}/e2e/targets/basic/stupid.py"],
+    )
 
     assert result.exception == None
     assert result.exit_code == 0

--- a/semgrep/tests/e2e/test_shouldafound.py
+++ b/semgrep/tests/e2e/test_shouldafound.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+from shutil import copy
 from shutil import copytree
 
 import pytest
@@ -104,6 +105,14 @@ def test_shouldafound_findings_output(
         "get_no_findings_msg",
         return_value=message,
     )
+
+    copy(
+        TESTS_PATH / "e2e" / "targets" / "basic" / "stupid.py",
+        tmp_path / "stupid.py",
+    )
+
+    monkeypatch.chdir(tmp_path)
+
     mocker.patch.object(scan, "possibly_notify_user", return_value=None)
 
     runner = CliRunner(
@@ -114,7 +123,7 @@ def test_shouldafound_findings_output(
 
     result = runner.invoke(
         cli,
-        ["-e", pattern, "-l", "python", f"{TESTS_PATH}/e2e/targets/basic/stupid.py"],
+        ["-e", pattern, "-l", "python"],
     )
 
     assert result.exception == None


### PR DESCRIPTION
Having the tests scan all of the targets dir means that the snapshots change frequently.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
