### PR TITLE
metavariable-comparison: Allow comparing any AST node as a string

### DIFF
--- a/changelog.d/metavariable-comparison-metavariable.changed
+++ b/changelog.d/metavariable-comparison-metavariable.changed
@@ -1,0 +1,3 @@
+`metavariable-comparison`: The `metavariable` field is now optional, except
+if `strip: true`. When `strip: false` (the default) the `metavaraible` field
+has no use so it was pointless to require it.

--- a/changelog.d/pa-1659.changed
+++ b/changelog.d/pa-1659.changed
@@ -1,6 +1,6 @@
 `metavariable-comparison` now also works on metavariables that cannot be evaluated
 to simple literals. In such cases, we take the string representation of the code
-bound by the metariable. The way to access this string representation is via
+bound by the metavariable. The way to access this string representation is via
 `str($MVAR)`. For example:
 
 ```

--- a/changelog.d/pa-1659.changed
+++ b/changelog.d/pa-1659.changed
@@ -1,0 +1,14 @@
+`metavariable-comparison` now also works on metavariables that cannot be evaluated
+to simple literals. In such cases, we take the string representation of the code
+bound by the metariable. The way to access this string representation is via
+`str($MVAR)`. For example:
+
+```
+- metavariable-comparison:
+    metavariable: $X
+    comparison: str($X) == str($Y)
+```
+
+Here `$X` and `$Y` may bind to two different code variables, and we check whether
+these two code variables have the same name (e.g. two different variables but both
+named `x`).

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -16,6 +16,8 @@ open Common
 module G = AST_generic
 module MV = Metavariable
 
+let logger = Logging.get_logger [ __MODULE__ ]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -145,7 +147,7 @@ and extra =
 
 (* See also engine/Eval_generic.ml *)
 and metavariable_comparison = {
-  metavariable : MV.mvar;
+  metavariable : MV.mvar option;
   comparison : AST_generic.expr;
   (* I don't think those are really needed; they can be inferred
    * from the values *)
@@ -490,14 +492,14 @@ let rec (convert_formula_old :
   and aux_and e =
     match e with
     | PatExtra (t, x) ->
-        let e = convert_extra ~rule_id x in
+        let e = convert_extra ~t ~rule_id x in
         Middle3 (t, e)
     | PatFocus (t, mvar) -> Right3 (t, mvar)
     | _ -> Left3 (aux e)
   in
   aux (remove_noop e)
 
-and convert_extra ~rule_id x =
+and convert_extra ~t ~rule_id x =
   match x with
   | MetavarRegexp (mvar, re, const_prop) -> CondRegexp (mvar, re, const_prop)
   | MetavarPattern (mvar, opt_xlang, formula_old) ->
@@ -517,11 +519,21 @@ and convert_extra ~rule_id x =
           let cond =
             (* if strip=true we rewrite the condition and insert Python's `int`
              * function to parse the integer value of mvar. *)
-            match strip with
-            | None
-            | Some false ->
+            match (mvar, strip) with
+            | _, None
+            | _, Some false ->
                 comparison
-            | Some true -> rewrite_metavar_comparison_strip mvar comparison
+            | None, Some true ->
+                (* This error should be caught already in Parse_rule, this is just
+                   defensive programming. *)
+                let error_msg =
+                  "'metavariable-comparison' is missing 'metavariable' despite \
+                   'strip: true'"
+                in
+                logger#error "%s" error_msg;
+                raise (InvalidRule (InvalidOther error_msg, rule_id, t))
+            | Some mvar, Some true ->
+                rewrite_metavar_comparison_strip mvar comparison
           in
           CondEval cond)
   | MetavarAnalysis (mvar, kind) -> CondAnalysis (mvar, kind)

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -137,6 +137,7 @@ let value_of_lit ~code x =
   (* big integers or floats can't be evaluated (Int (None, ...)) *)
   | G.Int (Some i, _t) -> Int i
   | G.Float (Some f, _t) -> Float f
+  | G.Null _ -> Int 0
   | _ -> raise (NotHandled code)
 
 let rec eval env code =
@@ -188,6 +189,10 @@ let rec eval env code =
   | G.Container (G.List, (_, xs, _)) ->
       let vs = Common.map (eval env) xs in
       List vs
+  (* Emulate Python str just enough *)
+  | G.Call ({ e = G.N (G.Id (("str", _), _)); _ }, (_, [ G.Arg e ], _)) ->
+      let v = eval env e in
+      eval_str env ~code v
   (* Emulate Python re.match just enough *)
   | G.Call
       ( {
@@ -277,6 +282,18 @@ and eval_op op values code =
    * contained the resolved content of metavariables *)
   | _ -> raise (NotHandled code)
 
+and eval_str _env ~code v =
+  let str =
+    match v with
+    | Bool b -> string_of_bool b
+    | Int i -> string_of_int i
+    | Float f -> string_of_float f
+    | String s -> s
+    | AST s -> s
+    | List _ -> raise (NotHandled code)
+  in
+  String str
+
 (*****************************************************************************)
 (* Env builders *)
 (*****************************************************************************)
@@ -302,6 +319,9 @@ let text_of_binding mvar mval =
           let range = Range.range_of_token_locations min max in
           Some (Range.content_at_range file range))
 
+let string_of_binding mvar mval =
+  Option.bind (text_of_binding mvar mval) @@ fun x -> Some (mvar, AST x)
+
 let bindings_to_env (config : Config_semgrep.t) bindings =
   let constant_propagation = config.constant_propagation in
   let mvars =
@@ -312,55 +332,17 @@ let bindings_to_env (config : Config_semgrep.t) bindings =
                Some
                  ( mvar,
                    eval { mvars = Hashtbl.create 0; constant_propagation } e )
-               (* this can happen when a metavar is binded to a complex expression,
-                  * e.g., os.getenv("foo") which can't be evaluated. It's ok to
-                  * filter those metavars then.
-               *)
              with
              | NotHandled _
              | NotInEnv _ ->
-                 logger#debug "filtering mvar %s, can't eval %s" mvar
-                   (MV.show_mvalue mval);
-                 (* todo: if not a value, could default to AST of range *)
-                 None
-           in
-           match mval with
-           (* this way we can leverage the constant propagation analysis
-              * in metavariable-comparison: too! This simplifies some rules.
-           *)
-           | MV.Id (i, Some id_info) ->
-               try_bind_to_exp (G.e (G.N (G.Id (i, id_info))))
-           | MV.E e -> try_bind_to_exp e
-           | x ->
-               logger#debug "filtering mvar %s, not an expr %s" mvar
-                 (MV.show_mvalue x);
-               None)
-    |> Common.hash_of_list
-  in
-  { mvars; constant_propagation }
-
-let string_of_binding mvar mval =
-  Option.bind (text_of_binding mvar mval) @@ fun x -> Some (mvar, String x)
-
-(* this is for metavariable-regexp *)
-let bindings_to_env_just_strings_const_prop bindings =
-  let mvars =
-    bindings
-    |> Common.map_filter (fun (mvar, mval) ->
-           let try_bind_to_exp e =
-             try
-               Some
-                 ( mvar,
-                   eval
-                     { mvars = Hashtbl.create 0; constant_propagation = true }
-                     e )
-               (* this can happen when a metavar is binded to a complex expression,
-                  * e.g., os.getenv("foo") which can't be evaluated. It's ok to
-                  * filter those metavars then.
-               *)
-             with
-             | NotHandled _
-             | NotInEnv _ ->
+                 (* These are expressions like `x` or `os.getenv("FOO")` that cannot
+                  * be evaluated. Previously we just filtered out all these cases, but
+                  * in some cases it's interesting to make comparisons based on the
+                  * string representation of these expressions. For example, given
+                  * $X and $Y binding to two code variables we may want to check
+                  * whether both code variables have the same name (even if they are
+                  *  in fact different variables). So, if we can obtain such a
+                  * string representation, we add it to the environment here. *)
                  string_of_binding mvar mval
            in
            match mval with
@@ -373,7 +355,7 @@ let bindings_to_env_just_strings_const_prop bindings =
            | x -> string_of_binding mvar x)
     |> Common.hash_of_list
   in
-  { mvars; constant_propagation = true }
+  { mvars; constant_propagation }
 
 let bindings_to_env_just_strings (config : Config_semgrep.t) xs =
   let mvars =

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -137,7 +137,6 @@ let value_of_lit ~code x =
   (* big integers or floats can't be evaluated (Int (None, ...)) *)
   | G.Int (Some i, _t) -> Int i
   | G.Float (Some f, _t) -> Float f
-  | G.Null _ -> Int 0
   | _ -> raise (NotHandled code)
 
 let rec eval env code =
@@ -224,6 +223,11 @@ let rec eval env code =
 
 and eval_op op values code =
   match (op, values) with
+  | _op, [ AST _; _ ]
+  | _op, [ _; AST _ ] ->
+      (* To compare `AST` values one needs to explicitly use the `str()` function!
+       * Otherwise we would introduce regressions. *)
+      raise (NotHandled code)
   | G.And, [ Bool b1; Bool b2 ] -> Bool (b1 && b2)
   | G.Not, [ Bool b1 ] -> Bool (not b1)
   | G.Or, [ Bool b1; Bool b2 ] -> Bool (b1 || b2)

--- a/semgrep-core/src/engine/Eval_generic.mli
+++ b/semgrep-core/src/engine/Eval_generic.mli
@@ -30,11 +30,9 @@ val test_eval : Common.filename -> unit
 (* used in regression testing code *)
 val parse_json : Common.filename -> env * code
 
-(* for MetavarCond *)
+(* for metavariable-comparison and also for metavariable-regex with constant-propagation: true *)
 val bindings_to_env_just_strings :
   Config_semgrep.t -> Metavariable.bindings -> env
-
-val bindings_to_env_just_strings_const_prop : Metavariable.bindings -> env
 
 (* For entropy analysis and other string analyzers.
    The mvar is only for making an error message. *)

--- a/semgrep-core/src/engine/Match_search_mode.ml
+++ b/semgrep-core/src/engine/Match_search_mode.ml
@@ -364,7 +364,13 @@ let rec filter_ranges env xs cond =
                    ( fk,
                      [
                        G.Arg (G.L (G.String (re_str, fk)) |> G.e);
-                       G.Arg (G.N (G.Id ((mvar, fk), fki)) |> G.e);
+                       G.Arg
+                         (G.Call
+                            ( G.N (G.Id (("str", fk), fki)) |> G.e,
+                              ( fk,
+                                [ G.Arg (G.N (G.Id ((mvar, fk), fki)) |> G.e) ],
+                                fk ) )
+                         |> G.e);
                      ],
                      fk ) )
                |> G.e
@@ -372,7 +378,7 @@ let rec filter_ranges env xs cond =
 
              let env =
                if const_prop && (fst env.config).constant_propagation then
-                 Eval_generic.bindings_to_env_just_strings_const_prop bindings
+                 Eval_generic.bindings_to_env (fst env.config) bindings
                else
                  Eval_generic.bindings_to_env_just_strings (fst env.config)
                    bindings

--- a/semgrep-core/src/engine/Match_search_mode.ml
+++ b/semgrep-core/src/engine/Match_search_mode.ml
@@ -355,25 +355,28 @@ let rec filter_ranges env xs cond =
                 * an expression manually.
                 *)
                let re_str = Regexp_engine.pcre_pattern re in
-               G.Call
-                 ( G.DotAccess
-                     ( G.N (G.Id (("re", fk), fki)) |> G.e,
-                       fk,
-                       FN (Id (("match", fk), fki)) )
-                   |> G.e,
-                   ( fk,
-                     [
-                       G.Arg (G.L (G.String (re_str, fk)) |> G.e);
-                       G.Arg
-                         (G.Call
-                            ( G.N (G.Id (("str", fk), fki)) |> G.e,
-                              ( fk,
-                                [ G.Arg (G.N (G.Id ((mvar, fk), fki)) |> G.e) ],
-                                fk ) )
-                         |> G.e);
-                     ],
-                     fk ) )
-               |> G.e
+               let re_exp = G.L (G.String (re_str, fk)) |> G.e in
+               let mvar_exp = G.N (G.Id ((mvar, fk), fki)) |> G.e in
+               let call_re_match re_exp str_exp =
+                 G.Call
+                   ( G.DotAccess
+                       ( G.N (G.Id (("re", fk), fki)) |> G.e,
+                         fk,
+                         FN (Id (("match", fk), fki)) )
+                     |> G.e,
+                     (fk, [ G.Arg re_exp; G.Arg str_exp ], fk) )
+                 |> G.e
+               in
+               let call_str x =
+                 G.Call
+                   (G.N (G.Id (("str", fk), fki)) |> G.e, (fk, [ G.Arg x ], fk))
+                 |> G.e
+               in
+               (* We generate a fake expression:
+                     re.match(re_str, str($MVAR))
+                  that matches `re_str` against the string representation of
+                  $MVAR's value. *)
+               call_re_match re_exp (call_str mvar_exp)
              in
 
              let env =

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -739,12 +739,19 @@ and parse_extra (env : env) (key : key) (value : G.expr) : Rule.extra =
   | "metavariable-comparison" ->
       let mv_comparison_dict = yaml_to_dict env key value in
       let metavariable, comparison, strip, base =
-        ( take mv_comparison_dict env parse_string "metavariable",
+        ( take_opt mv_comparison_dict env parse_string "metavariable",
           take mv_comparison_dict env parse_string "comparison",
           take_opt mv_comparison_dict env parse_bool "strip",
           take_opt mv_comparison_dict env parse_int "base" )
       in
       let comparison = parse_metavar_cond env key comparison in
+      (match (metavariable, strip) with
+      | None, Some true ->
+          error_at_key env key
+            (fst key
+           ^ ": 'metavariable' field is missing, but it is mandatory if \
+              'strip: true'")
+      | __else__ -> ());
       R.MetavarComparison { R.metavariable; comparison; strip; base }
   | _ -> error_at_key env key ("wrong parse_extra field: " ^ fst key)
 

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_str.go
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_str.go
@@ -9,7 +9,6 @@ func divide_remainder(a int, b int) (int,int) {
 
 // pointless function, but example of the bad pattern
 func bad(a int, b int, c int) int {
-    //todook: reinstantiated_variable_in_new_block
     foo, remainder :=  divide_remainder(a, b)
     if (c != 0) {
         //ruleid: reinstantiated_variable_in_new_block
@@ -20,7 +19,6 @@ func bad(a int, b int, c int) int {
 
 // pointless function, but example of a non problem
 func bad(a int, b int, c int) int {
-    //todook: reinstantiated_variable_in_new_block
     foo, remainder :=  divide_remainder(a, b)
     if (c != 0) {
         //ok: reinstantiated_variable_in_new_block
@@ -31,7 +29,6 @@ func bad(a int, b int, c int) int {
 
 // pointless function, but example of the acceptable pattern
 func good(a int, b int, c int) int {
-    //todook: reinstantiated_variable_in_new_block
     foo, remainder :=  divide_remainder(a, b)
     if (c != 0) {
         //ok: reinstantiated_variable_in_new_block

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_str.go
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_str.go
@@ -1,0 +1,41 @@
+import (
+    "math"
+)
+
+func divide_remainder(a int, b int) (int,int) {
+     return math.Floor(a/b), a%b
+}
+
+
+// pointless function, but example of the bad pattern
+func bad(a int, b int, c int) int {
+    //todook: reinstantiated_variable_in_new_block
+    foo, remainder :=  divide_remainder(a, b)
+    if (c != 0) {
+        //ruleid: reinstantiated_variable_in_new_block
+        _, remainder := divide_remainder(foo, c) //bad line
+    }
+    return remainder
+}
+
+// pointless function, but example of a non problem
+func bad(a int, b int, c int) int {
+    //todook: reinstantiated_variable_in_new_block
+    foo, remainder :=  divide_remainder(a, b)
+    if (c != 0) {
+        //ok: reinstantiated_variable_in_new_block
+        _, remainder2 := divide_remainder(foo, c) //ok line
+    }
+    return remainder
+}
+
+// pointless function, but example of the acceptable pattern
+func good(a int, b int, c int) int {
+    //todook: reinstantiated_variable_in_new_block
+    foo, remainder :=  divide_remainder(a, b)
+    if (c != 0) {
+        //ok: reinstantiated_variable_in_new_block
+        _, remainder = divide_remainder(foo, c) //good line
+    }
+    return remainder
+}

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_str.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_str.yaml
@@ -11,7 +11,6 @@ rules:
               ...
               ..., $Y := $REASSIGNMENT
       - metavariable-comparison:
-          metavariable: $X
           comparison: str($X) == str($Y)
       - focus-metavariable: $Y
     message: Re-instantiating a variable $X in a block after already declaring $Y

--- a/semgrep-core/tests/OTHER/rules/metavar_comparison_str.yaml
+++ b/semgrep-core/tests/OTHER/rules/metavar_comparison_str.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: reinstantiated_variable_in_new_block
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $X := $ASSIGNMENT
+              ...
+              $Y := $REASSIGNMENT
+          - pattern: |
+              ...,$X := $ASSIGNMENT
+              ...
+              ..., $Y := $REASSIGNMENT
+      - metavariable-comparison:
+          metavariable: $X
+          comparison: str($X) == str($Y)
+      - focus-metavariable: $Y
+    message: Re-instantiating a variable $X in a block after already declaring $Y
+    languages: [go]
+    severity: WARNING


### PR DESCRIPTION
And add basic support for Python's  `str`.

Closes PA-1659

test plan:
make test # added one test

PR checklist:

- [ ] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
