### PR TITLE
infra: add an e2e test

### DIFF
--- a/.github/workflows/e2e-semgrep-ci.yml
+++ b/.github/workflows/e2e-semgrep-ci.yml
@@ -6,9 +6,6 @@ on:
         description: "Docker Tag to Run. Default: edge"
         required: false
         default: "edge"
-  push:
-    branches:
-      - test-workflow
   schedule:
     - cron: "43 20 * * *"
 

--- a/.github/workflows/e2e-semgrep-ci.yml
+++ b/.github/workflows/e2e-semgrep-ci.yml
@@ -1,0 +1,18 @@
+name: Semgrep CI E2E Test
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 43 * * *"
+
+jobs:
+  semgrep:
+    name: Static Analysis Scan
+    runs-on: ubuntu-22.04
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_E2E_APP_TOKEN }}
+    container:
+      image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci

--- a/.github/workflows/e2e-semgrep-ci.yml
+++ b/.github/workflows/e2e-semgrep-ci.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       docker_tag:
-        description: "Docker Tag to Run. Default: edge"
+        description: "Docker Tag to Run. Default: develop"
         required: false
-        default: "edge"
+        default: "develop"
   schedule:
     - cron: "43 20 * * *"
 
@@ -19,7 +19,7 @@ jobs:
       - name: Set variables
         id: get-inputs
         env:
-          DEFAULT_TAG: edge
+          DOCKER_TAG: develop
         run: |
           echo "::set-output name=docker_tag::${{ inputs.docker_tag || env.DOCKER_TAG }}"
       - name: Debug

--- a/.github/workflows/e2e-semgrep-ci.yml
+++ b/.github/workflows/e2e-semgrep-ci.yml
@@ -1,18 +1,126 @@
 name: Semgrep CI E2E Test
 on:
   workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: "Docker Tag to Run. Default: edge"
+        required: false
+        default: "edge"
+  push:
+    branches:
+      - test-workflow
   schedule:
-    - cron: "20 43 * * *"
+    - cron: "43 20 * * *"
 
 jobs:
-  semgrep:
+  get-inputs:
+    name: Get Inputs
+    runs-on: ubuntu-22.04
+    outputs:
+      docker_tag: ${{ steps.get-inputs.outputs.docker_tag }}
+    steps:
+      - name: Set variables
+        id: get-inputs
+        env:
+          DEFAULT_TAG: edge
+        run: |
+          echo "::set-output name=docker_tag::${{ inputs.docker_tag || env.DOCKER_TAG }}"
+      - name: Debug
+        run: |
+          echo "${{ steps.get-inputs.outputs.docker_tag }}"
+
+  semgrep-ci:
     name: Static Analysis Scan
     runs-on: ubuntu-22.04
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_E2E_APP_TOKEN }}
+    needs: get-inputs
     container:
-      image: returntocorp/semgrep
-    if: (github.actor != 'dependabot[bot]')
+      image: "returntocorp/semgrep:${{ needs.get-inputs.outputs.docker_tag }}"
     steps:
       - uses: actions/checkout@v3
       - run: semgrep ci
