### PR TITLE
refactor: Simplify print_match

### DIFF
--- a/semgrep-core/src/engine/Match_search_mode.ml
+++ b/semgrep-core/src/engine/Match_search_mode.ml
@@ -184,7 +184,7 @@ let debug_semgrep config mini_rules file lang ast =
          logger#debug "Checking mini rule with pattern %s" mr.MR.pattern_string;
          let res =
            Match_patterns.check
-             ~hook:(fun _ _ -> ())
+             ~hook:(fun _ -> ())
              config [ mr ] (file, lang, ast)
          in
          if !debug_matches then
@@ -228,7 +228,7 @@ let matches_of_patterns ?range_filter config file_and_more patterns =
             else
               (* regular path *)
               Match_patterns.check
-                ~hook:(fun _ _ -> ())
+                ~hook:(fun _ -> ())
                 ?range_filter config mini_rules (file, lang, ast))
       in
       let errors = Parse_target.errors_from_skipped_tokens skipped_tokens in

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -284,10 +284,9 @@ let regression_tests_for_lang ~with_caching files lang =
              Common.save_excursion Flag_semgrep.with_opt_cache with_caching
                (fun () ->
                  Match_patterns.check
-                   ~hook:(fun _env matched_tokens ->
+                   ~hook:(fun { Pattern_match.tokens = (lazy xs); _ } ->
                      (* there are a few fake tokens in the generic ASTs now (e.g.,
                       * for DotAccess generated outside the grammar) *)
-                     let xs = Lazy.force matched_tokens in
                      let toks = xs |> List.filter Parse_info.is_origintok in
                      let minii, _maxii = Parse_info.min_max_ii_by_pos toks in
                      let minii_loc =

--- a/semgrep-core/src/experiments/synthesizing/Unit_synthesizer_targets.ml
+++ b/semgrep-core/src/experiments/synthesizing/Unit_synthesizer_targets.ml
@@ -69,8 +69,7 @@ let ranges_matched lang file pattern : Range.t list =
   (* Are equivalences necessary for this? *)
   let matches =
     Match_patterns.check
-      ~hook:(fun _env matched_tokens ->
-        let xs = Lazy.force matched_tokens in
+      ~hook:(fun { Pattern_match.tokens = (lazy xs); _ } ->
         let toks = xs |> List.filter Parse_info.is_origintok in
         let minii, _maxii = Parse_info.min_max_ii_by_pos toks in
         let minii_loc = Parse_info.unsafe_token_location_of_info minii in

--- a/semgrep-core/src/matching/Match_patterns.ml
+++ b/semgrep-core/src/matching/Match_patterns.ml
@@ -159,7 +159,7 @@ let match_rules_and_recurse lang config (file, hook, matches) rules matcher k
                   | Some range_loc ->
                       let tokens = lazy (V.ii_of_any (any x)) in
                       let rule_id = rule_id_of_mini_rule rule in
-                      Common.push
+                      let pm =
                         {
                           PM.rule_id;
                           file;
@@ -168,8 +168,9 @@ let match_rules_and_recurse lang config (file, hook, matches) rules matcher k
                           tokens;
                           taint_trace = None;
                         }
-                        matches;
-                      hook env tokens));
+                      in
+                      Common.push pm matches;
+                      hook pm));
   (* try the rules on substatements and subexpressions *)
   k x
 
@@ -294,7 +295,7 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                 let env = env.mv.full_env in
                                 let tokens = lazy (V.ii_of_any (E x)) in
                                 let rule_id = rule_id_of_mini_rule rule in
-                                Common.push
+                                let pm =
                                   {
                                     PM.rule_id;
                                     file;
@@ -303,8 +304,9 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                     tokens;
                                     taint_trace = None;
                                   }
-                                  matches;
-                                hook env tokens)
+                                in
+                                Common.push pm matches;
+                                hook pm)
                    | Some (start_loc, end_loc) ->
                        logger#info
                          "While matching pattern %s in file %s, we skipped \
@@ -346,7 +348,7 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                               | Some range_loc ->
                                   let tokens = lazy (V.ii_of_any (S x)) in
                                   let rule_id = rule_id_of_mini_rule rule in
-                                  Common.push
+                                  let pm =
                                     {
                                       PM.rule_id;
                                       file;
@@ -355,8 +357,9 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                       tokens;
                                       taint_trace = None;
                                     }
-                                    matches;
-                                  hook env tokens));
+                                  in
+                                  Common.push pm matches;
+                                  hook pm));
               k x
             in
             (* If bloom_filter is not enabled, always visit the statement *)
@@ -415,7 +418,7 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                            span)
                                     in
                                     let rule_id = rule_id_of_mini_rule rule in
-                                    Common.push
+                                    let pm =
                                       {
                                         PM.rule_id;
                                         file;
@@ -424,8 +427,9 @@ let check2 ~hook range_filter (config, equivs) rules (file, lang, ast) =
                                         tokens;
                                         taint_trace = None;
                                       }
-                                      matches;
-                                    hook env tokens)));
+                                    in
+                                    Common.push pm matches;
+                                    hook pm)));
             k x);
         V.ktype_ =
           (fun (k, _) x ->

--- a/semgrep-core/src/matching/Match_patterns.mli
+++ b/semgrep-core/src/matching/Match_patterns.mli
@@ -1,5 +1,5 @@
 val check :
-  hook:(Metavariable.bindings -> Parse_info.t list Lazy.t -> unit) ->
+  hook:(Pattern_match.t -> unit) ->
   ?range_filter:(Parse_info.token_location * Parse_info.token_location -> bool) ->
   Config_semgrep.t * Equivalence.equivalences ->
   Mini_rule.rules ->

--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -44,12 +44,9 @@ val replace_named_pipe_by_regular_file : Common.filename -> Common.filename
 
 val print_match :
   ?str:string ->
-  Matching_report.match_format ->
-  Metavariable.mvar list ->
-  Metavariable.bindings ->
+  Runner_config.t ->
+  Pattern_match.t ->
   (Metavariable.mvalue -> Parse_info.t list) ->
-  Parse_info.t list ->
-  Pattern_match.taint_trace Lazy.t option ->
   unit
 
 val exn_to_error : Common.filename -> Exception.t -> Semgrep_error_code.error


### PR DESCRIPTION
Based on review feedback in
https://github.com/returntocorp/semgrep/pull/5662

This makes `Run_semgrep.print_match` take a `Runner_config.t` and
`Pattern_match.t` as arguments instead of taking several of those
structures' assorted fields as individual arguments.

This also involved changing `Match_patterns.check` to take a hook that
takes a `Pattern_match.t` instead of a couple of individual fields.

Test plan: Automated tests

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
