### PR TITLE
Minor improvements to taint traces

### DIFF
--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -36,15 +36,20 @@
  * from a pattern:, we should not merge them!
  *)
 
+(* The locations of variables which taint propagates through *)
 type tainted_tokens = Parse_info.t list [@@deriving show]
+
+(* The tokens associated with a single pattern match involved in a taint trace
+ * *)
+type pattern_match_tokens = Parse_info.t list [@@deriving show]
 
 (* Simplified version of Taint.source_to_sink meant for finding reporting *)
 type taint_call_trace =
   (* A direct match *)
-  | Toks of Parse_info.t list
+  | Toks of pattern_match_tokens
   (* An indirect match through a function call *)
   | Call of {
-      call_toks : tainted_tokens;
+      call_toks : pattern_match_tokens;
       intermediate_toks : tainted_tokens;
       call_trace : taint_call_trace;
     }

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -50,7 +50,7 @@ type taint_call_trace =
   (* An indirect match through a function call *)
   | Call of {
       call_toks : pattern_match_tokens;
-      intermediate_toks : tainted_tokens;
+      intermediate_vars : tainted_tokens;
       call_trace : taint_call_trace;
     }
 [@@deriving show]

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -338,7 +338,7 @@ let rec convert_taint_call_trace = function
       PM.Call
         {
           call_toks = V.ii_of_any (G.E expr) |> List.filter PI.is_origintok;
-          intermediate_toks = toks;
+          intermediate_vars = toks;
           call_trace = convert_taint_call_trace ct;
         }
 

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -100,8 +100,11 @@ let print_taint_trace ~format taint_trace =
       pr
         (spf "  * These intermediate values are tainted: %s"
            (string_of_toks tokens));
-    pr "  * This is how taint reaches the sink:";
-    print_taint_call_trace ~format ~spaces:4 sink
+    match sink with
+    | Pattern_match.Toks _ -> ()
+    | Call _ ->
+        pr "  * This is how taint reaches the sink:";
+        print_taint_call_trace ~format ~spaces:4 sink
 
 let print_match ?str config match_ ii_of_any =
   (* there are a few fake tokens in the generic ASTs now (e.g.,

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -79,14 +79,14 @@ let string_of_toks toks =
 
 let rec print_taint_call_trace ~format ~spaces = function
   | Pattern_match.Toks toks -> Matching_report.print_match ~format ~spaces toks
-  | Call { call_toks; intermediate_toks; call_trace } ->
+  | Call { call_toks; intermediate_vars; call_trace } ->
       let spaces_string = String.init spaces (fun _ -> ' ') in
       pr (spaces_string ^ "call to");
       Matching_report.print_match ~format ~spaces call_toks;
-      if intermediate_toks <> [] then
+      if intermediate_vars <> [] then
         pr
           (spf "%sthese intermediate values are tainted: %s" spaces_string
-             (string_of_toks intermediate_toks));
+             (string_of_toks intermediate_vars));
       pr (spaces_string ^ "then");
       print_taint_call_trace ~format ~spaces:(spaces + 2) call_trace
 


### PR DESCRIPTION
Based on review feedback in https://github.com/returntocorp/semgrep/pull/5662

Test plan: Follow the test plan in https://github.com/returntocorp/semgrep/pull/5662:

```
eslint_obj_inj.js:4 with rule tainting
     return o[a]
  * Taint comes from:
    eslint_obj_inj.js:2
         var a = x
  * These intermediate values are tainted: a
eslint_obj_inj.js:10 with rule tainting
     var z = o[b]
  * Taint comes from:
    eslint_obj_inj.js:8
         var b = baz(0)
  * These intermediate values are tainted: b
eslint_obj_inj.js:21 with rule tainting
     return o[c]
  * Taint comes from:
    eslint_obj_inj.js:17
             c = x
  * These intermediate values are tainted: c
```

PR checklist:

- [x] Documentation is up-to-date
- [x] Changelog is up-to-date
- [x] Change has no security implications (otherwise, ping security team)
