### PR TITLE
PHP: Support named arguments in patterns + refactor arguments in AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Go: single pattern field can now match toplevel fields in a composite
   literal (#5452)
 - PHP: metavariable-pattern: works again when used with language: php (#5443)
-- PHP: named arguments work in patterns
+- PHP: named arguments work in patterns (#5508)
 
 ## [0.97.0](https://github.com/returntocorp/semgrep/releases/tag/v0.97.0) - 2022-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Go: single pattern field can now match toplevel fields in a composite
   literal (#5452)
 - PHP: metavariable-pattern: works again when used with language: php (#5443)
+- PHP: named arguments work in patterns
 
 ## [0.97.0](https://github.com/returntocorp/semgrep/releases/tag/v0.97.0) - 2022-06-08
 

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -335,7 +335,8 @@ and expr e : G.expr =
       G.Ref (t, v1)
   | Unpack v1 ->
       let v1 = expr v1 in
-      G.OtherExpr (("Unpack", fake ""), [ G.E v1 ])
+      G.Call
+        (G.IdSpecial (G.Spread, fake "...") |> G.e, G.fake_bracket [ G.Arg v1 ])
   | Call (v1, v2) ->
       let v1 = expr v1 and v2 = bracket (list argument) v2 in
       G.Call (v1, v2)
@@ -438,8 +439,7 @@ and match_ = function
 and argument = function
   | Arg e -> expr e |> G.arg
   | ArgRef (tok, e) -> G.Ref (tok, expr e) |> G.e |> G.arg
-  | ArgUnpack (tok, e) ->
-      G.OtherExpr (("Unpack", tok), [ G.E (expr e) ]) |> G.e |> G.arg
+  | ArgUnpack (tok, e) -> G.special (Spread, tok) [ expr e ] |> G.arg
   | ArgLabel (label, _tok, e) -> G.ArgKwd (label, expr e)
 
 and special = function

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -105,7 +105,9 @@ let stmt1 xs =
 
 let fake_call_to_builtin (env : env) tok args =
   let str, tok = tok in
-  A.Call (A.Id [ (A.builtin str, tok) ], Parse_info.fake_bracket tok args)
+  A.Call
+    ( A.Id [ (A.builtin str, tok) ],
+      Parse_info.fake_bracket tok (args |> Common.map (fun x -> A.Arg x)) )
 
 let rec chain_else_if (env : env) ifelses (else_ : A.stmt) : A.stmt =
   match ifelses with
@@ -681,15 +683,17 @@ and map_anon_choice_simple_param_5af5eb3 (env : env)
         }
 
 and map_argument (env : env) ((v1, v2) : CST.argument) =
-  let v1_todo =
-    match v1 with
-    | Some x -> Some (map_named_label_statement env x)
-    | None -> None
-  in
   let v2 =
     match v2 with
-    | `Vari_unpa x -> map_variadic_unpacking env x
-    | `Exp x -> map_expression env x
+    | `Vari_unpa (v1, v2) ->
+        let v1 = (* "..." *) token env v1 in
+        let v2 = map_expression env v2 in
+        A.ArgUnpack (v1, v2)
+    | `Exp x -> (
+        match v1 with
+        | Some (v1, v2) ->
+            A.ArgLabel (_str env v1, token env v2, map_expression env x)
+        | None -> A.Arg (map_expression env x))
   in
   v2
 
@@ -1122,13 +1126,14 @@ and map_dynamic_variable_name (env : env) (x : CST.dynamic_variable_name) =
       let v1 = (* "$" *) token env v1 in
       let v2 = map_variable_name_ env v2 in
       A.Call
-        (A.Id [ (A.builtin "eval_var", v1) ], Parse_info.fake_bracket v1 [ v2 ])
+        ( A.Id [ (A.builtin "eval_var", v1) ],
+          Parse_info.fake_bracket v1 [ A.Arg v2 ] )
   | `DOLLAR_LCURL_exp_RCURL (v1, v2, v3, v4) ->
       let v1 = (* "$" *) token env v1 in
       let v2 = (* "{" *) token env v2 in
       let v3 = map_expression env v3 in
       let v4 = (* "}" *) token env v4 in
-      A.Call (A.Id [ (A.builtin "eval_var", v1) ], (v2, [ v3 ], v4))
+      A.Call (A.Id [ (A.builtin "eval_var", v1) ], (v2, [ A.Arg v3 ], v4))
 
 and map_else_clause (env : env) ((v1, v2) : CST.else_clause) =
   let v1 = (* pattern [eE][lL][sS][eE] *) token env v1 in
@@ -1924,7 +1929,7 @@ and map_statement (env : env) (x : CST.statement) =
   | `Decl_stmt (v1, v2, v3, v4, v5) ->
       let v1 = (* "declare" *) token env v1 in
       let v2 = (* "(" *) token env v2 in
-      let v3 = map_declare_directive env v3 in
+      let v3 = A.Arg (map_declare_directive env v3) in
       let v4 = (* ")" *) token env v4 in
       let v5 =
         match v5 with
@@ -1950,13 +1955,13 @@ and map_statement (env : env) (x : CST.statement) =
   | `Unset_stmt (v1, v2, v3, v4, v5, v6) ->
       let v1 = (* "unset" *) token env v1 in
       let v2 = (* "(" *) token env v2 in
-      let v3 = map_variable env v3 in
+      let v3 = A.Arg (map_variable env v3) in
       let v4 =
         Common.map
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_variable env v2 in
-            v2)
+            A.Arg v2)
           v4
       in
       let v5 = (* ")" *) token env v5 in
@@ -2288,7 +2293,7 @@ and map_unary_op_expression (env : env) (x : CST.unary_op_expression) =
   match x with
   | `AT_exp (v1, v2) ->
       let v1 = (* "@" *) token env v1 in
-      let v2 = map_expression env v2 in
+      let v2 = A.Arg (map_expression env v2) in
       A.Call (A.Id [ (A.builtin "at", v1) ], Parse_info.fake_bracket v1 [ v2 ])
   | `Choice_PLUS_exp (v1, v2) ->
       let v1 =

--- a/semgrep-core/tests/php/named_arguments.php
+++ b/semgrep-core/tests/php/named_arguments.php
@@ -1,0 +1,7 @@
+<?php
+
+//ERROR: match
+setcookie("name","value",0,secure:true);
+
+//OK
+setcookie("name","value",0,secure:false);

--- a/semgrep-core/tests/php/named_arguments.sgrep
+++ b/semgrep-core/tests/php/named_arguments.sgrep
@@ -1,0 +1,1 @@
+setcookie(...,secure:true)


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/5508 / [PA-1497](https://linear.app/r2c/issue/PA-1497/semgrep-does-not-support-named-parameters-in-php)
This PR:
1. Updates the `pfff` PHP parser to support named arguments (`f(x:true)`).
2.  Refactors the representation of arguments in `ast_php.ml`. Previously we had the weird situation where function arguments were wrapped in special constructors in `cst_php.ml`, then unwrapped to plain expressions in `ast_php.ml`, and the re-wrapped in `php_to_generic.ml`. Now they are also wrapped in `ast_php.ml`, so their representation is uniform.
3. Updates the tree-sitter parser to parse named arguments as `ArgKwd`. Previously the label was just dropped.

test plan: make test (see added test)

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
