### PR TITLE
fix: correct python manifest paths

### DIFF
--- a/cli/MANIFEST.in
+++ b/cli/MANIFEST.in
@@ -1,4 +1,4 @@
-include src/semgrep/rule_schema.yaml
+include src/semgrep/semgrep_interfaces/rule_schema.yaml
 include src/semgrep/lang/lang.json
 include LICENSE
 include src/semgrep/templates/.semgrepignore


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!

Fixes CI failures caused by https://github.com/returntocorp/semgrep/pull/5742
