### PR TITLE
feat(dataflow): reify complex constructs in dataflow engine

### DIFF
--- a/changelog.d/pa-223.fixed
+++ b/changelog.d/pa-223.fixed
@@ -1,0 +1,5 @@
+Constant propagation now runs at the top level properly, and it runs from the top-level environment into classes and modules.
+
+This means that we can pass test cases like https://semgrep.dev/s/4KPg now.
+
+This was done via implementing a new kind of dataflow analysis on the CFG of the program.

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -1036,7 +1036,6 @@ and stmt_aux env st =
       (* TODO: deal with class parameters *)
       [ mk_s (ClassStmt (List.concat_map (fun (G.F s) -> stmt env s) fields)) ]
   | G.DefStmt (_, G.ModuleDef m) ->
-      (* TODO: deal with class parameters *)
       [ mk_s (ModuleStmt (module_stmt env m.mbody)) ]
   | G.DefStmt def -> [ mk_s (MiscStmt (DefStmt def)) ]
   | G.DirectiveStmt dir -> [ mk_s (MiscStmt (DirectiveStmt dir)) ]

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -267,10 +267,10 @@ let rec cfg_stmt : Lang.t -> state -> F.nodei option -> stmt -> cfg_stmt_result
   (* Any DefStmts which are FuncDefs are reified as proper Func nodes
      within the CFG, which contain their own smaller CFGs.
   *)
-  | MiscStmt (DefStmt (_, G.FuncDef fdef)) ->
+  | MiscStmt (DefStmt (ent, G.FuncDef fdef)) ->
       let _, stmts = AST_to_IL.function_definition lang fdef in
       let cfg = cfg_of_stmts lang stmts in
-      let newi = state.g#add_node { F.n = Func { fdef; cfg } } in
+      let newi = state.g#add_node { F.n = Func { fdef; cfg; ent } } in
       state.g |> add_arc_from_opt (previ, newi);
       CfgFirstLast (newi, Some newi)
   | MiscStmt x ->

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -270,6 +270,9 @@ let rec cfg_stmt : Lang.t -> state -> F.nodei option -> stmt -> cfg_stmt_result
   | FuncStmt { fdef; ent; body } -> (
       let cfg = cfg_of_stmts lang body in
       let newi = state.g#add_node { F.n = NFunc { fdef; cfg; ent } } in
+      (* If there is no previous node, we add an edge from the entrance node.
+         Why? This is so that the dataflow can run on unreachable functions.
+      *)
       match previ with
       | None ->
           state.g |> add_arc (state.enteri, newi);

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -264,6 +264,9 @@ let rec cfg_stmt : Lang.t -> state -> F.nodei option -> stmt -> cfg_stmt_result
       | None -> state.g |> add_arc (newi, state.exiti)
       | Some catchesi -> state.g |> add_arc (newi, catchesi));
       CfgFirstLast (newi, None)
+  (* Any DefStmts which are FuncDefs are reified as proper Func nodes
+     within the CFG, which contain their own smaller CFGs.
+  *)
   | MiscStmt (DefStmt (_, G.FuncDef fdef)) ->
       let _, stmts = AST_to_IL.function_definition lang fdef in
       let cfg = cfg_of_stmts lang stmts in

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -265,10 +265,14 @@ let rec cfg_stmt : Lang.t -> state -> F.nodei option -> stmt -> cfg_stmt_result
   (* Any DefStmts which are FuncDefs are reified as proper Func nodes
      within the CFG, which contain their own smaller CFGs.
   *)
-  | MiscStmt (DefStmt (ent, G.FuncDef fdef)) ->
-      let _, stmts = AST_to_IL.function_definition lang fdef in
-      let cfg = cfg_of_stmts lang stmts in
+  | FuncStmt { fdef; ent; body } ->
+      let cfg = cfg_of_stmts lang body in
       let newi = state.g#add_node { F.n = NFunc { fdef; cfg; ent } } in
+      state.g |> add_arc_from_opt (previ, newi);
+      CfgFirstLast (newi, Some newi)
+  | ClassStmt stmts ->
+      let cfg = cfg_of_stmts lang stmts in
+      let newi = state.g#add_node { F.n = NClass cfg } in
       state.g |> add_arc_from_opt (previ, newi);
       CfgFirstLast (newi, Some newi)
   | MiscStmt x ->

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -46,6 +46,10 @@ type state = {
   lang : Lang.t;
   g : (F.node, F.edge) Ograph_extended.ograph_mutable;
   (* We keep this so we can connect to unreachable nodes. *)
+  (* This is because if there is no previous node to a function, we add
+     an edge from the entrance node.
+     Why? This is so that the dataflow can run on unreachable functions.
+  *)
   enteri : F.nodei;
   (* When there is a 'return' we need to know the exit node to link to *)
   exiti : F.nodei;

--- a/semgrep-core/src/analyzing/CFG_build.mli
+++ b/semgrep-core/src/analyzing/CFG_build.mli
@@ -1,1 +1,1 @@
-val cfg_of_stmts : IL.stmt list -> IL.cfg
+val cfg_of_stmts : Lang.t -> IL.stmt list -> IL.cfg

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -672,7 +672,7 @@ let propagate_dataflow lang ast =
       let xs =
         AST_to_IL.stmt lang (G.Block (Parse_info.unsafe_fake_bracket ast) |> G.s)
       in
-      let flow = CFG_build.cfg_of_stmts xs in
+      let flow = CFG_build.cfg_of_stmts lang xs in
       propagate_dataflow_one_function lang [] flow
   | _ ->
       let v =
@@ -682,7 +682,7 @@ let propagate_dataflow lang ast =
             V.kfunction_definition =
               (fun (_k, _) def ->
                 let inputs, xs = AST_to_IL.function_definition lang def in
-                let flow = CFG_build.cfg_of_stmts xs in
+                let flow = CFG_build.cfg_of_stmts lang xs in
                 propagate_dataflow_one_function lang inputs flow);
           }
       in

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -675,15 +675,6 @@ let propagate_dataflow lang ast =
       let flow = CFG_build.cfg_of_stmts lang xs in
       propagate_dataflow_one_function lang [] flow
   | _ ->
-      let v =
-        V.mk_visitor
-          {
-            V.default_visitor with
-            V.kfunction_definition =
-              (fun (_k, _) def ->
-                let inputs, xs = AST_to_IL.function_definition lang def in
-                let flow = CFG_build.cfg_of_stmts lang xs in
-                propagate_dataflow_one_function lang inputs flow);
-          }
-      in
-      v (Pr ast)
+      let xs = AST_to_IL.stmt lang (G.stmt1 ast) in
+      let flow = CFG_build.cfg_of_stmts lang xs in
+      propagate_dataflow_one_function lang [] flow

