### PR TITLE
Scala: resolve names in typed patterns within classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   for 'abstract' modifier in more places
 - Scala: stop parsing parenthesized expressions as unary tuples
 - `yarn.lock` files with no depenencies, and with dependencies that lack URLs, now parse
+- Scala: fixed bug where typed patterns inside classes caused an exception during name resolution
 
 ## [0.96.0](https://github.com/returntocorp/semgrep/releases/tag/v0.96.0) - 2022-06-03
 

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -365,7 +365,8 @@ let is_resolvable_name_ctx env lang =
       (* true for JS/TS so that we can resolve class methods *)
       | Lang.Js
       | Lang.Ts
-      | Lang.Php ->
+      | Lang.Php
+      | Lang.Scala ->
           true
       | _ -> false)
 
@@ -382,7 +383,8 @@ let resolved_name_kind env lang =
       (* true for JS/TS to resolve class methods. *)
       | Lang.Js
       | Lang.Ts
-      | Lang.Php ->
+      | Lang.Php
+      | Lang.Scala ->
           EnclosedVar
       | _ -> raise Impossible)
 
@@ -632,7 +634,8 @@ let resolve lang prog =
                *)
               declare_var env lang id id_info ~explicit:true None None;
               k x
-          | PatTyped (PatId (id, id_info), ty) ->
+          | PatTyped (PatId (id, id_info), ty)
+            when is_resolvable_name_ctx env lang ->
               declare_var env lang id id_info ~explicit:true None (Some ty)
           (* do not recurse here, we don't want the PatId case above
            * to overwrite the job done here

--- a/semgrep-core/tests/scala/parsing/pat_typed_in_class.scala
+++ b/semgrep-core/tests/scala/parsing/pat_typed_in_class.scala
@@ -1,0 +1,6 @@
+class C {
+    val x = foo match {
+    case Foo(x : A) => e1
+    case Bar(y : B) => e2
+    }
+}


### PR DESCRIPTION
#5191 made semgrep aware of the types of typed patterns, but did not guard a call to `declare_var` with `is_resolvable_name_ctx`, which caused that branch of code to fail on typed patterns within classes in Scala. This PR fixes the bug by adding the guard and extending the guard to account for Scala.

test plan: make test

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
