### PR TITLE
fix(cli): Small reword of the `semgrep cli` output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Fixed
 
+- The output of `semgrep ci` should be clear it is exiting with error code 0
+  when there are findings but none of them being blockers
 - Java: support for Sealed classes and Text Blocks via tree-sitter-java
   (#3787, #4644)
 - Typescript: update to latest tree-sitter-typescript, with support

--- a/semgrep/semgrep/commands/ci.py
+++ b/semgrep/semgrep/commands/ci.py
@@ -455,7 +455,7 @@ def ci(
             logger.info("  Has findings for blocking rules so exiting with code 1")
             exit_code = 1
     else:
-        logger.info("  No findings so exiting with code 0")
+        logger.info("  No blocking findings so exiting with code 0")
         exit_code = 0
 
     if enable_version_check:


### PR DESCRIPTION
The output of `semgrep ci` should be clear it is exiting with error code 0 when there are findings but none of them being blockers

Here is an example of the new output:
```
CI scan completed successfully.
  Found 5 findings (0 blocking) from 1374 rules.
  Uploading findings to Semgrep App.
  No blocking findings so exiting with code 0
```

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
