### PR TITLE
Plumb spans for partial parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Changed
+
+- `--verbose` no longer toggles the display of timing information, use
+  `--verbose --time` to display this information.
+
 ## [0.101.1](https://github.com/returntocorp/semgrep/releases/tag/v0.101.1) - 2022-06-28
 
 ### Fixed

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -336,7 +336,7 @@ class OutputHandler:
                 semgrep_core_errors
             )
             final_error = self.semgrep_structured_errors[-1]
-            self.ignore_log.failed_to_analyze = failed_to_analyze_lines_by_path
+            self.ignore_log.core_failure_lines_by_file = failed_to_analyze_lines_by_path
 
         if self.has_output:
             output = self._build_output()

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -106,7 +106,7 @@ class FileTargetingLog:
     cli_includes: Set[Path] = Factory(set)
     cli_excludes: Set[Path] = Factory(set)
     size_limit: Set[Path] = Factory(set)
-    failed_to_analyze: Set[Path] = Factory(set)
+    failed_to_analyze: Dict[Path, Optional[int]] = Factory(dict)
 
     by_language: Dict[Language, Set[Path]] = Factory(lambda: defaultdict(set))
     rule_includes: Dict[str, Set[Path]] = Factory(lambda: defaultdict(set))
@@ -244,8 +244,14 @@ class FileTargetingLog:
 
         yield 1, "Skipped by analysis failure due to parsing or internal Semgrep error"
         if self.failed_to_analyze:
-            for path in self.failed_to_analyze:
-                yield 2, with_color(Colors.cyan, str(path))
+            for path, lines in self.failed_to_analyze.items():
+                if lines is None:
+                    skipped = "all"
+                else:
+                    # TODO: use pluralization library
+                    skipped = str(lines)
+
+                yield 2, with_color(Colors.cyan, f"{path} ({skipped} lines skipped)")
         else:
             yield 2, "<none>"
 

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -106,7 +106,7 @@ class FileTargetingLog:
     cli_includes: Set[Path] = Factory(set)
     cli_excludes: Set[Path] = Factory(set)
     size_limit: Set[Path] = Factory(set)
-    failed_to_analyze: Dict[Path, Optional[int]] = Factory(dict)
+    failed_to_analyze: Mapping[Path, Optional[int]] = Factory(dict)
 
     by_language: Dict[Language, Set[Path]] = Factory(lambda: defaultdict(set))
     rule_includes: Dict[str, Set[Path]] = Factory(lambda: defaultdict(set))

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -106,6 +106,8 @@ class FileTargetingLog:
     cli_includes: Set[Path] = Factory(set)
     cli_excludes: Set[Path] = Factory(set)
     size_limit: Set[Path] = Factory(set)
+
+    # "None" indicates that all lines were skipped
     core_failure_lines_by_file: Mapping[Path, Optional[int]] = Factory(dict)
 
     by_language: Dict[Language, Set[Path]] = Factory(lambda: defaultdict(set))

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -106,7 +106,7 @@ class FileTargetingLog:
     cli_includes: Set[Path] = Factory(set)
     cli_excludes: Set[Path] = Factory(set)
     size_limit: Set[Path] = Factory(set)
-    failed_to_analyze: Mapping[Path, Optional[int]] = Factory(dict)
+    core_failure_lines_by_file: Mapping[Path, Optional[int]] = Factory(dict)
 
     by_language: Dict[Language, Set[Path]] = Factory(lambda: defaultdict(set))
     rule_includes: Dict[str, Set[Path]] = Factory(lambda: defaultdict(set))
@@ -169,9 +169,9 @@ class FileTargetingLog:
             skip_fragments.append(
                 f"{len(self.semgrepignored)} files matching .semgrepignore patterns"
             )
-        if self.failed_to_analyze:
+        if self.core_failure_lines_by_file:
             partial_fragments.append(
-                f"{len(self.failed_to_analyze)} files only partially analyzed due to a parsing or internal Semgrep error"
+                f"{len(self.core_failure_lines_by_file)} files only partially analyzed due to a parsing or internal Semgrep error"
             )
 
         if not limited_fragments and not skip_fragments and not partial_fragments:
