### PR TITLE
filter_irrelevant_rules: Do not skip files due to PCRE errors

### DIFF
--- a/changelog.d/pa-1635.fixed
+++ b/changelog.d/pa-1635.fixed
@@ -1,0 +1,4 @@
+`-filter_irrelevant_rules` was incorrectly skipping files when the PCRE engine threw
+an error, while trying to match a regex that determines whether a rule is relevant
+for a file. This has been fixed so that, in case of a PCRE error, we assume that the
+rule could be relevant and we do run it on the file.

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -492,7 +492,9 @@ let run_cnf_step2 cnf big_str =
                   (* TODO: matching_exact_word does not work, why??
                      because string literals and metavariables are put under Idents? *)
                   let re = Regexp_engine.matching_exact_string id in
-                  Regexp_engine.unanchored_match re big_str)
+                  (* Note that in case of a PCRE error, we want to assume that the
+                     rule is relevant, hence ~default:true! *)
+                  Regexp_engine.unanchored_match ~default:true re big_str)
        | Regexp2_search re -> Regexp_engine.unanchored_match re big_str)
   [@@profiling]
 

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -493,8 +493,8 @@ let run_cnf_step2 cnf big_str =
                      because string literals and metavariables are put under Idents? *)
                   let re = Regexp_engine.matching_exact_string id in
                   (* Note that in case of a PCRE error, we want to assume that the
-                     rule is relevant, hence ~default:true! *)
-                  Regexp_engine.unanchored_match ~default:true re big_str)
+                     rule is relevant, hence ~on_error:true! *)
+                  Regexp_engine.unanchored_match ~on_error:true re big_str)
        | Regexp2_search re -> Regexp_engine.unanchored_match re big_str)
   [@@profiling]
 

