### PR TITLE
[5600] - fix(test/output) - fixes the semgrep test output and updates the snapshot

### DIFF
--- a/changelog.d/gh-5600.changed
+++ b/changelog.d/gh-5600.changed
@@ -1,0 +1,1 @@
+The semgrep test output used to produce expected lines and reported lines which is difficult to read and interpret. This change introduces missed lines and incorrect lines to make it easier for the users to pinpoint the differences in output.

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -251,13 +251,17 @@ def get_expected_and_reported_lines(
 
 
 def _generate_check_output_line(check_id: str, check_results: Mapping[str, Any]) -> str:
-    def _generate_expected_vs_reported_lines(matches: Mapping[str, Any]) -> str:
-        expected = f"expected lines: {matches['expected_lines']}"
-        reported = f"reported lines: {matches['reported_lines']}"
-        return f"{expected}, {reported}"
+    def _generate_missed_vs_incorrect_lines(matches: Mapping[str, Any]) -> str:
+        expected_lines = matches["expected_lines"]
+        reported_lines = matches["reported_lines"]
+        missed = f"missed lines: {list(set(expected_lines) - set(reported_lines))}"
+        incorrect = (
+            f"incorrect lines: {list(set(reported_lines) - set(expected_lines))}"
+        )
+        return f"{missed}, {incorrect}"
 
-    expected_vs_reported_lines = "\t\n".join(
-        _generate_expected_vs_reported_lines(matches)
+    missed_vs_incorrect_lines = "\t\n".join(
+        _generate_missed_vs_incorrect_lines(matches)
         for _, matches in check_results["matches"].items()
     )
 
@@ -265,7 +269,7 @@ def _generate_check_output_line(check_id: str, check_results: Mapping[str, Any])
         test_file for test_file, _ in check_results["matches"].items()
     )
 
-    return f"\t✖ {check_id.ljust(60)} {expected_vs_reported_lines} \n\ttest file path: {test_file_names}\n\n"
+    return f"\t✖ {check_id.ljust(60)} {missed_vs_incorrect_lines} \n\ttest file path: {test_file_names}\n\n"
 
 
 def _generate_fixcheck_output_line(

--- a/cli/tests/e2e/snapshots/test_fixtest/test_fixtest_test4_no_json/results.txt
+++ b/cli/tests/e2e/snapshots/test_fixtest/test_fixtest_test4_no_json/results.txt
@@ -9,7 +9,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
 === stdout - plain
 0/1: 1 unit tests did not pass:
 --------------------------------------------------------------------------------
-	✖ test4                                                        expected lines: [2, 5], reported lines: [] 
+	✖ test4                                                        missed lines: [2, 5], incorrect lines: [] 
 	test file path: <MASKED>/fixtest/test4.py
 
 


### PR DESCRIPTION
Acceptance Criteria (AC):
- Fixes https://github.com/returntocorp/semgrep/issues/5600.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
