### PR TITLE
Reduce size of targets file

### DIFF
--- a/changelog.d/pa-1618-2.changed
+++ b/changelog.d/pa-1618-2.changed
@@ -1,0 +1,6 @@
+Reduce memory consumption of semgrep by passing the targets in a more condensed
+structure. Previously, we told semgrep which rules to run on which target by
+listing out all the rule_ids each target should run. Now, we have a separate
+rule_id list and for each target we only ilst the rule_id indices. On large
+repos, particularly when run with multiple processes, this has a significant
+impact.

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -314,6 +314,8 @@ class Plan:
 
     def __init__(self, mappings: List[Task], rule_ids: List[str]):
         self.target_mappings = TargetMappings(mappings)
+        # important: this is a list of rule_ids, not a set
+        # target_mappings relies on the index of each rule_id in rule_ids
         self.rule_ids = rule_ids
 
     def split_by_lang_label(self) -> Dict[str, "TargetMappings"]:
@@ -332,6 +334,10 @@ class Plan:
             "target_mappings": [asdict(task) for task in self.target_mappings],
             "rule_ids": self.rule_ids,
         }
+
+    @property
+    def num_targets(self) -> int:
+        return len(self.target_mappings)
 
     def log(self) -> None:
         metrics = get_state().metrics
@@ -717,7 +723,7 @@ class CoreRunner:
                 print(" ".join(cmd))
                 sys.exit(0)
 
-            runner = StreamingSemgrepCore(cmd, len(plan.target_mappings))
+            runner = StreamingSemgrepCore(cmd, plan.num_targets)
             returncode = runner.execute()
 
             # Process output

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -305,6 +305,13 @@ class TargetMappings(List[Task]):
 
 
 class Plan:
+    """
+    Saves and displays knowledge of what will be run
+
+    to_json: creates the json passed to semgrep_core - see Input_to_core.atd
+    log: outputs a summary of how many files will be scanned for each file
+    """
+
     def __init__(self, mappings: List[Task], rule_ids: List[str]):
         self.target_mappings = TargetMappings(mappings)
         self.rule_ids = rule_ids
@@ -538,8 +545,9 @@ class CoreRunner:
         """
         Gets the targets to run for each rule
 
-        Returns this information as a list of targets with language and rule ids,
-        which semgrep-core requires to know what rules to run for each file
+        Returns this information as a list of rule ids and a list of targets with
+        language + index of the rule ids for the rules to run each target on.
+        Semgrep-core will use this to determine what to run (see Input_to_core.atd).
         Also updates all_targets, used by core_runner
 
         Note: this is a list because a target can appear twice (e.g. Java + Generic)

--- a/interfaces/Input_to_core.atd
+++ b/interfaces/Input_to_core.atd
@@ -25,13 +25,17 @@ type target = {
    * allow (by design) to use types defined in other files.
    *)
   language: string;
-  (* If there is no rule_id, the default we will use is '-' *)
+  (* Index in the rule_ids list in targets of the rule_id to
+   * run this target on *)
   rule_nums: int list;
 }
 
 (* The same path can be present multiple times in targets below, with
  * different languages each time, so a Python file can be both analyzed
  * with Python rules, but also with generic/regexp rules.
+ *
+ * To avoid repeating the rule_ids, targets contains a list of all the
+ * rule_ids and each target references the index of the rule_id
  *
  * alt: we could have a list of languages instead in target above, but
  * because of the way semgrep-core is designed (with its file_and_more type),
@@ -43,6 +47,7 @@ type target = {
  *)
 type targets = {
    target_mappings: target list;
+   (* If there is no rule_id, the default we will use is '-' *)
    rule_ids: string list
 }
 

--- a/interfaces/Input_to_core.atd
+++ b/interfaces/Input_to_core.atd
@@ -26,7 +26,7 @@ type target = {
    *)
   language: string;
   (* If there is no rule_id, the default we will use is '-' *)
-  rule_ids: string list;
+  rule_nums: int list;
 }
 
 (* The same path can be present multiple times in targets below, with
@@ -41,7 +41,10 @@ type target = {
  * alt: rule_ids above could also be used to analyze at once the same
  * file with both PL and generic/regexp rules.
  *)
-type targets = target list
+type targets = {
+   target_mappings: target list;
+   rule_ids: string list
+}
 
 
 (*****************************************************************************)

--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -116,7 +116,11 @@ let mk_extract_target dst_lang contents rule_ids =
   let dst_lang = dst_lang |> Lang.show in
   let f : Common.dirname = Common.new_temp_file "extracted" dst_lang in
   Common2.write_file ~file:f contents;
-  { In.path = f; language = dst_lang; rule_ids }
+  {
+    In.path = f;
+    language = dst_lang;
+    rule_nums = List.mapi (fun i _ -> i) rule_ids;
+  }
 
 (*****************************************************************************)
 (* Error reporting *)

--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -56,14 +56,15 @@ val exn_to_error : Common.filename -> Exception.t -> Semgrep_error_code.error
   See also JSON_report.json_of_exn for non-target related exn handling.
 *)
 
-val mk_rule_table : Rule.rule list -> (Rule.rule_id, Rule.rule) Hashtbl.t
+val mk_rule_table :
+  Rule.rule list -> Rule.rule_id list -> (int, Rule.rule) Hashtbl.t
 (** Helper to create the table of rules to run for each file **)
 
 val extract_targets_of_config :
   Runner_config.t ->
   Rule.rule_id list ->
   Rule.extract_rule list ->
-  Input_to_core_t.targets
+  Input_to_core_t.target list
   * ( Common.filename,
       Report.partial_profiling Report.match_result ->
       Report.partial_profiling Report.match_result )

--- a/semgrep-core/tests/e2e/target
+++ b/semgrep-core/tests/e2e/target
@@ -1,5 +1,7 @@
-[ {"path": "tests/e2e/targets/basic.py",
+{ "target_mappings": 
+  [{"path": "tests/e2e/targets/basic.py",
    "language": "python",
-   "rule_ids": ["-"]
-  }
-]
+   "rule_ids": [0]
+  }],
+  "rule_ids": ["-"]
+}

--- a/semgrep-core/tests/e2e/target
+++ b/semgrep-core/tests/e2e/target
@@ -1,7 +1,7 @@
 { "target_mappings": 
   [{"path": "tests/e2e/targets/basic.py",
    "language": "python",
-   "rule_ids": [0]
+   "rule_nums": [0]
   }],
   "rule_ids": ["-"]
 }


### PR DESCRIPTION
Rule_ids are often quite long. Instead of listing out every rule_id each time,
map targets to indices and list all the rules once at the end.
    
This reduces physical memory consumption from ~1.5GB to ~800MB with -j 1.
(on angular/angular).
With -j 12, memory consumption is reduced from ~1GB per process to ~300GB
per process.
    
Test plan: make test

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
