### PR TITLE
feat(sca): make `sca` a valid option for --config

### DIFF
--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -94,6 +94,9 @@ class ConfigPath:
         elif is_policy_id(config_str):
             state.metrics.add_feature("config", "policy")
             self._config_path = url_for_policy(config_str)
+        elif is_sca(config_str):
+            state.metrics.add_feature("config", "sca")
+            self._config_path = url_for_sca()
         elif is_registry_id(config_str):
             state.metrics.add_feature("config", f"registry:prefix-{config_str[0]}")
             self._config_path = registry_id_to_url(config_str)
@@ -555,6 +558,21 @@ def url_for_policy(config_str: str) -> str:
 
 def is_policy_id(config_str: str) -> bool:
     return config_str == "policy"
+
+
+def url_for_sca() -> str:
+    deployment_id = auth.get_deployment_id()
+    if deployment_id is None:
+        raise SemgrepError(
+            "Invalid API Key. Run `semgrep logout` and `semgrep login` again."
+        )
+    env = get_state().env
+    repo_name = os.environ.get("SEMGREP_REPO_NAME")
+    return f"{env.semgrep_url}/api/agent/deployments/{deployment_id}/repos/{repo_name}/rules.yaml?sca=true"
+
+
+def is_sca(config_str: str) -> bool:
+    return config_str == "sca"
 
 
 def saved_snippet_to_url(snippet_id: str) -> str:


### PR DESCRIPTION
SCA customers can now run `semgrep scan --config sca` and fetch their
SCA rules if they are logged in.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
