### PR TITLE
tainting: Fix function calls as from/to in taint propagators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   corrected here.
 - TS: fixed the parsing of type predicates and typeof queries
 - Deep expression matching now works on HTML in JavaScript
+- taint-mode: Taint propagation via `pattern-propagators` now works correclty when the
+  `from` or `to` metavariables match a function call. For example, given
+  `sqlBuilder.append(page.getOrderBy())`, we can now propagate taint from
+  `page.getOrderBy()` to `sqlBuilder`.
 
 ## [0.100.0](https://github.com/returntocorp/semgrep/releases/tag/v0.100.0) - 2022-06-22
 

--- a/semgrep-core/tests/OTHER/rules/taint_propagator4.java
+++ b/semgrep-core/tests/OTHER/rules/taint_propagator4.java
@@ -1,0 +1,45 @@
+package com.example.restservice;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.ArrayList;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.TypedQuery;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GreetingController {
+  
+  @GetMapping("/greeting")
+  public Greeting greeting(@RequestParam(value = "smth") String orderBy, HttpServletResponse response) {
+    Page page = new Page("greeting");
+
+    // NOTE: orderBy is the `source` here, it flows into Page object
+    page.setOrderBy(orderBy);
+
+    EntityManager em = HibernateOperations.getEntityManager();
+
+    // NOTE: insecurely generated SQL string using tainted `orderBy`
+    StringBuilder sqlBuilder = new StringBuilder();
+    sqlBuilder.append("SELECT * FROM ( ");
+    sqlBuilder.append(" SELECT TMP_PAGE.*, ROWNUM PAGEHELPER_ROW_ID FROM ( \n");
+    sqlBuilder.append(page.getName());
+    sqlBuilder.append("\n ) TMP_PAGE)");
+    sqlBuilder.append(" WHERE PAGEHELPER_ROW_ID <= ? AND PAGEHELPER_ROW_ID > ?");
+    sqlBuilder.append(" ORDER BY ");
+    sqlBuilder.append(page.getOrderBy());
+    // ruleid: jpa-sqli
+    TypedQuery<Greeting> q = em.createQuery(sqlBuilder.toString(), Greeting.class);
+    Greeting res = q.getSingleResult();
+    return res;
+  }
+
+}
+

--- a/semgrep-core/tests/OTHER/rules/taint_propagator4.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_propagator4.yaml
@@ -1,0 +1,56 @@
+rules:
+  - id: jpa-sqli
+    languages:
+      - java
+    severity: ERROR
+    message: User data flows into this manually-constructed SQL string. User data
+      can be safely inserted into SQL strings using prepared statements or an
+      object-relational mapper (ORM). Manually-constructed SQL strings is a
+      possible indicator of SQL injection, which could let an attacker steal or
+      manipulate data from the database. Instead, use prepared statements
+      (`connection.PreparedStatement`) or a safe library.
+    metadata:
+      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      owasp:
+        - A03:2021 - Injection
+        - A01:2017 - Injection
+      references:
+        - https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html
+      category: security
+      technology:
+        - spring
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ(...) $TYPE $SOURCE,...) {
+                    ...
+                  }
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ $TYPE $SOURCE,...) {
+                    ...
+                  }
+          - metavariable-regex:
+              metavariable: $REQ
+              regex: (RequestBody|PathVariable|RequestParam|RequestHeader|CookieValue)
+          - focus-metavariable: $SOURCE
+    pattern-propagators:
+    - patterns:
+      - pattern: (Page $PAGE).$SETTER($DATA)
+      - metavariable-regex:
+          metavariable: $SETTER
+          regex: ^set.*
+      from: $DATA
+      to: $PAGE
+    - pattern: (StringBuilder $BUILDER).append($STR)
+      from: $STR
+      to: $BUILDER
+    pattern-sinks:
+    - patterns:
+      - focus-metavariable: $SQL
+      - pattern-either:
+        - pattern-inside: (javax.persistence.EntityManager $EM).createQuery($SQL,...)
+        - pattern-inside: (javax.persistence.EntityManager $EM).createNativeQuery($SQL,...)
+


### PR DESCRIPTION
We were only checking IL varaibles and expressions for taint propagation,
and function calls are translated as instructions. So if taint had to be
propagated e.g. _from_ a function call, then it didn't work. (Note that
we require near-perfect matches to propagate taint.)

Helps PA-1534

test plan:
make test # added one test

PR checklist:

- [ ] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
