### PR TITLE
chore(deps): bump ocaml from 4.12 to 4.14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     # Custom image provides 'ocamlformat' with a specific version needed to check
     # ocaml code (must be the same than the one in semgrep-core/dev/dev.opam)
-    container: returntocorp/ocaml:ubuntu-2022-04-14
+    container: returntocorp/ocaml:ubuntu-2022-06-09
     steps:
       - name: Pre-checkout fixes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
   build-core:
     name: semgrep-core make test and semgrep make test/qa-test
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2022-04-14
+    container: returntocorp/ocaml:alpine-2022-06-09
     steps:
       - name: Install pipenv
         run: sudo pip install pipenv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
   build-core:
     name: build semgrep-core
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2022-04-14
+    container: returntocorp/ocaml:alpine-2022-06-09
     steps:
       - name: Pre-checkout fixes
         run: |
@@ -156,7 +156,7 @@ jobs:
   test-core:
     name: test semgrep-core
     runs-on: ubuntu-latest
-    container: returntocorp/ocaml:alpine-2022-04-14
+    container: returntocorp/ocaml:alpine-2022-06-09
     needs: [build-core] # save some CPU time by waiting till build cache is populated in that job
     steps:
       - name: Install pipenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,17 @@
 # of the 'semgrep-python' wrapping.
 #
 
-# The docker base image below in the FROM currently uses OCaml 4.12.0
+# The docker base image below in the FROM currently uses OCaml 4.14.0
 # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine.sh
 #
 # coupling: if you modify the OCaml version there, you probably also need
 # to modify:
-# - scripts/osx-release.sh
+# - scripts/{osx-release,osx-m1-release,setup-m1-builder}.sh
 # - doc/SEMGREP_CORE_CONTRIBUTING.md
 # - https://github.com/Homebrew/homebrew-core/blob/master/Formula/semgrep.rb
 # Note that many .github/workflows/ use returntocorp/ocaml:alpine, which should
 # be the latest, but may differ from this one.
-FROM returntocorp/ocaml:alpine-2022-03-31@sha256:4a42d4c82000df13148a4162d1689b32e8568bc256bf12faa5d8669570ffe8b7 as semgrep-core
+FROM returntocorp/ocaml:alpine-2022-06-09@sha256:99b453a838c9d94414991c0fd7be4711aa1bcc120f576e0f0653c7b921ea9718 as semgrep-core
 
 USER root
 # for ocaml-pcre now used in semgrep-core

--- a/scripts/osx-m1-release.sh
+++ b/scripts/osx-m1-release.sh
@@ -5,7 +5,7 @@
 set -e
 brew update # Needed to sidestep bintray brownout
 #coupling: this should be the same version than in our Dockerfile
-opam switch 4.12.0;
+opam switch 4.14.0;
 git submodule update --init --recursive --depth 1
 
 eval "$(opam env)"

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -4,8 +4,8 @@ brew update # Needed to sidestep bintray brownout
 brew install opam pkg-config coreutils
 opam init --no-setup --bare;
 #coupling: this should be the same version than in our Dockerfile
-opam switch create 4.12.0;
-opam switch 4.12.0;
+opam switch create 4.14.0;
+opam switch 4.14.0;
 git submodule update --init --recursive --depth 1
 
 eval "$(opam env)"

--- a/scripts/setup-m1-builder.sh
+++ b/scripts/setup-m1-builder.sh
@@ -20,8 +20,8 @@ brew update # Needed to sidestep bintray brownout
 brew install opam pkg-config coreutils python pcre
 opam init --no-setup --bare;
 #coupling: this should be the same version than in our Dockerfile
-opam switch create 4.12.0;
-opam switch 4.12.0;
+opam switch create 4.14.0;
+opam switch 4.14.0;
 git submodule update --init --recursive --depth 1
 
 eval "$(opam env)"

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -39,7 +39,7 @@ depends: [
   "re"
   "pcre"
   "parmap"
-  "ppxlib" {= "0.20.0" }
+  "ppxlib"
   "lsp" {= "1.7.0"}
   "comby-kernel" {= "1.4.1"}
 ]

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -121,7 +121,7 @@ let unify_mvars_sets mvars1 mvars2 =
   let xs =
     List.fold_left
       (fun xs (mvar, mval) ->
-        let* xs = xs in
+        let* xs in
         match List.assoc_opt mvar mvars2 with
         | None -> Some ((mvar, mval) :: xs)
         | Some mval' ->

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -121,7 +121,7 @@ let unify_mvars_sets mvars1 mvars2 =
   let xs =
     List.fold_left
       (fun xs (mvar, mval) ->
-        let* xs in
+        xs >>= fun xs ->
         match List.assoc_opt mvar mvars2 with
         | None -> Some ((mvar, mval) :: xs)
         | Some mval' ->


### PR DESCRIPTION
- Removes ppxlib pinned version to allow this
- Similar changes in pfff submodule

PR checklist:

- [x] Documentation is up-to-date (See https://github.com/returntocorp/semgrep-docs/pull/568)
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
