### PR TITLE
Fix incorrect exception re-raising

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -58,7 +58,7 @@ install:
 dev:
 	$(MAKE) all
 	rm -f ../cli/src/semgrep/bin/semgrep-core
-	ln -s ../../../semgrep-core/bin/semgrep-core \
+	ln -s ../../../../semgrep-core/bin/semgrep-core \
 	  ../cli/src/semgrep/bin/semgrep-core
 
 .PHONY: e2etest

--- a/semgrep-core/src/experiments/lsp/LSP_client.ml
+++ b/semgrep-core/src/experiments/lsp/LSP_client.ml
@@ -251,8 +251,9 @@ let type_at_tok tk uri io =
               | _ -> raise Impossible
             with
             | exn ->
+                let e = Exception.catch exn in
                 logger#error "Exn Parse_ml.type_of_string TODO: %s" s;
-                raise exn
+                Exception.reraise e
           in
           (* logger#info "type = %s" (G.show_type_ ty); *)
           Some ty

--- a/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
@@ -1447,8 +1447,9 @@ let parse file =
         | _ -> failwith "not a program"
       with
       | Failure "not implemented" as exn ->
+          let e = Exception.catch exn in
           H.debug_sexp_cst_after_error (CST.sexp_of_source cst);
-          raise exn)
+          Exception.reraise e)
 
 let parse_pattern str =
   H.wrap_parser

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2936,8 +2936,9 @@ let parse file =
       let env = { H.file; conv = H.line_col_to_pos file; extra } in
       try script env cst with
       | Failure "not implemented" as exn ->
+          let e = Exception.catch exn in
           H.debug_sexp_cst_after_error (CST.sexp_of_script cst);
-          raise exn)
+          Exception.reraise e)
 
 let parse_expression_or_source_file str =
   let res = Tree_sitter_hack.Parse.string str in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
@@ -1462,5 +1462,6 @@ let parse file =
       let env = { H.file; conv = H.line_col_to_pos file; extra = () } in
       try map_module_ env cst with
       | Failure "not implemented" as exn ->
+          let e = Exception.catch exn in
           H.debug_sexp_cst_after_error (CST.sexp_of_module_ cst);
-          raise exn)
+          Exception.reraise e)

--- a/semgrep-core/src/runner/Parse_with_caching.ml
+++ b/semgrep-core/src/runner/Parse_with_caching.ml
@@ -108,8 +108,10 @@ let parse_and_resolve_name ?(parsing_cache_dir = "") version lang file =
            * so we focus on just Timeout for now.
            *)
         with
-        | Match_rules.File_timeout as e -> Right e)
+        | Match_rules.File_timeout as exn ->
+            let e = Exception.catch exn in
+            Right e)
   in
   match v with
   | Left x -> x
-  | Right exn -> raise exn
+  | Right e -> Exception.reraise e

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -562,7 +562,7 @@ let semgrep_with_raw_results_and_exn_handler config =
       let res =
         { RP.empty_final_result with errors = [ E.exn_to_error "" e ] }
       in
-      (Some exn, res, [])
+      (Some e, res, [])
 
 let semgrep_with_rules_and_formatted_output config =
   let exn, res, files = semgrep_with_raw_results_and_exn_handler config in

--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -16,7 +16,8 @@ val semgrep_with_rules_and_formatted_output : Runner_config.t -> unit
 *)
 
 val semgrep_with_raw_results_and_exn_handler :
-  Runner_config.t -> exn option * Report.final_result * Common.filename list
+  Runner_config.t ->
+  Exception.t option * Report.final_result * Common.filename list
 (** [semgrep_with_raw_results_and_exn_handler config] runs the semgrep
     engine with a starting list of targets and returns
     (success, result, targets).

--- a/semgrep-core/src/runner/Runner_exit.ml
+++ b/semgrep-core/src/runner/Runner_exit.ml
@@ -7,13 +7,17 @@ open Common
 let logger = Logging.get_logger [ __MODULE__ ]
 
 (* Add new cases as needed *)
-type reason = Success | False | Bad_command_line | Unknown_exception of exn
+type reason =
+  | Success
+  | False
+  | Bad_command_line
+  | Unknown_exception of Exception.t
 
 let string_of_reason = function
   | Success -> "success"
   | False -> "false"
   | Bad_command_line -> "bad command line"
-  | Unknown_exception e -> spf "unknown exception %s" (Printexc.to_string e)
+  | Unknown_exception e -> spf "unknown exception %s" (Exception.to_string e)
 
 (*
    TODO: standardize these error codes to help the semgrep wrapper explain

--- a/semgrep-core/src/runner/Runner_exit.mli
+++ b/semgrep-core/src/runner/Runner_exit.mli
@@ -9,7 +9,7 @@ type reason =
   | Success (* 0 *)
   | False (* non-zero: not really an error, just a test returning false. *)
   | Bad_command_line
-  | Unknown_exception of exn
+  | Unknown_exception of Exception.t
 
 (*
    Call the 'exit' function with the appropriate exit code and logging.


### PR DESCRIPTION
Semgrep caught a bunch of incorrect invocations of `raise` in both pfff and semgrep-core. I'll publish the rule to the public repository of rules.

Uses https://github.com/returntocorp/pfff/pull/537

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