--- a/semgrep-core/src/utils/Regexp_engine.ml
+++ b/semgrep-core/src/utils/Regexp_engine.ml
@@ -72,12 +72,13 @@ let matching_exact_word s =
 *)
 let pcre_compile pat = (pat, SPcre.regexp ~flags:[ `MULTILINE ] pat)
 
-let anchored_match =
+let anchored_match ?default =
   (* ~iflags are precompiled flags for better performance compared to ~flags *)
   let iflags = Pcre.rflags [ `ANCHORED ] in
-  fun (_, re) str -> SPcre.pmatch_noerr ~iflags ~rex:re str
+  fun (_, re) str -> SPcre.pmatch_noerr ?default ~iflags ~rex:re str
 
-let unanchored_match (_, re) str = SPcre.pmatch_noerr ~rex:re str
+let unanchored_match ?default (_, re) str =
+  SPcre.pmatch_noerr ?default ~rex:re str
 
 let may_contain_end_of_string_assertions =
   (* The absence of the following guarantees (to the best of our knowledge)

--- a/semgrep-core/src/utils/Regexp_engine.ml
+++ b/semgrep-core/src/utils/Regexp_engine.ml
@@ -72,13 +72,13 @@ let matching_exact_word s =
 *)
 let pcre_compile pat = (pat, SPcre.regexp ~flags:[ `MULTILINE ] pat)
 
-let anchored_match ?default =
+let anchored_match ?on_error =
   (* ~iflags are precompiled flags for better performance compared to ~flags *)
   let iflags = Pcre.rflags [ `ANCHORED ] in
-  fun (_, re) str -> SPcre.pmatch_noerr ?default ~iflags ~rex:re str
+  fun (_, re) str -> SPcre.pmatch_noerr ?on_error ~iflags ~rex:re str
 
-let unanchored_match ?default (_, re) str =
-  SPcre.pmatch_noerr ?default ~rex:re str
+let unanchored_match ?on_error (_, re) str =
+  SPcre.pmatch_noerr ?on_error ~rex:re str
 
 let may_contain_end_of_string_assertions =
   (* The absence of the following guarantees (to the best of our knowledge)

--- a/semgrep-core/src/utils/Regexp_engine.mli
+++ b/semgrep-core/src/utils/Regexp_engine.mli
@@ -22,13 +22,13 @@ val matching_exact_word : string -> t
 (* Compile a regexp in PCRE syntax. *)
 val pcre_compile : string -> t
 
-val anchored_match : ?default:bool -> t -> string -> bool
+val anchored_match : ?on_error:bool -> t -> string -> bool
 (** Match the pattern at the beginning of the string (anchored match)
- * @param default is the value to return in case we encounter a PCRE error. *)
+ * @param on_error is the value to return in case we encounter a PCRE error. *)
 
-val unanchored_match : ?default:bool -> t -> string -> bool
+val unanchored_match : ?on_error:bool -> t -> string -> bool
 (** Match the pattern at any position in the string (unanchored match)
-* @param default is the value to return in case we encounter a PCRE error. *)
+* @param on_error is the value to return in case we encounter a PCRE error. *)
 
 (*
    Hack used for -filter_irrelevant_rules and metavariable-regex.

--- a/semgrep-core/src/utils/Regexp_engine.mli
+++ b/semgrep-core/src/utils/Regexp_engine.mli
@@ -22,11 +22,13 @@ val matching_exact_word : string -> t
 (* Compile a regexp in PCRE syntax. *)
 val pcre_compile : string -> t
 
-(* Match the pattern at the beginning of the string (anchored match) *)
-val anchored_match : t -> string -> bool
+val anchored_match : ?default:bool -> t -> string -> bool
+(** Match the pattern at the beginning of the string (anchored match)
+ * @param default is the value to return in case we encounter a PCRE error. *)
 
-(* Match the pattern at any position in the string (unanchored match) *)
-val unanchored_match : t -> string -> bool
+val unanchored_match : ?default:bool -> t -> string -> bool
+(** Match the pattern at any position in the string (unanchored match)
+* @param default is the value to return in case we encounter a PCRE error. *)
 
 (*
    Hack used for -filter_irrelevant_rules and metavariable-regex.

--- a/semgrep-core/src/utils/SPcre.ml
+++ b/semgrep-core/src/utils/SPcre.ml
@@ -72,12 +72,12 @@ let log_error subj err =
   logger#error "PCRE error: %s on input %S" (string_of_error err)
     string_fragment
 
-let pmatch_noerr ?iflags ?flags ?rex ?pos ?callout subj =
+let pmatch_noerr ?iflags ?flags ?rex ?pos ?callout ?(default = false) subj =
   match pmatch ?iflags ?flags ?rex ?pos ?callout subj with
   | Ok res -> res
   | Error err ->
       log_error subj err;
-      false
+      default
 
 let exec_noerr ?iflags ?flags ?rex ?pos ?callout subj =
   match exec ?iflags ?flags ?rex ?pos ?callout subj with

--- a/semgrep-core/src/utils/SPcre.ml
+++ b/semgrep-core/src/utils/SPcre.ml
@@ -72,12 +72,12 @@ let log_error subj err =
   logger#error "PCRE error: %s on input %S" (string_of_error err)
     string_fragment
 
-let pmatch_noerr ?iflags ?flags ?rex ?pos ?callout ?(default = false) subj =
+let pmatch_noerr ?iflags ?flags ?rex ?pos ?callout ?(on_error = false) subj =
   match pmatch ?iflags ?flags ?rex ?pos ?callout subj with
   | Ok res -> res
   | Error err ->
       log_error subj err;
-      default
+      on_error
 
 let exec_noerr ?iflags ?flags ?rex ?pos ?callout subj =
   match exec ?iflags ?flags ?rex ?pos ?callout subj with

--- a/semgrep-core/src/utils/SPcre.mli
+++ b/semgrep-core/src/utils/SPcre.mli
@@ -37,14 +37,14 @@ val pmatch :
   string ->
   (bool, Pcre.error) result
 
-(* Return 'default' in case of a PCRE error. The error is logged. *)
+(* Return 'on_error' in case of a PCRE error. The error is logged. *)
 val pmatch_noerr :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
   ?rex:Pcre.regexp ->
   ?pos:int ->
   ?callout:Pcre.callout ->
-  ?default:bool ->
+  ?on_error:bool ->
   string ->
   bool
 

--- a/semgrep-core/src/utils/SPcre.mli
+++ b/semgrep-core/src/utils/SPcre.mli
@@ -37,13 +37,14 @@ val pmatch :
   string ->
   (bool, Pcre.error) result
 
-(* Return 'false' in case of a PCRE error. The error is logged. *)
+(* Return 'default' in case of a PCRE error. The error is logged. *)
 val pmatch_noerr :
   ?iflags:Pcre.irflag ->
   ?flags:Pcre.rflag list ->
   ?rex:Pcre.regexp ->
   ?pos:int ->
   ?callout:Pcre.callout ->
+  ?default:bool ->
   string ->
   bool
 

--- a/semgrep-core/tests/OTHER/rules/relevant_rule_badutf8.js
+++ b/semgrep-core/tests/OTHER/rules/relevant_rule_badutf8.js
@@ -1,3 +1,4 @@
+// Char below somehow causes PCRE engine to throw a BadUTF8 error.
 // x — y : z
 //ruleid: test
 foo

--- a/semgrep-core/tests/OTHER/rules/relevant_rule_badutf8.js
+++ b/semgrep-core/tests/OTHER/rules/relevant_rule_badutf8.js
@@ -1,0 +1,3 @@
+// x — y : z
+//ruleid: test
+foo

--- a/semgrep-core/tests/OTHER/rules/relevant_rule_badutf8.yaml
+++ b/semgrep-core/tests/OTHER/rules/relevant_rule_badutf8.yaml
@@ -1,0 +1,6 @@
+rules:
+- id: test
+  message: Test
+  languages: [js]
+  severity: ERROR
+  pattern: foo


### PR DESCRIPTION
Closes PA-1635

test plan:
make test # added one test

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
