### PR TITLE
fix(deep): Retry match without resolved name

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -398,19 +398,19 @@ let rec m_name a b =
   | ( a,
       B.Id
         ( idb,
-          {
-            B.id_resolved =
-              {
-                contents =
-                  Some
-                    ( ( B.ImportedEntity dotted
-                      | B.ImportedModule (B.DottedName dotted)
-                      | B.ResolvedName dotted ),
-                      _sid );
-              };
-            _;
-          } ) ) -> (
-      m_name a (B.Id (idb, B.empty_id_info ()))
+          ({
+             B.id_resolved =
+               {
+                 contents =
+                   Some
+                     ( ( B.ImportedEntity dotted
+                       | B.ImportedModule (B.DottedName dotted)
+                       | B.ResolvedName dotted ),
+                       _sid );
+               };
+             _;
+           } as infob) ) ) -> (
+      m_name a (B.Id (idb, { infob with B.id_resolved = ref None }))
       >||>
       (* Try the resolved entity and parents *)
       match a with


### PR DESCRIPTION
Instead of using empty ID info when retrying the match, just set the
name to be unresolved. This way, the other information, like the type
and svalue, is preserved. This allows the correct information to be
bound to the metavariable when the recursive call eventually calls
`envf`.

This fixes the equivalence_constant_propagation3.js test when run under
DeepSemgrep.

Test plan: Automated tests both here and with this change applied to
DeepSemgrep

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
