### PR TITLE
Create automatic version compare script

### DIFF
--- a/cli/scripts/compare.py
+++ b/cli/scripts/compare.py
@@ -8,7 +8,7 @@ import click
 import requests
 from ruamel import yaml
 
-from semgrep.semgrep_types import LANGUAGE  # type: ignore  ## mypy isn't picking up src/ in this context
+from semgrep.semgrep_types import LANGUAGE
 
 
 SEMGREP_DEV_TIMEOUT_S = 30.0
@@ -60,7 +60,9 @@ def compare(start: str, end: str, snippet: str) -> int:
         with open("semgrep.yml", "w") as fd:
             yaml.safe_dump(definition, fd)  # type: ignore ## for some reason this is missing from ruamel stub
 
-        target_name = f"target.{LANGUAGE.definition_by_id[language].exts[0]}"
+        target_name = (
+            f"target.{next(e for e in LANGUAGE.definition_by_id[language].exts)}"
+        )
         with open(target_name, "w") as fd:
             fd.write(target)
 

--- a/cli/scripts/compare.py
+++ b/cli/scripts/compare.py
@@ -61,7 +61,7 @@ def compare(start: str, end: str, snippet: str) -> int:
             yaml.safe_dump(definition, fd)  # type: ignore ## for some reason this is missing from ruamel stub
 
         target_name = (
-            f"target.{next(e for e in LANGUAGE.definition_by_id[language].exts)}"
+            f"target{next(e for e in LANGUAGE.definition_by_id[language].exts)}"
         )
         with open(target_name, "w") as fd:
             fd.write(target)

--- a/cli/scripts/compare.py
+++ b/cli/scripts/compare.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import tempfile
+from typing import Sequence
+
+import click
+import requests
+from ruamel import yaml
+
+from semgrep.semgrep_types import LANGUAGE  # type: ignore  ## mypy isn't picking up src/ in this context
+
+
+SEMGREP_DEV_TIMEOUT_S = 30.0
+
+
+@click.command()
+@click.argument("start", type=str)
+@click.argument("end", type=str)
+@click.argument("snippet", type=str)
+def compare(start: str, end: str, snippet: str) -> int:
+
+    url = f"https://semgrep.dev/api/registry/rule/{snippet}?definition=1&test_cases=1"
+    data = requests.get(url, timeout=SEMGREP_DEV_TIMEOUT_S).json()
+
+    definition = data["definition"]
+    test_case = data["test_cases"][0]
+    language = test_case["language"]
+    target = test_case["target"]
+
+    def docker_cmd(dir: str, version: str) -> Sequence[str]:
+        return [
+            "docker",
+            "run",
+            "-v",
+            f"{dir}:/src",
+            f"returntocorp/semgrep:{version}",
+            "semgrep",
+            "scan",
+            "--config",
+            "semgrep.yml",
+            ".",
+        ]
+
+    with tempfile.TemporaryDirectory() as td:
+        os.chdir(td)
+
+        with open("semgrep.yml", "w") as fd:
+            yaml.safe_dump(definition, fd)  # type: ignore ## for some reason this is missing from ruamel stub
+
+        target_name = f"target.{LANGUAGE.definition_by_id[language].exts[0]}"
+        with open(target_name, "w") as fd:
+            fd.write(target)
+
+        click.secho(f"===== RUNNING WITH VERSION {start} =====\n", fg="blue", bold=True)
+        # The following rule shouldn't be running on Semgrep, it's an FP factory
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
+        subprocess.run(docker_cmd(td, start))
+        click.secho(
+            f"\n\n===== RUNNING WITH VERSION {end} =====\n", fg="blue", bold=True
+        )
+        # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
+        subprocess.run(docker_cmd(td, end))
+
+    return 0
+
+
+if __name__ == "__main__":
+    compare()

--- a/cli/scripts/compare.py
+++ b/cli/scripts/compare.py
@@ -16,9 +16,21 @@ SEMGREP_DEV_TIMEOUT_S = 30.0
 
 @click.command()
 @click.argument("start", type=str)
-@click.argument("end", type=str)
+@click.argument(
+    "end",
+    type=str,
+)
 @click.argument("snippet", type=str)
 def compare(start: str, end: str, snippet: str) -> int:
+    """
+    Compares behavior of two versions of Semgrep on a rule ID
+
+    START - The first version of Semgrep to run
+
+    END - The second version of Semgrep to run
+
+    SNIPPET - A snippet or rule ID (e.g. "Wlz")
+    """
 
     url = f"https://semgrep.dev/api/registry/rule/{snippet}?definition=1&test_cases=1"
     data = requests.get(url, timeout=SEMGREP_DEV_TIMEOUT_S).json()


### PR DESCRIPTION
Previously we had `?version=...` in the Semgrep.dev playground. That's
been removed due to its maintenance overhead. This script should replace
that for internal use with Semgrep and rule development.

Closes CLI-252.

PR checklist:

- [x] Change has no security implications (otherwise, ping security team)

