### PR TITLE
Put interface ancestors in `implements` instead of `extends`

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -2050,9 +2050,8 @@ and map_statement (env : env) (x : CST.statement) =
       in
       let v3 =
         match v3 with
-        (* TODO interfaces can extend multiple other interfaces, but we throw away everything but the first base interface here. *)
-        | Some x -> Some (List.hd (map_base_clause env x))
-        | None -> None
+        | Some x -> map_base_clause env x
+        | None -> []
       in
       let v4 = map_declaration_list env v4 in
       let opn, decls, cls = v4 in
@@ -2061,8 +2060,8 @@ and map_statement (env : env) (x : CST.statement) =
         {
           c_name = v2;
           c_kind = (A.Interface, v1);
-          c_extends = v3;
-          c_implements = [];
+          c_extends = None;
+          c_implements = v3;
           c_uses = uses;
           c_enum_type = None;
           c_modifiers = [];

--- a/semgrep-core/tests/php/multiple_interfaces.php
+++ b/semgrep-core/tests/php/multiple_interfaces.php
@@ -1,0 +1,21 @@
+<?php
+
+// ERROR: match
+interface Single extends Serializable {
+    function SomeFunc();
+}
+
+// ERROR: match
+interface Front extends Serializable, Throwable, Stringable {
+    function SomeFunc();
+}
+
+// ERROR: match
+interface Middle extends Throwable, Serializable, Stringable {
+    function SomeFunc();
+}
+
+// ERROR: match
+interface Last extends Throwable, Stringable, Serializable {
+    function SomeFunc();
+}

--- a/semgrep-core/tests/php/multiple_interfaces.sgrep
+++ b/semgrep-core/tests/php/multiple_interfaces.sgrep
@@ -1,0 +1,1 @@
+interface $SOME extends Serializable { ... }


### PR DESCRIPTION
So that we can extend multiple interfaces. This is also how pfff does it.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