@@ -243,8 +243,8 @@ class FileTargetingLog:
             yield 2, "<none>"
 
         yield 1, "Skipped by analysis failure due to parsing or internal Semgrep error"
-        if self.failed_to_analyze:
-            for path, lines in self.failed_to_analyze.items():
+        if self.core_failure_lines_by_file:
+            for path, lines in self.core_failure_lines_by_file.items():
                 if lines is None:
                     skipped = "all"
                 else:
@@ -300,7 +300,7 @@ class FileTargetingLog:
                 "reason": "exceeded_size_limit",
                 "size_limit_bytes": self.target_manager.max_target_bytes,
             }
-        for path in self.failed_to_analyze:
+        for path in self.core_failure_lines_by_file:
             yield {
                 "path": str(path),
                 "reason": "analysis_failed_parser_or_internal_error",

--- a/cli/tests/e2e/snapshots/test_check/test_max_memory/error.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_max_memory/error.txt
@@ -37,7 +37,7 @@ Files skipped:
 
   Skipped by analysis failure due to parsing or internal Semgrep error
 
-   • targets/equivalence/open_redirect.py
+   • targets/equivalence/open_redirect.py (all lines skipped)
 
 
 Some files were skipped or only partially analyzed.

--- a/cli/tests/e2e/snapshots/test_check/test_max_memory/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_max_memory/results.json
@@ -20,33 +20,5 @@
     ]
   },
   "results": [],
-  "time": {
-    "profiling_times": {
-      "config_time": 2.022,
-      "core_time": 2.022,
-      "ignores_time": 2.022,
-      "total_time": 2.022
-    },
-    "rules": [
-      {
-        "id": "rules.forcetimeout"
-      }
-    ],
-    "rules_parse_time": 2.022,
-    "targets": [
-      {
-        "match_times": [
-          2.022
-        ],
-        "num_bytes": 1763,
-        "parse_times": [
-          2.022
-        ],
-        "path": "targets/equivalence/open_redirect.py",
-        "run_time": 2.022
-      }
-    ],
-    "total_bytes": 1763
-  },
   "version": "0.42"
 }

