### PR TITLE
infra: add marks to unmarked tests

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -727,6 +727,7 @@ def test_inventory_finding_output(run_semgrep_in_tmp, snapshot):
     )
 
 
+@pytest.mark.kinda_slow
 def test_experiment_finding_output(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
         run_semgrep_in_tmp(

--- a/cli/tests/e2e/test_lsp.py
+++ b/cli/tests/e2e/test_lsp.py
@@ -49,12 +49,14 @@ def init_lsp(
     lsp.m_initialized()
 
 
+@pytest.mark.kinda_slow
 def test_lsp_init(lsp, tmp_path, snapshot):
     init_lsp(lsp, rule_path="rules/eqeq-python.yaml")
     assert lsp._ready
     snapshot.assert_match(json.dumps(lsp.config.settings), "settings.json")
 
 
+@pytest.mark.kinda_slow
 def test_lsp_diagnostics(lsp, tmp_path, snapshot):
     init_lsp(lsp, rule_path="rules/eqeq-python.yaml")
     lsp.m_text_document__did_open(
@@ -66,6 +68,7 @@ def test_lsp_diagnostics(lsp, tmp_path, snapshot):
     snapshot.assert_match(diagonstics, "diagnostics.json")
 
 
+@pytest.mark.kinda_slow
 def test_lsp_code_action(lsp, tmp_path, snapshot):
     init_lsp(lsp, rule_path="rules/autofix/autofix.yaml")
     # Open document
@@ -88,6 +91,7 @@ def test_lsp_code_action(lsp, tmp_path, snapshot):
     snapshot.assert_match(actions, "fixes.json")
 
 
+@pytest.mark.kinda_slow
 def test_lsp_inlay_hint(lsp, tmp_path, snapshot):
     init_lsp(lsp, rule_path="rules/eqeq-python.yaml")
     lsp.m_text_document__did_open(
@@ -110,6 +114,7 @@ def test_lsp_inlay_hint(lsp, tmp_path, snapshot):
     snapshot.assert_match(output, "inlay_hints.json")
 
 
+@pytest.mark.kinda_slow
 def test_lsp_workspace_folders(lsp, tmp_path):
     init_lsp(lsp, watch_workspace=True)
     dirs = []

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -116,6 +116,7 @@ def test_omit_inventory(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(stdout, "results.out")
 
 
+@pytest.mark.kinda_slow
 def test_omit_experiment(run_semgrep_in_tmp, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/experiment/experiment.yaml",


### PR DESCRIPTION
Given the runtime of the overall test suite (less than when these were
introduced) and the fact that we have a durations file
<https://github.com/returntocorp/semgrep/blob/develop/cli/.test_durations>
we can probably just handle this programatically anyway.

However, because this currently blocks `make` at the top level on
develop, we should at least fix it as we currently have it configured.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
