### PR TITLE
Elixir: cleanup Parse_elixir_tree_sitter.ml

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
@@ -77,7 +77,7 @@ type struct_ = expr
 (*****************************************************************************)
 (* Intermediate AST constructs to AST_generic *)
 (*****************************************************************************)
-let body_to_stmts es = es |> List.map G.exprstmt
+let body_to_stmts es = es |> Common.map G.exprstmt
 
 (*****************************************************************************)
 (* Helpers *)


### PR DESCRIPTION
Factorize code (reverse the unrolling done by ocaml-tree-sitter)

This will help #3698

test plan:
make test


PR checklist:

- [ ] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!