### PR TITLE
chore: update workflow to use correct tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp ./semgrep-osx/artifacts.zip semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
-          gh release upload ${{ steps.version.outputs.tag }} semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
+          gh release upload ${{ steps.get_version.outputs.VERSION }} semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
           rm semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip
       - name: Upload Release Checksum
         id: upload-checksum-asset-osx
@@ -50,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp ./semgrep-osx/artifacts.zip.sha256 semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
-          gh release upload ${{ steps.version.outputs.tag }} semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
+          gh release upload ${{ steps.get_version.outputs.VERSION }} semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
           rm semgrep-${{ steps.get_version.outputs.VERSION }}-osx.zip.sha256
 
           ## UBUNTU
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp ./semgrep-ubuntu/artifacts.tar.gz semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
-          gh release upload ${{ steps.version.outputs.tag }} semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
+          gh release upload ${{ steps.get_version.outputs.VERSION }} semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
           rm semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz
       - name: Upload Release Checksum
         id: upload-release-checksum-ubuntu
@@ -74,14 +74,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp ./semgrep-ubuntu/artifacts.tar.gz.sha256 semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz.sha256
-          gh release upload ${{ steps.version.outputs.tag }} semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz.sha256
+          gh release upload ${{ steps.get_version.outputs.VERSION }} semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz.sha256
           rm semgrep-${{ steps.get_version.outputs.VERSION }}-ubuntu-16.04.tgz.sha256
       - name: Publish Release
         id: publish_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release edit ${{ steps.version.outputs.tag }} --draft=false
+          gh release edit ${{ steps.get_version.outputs.VERSION }} --draft=false
 
   release-docker:
     name: Build and push Semgrep Docker image


### PR DESCRIPTION
Of note: we likely won't be able to use these changes when we re-run the failing release branch job - it's on a tag, so unless we move the tag (not a good idea IMO, but if anyone disagrees lmk) so I'll manually side-step this for now.

No changelog entry needed here.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