--- a/semgrep-core/src/analyzing/Dataflow_core.ml
+++ b/semgrep-core/src/analyzing/Dataflow_core.ml
@@ -217,6 +217,9 @@ module Make (F : Flow) = struct
     else
       let ni = NodeiSet.choose workset in
       let work' = NodeiSet.remove ni workset in
+      (*pr2 (Printf.sprintf "accessing node %d" ni);
+        display_mapping flow mapping (fun _ -> "<hidden>");
+      *)
       let old = mapping.(ni) in
       let new_ = trans mapping ni in
       let work'' =

--- a/semgrep-core/src/analyzing/Dataflow_core.ml
+++ b/semgrep-core/src/analyzing/Dataflow_core.ml
@@ -217,9 +217,6 @@ module Make (F : Flow) = struct
     else
       let ni = NodeiSet.choose workset in
       let work' = NodeiSet.remove ni workset in
-      (*pr2 (Printf.sprintf "accessing node %d" ni);
-        display_mapping flow mapping (fun _ -> "<hidden>");
-      *)
       let old = mapping.(ni) in
       let new_ = trans mapping ni in
       let work'' =

--- a/semgrep-core/src/analyzing/Dataflow_prog.ml
+++ b/semgrep-core/src/analyzing/Dataflow_prog.ml
@@ -57,49 +57,45 @@ module Make (F : Dataflow_core.Flow) = struct
       fixpoint ~enter_env:env ~eq ~init:new_mapping ~trans ~flow:new_flow
         ~get_input_env ~config ~forward ~name
     in
