### PR TITLE
feat(cli): Display dataflow traces in text output

### DIFF
--- a/changelog.d/pa-1599.added
+++ b/changelog.d/pa-1599.added
@@ -1,0 +1,1 @@
+Introduced the `--dataflow-traces` flag, which directs the Semgrep CLI to explain how non-local values lead to a finding. Currently, this only applies to taint mode findings and it will trace the path from the taint source to the taint sink.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -175,6 +175,7 @@ def ci(
     metrics: Optional[MetricsState],
     metrics_legacy: Optional[MetricsState],
     optimizations: str,
+    dataflow_traces: bool,
     output: Optional[str],
     sarif: bool,
     quiet: bool,

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -386,6 +386,11 @@ _scan_options: List[Callable] = [
         """,
     ),
     optgroup.option(
+        "--dataflow-traces",
+        is_flag=True,
+        help="Explain how non-local values reach the location of a finding (only affects text output).",
+    ),
+    optgroup.option(
         "-o",
         "--output",
         help="Save search results to a file or post to URL. Default is to print to stdout.",
@@ -620,6 +625,7 @@ def scan(
     metrics: Optional[MetricsState],
     metrics_legacy: Optional[MetricsState],
     optimizations: str,
+    dataflow_traces: bool,
     output: Optional[str],
     pattern: Optional[str],
     quiet: bool,
@@ -731,6 +737,7 @@ def scan(
         output_time=output_time,
         output_per_finding_max_lines_limit=max_lines_per_finding,
         output_per_line_max_chars_limit=max_chars_per_line,
+        dataflow_traces=dataflow_traces,
     )
 
     if test:

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -143,6 +143,7 @@ class OutputSettings(NamedTuple):
     strict: bool = False
     output_time: bool = False
     timeout_threshold: int = 0
+    dataflow_traces: bool = False
 
 
 class OutputHandler:
@@ -449,6 +450,7 @@ class OutputHandler:
             extra[
                 "per_line_max_chars_limit"
             ] = self.settings.output_per_line_max_chars_limit
+            extra["dataflow_traces"] = self.settings.dataflow_traces
 
         # the rules are used only by the SARIF formatter
         return self.formatter.output(

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -28,6 +28,7 @@ from semgrep.constants import NOSEM_INLINE_COMMENT_RE
 from semgrep.constants import RuleSeverity
 from semgrep.external.pymmh3 import hash128  # type: ignore[attr-defined]
 from semgrep.rule import Rule
+from semgrep.util import get_lines
 
 if TYPE_CHECKING:
     from semgrep.rule import Rule
@@ -127,20 +128,7 @@ class RuleMatch:
         Need to do on initialization instead of on read since file might not be the same
         at read time
         """
-        # Start and end line are one-indexed, but the subsequent slice call is
-        # inclusive for start and exclusive for end, so only subtract from start
-        start_line = self.start.line - 1
-        end_line = self.end.line
-
-        if start_line == -1 and end_line == 0:
-            # Completely empty file
-            return []
-
-        # buffering=1 turns on line-level reads
-        with self.path.open(buffering=1, errors="replace") as fd:
-            result = list(itertools.islice(fd, start_line, end_line))
-
-        return result
+        return get_lines(self.path, self.start.line, self.end.line)
 
     @previous_line.default
     def get_previous_line(self) -> str:

--- a/cli/src/semgrep/util.py
+++ b/cli/src/semgrep/util.py
@@ -1,4 +1,5 @@
 import functools
+import itertools
 import operator
 import os
 import subprocess
@@ -237,3 +238,28 @@ def read_range(fd: TextIOWrapper, start_offset: int, end_offset: int) -> str:
     length = end_offset - start_offset
     fd.seek(start_offset)
     return fd.read(length)
+
+
+def get_lines(
+    path: Path,
+    start_line: int,
+    end_line: int,
+) -> List[str]:
+    """
+    Return lines in the given file.
+
+    Assumes file exists.
+    """
+    # Start and end line are one-indexed, but the subsequent slice call is
+    # inclusive for start and exclusive for end, so only subtract from start
+    start_line = start_line - 1
+
+    if start_line == -1 and end_line == 0:
+        # Completely empty file
+        return []
+
+    # buffering=1 turns on line-level reads
+    with path.open(buffering=1, errors="replace") as fd:
+        result = list(itertools.islice(fd, start_line, end_line))
+
+    return result


### PR DESCRIPTION
This introduces a `--dataflow-traces` flag to the `scan` command. The
default behavior is unchanged, but when this flag is passed and the
output mode is text, the dataflow trace is also displayed. For now, it
is only available for taint mode findings, and includes the source of
the taint as well as intermediate variables through which the taint
flows to the sink.

The JSON output already includes this information.

In support of this change, I extracted the `get_lines` function into
`util.py`, and the `_format_lines` function out of `_finding_to_line`.

There are a bunch of edge cases and options when printing matches. I
wasn't sure how to exercise all of them, and I'm not at all confident
that this will look right for every possible input. However, I do
believe that the default behavior is unchanged, and since this is behind
a flag it's less important to get all of the edge cases right. We can
refine it as we get feedback from users who are motivated to use the
flag, and perhaps eventually remove the flag and make dataflow trace
display the default.

We already plan to display this data by default in PR/MR comments and
perhaps in the playground, so it would make sense to eventually display
it on the CLI as well. However, several people expressed concern that it
could get too verbose, so it is behind a flag for the moment.

Test plan: Automated tests for ensuring default behavior remains as-is

Manual test of `--dataflow-traces` flag:

```
(cli) $ python -m semgrep scan -c ../semgrep-core/tests/OTHER/rules/taint_lambda.yaml ../semgrep-core/tests/OTHER/rules/taint_lambda.js
Scanning 1 file.

Findings:

  ../semgrep-core/tests/OTHER/rules/taint_lambda.js
     semgrep-core.tests.OTHER.rules.test
        Test

          8┆ console.log(numbers.map(i => sink(i + x)));

Some files were skipped or only partially analyzed.
  Scan skipped: 1 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 1 rule on 1 file: 1 finding.
(cli) $ python -m semgrep scan -c ../semgrep-core/tests/OTHER/rules/taint_lambda.yaml ../semgrep-core/tests/OTHER/rules/taint_lambda.js --dataflow-traces
Scanning 1 file.

Findings:

  ../semgrep-core/tests/OTHER/rules/taint_lambda.js
     semgrep-core.tests.OTHER.rules.test
        Test

          8┆ console.log(numbers.map(i => sink(i + x)));
        Taint comes from:
          6┆ var x = source;
        Taint flows through these intermediate variables:
          6┆ var x = source;

Some files were skipped or only partially analyzed.
  Scan skipped: 1 files matching .semgrepignore patterns
  For a full list of skipped files, run semgrep with the --verbose flag.

Ran 1 rule on 1 file: 1 finding.
```

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
