### PR TITLE
Fix release validation jobs

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -16,6 +16,8 @@ jobs:
   release-setup:
     name: Setup Release Branch
     runs-on: ubuntu-20.04
+    outputs:
+      version: ${{ steps.next-version.outputs.next-version }}
     steps:
       - name: Get JWT for semgrep-ci GitHub App
         id: jwt

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -45,10 +45,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: "v${{ inputs.version }}"
+      # Although this action can do the checkout step for us, it is more explicit and maintainable to pass context in this manner.
       - name: build tester image
         uses: docker/build-push-action@v3
         with:
           push: false
-          path: scripts
-          dockerfile: scripts/Dockerfile.16.04
-          build_args: version=${{ inputs.version }}
+          context: "scripts"
+          file: scripts/Dockerfile.16.04
+          build-args: version=${{ inputs.version }}


### PR DESCRIPTION
The lack of the job output was causing some of our release validation jobs to to fail. 

Additionally, our release validation jobs were passing arguments that were unused by the jobs, resulting in weird behavior such as building off of other refs.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
