### PR TITLE
fix: Invalid_argument "index out of bounds"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Go: single pattern field can now match toplevel fields in a composite
   literal (#5452)
 - PHP: metavariable-pattern: works again when used with language: php (#5443)
+- Fixed a non-deterministic crash when matching a large number of regexes (#5277)
 
 ## [0.97.0](https://github.com/returntocorp/semgrep/releases/tag/v0.97.0) - 2022-06-08
 

--- a/semgrep-core/src/engine/Metavariable_pattern.ml
+++ b/semgrep-core/src/engine/Metavariable_pattern.ml
@@ -89,35 +89,46 @@ let satisfies_metavar_pattern_condition nested_formula_has_matches env r mvar
                   let content = Range.content_at_range mval_file mval_range in
                   Common2.with_tmp_file ~str:content ~ext:"mvar-pattern"
                     (fun file ->
-                      (* We don't want having to re-parse `content', but then we
-                       * need to fix the token locations in `mast`. *)
-                      let mast_start_loc =
-                        mval |> MV.ii_of_mval |> Visitor_AST.range_of_tokens
-                        |> fst |> PI.unsafe_token_location_of_info
-                      in
-                      let fix_loc loc =
-                        {
-                          loc with
-                          PI.charpos = loc.PI.charpos - mast_start_loc.charpos;
-                          line = loc.line - mast_start_loc.line + 1;
-                          column = loc.column - mast_start_loc.column;
-                          file;
-                        }
-                      in
-                      let fixing_visitor =
-                        Map_AST.mk_fix_token_locations fix_loc
-                      in
-                      let mast' = fixing_visitor.Map_AST.vprogram mast in
-                      let xtarget =
-                        {
-                          env.xtarget with
-                          file;
-                          lazy_ast_and_errors = lazy (mast', []);
-                          lazy_content = lazy content;
-                        }
-                      in
-                      nested_formula_has_matches { env with xtarget } formula
-                        (Some r')))
+                      Fun.protect
+                        ~finally:(fun () ->
+                          (* Invalidate the cached line/col lookup table when
+                           * this tmp file is no longer in use.
+                           * https://github.com/returntocorp/semgrep/issues/5277
+                           *
+                           * TODO remove the cache or do more principled cache
+                           * invalidation. *)
+                          Hashtbl.remove Xpattern_matcher.hmemo file)
+                        (fun () ->
+                          (* We don't want having to re-parse `content', but then we
+                           * need to fix the token locations in `mast`. *)
+                          let mast_start_loc =
+                            mval |> MV.ii_of_mval |> Visitor_AST.range_of_tokens
+                            |> fst |> PI.unsafe_token_location_of_info
+                          in
+                          let fix_loc loc =
+                            {
+                              loc with
+                              PI.charpos =
+                                loc.PI.charpos - mast_start_loc.charpos;
+                              line = loc.line - mast_start_loc.line + 1;
+                              column = loc.column - mast_start_loc.column;
+                              file;
+                            }
+                          in
+                          let fixing_visitor =
+                            Map_AST.mk_fix_token_locations fix_loc
+                          in
+                          let mast' = fixing_visitor.Map_AST.vprogram mast in
+                          let xtarget =
+                            {
+                              env.xtarget with
+                              file;
+                              lazy_ast_and_errors = lazy (mast', []);
+                              lazy_content = lazy content;
+                            }
+                          in
+                          nested_formula_has_matches { env with xtarget }
+                            formula (Some r'))))
           | Some xlang, MV.Text (content, _tok)
           | Some xlang, MV.Xmls [ XmlText (content, _tok) ]
           | Some xlang, MV.E { e = G.L (G.String (content, _tok)); _ } ->
@@ -127,37 +138,48 @@ let satisfies_metavar_pattern_condition nested_formula_has_matches env r mvar
               (* We re-parse the matched text as `xlang`. *)
               Common2.with_tmp_file ~str:content ~ext:"mvar-pattern"
                 (fun file ->
-                  let lazy_ast_and_errors =
-                    lazy
-                      (match xlang with
-                      | L (lang, _) ->
-                          let { Parse_target.ast; skipped_tokens; _ } =
-                            Parse_target.parse_and_resolve_name lang file
-                          in
-                          (* TODO: If we wanted to report the parse errors
-                           * then we should fix the parse info with
-                           * Parse_info.adjust_info_wrt_base! *)
-                          if skipped_tokens <> [] then
-                            pr2
-                              (spf
-                                 "rule %s: metavariable-pattern: failed to \
-                                  fully parse the content of %s"
-                                 (fst env.rule.Rule.id) mvar);
-                          (ast, skipped_tokens)
-                      | LRegex
-                      | LGeneric ->
-                          failwith "requesting generic AST for LRegex|LGeneric")
-                  in
-                  let xtarget =
-                    {
-                      Xtarget.file;
-                      xlang;
-                      lazy_ast_and_errors;
-                      lazy_content = lazy content;
-                    }
-                  in
-                  nested_formula_has_matches { env with xtarget } formula
-                    (Some r'))
+                  Fun.protect
+                    ~finally:(fun () ->
+                      (* Invalidate the cached line/col lookup table when this
+                       * tmp file is no longer in use.
+                       * https://github.com/returntocorp/semgrep/issues/5277
+                       *
+                       * TODO remove the cache or do more principled cache
+                       * invalidation. *)
+                      Hashtbl.remove Xpattern_matcher.hmemo file)
+                    (fun () ->
+                      let lazy_ast_and_errors =
+                        lazy
+                          (match xlang with
+                          | L (lang, _) ->
+                              let { Parse_target.ast; skipped_tokens; _ } =
+                                Parse_target.parse_and_resolve_name lang file
+                              in
+                              (* TODO: If we wanted to report the parse errors
+                               * then we should fix the parse info with
+                               * Parse_info.adjust_info_wrt_base! *)
+                              if skipped_tokens <> [] then
+                                pr2
+                                  (spf
+                                     "rule %s: metavariable-pattern: failed to \
+                                      fully parse the content of %s"
+                                     (fst env.rule.Rule.id) mvar);
+                              (ast, skipped_tokens)
+                          | LRegex
+                          | LGeneric ->
+                              failwith
+                                "requesting generic AST for LRegex|LGeneric")
+                      in
+                      let xtarget =
+                        {
+                          Xtarget.file;
+                          xlang;
+                          lazy_ast_and_errors;
+                          lazy_content = lazy content;
+                        }
+                      in
+                      nested_formula_has_matches { env with xtarget } formula
+                        (Some r')))
           | Some _lang, mval ->
               (* This is not necessarily an error in the rule, e.g. you may be
                * matching `$STRING + ...` and then add a metavariable-pattern on


### PR DESCRIPTION
Fixes #5277

When scanning a repository with a large number of regex rules, Semgrep
creates numerous tmp files. For each one, we create a lookup table to go
from offset -> line/col, and cache it keyed on filename.

This cache does not get properly invalidated when Semgrep is done with
the tmp file, even though the tmp file does get removed. The next time a
tmp file is requested, there is a chance that the randomly-generated
filename will collide with a previous one. Semgrep will rely on the
cached lookup table for the previous file with that filename, and chaos
ensues. This appears to only be an issue in practice when a very large
number of regex matches are attempted while scanning a repo.

This commit applies a quick, but hacky fix. We simply reach into the
cache and remove the entry at the same time that we are done with the
tmp file. I'm not aware of the context around this area of the system so
I don't know how feasible it would be to remove the cache, avoid using
tmp files altogether, or pass the lookup table for a file around
explicitly. It would probably be good to do one of those things at some
point, but for now I think we should fix the issue quickly.

Test plan:

Automated tests

At the following commits:

semgrep: 3c78f29ef4aebd4983caf70abd87a400a7446e1d
terraform-provider-aws: 1f270b150c411268fdf456bd31e004a62a8808db

Run `while python -m semgrep -c .semgrep-service-name0.yml ; do echo; done` in the `terraform-provider-aws` repo.

Observe a crash in about 5 or fewer minutes.

Update semgrep to this commit, and run the command again for 1 hour.
Observe no crash.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
