### PR TITLE
fix(taint): Top level envs into functions

### DIFF
--- a/changelog.d/gh-5219.fixed
+++ b/changelog.d/gh-5219.fixed
@@ -1,0 +1,1 @@
+Scala: Fixed erroneous parsing for `import` in Semgrep patterns.

--- a/changelog.d/pa-1656.fixed
+++ b/changelog.d/pa-1656.fixed
@@ -1,0 +1,14 @@
+
+Allowed tainted variables from top-level environments to spread into function bodies.
+
+For instance, a given the following example in Javascript:
+```js
+x = source
+
+function foo () {
+  sink(source)
+}
+```
+
+If we are looking for a `sink($SINK)`, before this Pr it would not be caught, because
+function bodies are all analyzed separately, with empty contexts.

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -30,7 +30,7 @@ let test_tainting lang file config def =
 
   Common.pr2 "\nDataflow";
   Common.pr2 "--------";
-  let mapping = Dataflow_tainting.fixpoint config flow in
+  let mapping = Dataflow_tainting.fixpoint config flow (fun _ _ _ _ _ -> ()) in
   DataflowX.display_mapping flow mapping (fun taint ->
       let show_taint t =
         match t.Taint.orig with

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -121,10 +121,19 @@ let v_dotted_name_of_stable_id (v1, v2) =
   let id = id_of_simple_ref v1 in
   id :: v2
 
-let rec v_import_expr tk (v1, v2) =
-  let module_name = G.DottedName (v_dotted_name_of_stable_id v1) in
-  let v2 = v_import_spec v2 in
-  v2 tk module_name
+let rec v_import_expr tk import_expr =
+  match import_expr with
+  | Left id ->
+      [
+        {
+          G.d = G.ImportAll (tk, FileName id, Parse_info.fake_info tk "");
+          d_attrs = [];
+        };
+      ]
+  | Right (v1, v2) ->
+      let module_name = G.DottedName (v_dotted_name_of_stable_id v1) in
+      let v2 = v_import_spec v2 in
+      v2 tk module_name
 
 and v_import_spec = function
   | ImportId v1 ->

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -87,6 +87,12 @@ val fixpoint :
   ?fun_env:fun_env (** Poor-man's interprocedural HACK (TO BE DEPRECATED) *) ->
   config ->
   IL.cfg ->
+  (Taint.Taint_set.t Dataflow_core.env ->
+  fun_env ->
+  config ->
+  AST_generic.entity option ->
+  AST_generic.function_definition ->
+  unit) ->
   mapping
 (** Main entry point, [fixpoint config cfg] returns a mapping (effectively a set)
   * containing all the tainted variables in [cfg]. Besides, if it infers any taint


### PR DESCRIPTION
**What**:
Currently, we have an issue where top-level declarations are not taken into account in the control flow graph, when doing the dataflow analysis for tainting. 

**Why:**
This is a pretty nice thing to be able to do, because it allows us to analyze examples like the following:
https://semgrep.dev/playground/s/brandon-wu:test_xss-copy

This stems from the code in `Match_tainting_mode.ml` doing two analyses - one which traverses each function definition (with an empty environment), and one which walks through the top-level of the program. Notably, each function body analysis is divorced from the code that came before it.

**How:**
I took the code which does an empty analysis on a function, and made it an argument to the transfer function in `Dataflow_tainting.ml`. This allows the analysis of a function node in the control flow graph, using the already-computed in-set from the dataflow analysis. Since this has no effect on the out-set, it simply exists to report any tainted patterns within the function body, and should not effect the actual values passed around in the analysis.

The reason why it is taken in as an argument (instead of just referenced as a variable) is because the function-checking function must take in the language that it is doing the analysis on, which is not already an input to the transfer function, as far as I can tell.

Making an extra argument to the transfer function is not an ideal solution, but it's the first one I thought of. Moreover, I'm not sure if a nicer one exists, because it seems like we would need to reify the function statement within the IL CFG in a better way, so as to leverage the existing transfer function (which should only ever do "one step" of the analysis, so to speak). However, this would require taking care of scoping (i.e., the computed out-set at the end of the function would need to be reset to whatever it was at the beginning of the function in the CFG).

Open to suggestions.

**Test plan:** TODO

**Fixes [PA-1656](https://linear.app/r2c/issue/PA-1656/js-taint-not-flowing-through-async-or-function)**

PR checklist:

- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
