### PR TITLE
Add `--github-actions` for GitHub Actions workflow commands format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   this allows to specify how taint propagates through side-effectful function calls.
   For example, you can specify that when tainted data is added to an array then the
   array itself becomes tainted. (#4509)
+- Add `--github-actions` option for GitHub Actions workflow commands format.
 
 ### Changed
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -185,6 +185,7 @@ def ci(
     enable_version_check: bool,
     exclude: Optional[Tuple[str, ...]],
     force_color: bool,
+    github_actions: bool,
     gitlab_sast: bool,
     gitlab_secrets: bool,
     include: Optional[Tuple[str, ...]],
@@ -257,6 +258,8 @@ def ci(
     output_format = OutputFormat.TEXT
     if json:
         output_format = OutputFormat.JSON
+    elif github_actions:
+        output_format = OutputFormat.GITHUB_ACTIONS
     elif gitlab_sast:
         output_format = OutputFormat.GITLAB_SAST
     elif gitlab_secrets:

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -444,6 +444,11 @@ _scan_options: List[Callable] = [
         "--json", is_flag=True, help="Output results in Semgrep's JSON format."
     ),
     optgroup.option(
+        "--github-actions",
+        is_flag=True,
+        help="Output results in GitHub Actions format.",
+    ),
+    optgroup.option(
         "--gitlab-sast",
         is_flag=True,
         help="Output results in GitLab SAST format.",
@@ -606,6 +611,7 @@ def scan(
     error_on_findings: bool,
     exclude: Optional[Tuple[str, ...]],
     force_color: bool,
+    github_actions: bool,
     gitlab_sast: bool,
     gitlab_secrets: bool,
     include: Optional[Tuple[str, ...]],
@@ -708,6 +714,8 @@ def scan(
     output_format = OutputFormat.TEXT
     if json:
         output_format = OutputFormat.JSON
+    elif github_actions:
+        output_format = OutputFormat.GITHUB_ACTIONS
     elif gitlab_sast:
         output_format = OutputFormat.GITLAB_SAST
     elif gitlab_secrets:

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -34,6 +34,7 @@ class OutputFormat(Enum):
     SARIF = auto()
     EMACS = auto()
     VIM = auto()
+    GITHUB_ACTIONS = auto()
 
     def is_json(self) -> bool:
         return self in [OutputFormat.JSON, OutputFormat.SARIF]

--- a/cli/src/semgrep/formatter/github_actions.py
+++ b/cli/src/semgrep/formatter/github_actions.py
@@ -1,0 +1,40 @@
+from typing import Any
+from typing import Iterable
+from typing import Mapping
+from typing import Sequence
+
+import semgrep.semgrep_interfaces.semgrep_output_v0 as out
+from semgrep.constants import RuleSeverity
+from semgrep.error import SemgrepError
+from semgrep.formatter.base import BaseFormatter
+from semgrep.rule import Rule
+from semgrep.rule_match import RuleMatch
+
+
+class GithubActionsFormatter(BaseFormatter):
+    @staticmethod
+    def _get_parts(rule_match: RuleMatch) -> str:
+        severity = {
+            RuleSeverity.INFO: "notice",
+            RuleSeverity.WARNING: "warning",
+            RuleSeverity.ERROR: "error",
+        }[rule_match.severity]
+        return "::{severity} file={path},line={line},col={col},endLine={endLine},endCol={endCol}::{message}".format(
+          severity=severity,
+          path=rule_match.path,
+          line=rule_match.start.line,
+          col=rule_match.start.col,
+          endLine=rule_match.end.line,
+          endCol=rule_match.end.col,
+          message=rule_match.message,
+        )
+
+    def format(
+        self,
+        rules: Iterable[Rule],
+        rule_matches: Iterable[RuleMatch],
+        semgrep_structured_errors: Sequence[SemgrepError],
+        cli_output_extra: out.CliOutputExtra,
+        extra: Mapping[str, Any],
+    ) -> str:
+        return "\n".join(self._get_parts(rm) for rm in rule_matches)

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -29,6 +29,7 @@ from semgrep.error import SemgrepCoreError
 from semgrep.error import SemgrepError
 from semgrep.formatter.base import BaseFormatter
 from semgrep.formatter.emacs import EmacsFormatter
+from semgrep.formatter.github_actions import GithubActionsFormatter
 from semgrep.formatter.gitlab_sast import GitlabSastFormatter
 from semgrep.formatter.gitlab_secrets import GitlabSecretsFormatter
 from semgrep.formatter.json import JsonFormatter
@@ -55,6 +56,7 @@ logger = getLogger(__name__)
 
 FORMATTERS: Mapping[OutputFormat, Type[BaseFormatter]] = {
     OutputFormat.EMACS: EmacsFormatter,
+    OutputFormat.GITHUB_ACTIONS: GithubActionsFormatter,
     OutputFormat.GITLAB_SAST: GitlabSastFormatter,
     OutputFormat.GITLAB_SECRETS: GitlabSecretsFormatter,
     OutputFormat.JSON: JsonFormatter,

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---github-actions/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---github-actions/results.txt
@@ -1,0 +1,38 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --github-actions
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+::error file=foo.py,line=4,col=5,endLine=4,endCol=11::useless comparison
+::error file=foo.py,line=5,col=5,endLine=5,endCol=11::useless comparison
+::error file=foo.py,line=7,col=5,endLine=7,endCol=11::useless comparison
+::error file=foo.py,line=11,col=5,endLine=11,endCol=11::useless comparison
+::error file=foo.py,line=19,col=5,endLine=19,endCol=13::useless comparison to 4
+::error file=foo.py,line=15,col=5,endLine=15,endCol=11::useless comparison to 5
+
+=== end of stdout - plain
+
+=== stderr - plain
+Scan environment:
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+  semgrep.dev - authenticated as org_name
+
+Fetching configuration from semgrep.dev
+Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
+Fetching rules from https://semgrep.dev/registry.
+Scanning 1 file with 4 python rules.
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 6 findings (5 blocking) from 3 rules.
+  Uploading findings to Semgrep App.
+  Has findings for blocking rules so exiting with code 1
+
+=== end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---github-actions/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---github-actions/results.txt
@@ -1,0 +1,38 @@
+=== command
+SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --github-actions
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+::error file=foo.py,line=4,col=5,endLine=4,endCol=11::useless comparison
+::error file=foo.py,line=5,col=5,endLine=5,endCol=11::useless comparison
+::error file=foo.py,line=7,col=5,endLine=7,endCol=11::useless comparison
+::error file=foo.py,line=11,col=5,endLine=11,endCol=11::useless comparison
+::error file=foo.py,line=19,col=5,endLine=19,endCol=13::useless comparison to 4
+::error file=foo.py,line=15,col=5,endLine=15,endCol=11::useless comparison to 5
+
+=== end of stdout - plain
+
+=== stderr - plain
+Scan environment:
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is unknown
+  semgrep.dev - authenticated as org_name
+
+Fetching configuration from semgrep.dev
+Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
+Fetching rules from https://semgrep.dev/registry.
+Scanning 1 file with 4 python rules.
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 6 findings (5 blocking) from 3 rules.
+  Uploading findings to Semgrep App.
+  Has findings for blocking rules so exiting with code 1
+
+=== end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_output/test_output_format/--github-actions/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format/--github-actions/results.out
@@ -1,0 +1,1 @@
+::error file=targets/basic/stupid.py,line=3,col=12,endLine=3,endCol=26::useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -537,7 +537,7 @@ def test_config_run(run_semgrep, git_tmp_path_with_commit, snapshot, mock_autofi
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "format",
-    ["--json", "--gitlab-sast", "--gitlab-secrets", "--sarif", "--emacs", "--vim"],
+    ["--json", "--gitlab-sast", "--gitlab-secrets", "--sarif", "--emacs", "--vim", "--github-actions"],
 )
 def test_outputs(git_tmp_path_with_commit, snapshot, format, mock_autofix, run_semgrep):
     result = run_semgrep(

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -94,7 +94,7 @@ def test_output_highlighting__force_color_and_no_color(run_semgrep_in_tmp, snaps
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
     "format",
-    ["--json", "--gitlab-sast", "--gitlab-secrets", "--sarif", "--emacs", "--vim"],
+    ["--json", "--gitlab-sast", "--gitlab-secrets", "--sarif", "--emacs", "--vim", "--github-actions"],
 )
 def test_output_format(run_semgrep_in_tmp, snapshot, format):
     stdout, _ = run_semgrep_in_tmp(


### PR DESCRIPTION
This pull request adds support for [workflow commands on GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message), allowing GitHub Actions to capture semgrep output and show the results in GitHub Annotations.

With this option, users can easily check for errors on their pull requests via annotations and checks by simply setting up the following workflow.

```yaml
# .github/workflows/semgrep.yml
name: semgrep

on:
  pull_request:

jobs:
  run:
    runs-on: ubuntu-20.04
    container:
      image: returntocorp/semgrep
    steps:
    - uses: actions/checkout@v3
    - run: semgrep ci --github-actions
```

example image:

![image](https://user-images.githubusercontent.com/111689/174519962-8e7049a1-8224-4d27-94cf-01c16532d549.png)

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
