### PR TITLE
tainting: Add experimental taint labels feature

### DIFF
--- a/changelog.d/pa-1362.added
+++ b/changelog.d/pa-1362.added
@@ -1,6 +1,6 @@
 Add experimental support for _taint labels_, that is the ability to attach labels to
 different kinds of taint. Both sources and sinks can retrict what labels are present
 in the data that passes through them in order to apply. This allows to write more
-complex taint rules that previously required ugly workarounds. Taint labels also
-allows us to write certain classes of typestate analyses (e.g., check that a file
+complex taint rules that previously required ugly workarounds. Taint labels are also
+useful for writing certain classes of typestate analyses (e.g., check that a file
 descriptor is not used after being closed).

--- a/changelog.d/pa-1362.added
+++ b/changelog.d/pa-1362.added
@@ -1,0 +1,6 @@
+Add experimental support for _taint labels_, that is the ability to attach labels to
+different kinds of taint. Both sources and sinks can retrict what labels are present
+in the data that passes through them in order to apply. This allows to write more
+complex taint rules that previously required ugly workarounds. Taint labels also
+allows us to write certain classes of typestate analyses (e.g., check that a file
+descriptor is not used after being closed).

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -167,15 +167,30 @@ type pformula = New of formula | Old of formula_old [@@deriving show, eq]
 (* Taint-specific types *)
 (*****************************************************************************)
 
-type sanitizer_spec = {
+type taint_source = {
+  formula : pformula;
+  label : string;  (** The label to attach to the data *)
+  requires : AST_generic.expr;
+      (** A Boolean formula over taint labels, the expression that
+       is being checked as a source must satisfy this in order to the
+       label to be produced. Note that with 'requires' a taint source
+       behaves a bit like a propagator ... *)
+}
+[@@deriving show]
+
+type taint_sanitizer = {
   not_conflicting : bool;
       (** If [not_conflicting] is enabled, the sanitizer cannot conflict with
     a sink or a source (i.e., match the exact same range) otherwise
     it is filtered out. This allows to e.g. declare `$F(...)` as a sanitizer,
     to assume that any other function will handle tainted data safely.
     Without this, `$F(...)` would automatically sanitize any other function
-    call acting as a sink or a source. *)
-  pformula : pformula;
+    call acting as a sink or a source.
+
+    THINK: In retrospective, I'm not sure this was a good idea. We should add
+    an option to disable the assumption that function calls always propagate
+    taint, and deprecate not-conflicting sanitizers. *)
+  formula : pformula;
 }
 [@@deriving show]
 
@@ -190,11 +205,17 @@ type taint_propagator = {
  * with "from" being `$X` and "to" being `$H`. So if `$X` is tainted then `$H`
  * will also be marked as tainted. *)
 
+type taint_sink = {
+  formula : pformula;  (** A Boolean formula over taint labels. *)
+  requires : AST_generic.expr;
+}
+[@@deriving show]
+
 type taint_spec = {
-  sources : pformula list;
+  sources : taint_source list;
   propagators : taint_propagator list;
-  sanitizers : sanitizer_spec list;
-  sinks : pformula list;
+  sanitizers : taint_sanitizer list;
+  sinks : taint_sink list;
 }
 [@@deriving show]
 

--- a/semgrep-core/src/engine/Match_tainting_mode.mli
+++ b/semgrep-core/src/engine/Match_tainting_mode.mli
@@ -1,9 +1,10 @@
 type debug_taint = {
-  sources : Range_with_metavars.ranges;
+  sources : (Range_with_metavars.t * Rule.taint_source) list;
       (** Ranges matched by `pattern-sources:` *)
   sanitizers : Range_with_metavars.ranges;
       (** Ranges matched by `pattern-sanitizers:` *)
-  sinks : Range_with_metavars.ranges;  (** Ranges matched by `pattern-sinks:` *)
+  sinks : (Range_with_metavars.t * Rule.taint_sink) list;
+      (** Ranges matched by `pattern-sinks:` *)
 }
 (** To facilitate debugging of taint rules. *)
 

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -35,7 +35,7 @@ let test_tainting lang file config def =
       let show_taint t =
         match t.Taint.orig with
         | Taint.Src src ->
-            let tok1, tok2 = (Taint.pm_of_trace src).range_loc in
+            let tok1, tok2 = (fst (Taint.pm_of_trace src)).range_loc in
             let r = Range.range_of_token_locations tok1 tok2 in
             Range.content_at_range file r
         | Taint.Arg i -> spf "arg %d" i
@@ -76,13 +76,13 @@ let test_dfg_tainting rules_file file =
   in
   Common.pr2 "\nSources";
   Common.pr2 "-------";
-  pr2_ranges file debug_taint.sources;
+  pr2_ranges file (debug_taint.sources |> Common.map fst);
   Common.pr2 "\nSanitizers";
   Common.pr2 "----------";
   pr2_ranges file debug_taint.sanitizers;
   Common.pr2 "\nSinks";
   Common.pr2 "-----";
-  pr2_ranges file debug_taint.sinks;
+  pr2_ranges file (debug_taint.sinks |> Common.map fst);
   let v =
     V.mk_visitor
       {

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -548,10 +548,14 @@ let regexp_prefilter_of_formula f : prefilter option =
 let regexp_prefilter_of_taint_rule (rule_id, rule_tok) taint_spec =
   (* We must be able to match some source _and_ some sink. *)
   let sources =
-    taint_spec.R.sources |> Common.map (R.formula_of_pformula ~rule_id)
+    taint_spec.R.sources
+    |> Common.map (fun (src : R.taint_source) ->
+           R.formula_of_pformula ~rule_id src.formula)
   in
   let sinks =
-    taint_spec.R.sinks |> Common.map (R.formula_of_pformula ~rule_id)
+    taint_spec.R.sinks
+    |> Common.map (fun (sink : R.taint_sink) ->
+           R.formula_of_pformula ~rule_id sink.formula)
   in
   let f =
     (* Note that this formula would likely not yield any meaningful result

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -812,8 +812,6 @@ let parse_extract_reduction ~id (s, t) =
 (* Sub parsers taint *)
 (*****************************************************************************)
 
-let builtin_label_SOURCE = "__SOURCE__"
-
 let parse_formula (env : env) (rule_dict : dict) : R.pformula =
   match Hashtbl.find_opt rule_dict.h "match" with
   | Some (_matchkey, v) -> R.New (parse_formula_new env v)
@@ -856,12 +854,12 @@ let parse_taint_source env (key : key) (value : G.expr) : Rule.taint_source =
   let source_dict = yaml_to_dict env key value in
   let label =
     take_opt source_dict env parse_string "label"
-    |> Option.value ~default:builtin_label_SOURCE
+    |> Option.value ~default:R.default_source_label
   in
   let requires =
     let tok = snd key in
     take_opt source_dict env parse_taint_requires "requires"
-    |> Option.value ~default:(G.L (G.Bool (true, tok)) |> G.e)
+    |> Option.value ~default:(R.default_source_requires tok)
   in
   let formula = parse_formula env source_dict in
   { formula; label; requires }
@@ -888,9 +886,7 @@ let parse_taint_sink env (key : key) (value : G.expr) : Rule.taint_sink =
   let requires =
     let tok = snd key in
     take_opt sink_dict env parse_taint_requires "requires"
-    |> Option.value
-         ~default:
-           (G.N (G.Id ((builtin_label_SOURCE, tok), G.empty_id_info ())) |> G.e)
+    |> Option.value ~default:(R.default_sink_requires tok)
   in
   let formula = parse_formula env sink_dict in
   { formula; requires }

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -181,6 +181,7 @@ let labels_in_taint taints : LabelSet.t =
          | Arg _ -> None)
   |> LabelSet.of_seq
 
+(* coupling: if you modify the code here, you may need to modify 'Parse_rule.parse_taint_requires' too. *)
 let rec eval_label_requires ~labels e =
   match e.G.e with
   | G.L (G.Bool (v, _)) -> v

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -7,17 +7,21 @@ type overlap = float
  * 1.0 means that the AST node matches the annotation perfectly. For
  * practical purposes we can interpret >0.99 as being the same as 1.0. *)
 
-type propagator_id = var
-type propagator_from = propagator_id
-type propagator_to = propagator_id
+type 'spec tmatch = { spec : 'spec; pm : Pattern_match.t; overlap : overlap }
+
+type a_propagator = {
+  kind : [ `From | `To ];
+  prop : Rule.taint_propagator;
+  var : var; (* REMOVE USE prop.id *)
+}
 
 type config = {
   filepath : Common.filename;  (** File under analysis, for Deep Semgrep. *)
   rule_id : string;  (** Taint rule id, for Deep Semgrep. *)
-  is_source : AST_generic.any -> (Pattern_match.t * overlap) list;
+  is_source : AST_generic.any -> Rule.taint_source tmatch list;
       (** Test whether 'any' is a taint source, this corresponds to
       * 'pattern-sources:' in taint-mode. *)
-  is_propagator : AST_generic.any -> propagator_from list * propagator_to list;
+  is_propagator : AST_generic.any -> a_propagator tmatch list;
       (** Test whether 'any' matches a taint propagator, this corresponds to
        * 'pattern-propagators:' in taint-mode.
        *
@@ -47,10 +51,10 @@ type config = {
        * anyhow it's clearly incorrect to taint `Shell`, so a better solution was
        * needed (hence `pattern-propagators`).
        *)
-  is_sink : AST_generic.any -> Pattern_match.t list;
+  is_sink : AST_generic.any -> Rule.taint_sink tmatch list;
       (** Test whether 'any' is a sink, this corresponds to 'pattern-sinks:'
       * in taint-mode. *)
-  is_sanitizer : AST_generic.any -> (Pattern_match.t * overlap) list;
+  is_sanitizer : AST_generic.any -> Rule.taint_sanitizer tmatch list;
       (** Test whether 'any' is a sanitizer, this corresponds to
       * 'pattern-sanitizers:' in taint-mode. *)
   unify_mvars : bool;  (** Unify metavariables in sources and sinks? *)
@@ -70,7 +74,7 @@ type mapping = Taint.taints Dataflow_core.mapping
 (** Mapping from variables to taint sources (if the variable is tainted).
   * If a variable is not in the map, then it's not tainted. *)
 
-type fun_env = (var, Pattern_match.Set.t) Hashtbl.t
+type fun_env = (var, Taint.Taint_set.t) Hashtbl.t
 (** Set of functions known to act as taint sources (their output is
   * tainted). This is used for a HACK to do some poor-man's intrafile
   * interprocedural taint tracking. TO BE DEPRECATED. *)

--- a/semgrep-core/src/tainting/Taint.mli
+++ b/semgrep-core/src/tainting/Taint.mli
@@ -5,14 +5,14 @@ type tainted_tokens = AST_generic.tok list [@@deriving show]
 (** A call trace to a source or sink match.
   * E.g. Call('foo(a)', PM('sink(x)')) is an indirect match for 'sink(x)'
   * through the function call 'foo(a)'. *)
-type call_trace =
-  | PM of Pattern_match.t  (** A direct match.  *)
-  | Call of AST_generic.expr * tainted_tokens * call_trace
+type 'a call_trace =
+  | PM of Pattern_match.t * 'a  (** A direct match.  *)
+  | Call of AST_generic.expr * tainted_tokens * 'a call_trace
       (** An indirect match through a function call. *)
 [@@deriving show]
 
-type source = call_trace [@@deriving show]
-type sink = call_trace [@@deriving show]
+type source = Rule.taint_source call_trace [@@deriving show]
+type sink = Rule.taint_sink call_trace [@@deriving show]
 type arg_pos = int [@@deriving show]
 
 type source_to_sink = {
@@ -60,8 +60,8 @@ module Taint_set : Set.S with type elt = taint
 
 type taints = Taint_set.t
 
-val trace_of_pm : Pattern_match.t -> call_trace
-val pm_of_trace : call_trace -> Pattern_match.t
-val taint_of_pm : Pattern_match.t -> taint
-val taints_of_pms : Pattern_match.t list -> taints
+val trace_of_pm : Pattern_match.t * 'a -> 'a call_trace
+val pm_of_trace : 'a call_trace -> Pattern_match.t * 'a
+val taint_of_pm : Pattern_match.t * Rule.taint_source -> taint
+val taints_of_pms : (Pattern_match.t * Rule.taint_source) list -> taints
 val show_taints : taints -> string

--- a/semgrep-core/tests/OTHER/rules/taint_labels.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels.py
@@ -1,0 +1,6 @@
+def foo():
+  a = source()
+  if cond():
+     b = a
+  #ruleid: tainting
+  sink(b)

--- a/semgrep-core/tests/OTHER/rules/taint_labels.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - requires: TAINTED
+        pattern: sink(...)
+    pattern-sources:
+      - label: TAINTED
+        pattern: source(...)
+    severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/taint_labels1.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels1.py
@@ -1,0 +1,6 @@
+def foo():
+  a = source()
+  if cond():
+     b = a
+  #OK: tainting
+  sink(b)

--- a/semgrep-core/tests/OTHER/rules/taint_labels1.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels1.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - requires: BAR
+        pattern: sink(...)
+    pattern-sources:
+      - label: FOO
+        pattern: source(...)
+    severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/taint_labels2.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels2.py
@@ -1,0 +1,24 @@
+def foo():
+  a = source()
+  if cond():
+    b = a
+    b = sanitize()
+  else:
+    b = a
+  #todoruleid: tainting
+  sink(b)
+
+def bar():
+  a = source()
+  if cond():
+    b = a
+    b = sanitize()
+  #OK: tainting
+  sink(b)
+
+def baz():
+  a = source()
+  if cond():
+    b = a
+  #ruleid: tainting
+  sink(b)

--- a/semgrep-core/tests/OTHER/rules/taint_labels2.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels2.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - requires: TAINTED and not CLEANED
+        pattern: sink(...)
+    pattern-sources:
+      - label: TAINTED
+        pattern: source(...)
+      - label: CLEANED
+        pattern: sanitize(...)
+    severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/taint_labels2.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels2.yaml
@@ -13,5 +13,6 @@ rules:
         pattern: source(...)
       - label: CLEANED
         pattern: sanitize(...)
+        # Yep, we can now use labels to implement sanitizers!
     severity: ERROR
 

--- a/semgrep-core/tests/OTHER/rules/taint_labels3.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels3.py
@@ -1,0 +1,26 @@
+def foo():
+  a = p()
+  if cond():
+     b = q(a)
+  #ruleid: tainting
+  sink(b)
+
+def bar():
+  a = p()
+  #OK: tainting
+  sink(a)
+
+def baz():
+  a = q()
+  #OK: tainting
+  sink(a)
+
+def boo():
+  if cond():
+    a = p()
+  else:
+    a = q()
+  # `a` doesn't really have labels P and Q at the same time,
+  # this trigger because taint from both branches is unioned.
+  #todook: tainting
+  sink(a)

--- a/semgrep-core/tests/OTHER/rules/taint_labels3.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels3.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - requires: P and Q
+        pattern: sink(...)
+    pattern-sources:
+      - label: P
+        pattern: p(...)
+      - label: Q
+        pattern: q(...)
+    severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/taint_labels4.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels4.py
@@ -1,0 +1,25 @@
+def foo():
+  a = p()
+  if cond():
+     b = q(a)
+  #ruleid: tainting
+  sink(b)
+
+def bar():
+  a = p()
+  #OK: tainting
+  sink(a)
+
+def baz():
+  a = q()
+  #OK: tainting
+  sink(a)
+
+def boo():
+  if cond():
+    a = p()
+  else:
+    a = q()
+  #OK: tainting
+  sink(a)
+ 

--- a/semgrep-core/tests/OTHER/rules/taint_labels4.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels4.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: tainting
+    mode: taint
+    languages:
+      - python
+    message: |
+      This confirms taint mode works.
+    pattern-sinks:
+      - requires: P and Q
+        pattern: sink(...)
+    pattern-sources:
+      - label: P
+        pattern: p(...)
+      - requires: P
+        label: Q
+        pattern: q(...)
+    severity: ERROR
+

--- a/semgrep-core/tests/OTHER/rules/taint_labels5.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels5.py
@@ -1,0 +1,14 @@
+def foo():
+    f = open()
+    f.write("a")
+    f.close()
+    #ruleid: test
+    f.write("b")
+
+def bar():
+    f = open()
+    f.write("a")
+    f.close()
+    f = open()
+    #ok: test
+    f.write("b")

--- a/semgrep-core/tests/OTHER/rules/taint_labels5.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels5.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: test
+    message: Test
+    severity: INFO
+    languages: [py]
+    mode: taint
+    pattern-sources:
+      - label: closed
+        patterns:
+          - pattern: |
+              $FILE.close()
+          - focus-metavariable: $FILE
+      - label: reopened
+        requires: closed
+        patterns:
+          - pattern: |
+              $FILE = open(...)
+          - focus-metavariable: $FILE
+    pattern-sinks:
+      - requires: closed and not reopened
+        patterns:
+          - pattern: $FILE.write(...)
+          - focus-metavariable: $FILE

--- a/semgrep-core/tests/OTHER/rules/taint_labels6.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels6.py
@@ -1,0 +1,19 @@
+def foo():
+    f = open()
+    f.write("bar")
+    f.close()
+    # ruleid: test
+    f.close()
+    # the following has no effect on the double-closing of `f`
+    # that already happened
+    f = open()
+    f.write("baz")
+
+def bar():
+    f = open()
+    f.write("bar")
+    f.close()
+    # we reopen `f` so it's fine to close it again
+    f = open()
+    # ok: test
+    f.close()

--- a/semgrep-core/tests/OTHER/rules/taint_labels6.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels6.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: test
+    message: Test
+    severity: INFO
+    languages: [py]
+    mode: taint
+    pattern-sources:
+      - label: closed
+        patterns:
+          - pattern: $FILE.close()
+          - focus-metavariable: $FILE
+      - label: closed_twice
+        requires: closed
+        patterns:
+          - pattern: $FILE.close()
+          - focus-metavariable: $FILE
+      - label: reopened
+        requires: closed
+        patterns:
+          - pattern: |
+              $FILE = open(...)
+          - focus-metavariable: $FILE
+    pattern-sinks:
+      - requires: closed_twice and not reopened
+        patterns:
+          - pattern: $FILE.close(...)
+          - focus-metavariable: $FILE

--- a/semgrep-core/tests/OTHER/rules/taint_labels7.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels7.py
@@ -1,0 +1,11 @@
+def foo():
+    s = set()
+    s.add(user_input)
+    #ruleid: test
+    sink(s)
+
+def bar():
+    s = set()
+    s.add(safe_data)
+    #ok: test
+    sink(s)

--- a/semgrep-core/tests/OTHER/rules/taint_labels7.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_labels7.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: test
+    message: Test
+    severity: INFO
+    languages: [py]
+    mode: taint
+    pattern-sources:
+      - label: tainted
+        pattern: user_input
+      - label: safe
+        pattern: safe_data
+    pattern-propagators:
+      - pattern: $S.add($A)
+        from: $A
+        to: $S
+    pattern-sinks:
+      - requires: tainted
+        patterns:
+          - pattern: sink($SINK)
+          - focus-metavariable: $SINK


### PR DESCRIPTION
It provides the ability to attach labels to different kinds of taint.
Both sources and sinks can retrict what labels are present in the data
that passes through them in order to apply. This allows to write more
complex taint rules that previously required ugly workarounds. It also
allows us to write certain classes of typestate analyses.

Closes PA-1362

test plan:
make test # added 7 tests

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