+
+  semgrep-ci-on-pr:
+    name: Run Semgrep CI on a PR
+    uses: ./.github/workflows/open-bump-pr.yml
+    secrets: inherit
+    needs: get-inputs
+    with:
+      version: "${{ needs.get-inputs.outputs.docker_tag }}"
+      repository: "returntocorp/e2e"
+      base_branch: "develop"
+      new_branch_name: "e2e-test-${{ github.run_id }}"
+      bump_script_path: "scripts/change-version.sh"
+
+  pr-url:
+    runs-on: ubuntu-22.04
+    needs: semgrep-ci-on-pr
+    steps:
+      - run: echo ${{ needs.semgrep-ci-on-pr.outputs.pr-url }}
+      - run: echo ${{ needs.semgrep-ci-on-pr.outputs.pr-number }}
+
+  wait-for-checks:
+    runs-on: ubuntu-22.04
+    needs: semgrep-ci-on-pr
+    steps:
+      - name: Get JWT for semgrep-ci GitHub App
+        id: jwt
+        uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
+        env:
+          EXPIRATION: 600 # seconds
+          ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }} # semgrep-ci GitHub App id
+          PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
+      - name: Get token for semgrep-ci GitHub App
+        id: token
+        run: |
+          TOKEN="$(curl -X POST \
+          -H "Authorization: Bearer ${{ steps.jwt.outputs.jwt }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/app/installations/${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID }}/access_tokens" | \
+          jq -r .token)"
+          echo "::add-mask::$TOKEN"
+          echo "::set-output name=token::$TOKEN"
+      - name: Wait for checks to register
+        id: register-checks
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          LEN_CHECKS=$(gh pr -R returntocorp/e2e view "${{ needs.semgrep-ci-on-pr.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
+
+          # Immediately after creation, the PR doesn't have any checks attached yet, wait until this is not the case
+          # If you immediately start waiting for checks, then it just fails saying there's no checks.
+          while [ ${LEN_CHECKS} = "0" ]; do
+            echo "No checks available yet"
+            sleep 30
+            LEN_CHECKS=$(gh pr -R returntocorp/e2e view "${{ needs.semgrep-ci-on-pr.outputs.pr-number }}" --json statusCheckRollup --jq '.statusCheckRollup | length');
+          done
+          echo "checks are valid"
+
+          echo ${LEN_CHECKS}
+
+          gh pr -R returntocorp/e2e view "${{ needs.semgrep-ci-on-pr.outputs.pr-number }}" --json statusCheckRollup
+      - name: Wait for checks to complete
+        id: wait-checks
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          # Wait for PR checks to finish
+          gh pr -R returntocorp/e2e checks "${{ needs.semgrep-ci-on-pr.outputs.pr-number }}" --interval 30 --watch
+
+  notify-failure:
+    needs: [semgrep-ci, semgrep-ci-on-pr, wait-for-checks]
+    name: Notify of Failure
+    runs-on: ubuntu-20.04
+    if: failure()
+    steps:
+      - name: Notify Failure
+        run: |
+          curl --request POST \
+          --url  ${{ secrets.SEMGREP_CI_E2E_NOTIFICATIONS_URL }} \
+          --header 'content-type: application/json' \
+          --data '{
+            "workflow_run_url": "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}} for more details!",
+            "docker_tag": "${{ needs.get-inputs.outputs.docker_tag }}",
+            "message": "The PR in `returntocorp/e2e` that had the failure was ${{ needs.semgrep-ci-on-pr.outputs.pr-number }}"
+          }'

--- a/.github/workflows/open-bump-pr.yml
+++ b/.github/workflows/open-bump-pr.yml
@@ -18,8 +18,11 @@ on:
         type: string
     outputs:
       pr-url:
-        description: "The first output string"
+        description: "The PR URL that's opened for the version bump"
         value: ${{ jobs.bump-version.outputs.pr-url }}
+      pr-number:
+        description: "The PR Number that's opened for the version bump"
+        value: ${{ jobs.bump-version.outputs.pr-number }}
 
 jobs:
   bump-version:
@@ -27,6 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       pr-url: ${{ steps.open-pr.outputs.pr-url }}
+      pr-number: ${{ steps.open-pr.outputs.pr-number }}
     steps:
       - name: Get JWT for semgrep-ci GitHub App
         id: jwt
@@ -63,7 +67,10 @@ jobs:
       - name: Create Release Branch
         id: release-branch
         run: |
-          RELEASE_BRANCH="release-${{ inputs.version }}"
+          RELEASE_BRANCH="${{ inputs.new_branch_name }}"
+          if [ -z "${{ inputs.new_branch_name }}" ]; then
+            RELEASE_BRANCH="release-${{ inputs.version }}"
+          fi
           git checkout -b ${RELEASE_BRANCH}
           echo ::set-output name=release-branch::${RELEASE_BRANCH}
       - name: Run release scripts

--- a/changelog.d/cli-253.infra
+++ b/changelog.d/cli-253.infra
@@ -1,0 +1,1 @@
+Using some building blocks from release, set up a workflow to test `semgrep ci` e2e.


### PR DESCRIPTION
This'll be expanded upon with other ongoing work that @zyannes and I are taking on.

This check does the following:

- Runs semgrep ci as a full scan (e.g., not in a PR)
- Then, checks out the repo `returntocorp/e2e`
- In this repo, it does some manipulations to set the docker image tag, either setting to an explicit version or to latest. 
    - I wanted to have the ability to repro issues more easily, so for example, we get a report that says “I’m on v0.103.0 and I’m seeing this error in my PRs” - we can just add 0.103.0 as an input and run the test, instead of having to do all the manual repro steps.
- The `returntocorp/e2e`  repo has checks configured that run semgrep ci as well - so the job in `returntocorp/semgrep` wait for the checks in `returntocorp/e2e` to either pass or fail
- Upon failure, sends us a slack message notifying the oncall that something's gone wrong

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
