### PR TITLE
fix(scala): allow single metavariables in imports

### DIFF
--- a/changelog.d/gh-5219.fixed
+++ b/changelog.d/gh-5219.fixed
@@ -1,0 +1,1 @@
+Scala: Fixed erroneous parsing for `import` in Semgrep patterns.

--- a/changelog.d/gh-5219.fixed
+++ b/changelog.d/gh-5219.fixed
@@ -1,1 +1,1 @@
-Scala: Fixed erroneous parsing for `import` in Semgrep patterns.
+Scala: Allow metavariables in `import` patterns

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -121,10 +121,19 @@ let v_dotted_name_of_stable_id (v1, v2) =
   let id = id_of_simple_ref v1 in
   id :: v2
 
-let rec v_import_expr tk (v1, v2) =
-  let module_name = G.DottedName (v_dotted_name_of_stable_id v1) in
-  let v2 = v_import_spec v2 in
-  v2 tk module_name
+let rec v_import_expr tk import_expr =
+  match import_expr with
+  | Left id ->
+      [
+        {
+          G.d = G.ImportAll (tk, FileName id, Parse_info.fake_info tk "");
+          d_attrs = [];
+        };
+      ]
+  | Right (v1, v2) ->
+      let module_name = G.DottedName (v_dotted_name_of_stable_id v1) in
+      let v2 = v_import_spec v2 in
+      v2 tk module_name
 
 and v_import_spec = function
   | ImportId v1 ->

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -124,12 +124,7 @@ let v_dotted_name_of_stable_id (v1, v2) =
 let rec v_import_expr tk import_expr =
   match import_expr with
   | Left id ->
-      [
-        {
-          G.d = G.ImportAll (tk, FileName id, Parse_info.fake_info tk "");
-          d_attrs = [];
-        };
-      ]
+      [ { G.d = G.ImportFrom (tk, DottedName [], id, None); d_attrs = [] } ]
   | Right (v1, v2) ->
       let module_name = G.DottedName (v_dotted_name_of_stable_id v1) in
       let v2 = v_import_spec v2 in

--- a/semgrep-core/tests/scala/import_metavariable.scala
+++ b/semgrep-core/tests/scala/import_metavariable.scala
@@ -1,2 +1,11 @@
 // MATCH:
 import A.B, C.D
+
+// MATCH:
+import this.x.foo
+
+// MATCH:
+import a.this.b.c
+
+// MATCH:
+import x.y.z

--- a/semgrep-core/tests/scala/import_metavariable.scala
+++ b/semgrep-core/tests/scala/import_metavariable.scala
@@ -1,0 +1,1 @@
+import A.B, C.D

--- a/semgrep-core/tests/scala/import_metavariable.scala
+++ b/semgrep-core/tests/scala/import_metavariable.scala
@@ -1,1 +1,2 @@
+// MATCH:
 import A.B, C.D

--- a/semgrep-core/tests/scala/import_metavariable.sgrep
+++ b/semgrep-core/tests/scala/import_metavariable.sgrep
@@ -1,0 +1,1 @@
+import $X


### PR DESCRIPTION
Currently blocked by https://github.com/returntocorp/pfff/pull/541.

**What:**
Scala `import` parsing is currently broken, and both does not conform to the specification, and does not handle metavariables properly. This manifests in Semgrep patterns such as `import $X` being rejected as invalid patterns at parse time. 

**Why:**
We should fix this because the above import pattern is useful to be able to do, particularly when `$X` is a metavariable regex or something.

**How:**
Via [scala-lang](https://www.scala-lang.org/files/archive/spec/2.11/13-syntax-summary.html), we obtain:
<img width="564" alt="Screen Shot 2022-07-19 at 10 38 23 PM" src="https://user-images.githubusercontent.com/49291449/179904979-998c1b01-9a92-493f-834d-7d3e62ca8f97.png">

Unrolling this once, we see that we get something like:
```
StableId ::= id
           | StableId '.' `id`
           | [id '.'] `this` `.` id
           | [id '.'] `super` [ClassQualifier] '.' id
```

Basically, a `StableId` starts as either a single `id`, or a `id.this.id2`, or a `id.super [class qualifier]`, and then sees some number of identifiers. Notably, because we have:
<img width="554" alt="Screen Shot 2022-07-19 at 10 43 17 PM" src="https://user-images.githubusercontent.com/49291449/179905578-8456766a-a7f1-442d-b011-975fdd4c4358.png">

in the case of an `import`, it must be at least one.

This means that something like `import X` is not actually syntactically permissible Scala. This is why, currently, `import $X` fails. But this is still something that would be nice to be able to do, so I went ahead and changed things so that we can support it.

Essentially, I've made it such that `import_expr`s are either what they normally are understood to be, _or_ they can be a metavariable. This makes it so that we don't parse things like `import x`, but we can parse `import $X`.

The previous code also permitted non-dots following an identifier, and I don't think that should actually be possible.

Fixes #5219.

**Test plan:**
So, ideally I'd like to write a ton of tests showing that things which do not conform to the Scala grammar do not parse. Unfortunately, the parsing tests seem to be more about what things _do_ parse, so I don't actually know how to do this. Feedback appreciated.

In the meantime, the test plan can be to try testing dumping patterns on the following `.sgrep` patterns. I've verified the following using `sc -dump_pattern test.sgrep -lang scala`:
| example | status |
|:-|:-|
| `import this.a` | FAILS |
| `import this.a._` | SUCCEEDS |
| `import $X` | SUCCEEDS |
| `import $X._` | SUCCEEDS |
| `import a.$X._` | SUCCEEDS |
| `import a` | FAILS |
| `import a.this.b` | FAILS |
| `import a.this.b._` | SUCCEEDS |

Not sure how to carve this in stone, so to speak, however. Let me know what you think.

PR checklist:

- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
