### PR TITLE
fix: pr templates and small workflow bugs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
@@ -4,5 +4,6 @@
 - [ ] Updated latest release and release date in `CHANGELOG.md`
 - [ ] Tests/CI passes on this Pull Request
 - [ ] All `release` and `validate-release` checks below succeed
-- [ ] Publish Github Release Page
 - [ ] At least one approval on this PR
+
+Don't forget to merge this PR when release is complete!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,8 @@ PR checklist:
   - \<type> is `added`, `changed`, `fixed`, or `infra`.
 - [ ] Change has no security implications (otherwise, ping security team)
 
-If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
+If you're unsure on any of this, please see:
+
+- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
+- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
+- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -310,7 +310,7 @@ jobs:
     with:
       version: ${{needs.release-setup.outputs.version}}
       repository: "returntocorp/semgrep-rpc"
-      base_branch: "develop"
+      base_branch: "main"
       bump_script_path: "scripts/bump-version.sh"
 
   notify-success:


### PR DESCRIPTION
This change updates the PR templates (both release and regular one) and also fixes a checkout bug.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
