### PR TITLE
chore(test-autofix): Prevent source pollution in test

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -357,6 +357,9 @@ def run_semgrep():
 
 @pytest.fixture
 def run_semgrep_in_tmp(monkeypatch, tmp_path):
+    """
+    Note that this can cause failures if Semgrep pollutes either the targets or rules path
+    """
     (tmp_path / "targets").symlink_to(Path(TESTS_PATH / "e2e" / "targets").resolve())
     (tmp_path / "rules").symlink_to(Path(TESTS_PATH / "e2e" / "rules").resolve())
     monkeypatch.chdir(tmp_path)
@@ -364,12 +367,12 @@ def run_semgrep_in_tmp(monkeypatch, tmp_path):
     yield _run_semgrep
 
 
-# Needed to test the project-depends-on rules
-# pathlib.glob (and semgrep by extension) do not traverse into symlinks
-# Lockfile targeting begins at the parent of the first semgrep target
-# which in this case is tmp_path, which normally contains only symlinks :/
 @pytest.fixture
-def run_semgrep_in_tmp_no_symlink(monkeypatch, tmp_path):
+def run_semgrep_on_copied_files(monkeypatch, tmp_path):
+    """
+    Like run_semgrep_in_tmp, but fully copies rule and target data to avoid
+    directory pollution, also avoids issues with symlink navigation
+    """
     copytree(Path(TESTS_PATH / "e2e" / "targets").resolve(), tmp_path / "targets")
     copytree(Path(TESTS_PATH / "e2e" / "rules").resolve(), tmp_path / "rules")
     monkeypatch.chdir(tmp_path)

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-not-dryrun/results.json
@@ -17,9 +17,6 @@
       "extra": {
         "fingerprint": "4a33397409b7b2d0e677e2e515c526be5568d00a2bf740196e13536ad2b2dfa554167db90394ec8e9779a89eb3ca6e98d86d690f9cc9625fca1fc18be633b1ac_0",
         "fix": "inputs.get(x)",
-        "fixed_lines": [
-          "  inputs.get(x) = 1"
-        ],
         "is_ignored": false,
         "lines": "  inputs[x] = 1",
         "message": "Use `.get()` method to avoid a KeyNotFound error",
@@ -79,9 +76,6 @@
       "extra": {
         "fingerprint": "592b33f0145ca2899616e587fca10aed02dc2cb1261f5e39597f7b66464e2c89cacb4a318c010006c6126e6a0de0a764a2b281dbad87315460dbbbd9a44cd412_0",
         "fix": "inputs.get(x + 1)",
-        "fixed_lines": [
-          "  if inputs.get(x + 1) == True:"
-        ],
         "is_ignored": false,
         "lines": "  if inputs[x + 1] == True:",
         "message": "Use `.get()` method to avoid a KeyNotFound error",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixcsv-writer.yaml-autofixcsv-writer.py-not-dryrun/results.json
@@ -20,9 +20,6 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
-        "fixed_lines": [
-          "csv.writer(csvfile, delimiter=',', quotechar='\"', quoting=csv.QUOTE_ALL)"
-        ],
         "is_ignored": false,
         "lines": "csv.writer(csvfile, delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",
@@ -56,9 +53,6 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, quoting=csv.QUOTE_ALL)"
         },
-        "fixed_lines": [
-          "csv.writer(get_file(), delimiter=',', quotechar='\"', quoting=csv.QUOTE_ALL)"
-        ],
         "is_ignored": false,
         "lines": "csv.writer(get_file(), delimiter=',', quotechar='\"')",
         "message": "Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdefaulthttpclient.yaml-autofixdefaulthttpclient.java-not-dryrun/results.json
@@ -20,9 +20,6 @@
           "regex": "DefaultHttpClient\\(",
           "replacement": "SystemDefaultHttpClient("
         },
-        "fixed_lines": [
-          "\t\tHttpClient client = new SystemDefaultHttpClient();"
-        ],
         "is_ignored": false,
         "lines": "\t\tHttpClient client = new DefaultHttpClient();",
         "message": "DefaultHttpClient is deprecated. Further, it does not support connections\nusing TLS1.2, which makes using DefaultHttpClient a security hazard.\nUse SystemDefaultHttpClient instead, which supports TLS1.2.\n",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-not-dryrun/results.json
