### PR TITLE
feat: Expose taint traces in semgrep-core text output

### DIFF
--- a/semgrep-core/src/engine/Match_rules.mli
+++ b/semgrep-core/src/engine/Match_rules.mli
@@ -8,12 +8,7 @@ exception File_timeout
    This can raise File_timeout.
 *)
 val check :
-  match_hook:
-    (string ->
-    Metavariable.bindings ->
-    Parse_info.t list Lazy.t ->
-    Taint.finding option ->
-    unit) ->
+  match_hook:(string -> Pattern_match.t -> unit) ->
   timeout:float ->
   timeout_threshold:int ->
   Config_semgrep.t * Equivalence.equivalences ->

--- a/semgrep-core/src/engine/Match_search_mode.ml
+++ b/semgrep-core/src/engine/Match_search_mode.ml
@@ -286,6 +286,7 @@ let apply_focus_on_ranges env focus ranges : RM.ranges =
         PM.range_loc;
         PM.tokens = lazy (MV.ii_of_mval mval);
         PM.env = range.mvars;
+        PM.taint_trace = None;
       }
     in
     let focus_range = RM.match_result_to_range focus_match in
@@ -585,7 +586,7 @@ let check_rule ({ R.mode = `Search pformula; _ } as r) hook
              v
              |> List.iter (fun (m : Pattern_match.t) ->
                     let str = spf "with rule %s" rule_id in
-                    hook str m.env m.tokens None));
+                    hook str m));
     errors = res.errors |> Common.map (error_with_rule_id rule_id);
     skipped_targets = res.skipped_targets;
     profiling = res.profiling;

--- a/semgrep-core/src/engine/Match_search_mode.mli
+++ b/semgrep-core/src/engine/Match_search_mode.mli
@@ -1,11 +1,7 @@
 (* main entry point *)
 val check_rule :
   Rule.search_rule ->
-  (string ->
-  Metavariable.bindings ->
-  Parse_info.t list Lazy.t ->
-  _ option ->
-  unit) ->
+  (string -> Pattern_match.t -> unit) ->
   Config_semgrep.t * Equivalence.equivalences ->
   Xtarget.t ->
   Report.rule_profiling Report.match_result

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -22,6 +22,7 @@ module PM = Pattern_match
 module RM = Range_with_metavars
 module RP = Report
 module T = Taint
+module PI = Parse_info
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -329,9 +330,28 @@ let taint_config_of_rule default_config equivs file ast_and_errors
       sinks = sinks_ranges;
     } )
 
+let rec convert_taint_call_trace = function
+  | Taint.PM pm ->
+      let toks = Lazy.force pm.PM.tokens |> List.filter PI.is_origintok in
+      PM.Toks toks
+  | Taint.Call (expr, toks, ct) ->
+      PM.Call
+        {
+          call_toks = V.ii_of_any (G.E expr) |> List.filter PI.is_origintok;
+          intermediate_toks = toks;
+          call_trace = convert_taint_call_trace ct;
+        }
+
+let taint_trace_of_src_to_sink source tokens sink =
+  {
+    Pattern_match.source = convert_taint_call_trace source;
+    tokens;
+    sink = convert_taint_call_trace sink;
+  }
+
 let pm_of_finding finding =
   match finding with
-  | T.SrcToSink { source = _; tokens = _; sink; merged_env } ->
+  | T.SrcToSink { source; tokens; sink; merged_env } ->
       (* We always report the finding on the sink that gets tainted, the call trace
        * must be used to explain how exactly the taint gets there. At some point
        * we experimented with reporting the match on the `sink`'s function call that
@@ -347,8 +367,11 @@ let pm_of_finding finding =
        * for the injection bug... but most users seem to be confused about this. They
        * already expect Semgrep (and DeepSemgrep) to report the match on `sink(x)`.
        *)
+      let taint_trace =
+        Some (lazy (taint_trace_of_src_to_sink source tokens sink))
+      in
       let sink_pm = T.pm_of_trace sink in
-      Some { sink_pm with env = merged_env }
+      Some { sink_pm with env = merged_env; taint_trace }
   | T.SrcToReturn _
   (* TODO: We might want to report functions that let input taint
    * go into a sink (?) *)
@@ -420,22 +443,8 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
   check_stmt ?name ~in_env lang fun_env taint_config
     (H.funcbody_to_stmt fdef.G.fbody)
 
-(* TODO: Pass a hashtable to cache the CFG of each def, otherwise we are
- * recomputing the CFG for each taint rule. *)
-module PMtbl = Hashtbl.Make (struct
-  type t = PM.t
-
-  let hash (pm : PM.t) = Hashtbl.hash (pm.rule_id, pm.file, pm.range_loc, pm.env)
-
-  (* TODO: Shouldn't be the PM.equal that does the right thing? Instead of
-   * deriving `equal` for `Metavariable.bindings` via ppx_deriving, perhaps
-   * we need to have a custom definition that relies on AST_utils there. *)
-  let equal = AST_utils.with_structural_equal PM.equal
-end)
-
 let check_rule rule match_hook (default_config, equivs) xtarget =
   let matches = ref [] in
-  let pm2finding = PMtbl.create 10 in
 
   let { Xtarget.file; xlang; lazy_ast_and_errors; _ } = xtarget in
   let lang =
@@ -453,9 +462,7 @@ let check_rule rule match_hook (default_config, equivs) xtarget =
       findings
       |> List.iter (fun finding ->
              pm_of_finding finding
-             |> Option.iter (fun pm ->
-                    Common.push pm matches;
-                    PMtbl.add pm2finding pm finding))
+             |> Option.iter (fun pm -> Common.push pm matches))
     in
     taint_config_of_rule default_config equivs file (ast, []) rule
       handle_findings
@@ -502,8 +509,7 @@ let check_rule rule match_hook (default_config, equivs) xtarget =
            v
            |> List.iter (fun (m : Pattern_match.t) ->
                   let str = Common.spf "with rule %s" m.rule_id.id in
-                  let opt_finding = PMtbl.find_opt pm2finding m in
-                  match_hook str m.env m.tokens opt_finding))
+                  match_hook str m))
     |> Common.map (fun m ->
            { m with PM.rule_id = convert_rule_id rule.Rule.id })
   in

--- a/semgrep-core/src/engine/Match_tainting_mode.mli
+++ b/semgrep-core/src/engine/Match_tainting_mode.mli
@@ -22,11 +22,7 @@ val taint_config_of_rule :
 
 val check_rule :
   Rule.taint_rule ->
-  (string ->
-  Metavariable.bindings ->
-  Parse_info.t list Lazy.t ->
-  Taint.finding option ->
-  unit) ->
+  (string -> Pattern_match.t -> unit) ->
   Config_semgrep.t * Equivalence.equivalences ->
   Xtarget.t ->
   Report.rule_profiling Report.match_result * debug_taint

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -153,7 +153,7 @@ let make_tests ?(unit_testing = false) xs =
              let res =
                try
                  Match_rules.check
-                   ~match_hook:(fun _ _ _ _ -> ())
+                   ~match_hook:(fun _ _ -> ())
                    ~timeout:0. ~timeout_threshold:0 (config, []) rules xtarget
                with
                | exn ->

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -470,7 +470,7 @@ let tainting_test lang rules_file file =
            in
            let res, _debug =
              Match_tainting_mode.check_rule rule
-               (fun _ _ _ _ -> ())
+               (fun _ _ -> ())
                (Config_semgrep.default_config, equivs)
                xtarget
            in

--- a/semgrep-core/src/engine/Xpattern_matcher.ml
+++ b/semgrep-core/src/engine/Xpattern_matcher.ml
@@ -83,6 +83,7 @@ let (matches_of_matcher :
                               file;
                               range_loc = (loc1, loc2);
                               env;
+                              taint_trace = None;
                               tokens = lazy [ info_of_token_location loc1 ];
                             }))
               |> List.flatten)

--- a/semgrep-core/src/matching/Match_patterns.ml
+++ b/semgrep-core/src/matching/Match_patterns.ml
@@ -160,7 +160,14 @@ let match_rules_and_recurse lang config (file, hook, matches) rules matcher k
                       let tokens = lazy (V.ii_of_any (any x)) in
                       let rule_id = rule_id_of_mini_rule rule in
                       Common.push
-                        { PM.rule_id; file; env; range_loc; tokens }
+                        {
+                          PM.rule_id;
+                          file;
+                          env;
+                          range_loc;
+                          tokens;
+                          taint_trace = None;
+                        }
                         matches;
                       hook env tokens));
   (* try the rules on substatements and subexpressions *)
@@ -288,7 +295,14 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                 let tokens = lazy (V.ii_of_any (E x)) in
                                 let rule_id = rule_id_of_mini_rule rule in
                                 Common.push
-                                  { PM.rule_id; file; env; range_loc; tokens }
+                                  {
+                                    PM.rule_id;
+                                    file;
+                                    env;
+                                    range_loc;
+                                    tokens;
+                                    taint_trace = None;
+                                  }
                                   matches;
                                 hook env tokens)
                    | Some (start_loc, end_loc) ->
@@ -333,7 +347,14 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                   let tokens = lazy (V.ii_of_any (S x)) in
                                   let rule_id = rule_id_of_mini_rule rule in
                                   Common.push
-                                    { PM.rule_id; file; env; range_loc; tokens }
+                                    {
+                                      PM.rule_id;
+                                      file;
+                                      env;
+                                      range_loc;
+                                      tokens;
+                                      taint_trace = None;
+                                    }
                                     matches;
                                   hook env tokens));
               k x
@@ -401,6 +422,7 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                         env;
                                         range_loc;
                                         tokens;
+                                        taint_trace = None;
                                       }
                                       matches;
                                     hook env tokens)));

--- a/semgrep-core/src/reporting/Matching_report.ml
+++ b/semgrep-core/src/reporting/Matching_report.ml
@@ -58,7 +58,7 @@ let rec join_with_space_if_needed xs =
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
-let print_match ?(format = Normal) ?(str = "") ii =
+let print_match ?(format = Normal) ?(str = "") ?(spaces = 0) ii =
   try
     let mini, maxi = PI.min_max_ii_by_pos ii in
     let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
@@ -69,11 +69,12 @@ let print_match ?(format = Normal) ?(str = "") ii =
     match format with
     | Normal ->
         let prefix = if str = "" then prefix else prefix ^ " " ^ str in
-        pr prefix;
+        let spaces_string = String.init spaces (fun _ -> ' ') in
+        pr (spaces_string ^ prefix);
         (* todo? some context too ? *)
         lines
         |> Common.map (fun i -> arr.(i))
-        |> List.iter (fun s -> pr (" " ^ s))
+        |> List.iter (fun s -> pr (spaces_string ^ " " ^ s))
     (* bugfix: do not add extra space after ':', otherwise M-x wgrep will not work *)
     | Emacs -> pr (prefix ^ ":" ^ arr.(List.hd lines))
     | OneLine ->

--- a/semgrep-core/src/reporting/Matching_report.mli
+++ b/semgrep-core/src/reporting/Matching_report.mli
@@ -11,6 +11,10 @@ type match_format =
   | OneLine
 
 val print_match :
-  ?format:match_format -> ?str:string -> Parse_info.t list -> unit
+  ?format:match_format ->
+  ?str:string ->
+  ?spaces:int ->
+  Parse_info.t list ->
+  unit
 
 val join_with_space_if_needed : string list -> string

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -74,8 +74,37 @@ let replace_named_pipe_by_regular_file path =
 (* for -gen_layer, see Experiments.ml *)
 let _matching_tokens = ref []
 
+let string_of_toks toks =
+  String.concat ", " (Common.map (fun tok -> PI.str_of_info tok) toks)
+
+let rec print_taint_call_trace ~format ~spaces = function
+  | Pattern_match.Toks toks -> Matching_report.print_match ~format ~spaces toks
+  | Call { call_toks; intermediate_toks; call_trace } ->
+      let spaces_string = String.init spaces (fun _ -> ' ') in
+      pr (spaces_string ^ "call to");
+      Matching_report.print_match ~format ~spaces call_toks;
+      if intermediate_toks <> [] then
+        pr
+          (spf "%sthese intermediate values are tainted: %s" spaces_string
+             (string_of_toks intermediate_toks));
+      pr (spaces_string ^ "then");
+      print_taint_call_trace ~format ~spaces:(spaces + 2) call_trace
+
+let print_taint_trace ~format taint_trace =
+  if format <> Matching_report.Normal then ()
+  else
+    let (lazy { Pattern_match.source; tokens; sink }) = taint_trace in
+    pr "  * Taint comes from:";
+    print_taint_call_trace ~format ~spaces:4 source;
+    if tokens <> [] then
+      pr
+        (spf "  * These intermediate values are tainted: %s"
+           (string_of_toks tokens));
+    pr "  * This is how taint reaches the sink:";
+    print_taint_call_trace ~format ~spaces:4 sink
+
 let print_match ?str match_format mvars mvar_binding ii_of_any
-    tokens_matched_code =
+    tokens_matched_code taint_trace =
   (* there are a few fake tokens in the generic ASTs now (e.g.,
    * for DotAccess generated outside the grammar) *)
   let toks = tokens_matched_code |> List.filter PI.is_origintok in
@@ -100,6 +129,7 @@ let print_match ?str match_format mvars mvar_binding ii_of_any
     in
     pr (spf "%s:%d: %s" file line (Common.join ":" strings_metavars));
     ());
+  Option.iter (print_taint_trace ~format:match_format) taint_trace;
   toks |> List.iter (fun x -> Common.push x _matching_tokens)
 
 let timeout_function file timeout f =
@@ -511,11 +541,12 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
            in
 
            let xtarget = xtarget_of_file config xlang file in
-           let match_hook str env matched_tokens _opt_taint_finding =
+           let match_hook str match_ =
              if config.output_format = Text then
-               let xs = Lazy.force matched_tokens in
-               print_match ~str config.match_format config.mvars env
-                 Metavariable.ii_of_mval xs
+               let xs = Lazy.force match_.Pattern_match.tokens in
+               print_match ~str config.match_format config.mvars
+                 match_.Pattern_match.env Metavariable.ii_of_mval xs
+                 match_.Pattern_match.taint_trace
            in
            let res =
              Match_rules.check ~match_hook ~timeout:config.timeout
@@ -705,7 +736,7 @@ let semgrep_with_one_pattern config =
                      ~hook:(fun env matched_tokens ->
                        let xs = Lazy.force matched_tokens in
                        print_match config.match_format config.mvars env
-                         Metavariable.ii_of_mval xs)
+                         Metavariable.ii_of_mval xs None)
                      ( Config_semgrep.default_config,
                        parse_equivalences config.equivalences_file )
                      minirule (file, lang, ast)

--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -49,6 +49,7 @@ val print_match :
   Metavariable.bindings ->
   (Metavariable.mvalue -> Parse_info.t list) ->
   Parse_info.t list ->
+  Pattern_match.taint_trace Lazy.t option ->
   unit
 
 val exn_to_error : Common.filename -> Exception.t -> Semgrep_error_code.error


### PR DESCRIPTION
This isn't plumbed through to the CLI yet, so it's not user-facing. But,
it's a step in that direction. The raw semgrep-core output is mostly
only used by Semgrep developers.

Instead of using the taint trace data separately provided to the match
hook (which isn't the codepath that JSON output uses), this change makes
it part of the `Pattern_match.t`. This involved defining a separate type
for taint traces that is more appropriate for match reporting, and
avoids a circular dependency. This will allow us to fairly easily add it
to the JSON output too, which is consumed by the CLI and the App.

Because this changes how the taint trace is accessed from the match
hook, a corresponding change to DeepSemgrep (which consumes taint trace
data there) will be required.

Test plan:

Run semgrep-core on the `tainting_rules/js/eslint_obj_inj.js` test:

```
eslint_obj_inj.js:4 with rule tainting
     return o[a]
  * Taint comes from:
    eslint_obj_inj.js:2
         var a = x
  * These intermediate values are tainted: a
  * This is how taint reaches the sink:
    eslint_obj_inj.js:4
         return o[a]
eslint_obj_inj.js:10 with rule tainting
     var z = o[b]
  * Taint comes from:
    eslint_obj_inj.js:8
         var b = baz(0)
  * These intermediate values are tainted: b
  * This is how taint reaches the sink:
    eslint_obj_inj.js:10
         var z = o[b]
eslint_obj_inj.js:21 with rule tainting
     return o[c]
  * Taint comes from:
    eslint_obj_inj.js:17
             c = x
  * These intermediate values are tainted: c
  * This is how taint reaches the sink:
    eslint_obj_inj.js:21
         return o[c]
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
