### PR TITLE
Avoid duplicate matches due to naming equivalences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Inline join mode rules can now run taint-mode rules
 - Python: correctly handle `with` context expressions where the value is not
   bound (#5513)
+- Avoid duplicate findings due to naming equivalences (#5569)
 
 ## [0.98.0](https://github.com/returntocorp/semgrep/releases/tag/v0.98.0) - 2022-06-15
 


### PR DESCRIPTION
Closes PA-1520
Closes #5569

Related-to: fbd33396c64 ("fix(deep): Don't attempt metavariable matches against parent classes (#5368)")

test plan:

    % cat 5569.py
    from foo.bar import Baz

    class C:
        def f(self) -> None:
            Baz.query.filter()
    % bin/semgrep-core -lang py -e '$MODEL.query.$METHOD(...)' 5569.py
    5569.py:5
            Baz.query.filter()
    # ^^^ just one match rather than two

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
