### PR TITLE
chore: break up workflow into jobs for re-runnability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,19 @@ jobs:
     needs: [upload-wheels, release-ubuntu-16-04]
     if: ${{ !contains(github.ref, '-test-release') }}
     steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      # wait for the draft release since these may not be ready after the refactor of the start-release.
+      - name: Wait for Draft Release if not Ready
+        id: wait-draft-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          while ! gh release --repo returntocorp/semgrep list -L 5 | grep -q "${{ steps.get_version.outputs.VERSION }}"; do
+            echo "release not yet ready, sleeping for 5 seconds"
+            sleep 5
+          done
       # OSX
       - uses: actions/download-artifact@v3
         with:
@@ -23,9 +36,6 @@ jobs:
           path: semgrep-osx
       - name: Compute checksum
         run: cat ./semgrep-osx/artifacts.zip | sha256sum > ./semgrep-osx/artifacts.zip.sha256
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - name: Upload Release Asset
         id: upload-release-asset-osx
         env:

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.next-version.outputs.next-version }}
+      pr-number: ${{ steps.open-pr.outputs.pr-number }}
+      release-branch: ${{ steps.release-branch.outputs.release-branch }}
     steps:
       - name: Get JWT for semgrep-ci GitHub App
         id: jwt
@@ -85,6 +87,12 @@ jobs:
           pip3 install pipenv==2022.6.7
           pipenv install --dev
           pipenv run towncrier build --draft --version ${{ steps.next-version.outputs.next-version }} > release_body.txt
+      - name: Upload Changelog Body Artifact
+        id: upload-changelog-artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release_body_${{ steps.next-version.outputs.next-version }}
+          path: scripts/release/release_body.txt
       - name: Update Changelog
         working-directory: scripts/release
         run: |
@@ -128,32 +136,40 @@ jobs:
           PR_NUMBER=$(echo $PR_URL | sed 's|.*pull/\(.*\)|\1|')
 
           echo "::set-output name=pr-number::$PR_NUMBER"
