### PR TITLE
fix: return InvalidRule exn for rules using pattern-where-python:

### DIFF
--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -585,9 +585,10 @@ let rec parse_formula_old env ((key, value) : key * G.expr) : R.formula_old =
   | "metavariable-analysis"
   | "metavariable-regex"
   | "metavariable-pattern"
-  | "metavariable-comparison"
-  | "pattern-where-python" ->
+  | "metavariable-comparison" ->
       R.PatExtra (t, parse_extra env key value)
+  | "pattern-where-python" ->
+      raise (R.InvalidRule (R.DeprecatedFeature (fst key), env.id, t))
   (* fix suggestions *)
   | "metavariable-regexp" ->
       error_at_key env key
@@ -744,7 +745,6 @@ and parse_extra (env : env) (key : key) (value : G.expr) : Rule.extra =
       in
       let comparison = parse_metavar_cond env key comparison in
       R.MetavarComparison { R.metavariable; comparison; strip; base }
-  | "pattern-where-python" -> R.PatWherePython (parse_string env key value)
   | _ -> error_at_key env key ("wrong parse_extra field: " ^ fst key)
 
 let parse_languages ~id langs : Xlang.t =

--- a/semgrep-core/tests/OTHER/errors/pattern_where_python_deprecated.yaml
+++ b/semgrep-core/tests/OTHER/errors/pattern_where_python_deprecated.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: integer-overflow-int16
+    message:
+      Detected conversion of the result of a strconv.Atoi command to an int16. This could lead to an integer overflow,
+      which could possibly result in unexpected behavior and even privilege escalation. Instead, use `strconv.ParseInt`.
+    languages: [go]
+    severity: WARNING
+    patterns:
+      - pattern: |
+          $F, $ERR := strconv.Atoi($NUM)
+          ...
+          int16($F)
+      #ERROR: deprecated feature
+      - pattern-where-python: int(vars['$NUM'].replace('"', '')) > 32767 or int(vars['$NUM'].replace('"', '')) < -32768
+#      - metavariable-comparison:
+#          metavariable: $NUM
+#          comparison: $NUM > 32767 or $NUM < -32768
+#          strip: true
+    metadata:
+      category: correctness
+      technology:
+        - go


### PR DESCRIPTION
this closes #5320

test plan:
```
$ semgrep-core -l go -rules tests/OTHER/errors/pattern_where_python_deprecated.yaml tests/go/
tests/OTHER/errors/pattern_where_python_deprecated.yaml:14:8: "Rule parse error": deprecated feature: pattern-where-python
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)