-    let res =
-      CoreDataflow.fixpoint ~eq ~init
-        ~trans:(fun mapping ni ->
-          let env = get_input_env enter_env flow mapping ni config in
-          match (flow.graph#nodes#assoc ni).n with
-          | NFunc { cfg = new_flow; ent; _ } ->
-              (* We want the entrance env to this function node, computed via looking at
-                 the current node within the old flow, along with the function definition.
-              *)
-              (*Common.(pr2 (spf "accesing at node %d" ni));
-                CoreDataflow.display_mapping flow mapping (fun _ -> "thinggoeshere");
-              *)
-              let name =
-                let* name = AST_to_IL.name_of_entity ent in
-                Some (str_of_name name)
-              in
-              enter_new_cfg ~env ~name ~flow:new_flow |> ignore;
-              (* Environment does not change for a function node. *)
-              { in_env = env; out_env = env }
-          | NClass cfg ->
-              enter_new_cfg ~env ~name:None ~flow:cfg |> ignore;
-              (* Assume that environment does not change for a class node *)
-              { in_env = env; out_env = env }
-          | Enter
-          | Exit
-          | TrueNode
-          | FalseNode
-          | Join
-          | NInstr _
-          | NCond _
-          | NGoto _
-          | NReturn _
-          | NThrow _
-          | NOther _
-          | NTodo _ ->
-              trans name flow enter_env mapping ni)
-        ~flow ~forward
-    in
-
-    (*Common.pr2 "fixpoint on new function";
-      Display_IL.display_cfg flow;
-    *)
-    res
+    CoreDataflow.fixpoint ~eq ~init
+      ~trans:(fun mapping ni ->
+        (* Input env gets the entering environment in case that it encounters
+           an Enter node.
+           It returns the proper entering environment (given parameters to functions, etc)
+           for that node.
+        *)
+        let env = get_input_env enter_env flow mapping ni config in
+        match (flow.graph#nodes#assoc ni).n with
+        | NFunc { cfg = new_flow; ent; _ } ->
+            (* We want the entrance env to this function node, computed via looking at
+               the current node within the old flow, along with the function definition.
+            *)
+            let name =
+              let* name = AST_to_IL.name_of_entity ent in
+              Some (str_of_name name)
+            in
+            enter_new_cfg ~env ~name ~flow:new_flow |> ignore;
+            (* Environment does not change for a function node. *)
+            { in_env = env; out_env = env }
+        | NClass cfg
+        | NModule cfg ->
+            enter_new_cfg ~env ~name:None ~flow:cfg |> ignore;
+            (* Assume that environment does not change for a class node *)
+            { in_env = env; out_env = env }
+        | Enter
+        | Exit
+        | TrueNode
+        | FalseNode
+        | Join
+        | NInstr _
+        | NCond _
+        | NGoto _
+        | NReturn _
+        | NThrow _
+        | NOther _
+        | NTodo _ ->
+            trans name flow env mapping ni)
+      ~flow ~forward
 
   let new_node_array = CoreDataflow.new_node_array
   let display_mapping = CoreDataflow.display_mapping

--- a/semgrep-core/src/analyzing/Dataflow_prog.ml
+++ b/semgrep-core/src/analyzing/Dataflow_prog.ml
@@ -43,19 +43,26 @@ module Make (F : Dataflow_core.Flow) = struct
       init:'a DC.mapping ->
       trans:(Dataflow_core.var option -> IL.cfg -> 'a DC.env -> 'a DC.transfn) ->
       flow:IL.cfg ->
-      get_input_env:
+      meet:
         ('a DC.env -> IL.cfg -> 'a DC.mapping -> nodei -> 'config -> 'a DC.env) ->
+      modify_env:('a DC.env -> IL.node -> 'config -> 'a DC.env) ->
       config:'config ->
       forward:bool ->
       name:Dataflow_core.var option ->
+      conclude:(IL.cfg -> 'a DC.mapping -> unit) ->
       'a DC.mapping =
-   fun ~enter_env ~eq ~init ~trans ~flow ~get_input_env ~config ~forward ~name ->
+   fun ~enter_env ~eq ~init ~trans ~flow ~meet ~modify_env ~config ~forward
+       ~name ~conclude ->
     let enter_new_cfg ~env ~name ~flow:new_flow =
       let new_mapping =
         CoreDataflow.new_node_array new_flow (Dataflow_core.empty_inout ())
       in
-      fixpoint ~enter_env:env ~eq ~init:new_mapping ~trans ~flow:new_flow
-        ~get_input_env ~config ~forward ~name
+      let res =
+        fixpoint ~enter_env:env ~eq ~init:new_mapping ~trans ~flow:new_flow
+          ~meet ~modify_env ~config ~forward ~name ~conclude
+      in
+      conclude new_flow new_mapping;
+      res
     in
     CoreDataflow.fixpoint ~eq ~init
       ~trans:(fun mapping ni ->
@@ -64,24 +71,35 @@ module Make (F : Dataflow_core.Flow) = struct
            It returns the proper entering environment (given parameters to functions, etc)
            for that node.
         *)
-        let env = get_input_env enter_env flow mapping ni config in
+        let in_env = meet enter_env flow mapping ni config in
         match (flow.graph#nodes#assoc ni).n with
         | NFunc { cfg = new_flow; ent; _ } ->
             (* We want the entrance env to this function node, computed via looking at
                the current node within the old flow, along with the function definition.
             *)
+            let new_env =
+              modify_env in_env (flow.graph#nodes#assoc ni) config
+            in
+            let out_env = in_env in
             let name =
               let* name = AST_to_IL.name_of_entity ent in
               Some (str_of_name name)
             in
-            enter_new_cfg ~env ~name ~flow:new_flow |> ignore;
+            enter_new_cfg ~env:new_env ~name ~flow:new_flow |> ignore;
             (* Environment does not change for a function node. *)
-            { in_env = env; out_env = env }
+            { in_env; out_env }
         | NClass cfg
         | NModule cfg ->
-            enter_new_cfg ~env ~name:None ~flow:cfg |> ignore;
+            let new_env =
+              modify_env in_env (flow.graph#nodes#assoc ni) config
+            in
+            let out_env = in_env in
+            enter_new_cfg ~env:new_env ~name:None ~flow:cfg |> ignore;
             (* Assume that environment does not change for a class node *)
-            { in_env = env; out_env = env }
+            { in_env; out_env }
+        | NInstr { i = AssignAnon (_, Lambda _); _ } ->
+            let in_env = modify_env in_env (flow.graph#nodes#assoc ni) config in
+            { in_env; out_env = in_env }
         | Enter
         | Exit
         | TrueNode
@@ -94,7 +112,7 @@ module Make (F : Dataflow_core.Flow) = struct
         | NThrow _
         | NOther _
         | NTodo _ ->
-            trans name flow env mapping ni)
+            trans name flow in_env mapping ni)
       ~flow ~forward
 
   let new_node_array = CoreDataflow.new_node_array

--- a/semgrep-core/src/analyzing/Dataflow_prog.ml
+++ b/semgrep-core/src/analyzing/Dataflow_prog.ml
@@ -1,0 +1,58 @@
+module DC = Dataflow_core
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* This is a wrapper around Dataflow_core, specifically specialized to deal
+   with analyses on programs.
+   Specifically, our notion of CFGs currently has a "second-class" representation
+   for functions, which results in a lot of code where we need to tip-toe around
+   function definitions especially. This is harmful, because it leads to bugs when
+   dealing with any analyses that deal with bringing top-level domains into the
+   functions.
+   Dataflow_prog has a "first-class" notion of functions via "function nodes",
+   which are mandated to be such that the dataflow analysis will run as normal on
+   these special nodes, but the out-set of these function nodes must be the same as
+   the in-set to the function node.
+*)
+
+type nodei = int
+type var = string
+
+module VarMap = Dataflow_core.VarMap
+module VarSet = Dataflow_core.VarSet
+
+module Make (F : Dataflow_core.Flow) = struct
+  module ProgFlow = struct
+    type node = Reg of F.node | Func of flow
+    and edge = F.edge
+    and flow = (node, edge) CFG.t
+
+    let short_string_of_node = function
+      | Reg node -> "Reg " ^ F.short_string_of_node node
+      | Func _ -> "<func>"
+  end
+
+  module ProgDataflow = Dataflow_core.Make (ProgFlow)
+
+  let rec fixpoint :
+      eq:('a -> 'a -> bool) ->
+      init:'a DC.mapping ->
+      trans:'a DC.transfn ->
+      flow:ProgFlow.flow ->
+      get_input_env:('a DC.mapping -> nodei -> 'a DC.env) ->
+      forward:bool ->
+      'a DC.mapping =
+   fun ~eq ~init ~trans ~flow ~get_input_env ~forward ->
+    ProgDataflow.fixpoint ~eq ~init
+      ~trans:(fun mapping ni ->
+        match flow.graph#nodes#assoc ni with
+        | Reg _ -> trans mapping ni
+        | Func flow ->
+            fixpoint ~eq ~init:mapping ~trans ~flow ~get_input_env ~forward
+            |> ignore;
+            (* Environment does not change for a function node. *)
+            let env = get_input_env mapping ni in
+            { in_env = env; out_env = env })
+      ~flow ~forward
+end

--- a/semgrep-core/src/analyzing/Dataflow_prog.ml
+++ b/semgrep-core/src/analyzing/Dataflow_prog.ml
@@ -108,6 +108,10 @@ module Make (F : Dataflow_core.Flow) = struct
             (* Assume that environment does not change for a class node *)
             { in_env; out_env }
         | NInstr { i = AssignAnon (_, Lambda _); _ } ->
+            (* Lambdas change the environment resulting from the statements in the lambda.
+               This could permit escape of some things within the scope of the lambda, but
+               it already did this, so we're just staying consistent.
+            *)
             let in_env = modify_env in_env (flow.graph#nodes#assoc ni) config in
             { in_env; out_env = in_env }
         | Enter

--- a/semgrep-core/src/analyzing/Dataflow_prog.ml
+++ b/semgrep-core/src/analyzing/Dataflow_prog.ml
@@ -51,6 +51,7 @@ module Make (F : Dataflow_core.Flow) = struct
         match n with
         | IL.Reg _ -> trans mapping ni
         | Func { cfg = flow; _ } ->
+            (* TODO: change mapping here depending on the function inputs *)
             fixpoint ~eq ~init:mapping ~trans ~flow ~get_input_env ~forward
             |> ignore;
             (* Environment does not change for a function node. *)

--- a/semgrep-core/src/analyzing/Dataflow_prog.mli
+++ b/semgrep-core/src/analyzing/Dataflow_prog.mli
@@ -27,14 +27,8 @@ module Make (F : Dataflow_core.Flow) : sig
     init:'a DC.mapping ->
     trans:(Dataflow_core.var option -> IL.cfg -> 'a DC.env -> 'a DC.transfn) ->
     flow:IL.cfg ->
-    get_func_input_env:
-      ('a DC.env ->
-      IL.cfg ->
-      'a DC.mapping ->
-      nodei ->
-      'config ->
-      AST_generic.function_definition ->
-      'a DC.env) ->
+    get_input_env:
+      ('a DC.env -> IL.cfg -> 'a DC.mapping -> nodei -> 'config -> 'a DC.env) ->
     config:'config ->
     forward:bool ->
     name:DC.var option ->

--- a/semgrep-core/src/analyzing/Dataflow_prog.mli
+++ b/semgrep-core/src/analyzing/Dataflow_prog.mli
@@ -27,11 +27,12 @@ module Make (F : Dataflow_core.Flow) : sig
     init:'a DC.mapping ->
     trans:(Dataflow_core.var option -> IL.cfg -> 'a DC.env -> 'a DC.transfn) ->
     flow:IL.cfg ->
-    get_input_env:
-      ('a DC.env -> IL.cfg -> 'a DC.mapping -> nodei -> 'config -> 'a DC.env) ->
+    meet:('a DC.env -> IL.cfg -> 'a DC.mapping -> nodei -> 'config -> 'a DC.env) ->
+    modify_env:('a DC.env -> IL.node -> 'config -> 'a DC.env) ->
     config:'config ->
     forward:bool ->
-    name:DC.var option ->
+    name:Dataflow_core.var option ->
+    conclude:(IL.cfg -> 'a DC.mapping -> unit) ->
     'a DC.mapping
 
   val new_node_array : IL.cfg -> 'a -> 'a array

--- a/semgrep-core/src/analyzing/Dataflow_prog.mli
+++ b/semgrep-core/src/analyzing/Dataflow_prog.mli
@@ -1,0 +1,31 @@
+type nodei = int
+
+(* The comparison function uses only the name of a variable (a string), so
+ * two variables at different positions in the code will be agglomerated
+ * correctly in the Set or Map.
+ *)
+type var = string
+
+module VarMap : Map.S with type key = String.t
+module VarSet : Set.S with type elt = String.t
+
+module Make (F : Dataflow_core.Flow) : sig
+  module ProgFlow : sig
+    type node = Reg of F.node | Func of flow
+    and edge = F.edge
+    and flow = (node, edge) CFG.t
+
+    val short_string_of_node : node -> string
+  end
+
+  module ProgDataflow : module type of Dataflow_core.Make (ProgFlow)
+
+  val fixpoint :
+    eq:('a -> 'a -> bool) ->
+    init:'a Dataflow_core.mapping ->
+    trans:'a Dataflow_core.transfn ->
+    flow:ProgFlow.flow ->
+    get_input_env:('a Dataflow_core.mapping -> nodei -> 'a Dataflow_core.env) ->
+    forward:bool ->
+    'a Dataflow_core.mapping
+end

--- a/semgrep-core/src/analyzing/Dataflow_prog.mli
+++ b/semgrep-core/src/analyzing/Dataflow_prog.mli
@@ -8,6 +8,7 @@ type var = string
 
 module VarMap : Map.S with type key = String.t
 module VarSet : Set.S with type elt = String.t
+module DC = Dataflow_core
 
 module Make (F : Dataflow_core.Flow) : sig
   module ProgFlow : sig
@@ -18,16 +19,26 @@ module Make (F : Dataflow_core.Flow) : sig
     val short_string_of_node : node -> string
   end
 
-  module ProgDataflow : module type of Dataflow_core.Make (ProgFlow)
+  module CoreDataflow : module type of Dataflow_core.Make (ProgFlow)
 
   val fixpoint :
+    enter_env:'a DC.env ->
     eq:('a -> 'a -> bool) ->
-    init:'a Dataflow_core.mapping ->
-    trans:'a Dataflow_core.transfn ->
+    init:'a DC.mapping ->
+    trans:(Dataflow_core.var option -> IL.cfg -> 'a DC.env -> 'a DC.transfn) ->
     flow:IL.cfg ->
-    get_input_env:('a Dataflow_core.mapping -> nodei -> 'a Dataflow_core.env) ->
+    get_func_input_env:
+      ('a DC.env ->
+      IL.cfg ->
+      'a DC.mapping ->
+      nodei ->
+      'config ->
+      AST_generic.function_definition ->
+      'a DC.env) ->
+    config:'config ->
     forward:bool ->
-    'a Dataflow_core.mapping
+    name:DC.var option ->
+    'a DC.mapping
 
   val new_node_array : IL.cfg -> 'a -> 'a array
 

--- a/semgrep-core/src/analyzing/Dataflow_prog.mli
+++ b/semgrep-core/src/analyzing/Dataflow_prog.mli
@@ -22,17 +22,25 @@ module Make (F : Dataflow_core.Flow) : sig
   module CoreDataflow : module type of Dataflow_core.Make (ProgFlow)
 
   val fixpoint :
-    enter_env:'a DC.env ->
-    eq:('a -> 'a -> bool) ->
-    init:'a DC.mapping ->
+    eq:
+      ((* Arguments that will remain constant throughout the fixpoint.
+      *)
+       'a ->
+      'a ->
+      bool) ->
     trans:(Dataflow_core.var option -> IL.cfg -> 'a DC.env -> 'a DC.transfn) ->
-    flow:IL.cfg ->
     meet:('a DC.env -> IL.cfg -> 'a DC.mapping -> nodei -> 'config -> 'a DC.env) ->
     modify_env:('a DC.env -> IL.node -> 'config -> 'a DC.env) ->
     config:'config ->
     forward:bool ->
-    name:Dataflow_core.var option ->
     conclude:(IL.cfg -> 'a DC.mapping -> unit) ->
+    (* Arguments that will remain change throughout the fixpoint, as
+        we traverse through smaller CFGs.
+    *)
+    enter_env:'a DC.env ->
+    init:'a DC.mapping ->
+    flow:IL.cfg ->
+    name:Dataflow_core.var option ->
     'a DC.mapping
 
   val new_node_array : IL.cfg -> 'a -> 'a array

--- a/semgrep-core/src/analyzing/Dataflow_prog.mli
+++ b/semgrep-core/src/analyzing/Dataflow_prog.mli
@@ -11,9 +11,9 @@ module VarSet : Set.S with type elt = String.t
 
 module Make (F : Dataflow_core.Flow) : sig
   module ProgFlow : sig
-    type node = Reg of F.node | Func of flow
-    and edge = F.edge
-    and flow = (node, edge) CFG.t
+    type node = IL.node
+    and edge = IL.edge
+    and flow = IL.cfg
 
     val short_string_of_node : node -> string
   end
@@ -24,8 +24,14 @@ module Make (F : Dataflow_core.Flow) : sig
     eq:('a -> 'a -> bool) ->
     init:'a Dataflow_core.mapping ->
     trans:'a Dataflow_core.transfn ->
-    flow:ProgFlow.flow ->
+    flow:IL.cfg ->
     get_input_env:('a Dataflow_core.mapping -> nodei -> 'a Dataflow_core.env) ->
     forward:bool ->
     'a Dataflow_core.mapping
+
+  val new_node_array : IL.cfg -> 'a -> 'a array
+
+  (* debugging output *)
+  val display_mapping :
+    IL.cfg -> 'a Dataflow_core.mapping -> ('a -> string) -> unit
 end

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -492,6 +492,7 @@ let transfer :
     | NOther _
     | NFunc _
     | NClass _
+    | NModule _
     | NTodo _ ->
         inp'
     | NInstr instr -> (

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -490,6 +490,8 @@ let transfer :
     | NReturn _
     | NThrow _
     | NOther _
+    | NFunc _
+    | NClass _
     | NTodo _ ->
         inp'
     | NInstr instr -> (
@@ -528,7 +530,6 @@ let transfer :
             match lvar_opt with
             | None -> inp'
             | Some lvar -> D.VarMap.remove (str_of_name lvar) inp'))
-    | NFunc _ -> inp'
   in
 
   { D.in_env = inp'; out_env = out' }

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -29,7 +29,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* map for each node/var whether a variable is constant *)
 type mapping = G.svalue Dataflow_core.mapping
 
-module DataflowX = Dataflow_core.Make (struct
+module DataflowX = Dataflow_prog.Make (struct
   type node = F.node
   type edge = F.edge
   type flow = (node, edge) CFG.t
@@ -430,7 +430,7 @@ let union_env =
       let* c2 = c2_opt in
       Some (union c1 c2))
 
-let input_env ~enter_env ~(flow : F.cfg) mapping ni =
+let input_env enter_env (flow : F.cfg) mapping ni _config =
   let node = flow.graph#nodes#assoc ni in
   match node.F.n with
   | Enter -> enter_env
@@ -468,15 +468,15 @@ let update_env_with env var sval =
 
 let transfer :
     lang:Lang.t ->
-    enter_env:G.svalue Dataflow_core.env ->
     flow:F.cfg ->
+    'a Dataflow_core.env ->
     G.svalue Dataflow_core.transfn =
- fun ~lang ~enter_env ~flow
+ fun ~lang ~flow
      (* the transfer function to update the mapping at node index ni *)
-       mapping ni ->
+       env _mapping ni ->
   let node = flow.graph#nodes#assoc ni in
 
-  let inp' = input_env ~enter_env ~flow mapping ni in
+  let inp' = env in
 
   let out' =
     match node.F.n with
@@ -539,15 +539,21 @@ let transfer :
 (* Entry point *)
 (*****************************************************************************)
 
-let (fixpoint : Lang.t -> IL.name list -> F.cfg -> mapping) =
+let rec (fixpoint : Lang.t -> IL.name list -> F.cfg -> mapping) =
  fun lang _inputs flow ->
   let enter_env = D.VarMap.empty in
-  DataflowX.fixpoint ~eq
+  DataflowX.fixpoint ~enter_env ~eq
     ~init:(DataflowX.new_node_array flow (Dataflow_core.empty_inout ()))
-    ~trans:(transfer ~lang ~enter_env ~flow) (* svalue is a forward analysis! *)
-    ~forward:true ~flow
+    ~trans:(fun _name flow env -> transfer ~lang ~flow env)
+      (* svalue is a forward analysis! *)
+    ~forward:true ~flow ~meet:input_env
+    ~modify_env:(fun env node _ ->
+      match node.n with
+      | NFunc _ -> VarMap.empty
+      | _ -> env)
+    ~config:() ~name:None ~conclude:update_svalue
 
-let update_svalue (flow : F.cfg) mapping =
+and update_svalue (flow : F.cfg) mapping =
   let for_all_id_info : (G.id_info -> bool) -> G.any -> bool =
     (* Check that all id_info's satisfy a given condition. We use refs so that
      * we can have a single visitor for all calls, given that `mk_visitor` is

--- a/semgrep-core/src/analyzing/Test_analyze_generic.ml
+++ b/semgrep-core/src/analyzing/Test_analyze_generic.ml
@@ -68,7 +68,7 @@ let test_cfg_il ~parse_program file =
         V.kfunction_definition =
           (fun (_k, _) def ->
             let _, xs = AST_to_IL.function_definition lang def in
-            let cfg = CFG_build.cfg_of_stmts xs in
+            let cfg = CFG_build.cfg_of_stmts lang xs in
             Display_IL.display_cfg cfg);
       }
   in
@@ -81,7 +81,8 @@ module DataflowY = Dataflow_core.Make (struct
   type edge = F2.edge
   type flow = (node, edge) CFG.t
 
-  let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
+  let short_string_of_node n =
+    Display_IL.short_string_of_augmented_node_kind n.F2.n
 end)
 
 let test_dfg_svalue ~parse_program file =
@@ -95,7 +96,7 @@ let test_dfg_svalue ~parse_program file =
         V.kfunction_definition =
           (fun (_k, _) def ->
             let inputs, xs = AST_to_IL.function_definition lang def in
-            let flow = CFG_build.cfg_of_stmts xs in
+            let flow = CFG_build.cfg_of_stmts lang xs in
             pr2 "Constness";
             let mapping = Dataflow_svalue.fixpoint lang inputs flow in
             Dataflow_svalue.update_svalue flow mapping;

--- a/semgrep-core/src/analyzing/Test_analyze_generic.ml
+++ b/semgrep-core/src/analyzing/Test_analyze_generic.ml
@@ -81,8 +81,7 @@ module DataflowY = Dataflow_core.Make (struct
   type edge = F2.edge
   type flow = (node, edge) CFG.t
 
-  let short_string_of_node n =
-    Display_IL.short_string_of_augmented_node_kind n.F2.n
+  let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
 end)
 
 let test_dfg_svalue ~parse_program file =

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -49,6 +49,7 @@ let short_string_of_node_kind nkind =
   | NTodo _ -> "<to-do stmt>"
   | NFunc _ -> "<func>"
   | NClass _ -> "<class>"
+  | NModule _ -> "<module>"
 
 (* using internally graphviz dot and ghostview on X11 *)
 let (display_cfg : cfg -> unit) =

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -48,6 +48,7 @@ let short_string_of_node_kind nkind =
       | FixmeInstr _ -> "<fix-me instr>")
   | NTodo _ -> "<to-do stmt>"
   | NFunc _ -> "<func>"
+  | NClass _ -> "<class>"
 
 (* using internally graphviz dot and ghostview on X11 *)
 let (display_cfg : cfg -> unit) =

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -47,11 +47,7 @@ let short_string_of_node_kind nkind =
             (IL.show_call_special call_special)
       | FixmeInstr _ -> "<fix-me instr>")
   | NTodo _ -> "<to-do stmt>"
-
-let short_string_of_augmented_node_kind ankind =
-  match ankind with
-  | Reg nk -> short_string_of_node_kind nk
-  | Func _ -> "<func>"
+  | NFunc _ -> "<func>"
 
 (* using internally graphviz dot and ghostview on X11 *)
 let (display_cfg : cfg -> unit) =
@@ -59,4 +55,4 @@ let (display_cfg : cfg -> unit) =
   flow.graph
   |> Ograph_extended.print_ograph_mutable_generic
        ~s_of_node:(fun (_nodei, node) ->
-         (short_string_of_augmented_node_kind node.n, None, None))
+         (short_string_of_node_kind node.n, None, None))

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -48,10 +48,15 @@ let short_string_of_node_kind nkind =
       | FixmeInstr _ -> "<fix-me instr>")
   | NTodo _ -> "<to-do stmt>"
 
+let short_string_of_augmented_node_kind ankind =
+  match ankind with
+  | Reg nk -> short_string_of_node_kind nk
+  | Func _ -> "<func>"
+
 (* using internally graphviz dot and ghostview on X11 *)
 let (display_cfg : cfg -> unit) =
  fun flow ->
   flow.graph
   |> Ograph_extended.print_ograph_mutable_generic
        ~s_of_node:(fun (_nodei, node) ->
-         (short_string_of_node_kind node.n, None, None))
+         (short_string_of_augmented_node_kind node.n, None, None))

--- a/semgrep-core/src/core/il/Display_IL.mli
+++ b/semgrep-core/src/core/il/Display_IL.mli
@@ -7,6 +7,7 @@ val display_cfg : IL.cfg -> unit
 
 (*s: signature [[Meta_IL.short_string_of_node_kind]] *)
 val short_string_of_node_kind : IL.node_kind -> string
+val short_string_of_augmented_node_kind : IL.augmented_node_kind -> string
 
 (*e: signature [[Meta_IL.short_string_of_node_kind]] *)
 (*e: pfff/lang_GENERIC/analyze/Meta_IL.mli *)

--- a/semgrep-core/src/core/il/Display_IL.mli
+++ b/semgrep-core/src/core/il/Display_IL.mli
@@ -7,7 +7,6 @@ val display_cfg : IL.cfg -> unit
 
 (*s: signature [[Meta_IL.short_string_of_node_kind]] *)
 val short_string_of_node_kind : IL.node_kind -> string
-val short_string_of_augmented_node_kind : IL.augmented_node_kind -> string
 
 (*e: signature [[Meta_IL.short_string_of_node_kind]] *)
 (*e: pfff/lang_GENERIC/analyze/Meta_IL.mli *)

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -335,7 +335,7 @@ type ('a, 'b) cfg_opaque = ('a, 'b) CFG.t
 let pp_cfg_opaque _ _ _ _ = ()
 
 type node = {
-  n : augmented_node_kind;
+  n : node_kind;
       (* old: there are tok in the nodes anyway
        * t: Parse_info.t option;
        *)
@@ -352,17 +352,14 @@ and node_kind =
   | NGoto of tok * label
   | NReturn of tok * exp
   | NThrow of tok * exp
-  | NOther of other_stmt
-  | NTodo of stmt
-[@@deriving show { with_path = false }]
-
-and augmented_node_kind =
-  | Reg of node_kind
-  | Func of {
+  | NFunc of {
       fdef : G.function_definition;
       cfg : (node, edge) cfg_opaque;
       ent : G.entity;
     }
+  | NOther of other_stmt
+  | NTodo of stmt
+[@@deriving show { with_path = false }]
 
 (* For now there is just one kind of edge.
  * (we may use more? the "ShadowNode" idea of Julia Lawall?)

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -275,7 +275,7 @@ and call_special =
    | StringAccess of string (* for records/hashes *)
 *)
 and anonymous_entity =
-  | Lambda of function_definition
+  | Lambda of G.function_definition * function_definition
   | AnonClass of G.class_definition
 
 (*****************************************************************************)
@@ -308,6 +308,7 @@ and stmt_kind =
       body : stmt list;
     }
   | ClassStmt of stmt list
+  | ModuleStmt of stmt list
   | MiscStmt of other_stmt
   | FixmeStmt of fixme_kind * G.any
 
@@ -364,6 +365,7 @@ and node_kind =
       ent : G.entity;
     }
   | NClass of (node, edge) cfg_opaque
+  | NModule of (node, edge) cfg_opaque
   | NOther of other_stmt
   | NTodo of stmt
 [@@deriving show { with_path = false }]

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -302,6 +302,12 @@ and stmt_kind =
       * (name * stmt list) list (* catches *)
       * stmt list (* finally *)
   | Throw of tok * exp (* less: enforce lval here? *)
+  | FuncStmt of {
+      fdef : G.function_definition;
+      ent : G.entity;
+      body : stmt list;
+    }
+  | ClassStmt of stmt list
   | MiscStmt of other_stmt
   | FixmeStmt of fixme_kind * G.any
 
@@ -357,6 +363,7 @@ and node_kind =
       cfg : (node, edge) cfg_opaque;
       ent : G.entity;
     }
+  | NClass of (node, edge) cfg_opaque
   | NOther of other_stmt
   | NTodo of stmt
 [@@deriving show { with_path = false }]

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -358,7 +358,11 @@ and node_kind =
 
 and augmented_node_kind =
   | Reg of node_kind
-  | Func of { fdef : G.function_definition; cfg : (node, edge) cfg_opaque }
+  | Func of {
+      fdef : G.function_definition;
+      cfg : (node, edge) cfg_opaque;
+      ent : G.entity;
+    }
 
 (* For now there is just one kind of edge.
  * (we may use more? the "ShadowNode" idea of Julia Lawall?)

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -329,8 +329,13 @@ and function_definition = {
 (*****************************************************************************)
 (* Similar to controlflow.ml, but with a simpler node_kind.
  * See controlflow.ml for more information. *)
+
+type ('a, 'b) cfg_opaque = ('a, 'b) CFG.t
+
+let pp_cfg_opaque _ _ _ _ = ()
+
 type node = {
-  n : node_kind;
+  n : augmented_node_kind;
       (* old: there are tok in the nodes anyway
        * t: Parse_info.t option;
        *)
@@ -351,10 +356,15 @@ and node_kind =
   | NTodo of stmt
 [@@deriving show { with_path = false }]
 
+and augmented_node_kind =
+  | Reg of node_kind
+  | Func of { fdef : G.function_definition; cfg : (node, edge) cfg_opaque }
+
 (* For now there is just one kind of edge.
  * (we may use more? the "ShadowNode" idea of Julia Lawall?)
  *)
-type edge = Direct
+and edge = Direct
+
 type cfg = (node, edge) CFG.t
 
 (* an int representing the index of a node in the graph *)

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -106,6 +106,7 @@ let rlvals_of_node_kind = function
   | NGoto _
   | NFunc _
   | NClass _
+  | NModule _
   | Join ->
       []
   | NInstr x -> rlvals_of_instr x

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -98,23 +98,20 @@ let lvar_of_instr_opt x =
   | Mem _ ->
       None
 
-let rlvals_of_augmented_node_kind ankind =
-  match ankind with
-  | Reg nkind -> (
-      match nkind with
-      | Enter
-      | Exit
-      | TrueNode
-      | FalseNode
-      | NGoto _
-      | Join ->
-          []
-      | NInstr x -> rlvals_of_instr x
-      | NCond (_, e)
-      | NReturn (_, e)
-      | NThrow (_, e) ->
-          lvals_of_exp e
-      | NOther _
-      | NTodo _ ->
-          [])
-  | Func _ -> []
+let rlvals_of_node_kind = function
+  | Enter
+  | Exit
+  | TrueNode
+  | FalseNode
+  | NGoto _
+  | Join ->
+      []
+  | NInstr x -> rlvals_of_instr x
+  | NCond (_, e)
+  | NReturn (_, e)
+  | NThrow (_, e) ->
+      lvals_of_exp e
+  | NOther _
+  | NTodo _ ->
+      []
+  | NFunc _ -> []

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -98,19 +98,23 @@ let lvar_of_instr_opt x =
   | Mem _ ->
       None
 
-let rlvals_of_node = function
-  | Enter
-  | Exit
-  | TrueNode
-  | FalseNode
-  | NGoto _
-  | Join ->
-      []
-  | NInstr x -> rlvals_of_instr x
-  | NCond (_, e)
-  | NReturn (_, e)
-  | NThrow (_, e) ->
-      lvals_of_exp e
-  | NOther _
-  | NTodo _ ->
-      []
+let rlvals_of_augmented_node_kind ankind =
+  match ankind with
+  | Reg nkind -> (
+      match nkind with
+      | Enter
+      | Exit
+      | TrueNode
+      | FalseNode
+      | NGoto _
+      | Join ->
+          []
+      | NInstr x -> rlvals_of_instr x
+      | NCond (_, e)
+      | NReturn (_, e)
+      | NThrow (_, e) ->
+          lvals_of_exp e
+      | NOther _
+      | NTodo _ ->
+          [])
+  | Func _ -> []

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -104,6 +104,8 @@ let rlvals_of_node_kind = function
   | TrueNode
   | FalseNode
   | NGoto _
+  | NFunc _
+  | NClass _
   | Join ->
       []
   | NInstr x -> rlvals_of_instr x
@@ -114,4 +116,3 @@ let rlvals_of_node_kind = function
   | NOther _
   | NTodo _ ->
       []
-  | NFunc _ -> []

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.mli
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.mli
@@ -1,2 +1,2 @@
 val lvar_of_instr_opt : IL.instr -> IL.name option
-val rlvals_of_node : IL.node_kind -> IL.lval list
+val rlvals_of_augmented_node_kind : IL.augmented_node_kind -> IL.lval list

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.mli
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.mli
@@ -1,2 +1,2 @@
 val lvar_of_instr_opt : IL.instr -> IL.name option
-val rlvals_of_augmented_node_kind : IL.augmented_node_kind -> IL.lval list
+val rlvals_of_node_kind : IL.node_kind -> IL.lval list

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -91,8 +91,7 @@ module DataflowY = Dataflow_core.Make (struct
   type edge = F2.edge
   type flow = (node, edge) CFG.t
 
-  let short_string_of_node n =
-    Display_IL.short_string_of_augmented_node_kind n.F2.n
+  let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
 end)
 
 let convert_rule_id (id, _tok) = { PM.id; message = ""; pattern_string = id }

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -91,7 +91,8 @@ module DataflowY = Dataflow_core.Make (struct
   type edge = F2.edge
   type flow = (node, edge) CFG.t
 
-  let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
+  let short_string_of_node n =
+    Display_IL.short_string_of_augmented_node_kind n.F2.n
 end)
 
 let convert_rule_id (id, _tok) = { PM.id; message = ""; pattern_string = id }
@@ -379,7 +380,7 @@ let pm_of_finding finding =
   | T.ArgToReturn _ ->
       None
 
-let check_fundef lang fun_env taint_config opt_ent fdef =
+let _check_fundef lang fun_env taint_config opt_ent fdef =
   let name =
     let* ent = opt_ent in
     let* name = AST_to_IL.name_of_entity ent in
@@ -433,7 +434,7 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
       Dataflow_core.VarMap.empty fdef.G.fparams
   in
   let _, xs = AST_to_IL.function_definition lang fdef in
-  let flow = CFG_build.cfg_of_stmts xs in
+  let flow = CFG_build.cfg_of_stmts lang xs in
   Dataflow_tainting.fixpoint ~in_env ?name ~fun_env taint_config flow |> ignore
 
 let check_rule rule match_hook (default_config, equivs) xtarget =
@@ -463,6 +464,7 @@ let check_rule rule match_hook (default_config, equivs) xtarget =
 
   let fun_env = Hashtbl.create 8 in
 
+  (*
   let v =
     V.mk_visitor
       {
@@ -484,6 +486,7 @@ let check_rule rule match_hook (default_config, equivs) xtarget =
   in
   (* Check each function definition. *)
   v (G.Pr ast);
+  *)
   (* Check the top-level statements.
    * In scripting languages it is not unusual to write code outside
    * function declarations and we want to check this too. We simply
@@ -491,7 +494,7 @@ let check_rule rule match_hook (default_config, equivs) xtarget =
   let (), match_time =
     Common.with_time (fun () ->
         let xs = AST_to_IL.stmt lang (G.stmt1 ast) in
-        let flow = CFG_build.cfg_of_stmts xs in
+        let flow = CFG_build.cfg_of_stmts lang xs in
         Dataflow_tainting.fixpoint ~fun_env taint_config flow |> ignore)
   in
 

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -10,8 +10,7 @@ module DataflowX = Dataflow_core.Make (struct
   type edge = IL.edge
   type flow = (node, edge) CFG.t
 
-  let short_string_of_node n =
-    Display_IL.short_string_of_augmented_node_kind n.IL.n
+  let short_string_of_node n = Display_IL.short_string_of_node_kind n.IL.n
 end)
 
 let pr2_ranges file rwms =

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -10,7 +10,8 @@ module DataflowX = Dataflow_core.Make (struct
   type edge = IL.edge
   type flow = (node, edge) CFG.t
 
-  let short_string_of_node n = Display_IL.short_string_of_node_kind n.IL.n
+  let short_string_of_node n =
+    Display_IL.short_string_of_augmented_node_kind n.IL.n
 end)
 
 let pr2_ranges file rwms =
@@ -26,7 +27,7 @@ let pr2_ranges file rwms =
 
 let test_tainting lang file config def =
   let xs = AST_to_IL.stmt lang (H.funcbody_to_stmt def.fbody) in
-  let flow = CFG_build.cfg_of_stmts xs in
+  let flow = CFG_build.cfg_of_stmts lang xs in
 
   Common.pr2 "\nDataflow";
   Common.pr2 "--------";

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -46,8 +46,7 @@ module DataflowX = Dataflow_prog.Make (struct
   type edge = F.edge
   type flow = (node, edge) CFG.t
 
-  let short_string_of_node n =
-    Display_IL.short_string_of_augmented_node_kind n.F.n
+  let short_string_of_node n = Display_IL.short_string_of_node_kind n.F.n
 end)
 
 (*****************************************************************************)
@@ -560,7 +559,7 @@ let check_tainted_return env tok e : Taints.t * var_env =
 let input_env ~enter_env ~(flow : IL.cfg) mapping ni =
   let node = flow.graph#nodes#assoc ni in
   match node.F.n with
-  | Reg Enter -> enter_env
+  | Enter -> enter_env
   | _else -> (
       let pred_envs =
         CFG.predecessors flow ni
@@ -633,11 +632,8 @@ let (transfer :
   let node = flow.graph#nodes#assoc ni in
   let out' : Taints.t VarMap.t =
     let env = { config; fun_name = opt_name; fun_env; var_env = in' } in
-    pr2
-      (spf "transfer analyzing instr %s"
-         ([%show: augmented_node_kind] node.F.n));
     match node.F.n with
-    | Reg (NInstr x) -> (
+    | NInstr x -> (
         let taints, var_env' = check_tainted_instr env x in
         let var_env' =
           match LV.lvar_of_instr_opt x with
@@ -655,7 +651,7 @@ let (transfer :
         (* There is no variable being assigned, presumably the Instruction
          * returns 'void'. *)
         | _, None -> var_env')
-    | Reg (NReturn (tok, e)) -> (
+    | NReturn (tok, e) -> (
         (* TODO: Move most of this to check_tainted_return. *)
         let taints, var_env' = check_tainted_return env tok e in
         let findings = findings_of_tainted_return taints tok in

--- a/semgrep-core/tests/OTHER/rules/const_prop_toplevel.py
+++ b/semgrep-core/tests/OTHER/rules/const_prop_toplevel.py
@@ -1,0 +1,10 @@
+# ruleid: const_prop_toplevel
+x = "ls"
+
+foo = "ls"
+# ruleid: const_prop_toplevel
+x = foo
+
+foo = "ls"
+# ruleid: const_prop_toplevel
+x = foo

--- a/semgrep-core/tests/OTHER/rules/const_prop_toplevel.yaml
+++ b/semgrep-core/tests/OTHER/rules/const_prop_toplevel.yaml
@@ -1,0 +1,7 @@
+rules:
+- id: const_prop_toplevel 
+  pattern: x = "..."
+  message: Semgrep found a match
+  languages:
+    - python
+  severity: WARNING

--- a/semgrep-core/tests/OTHER/rules/prop_into_class.java
+++ b/semgrep-core/tests/OTHER/rules/prop_into_class.java
@@ -1,0 +1,7 @@
+static String secret = "secret"
+
+public class App
+{
+    // ruleid: prop-into-class 
+    String foo = sink(secret) 
+}

--- a/semgrep-core/tests/OTHER/rules/prop_into_class.yaml
+++ b/semgrep-core/tests/OTHER/rules/prop_into_class.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: prop-into-class 
+  message: variables should be able to flow into classes! 
+  options:
+    symbolic_propagation: true
+  languages:
+    - java
+  severity: ERROR
+  pattern-either:
+    - pattern: |
+        sink("...");
+


### PR DESCRIPTION
**What:**
Currently, our set-up for dataflow has a "second-class" notion of functions, classes, and modules (complex constructs which may contain smaller statements). That is to say, when an AST is translated to the IL, each of these constructs is contained within its own (un-translated) `MiscStmt` node. This is preserved in a `NOther` node within the CFG, when converting the list of IL stmts to a CFG, which notably does not interact interestingly with the dataflow's transfer function.

The reason why this is problematic is because the dataflow engine only knows about things at the granularity of nodes. The transfer function can only be applied on a per-node basis, in-sets and out-sets can only be computed at the granularity of nodes, so on and so forth. This means that, if there is a "function node" in the CFG, the dataflow engine doesn't know that it contains a "list of statements", in intention. It just knows that it needs to apply the transfer function once.

----------------------------------

**Why:**
This produces a lot of annoying code, such as `Constant_propagation.ml:662` and `Match_tainting_mode.ml:383`, where we need to do separate analyses for the top-level and each function. It tends to produce a distinction between our analyses on functions and the rest of the program. This distinction can lead to examples like [this one](https://semgrep.dev/s/PK8N), where the analysis works when the code is contained within a function, but not when it's at the top level, which is a distinction that need not exist. Moreover, we can fail use-cases which require information from the top-level to be brought into classes or modules: https://semgrep.dev/s/4KPg.

While this approach still has a distinction between functions and other parts of the program, it is done "automatically" via the dataflow engine. This means that we do not need to use the visitor AST to recurse into the program, but can instead trust dataflow to do it instead.

----------------------------------

**How:**
I propose a refinement of the general dataflow engine, which is specialized to work on IL CFGs. This dataflow is located in `Dataflow_prog.ml`, and operates on CFGs whose nodes are either normal IL nodes, as understood prior to this PR, but also special nodes for functions, classes, and modules. These nodes are special in that they contain the CFG for the body of the construct that it describes.

This enables the new dataflow engine to do its normal analysis throughout the master CFG, but as soon as it reaches a special node, it does the subsidiary analysis on the smaller CFG, using a function which modifies the environment based on the kind of node. Since these analyses are "local" to the scope of the construct, the in-set and out-set are maintained to be just the entering environment, so as to not allow escape, for instance of tainted variables within the scope of a class.

Code was shifted around elsewhere to accommodate this.

----------------------------------

**Important Changes:**
Some important things were changed in this PR. Most notably:
- CFG building works differently, and now there are special nodes for functions, classes, and modules.
- There may be edges from the start node to unreachable function nodes.
- CFG building requires the building of multiple CFGs. Dataflow analysis using `Dataflow_prog` may involve dataflow on multiple CFGs.
- There is a new file `Dataflow_prog.ml`.
- `Dataflow_svalue` and `Dataflow_tainting` now make use of this new dataflow procedure, and they no longer use `Visitor_AST`.

----------------------------------

**Test plan:** `make test`

----------------------------------

**Solves:** [PR-223](https://linear.app/r2c/issue/PA-223/constant-propagation-only-runs-inside-functions)

----------------------------------

PR checklist:

- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
