### PR TITLE
[ruby] tainting: Handle simple cases of implicit return

### DIFF
--- a/semgrep-core/src/analyzing/Test_analyze_generic.ml
+++ b/semgrep-core/src/analyzing/Test_analyze_generic.ml
@@ -67,8 +67,7 @@ let test_cfg_il ~parse_program file =
         V.default_visitor with
         V.kfunction_definition =
           (fun (_k, _) def ->
-            let body = H.funcbody_to_stmt def.fbody in
-            let xs = AST_to_IL.stmt lang body in
+            let _, xs = AST_to_IL.function_definition lang def in
             let cfg = CFG_build.cfg_of_stmts xs in
             Display_IL.display_cfg cfg);
       }

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -318,7 +318,7 @@ and label = ident * G.sid
 (*****************************************************************************)
 (* See AST_generic.ml *)
 and function_definition = {
-  foarams : name list;
+  fparams : name list;
   frettype : G.type_ option;
   fbody : stmt list;
 }

--- a/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
@@ -83,7 +83,7 @@ let dump_il file =
             pr2 s;
             pr2 "==>";
 
-            let xs = AST_to_IL.stmt lang (H.funcbody_to_stmt def.G.fbody) in
+            let _, xs = AST_to_IL.function_definition lang def in
             let s = IL.show_any (IL.Ss xs) in
             pr2 s);
       }

--- a/semgrep-core/tests/OTHER/rules/taint_poorman_interproc_implicit_return.rb
+++ b/semgrep-core/tests/OTHER/rules/taint_poorman_interproc_implicit_return.rb
@@ -1,0 +1,11 @@
+def foo
+  user_input
+end
+
+def test
+  # Poor-man's interpocedural analysis will detect that `foo` is
+  # tainted
+  x = foo
+  #ruleid: test
+  sink(x)
+end

--- a/semgrep-core/tests/OTHER/rules/taint_poorman_interproc_implicit_return.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_poorman_interproc_implicit_return.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: test
+  message: Test
+  severity: ERROR
+  languages: [ruby]
+  mode: taint
+  pattern-sources:
+  - pattern: user_input
+  pattern-sinks:
+  - pattern: sink(...)


### PR DESCRIPTION
It's useful for users of DeepSemgrep to have this hack now while we
find time to tackle PA-1020.

Helps PA-1641

test plan:
make test # added one test

PR checklist:

- [x] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
