### PR TITLE
test: Fix syntax error in misc_naming_recursion test

### DIFF
--- a/semgrep-core/tests/ts/misc_naming_recursion.ts
+++ b/semgrep-core/tests/ts/misc_naming_recursion.ts
@@ -8,7 +8,7 @@ export function foobar(
 ) {
 
   //ERROR: match
-m  return Array(number)
+  return Array(number)
     //ERROR: match
     .fill(true)
     //ERROR: match


### PR DESCRIPTION
I don't see anything in #2615 indicating that this syntax error was
intentional. The test still passes after this change.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
