### PR TITLE
Stop using union-merge for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,13 @@
-# Prevent frequent conflict resolution in the changelog by
-# asking git to always take both sides of a branch in the
-# changelog. As a downside, two edits to an existing line
-# in the changelog will show up as two lines in the merged
-# output. We should remove these duplicates at release time.
-CHANGELOG.md merge=union
+# This causes the changelog to become incorrect with virtually
+# every release PR that is merged. Unfortunately union-merges
+# are quite dumb. Perhaps it's better to deal with the conflicts
+# manually but do it well.
+# # Prevent frequent conflict resolution in the changelog by
+# # asking git to always take both sides of a branch in the
+# # changelog. As a downside, two edits to an existing line
+# # in the changelog will show up as two lines in the merged
+# # output. We should remove these duplicates at release time.
+# CHANGELOG.md merge=union
 
 # https://github.com/github/linguist/blob/master/docs/overrides.md
 # Don't consider test files in language stats for the repository on Github


### PR DESCRIPTION
Union-merges are helpful in some cases... but they also cause the
changelog to become incorrect with virtually every release PR that is
merged. Unfonrtunately union-merge is quite dumb. Perhaps it's better
to deal with the conflicts manually but do it well.

Reverts: ffba1572570 ("Merge changelog using union conflicts by default (#3379)")

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
