### PR TITLE
feat(taint): Provide taint traces in semgrep's JSON output

### DIFF
--- a/changelog.d/pa-1271.added
+++ b/changelog.d/pa-1271.added
@@ -1,0 +1,1 @@
+Added taint traces as part of Semgrep's JSON output. This helps explain how the sink became tainted.

--- a/cli/src/semgrep/formatter/json.py
+++ b/cli/src/semgrep/formatter/json.py
@@ -29,6 +29,7 @@ class JsonFormatter(BaseFormatter):
             # 'lines' already contains '\n' at the end of each line
             lines="".join(rule_match.lines).rstrip(),
             metavars=rule_match.match.extra.metavars,
+            dataflow_trace=rule_match.match.extra.dataflow_trace,
         )
 
         if rule_match.extra.get("dependency_matches"):

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -324,6 +324,7 @@ class RuleMatch:
             match_based_id=self.match_based_id,
             metadata=out.RawJson(self.metadata),
             is_blocking=self.is_blocking,
+            dataflow_trace=self.match.extra.dataflow_trace,
         )
 
         if self.extra.get("fixed_lines"):

--- a/cli/tests/e2e/snapshots/test_check/test_taint_mode/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_taint_mode/results.json
@@ -15,6 +15,77 @@
         "offset": 162
       },
       "extra": {
+        "dataflow_trace": {
+          "intermediate_vars": [
+            {
+              "end": {
+                "col": 6,
+                "line": 3,
+                "offset": 62
+              },
+              "path": "targets/taint/taint.py",
+              "start": {
+                "col": 5,
+                "line": 3,
+                "offset": 61
+              }
+            },
+            {
+              "end": {
+                "col": 10,
+                "line": 8,
+                "offset": 145
+              },
+              "path": "targets/taint/taint.py",
+              "start": {
+                "col": 9,
+                "line": 8,
+                "offset": 144
+              }
+            }
+          ],
+          "taint_source": [
+            {
+              "end": {
+                "col": 16,
+                "line": 3,
+                "offset": 72
+              },
+              "path": "targets/taint/taint.py",
+              "start": {
+                "col": 9,
+                "line": 3,
+                "offset": 65
+              }
+            },
+            {
+              "end": {
+                "col": 17,
+                "line": 3,
+                "offset": 73
+              },
+              "path": "targets/taint/taint.py",
+              "start": {
+                "col": 16,
+                "line": 3,
+                "offset": 72
+              }
+            },
+            {
+              "end": {
+                "col": 18,
+                "line": 3,
+                "offset": 74
+              },
+              "path": "targets/taint/taint.py",
+              "start": {
+                "col": 17,
+                "line": 3,
+                "offset": 73
+              }
+            }
+          ]
+        },
         "fingerprint": "b7d9e6f63610bc461ccd05b612b609b516a1ba6c6fb63268160f62de8bb894cd8c2ef9e389681db5d538050af75010b0219f21d41f67488da439ca426798dbde_0",
         "is_ignored": false,
         "lines": "    sink1(b)",


### PR DESCRIPTION
Test plan: Automated tests

For the Semgrep App integration, log in, then add this rule to my board: https://semgrep.dev/orgs/-/editor/s/XO6q

Download the test file for that rule, then run:

`python -m semgrep ci --dry-run --include test.js`

Observe in the JSON output that the `dataflow_trace` field on the finding appears as expected: https://gist.github.com/nmote/5ad538b49697cc483680f54e49ddf57a

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
