### PR TITLE
semgrep-core: just display a WARNING for partial parsing errors

### DIFF
--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -602,8 +602,9 @@ let semgrep_with_rules_and_formatted_output config =
       | None -> ())
   | Text ->
       (* the match has already been printed above. We just print errors here *)
-      (* pr (spf "number of errors: %d" (List.length errs)); *)
-      res.errors |> List.iter (fun err -> pr (E.string_of_error err))
+      if not (null res.errors) then (
+        pr "WARNING: some files were skipped on only partially analyzed:";
+        res.errors |> List.iter (fun err -> pr (E.string_of_error err)))
 
 (*****************************************************************************)
 (* Semgrep -e/-f *)


### PR DESCRIPTION
test plan:
```
$ yy -l java -rules ~/eqeq.yaml ~/DEEPROOT/partial_parsing.java
WARNING: some files were skipped on only partially analyzed:
/home/pad/DEEPROOT/partial_parsing.java:2:41: ["PartialParsing",[{"path":"/home/pad/DEEPROOT/partial_parsing.java","start":{"line":2,"col":42,"offset":0},"end":{"line":2,"col":67,"offset":25}}]]: `, long @NotNull ... flags` was unexpected
```


PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)