### PR TITLE
[5633] - fix(formatter) - fixes the list index out of range error in the text formatter

### DIFF
--- a/changelog.d/gh-5633.fixed
+++ b/changelog.d/gh-5633.fixed
@@ -1,2 +1,1 @@
-Semgrep threw list index out of range error in the text formatter when the dedented_lines list was empty.
-This PR adds a conditions to factor for that and fixes the relevant issue.
+Semgrep used to crash when trying to print findings that match only whitespace, such as when a rule disallows two newlines at the end of a file. This crash is now fixed.

--- a/changelog.d/gh-5633.fixed
+++ b/changelog.d/gh-5633.fixed
@@ -1,0 +1,2 @@
+Semgrep threw list index out of range error in the text formatter when the dedented_lines list was empty.
+This PR adds a conditions to factor for that and fixes the relevant issue.

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -99,6 +99,8 @@ class TextFormatter(BaseFormatter):
             dedented_lines = textwrap.dedent("".join(lines)).splitlines()
             indent_len = (
                 len(lines[0].rstrip()) - len(dedented_lines[0].rstrip())
+                if len(dedented_lines) > 0
+                else len(lines[0].rstrip())
                 if len(lines) > 0
                 else 0
             )

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -99,9 +99,7 @@ class TextFormatter(BaseFormatter):
             dedented_lines = textwrap.dedent("".join(lines)).splitlines()
             indent_len = (
                 len(lines[0].rstrip()) - len(dedented_lines[0].rstrip())
-                if len(dedented_lines) > 0
-                else len(lines[0].rstrip())
-                if len(lines) > 0
+                if len(dedented_lines) > 0 and len(lines) > 0
                 else 0
             )
 


### PR DESCRIPTION
Acceptance Criteria:
- Fixes [5633](https://github.com/returntocorp/semgrep/issues/5633).

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
