### PR TITLE
Only include skipped_targets in result when --debug is passed

### DIFF
--- a/changelog.d/pa-1618.fixed
+++ b/changelog.d/pa-1618.fixed
@@ -1,0 +1,2 @@
+Memory usage improvement: don't save skipped targets when `--debug` isn't passed
+since it isn't read unless `--debug` is used

--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -91,7 +91,7 @@ def parse_core_output(raw_json: JsonObject) -> core.CoreMatchResults:
     if not terminal.is_debug:
         # Previously we skipped the loop below to save time with large
         # skipped_targets. Now, there are no skipped targets returned unless
-        # core is run in debug mode, so this if-statement is left to make
+        # core is run in debug mode, but this if-statement is left to make
         # that obvious
         return match_results
 

--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -89,8 +89,10 @@ def parse_core_output(raw_json: JsonObject) -> core.CoreMatchResults:
     terminal = get_state().terminal
     match_results = core.CoreMatchResults.from_json(raw_json)
     if not terminal.is_debug:
-        # skipping the loop below can save seconds with lots of skipped_targets
-        # note that the skip logs will be missing from the last.log file as well
+        # Previously we skipped the loop below to save time with large
+        # skipped_targets. Now, there are no skipped targets returned unless
+        # core is run in debug mode, so this if-statement is left to make
+        # that obvious
         return match_results
 
     for skip in match_results.skipped_targets:

--- a/semgrep-core/src/core/Report.ml
+++ b/semgrep-core/src/core/Report.ml
@@ -175,7 +175,9 @@ let make_final_result results rules ~debug ~report_time ~rules_parse_time =
 
   (* These fields take a lot of space and aren't always necessary *)
   let skipped_targets =
-    if debug then results |> Common.map (fun x -> x.skipped_targets) |> List.flatten else []
+    if debug then
+      results |> Common.map (fun x -> x.skipped_targets) |> List.flatten
+    else []
   in
   let file_times = results |> Common.map (fun x -> x.profiling) in
   let final_profiling =

--- a/semgrep-core/src/core/Report.ml
+++ b/semgrep-core/src/core/Report.ml
@@ -173,7 +173,8 @@ let make_final_result results rules ~debug ~report_time ~rules_parse_time =
   let matches = results |> Common.map (fun x -> x.matches) |> List.flatten in
   let errors = results |> Common.map (fun x -> x.errors) |> List.flatten in
 
-  (* These fields take a lot of space and aren't always necessary *)
+  (* These fields take a lot of space and aren't necessary except
+    when running in debugging mode *)
   let skipped_targets =
     if debug then
       results |> Common.map (fun x -> x.skipped_targets) |> List.flatten

--- a/semgrep-core/src/core/Report.ml
+++ b/semgrep-core/src/core/Report.ml
@@ -174,7 +174,7 @@ let make_final_result results rules ~debug ~report_time ~rules_parse_time =
   let errors = results |> Common.map (fun x -> x.errors) |> List.flatten in
 
   (* These fields take a lot of space and aren't necessary except
-    when running in debugging mode *)
+     when running in debugging mode *)
   let skipped_targets =
     if debug then
       results |> Common.map (fun x -> x.skipped_targets) |> List.flatten

--- a/semgrep-core/src/core/Report.ml
+++ b/semgrep-core/src/core/Report.ml
@@ -169,11 +169,13 @@ let collate_rule_results :
     profiling = { file; rule_times = profiling };
   }
 
-let make_final_result results rules ~report_time ~rules_parse_time =
+let make_final_result results rules ~debug ~report_time ~rules_parse_time =
   let matches = results |> Common.map (fun x -> x.matches) |> List.flatten in
   let errors = results |> Common.map (fun x -> x.errors) |> List.flatten in
+
+  (* These fields take a lot of space and aren't always necessary *)
   let skipped_targets =
-    results |> Common.map (fun x -> x.skipped_targets) |> List.flatten
+    if debug then results |> Common.map (fun x -> x.skipped_targets) |> List.flatten else []
   in
   let file_times = results |> Common.map (fun x -> x.profiling) in
   let final_profiling =

--- a/semgrep-core/src/core/Report.mli
+++ b/semgrep-core/src/core/Report.mli
@@ -60,6 +60,7 @@ val collate_pattern_results : times match_result list -> times match_result
 val make_final_result :
   file_profiling match_result list ->
   Rule.rule list ->
+  debug:bool ->
   report_time:bool ->
   rules_parse_time:float ->
   final_result

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -564,7 +564,8 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
            res)
   in
   let res =
-    RP.make_final_result file_results rules config.debug config.report_time rules_parse_time
+    RP.make_final_result file_results rules config.debug config.report_time
+      rules_parse_time
   in
   let res = { res with skipped_targets = skipped @ res.skipped_targets } in
   logger#info "found %d matches, %d errors, %d skipped targets"

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -564,7 +564,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
            res)
   in
   let res =
-    RP.make_final_result file_results rules config.report_time rules_parse_time
+    RP.make_final_result file_results rules config.debug config.report_time rules_parse_time
   in
   let res = { res with skipped_targets = skipped @ res.skipped_targets } in
   logger#info "found %d matches, %d errors, %d skipped targets"


### PR DESCRIPTION
Skipped_targets takes a huge amount of memory and isn't even read by core_output
when debug isn't set (see `core_output.py`). Frankly I have questions whether it's
useful at all in this form, but let's start by not including it in the final
result if `--debug` isn't passed.

On angular/angular, reduces final physical memory used by 1G.

I'd like to restructure our code so that skipped targets aren't being saved at all when
--debug isn't passed, but that's more work so fixing this part first.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
