### PR TITLE
Add and use Semgrep_prefilter.atd instead of using JSON directly

### DIFF
--- a/interfaces/Semgrep_prefilter.atd
+++ b/interfaces/Semgrep_prefilter.atd
@@ -1,0 +1,36 @@
+(* Schema for the JSON output of semgrep-core -prefilter_of_rules.
+ *
+ * Those prefilters are used internally by semgrep-core to implement
+ * the -filter_irrelevant_rules optimization. They could also be used by
+ * external tools (e.g., the Semgrep query console) to avoid parsing
+ * certain files.
+ *
+ * For more information, see semgrep-core/src/optimizing/Analyze_rule.ml
+ *)
+
+(* less: we could make this polymorphic and in a separate formula.atd that
+ * could be reused through different ATD files.
+ * note: there is no 'Not of formula' for now; not useful for Analyze_rule.ml
+ *)
+type formula = [
+  | Pred of predicate
+  | And of formula list (* at least 2 elements *)
+  (* less: maybe we could reduce that to a regexp too, inserting some | *)
+  | Or of formula list (* at least 2 elements *)
+  ]
+
+type predicate = [
+  (* less: maybe we could also reduce that to a regexp?
+   * But how to do an And with regexps? *)
+  | Idents of string list (* equivalent of an And; all idents must be present *)
+  | Regexp of string (* PCRE-compatible regexp *)
+]
+
+type prefilter = {
+  (* TODO: once we have ATD modules, we could reference rule_id type in another .atd *)
+    rule_id: string;
+    (* None means no prefilter for this rule *)
+    filter: formula option;
+}
+
+type prefilters = prefilter list

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -285,17 +285,14 @@ let prefilter_of_rules file =
   let xs =
     rules
     |> Common.map (fun r ->
-           let pre = Analyze_rule.regexp_prefilter_of_rule r in
-           let json =
-             match pre with
-             | None -> J.Null
-             | Some pre -> Analyze_rule.json_of_prefilter pre
+           let pre_opt = Analyze_rule.regexp_prefilter_of_rule r in
+           let pre_atd_opt =
+             Option.map Analyze_rule.prefilter_formula_of_prefilter pre_opt
            in
            let id = r.Rule.id |> fst in
-           J.Object [ ("id", J.String id); ("prefilter", json) ])
+           { Semgrep_prefilter_t.rule_id = id; filter = pre_atd_opt })
   in
-  let json = J.Array xs in
-  let s = J.string_of_json json in
+  let s = Semgrep_prefilter_j.string_of_prefilters xs in
   pr s
 
 (*****************************************************************************)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -88,10 +88,13 @@ let check ~match_hook ~timeout ~timeout_threshold default_config rules xtarget =
              if !Flag_semgrep.filter_irrelevant_rules then (
                match Analyze_rule.regexp_prefilter_of_rule r with
                | None -> true
-               | Some (_json, re, f) ->
+               | Some (prefilter_formula, func) ->
                    let content = Lazy.force lazy_content in
-                   logger#trace "looking for %s in %s" re file;
-                   f content)
+                   let s =
+                     Semgrep_prefilter_j.string_of_formula prefilter_formula
+                   in
+                   logger#trace "looking for %s in %s" s file;
+                   func content)
              else true
            in
            if not relevant_rule then (

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -380,12 +380,13 @@ let test_irrelevant_rule rule_file target_file =
          | None ->
              Alcotest.fail
                (spf "Rule %s: no regex prefilter formula" (fst rule.id))
-         | Some (_json, re, f) ->
+         | Some (f, func) ->
              let content = read_file target_file in
-             if f content then
+             let s = Semgrep_prefilter_j.string_of_formula f in
+             if func content then
                Alcotest.fail
                  (spf "Rule %s considered relevant by regex prefilter: %s"
-                    (fst rule.id) re))
+                    (fst rule.id) s))
 
 let test_irrelevant_rule_file target_file =
   ( Filename.basename target_file,

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -288,7 +288,8 @@ let stat_files fparser xs =
                     pr2
                       (spf "PB: no regexp prefilter for rule %s:%s" file
                          (fst r.id))
-                | Some (_json, s, _f) ->
+                | Some (f, _f) ->
                     incr good;
+                    let s = Semgrep_prefilter_j.string_of_formula f in
                     pr2 (spf "regexp: %s" s)));
   pr2 (spf "good = %d, no regexp found = %d" !good !bad)

--- a/semgrep-core/src/optimizing/Analyze_rule.mli
+++ b/semgrep-core/src/optimizing/Analyze_rule.mli
@@ -1,14 +1,15 @@
-(* see below for more information *)
-type prefilter = JSON.t * string (* for debugging *) * (string -> bool)
-
-(* This function analyzes a rule and returns optionaly a function
+(* A prefilter is a pair containing a function
  * that when applied to the content of a file will return whether
  * or not we should process the file. False means that we can
  * skip the file (or more accurately, it means we can skip this rule
  * for this file, and if there are no more rules left for this target file,
  * we will entirely skip the file because we now parse files lazily).
+ *)
+type prefilter = Semgrep_prefilter_t.formula * (string -> bool)
+
+(* This function analyzes a rule and returns optionaly a prefilter.
  *
- * Internally, this returned function relies on a formula of
+ * The return prefilter relies on a formula of
  * regexps that we try to extract from the rule. For example, with:
  *   pattern-either: foo()
  *   pattern-either: bar()
@@ -32,4 +33,4 @@ val regexp_prefilter_of_formula : Rule.formula -> prefilter option
 (* For external tools like Semgrep query console to be able to
  * also prune certain rules/files.
  *)
-val json_of_prefilter : prefilter -> JSON.t
+val prefilter_formula_of_prefilter : prefilter -> Semgrep_prefilter_t.formula

--- a/semgrep-core/src/optimizing/Semgrep_prefilter.atd
+++ b/semgrep-core/src/optimizing/Semgrep_prefilter.atd
@@ -1,0 +1,1 @@
+../../../interfaces/Semgrep_prefilter.atd

--- a/semgrep-core/src/optimizing/dune
+++ b/semgrep-core/src/optimizing/dune
@@ -14,3 +14,13 @@
    )
  )
 )
+
+(rule
+ (targets Semgrep_prefilter_j.ml Semgrep_prefilter_j.mli)
+ (deps    Semgrep_prefilter.atd)
+ (action  (run atdgen -j -j-strict-fields -j-std %{deps})))
+
+(rule
+ (targets Semgrep_prefilter_t.ml Semgrep_prefilter_t.mli)
+ (deps    Semgrep_prefilter.atd)
+ (action  (run atdgen -t %{deps})))


### PR DESCRIPTION
This will help PA-1509

test plan:
```
$ semgrep-core -prefilter_of_rules pattern-or.yaml
[{"rule_id":"simple-or","filter":["Some",["Or",[["Pred",["Idents",["bar"]]],["Pred",["Idents",["foo"]]]]]]}]
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)