### PR TITLE
add: Include untyped SCA info in semgrep-app findings output

### DIFF
--- a/semgrep/semgrep/rule_match.py
+++ b/semgrep/semgrep/rule_match.py
@@ -293,6 +293,12 @@ class RuleMatch:
 
         if self.extra.get("fixed_lines"):
             ret.fixed_lines = self.extra.get("fixed_lines")
+        if "dependency_match_only" in self.extra and "dependency_matches" in self.extra:
+            ret.sca_info = out.ScaInfo(
+                dependency_match_only=self.extra["dependency_match_only"],
+                dependency_matches=self.extra["dependency_matches"],
+            )
+
         return ret
 
     def __hash__(self) -> int:


### PR DESCRIPTION
This PR adds SCA information to the output sent to semgrep-app. It still treats the SCA info as raw json. I'm in the process of making the SCA info itself be typed, but that got held up by some ATD annoyances, and I want to get this into the next release.

PR checklist:

- [x] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
