### PR TITLE
PHP: Fix Common.Impossible on attributes

### DIFF
--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -560,13 +560,13 @@ and modifier v = wrap modifierbis v
 
 and attribute v =
   match v with
-  | Id [ id ] ->
-      let id = ident id in
-      G.NamedAttr (fake "@", G.Id (id, G.empty_id_info ()), fb [])
-  | Call (Id [ id ], args) ->
-      let id = ident id in
+  | Id xs ->
+      let name = name_of_qualified_ident xs in
+      G.NamedAttr (fake "@", name, fb [])
+  | Call (Id xs, args) ->
+      let name = name_of_qualified_ident xs in
       let args = bracket (list argument) args in
-      G.NamedAttr (fake "@", G.Id (id, G.empty_id_info ()), args)
+      G.NamedAttr (fake "@", name, args)
   | _ -> raise Impossible
 
 (* see ast_php_build.ml *)

--- a/semgrep-core/tests/php/parsing/attributes_qualified.php
+++ b/semgrep-core/tests/php/parsing/attributes_qualified.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Attributes;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class FooAttributes
+{
+    public string $class;
+    public array $foo = [];
+
+    public function __construct(string $class, array $foo)
+    {
+        $this->class = $class;
+        $this->foo = $foo;
+    }
+}

--- a/semgrep-core/tests/php/parsing/attributes_qualified2.php
+++ b/semgrep-core/tests/php/parsing/attributes_qualified2.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final class CustomAnyAttribute
+{
+}


### PR DESCRIPTION
This restores our parsing stats from 99.1% to 99.95%

test plan:
```
$ cd parsing-stats
$ ./run-lang php
...
stats available in lang/php/stats.json
lang/php/stats.json:3
   "global": {
     "name": "*",
     "parsing_rate": 0.9995191615353355,
     "line_count": 5305316,
     "error_line_count": 2551,
     "file_count": 34978,
     "error_file_count": 205
   },
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)