### PR TITLE
Add support to cli/scripts/compare.py for podman environments

### DIFF
--- a/changelog.d/compare-script-podman.added
+++ b/changelog.d/compare-script-podman.added
@@ -1,0 +1,1 @@
+Add support to cli/scripts/compare.py for podman environments

--- a/cli/scripts/compare.py
+++ b/cli/scripts/compare.py
@@ -58,6 +58,7 @@ def compare(start: str, end: str, snippet: str, use_podman: bool) -> int:
         return [
             docker_executable,
             "run",
+            "--rm",
             *(["-ti"] if sys.stdout.isatty() else []),
             *(["--security-opt", "label=disable"] if use_podman else []),
             "-v",

--- a/cli/scripts/compare.py
+++ b/cli/scripts/compare.py
@@ -15,6 +15,13 @@ from semgrep.semgrep_types import LANGUAGE
 SEMGREP_DEV_TIMEOUT_S = 30.0
 
 
+def compute_docker_executable(use_podman: bool) -> str:
+    if use_podman:
+        return "podman"
+
+    return "docker"
+
+
 @click.command()
 @click.argument("start", type=str)
 @click.argument(
@@ -22,7 +29,8 @@ SEMGREP_DEV_TIMEOUT_S = 30.0
     type=str,
 )
 @click.argument("snippet", type=str)
-def compare(start: str, end: str, snippet: str) -> int:
+@click.option("--use-podman", is_flag=True, help="Use podman instead of docker.")
+def compare(start: str, end: str, snippet: str, use_podman: bool) -> int:
     """
     Compares behavior of two versions of Semgrep on a rule ID
 
@@ -45,11 +53,13 @@ def compare(start: str, end: str, snippet: str) -> int:
     language = test_case["language"]
     target = test_case["target"]
 
-    def docker_cmd(dir: str, version: str) -> Sequence[str]:
+    def docker_cmd(use_podman: bool, dir: str, version: str) -> Sequence[str]:
+        docker_executable = compute_docker_executable(use_podman)
         return [
-            "docker",
+            docker_executable,
             "run",
             *(["-ti"] if sys.stdout.isatty() else []),
+            *(["--security-opt", "label=disable"] if use_podman else []),
             "-v",
             f"{dir}:/src",
             f"returntocorp/semgrep:{version}",
@@ -75,12 +85,12 @@ def compare(start: str, end: str, snippet: str) -> int:
         click.secho(f"===== RUNNING WITH VERSION {start} =====\n", fg="blue", bold=True)
         # The following rule shouldn't be running on Semgrep, it's an FP factory
         # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
-        subprocess.run(docker_cmd(td, start))
+        subprocess.run(docker_cmd(use_podman, td, start))
         click.secho(
             f"\n\n===== RUNNING WITH VERSION {end} =====\n", fg="blue", bold=True
         )
         # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
-        subprocess.run(docker_cmd(td, end))
+        subprocess.run(docker_cmd(use_podman, td, end))
 
     return 0
 


### PR DESCRIPTION
Fedora does not have docker and only supports podman.
This is a small change to make the compare.py script works with podman.

PR checklist:

- [ ] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
