### PR TITLE
New -prefilter_of_rules command for semgrep-core

### DIFF
--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -88,7 +88,7 @@ let check ~match_hook ~timeout ~timeout_threshold default_config rules xtarget =
              if !Flag_semgrep.filter_irrelevant_rules then (
                match Analyze_rule.regexp_prefilter_of_rule r with
                | None -> true
-               | Some (re, f) ->
+               | Some (_json, re, f) ->
                    let content = Lazy.force lazy_content in
                    logger#trace "looking for %s in %s" re file;
                    f content)

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -380,7 +380,7 @@ let test_irrelevant_rule rule_file target_file =
          | None ->
              Alcotest.fail
                (spf "Rule %s: no regex prefilter formula" (fst rule.id))
-         | Some (re, f) ->
+         | Some (_json, re, f) ->
              let content = read_file target_file in
              if f content then
                Alcotest.fail

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -288,7 +288,7 @@ let stat_files fparser xs =
                     pr2
                       (spf "PB: no regexp prefilter for rule %s:%s" file
                          (fst r.id))
-                | Some (s, _f) ->
+                | Some (_json, s, _f) ->
                     incr good;
                     pr2 (spf "regexp: %s" s)));
   pr2 (spf "good = %d, no regexp found = %d" !good !bad)

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2021 r2c
+ * Copyright (C) 2021-2022 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -17,6 +17,7 @@ module R = Rule
 module XP = Xpattern
 module MV = Metavariable
 module PI = Parse_info
+module J = JSON
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -71,8 +72,9 @@ let logger = Logging.get_logger [ __MODULE__ ]
  * todo? the evaluation engine prefers to work on DNF where negation
  * must be inside a And, so maybe better to work also on DNF here?
  * and skip correctly the negations?
+ *
  * update: I now use run_cnf_step2 to eval a cnf, so I could do it
- * on a dnf too because I don't anymore reduce everything to a single regexp
+ * on a DNF too because I don't anymore reduce everything to a single regexp
  * (it's fast enough to run many regexps on a file).
  *
  *)
@@ -88,7 +90,7 @@ exception EmptyOr
 exception CNF_exploded
 
 (*****************************************************************************)
-(* Utils *)
+(* Helpers *)
 (*****************************************************************************)
 
 let ( let* ) = Common.( >>= )
@@ -385,6 +387,23 @@ let and_step2 (And xs) =
   if null ys then raise GeneralPattern;
   And ys
 
+let json_of_cnf_step2 (And xs) : J.t =
+  J.Array
+    (xs
+    |> Common.map (fun (Or ys) ->
+           J.Array
+             (ys
+             |> Common.map (function
+                  | Idents xs ->
+                      J.Object
+                        [
+                          ( "idents",
+                            J.Array (xs |> Common.map (fun s -> J.String s)) );
+                        ]
+                  | Regexp2_search re ->
+                      let re_str = Regexp_engine.show re in
+                      J.Object [ ("regexp", J.String re_str) ]))))
+
 (*****************************************************************************)
 (* Final Step: just regexps? *)
 (*****************************************************************************)
@@ -474,6 +493,15 @@ let run_cnf_step2 cnf big_str =
 (* Entry points *)
 (*****************************************************************************)
 
+(* see mli for more information
+ * TODO: use a record.
+ *)
+type prefilter = JSON.t * string (* for debugging *) * (string -> bool)
+
+let json_of_prefilter (pre : prefilter) : J.t =
+  let json, _s, _f = pre in
+  json
+
 let compute_final_cnf f =
   let* f = remove_not_final f in
   let cnf = cnf f in
@@ -492,11 +520,12 @@ let compute_final_cnf f =
 
 let str_final final = show_cnf_step2 final [@@profiling]
 
-let regexp_prefilter_of_formula f =
+let regexp_prefilter_of_formula f : prefilter option =
   try
     let* final = compute_final_cnf f in
     Some
-      ( str_final final,
+      ( json_of_cnf_step2 final,
+        str_final final,
         fun big_str ->
           try
             run_cnf_step2 final big_str

--- a/semgrep-core/src/optimizing/Analyze_rule.mli
+++ b/semgrep-core/src/optimizing/Analyze_rule.mli
@@ -1,3 +1,6 @@
+(* see below for more information *)
+type prefilter = JSON.t * string (* for debugging *) * (string -> bool)
+
 (* This function analyzes a rule and returns optionaly a function
  * that when applied to the content of a file will return whether
  * or not we should process the file. False means that we can
@@ -21,9 +24,12 @@
  *
  * Note that this function use Common.memoized on the rule id
  *)
-val regexp_prefilter_of_rule :
-  Rule.t -> (string (* for debugging *) * (string -> bool)) option
+val regexp_prefilter_of_rule : Rule.t -> prefilter option
 
 (* internal, do not use directly, not memoized *)
-val regexp_prefilter_of_formula :
-  Rule.formula -> (string (* for debugging *) * (string -> bool)) option
+val regexp_prefilter_of_formula : Rule.formula -> prefilter option
+
+(* For external tools like Semgrep query console to be able to
+ * also prune certain rules/files.
+ *)
+val json_of_prefilter : prefilter -> JSON.t

--- a/semgrep-core/tests/OTHER/irrelevant_rules/pattern-or.js
+++ b/semgrep-core/tests/OTHER/irrelevant_rules/pattern-or.js
@@ -1,0 +1,5 @@
+
+"not fo o"
+"not ba r"
+
+// fo o

--- a/semgrep-core/tests/OTHER/irrelevant_rules/pattern-or.yaml
+++ b/semgrep-core/tests/OTHER/irrelevant_rules/pattern-or.yaml
@@ -1,0 +1,8 @@
+rules:
+- id: simple-or
+  pattern-either:
+    - pattern: foo()
+    - pattern: bar()
+  message: matched
+  languages: [js]
+  severity: WARNING


### PR DESCRIPTION
This will help PA-1509

test plan:
```
semgrep-core -prefilter_of_rules pattern-or.yaml
[{"id":"simple-or","prefilter":[[{"idents":["bar"]},{"idents":["foo"]}]]}]
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)