@@ -20,12 +20,6 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
-        "fixed_lines": [
-          "        new_password = request.data.get(\"password\", None)",
-          "        validate_password(new_password, user=user)",
-          "        user.set_password(new_password)",
-          "        user.save()"
-        ],
         "is_ignored": false,
         "lines": "        new_password = request.data.get(\"password\", \"\")\n        validate_password(new_password, user=user)\n        user.set_password(new_password)\n        user.save()",
         "message": "'new_password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",
@@ -128,19 +122,6 @@
           "regex": "(password.*)\"\"",
           "replacement": "\\1None"
         },
-        "fixed_lines": [
-          "    def create_user(self, email, password=None):",
-          "        \"\"\"",
-          "        Creates and saves a Poster with the given email and password.",
-          "        \"\"\"",
-          "        if not email:",
-          "            raise ValueError('Users must have an email address')",
-          "",
-          "        user = self.model(email=self.normalize_email(email))",
-          "        user.set_password(password)",
-          "        user.save(using=self._db)",
-          "        return user"
-        ],
         "is_ignored": false,
         "lines": "    def create_user(self, email, password=\"\"):\n        \"\"\"\n        Creates and saves a Poster with the given email and password.\n        \"\"\"\n        if not email:\n            raise ValueError('Users must have an email address')\n\n        user = self.model(email=self.normalize_email(email))\n        user.set_password(password)\n        user.save(using=self._db)\n        return user",
         "message": "'password' is using the empty string as its default and is being used to set\nthe password on 'user'. If you meant to set an unusable password, set\nthe default value to 'None' or call 'set_unusable_password()'.\n",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-not-dryrun/results.json
@@ -21,9 +21,6 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
-        "fixed_lines": [
-          "    return flask.jsonify(user_dict)"
-        ],
         "is_ignored": false,
         "lines": "    return json.dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",
@@ -70,9 +67,6 @@
           "regex": "(json\\.){0,1}dumps",
           "replacement": "flask.jsonify"
         },
-        "fixed_lines": [
-          "    return flask.jsonify(user_dict)"
-        ],
         "is_ignored": false,
         "lines": "    return dumps(user_dict)",
         "message": "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-not-dryrun/results.json
