### PR TITLE
fix(const prop): toplevel const prop

### DIFF
--- a/changelog.d/pa-223.fixed
+++ b/changelog.d/pa-223.fixed
@@ -1,0 +1,3 @@
+Constant propagation: Added a fix which properly does dataflow analysis for constant propagation at the top level.
+
+Basically, it was doing the dataflow correctly inside of functions, but not at the top level. So this PR just regards the whole top-level program as the inside of a function, and uses the method which already works.

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -688,6 +688,8 @@ let propagate_dataflow lang ast =
       in
       (* Hack to do dataflow on the entire AST.
          Just think of it as a function body for a function which takes no arguments.
+         
+         Shouldn't repeat work, because the overall dataflow engine doesn't know about the inside of functions. (To be changed?)
       *)
       let stmts = List.concat_map (AST_to_IL.stmt lang) ast in
       let prog_flow = CFG_build.cfg_of_stmts stmts in

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -686,4 +686,10 @@ let propagate_dataflow lang ast =
                 propagate_dataflow_one_function lang inputs flow);
           }
       in
+      (* Hack to do dataflow on the entire AST.
+         Just think of it as a function body for a function which takes no arguments.
+      *)
+      let stmts = List.concat_map (AST_to_IL.stmt lang) ast in
+      let prog_flow = CFG_build.cfg_of_stmts stmts in
+      propagate_dataflow_one_function lang [] prog_flow;
       v (Pr ast)


### PR DESCRIPTION
**What:**
Currently, constant propagation at the top level in a program is not behaving as intended.

**Why:**
We should fix this because it makes examples like [this](https://semgrep.dev/s/A9QL) not work properly, but permits examples like [this](https://semgrep.dev/s/D9Qd).

**How:**
Firstly, we notice that the second link above works properly, meaning that dataflow is being done properly for function definitions. Within the code of `Constant_propagation.ml`, this is done via the `propagate_dataflow_one_function` function, which is only called on function definitions.

So this fix just regards the entire top-level AST as the inside of a function, and then runs the working `propagate_dataflow_one_function` on it. I don't believe this should repeat work, because the overall dataflow engine doesn't know about the inside of functions.

I first tried running `propagate_basic` on the entire AST, which looks promising, but it didn't work. I'm not entirely sure why.

**Test plan:** `make test`

**Fixes [PA-223](https://linear.app/r2c/issue/PA-223/constant-propagation-only-runs-inside-functions)**.

PR checklist:

- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
