### PR TITLE
feat(extract): allow `generic` as language

### DIFF
--- a/changelog.d/pa-1648.added
+++ b/changelog.d/pa-1648.added
@@ -1,0 +1,1 @@
+Extract mode: generic is now permitted as a `languages` value

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -205,11 +205,7 @@ type extract_reduction = Separate | Concat [@@deriving show]
 type extract_spec = {
   pformula : pformula;
   reduce : extract_reduction;
-  (* TODO: really want Lang.t | Generic --- the requirement that the
-     destination is a real langauge is potentially awkward for template files
-     with DSLs, though this might require some sort of additional label system
-     to be robust *)
-  dst_lang : Lang.t;
+  dst_lang : Xlang.t;
   extract : string;
 }
 [@@deriving show]

--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -113,7 +113,12 @@ let offsets_of_mval extract_mvalue =
          })
 
 let mk_extract_target dst_lang contents rule_ids =
-  let dst_lang = dst_lang |> Lang.show in
+  let dst_lang =
+    match dst_lang with
+    | Xlang.LGeneric -> "generic"
+    | Xlang.LRegex -> "regex"
+    | Xlang.L (x, _) -> Lang.show x
+  in
   let f : Common.dirname = Common.new_temp_file "extracted" dst_lang in
   Common2.write_file ~file:f contents;
   { In.path = f; language = dst_lang; rule_ids }

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -748,6 +748,15 @@ and parse_extra (env : env) (key : key) (value : G.expr) : Rule.extra =
       R.MetavarComparison { R.metavariable; comparison; strip; base }
   | _ -> error_at_key env key ("wrong parse_extra field: " ^ fst key)
 
+let parse_extract_dest ~id lang : Xlang.t =
+  match lang with
+  | ("none" | "regex"), _ -> LRegex
+  | "generic", _ -> LGeneric
+  | s, t -> (
+      match Lang.lang_of_string_opt s with
+      | None -> raise (R.InvalidRule (R.InvalidLanguage s, id, t))
+      | Some l -> L (l, []))
+
 let parse_language ~id ((s, t) as _lang) : Lang.t =
   match Lang.lang_of_string_opt s with
   | None -> raise (R.InvalidRule (R.InvalidLanguage s, id, t))
@@ -863,7 +872,7 @@ let parse_mode env mode_opt (rule_dict : dict) : R.mode =
       let pformula = parse_formula env rule_dict in
       let dst_lang =
         take rule_dict env parse_string_wrap "dest-language"
-        |> parse_language ~id:env.id
+        |> parse_extract_dest ~id:env.id
       in
       (* TODO: determine fmt---string with interpolated metavars? *)
       let extract = take rule_dict env parse_string "extract" in

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -748,15 +748,6 @@ and parse_extra (env : env) (key : key) (value : G.expr) : Rule.extra =
       R.MetavarComparison { R.metavariable; comparison; strip; base }
   | _ -> error_at_key env key ("wrong parse_extra field: " ^ fst key)
 
-let parse_extract_dest ~id lang : Xlang.t =
-  match lang with
-  | ("none" | "regex"), _ -> LRegex
-  | "generic", _ -> LGeneric
-  | s, t -> (
-      match Lang.lang_of_string_opt s with
-      | None -> raise (R.InvalidRule (R.InvalidLanguage s, id, t))
-      | Some l -> L (l, []))
-
 let parse_language ~id ((s, t) as _lang) : Lang.t =
   match Lang.lang_of_string_opt s with
   | None -> raise (R.InvalidRule (R.InvalidLanguage s, id, t))
@@ -774,6 +765,12 @@ let parse_languages ~id langs : Xlang.t =
             (R.InvalidRule
                (R.InvalidOther "we need at least one language", fst id, snd id))
       | x :: xs -> L (x, xs))
+
+let parse_extract_dest ~id lang : Xlang.t =
+  match lang with
+  | ("none" | "regex"), _ -> LRegex
+  | "generic", _ -> LGeneric
+  | lang -> L (parse_language ~id lang, [])
 
 let parse_severity ~id (s, t) =
   match s with


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!

Closes #5741 / Fixes PA-1648

Like I said in #5741, I don't think this is the best final design, and if there's more interested in this feature then we may need to handle `paths:` with extracted targets. That said, the filtering logic is a layer above where we do the extraction, and just allowing this should just enable latent functionality, so I don't see why not.