@@ -17,9 +17,6 @@
       "extra": {
         "fingerprint": "e5002706f4a47ec1426dbf547dd222507334ffa884506e66d0a86a4a96273f49a23ca5c5bfade9187a8520ac36a40df4d9e13928c159c85d18e1fbb02078cb5e_0",
         "fix": "wrap(\"a\")",
-        "fixed_lines": [
-          "        return wrap(\"a\") + \"b\";"
-        ],
         "is_ignored": false,
         "lines": "        return \"a\" + \"b\";",
         "message": "Wrap strings",
@@ -62,9 +59,6 @@
       "extra": {
         "fingerprint": "9bea0af7038080d9689cbcddeba562ce5b15d36e7baaba682812eb4ac7b9c431b8f10715c399e56cf070bd526fed6502f2587d7209ce4f9f0121e4ef1b8c75e4_1",
         "fix": "wrap(\"b\")",
-        "fixed_lines": [
-          "        return \"a\" + wrap(\"b\");"
-        ],
         "is_ignored": false,
         "lines": "        return \"a\" + \"b\";",
         "message": "Wrap strings",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
@@ -17,9 +17,6 @@
       "extra": {
         "fingerprint": "2eebc4dac7d402148a5565787d195bafb27e2902a43519614d0eae483689a085fd841aa534bdac28a09684809a42ae9bc516ec4e79c804dd138efcc905f0a760_0",
         "fix": "a_function_call (wrap (the_argument))",
-        "fixed_lines": [
-          "let one = a_function_call (wrap (the_argument))"
-        ],
         "is_ignored": false,
         "lines": "let one = a_function_call the_argument",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -62,9 +59,6 @@
       "extra": {
         "fingerprint": "160b7c0475d9423f449797c1b3ad86bfee51e1c0fe60989a120481ca92f70c270a99be5387fd20593e5b6f467c3fda830b2678e4a1a236389f29f7ef5c07df24_0",
         "fix": "a_function_call (wrap ((the_argument)))",
-        "fixed_lines": [
-          "let two = a_function_call (wrap ((the_argument)))"
-        ],
         "is_ignored": false,
         "lines": "let two = a_function_call (the_argument)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -107,9 +101,6 @@
       "extra": {
         "fingerprint": "6df85294f747752d911dc7312d6a7c4cf9237ad45297093bfbaf316360c22502deb76ff41713eaaefa42ff75100a89abb9996b4c667ec416f393e17ed6d882d5_0",
         "fix": "a_function_call (wrap ((another_func the_argument)))",
-        "fixed_lines": [
-          "let three = a_function_call (wrap ((another_func the_argument)))"
-        ],
         "is_ignored": false,
         "lines": "let three = a_function_call (another_func the_argument)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",
@@ -152,9 +143,6 @@
       "extra": {
         "fingerprint": "eec5907e334a3cface44f3f4ddd6ccfffaff33d2a8af7e566b58457c8b2b13db2729e242053f31455d89c9f85ba5547c8c46808a101afeaa0135b40bd06632b7_0",
         "fix": "a_function_call (wrap ((tuple_member, threeple_member)))",
-        "fixed_lines": [
-          "let three = a_function_call (wrap ((tuple_member, threeple_member)))"
-        ],
         "is_ignored": false,
         "lines": "let three = a_function_call (tuple_member, threeple_member)",
         "message": "Wrap the arguments to `a_function_call` with `wrap` first",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-not-dryrun/results.json
@@ -17,9 +17,6 @@
       "extra": {
         "fingerprint": "6dc6dadef59330502a9d1988fb7c6f14c516b0a94fb7b7c903da09b8b3e91c58bcc5d2e9b733c82887556765c32153a89c1ed3625b95cbe63a53ab03dd770110_0",
         "fix": "assert \"a\"",
-        "fixed_lines": [
-          "assert \"a\""
-        ],
         "is_ignored": false,
         "lines": "assert_eq(\n    True, \"a\"\n)",
         "message": "Change assert_eq(True, x) to assert x",
@@ -62,9 +59,6 @@
       "extra": {
         "fingerprint": "47499af8016a3d73a8ac0cb0709ce0cd314cdf477741c8a9e03d4aa03531123e2ff120224289f160fa7623d5960ac44f9e399dbe177a628236bd128af9be2c27_0",
         "fix": "assert \"b\"",
-        "fixed_lines": [
-          "assert \"b\""
-        ],
         "is_ignored": false,
         "lines": "assert_eq(\n    True, \"b\"\n)",
         "message": "Change assert_eq(True, x) to assert x",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixrequests-use-timeout.yaml-autofixrequests-use-timeout.py-not-dryrun/results.json
@@ -20,9 +20,6 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
-        "fixed_lines": [
-          "r = requests.get(url, timeout=30)"
-        ],
         "is_ignored": false,
         "lines": "r = requests.get(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -50,9 +47,6 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
-        "fixed_lines": [
-          "r = requests.post(url, timeout=30)"
-        ],
         "is_ignored": false,
         "lines": "r = requests.post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -80,9 +74,6 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
-        "fixed_lines": [
-          "r = requests.request(\"GET\", url, timeout=30)"
-        ],
         "is_ignored": false,
         "lines": "r = requests.request(\"GET\", url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -110,9 +101,6 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
-        "fixed_lines": [
-          "r = requests.request(\"GET\", return_url(), timeout=30)"
-        ],
         "is_ignored": false,
         "lines": "r = requests.request(\"GET\", return_url())",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",
@@ -140,9 +128,6 @@
           "regex": "(.*)\\)",
           "replacement": "\\1, timeout=30)"
         },
-        "fixed_lines": [
-          "    r = post(url, timeout=30)"
-        ],
         "is_ignored": false,
         "lines": "    r = post(url)",
         "message": "'requests' calls default to waiting until the connection is closed.\nThis means a 'requests' call without a timeout will hang the program\nif a response is never received. Consider setting a timeout for all\n'requests'.\n",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-not-dryrun/results.json
@@ -20,16 +20,6 @@
           "regex": "(.*)\\}",
           "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
         },
-        "fixed_lines": [
-          "resource \"aws_instance\" \"example1\" {",
-          "  ami           = \"ami-005e54dee72cc1d01\"",
-          "  instance_type = \"t2.micro\"",
-          "",
-          "  metadata_options {",
-          "    http_tokens = \"required\"",
-          "  }",
-          "}"
-        ],
         "is_ignored": false,
         "lines": "resource \"aws_instance\" \"example1\" {\n  ami           = \"ami-005e54dee72cc1d01\"\n  instance_type = \"t2.micro\"\n}",
         "message": "EC2 instance does not set metadata options",
@@ -75,16 +65,6 @@
           "regex": "(.*)\\}",
           "replacement": "\\1\n  metadata_options {\n    http_tokens = \"required\"\n  }\n}\n"
         },
-        "fixed_lines": [
-          "resource \"aws_instance\" \"example2\" {",
-          "  ami           = \"ami-005e54dee72cc1d02\"",
-          "  instance_type = \"t2.micro\"",
-          "",
-          "  metadata_options {",
-          "    http_tokens = \"required\"",
-          "  }",
-          "}"
-        ],
         "is_ignored": false,
         "lines": "resource \"aws_instance\" \"example2\" {\n  ami           = \"ami-005e54dee72cc1d02\"\n  instance_type = \"t2.micro\"\n}",
         "message": "EC2 instance does not set metadata options",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixtwo-autofixes.yaml-autofixtwo-autofixes.txt-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixtwo-autofixes.yaml-autofixtwo-autofixes.txt-not-dryrun/results.json
@@ -17,9 +17,6 @@
       "extra": {
         "fingerprint": "070c76f072fcc5c05b90e7e6f2ed676961207fdae73acfd5c78253a8c2294126a6f19168fbbc00272bb3ca882b71f84df59a71277082f6235f5132effdf037a6_0",
         "fix": "one",
-        "fixed_lines": [
-          "one"
-        ],
         "is_ignored": false,
         "lines": "one\ntwo",
         "message": "This rule changes the line numbers for the other rule's match",
@@ -44,9 +41,6 @@
       "extra": {
         "fingerprint": "36e519fa759ca74dea55c0aef65e0e3e081cdfeb4370a8b8a2546e77f65952ead0e128ca7b79e10645edaac3006b670ff0e122e96ee1569dca4105167a8b6b7e_0",
         "fix": "four",
-        "fixed_lines": [
-          "four"
-        ],
         "is_ignored": false,
         "lines": "three\nfour",
         "message": "If semgrep is not smart enough, the match of this rule will be out of range",

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -42,9 +42,9 @@ from ..conftest import TESTS_PATH
         ),
     ],
 )
-def test_dependency_aware_rules(run_semgrep_in_tmp_no_symlink, snapshot, rule, target):
+def test_dependency_aware_rules(run_semgrep_on_copied_files, snapshot, rule, target):
     snapshot.assert_match(
-        run_semgrep_in_tmp_no_symlink(rule, target_name=target).as_snapshot(),
+        run_semgrep_on_copied_files(rule, target_name=target).as_snapshot(),
         "results.txt",
     )
 

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -311,8 +311,8 @@ def test_git_repo_output(run_semgrep, git_repo, tmp_path, monkeypatch, snapshot)
 
 
 @pytest.mark.kinda_slow
-def test_sca_output(run_semgrep_in_tmp_no_symlink, snapshot):
-    results, _errors = run_semgrep_in_tmp_no_symlink(
+def test_sca_output(run_semgrep_on_copied_files, snapshot):
+    results, _errors = run_semgrep_on_copied_files(
         "rules/dependency_aware/monorepo_with_first_party.yaml",
         target_name="dependency_aware/monorepo",
         output_format=OutputFormat.TEXT,


### PR DESCRIPTION
Previously, tests would intermittently fail due to pollution of
`cli/tests/e2e/targets`. This was caused by `test_autofix` creating
a temporary file within this path at test run time.

Issue was reproduced using `chmod -R 0400 cli/tests/e2e/targets`, then
running `pytest`.

This commit updates test_autofix to run entirely in a copied file-system
context, thereby avoiding any pollution of the test sources. As a bonus,
the test_autofix code has been drastically simplified and runs 2x
faster.

I've also renamed `run_semgrep_no_symlink` to
`run_semgrep_on_copied_files` for developer clarity.

This commit also updates snapshots to reflect the actual output of
semgrep when `--dryrun` is ommitted from its invocation. (Note that the
output with `--dryrun` is still captured in a corresponding set of
snapshots).

No changelog needed with this commit.

PR checklist:

- [x] Change has no security implications (otherwise, ping security team)

