### PR TITLE
fix(js): Parse `New` as a separate construct from `Call`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Fixed a non-deterministic crash when matching a large number of regexes (#5277)
 - Fixed issue when running in GithubActions that caused semgrep to report on
   files not changed in the PR (#5453)
+- JS/TS: `$X()` no longer matches `new Foo()`, for consistency with other languages (#5510)
 
 ## [0.97.0](https://github.com/returntocorp/semgrep/releases/tag/v0.97.0) - 2022-06-08
 

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -79,8 +79,6 @@ let special (x, tok) =
   | Module -> other_expr "Module"
   | Define -> other_expr "Define"
   | Arguments -> other_expr "Arguments"
-  (* TODO: lift up New in ast_js.ml in pfff *)
-  | New -> other_expr "New"
   | NewTarget -> other_expr "NewTarget"
   | Eval -> SR_Special (G.Eval, tok)
   | Seq -> SR_NeedArgs (fun args -> G.Seq args)
@@ -302,6 +300,11 @@ and expr (x : expr) =
   | Apply (v1, v2) ->
       let v1 = expr v1 and v2 = bracket (list expr) v2 in
       G.Call (v1, bracket (List.map (fun e -> G.Arg e)) v2)
+  | New (tok, e, args) ->
+      let tok = info tok in
+      let e = expr e in
+      let args = bracket (list (fun arg -> G.Arg (expr arg))) args in
+      G.New (tok, H.expr_to_type e, args)
   | Arr v1 ->
       let v1 = bracket (list expr) v1 in
       G.Container (G.Array, v1)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -1689,9 +1689,7 @@ and expression (env : env) (x : CST.expression) : expr =
         | Some x -> arguments env x
         | None -> fb []
       in
-      (* less: we should remove the extra Apply but that's what we do in pfff*)
-      let newcall = Apply (IdSpecial (New, v1), fb [ v2 ]) in
-      Apply (newcall, (t1, xs, t2))
+      New (v1, v2, (t1, xs, t2))
   | `Yield_exp (v1, v2) ->
       let v1 = token env v1 (* "yield" *) in
       let v2 =


### PR DESCRIPTION
See the corresponding `pfff` commit for background.

Note that this changes the output on a `semgrep-rules` test. It looks
like this is because the `Call` pattern also happened to match `New`
expressions, since `New` expressions were represented as `Call`s. I'm
not sure how to address this. The new behavior seems correct, but it is
also clear that the rule author intended the rule to match both
constructor calls and function calls. I would appreciate reviewer
feedback on this issue.

Corresponding semgrep-rules PR:
https://github.com/returntocorp/semgrep-rules/pull/2130

Test plan: Automated tests

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
