### PR TITLE
Restore use of Unit_metachecking.ml

### DIFF
--- a/semgrep-core/tests/OTHER/errors/only_negative_terms.yaml
+++ b/semgrep-core/tests/OTHER/errors/only_negative_terms.yaml
@@ -1,5 +1,6 @@
 rules:
 - id: empty-test
+  #ERROR: only negative terms
   patterns:
   - pattern-not-regex: |
       function

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -67,7 +67,7 @@ let tests () = List.flatten [
   (* TODO Unit_matcher.spatch_unittest ~xxx *)
   (* TODO Unit_matcher_php.unittest; (* sgrep, spatch, refactoring, unparsing *) *)
   Unit_engine.tests ();
-  (*Unit_metachecking.tests (); TODO: fix test 'only_negative_terms.yaml' *)
+  Unit_metachecking.tests ();
 ]
 
 (*****************************************************************************)


### PR DESCRIPTION
This closes #5432

test plan:
make test


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)