### PR TITLE
chore(test): Remove additional test target pollution

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -267,7 +267,7 @@ def _run_semgrep(
     """Run the semgrep CLI.
 
     :param config: what to pass as --config's value
-    :param target_name: which directory within ./e2e/targets/ to scan
+    :param target_name: which path (either relative or absolute) within ./e2e/targets/ to scan
     :param options: additional CLI flags to add
     :param output_format: which format to use
     :param stderr: whether to merge stderr into the returned string

--- a/cli/tests/e2e/test_match_based_id.py
+++ b/cli/tests/e2e/test_match_based_id.py
@@ -34,23 +34,20 @@ def test_id_change(run_semgrep_on_copied_files, tmp_path, rule, target, expect_c
 
     suffix = Path(target).suffix
 
-    # Target file prior to edit
-    before_target = tmp_path / "targets" / "match_based_id" / "before" / target
-    # Target file after edit
-    after_target = tmp_path / "targets" / "match_based_id" / "after" / target
     # Static file path (necessary to obtain static id)
     static_target = tmp_path / "targets" / ("_match_based_id" + suffix)
 
-    def run_on_target(target):
-        shutil.copy(target, static_target)
-        before_results, _ = run_semgrep_on_copied_files(
+    def run_on_target(subpath):
+        source_target = tmp_path / "targets" / "match_based_id" / subpath / target
+        shutil.copy(source_target, static_target)
+        results, _ = run_semgrep_on_copied_files(
             rule,
             target_name=static_target,
             output_format=OutputFormat.JSON,
         )
-        return json.loads(before_results)["results"][0]["extra"]["fingerprint"]
+        return json.loads(results)["results"][0]["extra"]["fingerprint"]
 
-    before_id = run_on_target(before_target)
-    after_id = run_on_target(after_target)
+    before_id = run_on_target("before")
+    after_id = run_on_target("after")
 
     assert (after_id != before_id) == expect_change

--- a/cli/tests/e2e/test_match_based_id.py
+++ b/cli/tests/e2e/test_match_based_id.py
@@ -19,7 +19,7 @@ def test_duplicate_matches_indexing(run_semgrep_in_tmp, snapshot):
 
 @pytest.mark.kinda_slow
 @pytest.mark.parametrize(
-    "rule,target,expect_change",
+    "rule,target_name,expect_change",
     [
         # ("rules/match_based_id/","",True)
         ("rules/match_based_id/formatting.yaml", "formatting.c", False),
@@ -30,15 +30,33 @@ def test_duplicate_matches_indexing(run_semgrep_in_tmp, snapshot):
         ("rules/match_based_id/join.yaml", "join.py", True),
     ],
 )
-def test_id_change(run_semgrep_on_copied_files, tmp_path, rule, target, expect_change):
+def test_id_change(
+    run_semgrep_on_copied_files, tmp_path, rule, target_name, expect_change
+):
+    """
+    Ensures that match-based IDs are resistant to various types of changes in code.
 
-    suffix = Path(target).suffix
+    These changes are enumerated in
+       targets / match_based_id / (before|after) / <target_name>
 
-    # Static file path (necessary to obtain static id)
-    static_target = tmp_path / "targets" / ("_match_based_id" + suffix)
+    To edit these cases, edit these files directly. To add new cases, add a corresponding pair
+    of files, and update the parameterization above.
+
+    :param rule: The Semgrep rule that should trigger a finding
+    :param target: The filename of the target pair
+    :param expect_change: Whether or not to expect an ID change
+    """
+
+    # Since the match_based_id includes the target path, we must create a static target path.
+    # Note that b/c we use run_semgrep_on_copied_files, the current working directory
+    # for Semgrep is tmp_path; I specify the target as an absolute path so that things
+    # will bomb out if, for whatever reason, the working directory changes.
+    static_target = (
+        tmp_path / "targets" / ("_match_based_id" + Path(target_name).suffix)
+    )
 
     def run_on_target(subpath):
-        source_target = tmp_path / "targets" / "match_based_id" / subpath / target
+        source_target = tmp_path / "targets" / "match_based_id" / subpath / target_name
         shutil.copy(source_target, static_target)
         results, _ = run_semgrep_on_copied_files(
             rule,


### PR DESCRIPTION
Like #5706, except captures the other test file where this pollution
occurred.

I used `rg NamedTemporaryFile\(.*targets.*\)` to make sure this doesn't
occur anywhere else.

No need for changelog.

PR checklist:

- [x] Change has no security implications (otherwise, ping security team)

