### PR TITLE
test(ts): Add test for complex dots import pattern

### DIFF
--- a/semgrep-core/tests/ts/dots_import_complex.sgrep
+++ b/semgrep-core/tests/ts/dots_import_complex.sgrep
@@ -1,0 +1,1 @@
+import Foo, { ..., x, ... } from "bar";

--- a/semgrep-core/tests/ts/dots_import_complex.ts
+++ b/semgrep-core/tests/ts/dots_import_complex.ts
@@ -1,0 +1,6 @@
+// TODO:
+import Foo, { y, x } from "bar";
+// MATCH:
+import Foo, { x, y } from "bar";
+// MATCH:
+import Foo, { x } from "bar";


### PR DESCRIPTION
This illustrates the problem at the root of #5305. The issue is that we
desugar import statements that import multiple things into separate
import statements that each import a single thing. Combined with the
ellipses in the import list (which are just dropped, see
https://github.com/returntocorp/pfff/commit/045e544ee7fd83ee0dd7e71f57bcb02d1dfbd09e),
this leads to unexpected behavior.

We parse this pattern as a default import of `Foo`, followed by a named
import of `x`. Unfortunately, if there is an intervening import (`y`, in
this example), then the pattern doesn't match.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
