### PR TITLE
Add temporary PAT auth for e2e tests

### DIFF
--- a/.github/workflows/e2e-semgrep-ci.yml
+++ b/.github/workflows/e2e-semgrep-ci.yml
@@ -61,23 +61,11 @@ jobs:
     runs-on: ubuntu-22.04
     needs: semgrep-ci-on-pr
     steps:
-      - name: Get JWT for semgrep-ci GitHub App
-        id: jwt
-        uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
-        env:
-          EXPIRATION: 600 # seconds
-          ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }} # semgrep-ci GitHub App id
-          PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
-      - name: Get token for semgrep-ci GitHub App
+      - name: Get PAT
         id: token
         run: |
-          TOKEN="$(curl -X POST \
-          -H "Authorization: Bearer ${{ steps.jwt.outputs.jwt }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/app/installations/${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID }}/access_tokens" | \
-          jq -r .token)"
-          echo "::add-mask::$TOKEN"
-          echo "::set-output name=token::$TOKEN"
+          echo "::add-mask::${{ secrets.TEMPORARY_PAT }}"
+          echo "::set-output name=token::${{ secrets.TEMPORARY_PAT }}"
       - name: Wait for checks to register
         id: register-checks
         env:


### PR DESCRIPTION
This change swaps out the semgrep-ci bot in our e2e test for a 30-day PAT issued and added to the repo as a secret. We need this workflow operational again so we can:
- continue to test semgrep
- build off of this for our fail-open infra/e2e tests

The PAT was issued with minimal perms specifcally for this use and with a 30-day expiry. It is not used elsewhere.

Plan is to continue addressing this in the future, and open a bug report with GHA to ensure we're not making a mistake with the semgrep-ci bot.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
