### PR TITLE
fixed: SEMGREP_URL not reflected in log message

### DIFF
--- a/changelog.d/gh-5753.fixed
+++ b/changelog.d/gh-5753.fixed
@@ -1,0 +1,1 @@
+Fixed the logged message describing the endpoint where rules are fetched from when SEMGREP_URL is set

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -210,7 +210,7 @@ class Metrics:
     @is_using_registry.setter
     def is_using_registry(self, value: bool) -> None:
         if self.is_using_registry is False and value is True:
-            logger.info(f"Fetching rules from {os.environ.get('SEMGREP_URL')}")
+            logger.info(f"Fetching rules from {os.environ.get('SEMGREP_URL', 'https://semgrep.dev/registry')}.")
 
         self._is_using_registry = value
 

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -213,6 +213,7 @@ class Metrics:
             logger.info(
                 f"Fetching rules from {os.environ.get('SEMGREP_URL', 'https://semgrep.dev/registry')}."
             )
+
         self._is_using_registry = value
 
     @suppress_errors

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -210,8 +210,9 @@ class Metrics:
     @is_using_registry.setter
     def is_using_registry(self, value: bool) -> None:
         if self.is_using_registry is False and value is True:
-            logger.info(f"Fetching rules from {os.environ.get('SEMGREP_URL', 'https://semgrep.dev/registry')}.")
-
+            logger.info(
+                f"Fetching rules from {os.environ.get('SEMGREP_URL', 'https://semgrep.dev/registry')}."
+            )
         self._is_using_registry = value
 
     @suppress_errors

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -210,7 +210,7 @@ class Metrics:
     @is_using_registry.setter
     def is_using_registry(self, value: bool) -> None:
         if self.is_using_registry is False and value is True:
-            logger.info("Fetching rules from https://semgrep.dev/registry.")
+            logger.info(f"Fetching rules from {os.environ.get('SEMGREP_URL')}")
 
         self._is_using_registry = value
 


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
