### PR TITLE
update changelog to show version 0.99.0 skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## 0.99.0 - Skipped
 
-Version 0.99.0 of semgrep was intentionally skipped. Version 0.100.0 immediately follows version 0.98.0.
+Version 0.99.0 of Semgrep was intentionally skipped. Version 0.100.0 immediately follows version 0.98.0.
 
 ## [0.98.0](https://github.com/returntocorp/semgrep/releases/tag/v0.98.0) - 2022-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   now be propagated to the iteration variable. This should fix some false negatives
   (i.e., findings not being reported) in the presence of for-each loops. (#5590)
 
+## 0.99.0 - Skipped
+
+Version 0.99.0 of semgrep was intentionally skipped. Version 0.100.0 immediately follows version 0.98.0.
+
 ## [0.98.0](https://github.com/returntocorp/semgrep/releases/tag/v0.98.0) - 2022-06-15
 
 ### Added


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