+
+  wait-for-pr-checks:
+    name: Wait for PR Checks
+    runs-on: ubuntu-20.04
+    needs: release-setup
+    outputs:
+      num-checks: ${{ steps.num-checks.outputs.num-checks }}
+    steps:
       - name: Wait for checks to register
         id: register-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LEN_CHECKS=$(gh pr view "${{ steps.open-pr.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
+          LEN_CHECKS=$(gh pr -R returntocorp/semgrep view "${{ needs.release-setup.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
 
           # Immediately after creation, the PR doesn't have any checks attached yet, wait until this is not the case
           # If you immediately start waiting for checks, then it just fails saying there's no checks.
           while [ ${LEN_CHECKS} = "0" ]; do
             echo "No checks available yet"
             sleep 1
-            LEN_CHECKS=$(gh pr view "${{ steps.open-pr.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
+            LEN_CHECKS=$(gh pr -R returntocorp/semgrep view "${{ needs.release-setup.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
           done
           echo "checks are valid"
 
           echo ${LEN_CHECKS}
 
-          gh pr view "${{ steps.open-pr.outputs.pr-number }}" --json statusCheckRollup
+          gh pr -R returntocorp/semgrep view "${{ needs.release-setup.outputs.pr-number }}" --json statusCheckRollup
       - name: Wait for checks to complete
         id: wait-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Wait for PR checks to finish
-          gh pr checks "${{ steps.open-pr.outputs.pr-number }}" --interval 90 --watch
+          gh pr -R returntocorp/semgrep checks "${{ needs.release-setup.outputs.pr-number }}" --interval 2 --watch
       - name: Get Current Num Checks
         id: num-checks
         env:
@@ -162,51 +178,100 @@ jobs:
           # Once all checks are complete on the PR, find the number of checks so that we can wait for the new checks to register.
           # We can't do this above because sometimes all checks aren't yet ready by the time the first one is, so we end up in a case where
           # we aren't getting waiting for all checks.
-          LEN_CHECKS=$(gh pr view "${{ steps.open-pr.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
+          LEN_CHECKS=$(gh pr -R returntocorp/semgrep view "${{ needs.release-setup.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
           echo "::set-output name=num-checks::${LEN_CHECKS}"
+
+  create-tag:
+    name: Create Release Tag
+    runs-on: ubuntu-20.04
+    needs: [release-setup, wait-for-pr-checks]
+    steps:
+      - name: Get JWT for semgrep-ci GitHub App
+        id: jwt
+        uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
+        env:
+          EXPIRATION: 600 # seconds
+          ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }} # semgrep-ci GitHub App id
+          PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
+      - name: Get token for semgrep-ci GitHub App
+        id: token
+        run: |
+          TOKEN="$(curl -X POST \
+          -H "Authorization: Bearer ${{ steps.jwt.outputs.jwt }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/app/installations/${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID }}/access_tokens" | \
+          jq -r .token)"
+          echo "::add-mask::$TOKEN"
+          echo "::set-output name=token::$TOKEN"
+      - name: Check out code
+        uses: actions/checkout@v3
+        id: checkout
+        with:
+          ref: "${{ needs.release-setup.outputs.release-branch }}"
+          token: "${{ steps.token.outputs.token }}"
       - name: Create release version tag
         id: create-tag
         run: |
-          git tag -a -m "Release ${{ steps.next-version.outputs.next-version }}" "v${{ steps.next-version.outputs.next-version }}"
-          git push origin "v${{ steps.next-version.outputs.next-version }}"
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          git tag -a -m "Release ${{ needs.release-setup.outputs.version }}" "v${{ needs.release-setup.outputs.version }}"
+          git push origin "v${{ needs.release-setup.outputs.version }}"
+
+  create-draft-release:
+    name: Create Draft Release
+    runs-on: ubuntu-20.04
+    needs: [release-setup, create-tag]
+    steps:
+      - name: Download Release Body Artifact
+        id: download_body
+        uses: actions/download-artifact@v3
+        with:
+          name: "release_body_${{ needs.release-setup.outputs.version }}"
+          path: scripts/release
       - name: Create Draft Release
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: "v${{ steps.next-version.outputs.next-version }}"
-          name: Release v${{ steps.next-version.outputs.next-version }}
+          tag_name: "v${{ needs.release-setup.outputs.version }}"
+          name: Release v${{ needs.release-setup.outputs.version }}
           body_path: scripts/release/release_body.txt
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           draft: true
+
+  wait-for-release-checks:
+    name: Wait for Release Checks
+    runs-on: ubuntu-20.04
+    needs: [release-setup, wait-for-pr-checks, create-tag]
+    steps:
       - name: Wait for release checks to register
         id: register-release-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LEN_CHECKS=$(gh pr view "${{ steps.open-pr.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
+          LEN_CHECKS=$(gh pr -R returntocorp/semgrep view "${{ needs.release-setup.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
 
           # We need to wait for the new checks to register when the release tag is pushed
-          while [ ${LEN_CHECKS} = ${{ steps.num-checks.outputs.num-checks }} ]; do
+          while [ ${LEN_CHECKS} = ${{ needs.wait-for-pr-checks.outputs.num-checks }} ]; do
             echo "No checks available yet"
             sleep 1
-            LEN_CHECKS=$(gh pr view "${{ steps.open-pr.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
+            LEN_CHECKS=$(gh pr -R returntocorp/semgrep view "${{ needs.release-setup.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
           done
           echo "checks are valid"
 
           echo ${LEN_CHECKS}
 
-          gh pr view "${{ steps.open-pr.outputs.pr-number }}" --json statusCheckRollup
+          gh pr -R returntocorp/semgrep view "${{ needs.release-setup.outputs.pr-number }}" --json statusCheckRollup
       - name: Wait for release checks
         id: wait-release-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Wait for PR checks to finish
-          gh pr checks "${{ steps.open-pr.outputs.pr-number }}" --interval 90 --watch
+          gh pr -R returntocorp/semgrep checks "${{ needs.release-setup.outputs.pr-number }}" --interval 2 --watch
 
   validate-release-trigger:
-    needs: [release-setup]
+    needs: [wait-for-release-checks, release-setup]
     name: Trigger Release Validation
     uses: ./.github/workflows/validate-release.yml
     secrets: inherit


### PR DESCRIPTION
No changelog entry needed.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
