### PR TITLE
Revert "feat(ci): publish linux/arm64 image (#5736)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref,'-test-release') }}
     steps:
-      - name: Set up QEMU # required for multiarch
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -97,7 +95,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           load: true
-          platforms: linux/amd64,linux/arm64
           tags: candidate-image
           cache-from: type=gha,src=/tmp/.buildx-cache
           cache-to: type=gha,dest=/tmp/.buildx-cache,mode=max
@@ -128,7 +125,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,src=/tmp/.buildx-cache

--- a/changelog.d/gh-5704.added
+++ b/changelog.d/gh-5704.added
@@ -1,1 +1,0 @@
-Start publishing container image for linux/arm64 along with linux/amd64.


### PR DESCRIPTION
This reverts commit 465f7ee4e31c1a0d146d3856456049c434527ea5. 

This caused issues with release, and we'll revisit after testing more thoroughly.

@wilsonehusin (the original author) - looks like there may be some issues with how we're building locally before pushing (combined with an issue in upstream docker - https://github.com/docker/buildx/issues/59) so we need to pull this out for our current release and can bring it back in once we've reconciled that different. We appreciate the PR, though!

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
