### PR TITLE
opti: new -use_parsing_cache option to semgrep-core

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -129,6 +129,7 @@ let ncores = ref 1
 (* optional optimizations *)
 (* ------------------------------------------------------------------------- *)
 (* see Flag_semgrep.ml *)
+let use_parsing_cache = ref ""
 
 (* ------------------------------------------------------------------------- *)
 (* flags used by the semgrep-python wrapper *)
@@ -308,6 +309,7 @@ let mk_config () =
     max_memory_mb = !max_memory_mb;
     max_match_per_file = !max_match_per_file;
     ncores = !ncores;
+    parsing_cache_dir = !use_parsing_cache;
     target_file = !target_file;
     action = !action;
     version = Version.version;
@@ -450,6 +452,12 @@ let options () =
       Arg.Set_string equivalences_file,
       " <file> obtain list of code equivalences from YAML file" );
     ("-j", Arg.Set_int ncores, " <int> number of cores to use (default = 1)");
+    ( "-opt_cache",
+      Arg.Set Flag.with_opt_cache,
+      " enable caching optimization during matching" );
+    ( "-use_parsing_cache",
+      Arg.Set_string use_parsing_cache,
+      " <dir> store and use the parsed generic ASTs in dir" );
     ( "-opt_cache",
       Arg.Set Flag.with_opt_cache,
       " enable caching optimization during matching" );

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -443,8 +443,7 @@ let options () =
         Xlang.supported_xlangs );
     ( "-l",
       Arg.String (fun s -> lang := Some (Xlang.of_string s)),
-      spf " <str> choose language (valid choices:\n     %s)"
-        Xlang.supported_xlangs );
+      spf " <str> shortcut for -lang" );
     ( "-targets",
       Arg.Set_string target_file,
       " <file> obtain list of targets to run patterns on" );
@@ -452,9 +451,6 @@ let options () =
       Arg.Set_string equivalences_file,
       " <file> obtain list of code equivalences from YAML file" );
     ("-j", Arg.Set_int ncores, " <int> number of cores to use (default = 1)");
-    ( "-opt_cache",
-      Arg.Set Flag.with_opt_cache,
-      " enable caching optimization during matching" );
     ( "-use_parsing_cache",
       Arg.Set_string use_parsing_cache,
       " <dir> store and use the parsed generic ASTs in dir" );

--- a/semgrep-core/src/metachecking/Test_metachecking.ml
+++ b/semgrep-core/src/metachecking/Test_metachecking.ml
@@ -52,6 +52,7 @@ let config =
     max_memory_mb = 0;
     max_match_per_file = 10000;
     ncores = 1;
+    parsing_cache_dir = "";
     target_file = "";
     action = "";
     version = "test";

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -375,6 +375,7 @@ let rec just_parse_with_lang lang file =
         [ TreeSitter (Parse_vue_tree_sitter.parse parse_embedded_js) ]
         (fun x -> x)
   | Lang.Hcl -> run file [ TreeSitter Parse_hcl_tree_sitter.parse ] (fun x -> x)
+  [@@profiling]
 
 (*****************************************************************************)
 (* Entry point *)
@@ -399,6 +400,7 @@ let parse_and_resolve_name lang file =
 
   logger#info "Parse_target.parse_and_resolve_name_use_pfff_or_treesitter done";
   res
+  [@@profiling]
 
 (* used in test files *)
 let parse_and_resolve_name_warn_if_partial lang file =

