### PR TITLE
fix: Errors regarding using /src in docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Fixed a bug where `--disable-version-check` would still send a request
   when a scan resulted in zero findings.
+- Fixed a regression in 0.97 where the Docker image's working directory changed from `/src` without notice.
+  This also could cause permission issues when running the image.
 
 ## [0.97.0](https://github.com/returntocorp/semgrep/releases/tag/v0.97.0) - 2022-06-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,8 @@ ENV SEMGREP_IN_DOCKER=1 \
      SEMGREP_VERSION_CACHE_PATH=/tmp/.cache/semgrep_version \
      SEMGREP_USER_AGENT_APPEND="Docker"
 
+WORKDIR /src
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["semgrep", "--help"]
 LABEL maintainer="support@r2c.dev"

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -59,6 +59,6 @@ echo "if 1 == 1: pass" \
     | docker run -i "$image" semgrep -l python -e '$X == $X' - \
     | grep -q "1 == 1"
 
-mkdir foo
-echo "if 1 == 1: pass" > foo/bar.py
-docker run -v foo:/src -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"
+TEMP_DIR=$(mktemp -d)
+echo "if 1 == 1: pass" > "${TEMP_DIR}/bar.py"
+docker run -v "${TEMP_DIR}:/src" -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"

--- a/scripts/validate-docker-build.sh
+++ b/scripts/validate-docker-build.sh
@@ -58,3 +58,7 @@ docker run "$image" publish --help
 echo "if 1 == 1: pass" \
     | docker run -i "$image" semgrep -l python -e '$X == $X' - \
     | grep -q "1 == 1"
+
+mkdir foo
+echo "if 1 == 1: pass" > foo/bar.py
+docker run -v foo:/src -i "$image" semgrep -l python -e '$X == $X' | grep -q "1 == 1"

--- a/semgrep/semgrep/config_resolver.py
+++ b/semgrep/semgrep/config_resolver.py
@@ -413,11 +413,15 @@ def adjust_for_docker() -> None:
     """change into this folder so that all paths are relative to it"""
     env = get_state().env
     if env.in_docker and not env.in_gh_action:
-        if not env.src_directory.exists():
+        try:
+            # check if there's at least one file in /src
+            next(env.src_directory.iterdir())
+        except (NotADirectoryError, StopIteration):
             raise SemgrepError(
                 f"Detected Docker environment without a code volume, please include '-v \"${{PWD}}:{env.src_directory}\"'"
             )
-        os.chdir(env.src_directory)
+        else:
+            os.chdir(env.src_directory)
 
 
 def indent(msg: str) -> str:


### PR DESCRIPTION
This reimplements https://github.com/returntocorp/semgrep/pull/5442/commits/6ef4d854f2251a0c46672647406a868d500be26a
in a safer way.

The WORKDIR /src is readded to the Dockerfile,
and we now check if it contains any files instead of its existence.

Fixes https://github.com/returntocorp/semgrep/issues/5479
Fixes https://github.com/returntocorp/semgrep/issues/5488

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
