### PR TITLE
Field Sensitive Tainting

### DIFF
--- a/changelog.d/pa-1278.added
+++ b/changelog.d/pa-1278.added
@@ -1,0 +1,3 @@
+taint-mode: Experimental support for basic field-sensitive taint tracking. If `x`
+is tainted, but `x.a.b` is set to something safe, `sink(x.a.b)` will no longer
+be reported.

--- a/changelog.d/pa-1278.added
+++ b/changelog.d/pa-1278.added
@@ -1,3 +1,6 @@
-taint-mode: Experimental support for basic field-sensitive taint tracking. If `x`
-is tainted, but `x.a.b` is set to something safe, `sink(x.a.b)` will no longer
-be reported.
+taint-mode: Experimental support for basic field-sensitive taint tracking.
+Semgrep can now track `x.a` and `x.b` separately, so that e.g. `x.a` can be
+tainted at the same time as `x.b` is clean, hence `sink(x.a)` would produce
+a finding but `sink(x.b)` would not. It is also possible for `x` to be tainted
+while `x.a` is clean. We expect this to have an net positive effect by reducing
+false positives.

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -115,7 +115,7 @@ let fresh_label ?(label = "_label") _env tok =
 
 let fresh_lval ?str env tok =
   let var = fresh_var ?str env tok in
-  { base = Var var; offset = NoOffset }
+  { base = Var var; offset = [] }
 
 let var_of_id_info id id_info =
   let sid =
@@ -137,14 +137,14 @@ let var_of_name name =
 
 let lval_of_id_info _env id id_info =
   let var = var_of_id_info id id_info in
-  { base = Var var; offset = NoOffset }
+  { base = Var var; offset = [] }
 
 (* TODO: use also qualifiers? *)
 let lval_of_id_qualified env
     { G.name_last = id, _typeargsTODO; name_info = id_info; _ } =
   lval_of_id_info env id id_info
 
-let lval_of_base base = { base; offset = NoOffset }
+let lval_of_base base = { base; offset = [] }
 
 (* TODO: should do first pass on body to get all labels and assign
  * a gensym to each.
@@ -165,7 +165,7 @@ let add_instr env instr = Common.push (mk_s (Instr instr)) env.stmts
  * itself is already a variable! *)
 let mk_aux_var ?str env tok exp =
   match exp.e with
-  | Fetch ({ base = Var var; offset = NoOffset; _ } as lval) -> (var, lval)
+  | Fetch ({ base = Var var; offset = []; _ } as lval) -> (var, lval)
   | _ ->
       let var = fresh_var ?str env tok in
       let lval = lval_of_base (Var var) in
@@ -225,26 +225,38 @@ let rec lval env eorig =
   match eorig.G.e with
   | G.N n -> name env n
   | G.IdSpecial (G.This, tok) -> lval_of_base (VarSpecial (This, tok))
