### PR TITLE
Catch errors from semgrep run as validation errors

### DIFF
--- a/semgrep/semgrep/commands/scan.py
+++ b/semgrep/semgrep/commands/scan.py
@@ -843,15 +843,17 @@ def scan(
 
                 # Run metachecks specifically on the config files
                 if config:
-                    metacheck_errors = CoreRunner(
-                        jobs=jobs,
-                        timeout=timeout,
-                        max_memory=max_memory,
-                        timeout_threshold=timeout_threshold,
-                        optimizations=optimizations,
-                        core_opts_str=core_opts,
-                    ).validate_configs(config)
-
+                    try:
+                        metacheck_errors = CoreRunner(
+                            jobs=jobs,
+                            timeout=timeout,
+                            max_memory=max_memory,
+                            timeout_threshold=timeout_threshold,
+                            optimizations=optimizations,
+                            core_opts_str=core_opts,
+                        ).validate_configs(config)
+                    except SemgrepError as e:
+                        metacheck_errors = [e]
                 config_errors = list(chain(config_errors, metacheck_errors))
 
                 valid_str = "invalid" if config_errors else "valid"


### PR DESCRIPTION
So that errors are shown on the output.

Closes #5293.

This is duplicating https://github.com/returntocorp/semgrep/pull/5474 because I
don't know what's going on with the tests there

PR checklist:

- [ ] Documentation is up-to-date
- [ ] Changelog is up-to-date
- [ ] Change has no security implications (otherwise, ping security team)
