### PR TITLE
chore(deepsemgrep): Expose empty_extra

### DIFF
--- a/semgrep-core/src/core/Report.mli
+++ b/semgrep-core/src/core/Report.mli
@@ -68,6 +68,7 @@ type final_result = {
 }
 [@@deriving show]
 
+val empty_extra : 'a -> 'a debug_info
 val empty_partial_profiling : Common.filename -> partial_profiling
 val empty_rule_profiling : Rule.t -> rule_profiling
 val empty_semgrep_result : times match_result


### PR DESCRIPTION
For https://github.com/returntocorp/deep-semgrep/pull/220

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!
