### PR TITLE
style: Remove code separator when there is no code

### DIFF
--- a/changelog.d/sca-ui.changed
+++ b/changelog.d/sca-ui.changed
@@ -1,0 +1,1 @@
+Separator lines are no longer drawn between findings that have no source code snippet.

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -154,11 +154,12 @@ class TextFormatter(BaseFormatter):
             if stripped:
                 stripped_str = f"[shortened a long line from output, adjust with {MAX_CHARS_FLAG_NAME}]"
                 yield " " * FINDINGS_INDENT_DEPTH + stripped_str
+
             if per_finding_max_lines_limit != 1:
                 if trimmed > 0:
                     trimmed_str = f" [hid {trimmed} additional lines, adjust with {MAX_LINES_FLAG_NAME}] "
                     yield " " * FINDINGS_INDENT_DEPTH + trimmed_str
-                elif show_separator:
+                elif lines and show_separator:
                     yield f" " * FINDINGS_INDENT_DEPTH + f"⋮┆" + f"-" * 40
 
     @staticmethod


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!

## Before

<img width="886" alt="CleanShot 2022-07-12 at 10 18 41@2x" src="https://user-images.githubusercontent.com/1060436/178553574-350fae3f-c715-423a-a20d-c7bba3b6f0d4.png">

## After

<img width="892" alt="CleanShot 2022-07-12 at 10 18 18@2x" src="https://user-images.githubusercontent.com/1060436/178553484-b9443d08-f4c1-4803-8969-a4523918d15d.png">