-  | G.DotAccess (e1orig, tok, field) -> (
+  | G.DotAccess (e1orig, tok, field) ->
+      let offset' =
+        match field with
+        | G.FN (G.Id (id, idinfo)) -> Dot (var_of_id_info id idinfo)
+        | G.FN name ->
+            let attr = expr env (G.N name |> G.e) in
+            Index attr
+        | G.FDynamic e2orig ->
+            let attr = expr env e2orig in
+            Index attr
+      in
       let e1 = nested_lval env tok e1orig in
-      match field with
-      | G.FN (G.Id (id, idinfo)) ->
-          { base = e1; offset = Dot (var_of_id_info id idinfo) }
-      | G.FN name ->
-          let attr = expr env (G.N name |> G.e) in
-          { base = e1; offset = Index attr }
-      | G.FDynamic e2orig ->
-          let attr = expr env e2orig in
-          { base = e1; offset = Index attr })
+      { e1 with offset = offset' :: e1.offset }
   | G.ArrayAccess (e1orig, (_, e2orig, _)) ->
-      let tok = G.fake "[]" in
-      let e1 = nested_lval env tok e1orig in
+      let e1 = nested_lval env (G.fake "[]") e1orig in
       let e2 = expr env e2orig in
-      { base = e1; offset = Index e2 }
+      { e1 with offset = Index e2 :: e1.offset }
   | G.DeRef (_, e1orig) ->
       let e1 = expr env e1orig in
       lval_of_base (Mem e1)
   | _ -> todo (G.E eorig)
+
+and nested_lval env tok e_gen : lval =
+  let lval =
+    match expr env e_gen with
+    | { e = Fetch lval; _ } -> lval
+    | rhs ->
+        let fresh = fresh_lval env tok in
+        add_instr env (mk_i (Assign (fresh, rhs)) (related_exp e_gen));
+        fresh
+  in
+  lval
 
 and name env = function
   | G.Id (("_", tok), _) ->
@@ -256,18 +268,6 @@ and name env = function
   | G.IdQualified qualified_info ->
       let lval = lval_of_id_qualified env qualified_info in
       lval
-
-and nested_lval env tok e_gen : base =
-  let lval =
-    match expr env e_gen with
-    | { e = Fetch ({ offset = NoOffset; _ } as lval); _ } -> lval
-    | rhs ->
-        let fresh = fresh_lval env tok in
-        add_instr env (mk_i (Assign (fresh, rhs)) (related_exp e_gen));
-        fresh
-  in
-  assert (lval.offset = NoOffset);
-  lval.base
 
 (*****************************************************************************)
 (* Pattern *)
@@ -294,7 +294,7 @@ and pattern env pat =
         |> List.mapi (fun i pat_i ->
                let eorig = Related (G.P pat_i) in
                let index_i = Literal (G.Int (Some i, tok1)) in
-               let offset_i = Index { e = index_i; eorig } in
+               let offset_i = [ Index { e = index_i; eorig } ] in
                let lval_i = { base = Var tmp; offset = offset_i } in
                pattern_assign_statements env
                  (mk_e (Fetch lval_i) eorig)
@@ -353,7 +353,7 @@ and assign env lhs tok rhs_exp e_gen =
         |> List.mapi (fun i lhs_i ->
                let index_i = Literal (G.Int (Some i, tok1)) in
                let offset_i =
-                 Index { e = index_i; eorig = related_exp lhs_i }
+                 [ Index { e = index_i; eorig = related_exp lhs_i } ]
                in
                let lval_i = { base = Var tmp; offset = offset_i } in
                assign env lhs_i tok1
@@ -398,7 +398,7 @@ and assign env lhs tok rhs_exp e_gen =
                  let vari_lval = lval_of_base (Var vari) in
                  let ei =
                    mk_e
-                     (Fetch { base = Var tmp; offset = Dot fldi })
+                     (Fetch { base = Var tmp; offset = [ Dot fldi ] })
                      (related_tok tok)
                  in
                  add_instr env (mk_i (Assign (vari_lval, ei)) (related_tok tok));
@@ -446,7 +446,7 @@ and expr_aux env ?(void = false) e_gen =
               fresh_var env tok ~str:(Parse_info.str_of_info tok)
             in
             let method_lval =
-              { base = Var obj_var; offset = Dot method_name }
+              { base = Var obj_var; offset = [ Dot method_name ] }
             in
             let method_ = { e = Fetch method_lval; eorig = related_tok tok } in
             add_call env tok eorig ~void (fun res -> Call (res, method_, args'))
@@ -1428,7 +1428,7 @@ and python_with_stmt env manager opt_pat body =
       (* type(mgr).__method___ *)
       {
         base = Var type_mgr_var;
-        offset = Dot (fresh_var env G.sc ~str:method_name);
+        offset = [ Dot (fresh_var env G.sc ~str:method_name) ];
       }
     in
     let ss =

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -96,7 +96,7 @@ let result_of_function_call_is_constant lang f args =
                     ident = ("escapeshellarg" | "htmlspecialchars_decode"), _;
                     _;
                   };
-              offset = NoOffset;
+              offset = [];
             };
         _;
       },
@@ -108,11 +108,15 @@ let result_of_function_call_is_constant lang f args =
         (* If there is an offset, the full resolved name will be found
            there. Otherwise, it will be found in the base *)
         e =
-          ( Fetch { offset = Dot { ident; id_info = { id_resolved; _ }; _ }; _ }
+          ( Fetch
+              {
+                offset = Dot { ident; id_info = { id_resolved; _ }; _ } :: _;
+                _;
+              }
           | Fetch
               {
                 base = Var { ident; id_info = { id_resolved; _ }; _ };
-                offset = NoOffset | Index _;
+                offset = Index _ :: _ | [];
               } );
         _;
       },
@@ -319,7 +323,7 @@ let rec eval (env : G.svalue Var_env.t) exp : G.svalue =
 
 and eval_lval env lval =
   match lval with
-  | { base = Var x; offset = NoOffset } -> (
+  | { base = Var x; offset = [] } -> (
       let opt_c = VarMap.find_opt (str_of_name x) env in
       match (!(x.id_info.id_svalue), opt_c) with
       | None, None -> G.NotCst
@@ -495,11 +499,11 @@ let transfer :
     | NInstr instr -> (
         (* TODO: For now we only handle the simplest cases. *)
         match instr.i with
-        | Assign ({ base = Var var; offset = NoOffset }, exp) ->
+        | Assign ({ base = Var var; offset = [] }, exp) ->
             (* var = exp *)
             let cexp = eval_or_sym_prop inp' exp in
             update_env_with inp' var cexp
-        | Call (Some { base = Var var; offset = NoOffset }, func, args) ->
+        | Call (Some { base = Var var; offset = [] }, func, args) ->
             let args_val = Common.map (eval inp') args in
             if result_of_function_call_is_constant lang func args_val then
               VarMap.add (str_of_name var) (G.Cst G.Cstr) inp'
@@ -510,13 +514,15 @@ let transfer :
                * call itself as a symbolic expression. *)
               let ccall = sym_prop instr.iorig in
               update_env_with inp' var ccall
-        | CallSpecial
-            (Some { base = Var var; offset = NoOffset }, (Concat, _), args) ->
+        | CallSpecial (Some { base = Var var; offset = [] }, (Concat, _), args)
+          ->
             (* var = concat(args) *)
             let cexp = eval_concat inp' args in
             update_env_with inp' var cexp
-        | Call (None, { e = Fetch { base = Var var; offset = Dot _; _ }; _ }, _)
-          ->
+        | Call
+            ( None,
+              { e = Fetch { base = Var var; offset = Dot _ :: _; _ }; _ },
+              _ ) ->
             (* Method call `var.f(args)` that returns void, we conservatively
              * assume that it may be updating `var`; e.g. in Ruby strings are
              * mutable. *)
@@ -527,7 +533,9 @@ let transfer :
             let lvar_opt = LV.lvar_of_instr_opt instr in
             match lvar_opt with
             | None -> inp'
-            | Some lvar -> VarMap.remove (str_of_name lvar) inp'))
+            | Some (lvar, [])
+            | Some (_, lvar :: _) ->
+                VarMap.remove (str_of_name lvar) inp'))
   in
 
   { D.in_env = inp'; out_env = out' }

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -7,11 +7,12 @@ let string_of_lval x =
       Common.spf "%s:%d" (fst n.ident) n.sid
   | VarSpecial _ -> "<varspecial>"
   | Mem _ -> "<Mem>")
-  ^
-  match x.offset with
-  | NoOffset -> ""
-  | Dot n -> "." ^ str_of_name n
-  | Index _ -> "[...]"
+  ^ List.fold_left
+      (fun s o ->
+        match o with
+        | Dot n -> s ^ "." ^ str_of_name n
+        | Index _ -> s ^ "[...]")
+      "" x.offset
 
 let string_of_exp e =
   match e.e with

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -1,18 +1,22 @@
 open IL
 
-let string_of_lval x =
-  (match x.base with
-  | Var n ->
-      (* coupling: Dataflow_xyz.str_of_name *)
-      Common.spf "%s:%d" (fst n.ident) n.sid
-  | VarSpecial _ -> "<varspecial>"
-  | Mem _ -> "<Mem>")
-  ^ List.fold_left
-      (fun s o ->
-        match o with
-        | Dot n -> s ^ "." ^ str_of_name n
-        | Index _ -> s ^ "[...]")
-      "" x.offset
+let string_of_base base =
+  match base with
+  | Var x -> str_of_name x ^ ":" ^ string_of_int x.sid
+  | VarSpecial _ -> "<VarSpecial>"
+  | Mem _ -> "<Mem>"
+
+let string_of_offset offset =
+  match offset with
+  | Dot a -> str_of_name a
+  | Index _ -> "[...]"
+
+let string_of_lval { base; rev_offset } =
+  string_of_base base
+  ^
+  if rev_offset <> [] then
+    "." ^ String.concat "." (List.rev_map string_of_offset rev_offset)
+  else ""
 
 let string_of_exp e =
   match e.e with

--- a/semgrep-core/src/core/il/Display_IL.mli
+++ b/semgrep-core/src/core/il/Display_IL.mli
@@ -9,4 +9,7 @@ val display_cfg : IL.cfg -> unit
 val short_string_of_node_kind : IL.node_kind -> string
 
 (*e: signature [[Meta_IL.short_string_of_node_kind]] *)
+
+val string_of_lval : IL.lval -> string
+
 (*e: pfff/lang_GENERIC/analyze/Meta_IL.mli *)

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -154,7 +154,8 @@ let any_of_orig = function
 (*****************************************************************************)
 
 (* An lvalue, represented as in CIL as a pair. *)
-type lval = { base : base; offset : offset }
+(* The offset list is *backwards* *)
+type lval = { base : base; offset : offset list }
 
 and base =
   | Var of name
@@ -164,7 +165,6 @@ and base =
   | Mem of exp
 
 and offset =
-  | NoOffset
   (* What about nested field access? foo.x.y?
    * - use intermediate variable for that. TODO? same semantic?
    * - do as in CIL and have recursive offset and stop with NoOffset.

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -153,9 +153,16 @@ let any_of_orig = function
 (* Lvalue *)
 (*****************************************************************************)
 
-(* An lvalue, represented as in CIL as a pair. *)
-(* The offset list is *backwards* *)
-type lval = { base : base; offset : offset list }
+type lval = { base : base; rev_offset : offset list }
+(** An lvalue, represented similarly as in CIL as a pair: base and offsets.
+
+  The offset list is *reversed*, so the first element in this list is the _last_
+  offset!
+
+  old: Previously we only kept one offset in lval and instead we used auxiliary
+       variables. But then we added field sensitivity to taint-mode and all those
+       extra variables became a problem, they would force us to add alias analysis
+       to handle even trivial cases of field sensitivity. *)
 
 and base =
   | Var of name
@@ -165,10 +172,7 @@ and base =
   | Mem of exp
 
 and offset =
-  (* What about nested field access? foo.x.y?
-   * - use intermediate variable for that. TODO? same semantic?
-   * - do as in CIL and have recursive offset and stop with NoOffset.
-   * What about computed field names?
+  (* What about computed field names?
    * - handle them in Special?
    * - convert in Index with a string exp?
    * Note that Dot is used to access many different kinds of entities:

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -13,30 +13,15 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
  *)
-open Common
 open IL
 
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* Lvalue/Rvalue helpers working on the IL
- *)
 
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-let lval_of_instr_opt x =
-  match x.i with
-  | Assign (lval, _)
-  | AssignAnon (lval, _)
-  | Call (Some lval, _, _)
-  | CallSpecial (Some lval, _, _) ->
-      Some lval
-  | Call _
-  | CallSpecial _ ->
-      None
-  | FixmeInstr _ -> None
+let compare_name x y =
+  let ident_cmp = String.compare (fst x.ident) (fst y.ident) in
+  if ident_cmp <> 0 then ident_cmp else Int.compare x.sid y.sid
 
 let rexps_of_instr x =
   match x.i with
@@ -76,7 +61,7 @@ and lvals_in_lval lval =
       (function
         | Index e -> lvals_of_exp e
         | _ -> [])
-      lval.offset
+      lval.rev_offset
   in
   base_lvals @ offset_lvals
 
@@ -88,43 +73,54 @@ let rlvals_of_instr x =
   lvals_of_exps exps
 
 (*****************************************************************************)
-(* API *)
+(* Public *)
 (*****************************************************************************)
 
-let dotted_lvars_of_lval = function
-  | { base = Var name; offset } -> (
-      let id, tok = name.ident in
-      let str_of_name name = Common.spf "%s-%d" (fst name.ident) name.sid in
-      let dot_strs =
-        List.fold_right
-          (fun o s ->
-            match (s, o) with
-            | Some (s :: ss), Dot name ->
-                let x = s ^ "." ^ str_of_name name in
-                Some (x :: s :: ss)
-            | Some [], Dot name -> Some [ "." ^ str_of_name name ]
-            (* We only care about tracking taint through fields
-             * So if we hit a non-Dot offset, we just give up
-             *)
-            | Some _, Index _
-            | None, _ ->
-                None)
-          offset (Some [])
-      in
-      match dot_strs with
-      | None -> []
-      | Some dot_strs ->
-          let add_dots dots = { name with ident = (id ^ ";" ^ dots, tok) } in
-          Common.map add_dots dot_strs)
-  | _ -> []
+let lval_is_var_and_dots { base; rev_offset } =
+  match base with
+  | Var _ ->
+      rev_offset
+      |> List.for_all (function
+           | Dot _ -> true
+           | Index _ -> false)
+  | VarSpecial _
+  | Mem _ ->
+      false
+
+let lval_is_dotted_prefix lval1 lval2 =
+  let eq_name x y = compare_name x y = 0 in
+  let rec offset_prefix os1 os2 =
+    match (os1, os2) with
+    | [], _ -> true
+    | _ :: _, [] -> false
+    | Index _ :: _, _
+    | _, Index _ :: _ ->
+        false
+    | Dot a :: os1, Dot b :: os2 -> eq_name a b && offset_prefix os1 os2
+  in
+  match (lval1, lval2) with
+  | { base = Var x; rev_offset = ro1 }, { base = Var y; rev_offset = ro2 } ->
+      eq_name x y && offset_prefix (List.rev ro1) (List.rev ro2)
+  | _ -> false
+
+let lval_of_instr_opt x =
+  match x.i with
+  | Assign (lval, _)
+  | AssignAnon (lval, _)
+  | Call (Some lval, _, _)
+  | CallSpecial (Some lval, _, _) ->
+      Some lval
+  | Call _
+  | CallSpecial _ ->
+      None
+  | FixmeInstr _ -> None
 
 let lvar_of_instr_opt x =
-  let* lval = lval_of_instr_opt x in
-  match lval with
-  | { base = Var base_name; _ } ->
-      let dots = dotted_lvars_of_lval lval in
-      Some (base_name, dots)
-  | _ -> None
+  match lval_of_instr_opt x with
+  | Some { base = Var x; _ } -> Some x
+  | Some _
+  | None ->
+      None
 
 let rlvals_of_node = function
   | Enter
@@ -142,3 +138,26 @@ let rlvals_of_node = function
   | NOther _
   | NTodo _ ->
       []
+
+module LvalOrdered = struct
+  type t = lval
+
+  let compare lval1 lval2 =
+    (* Right now we only care about comparing lvals of the form `x.a_1. ... . a_n,
+       so it's OK if `Stdlib.compare` may not be the ideal comparison function for
+       the remaining cases. *)
+    match (lval1, lval2) with
+    | { base = Var x; rev_offset = ro1 }, { base = Var y; rev_offset = ro2 } ->
+        let name_cmp = compare_name x y in
+        if name_cmp <> 0 then name_cmp
+        else
+          List.compare
+            (fun offset1 offset2 ->
+              match (offset1, offset2) with
+              | Dot a, Dot b -> compare_name a b
+              | Index _, _
+              | _, Index _ ->
+                  Stdlib.compare offset1 offset2)
+            ro1 ro2
+    | _, _ -> Stdlib.compare lval1 lval2
+end

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -72,9 +72,11 @@ and lvals_in_lval lval =
     | _else_ -> []
   in
   let offset_lvals =
-    match lval.offset with
-    | Index e -> lvals_of_exp e
-    | __else_ -> []
+    List.concat_map
+      (function
+        | Index e -> lvals_of_exp e
+        | _ -> [])
+      lval.offset
   in
   base_lvals @ offset_lvals
 
@@ -89,13 +91,40 @@ let rlvals_of_instr x =
 (* API *)
 (*****************************************************************************)
 
+let dotted_lvars_of_lval = function
+  | { base = Var name; offset } -> (
+      let id, tok = name.ident in
+      let str_of_name name = Common.spf "%s-%d" (fst name.ident) name.sid in
+      let dot_strs =
+        List.fold_right
+          (fun o s ->
+            match (s, o) with
+            | Some (s :: ss), Dot name ->
+                let x = s ^ "." ^ str_of_name name in
+                Some (x :: s :: ss)
+            | Some [], Dot name -> Some [ "." ^ str_of_name name ]
+            (* We only care about tracking taint through fields
+             * So if we hit a non-Dot offset, we just give up
+             *)
+            | Some _, Index _
+            | None, _ ->
+                None)
+          offset (Some [])
+      in
+      match dot_strs with
+      | None -> []
+      | Some dot_strs ->
+          let add_dots dots = { name with ident = (id ^ ";" ^ dots, tok) } in
+          Common.map add_dots dot_strs)
+  | _ -> []
+
 let lvar_of_instr_opt x =
   let* lval = lval_of_instr_opt x in
-  match lval.base with
-  | Var n -> Some n
-  | VarSpecial _
-  | Mem _ ->
-      None
+  match lval with
+  | { base = Var base_name; _ } ->
+      let dots = dotted_lvars_of_lval lval in
+      Some (base_name, dots)
+  | _ -> None
 
 let rlvals_of_node = function
   | Enter

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.mli
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.mli
@@ -1,2 +1,3 @@
-val lvar_of_instr_opt : IL.instr -> IL.name option
+val dotted_lvars_of_lval : IL.lval -> IL.name list
+val lvar_of_instr_opt : IL.instr -> (IL.name * IL.name list) option
 val rlvals_of_node : IL.node_kind -> IL.lval list

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.mli
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.mli
@@ -1,3 +1,27 @@
-val dotted_lvars_of_lval : IL.lval -> IL.name list
-val lvar_of_instr_opt : IL.instr -> (IL.name * IL.name list) option
+(** Lvalue/Rvalue helpers working on the IL *)
+
+val lval_is_var_and_dots : IL.lval -> bool
+(** Test whether an lvalue is of the form x.a_1. ... .a_n *)
+
+val lval_is_dotted_prefix : IL.lval -> IL.lval -> bool
+(** [lval_is_dotted_prefix lval1 lval2] tests whether [lval1] is of the
+    form x.a_1. ... .a_n, and whether [lval2] is an extension of [lval1],
+    that is, x.a_1. ... .a_n.o_1 ... . o_M. *)
+
+val lval_of_instr_opt : IL.instr -> IL.lval option
+(** If the given instruction stores its result in [lval] then it is
+    [Some lval], otherwise it is [None]. *)
+
+val lvar_of_instr_opt : IL.instr -> IL.name option
+(** If the given instruct stores its result in an lvalue of the form
+    x.o_1. ... .o_N, then it is [Some x], otherwise it is [None]. *)
+
 val rlvals_of_node : IL.node_kind -> IL.lval list
+(** The lvalues that occur in the RHS of a node. *)
+
+(** Useful to instantiate data strutures like Map and Set. *)
+module LvalOrdered : sig
+  type t = IL.lval
+
+  val compare : t -> t -> int
+end

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -500,7 +500,7 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
       |> Common.map (fun (x : _ D.tmatch) -> (x.pm, x.spec))
       |> T.taints_of_pms
     in
-    Var_env.VarMap.add var taint env
+    Var_env.VarMap.add var (Dataflow_tainting.Tainted taint) env
   in
   let in_env =
     (* For each argument, check if it's a source and, if so, add it to the input

--- a/semgrep-core/src/engine/Match_tainting_mode.mli
+++ b/semgrep-core/src/engine/Match_tainting_mode.mli
@@ -16,7 +16,7 @@ val taint_config_of_rule :
   Rule.taint_rule ->
   (Dataflow_tainting.var option ->
   Taint.finding list ->
-  Dataflow_tainting.taint_info Dataflow_var_env.t ->
+  Taint_lval_env.t ->
   unit) ->
   Dataflow_tainting.config * debug_taint * Matching_explanation.t list
 

--- a/semgrep-core/src/engine/Match_tainting_mode.mli
+++ b/semgrep-core/src/engine/Match_tainting_mode.mli
@@ -16,7 +16,7 @@ val taint_config_of_rule :
   Rule.taint_rule ->
   (Dataflow_tainting.var option ->
   Taint.finding list ->
-  Taint.taints Dataflow_var_env.t ->
+  Dataflow_tainting.taint_info Dataflow_var_env.t ->
   unit) ->
   Dataflow_tainting.config * debug_taint * Matching_explanation.t list
 

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -44,14 +44,7 @@ let test_tainting lang file config def =
     |> String.concat ", "
     |> fun str -> "{ " ^ str ^ " }"
   in
-  let taint_info_to_str =
-    Dataflow_tainting.(
-      function
-      | MarkedClean -> "CLEAN"
-      | Tainted taint -> taint_to_str taint)
-  in
-  DataflowX.display_mapping flow mapping
-    (Dataflow_var_env.env_to_str taint_info_to_str)
+  DataflowX.display_mapping flow mapping (Taint_lval_env.to_string taint_to_str)
 
 let test_dfg_tainting rules_file file =
   let lang = List.hd (Lang.langs_of_filename file) in

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -44,8 +44,14 @@ let test_tainting lang file config def =
     |> String.concat ", "
     |> fun str -> "{ " ^ str ^ " }"
   in
+  let taint_info_to_str =
+    Dataflow_tainting.(
+      function
+      | MarkedClean -> "CLEAN"
+      | Tainted taint -> taint_to_str taint)
+  in
   DataflowX.display_mapping flow mapping
-    (Dataflow_var_env.env_to_str taint_to_str)
+    (Dataflow_var_env.env_to_str taint_info_to_str)
 
 let test_dfg_tainting rules_file file =
   let lang = List.hd (Lang.langs_of_filename file) in

--- a/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
@@ -83,7 +83,7 @@ let instr env x =
   match x.i with
   | Assign (lval, e) -> (
       match (lval, e.e) with
-      | { base = Var n; offset = NoOffset }, Literal (G.Int s) ->
+      | { base = Var n; offset = [] }, Literal (G.Int s) ->
           let v = var_of_name env n in
           let h = heap_of_int env s in
           add env (D.PointTo (v, h))

--- a/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
@@ -83,7 +83,7 @@ let instr env x =
   match x.i with
   | Assign (lval, e) -> (
       match (lval, e.e) with
-      | { base = Var n; offset = [] }, Literal (G.Int s) ->
+      | { base = Var n; rev_offset = [] }, Literal (G.Int s) ->
           let v = var_of_name env n in
           let h = heap_of_int env s in
           add env (D.PointTo (v, h))

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -65,6 +65,14 @@ type a_propagator = {
   var : var;
 }
 
+type taint_info = Tainted of Taints.t | MarkedClean
+
+let equal_taint_info a b =
+  match (a, b) with
+  | Tainted taints1, Tainted taints2 -> Taints.equal taints1 taints2
+  | MarkedClean, MarkedClean -> true
+  | _ -> false
+
 type config = {
   filepath : Common.filename;
   rule_id : string;
@@ -73,14 +81,14 @@ type config = {
   is_sink : G.any -> R.taint_sink tmatch list;
   is_sanitizer : G.any -> R.taint_sanitizer tmatch list;
   unify_mvars : bool;
-  handle_findings : var option -> T.finding list -> Taints.t Var_env.t -> unit;
+  handle_findings : var option -> T.finding list -> taint_info Var_env.t -> unit;
 }
 
-type mapping = Taints.t Var_env.mapping
+type mapping = taint_info Var_env.mapping
 
 (* HACK: Tracks tainted functions intrafile. *)
 type fun_env = (var, Taints.t) Hashtbl.t
-type var_env = Taints.t VarMap.t
+type var_env = taint_info VarMap.t
 
 type env = {
   config : config;
@@ -99,7 +107,15 @@ let hook_function_taint_signature = ref None
 (* Helpers *)
 (*****************************************************************************)
 
-let union_vars = Var_env.varmap_union Taints.union
+let union_taint_info a b =
+  match (a, b) with
+  | MarkedClean, MarkedClean -> MarkedClean
+  | Tainted taints1, Tainted taints2 -> Tainted (Taints.union taints1 taints2)
+  | MarkedClean, Tainted taint
+  | Tainted taint, MarkedClean ->
+      Tainted taint
+
+let union_vars = Var_env.varmap_union union_taint_info
 
 let union_map_taints_and_vars env f xs =
   xs
@@ -281,7 +297,7 @@ let exp_is_sanitized env exp =
   | [] -> None
   | sanitizer_pms -> (
       match exp.e with
-      | Fetch { base = Var var; offset = NoOffset; _ } ->
+      | Fetch { base = Var var; offset = []; _ } ->
           Some (sanitize_var env.var_env sanitizer_pms var)
       | _ -> Some env.var_env)
 
@@ -290,9 +306,11 @@ let add_taint_to_strid_in_env var_env strid taints =
   else
     VarMap.update strid
       (function
-        | None -> Some taints
+        | None
+        | Some MarkedClean ->
+            Some (Tainted taints)
         (* THINK: couldn't we just replace the existing taints? *)
-        | Some taints' -> Some (Taints.union taints taints'))
+        | Some (Tainted taints') -> Some (Tainted (Taints.union taints taints')))
       var_env
 
 (* Add `var -> taints` to `var_env`. *)
@@ -338,8 +356,11 @@ let handle_taint_propagators env x taints =
     List.fold_left
       (fun taints_in_acc prop ->
         let taints_strid =
-          VarMap.find_opt prop.spec.var var_env
-          |> Option.value ~default:Taints.empty
+          VarMap.find_opt prop.spec.var var_env |> function
+          | None
+          | Some MarkedClean ->
+              Taints.empty
+          | Some (Tainted taints) -> taints
         in
         Taints.union taints_in_acc taints_strid)
       Taints.empty propagate_tos
@@ -385,8 +406,11 @@ let check_tainted_var env (var : IL.name) : Taints.t * var_env =
       let taints_sources_reg = reg_source_pms |> taints_of_matches
       and taints_sources_mut = mut_source_pms |> taints_of_matches
       and taints_var_env =
-        VarMap.find_opt (str_of_name var) env.var_env
-        |> Option.value ~default:Taints.empty
+        VarMap.find_opt (str_of_name var) env.var_env |> function
+        | None
+        | Some MarkedClean ->
+            Taints.empty
+        | Some (Tainted taints) -> taints
       and taints_fun_env =
         (* TODO: Move this to check_tainted_instr ? *)
         Hashtbl.find_opt env.fun_env (str_of_name var)
@@ -421,23 +445,41 @@ let rec check_tainted_expr env exp : Taints.t * var_env =
   in
   let check_offset env = function
     | Index e -> check env e
-    | NoOffset
-    | Dot _ ->
-        (Taints.empty, env.var_env)
+    | Dot _ -> (Taints.empty, env.var_env)
   in
   let check_subexpr exp =
     match exp.e with
-    | Fetch { base = VarSpecial (This, _); offset = Dot fld; _ } ->
+    | Fetch { base = VarSpecial (This, _); offset = Dot fld :: _; _ } ->
         (* TODO: Move this to check_tainted_instr ? *)
         let taints =
           Hashtbl.find_opt env.fun_env (str_of_name fld)
           |> Option.value ~default:Taints.empty
         in
         (taints, env.var_env)
-    | Fetch { base; offset; _ } ->
-        let base_taints, var_env = check_base env base in
-        let offset_taints, var_env = check_offset { env with var_env } offset in
-        (Taints.union base_taints offset_taints, var_env)
+    | Fetch ({ base; offset; _ } as lval) -> (
+        let dotted_lvars = IL_lvalue_helpers.dotted_lvars_of_lval lval in
+        (* Find the first dotted lvar that we know something definitive about *)
+        let known_lvar_status =
+          Common.find_some_opt
+            (fun x -> VarMap.find_opt (str_of_name x) env.var_env)
+            dotted_lvars
+        in
+        let var_info =
+          match known_lvar_status with
+          | None -> `CheckTaint (Taints.empty, env.var_env)
+          | Some (Tainted t) -> `CheckTaint (t, env.var_env)
+          | Some MarkedClean -> `Clean (Taints.empty, env.var_env)
+        in
+        (* TODO: if we know two different sub dotted lvars are tainted, should we union their taints? *)
+        match var_info with
+        | `Clean info -> info
+        | `CheckTaint (var_taints, var_env) ->
+            let base_taints, var_env = check_base { env with var_env } base in
+            let offset_taints, var_env =
+              union_map_taints_and_vars { env with var_env } check_offset offset
+            in
+            ( Taints.union var_taints (Taints.union base_taints offset_taints),
+              var_env ))
     | FixmeExp (_, _, Some e) -> check env e
     | Literal _
     | FixmeExp (_, _, None) ->
@@ -611,6 +653,35 @@ let check_tainted_return env tok e : Taints.t * var_env =
   (taints, var_env')
 
 (*****************************************************************************)
+(* Find lvars with prefix *)
+(* This is kind of a horrible hack to avoid changing the fact that var_envs contain only strings *)
+(*****************************************************************************)
+
+let parse_str str =
+  match String.split_on_char ':' str with
+  | [ id_and_dots; sid ] -> (
+      match String.split_on_char ';' id_and_dots with
+      | [ id; dots ] -> Some (id, dots, sid)
+      | [ id ] -> Some (id, "", sid)
+      | _ -> None)
+  | _ -> None
+
+let rec is_prefix prefix str =
+  match (prefix, str) with
+  | c0 :: prefix, c1 :: str -> Char.equal c0 c1 && is_prefix prefix str
+  | [], _ -> true
+  | _ :: _, [] -> false
+
+let is_dotted_prefix clean_var new_var =
+  let ( let* ) x f = Option.fold x ~none:false ~some:f in
+  let* id0, dots0, sid0 = parse_str clean_var in
+  let* id1, dots1, sid1 = parse_str new_var in
+  String.equal id0 id1 && String.equal sid0 sid1
+  && is_prefix
+       (List.of_seq (String.to_seq dots0))
+       (List.of_seq (String.to_seq dots1))
+
+(*****************************************************************************)
 (* Transfer *)
 (*****************************************************************************)
 
@@ -631,34 +702,56 @@ let input_env ~enter_env ~(flow : F.cfg) mapping ni =
 let (transfer :
       config ->
       fun_env ->
-      Taints.t Var_env.t ->
+      taint_info Var_env.t ->
       string option ->
       flow:F.cfg ->
-      Taints.t Var_env.transfn) =
+      taint_info Var_env.transfn) =
  fun config fun_env enter_env opt_name ~flow
      (* the transfer function to update the mapping at node index ni *)
        mapping ni ->
   (* DataflowX.display_mapping flow mapping show_tainted; *)
-  let in' : Taints.t VarMap.t = input_env ~enter_env ~flow mapping ni in
+  let in' : taint_info VarMap.t = input_env ~enter_env ~flow mapping ni in
   let node = flow.graph#nodes#assoc ni in
-  let out' : Taints.t VarMap.t =
+  let out' : taint_info VarMap.t =
     let env = { config; fun_name = opt_name; fun_env; var_env = in' } in
     match node.F.n with
     | NInstr x -> (
         let taints, var_env' = check_tainted_instr env x in
+        let lvar = LV.lvar_of_instr_opt x in
         let var_env' =
-          match LV.lvar_of_instr_opt x with
+          match lvar with
           | None -> var_env'
-          | Some var ->
+          | Some (name, [])
+          | Some (_, name :: _) ->
               (* We call `check_tainted_var` here because the assigned `var`
                * itself could be annotated as a source of taint. *)
-              check_tainted_var { env with var_env = var_env' } var |> snd
+              check_tainted_var { env with var_env = var_env' } name |> snd
         in
-        match (Taints.is_empty taints, LV.lvar_of_instr_opt x) with
+        match (Taints.is_empty taints, lvar) with
         (* Instruction returns safe data, remove taint from `var`. *)
-        | true, Some var -> VarMap.remove (str_of_name var) var_env'
-        (* Instruction returns tainted data, add taints to `var`. *)
-        | false, Some var -> add_taint_to_var_in_env var_env' var taints
+        | true, Some (name, []) -> VarMap.remove (str_of_name name) var_env'
+        (* Instruction returns safe data, and we have a dotted lvar, remove taint from anything
+           with name as a dotted prefix. If [a.b] is clean then [a.b.c] and [a.b.c.d] are too
+        *)
+        | true, Some (_, name :: _) ->
+            let var = str_of_name name in
+            VarMap.fold
+              (fun str taint map ->
+                if is_dotted_prefix var str then VarMap.add str MarkedClean map
+                else VarMap.add str taint map)
+              (VarMap.add var MarkedClean var_env')
+              VarMap.empty
+        (* Instruction returns tainted data, add taint to [name] *)
+        | false, Some (name, [] | _, name :: _) ->
+            add_taint_to_var_in_env var_env' name taints
+        (* TODO: propagate taint through all dotted prefixes?
+              So tainting [a.b.c] also taints [a.b] and [a]
+
+           | false, Some (base_name, dots) ->
+               List.fold_left
+                 (fun var_env var -> add_taint_to_var_in_env var_env var taints)
+                 var_env' (base_name :: dots)
+        *)
         (* There is no variable being assigned, presumably the Instruction
          * returns 'void'. *)
         | _, None -> var_env')
@@ -694,7 +787,7 @@ let (transfer :
 (*****************************************************************************)
 
 let (fixpoint :
-      ?in_env:Taints.t Var_env.t ->
+      ?in_env:taint_info Var_env.t ->
       ?name:Var_env.var ->
       ?fun_env:fun_env ->
       config ->
@@ -710,7 +803,7 @@ let (fixpoint :
   (* THINK: Why I cannot just update mapping here ? if I do, the mapping gets overwritten later on! *)
   (* DataflowX.display_mapping flow init_mapping show_tainted; *)
   DataflowX.fixpoint
-    ~eq_env:(Var_env.eq_env Taints.equal)
+    ~eq_env:(Var_env.eq_env equal_taint_info)
     ~init:init_mapping
     ~trans:(transfer config fun_env enter_env opt_name ~flow)
       (* tainting is a forward analysis! *)

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -15,8 +15,6 @@ type a_propagator = {
   var : var; (* REMOVE USE prop.id *)
 }
 
-type taint_info = Tainted of Taint.taints | MarkedClean
-
 type config = {
   filepath : Common.filename;  (** File under analysis, for Deep Semgrep. *)
   rule_id : string;  (** Taint rule id, for Deep Semgrep. *)
@@ -63,7 +61,7 @@ type config = {
   handle_findings :
     var option (** function name ('None' if anonymous) *) ->
     Taint.finding list ->
-    taint_info Dataflow_var_env.t ->
+    Taint_lval_env.t ->
     unit;
       (** Callback to report findings. *)
 }
@@ -72,7 +70,7 @@ type config = {
   * For a source to taint a sink, the bindings of both source and sink must be
   * unifiable. See 'unify_meta_envs'. *)
 
-type mapping = taint_info Dataflow_var_env.mapping
+type mapping = Taint_lval_env.t Dataflow_core.mapping
 (** Mapping from variables to taint sources (if the variable is tainted).
   * If a variable is not in the map, then it's not tainted. *)
 
@@ -88,7 +86,7 @@ val hook_function_taint_signature :
 (** Deep Semgrep *)
 
 val fixpoint :
-  ?in_env:taint_info Dataflow_var_env.VarMap.t ->
+  ?in_env:Taint_lval_env.t ->
   ?name:var ->
   ?fun_env:fun_env (** Poor-man's interprocedural HACK (TO BE DEPRECATED) *) ->
   config ->

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -15,6 +15,8 @@ type a_propagator = {
   var : var; (* REMOVE USE prop.id *)
 }
 
+type taint_info = Tainted of Taint.taints | MarkedClean
+
 type config = {
   filepath : Common.filename;  (** File under analysis, for Deep Semgrep. *)
   rule_id : string;  (** Taint rule id, for Deep Semgrep. *)
@@ -61,7 +63,7 @@ type config = {
   handle_findings :
     var option (** function name ('None' if anonymous) *) ->
     Taint.finding list ->
-    Taint.taints Dataflow_var_env.t ->
+    taint_info Dataflow_var_env.t ->
     unit;
       (** Callback to report findings. *)
 }
@@ -70,7 +72,7 @@ type config = {
   * For a source to taint a sink, the bindings of both source and sink must be
   * unifiable. See 'unify_meta_envs'. *)
 
-type mapping = Taint.taints Dataflow_var_env.mapping
+type mapping = taint_info Dataflow_var_env.mapping
 (** Mapping from variables to taint sources (if the variable is tainted).
   * If a variable is not in the map, then it's not tainted. *)
 
@@ -86,7 +88,7 @@ val hook_function_taint_signature :
 (** Deep Semgrep *)
 
 val fixpoint :
-  ?in_env:Taint.taints Dataflow_var_env.VarMap.t ->
+  ?in_env:taint_info Dataflow_var_env.VarMap.t ->
   ?name:var ->
   ?fun_env:fun_env (** Poor-man's interprocedural HACK (TO BE DEPRECATED) *) ->
   config ->

--- a/semgrep-core/src/tainting/Taint_lval_env.ml
+++ b/semgrep-core/src/tainting/Taint_lval_env.ml
@@ -1,0 +1,165 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2022 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+module T = Taint
+module Taints = T.Taint_set
+module LV = IL_lvalue_helpers
+module Var_env = Dataflow_var_env
+module VarMap = Var_env.VarMap
+module LvalMap = Map.Make (LV.LvalOrdered)
+module LvalSet = Set.Make (LV.LvalOrdered)
+
+type t = {
+  tainted : T.taints LvalMap.t;  (** Lvalues that are tainted. *)
+  propagated : T.taints VarMap.t;
+      (** Taint that is propagated via taint propagators (internally represented by
+    unique propagator variables). *)
+  cleaned : LvalSet.t;
+      (** Lvalues that are clean, these should be extensions of other lvalues that
+      are tainted. *)
+}
+
+type env = t
+
+let empty =
+  {
+    tainted = LvalMap.empty;
+    propagated = VarMap.empty;
+    cleaned = LvalSet.empty;
+  }
+
+let empty_inout = { Dataflow_core.in_env = empty; out_env = empty }
+
+let union le1 le2 =
+  let tainted =
+    LvalMap.union (fun _ x y -> Some (Taints.union x y)) le1.tainted le2.tainted
+  in
+  let cleaned1 =
+    le1.cleaned |> LvalSet.filter (fun lv -> not @@ LvalMap.mem lv le2.tainted)
+  in
+  let cleaned2 =
+    le2.cleaned |> LvalSet.filter (fun lv -> not @@ LvalMap.mem lv le1.tainted)
+  in
+  {
+    tainted;
+    propagated = Var_env.varmap_union Taints.union le1.propagated le2.propagated;
+    cleaned = LvalSet.union cleaned1 cleaned2;
+  }
+
+let add lval taints ({ tainted; propagated; cleaned } as lval_env) =
+  let taints =
+    (* If the lvalue is a simple variable, we record it as part of
+       the taint trace. *)
+    match lval with
+    | { IL.base = Var var; rev_offset = [] } ->
+        let var_tok = snd var.ident in
+        if Parse_info.is_fake var_tok then taints
+        else
+          taints
+          |> Taints.map (fun t -> { t with tokens = var_tok :: t.tokens })
+    | _ -> taints
+  in
+  if Taints.is_empty taints then lval_env
+  else
+    {
+      tainted =
+        LvalMap.update lval
+          (function
+            | None -> Some taints
+            (* THINK: couldn't we just replace the existing taints? *)
+            | Some taints' -> Some (Taints.union taints taints'))
+          tainted;
+      propagated;
+      cleaned = LvalSet.remove lval cleaned;
+    }
+
+(* Add `var -> taints` to `var_env`. *)
+let add_var var taints lval_env =
+  let aux = { IL.base = Var var; rev_offset = [] } in
+  add aux taints lval_env
+
+let propagate_to prop_var taints env =
+  if Taints.is_empty taints then env
+  else { env with propagated = VarMap.add prop_var taints env.propagated }
+
+let _find_lval { tainted; cleaned; _ } lval =
+  if LvalSet.mem lval cleaned then `Clean
+  else
+    match LvalMap.find_opt lval tainted with
+    | None -> `None
+    | Some taints -> `Tainted taints
+
+let find_var var lval_env =
+  let aux = { IL.base = Var var; rev_offset = [] } in
+  match _find_lval lval_env aux with
+  | `Clean
+  | `None ->
+      None
+  | `Tainted taints -> Some taints
+
+let rec find lval lval_env =
+  match _find_lval lval_env lval with
+  | `Clean -> `Clean
+  | `Tainted taints -> `Tainted taints
+  | `None -> (
+      match lval.rev_offset with
+      | _ :: rev_offset' -> find { lval with rev_offset = rev_offset' } lval_env
+      | [] -> `None)
+
+let propagate_from prop_var env = VarMap.find_opt prop_var env.propagated
+
+let clean lval { tainted; propagated; cleaned } =
+  let prefix_is_tainted =
+    tainted |> LvalMap.exists (fun lv _ -> LV.lval_is_dotted_prefix lv lval)
+  in
+  let needs_clean_mark = prefix_is_tainted && lval.rev_offset <> [] in
+  (* If [a.b] is clean then [a.b.c] and [a.b.c.d] are too *)
+  {
+    tainted =
+      tainted
+      |> LvalMap.filter (fun lv _ -> not (LV.lval_is_dotted_prefix lval lv));
+    propagated;
+    cleaned =
+      (cleaned
+      |> LvalSet.filter (fun lv -> not (LV.lval_is_dotted_prefix lval lv))
+      |> if needs_clean_mark then LvalSet.add lval else fun x -> x);
+  }
+
+let clean_var var { tainted; propagated; cleaned } =
+  let aux = { IL.base = Var var; rev_offset = [] } in
+  {
+    tainted = LvalMap.remove aux tainted;
+    propagated;
+    (* TODO: Should we remove any var.x ... from cleaned?  *)
+    cleaned;
+  }
+
+let equal le1 le2 =
+  LvalMap.equal Taints.equal le1.tainted le2.tainted
+  && VarMap.equal Taints.equal le1.propagated le2.propagated (* ? *)
+  && LvalSet.equal le1.cleaned le2.cleaned
+
+let to_string taint_to_str { tainted; propagated; cleaned } =
+  (* FIXME: lval_to_str *)
+  LvalMap.fold
+    (fun dn v s ->
+      s ^ Display_IL.string_of_lval dn ^ ":" ^ taint_to_str v ^ " ")
+    tainted "[TAINTED]"
+  ^ VarMap.fold
+      (fun dn v s -> s ^ dn ^ ":" ^ taint_to_str v ^ " ")
+      propagated "[PROPAGATED]"
+  ^ LvalSet.fold
+      (fun dn s -> s ^ Display_IL.string_of_lval dn ^ " ")
+      cleaned "[CLEANED]"

--- a/semgrep-core/src/tainting/Taint_lval_env.mli
+++ b/semgrep-core/src/tainting/Taint_lval_env.mli
@@ -1,0 +1,67 @@
+(** Lval-to-taints environments used by taint-mode.
+ *
+ * Only lvalues of the form x.a_1. ... . a_N (i.e. a variable followed by field
+ * accesses) are tracked. The main purpose of tracking fields is to remove FPs.
+ *
+ * These environments help making taint analysis sensitive to individual fields
+ * in records/objects in a limited way. Essentially, they add per variable field
+ * sensitivity, but not per object in memory field sensitivity. There is no alias
+ * analysis involved!
+ *)
+
+type t
+type env = t
+
+val empty : env
+val empty_inout : env Dataflow_core.inout
+
+val add : IL.lval -> Taint.taints -> env -> env
+(** Add taint to an lvalue.
+
+    Note that if we add taint to x.a_1. ... .a_N, the prefixes
+    x.a_1. ... .a_i (i < N) will not be considered tainted (unless they become
+    tainted separately).
+ *)
+
+val add_var : IL.name -> Taint.taints -> env -> env
+
+(* THINK: Perhaps keep propagators outside of this environment? *)
+val propagate_to : Dataflow_var_env.var -> Taint.taints -> env -> env
+
+val find : IL.lval -> env -> [ `None | `Clean | `Tainted of Taint.taints ]
+(** Find whether an lvalue is tainted or not.
+
+    [`None] means no taint.
+    [`Clean] means no taint for this particular lvalue x.a_1. ... .a_N, but
+    some of its prefixes x.a_1. ... .a_i (i < N) is tainted.
+
+    Given x.a_1. ... . a_N, it recursively checks all the prefixes of the
+    lvalue (from longest to shortest) until it finds one that is either
+    explicitly tainted (returns [`Tainted]) or explicitly clean (returns
+    [`Clean]). If none is found then it returns [`None].
+
+    If x.a.b is tainted with label B and x.a is tainted with label A,
+    the taint of x.a.b is still just B. *)
+
+val find_var : IL.name -> env -> Taint.taints option
+val propagate_from : Dataflow_var_env.var -> env -> Taint.taints option
+
+val clean : IL.lval -> env -> env
+(** Remove taint from an lvalue.
+
+    Given x.a_1. ... .a_N, it will clean that lvalue as well as all its
+    extensions x.a_1. ... .a_N. ... .a_M.  *)
+
+val clean_var : IL.name -> env -> env
+
+val union : env -> env -> env
+(** Compute the environment for the join of two branches.
+
+     If an lvalue x.a_1. ... .a_N was clean in one branch, we still consider it
+     clean in the union unless it is explicitly tainted in the other branch.
+     Note that f e.g. x.a_1. ... .a_i (with i <> N) were tainted in the other
+     branch, then  x.a_1. ... . a_N may no longer be clean, but we assume the
+     best case scenario. *)
+
+val equal : env -> env -> bool
+val to_string : (Taint.taints -> string) -> env -> string

--- a/semgrep-core/tests/OTHER/rules/deep_expr_xml.js
+++ b/semgrep-core/tests/OTHER/rules/deep_expr_xml.js
@@ -11,12 +11,14 @@ export default function TestComponent4({assets, children, title}) {
         <body>
           <noscript
             dangerouslySetInnerHTML={{
+              //OK:
               __html: `<b>Enable JavaScript to run this app.</b>`,
             }}
           />
           {children}
           <script
             dangerouslySetInnerHTML={{
+             //OK:
               __html: `assetManifest = ${JSON.stringify(assets)};`,
             }}
           />

--- a/semgrep-core/tests/OTHER/rules/field_sensitive1.js
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive1.js
@@ -1,0 +1,11 @@
+// Separately mark taint/no taint on each field of `a`
+function f() {
+    a.b = source
+    a.c = safe
+
+    //ruleid: test
+    sink(a.b)
+
+    //ok: test
+    sink(a.c)
+}

--- a/semgrep-core/tests/OTHER/rules/field_sensitive1.yaml
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive1.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+        - pattern: source
+    pattern-sinks:
+        - pattern: sink(...)
+    message: test
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/field_sensitive2.js
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive2.js
@@ -1,0 +1,14 @@
+// Mark taint on all of `a`, remember that only `a.b` is clean
+function f() {
+    a = source
+    a.b = safe
+    
+    //ruleid: test
+    sink(a)
+
+    //ruleid: test
+    sink(a.c)
+
+    //ok: test
+    sink(a.b)
+}

--- a/semgrep-core/tests/OTHER/rules/field_sensitive2.yaml
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive2.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+        - pattern: source
+    pattern-sinks:
+        - pattern: sink(...)
+    message: test
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/field_sensitive3.js
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive3.js
@@ -1,0 +1,13 @@
+// If `a.b.c` is tainted, then all its prefixes are also tainted
+function f() {
+    a.b.c = source
+
+    //ruleid: test
+    sink(a.b.c)
+
+    // These are ok because we have not enabled propagation of taint up through fields, to avoid FPs
+    //ok: test
+    sink(a.b)
+    //ok: test
+    sink(a)
+}

--- a/semgrep-core/tests/OTHER/rules/field_sensitive3.js
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive3.js
@@ -1,4 +1,3 @@
-// If `a.b.c` is tainted, then all its prefixes are also tainted
 function f() {
     a.b.c = source
 

--- a/semgrep-core/tests/OTHER/rules/field_sensitive3.yaml
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive3.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+        - pattern: source
+    pattern-sinks:
+        - pattern: sink(...)
+    message: test
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/field_sensitive4.js
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive4.js
@@ -1,0 +1,16 @@
+// If `a.b` is marked clean, then anything that is prefix of `a.b` should become clean
+function f() {
+    a.b.c = source
+    a.b.d = source
+    //ruleid: test
+    sink(a.b.c.x)
+    a.b = safe
+    //ok: test
+    sink(a.b)
+    //ok: test
+    sink(a.b.c)
+    //ok: test
+    sink(a.b.c.d)
+    //ok: test
+    sink(a.b.c.x)
+}

--- a/semgrep-core/tests/OTHER/rules/field_sensitive4.js
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive4.js
@@ -1,4 +1,5 @@
-// If `a.b` is marked clean, then anything that is prefix of `a.b` should become clean
+// If `a.b` is marked clean, then any l-value that starts with `a.b` should
+// become clean too!
 function f() {
     a.b.c = source
     a.b.d = source

--- a/semgrep-core/tests/OTHER/rules/field_sensitive4.yaml
+++ b/semgrep-core/tests/OTHER/rules/field_sensitive4.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+        - pattern: source
+    pattern-sinks:
+        - pattern: sink(...)
+    message: test
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/taint_flask.py
+++ b/semgrep-core/tests/OTHER/rules/taint_flask.py
@@ -1,0 +1,47 @@
+from flask import Flask, render_template, session, request
+from pyappdata.flask import appdata
+import settings
+import logging
+import json
+from logging.handlers import RotatingFileHandler
+
+app = Flask(__name__)
+app.secret_key = settings.secret_key
+app.config.from_object(settings.configClass)
+
+formatter = logging.Formatter(settings.LOG_FORMAT)
+handler = RotatingFileHandler(
+    settings.LOG_FILE,
+    maxBytes=settings.LOG_MAX_BYTES,
+    backupCount=settings.LOG_BACKUP_COUNT
+)
+handler.setLevel(logging.getLevelName(settings.LOG_LEVEL))
+handler.setFormatter(formatter)
+app.logger.addHandler(handler)
+
+def return_error(msg):
+    return render_template('error.htm.j2', msg=msg)
+
+
+def error(exception=None):
+    app.logger.error("Pyappdata error: {}".format(exception))
+    return return_error('''Authentication error,
+        please refresh and try again. If this error persists,
+        please contact support.''')
+
+
+@app.route('/launch', methods=['POST', 'GET'])
+@appdata(error=error, request='initial', role='any', app=app)
+def launch():
+    session['person_name_full'] = request.form.get('person_name_full')
+    app.logger.info(json.dumps(request.form, indent=2))
+    #ruleid: user-input
+    return render_template('launch.htm.j2', person_name_full=session['person_name_full'])
+
+
+# Home page
+@app.route('/', methods=['GET'])
+def index():
+    return render_template('index.htm.j2')
+
+print("Hi")

--- a/semgrep-core/tests/OTHER/rules/taint_flask.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_flask.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: user-input
+    languages: [python]
+    mode: taint
+    pattern-sources:
+    - pattern: flask.request
+    pattern-sinks:
+    - patterns:
+      - pattern: flask.render_template("$TEMPLATE", ..., $KWARG=$VAR, ...)
+      - metavariable-regex:
+          metavariable: $TEMPLATE
+          regex: ".*(?<!html)$"
+    message: |
+      Detected a XSS vulnerability: '$VAR' is rendered
+      unsafely in '$TEMPLATE'.
+    severity: ERROR


### PR DESCRIPTION
Closes PA-1278

This PR makes taint analysis sensitive to individual fields in records/objects in a limited way. Essentially, it adds _per variable_ field sensitivity and not _per object in memory_ field sensitivity. There is no alias analysis involved. A summary of new behavior

 1. Taintedness/cleaness is tracked individually for each field of each variable
 2. If a field `a.b.c` is marked tainted, it does not affect whether `a` and `a.b` are marked tainted. This should reduce FPs at the cost of more FNs. This could be considered a *breaking* change, but hopefully for the best. 
 3. If a field `a.b.c` is marked clean, then `a.b.c` and any previously tainted field of which `a.b.c` is a _prefix_ is marked clean. So `a.b.c.d` will now be clean, even if had been previously tainted.
 4. When checking the taintedness of some dot expression `a.b.c.d`, we use the most up to date knowledge of its fields. That is, if we know only that `a.b` is tainted, then `a.b.c.d` is tainted. But if we know that `a.b.c` was marked clean after `a.b` was tainted, then `a.b.c.d` is clean.

The following technical changes are needed to enable this behavior:
1. IL lvals now have their offsets represented as _backwards lists_. So `a.b.c` is `{base = a, rev_offset = [.c ; .b]}`. This allows even nested field access lvals to be represented as single variables.
2. We differentiate between a variable with _unknown taint_ and one with _known lack of taint_. To see why this is needed, consider:
    ```
    a = source
    a.b = safe
    sink(a.b)
    ```
    If `a.b = safe` simply removed the string corresponding to `a.b` from the set of tainted variables, it would do nothing. We need to specifically remember the fact that `a.b` is clean!

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
