### PR TITLE
fix: Match metavariables against resolved names

### DIFF
--- a/changelog.d/gh-5690.fixed
+++ b/changelog.d/gh-5690.fixed
@@ -1,0 +1,1 @@
+Fixed a regression in name resolution that occurred with metavariable patterns

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -420,6 +420,8 @@ let rec m_name a b =
            } as infob) ) ) -> (
       m_name a (B.Id (idb, { infob with B.id_resolved = ref None }))
       >||> try_alternate_names resolved
+      (* Try the resolved entity *)
+      >||> m_name a (H.name_of_ids dotted)
       >||>
       (* Try the resolved entity and parents *)
       match a with
@@ -437,8 +439,8 @@ let rec m_name a b =
        *)
       | G.Id ((str, _tok), _info) when MV.is_metavar_name str -> fail ()
       | _ ->
-          (* try this time a match with the resolved entity *)
-          m_name a (H.name_of_ids dotted) >||> try_parents dotted)
+          (* Try matching against parent classes *)
+          try_parents dotted)
   (* extension: metatypes *)
   | G.Id (((str, t) as a1), a_info), B.Id (b1, b2) -> (
       (* this will handle metavariables in Id *)

--- a/semgrep-core/tests/OTHER/rules/metavariable_name_resolution.java
+++ b/semgrep-core/tests/OTHER/rules/metavariable_name_resolution.java
@@ -1,0 +1,10 @@
+import org.foo.Foo;
+
+public class Test {
+    public static void main(String[] args) {
+        Foo foo = new Foo();
+        // ruleid: metavariable-resolution-test
+        foo.bar();
+        foo.baz();
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/metavariable_name_resolution.yml
+++ b/semgrep-core/tests/OTHER/rules/metavariable_name_resolution.yml
@@ -1,0 +1,13 @@
+rules:
+- id: metavariable-resolution-test
+  patterns:
+    - pattern: ($FOO $VAR).bar()
+    - metavariable-pattern:
+        metavariable: $FOO
+        pattern-either:
+          - pattern: org.foo.Foo
+  languages:
+    - java
+  message: bad
+  severity: ERROR
+


### PR DESCRIPTION
This undoes #5437, which turned out to be a misguided attempt to cut
down on duplicate matches. Perhaps we could ignore the metavariable
binding information when we dedup, though that may come with its own
problems. For now, we'd rather deal with duplicates than fail to match
in cases where we should.

Test plan: Automated tests

Fixes #5690

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