--- a/semgrep-core/src/runner/Parse_with_caching.ml
+++ b/semgrep-core/src/runner/Parse_with_caching.ml
@@ -1,0 +1,115 @@
+open Common
+
+let logger = Logging.get_logger [ __MODULE__ ]
+
+(*****************************************************************************)
+(* Purpose *)
+(*****************************************************************************)
+(* Cache parsed generic ASTs between runs to speedup things.
+ *
+ * On some big repositories (e.g., Java elasticsearch), the speedup can be
+ * very important (e.g., 10x).
+ * Indeed:
+ *  $ time semgrep-core -l java -rules ~/eqeq.yaml ~/elasticsearch/
+ *  real: 1m22s
+ *  $ time semgrep-core -use_parsing_cache ~/.semgrep/cache -l java -rules ~/eqeq.yaml ~/elasticsearch/
+ *  real: 0.11s
+ *
+ * history: this used to be necessary because the Semgrep Python wrapper was
+ * making multiple calls to semgrep-core and we didn't want to reparse again
+ * again the same file for each rule. After migrating the processing of
+ * a whole rule to semgrep-core, this was not anymore necessary, but
+ * it is now useful to speedup semgrep when running semgrep
+ * multiple times on the same reposotiry.
+ *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+let filemtime file = (Unix.stat file).Unix.st_mtime
+
+(* The function below is mostly a copy-paste of Common.cache_computation.
+ * This function is slightly more flexible because we can put the cache file
+ * anywhere thanks to the argument 'cache_file_of_file'.
+ * We also try to be a bit more type-safe by using the version tag above.
+ * TODO: merge in pfff/commons/Common.ml at some point
+ *)
+let cache_computation use_parsing_cache version_cur file cache_file_of_file f =
+  if not use_parsing_cache then f ()
+  else if not (Sys.file_exists file) then (
+    logger#warning "cache_computation: can't find file %s " file;
+    logger#warning "defaulting to calling the function";
+    f ())
+  else
+    let file_cache = cache_file_of_file file in
+    if Sys.file_exists file_cache && filemtime file_cache >= filemtime file then (
+      logger#trace "using cache: %s" file_cache;
+      let version, file2, res = Common2.get_value file_cache in
+      if version <> version_cur then
+        failwith (spf "Version mismatch! Clean the cache file %s" file_cache);
+      if file <> file2 then
+        failwith
+          (spf "Not the same file! Md5sum collision! Clean the cache file %s"
+             file_cache);
+
+      res)
+    else
+      let res = f () in
+      (try Common2.write_value (version_cur, file, res) file_cache with
+      | Sys_error err ->
+          (* We must ignore SIGXFSZ to get this exception, see
+           * note "SIGXFSZ (file size limit exceeded)". *)
+          logger#error "Could not write cache file for %s (%s): %s" file
+            file_cache err;
+          (* Make sure we don't leave corrupt cache files behind us. *)
+          if Sys.file_exists file_cache then Sys.remove file_cache);
+      res
+  [@@profiling]
+
+let cache_file_of_file parsing_cache_dir ext filename =
+  let dir = parsing_cache_dir in
+  if not (Sys.file_exists dir) then Unix.mkdir dir 0o700;
+  (* hopefully there will be no collision *)
+  let md5 = Digest.string filename in
+  Filename.concat dir (spf "%s.%s" (Digest.to_hex md5) ext)
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+(* A wrapper around Parse_target.parse_and_resolve_name *)
+let parse_and_resolve_name ?(parsing_cache_dir = "") version lang file =
+  let v =
+    cache_computation (parsing_cache_dir <> "") version file
+      (fun file ->
+        (* we may use different parsers for the same file (e.g., in Python3 or
+         * Python2 mode), so put the lang as part of the cache "dependency".
+         * We also add version here so bumping the version will not
+         * try to use the old cache file (which should generate an exception).
+         *)
+        let full_filename =
+          spf "%s__%s__%s" file (Lang.to_string lang) version
+        in
+        cache_file_of_file parsing_cache_dir "ast_cache" full_filename)
+      (fun () ->
+        try
+          logger#trace "parsing %s" file;
+          (* finally calling the actual function *)
+          let { Parse_target.ast; skipped_tokens; _ } =
+            Parse_target.parse_and_resolve_name lang file
+          in
+          Left (ast, skipped_tokens)
+          (* We stores also in the cache whether we had
+           * an exception on this file, especially Timeout. We store the exn
+           * in the cache, and below we reraise it after we got it back
+           * from the cache.
+           * TODO: right now we just capture Timeout, but we should capture
+           * any exn. But doing so introduced some weird regressions in CI
+           * so we focus on just Timeout for now.
+           *)
+        with
+        | Match_rules.File_timeout as e -> Right e)
+  in
+  match v with
+  | Left x -> x
+  | Right exn -> raise exn

--- a/semgrep-core/src/runner/Parse_with_caching.mli
+++ b/semgrep-core/src/runner/Parse_with_caching.mli
@@ -1,0 +1,6 @@
+val parse_and_resolve_name :
+  ?parsing_cache_dir:string (* "" means no parsing cache *) ->
+  string (* semgrep or AST generic version *) ->
+  Lang.t ->
+  Common.filename ->
+  AST_generic.program * Parse_info.token_location list

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -384,17 +384,17 @@ let mk_rule_table rules =
   let rule_pairs = Common.map (fun r -> (fst r.R.id, r)) rules in
   Common.hash_of_list rule_pairs
 
-let xtarget_of_file _config xlang file =
+let xtarget_of_file config xlang file =
   let lazy_ast_and_errors =
     match xlang with
     | Xlang.L (lang, other_langs) ->
         (* xlang from the language field in -target, which should be unique *)
         assert (other_langs = []);
         lazy
-          (let { Parse_target.ast; skipped_tokens; _ } =
-             Parse_target.parse_and_resolve_name lang file
-           in
-           (ast, skipped_tokens))
+          (Parse_with_caching.parse_and_resolve_name
+             ~parsing_cache_dir:"/home/pad/.semgrep/cache"
+             (* alt: could define a AST_generic.version *)
+             config.version lang file)
     | _ -> lazy (failwith "requesting generic AST for LRegex|LGeneric")
   in
 

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -392,7 +392,7 @@ let xtarget_of_file config xlang file =
         assert (other_langs = []);
         lazy
           (Parse_with_caching.parse_and_resolve_name
-             ~parsing_cache_dir:"/home/pad/.semgrep/cache"
+             ~parsing_cache_dir:config.parsing_cache_dir
              (* alt: could define a AST_generic.version *)
              config.version lang file)
     | _ -> lazy (failwith "requesting generic AST for LRegex|LGeneric")

--- a/semgrep-core/src/runner/Runner_config.ml
+++ b/semgrep-core/src/runner/Runner_config.ml
@@ -36,6 +36,7 @@ type t = {
   max_memory_mb : int;
   max_match_per_file : int;
   ncores : int;
+  parsing_cache_dir : Common.dirname; (* "" means no cache *)
   (* Flag used by the semgrep-python wrapper *)
   target_file : string;
   (* Common.ml action for the -dump_xxx *)


### PR DESCRIPTION
This PR caches the parsed generic ASTs on the disk (e.g., in
~/.semgrep/cache) to speedup semgrep between 2 runs.

This fixes PA-1509

test plan:
```
$ rm -rf ~/.semgrep/cache
$ time yy -profile -use_parsing_cache ~/.semgrep/cache/ -l java -rules ~/eqeq.yaml ~/work/lang-java/elasticsearch/ -log_config_file /tmp/xxx
1m32s
$ time yy -profile -use_parsing_cache ~/.semgrep/cache/ -l java -rules ~/eqeq.yaml ~/work/lang-java/elasticsearch/ -log_config_file /tmp/xxx
11s
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)