### PR TITLE
Go: allow single pattern field to match composite literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   when a scan resulted in zero findings.
 - Fixed a regression in 0.97 where the Docker image's working directory changed from `/src` without notice.
   This also could cause permission issues when running the image.
+- Go: single pattern field can now match toplevel fields in a composite
+  literal (#5452)
 
 ## [0.97.0](https://github.com/returntocorp/semgrep/releases/tag/v0.97.0) - 2022-06-08
 

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1735,6 +1735,11 @@ and partial =
   | PartialMatch of tok * expr
   (* partial objects (just used in JSON and YAML patterns for now)
    * alt: todo? could be considered a full thing and use Fld?
+   * This matches single fields in field list bracket (in Record or cbody).
+   * Note that this actually also matches ArgKwd and certain List
+   * because in Go composite literals are translated in mix of Calls with
+   * ArgKwd and List/Tuples with pairs for fields.
+   * alt: have a PartialSingleFieldOrArgKwd special construct for Go?
    *)
   | PartialSingleField of string wrap (* id or str *) * tok (*:*) * expr
   (* not really a partial, but the partial machinery can help with that *)

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -277,6 +277,9 @@ let (mk_visitor :
           ()
       | Container (v1, v2) ->
           (match v1 with
+          (* less: could factorize with case below by doing List|Dict here and
+           * below in Tuple a String|Id
+           *)
           | Dict ->
               v2 |> unbracket
               |> List.iter (fun e ->
@@ -287,7 +290,9 @@ let (mk_visitor :
                          v_partial ~recurse:false
                            (PartialSingleField (id, t, e))
                      | _ -> ())
-          (* for Go where we use List for composite literals *)
+          (* for Go where we use List for composite literals.
+           * TODO? generate Dict in go_to_generic.ml instead directly?
+           *)
           | List ->
               v2 |> unbracket
               |> List.iter (fun e ->
@@ -526,6 +531,9 @@ let (mk_visitor :
         let v1 = v_type_ v1 in
         ()
     | ArgKwd (v1, v2) ->
+        let tok = snd v1 in
+        let t = PI.fake_info tok ":" in
+        v_partial ~recurse:false (PartialSingleField (v1, t, v2));
         let v1 = v_ident v1 and v2 = v_expr v2 in
         ()
     | ArgKwdOptional (v1, v2) ->

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -354,7 +354,18 @@ let top_func () =
         G.Container (G.Tuple, G.fake_bracket [ v1; v3 ]) |> G.e
     | InitBraces v1 ->
         let v1 = bracket (list init) v1 in
+        (* Note that here we generate a List instead of a Dict
+         * because not all elements are InitKeyValue (some are InitExpr).
+         * TODO? we could detect if only has InitKeyValue and generate a Dict
+         * instead?
+         *)
         G.Container (G.List, v1) |> G.e
+  (* Why generating ArgKwd instead of a Record with fields? Because in Go you
+   * don't have to name every fields in a CompositeLit, so we need a case for
+   * unamed fields, hence Arg and ArgKwd.
+   * TODO? why do we generate Arg and ArgKwd for toplevel CompositeLit inits
+   * and Container(List) for nested inits (see init() abobe)?
+   *)
   and init_for_composite_lit = function
     | InitExpr v1 ->
         let v1 = expr v1 in

--- a/semgrep-core/tests/go/partial_single_field2.go
+++ b/semgrep-core/tests/go/partial_single_field2.go
@@ -1,0 +1,23 @@
+package main
+
+//import (
+//    "crypto/tls"
+//    "fmt"
+//    "net/http"
+//)
+
+func connect() {
+	//    Conn.Password = Config.Password
+	//    Conn.UseTLS = Config.UseTLS
+    Conn.TLSConfig = &tls.Config {
+        ServerName: getServerName(),
+
+        //ERROR: match
+        InsecureSkipVerify: true,
+    }
+	//    Conn.VerboseCallbackHandler = Config.Debug
+	//    err := Conn.Connect(Config.Server)
+	//    if err != nil {
+	//        log.Fatal(err)
+	//    }
+}

--- a/semgrep-core/tests/go/partial_single_field2.sgrep
+++ b/semgrep-core/tests/go/partial_single_field2.sgrep
@@ -1,0 +1,1 @@
+InsecureSkipVerify: true


### PR DESCRIPTION
This closes #5452

test plan:
test file included


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)