### PR TITLE
fix: More descriptive error when expecting explicit type

### DIFF
--- a/changelog.d/gh-5068.fixed
+++ b/changelog.d/gh-5068.fixed
@@ -1,0 +1,17 @@
+What:
+Currently, `Impossible` is raised for certain C# programs, when an explicit type is expected 
+where an implicit one was provided (for instance, when introduced by the `var` keyword). An example
+program which triggers this is provided below:
+```
+public class Foo {
+    public void Foo(var a) {
+    }
+}
+```
+
+Why:
+We should reject this program, but with a better error message.
+
+How:
+Change it to be raising an exception, specifically a `Parse_info.Other_error`. This is not a `Parse_info.Parse_error`
+because this is not exactly a parsing bug, c.f. the GitHub discussion in the issue.

--- a/changelog.d/gh-5068.fixed
+++ b/changelog.d/gh-5068.fixed
@@ -1,17 +1,1 @@
-What:
-Currently, `Impossible` is raised for certain C# programs, when an explicit type is expected 
-where an implicit one was provided (for instance, when introduced by the `var` keyword). An example
-program which triggers this is provided below:
-```
-public class Foo {
-    public void Foo(var a) {
-    }
-}
-```
-
-Why:
-We should reject this program, but with a better error message.
-
-How:
-Change it to be raising an exception, specifically a `Parse_info.Other_error`. This is not a `Parse_info.Parse_error`
-because this is not exactly a parsing bug, c.f. the GitHub discussion in the issue.
+C#: Improved error message when function parameters are declared with `var`

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2308,7 +2308,7 @@ and type_ (env : env) (x : CST.type_) : G.type_ =
   | `Impl_type _tok ->
       (* When type_ is called, we expect an explicit type, not "var".
          The implicit type is handled in local_variable_type. *)
-      raise Impossible
+      raise (Parse_info.Other_error ("Expected explicit type", Parse_tree_sitter_helpers.token env _tok))
   | `Array_type x -> array_type env x
   | `Name x ->
       let n = name env x in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -2308,7 +2308,9 @@ and type_ (env : env) (x : CST.type_) : G.type_ =
   | `Impl_type _tok ->
       (* When type_ is called, we expect an explicit type, not "var".
          The implicit type is handled in local_variable_type. *)
-      raise (Parse_info.Other_error ("Expected explicit type", Parse_tree_sitter_helpers.token env _tok))
+      raise
+        (Parse_info.Other_error
+           ("Expected explicit type", Parse_tree_sitter_helpers.token env _tok))
   | `Array_type x -> array_type env x
   | `Name x ->
       let n = name env x in


### PR DESCRIPTION
What:
Currently, `Impossible` is raised for certain C# programs, when an explicit type is expected 
where an implicit one was provided (for instance, when introduced by the `var` keyword). An example
program which triggers this is provided below:
```
public class Foo {
    public void Foo(var a) {
    }
}
```

Why:
We should reject this program, but with a better error message.

How:
Change it to be raising an exception, specifically a `Parse_info.Other_error`. This is not a `Parse_info.Parse_error`
because this is not exactly a parsing bug, c.f. the GitHub discussion in the issue.Currently, there is an `Impossible` exception being raised when expecting an explicit error, but receiving an implicit one. This is not impossible, but should be rejected with a descriptive error message.

Fixes #5068.

- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

