### PR TITLE
fix(deep): Skip matching against resolved name when pattern is metavariable

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -411,16 +411,17 @@ let rec m_name a b =
             _;
           } ) ) -> (
       m_name a (B.Id (idb, B.empty_id_info ()))
-      >||> (* try this time a match with the resolved entity *)
-      m_name a (H.name_of_ids dotted)
       >||>
-      (* Try the parents *)
+      (* Try the resolved entity and parents *)
       match a with
       (* If we're matching against a metavariable, don't bother checking
-       * parents. It will only cause duplicate matches that can't be deduped,
-       * since the captured metavariable will be different. *)
+       * the resolved entity or parents. It will only cause duplicate matches
+       * that can't be deduped, since the captured metavariable will be
+       * different. *)
       | G.Id ((str, _tok), _info) when MV.is_metavar_name str -> fail ()
-      | _ -> try_parents dotted)
+      | _ ->
+          (* try this time a match with the resolved entity *)
+          m_name a (H.name_of_ids dotted) >||> try_parents dotted)
   (* extension: metatypes *)
   | G.Id (((str, t) as a1), a_info), B.Id (b1, b2) -> (
       (* this will handle metavariables in Id *)


### PR DESCRIPTION
This is very similar to
https://github.com/returntocorp/semgrep/pull/5368, and relies on the
same intuition: that it's strange to attempt to match a metavariable
against resolved names, since it will already match the non-resolved
name anyway.

Test plan:

Automated tests:
* No change in semgrep
* In deep-semgrep, the Python `useless-innerfunction` test, which was
  previously expected to fail, now passes. I looked into this a little
  bit and while I didn't figure out exactly why this change fixes it,
  it's pretty clear to me that the overmatching that deep-semgrep
  previously did there was incorrect behavior.

Manual test:

`test.rb`:

```
module A
  class B
  end

  class C < B
  end
end
```

`test.sgrep`:

```
class $X < B
  ...
end
```

`deep-semgrep --lang ruby -f test.sgrep .`

This previously returned two matches on line 5, and now it returns one.
Though, without my work in progress on deep semgrep (currently up for
review), which improves name resolution, it returned only one match
because it couldn't resolve some names.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
