### PR TITLE
AST_to_IL: Translate typed patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   bound (#5513)
 - Solidity: update to a more recent tree-sitter-solidity to fix certain parsing
   errors (#4957)
+- taint-mode: Correctly propagate taint in for-each loops with typed iteration
+  variables (as in Java or C#). If the iterator object is tainted, that taint will
+  now be propagated to the iteration variable. This should fix some false negatives
+  (i.e., findings not being reported) in the presence of for-each loops. (#5590)
 
 ## [0.98.0](https://github.com/returntocorp/semgrep/releases/tag/v0.98.0) - 2022-06-15
 

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -290,6 +290,7 @@ and pattern env pat =
         |> List.concat
       in
       (tmp_lval, ss)
+  | G.PatTyped (pat1, _typTODO) -> pattern env pat1
   | _ -> todo (G.P pat)
 
 and _catch_exn env exn =

--- a/semgrep-core/tests/OTHER/rules/taint_foreach.java
+++ b/semgrep-core/tests/OTHER/rules/taint_foreach.java
@@ -1,0 +1,9 @@
+// https://github.com/returntocorp/semgrep/issues/5590
+public class TypedEnumerationExample{
+    public void bad(){
+        for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
+            // ruleid: java-iterator-missed-propagation
+            System.out.println(ste);
+        }
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/taint_foreach.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_foreach.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: java-iterator-missed-propagation
+  mode: taint
+  pattern-sources:
+    - pattern: $ANYTHING.getStackTrace(...)
+  pattern-sinks:
+    - pattern: System.out.println(...)
+  message: Semgrep found a match
+  languages:
+    - java
+  severity: WARNING


### PR DESCRIPTION
This made taint-mode not report some findings in Java code involving
for-each loops. We actually don't use types right now in the IL
anyways.

Closes #5590
Closes PA-1546

test plan:
make test # added one test

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
