### PR TITLE
fix(scala): allowed percolation of name information from class parameters

### DIFF
--- a/changelog.d/gh-5506.fixed
+++ b/changelog.d/gh-5506.fixed
@@ -1,1 +1,10 @@
 Scala/others: Added a fix allowing percolation of name information from class parameters
+
+For example, classes which take in arguments like the following in Scala:
+```scala
+class ExampleClass(val x: TypeName) {
+}
+```
+
+do not properly enter the context. So in our analysis, we would not know that the identifier
+`x` has type `TypeName`, within the body of `ExampleClass`.

--- a/changelog.d/gh-5506.fixed
+++ b/changelog.d/gh-5506.fixed
@@ -1,0 +1,1 @@
+Scala/others: Added a fix allowing percolation of name information from class parameters

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -457,7 +457,9 @@ let resolve lang prog =
           (* todo: we should first process all fields in the class before
            * processing the methods, as some languages may allow forward ref.
            *)
-          with_new_context InClass env (fun () -> k x));
+          let class_params = params_of_parameters env x.cparams in
+          with_new_context InClass env (fun () ->
+              with_new_function_scope class_params env.names (fun () -> k x)));
       V.kdef =
         (fun (k, _v) x ->
           match x with

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -459,6 +459,7 @@ let resolve lang prog =
            *)
           let class_params = params_of_parameters env x.cparams in
           with_new_context InClass env (fun () ->
+              (* TODO? Maybe we need a `with_new_class_scope`. For now, abusing `with_new_function_scope`. *)
               with_new_function_scope class_params env.names (fun () -> k x)));
       V.kdef =
         (fun (k, _v) x ->

--- a/semgrep-core/tests/scala/class_params.scala
+++ b/semgrep-core/tests/scala/class_params.scala
@@ -1,0 +1,8 @@
+class ExampleClass(val x: TypeName) {
+  // ERROR: match
+  val res = x.foo
+
+  def test(val y: TypeName) : Unit =
+    // ERROR: match
+    y.foo
+}

--- a/semgrep-core/tests/scala/class_params.sgrep
+++ b/semgrep-core/tests/scala/class_params.sgrep
@@ -1,0 +1,1 @@
+($OBJ : TypeName).foo


### PR DESCRIPTION
**What:**
Currently, during the naming stage, class parameters are not properly added to the scope. This means that certain identifiers with type information attached to them are not actually known to Semgrep to have those types, if introduced via class parameters. 

**Why:**
We should allow this, because otherwise Semgrep cannot fulfill certain typed metavariable queries.

For instance, in Scala:
```scala
class ExampleClass(val x: TypeName) {
}
```

The identifier `x` should be known to have type `TypeName`, but currently does not.

**How:**
I added some code which adds these parameters to the scope. I used `with_new_function_scope`, even though this is a class scope, since when looking through the code, it seems that this is just a general scoping thing which is undone later. Let me know if that's not the right thing to do, though.

Fixes #5506.

Test plan: `make test`

PR checklist:
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
