### PR TITLE
Fix repo url format to remove .git

### DIFF
--- a/changelog.d/cli-278.fixed
+++ b/changelog.d/cli-278.fixed
@@ -1,0 +1,1 @@
+Fixed format of repository urls so links to findings can be properly displayed on semgrep.dev

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -23,7 +23,10 @@ logger = getLogger(__name__)
 
 
 def get_url_from_sstp_url(sstp_url: Optional[str]) -> Optional[str]:
-    """Gets regular url from sstp url"""
+    """Gets regular url from sstp url.
+    We use repo urls on semgrep-app to link to files, so we need to make sure they are
+    in the right format to be appended to.
+    """
     if sstp_url is None:
         return None
     url = sstp_url
@@ -109,7 +112,7 @@ class GitMeta:
 
     @property
     def repo_url(self) -> Optional[str]:
-        return os.getenv("SEMGREP_REPO_URL")
+        return get_url_from_sstp_url(os.getenv("SEMGREP_REPO_URL"))
 
     @property
     def commit_sha(self) -> Optional[str]:
@@ -607,7 +610,7 @@ class JenkinsMeta(GitMeta):
 
     @property
     def repo_url(self) -> Optional[str]:
-        return os.getenv("GIT_URL", os.getenv("GIT_URL_1"))
+        return get_url_from_sstp_url(os.getenv("GIT_URL", os.getenv("GIT_URL_1")))
 
     @property
     def branch(self) -> Optional[str]:
@@ -638,7 +641,7 @@ class BitbucketMeta(GitMeta):
 
     @property
     def repo_url(self) -> Optional[str]:
-        return os.getenv("BITBUCKET_GIT_HTTP_ORIGIN")
+        return get_url_from_sstp_url(os.getenv("BITBUCKET_GIT_HTTP_ORIGIN"))
 
     @property
     def branch(self) -> Optional[str]:
@@ -770,7 +773,7 @@ class TravisMeta(GitMeta):
 
     @property
     def repo_url(self) -> Optional[str]:
-        return f"https://github.com/{self.repo_name}.git"
+        return f"https://github.com/{self.repo_name}"
 
     @property
     def branch(self) -> Optional[str]:

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "org/repo",
-    "repo_url": "https://github.com/org/repo.git",
+    "repo_url": "https://github.com/org/repo",
     "branch": "some/branch-name",
     "ci_job_url": "https://jenkins.build.url",
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
-    "repo_url": "https://github.com/project_name/project_name.git",
+    "repo_url": "https://github.com/project_name/project_name",
     "branch": "some/branch-name",
     "ci_job_url": "https://travis.job.web.url/",
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "org/repo",
-    "repo_url": "https://github.com/org/repo.git",
+    "repo_url": "https://github.com/org/repo",
     "branch": "some/branch-name",
     "ci_job_url": "https://jenkins.build.url",
     "commit": "sanitized",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
@@ -2,7 +2,7 @@
   "meta": {
     "semgrep_version": "<sanitized version>",
     "repository": "project_name/project_name",
-    "repo_url": "https://github.com/project_name/project_name.git",
+    "repo_url": "https://github.com/project_name/project_name",
     "branch": "some/branch-name",
     "ci_job_url": "https://travis.job.web.url/",
     "commit": "sanitized",


### PR DESCRIPTION
PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see the [Contribution guidelines](https://semgrep.dev/docs/contributing/how-to-contribute/)!

Fixes CLI-278