### PR TITLE
Fix path to dist.zip for the manylinux-wheel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: manylinux-wheel
-          path: semgrep/dist.zip
+          path: cli/dist.zip
 
   test-wheels-manylinux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This might work, I'm not sure.

This is meant to fix the error we're getting during the release workflow:
https://github.com/returntocorp/semgrep/runs/6996216152?check_suite_focus=true

```
Run actions/download-artifact@v1
  with:
    name: manylinux-wheel
Downloading artifact 'manylinux-wheel' to: '/home/runner/work/semgrep/semgrep/manylinux-wheel'
Error: An Artifact with name "manylinux-wheel" was not found.
Error: Exit code 1 returned from process: file name '/home/runner/runners/[2](https://github.com/returntocorp/semgrep/runs/6996216152?check_suite_focus=true#step:3:2).29[3](https://github.com/returntocorp/semgrep/runs/6996216152?check_suite_focus=true#step:3:3).0/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Artifact.DownloadArtifact, Runner.Plugins"'.
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
