### PR TITLE
add metavar_ellipsis_args to GA maturity condition

### DIFF
--- a/scripts/generate_cheatsheet.py
+++ b/scripts/generate_cheatsheet.py
@@ -3,13 +3,13 @@
 # Generate cheatsheets displayed next to the live editor, for each language.
 #
 # Usage:
-#   cd semgrep
-#   pipenv run ../scripts/generate_cheatsheet.py --json --directory \
+#   $ ./scripts/generate-cheatsheet
+#
+# or more explicitely:
+#   $ cd cli
+#   $ pipenv run ../scripts/generate_cheatsheet.py --json --directory \
 #     ../semgrep-core/tests --output-file cheatsheet.json
 #
-# or just:
-#
-#   ./scripts/generate-cheatsheet
 #
 # If you add support for a new language, you may need to update
 # LANG_DIR_TO_EXT below.
@@ -157,7 +157,7 @@ BETA_FEATURES = {
 }
 
 GA_FEATURES = {
-    "metavar": ["typed", "anno", "key_value"],
+    "metavar": ["typed", "anno", "key_value", "ellipsis_args"],
     "regexp": ["string"],
     "equivalence": [
         "naming_import",

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2021 r2c
+ * Copyright (C) 2021-2022 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -27,16 +27,6 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
-(*
-let (lang_of_rules: Rule.t list -> Lang.t) = fun rs ->
-  match rs |> Common.find_some_opt (fun r ->
-    match r.R.languages with
-    | R.L (l, _) -> Some l
-    | _ -> None
-  ) with
-  | Some l -> l
-  | None -> failwith "could not find a language"
-*)
 
 let (xlangs_of_rules : Rule.t list -> Xlang.t list) =
  fun rs -> rs |> Common.map (fun r -> r.R.languages) |> List.sort_uniq compare

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -79,6 +79,8 @@ let ga_features =
       "metavar_anno";
       "metavar_key_value";
       "metavar_typed";
+      "metavar_ellipsis_args";
+      (* TODO: metavar_ellipsis_params *)
       "regexp_string";
     ]
 
@@ -98,13 +100,14 @@ let language_exceptions =
   [
     (* GA languages *)
 
-    (* TODO: NA for Java? *)
-    (Lang.Java, [ "equivalence_naming_import"; "metavar_key_value" ]);
-    (* TODO: why not metavar_typed? regexp_string? NA for naming_import? *)
+    (* TODO: why not regexp_string? NA for naming_import? *)
     ( Lang.Csharp,
-      [ "equivalence_naming_import"; "metavar_typed"; "regexp_string" ] );
+      [ "equivalence_naming_import"; "metavar_ellipsis_args"; "regexp_string" ]
+    );
     (* TODO: metavar_anno sounds like an NA, but the other?? *)
     (Lang.Go, [ "metavar_class_def"; "metavar_import"; "metavar_anno" ]);
+    (* TODO: NA for Java? *)
+    (Lang.Java, [ "equivalence_naming_import"; "metavar_key_value" ]);
     (* metavar_typed is NA (dynamic language) *)
     (Lang.Js, [ "equivalence_naming_import"; "metavar_typed" ]);
     ( Lang.Ts,
@@ -114,10 +117,14 @@ let language_exceptions =
         "metavar_anno";
         "metavar_class_def";
       ] );
+    (* good boy *)
+    (Lang.Php, []);
     (* good boy, metavar_typed is working just for constants though *)
     (Lang.Python, []);
     (* metavar_typed is NA (dynamic language), metavar_anno also NA? *)
     (Lang.Ruby, [ "equivalence_naming_import"; "metavar_typed"; "metavar_anno" ]);
+    (* regexp_string feature has been deprecated *)
+    (Lang.Scala, [ "regexp_string"; "metavar_ellipsis_args" ]);
     (* Beta languages *)
 
     (* TODO: to fix *)
@@ -131,10 +138,6 @@ let language_exceptions =
     (Lang.Lua, []);
     (* dots_stmts is maybe NA, same with deep_exprstmt *)
     (Lang.Ocaml, [ "deep_exprstmt"; "dots_stmts" ]);
-    (* good boy *)
-    (Lang.Php, []);
-    (* good boy, this feature has been deprecated *)
-    (Lang.Scala, [ "regexp_string" ]);
     (* Experimental languages *)
     (Lang.R, [ "deep_exprstmt" ]);
   ]
@@ -150,6 +153,13 @@ let maturity_tests () =
          try List.assoc lang language_exceptions with
          | Not_found -> []
        in
+       (* sanity check exns *)
+       exns
+       |> List.iter (fun base ->
+              let path = Filename.concat dir (base ^ ext) in
+              if Sys.file_exists path then
+                failwith
+                  (spf "%s actually exist! remove it from exceptions" path));
        let features = Common2.minus_set features exns in
        features
        |> Common.map (fun base ->

--- a/semgrep-core/tests/ts/metavar_ellipsis_args.ts
+++ b/semgrep-core/tests/ts/metavar_ellipsis_args.ts
@@ -1,0 +1,5 @@
+function test() {
+    //ERROR: match
+    foo(1, 2, 3, 1, 2);
+    foo(1, 2, 3, 4, 5);
+}


### PR DESCRIPTION
This closes #3226

test plan:
make test
./scripts/generate-cheatsheet


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)