### PR TITLE
fix(junit_xml_output): failure content should not be a python list of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   the imported name (#3964)
 - Constant propagation is now faster and memory efficient when analyzing
   large functions with lots of variables.
+- The JUnit XML output should serialize the failure messages as a single
+  string instead of a python list of strings.
 
 ## [0.94.0](https://github.com/returntocorp/semgrep/releases/tag/v0.94.0) - 2022-05-25
 

--- a/semgrep/semgrep/formatter/junit_xml.py
+++ b/semgrep/semgrep/formatter/junit_xml.py
@@ -25,7 +25,7 @@ class JunitXmlFormatter(BaseFormatter):
         )
         test_case.add_failure_info(
             message=rule_match.message,
-            output=rule_match.lines,
+            output="".join(rule_match.lines),
             failure_type=rule_match.severity.value,
         )
         return test_case

--- a/semgrep/tests/e2e/snapshots/test_output/test_junit_xml_output/results.xml
+++ b/semgrep/tests/e2e/snapshots/test_output/test_junit_xml_output/results.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" ?>
 <testsuites disabled="0" errors="0" failures="2" tests="2" time="0.0">
 	<testsuite disabled="0" errors="0" failures="2" name="semgrep results" skipped="0" tests="2" time="0">
-		<testcase classname="targets/basic/stupid.py" file="targets/basic/stupid.py" line="3" name="rules.eqeq-is-bad">
-			<failure message="useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?" type="ERROR">['    return a + b == a + b\n']</failure>
+		<testcase name="rules.eqeq-is-bad" classname="targets/basic/stupid.py" file="targets/basic/stupid.py" line="3">
+			<failure type="ERROR" message="useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?">    return a + b == a + b
+</failure>
 		</testcase>
-		<testcase classname="targets/basic/stupid.js" file="targets/basic/stupid.js" line="3" name="rules.javascript-basic-eqeq-bad">
-			<failure message="useless comparison" type="ERROR">['console.log(x == x)\n']</failure>
+		<testcase name="rules.javascript-basic-eqeq-bad" classname="targets/basic/stupid.js" file="targets/basic/stupid.js" line="3">
+			<failure type="ERROR" message="useless comparison">console.log(x == x)
+</failure>
 		</testcase>
 	</testsuite>
 </testsuites>


### PR DESCRIPTION
The JUnit xml output would serialize the failure messages as a python list of strings.
This change addresses this problem by grouping the lines together.

Fixes #5223

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
