### PR TITLE
test(ts): Remove deep-specific part of test

### DIFF
--- a/semgrep-core/tests/ts/metavar_typed_class.ts
+++ b/semgrep-core/tests/ts/metavar_typed_class.ts
@@ -2,8 +2,6 @@ class C {
   f() {}
 }
 
-class D extends C { }
-
 const c1: C = new C();
 const c2 = new C();
 
@@ -16,10 +14,3 @@ c1.f();
 c2.f();
 // MATCH:
 (new C()).f();
-
-// DEEP:
-d1.f();
-// DEEP:
-d2.f();
-// DEEP:
-(new D()).f();


### PR DESCRIPTION
I'm moving this to DeepSemgrep based on feedback from @aryx

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
