### PR TITLE
feat(taint)!: Improve dataflow trace JSON output

### DIFF
--- a/changelog.d/dataflow-trace-json.changed
+++ b/changelog.d/dataflow-trace-json.changed
@@ -1,0 +1,1 @@
+Made breaking changes to the dataflow_trace JSON output to make it more easily consumable by the App. Added content for taint_source and intermediate_vars, and collapsed the multile taint_source locations into one.

--- a/cli/src/semgrep/formatter/json.py
+++ b/cli/src/semgrep/formatter/json.py
@@ -29,7 +29,7 @@ class JsonFormatter(BaseFormatter):
             # 'lines' already contains '\n' at the end of each line
             lines="".join(rule_match.lines).rstrip(),
             metavars=rule_match.match.extra.metavars,
-            dataflow_trace=rule_match.match.extra.dataflow_trace,
+            dataflow_trace=rule_match.dataflow_trace,
         )
 
         if rule_match.extra.get("dependency_matches"):

--- a/cli/tests/e2e/snapshots/test_check/test_taint_mode/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_taint_mode/results.json
@@ -18,60 +18,41 @@
         "dataflow_trace": {
           "intermediate_vars": [
             {
-              "end": {
-                "col": 6,
-                "line": 3,
-                "offset": 62
-              },
-              "path": "targets/taint/taint.py",
-              "start": {
-                "col": 5,
-                "line": 3,
-                "offset": 61
+              "content": "a",
+              "location": {
+                "end": {
+                  "col": 6,
+                  "line": 3,
+                  "offset": 62
+                },
+                "path": "targets/taint/taint.py",
+                "start": {
+                  "col": 5,
+                  "line": 3,
+                  "offset": 61
+                }
               }
             },
             {
-              "end": {
-                "col": 10,
-                "line": 8,
-                "offset": 145
-              },
-              "path": "targets/taint/taint.py",
-              "start": {
-                "col": 9,
-                "line": 8,
-                "offset": 144
+              "content": "b",
+              "location": {
+                "end": {
+                  "col": 10,
+                  "line": 8,
+                  "offset": 145
+                },
+                "path": "targets/taint/taint.py",
+                "start": {
+                  "col": 9,
+                  "line": 8,
+                  "offset": 144
+                }
               }
             }
           ],
-          "taint_source": [
-            {
-              "end": {
-                "col": 16,
-                "line": 3,
-                "offset": 72
-              },
-              "path": "targets/taint/taint.py",
-              "start": {
-                "col": 9,
-                "line": 3,
-                "offset": 65
-              }
-            },
-            {
-              "end": {
-                "col": 17,
-                "line": 3,
-                "offset": 73
-              },
-              "path": "targets/taint/taint.py",
-              "start": {
-                "col": 16,
-                "line": 3,
-                "offset": 72
-              }
-            },
-            {
+          "taint_source": {
+            "content": "source1()",
+            "location": {
               "end": {
                 "col": 18,
                 "line": 3,
@@ -79,12 +60,12 @@
               },
               "path": "targets/taint/taint.py",
               "start": {
-                "col": 17,
+                "col": 9,
                 "line": 3,
-                "offset": 73
+                "offset": 65
               }
             }
-          ]
+          }
         },
         "fingerprint": "b7d9e6f63610bc461ccd05b612b609b516a1ba6c6fb63268160f62de8bb894cd8c2ef9e389681db5d538050af75010b0219f21d41f67488da439ca426798dbde_0",
         "is_ignored": false,


### PR DESCRIPTION
This is a breaking change to the dataflow trace JSON output produced by
the CLI.

It makes the following changes requested by the Findings team:

- Combine the multiple taint source tokens into one range spanning the
  entire taint source.
- Include `content` for taint source and intermediate vars.

Test plan: Automated tests

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
