### PR TITLE
New debug script calling ocamldebug

### DIFF
--- a/semgrep-core/debug
+++ b/semgrep-core/debug
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+#
+# Run the semgrep-core program with ocamldebug.
+#
+# Example of use:
+#  $ ./debug
+#  ...
+#  (ocd) set arguments -debugger -e 'foo($X, $Y)' -l java tests/java/concrete_syntax.java
+#  (ocd) run
+#  ...
+# The -debugger arguments to semgrep-core is to change the behavior of
+# Common.finalize to let the exn bubble up, for a better debugging experience
+
+set -eu
+
+./scripts/run-ocamldebug.sh ./_build/default/src/cli/Main.bc


### PR DESCRIPTION
Just like we have a test script, it's convenient
to have a debug script that does the right thing
for you.

This also adjust Common.finalize to not catch exns when
in "debugger" mode for a better debugging experience

test plan:
```
./debug
(ocd) set arguments -debugger -e '$X==$X' tests
(ocd) run
...
Loading program... done.
[2.854  Info       Main.Setup_logging   ] loaded log_config.json
[2.854  Info       Main.Dune__exe__Main ] Executed as: /home/pad/github/semgrep/semgrep-core/./_build/default/src/cli/Main.bc -debugger -e $X==$X tests
[2.855  Info       Main.Dune__exe__Main ] Version: semgrep-core version: 0.97.0, pfff: 0.42
Time: 2281345
Program end.
Uncaught exception: Failure "no language specified; use -lang"
(ocd) b
[2.855  Info       Main.Dune__exe__Main ] Version: semgrep-core version: 0.97.0, pfff: 0.42
Time: 2281344 - pc: 0:8448 - module Stdlib
29 let failwith s = raise(Failure s)<|a|>
(ocd) b
Time: 2281343 - pc: 0:8428 - module Stdlib
29 let failwith s = <|b|>raise(Failure s)
(ocd) b
Time: 2281342 - pc: 0:15468180 - module Xlang
28   | None -> failwith (Lang.unsupported_language_message "unset")<|a|>
```

Before this PR typing 'b' (for back) will lead
to some code in Common.ml to calls some cleanup() functions
that makes it more difficult to debug toplevel exn.


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)