--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error.txt
@@ -44,7 +44,7 @@ Files skipped:
 
   [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
 
-   • [36m[22m[24mtargets/equivalence/open_redirect.py[0m
+   • [36m[22m[24mtargets/equivalence/open_redirect.py (all lines skipped)[0m
 
 
 Some files were skipped or only partially analyzed.

--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/error_2.txt
@@ -42,7 +42,7 @@ Files skipped:
 
   [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
 
-   • [36m[22m[24mtargets/equivalence/open_redirect.py[0m
+   • [36m[22m[24mtargets/equivalence/open_redirect.py (all lines skipped)[0m
 
 
 Some files were skipped or only partially analyzed.

--- a/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_timeout_threshold/results.json
@@ -21,43 +21,5 @@
     ]
   },
   "results": [],
-  "time": {
-    "profiling_times": {
-      "config_time": 2.022,
-      "core_time": 2.022,
-      "ignores_time": 2.022,
-      "total_time": 2.022
-    },
-    "rules": [
-      {
-        "id": "rules.forcetimeout"
-      },
-      {
-        "id": "rules.forcetimeout2"
-      },
-      {
-        "id": "rules.forcetimeout3"
-      }
-    ],
-    "rules_parse_time": 2.022,
-    "targets": [
-      {
-        "match_times": [
-          2.022,
-          2.022,
-          2.022
-        ],
-        "num_bytes": 1763,
-        "parse_times": [
-          2.022,
-          2.022,
-          2.022
-        ],
-        "path": "targets/equivalence/open_redirect.py",
-        "run_time": 2.022
-      }
-    ],
-    "total_bytes": 1763
-  },
   "version": "0.42"
 }

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
@@ -6,17 +6,3 @@ Findings:
         Basic test
 
           2┆ print([1m[x.xxx == 1[0m)
-
-============================[ summary ]============================
-Total time: x.xxxs Config time: x.xxxs Core time: x.xxxs
-
-Semgrep-core time:
-Total CPU time: x.xxxs  File parse time: x.xxxs  Rule parse time: x.xxxs  Match time: x.xxxs
-Slowest x.xxx files
-[32m[22m[24mtargets/cli_test/basic/basic.py                   [0m ( 35B):  x.xxxs (x.xxxs to parse)
-Slowest 5 rules to match
-[33m[22m[24mrules.cli_test.basic.basic-test:                           [0m x.xxxs
-
-Analyzed: 1 python files ( 35B in x.xxx seconds)
-Errors:   0 files with errors
-

--- a/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_parse_errors/errors.txt
@@ -41,7 +41,7 @@ Files skipped:
 
   [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
 
-   • [36m[22m[24mtargets/cli_test/parse_errors/invalid_javascript.js[0m
+   • [36m[22m[24mtargets/cli_test/parse_errors/invalid_javascript.js (2 lines skipped)[0m
 
 
 Some files were skipped or only partially analyzed.

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/error.txt
@@ -1,0 +1,48 @@
+running 1 rules from 1 config rules/eqeq-basic.yaml_0
+No .semgrepignore found. Using default .semgrepignore rules. See the docs for the list of default ignores: https://semgrep.dev/docs/cli-usage/#ignoring-files
+Rules:
+- rules.eqeq-bad
+Scanning 1 file.
+
+========================================
+Files skipped:
+========================================
+
+  [1m[24mAlways skipped by Semgrep:[0m
+
+   • <none>
+
+  [1m[24mSkipped by .gitignore:[0m
+  [1m[24m(Disable by passing --no-git-ignore)[0m
+
+   • <all files not listed by `git ls-files` were skipped>
+
+  [1m[24mSkipped by .semgrepignore:[0m
+  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
+  defaults)[0m
+
+   • <none>
+
+  [1m[24mSkipped by --include patterns:[0m
+
+   • <none>
+
+  [1m[24mSkipped by --exclude patterns:[0m
+
+   • <none>
+
+  [1m[24mSkipped by limiting to files smaller than 1000000 bytes:[0m
+  [1m[24m(Adjust with the --max-target-bytes flag)[0m
+
+   • <none>
+
+  [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
+
+   • [36m[22m[24mtargets/bad/invalid_go.go (2 lines skipped)[0m
+
+
+Some files were skipped or only partially analyzed.
+  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+
+Ran 1 rule on 1 file: 0 findings.
+Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/out.json
@@ -1,0 +1,48 @@
+{
+  "errors": [
+    {
+      "code": 3,
+      "level": "warn",
+      "message": "\u001b[31m\u001b[41m\u001b[22m\u001b[24m[\u001b[0m\u001b[38;5;231m\u001b[41m\u001b[1m\u001b[24mWARN\u001b[0m\u001b[31m\u001b[41m\u001b[22m\u001b[24m]\u001b[0m Syntax error at line targets/bad/invalid_go.go:9:\n `str` was unexpected",
+      "path": "targets/bad/invalid_go.go",
+      "spans": [
+        {
+          "end": {
+            "col": 13,
+            "line": 9
+          },
+          "file": "targets/bad/invalid_go.go",
+          "start": {
+            "col": 10,
+            "line": 9
+          }
+        },
+        {
+          "end": {
+            "col": 12,
+            "line": 10
+          },
+          "file": "targets/bad/invalid_go.go",
+          "start": {
+            "col": 10,
+            "line": 10
+          }
+        }
+      ],
+      "type": "Syntax error"
+    }
+  ],
+  "paths": {
+    "scanned": [
+      "targets/bad/invalid_go.go"
+    ],
+    "skipped": [
+      {
+        "path": "targets/bad/invalid_go.go",
+        "reason": "analysis_failed_parser_or_internal_error"
+      }
+    ]
+  },
+  "results": [],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
@@ -1,0 +1,49 @@
+running 2 rules from 1 config rules/eqeq-python.yaml_0
+No .semgrepignore found. Using default .semgrepignore rules. See the docs for the list of default ignores: https://semgrep.dev/docs/cli-usage/#ignoring-files
+Rules:
+- rules.assert-eqeq-is-ok
+- rules.eqeq-is-bad
+Scanning 1 file with 2 python rules.
+
+========================================
+Files skipped:
+========================================
+
+  [1m[24mAlways skipped by Semgrep:[0m
+
+   • <none>
+
+  [1m[24mSkipped by .gitignore:[0m
+  [1m[24m(Disable by passing --no-git-ignore)[0m
+
+   • <all files not listed by `git ls-files` were skipped>
+
+  [1m[24mSkipped by .semgrepignore:[0m
+  [1m[24m(See: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-
+  defaults)[0m
+
+   • <none>
+
+  [1m[24mSkipped by --include patterns:[0m
+
+   • <none>
+
+  [1m[24mSkipped by --exclude patterns:[0m
+
+   • <none>
+
+  [1m[24mSkipped by limiting to files smaller than 1000000 bytes:[0m
+  [1m[24m(Adjust with the --max-target-bytes flag)[0m
+
+   • <none>
+
+  [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
+
+   • [36m[22m[24mtargets/bad/invalid_python.py (all lines skipped)[0m
+
+
+Some files were skipped or only partially analyzed.
+  Partially scanned: 1 files only partially analyzed due to a parsing or internal Semgrep error
+
+Ran 2 rules on 1 file: 0 findings.
+Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
@@ -1,0 +1,24 @@
+{
+  "errors": [
+    {
+      "code": 3,
+      "level": "warn",
+      "message": "\u001b[31m\u001b[41m\u001b[22m\u001b[24m[\u001b[0m\u001b[38;5;231m\u001b[41m\u001b[1m\u001b[24mWARN\u001b[0m\u001b[31m\u001b[41m\u001b[22m\u001b[24m]\u001b[0m Syntax error at line targets/bad/invalid_python.py:1:\n `\n    ` was unexpected",
+      "path": "targets/bad/invalid_python.py",
+      "type": "Syntax error"
+    }
+  ],
+  "paths": {
+    "scanned": [
+      "targets/bad/invalid_python.py"
+    ],
+    "skipped": [
+      {
+        "path": "targets/bad/invalid_python.py",
+        "reason": "analysis_failed_parser_or_internal_error"
+      }
+    ]
+  },
+  "results": [],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/bad/invalid_go.go
+++ b/cli/tests/e2e/targets/bad/invalid_go.go
@@ -1,0 +1,11 @@
+package hacknews
+
+import (
+	"fmt"
+)
+
+// Initializer -- represents the kind of requests that we want to fetch
+type Initializer struct {
+	Story   str ing
+	NbPosts in t
+}

--- a/cli/tests/e2e/test_semgrep_core_parse_error.py
+++ b/cli/tests/e2e/test_semgrep_core_parse_error.py
@@ -5,18 +5,20 @@ from semgrep.constants import OutputFormat
 
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
-    "filename",
+    "settings",
     [
-        "invalid_python.py",
+        {"filename": "invalid_go.go", "rule": "eqeq-basic.yaml"},
+        {"filename": "invalid_python.py", "rule": "eqeq-python.yaml"},
     ],
 )
-def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, filename):
-    _, stderr = run_semgrep_in_tmp(
-        config="rules/eqeq-python.yaml",
-        target_name=f"bad/{filename}",
-        options=["--verbose"],
-        output_format=OutputFormat.TEXT,
+def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, settings):
+    stdout, stderr = run_semgrep_in_tmp(
+        config=f"rules/{settings['rule']}",
+        target_name=f"bad/{settings['filename']}",
+        options=["--verbose", "--no-time"],
+        output_format=OutputFormat.JSON,
         force_color=True,
         assert_exit_code=3,
     )
+    snapshot.assert_match(stdout, "out.json")
     snapshot.assert_match(stderr, "error.txt")


### PR DESCRIPTION
Spans were emitted from the core for partial parsing errors, but never
wired up so they appeared in CLI output. This change makes that work.

Some nuances:
- Previously, `semgrep --verbose --no-time` would still emit timing
  information; this commit removes the toggling of timing information
  with the verbose flag. Now, neither `semgrep --verbose` nor
  `semgrep --verbose --no-time` will emit timing information.

Fixes PA-1254.

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
