### PR TITLE
chore: hide internal findings in count

### DIFF
--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -352,14 +352,19 @@ class OutputHandler:
                         ) from ex
 
         if self.filtered_rules:
-            fingerprint_matches, regular_matches = partition(
+            _, regular_matches = partition(
                 self.rule_matches,
                 lambda m: m.severity
                 in [RuleSeverity.INVENTORY, RuleSeverity.EXPERIMENT],
             )
+            _, regular_rules = partition(
+                self.filtered_rules,
+                lambda r: r.severity
+                in [RuleSeverity.INVENTORY, RuleSeverity.EXPERIMENT],
+            )
             num_findings = len(regular_matches)
             num_targets = len(self.all_targets)
-            num_rules = len(self.filtered_rules)
+            num_rules = len(regular_rules)
 
             ignores_line = str(ignore_log or "No ignore information available")
             suggestion_line = ""

--- a/cli/tests/e2e/snapshots/test_check/test_experiment_finding_output/output.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_experiment_finding_output/output.txt
@@ -3,4 +3,4 @@ Scanning 1 file.
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
-Ran 1 rule on 1 file: 0 findings.
+Ran 0 rules on 1 file: 0 findings.

--- a/cli/tests/e2e/snapshots/test_check/test_inventory_finding_output/output.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_inventory_finding_output/output.txt
@@ -3,4 +3,4 @@ Scanning 1 file.
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
-Ran 1 rule on 1 file: 0 findings.
+Ran 0 rules on 1 file: 0 findings.


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
