### PR TITLE
tainting: Yoann's review of returntocorp/semgrep#5547

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   `SEMGREP_ENABLE_VERSION_CHECK=0`
 - Dataflow: spread operators in record expressions (e.g. `{...foo}`) are now translated into the Dataflow IL
 - An experimental LSP daemon mode for semgrep. Try it with `semgrep lsp --config auto`!
-- taint-mode: New experimental `taint-propagators` feature that allows to specify
+- taint-mode: New experimental `pattern-propagators` feature that allows to specify
   arbitrary patterns for the propagation of taint by side-effect. In particular,
   this allows to specify how taint propagates through side-effectful function calls.
   For example, you can specify that when tainted data is added to an array then the

--- a/cli/src/semgrep/rule_schema.yaml
+++ b/cli/src/semgrep/rule_schema.yaml
@@ -185,6 +185,8 @@ definitions:
                 - taint
             pattern-sources:
               $ref: "#/definitions/taint-content"
+            pattern-propagators:
+              $ref: "#/definitions/taint-content"
             pattern-sinks:
               $ref: "#/definitions/taint-content"
             pattern-sanitizers:
@@ -466,6 +468,8 @@ properties:
           $ref: "#/definitions/taint-content"
         pattern-sources:
           $ref: "#/definitions/taint-content"
+        pattern-propagators:
+          $ref: "#/definitions/taint-content"
         pattern-sanitizers:
           $ref: "#/definitions/taint-content"
         join:
@@ -621,6 +625,8 @@ properties:
                   - pattern-sinks
               - required:
                   - pattern-sources
+              - required:
+                  - pattern-propagators
               - required:
                   - pattern-sanitizers
               - required:

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -186,7 +186,7 @@ type taint_propagator = {
 (** e.g. if we want to specify that adding tainted data to a `HashMap` makes the
  * `HashMap` tainted too, then "formula" could be `(HashMap $H).add($X)`,
  * with "from" being `$X` and "to" being `$H`. So if `$X` is tainted then `$H`
- * will be marked as tainted too. *)
+ * will also be marked as tainted. *)
 
 type taint_spec = {
   sources : pformula list;

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -238,7 +238,7 @@ let handle_taint_propagators env x taints =
    * simple but it has limitations, we can only propagate "forward" and, within
    * an instruction node, we can only propagate in the order in which we visit
    * the subexpressions. E.g. in `x.f(y,z)` we can propagate taint from `y` or
-   * `z` to `z`, or from `y` to `z`; but we cannot propagate taint from `x` to
+   * `z` to `x`, or from `y` to `z`; but we cannot propagate taint from `x` to
    * `y` or `z`, or from `z` to `y`. *)
   let var_env = env.var_env in
   let propagate_froms, propagate_tos =
@@ -270,7 +270,10 @@ let handle_taint_propagators env x taints =
   let taints = Taints.union taints taints_incoming in
   let var_env =
     match x with
-    | `Var var -> add_taint_to_var_in_env var_env var taints_incoming
+    | `Var var ->
+        (* If `x` is a variable, then taint is propagated by side-effect. This
+         * allows us to e.g. propagate taint from `x` to `y` in `f(x,y)`. *)
+        add_taint_to_var_in_env var_env var taints_incoming
     | `Exp _ -> var_env
   in
   (taints, var_env)

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -19,7 +19,34 @@ type config = {
       * 'pattern-sources:' in taint-mode. *)
   is_propagator : AST_generic.any -> propagator_from list * propagator_to list;
       (** Test whether 'any' matches a taint propagator, this corresponds to
-       * 'pattern-propagators:' in taint-mode. *)
+       * 'pattern-propagators:' in taint-mode.
+       *
+       * Propagators allow to specify how taint propagates through side effects.
+       *
+       * Note that we tried to solve this with a hack in returntocorp/semgrep#5150
+       * but it caused a bunch of FPs in semgrep-rules. The hack was essentially
+       * to assume that in `x.f(y)` taint always propagated from `y` to `x`.
+       *
+       * The typical FP was a call that incorrectly tainted an object or module,
+       * that also happened to be part of a sink specification. For example, in
+       * rule ruby.rails.security.audit.avoid-tainted-shell-call the `Shell` class
+       * does not really get tainted even if we call `Shell.cat` on tainted data:
+       *
+       *     # ruleid: avoid-tainted-shell-call
+       *     Shell.cat(params[:filename])
+       *
+       * But with the hack, `Shell` becomes tainted. Later on, when we call
+       * `Shell.cat` on safe data, it triggered an FP. Why? Because the entire
+       * `Shell.cat(...)` was marked as a sink, and `Shell` was considered
+       * tainted!
+       *
+       *     # ok: avoid-tainted-shell-call
+       *     Shell.cat("/var/log/www/access.log")
+       *
+       * Most of these FPs could be prevented by fine tuning pattern-sinks. But
+       * anyhow it's clearly incorrect to taint `Shell`, so a better solution was
+       * needed (hence `pattern-propagators`).
+       *)
   is_sink : AST_generic.any -> Pattern_match.t list;
       (** Test whether 'any' is a sink, this corresponds to 'pattern-sinks:'
       * in taint-mode. *)

--- a/semgrep-core/tests/OTHER/rules/taint_propagator3.py
+++ b/semgrep-core/tests/OTHER/rules/taint_propagator3.py
@@ -1,0 +1,7 @@
+def test():
+    x = user_input
+    f(x, y)
+    x = "safe"
+    g(y, z)
+    #ruleid: test
+    sink(z)

--- a/semgrep-core/tests/OTHER/rules/taint_propagator3.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_propagator3.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: test
+    message: Test
+    severity: INFO
+    languages: [py]
+    mode: taint
+    pattern-sources:
+      - pattern: user_input
+    pattern-propagators:
+      - pattern: f($X, $Y)
+        from: $X
+        to: $Y
+      - pattern: g($X, $Y)
+        from: $X
+        to: $Y
+    pattern-sinks:
+      - patterns:
+          - pattern: sink($SINK)
+          - focus-metavariable: $SINK


### PR DESCRIPTION
Follows: 163ceee7656 ("tainting: Add experimental taint-propagators feature (#5547)")

Note that we tried to solve this with a hack in returntocorp/semgrep#5150
but it caused a bunch of FPs in semgrep-rules. The hack was essentially
to assume that in `x.f(y)` taint always propagated from `y` to `x`.

The typical FP was a call that incorrectly tainted an object or module,
that also happened to be part of a sink specification. For example, in
rule ruby.rails.security.audit.avoid-tainted-shell-call the `Shell` class
does not really get tainted even if we call `Shell.cat` on tainted data:

    # ruleid: avoid-tainted-shell-call
    Shell.cat(params[:filename])

But with the hack, `Shell` becomes tainted. Later on, when we call
`Shell.cat` on safe data, it triggered an FP. Why? Because the entire
`Shell.cat(...)` was marked as a sink, and `Shell` was considered
tainted!

    # ok: avoid-tainted-shell-call
    Shell.cat("/var/log/www/access.log")

Most of these FPs could be prevented by fine tuning pattern-sinks. But
anyhow it's clearly incorrect to taint `Shell`, so a better solution was
needed (hence `pattern-propagators`).

test plan:
make test # added one more test

PR checklist:

- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
