### PR TITLE
feat(metrics): report ignored-by-language file extensions to metrics

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -109,6 +109,7 @@ Semgrep reports data that indicate how useful a run is for the end user; e.g.
 - Number of ignored findings
 - Pseudoanonymized hashes of the rule definitions that yield findings
 - The [Semgrep features used](#feature-usage) during the scan
+- File extensions of unscanned files
 
 ### Pseudoanonymization
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -170,6 +170,7 @@ r2c will:
 |             | Rule hashes with findings               | Map of rule hashes to number of findings                               | Understand which rules are providing value to the user; diagnose high false-positive rates | `{"7c43c962dfdbc52882f80021e4d0ef2396e6a950867e81e5f61e68390ee9e166": 4}`                                                                                                             | Object         |
 |             | Total Findings                          | Count of all findings                                                  | Understand if rules are super noisy for the user                                           | 7                                                                                                                                                                                     | Number         |
 |             | Total Nosems                            | Count of all `nosem` annotations that tell semgrep to ignore a finding | Understand if rules are super noisy for the user                                           | 3                                                                                                                                                                                     | Number         |
+|             | Unsupported Extensions                  | List of file extensions that did not match language and number of each | Understand demand by language for new rules and language supprt                            | `{".txt": 3, ".erb": 2, ".java": 5}`                                                                                                                                                  |
 
 ### Anonymous user ID
 
@@ -269,6 +270,7 @@ This is a sample blob of the aggregate metrics described above:
         "numFindings": 7,
         "numIgnored": 3,
         "features": ["language/python", "option/deep", "option/no-git-ignore", "key/metavariable-comparison"]
+        "unsupportedExts": {".txt": 3, ".erb": 2, ".java": 5}
     }
 }
 ```

--- a/changelog.d/app-1354.added
+++ b/changelog.d/app-1354.added
@@ -1,0 +1,1 @@
+Added metrics to report extensions of files that do not match the language of any enabled rules in order to enable more effective language prioritization while developing new rules.

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -24,6 +24,8 @@ FIXTEST_SUFFIX = ".fixed"
 
 RETURNTOCORP_LEVER_URL = "https://api.lever.co/v0/postings/returntocorp?mode=json"
 
+UNSUPPORTED_EXT_IGNORE_LANGS = {"generic", "regex"}
+
 
 class OutputFormat(Enum):
     TEXT = auto()

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -101,15 +101,12 @@ class ValueSchema(ValueRequiredSchema, total=False):
     numFindings: int
     numIgnored: int
     ruleHashesWithFindings: Dict[str, int]
+    unsupportedExts: Dict[str, int]
 
 
 class FixRateSchema(TypedDict, total=False):
     lowerLimits: Dict[str, int]
     upperLimits: Dict[str, int]
-
-
-class IgnoresSchema(TypedDict, total=False):
-    unsupported_exts: Dict[str, int]
 
 
 class TopLevelSchema(TypedDict, total=False):
@@ -125,7 +122,6 @@ class PayloadSchema(TopLevelSchema):
     errors: ErrorsSchema
     value: ValueSchema
     fix_rate: FixRateSchema
-    ignores: IgnoresSchema
 
 
 class MetricsJsonEncoder(json.JSONEncoder):
@@ -175,7 +171,6 @@ class Metrics:
             performance=PerformanceSchema(),
             value=ValueSchema(features=set()),
             fix_rate=FixRateSchema(),
-            ignores=IgnoresSchema(),
         )
     )
 
@@ -308,7 +303,7 @@ class Metrics:
     def add_ignores(self, ignored: Set[Path]) -> None:
         ignored_ext_freqs = Counter([os.path.splitext(path)[1] for path in ignored])
         ignored_ext_freqs.pop("", None)  # don't count files with no extension
-        self.payload["ignores"]["unsupported_exts"] = ignored_ext_freqs
+        self.payload["value"]["unsupportedExts"] = ignored_ext_freqs
 
     @suppress_errors
     def add_errors(self, errors: List[SemgrepError]) -> None:

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 import uuid
+from collections import Counter
 from datetime import datetime
 from enum import auto
 from enum import Enum
@@ -305,12 +306,8 @@ class Metrics:
 
     @suppress_errors
     def add_ignores(self, ignored: Set[Path]) -> None:
-        ignored_ext_freqs: Dict[str, int] = {}
-        for path in ignored:
-            ext = os.path.splitext(path)[1]
-            if not ext:
-                continue
-            ignored_ext_freqs[ext] = ignored_ext_freqs.get(ext, 0) + 1
+        ignored_ext_freqs = Counter([os.path.splitext(path)[1] for path in ignored])
+        ignored_ext_freqs.pop("", None)  # don't count files with no extension
         self.payload["ignores"]["unsupported_exts"] = ignored_ext_freqs
 
     @suppress_errors

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -311,7 +311,6 @@ class Metrics:
             if not ext:
                 continue
             ignored_ext_freqs[ext] = ignored_ext_freqs.get(ext, 0) + 1
-        print("Ignored Extensions Metrics:", ignored_ext_freqs)
         self.payload["ignores"]["unsupported_exts"] = ignored_ext_freqs
 
     @suppress_errors

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -449,6 +449,7 @@ def main(
         metrics.add_findings(filtered_matches_by_rule)
         metrics.add_errors(semgrep_errors)
         metrics.add_profiling(profiler)
+        metrics.add_ignores(target_manager.ignore_log.unsupported_lang_paths)
 
     if autofix:
         apply_fixes(filtered_matches_by_rule.kept, dryrun)

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -441,6 +441,7 @@ def main(
     profiler.save("total_time", rule_start_time)
 
     metrics = get_state().metrics
+    metrics.add_ignores(target_manager.ignore_log.unsupported_lang_paths)
     if metrics.is_enabled:
         metrics.add_project_url(project_url)
         metrics.add_configs(configs)
@@ -449,7 +450,6 @@ def main(
         metrics.add_findings(filtered_matches_by_rule)
         metrics.add_errors(semgrep_errors)
         metrics.add_profiling(profiler)
-        metrics.add_ignores(target_manager.ignore_log.unsupported_lang_paths)
 
     if autofix:
         apply_fixes(filtered_matches_by_rule.kept, dryrun)

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -441,7 +441,6 @@ def main(
     profiler.save("total_time", rule_start_time)
 
     metrics = get_state().metrics
-    metrics.add_ignores(target_manager.ignore_log.unsupported_lang_paths)
     if metrics.is_enabled:
         metrics.add_project_url(project_url)
         metrics.add_configs(configs)
@@ -450,6 +449,7 @@ def main(
         metrics.add_findings(filtered_matches_by_rule)
         metrics.add_errors(semgrep_errors)
         metrics.add_profiling(profiler)
+        metrics.add_ignores(target_manager.ignore_log.unsupported_lang_paths)
 
     if autofix:
         apply_fixes(filtered_matches_by_rule.kept, dryrun)

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -133,18 +133,16 @@ class FileTargetingLog:
     @property
     def unsupported_lang_paths(self) -> FrozenSet[Path]:
         # paths of all files that were ignored by ALL non-generic langs
-        return (
-            frozenset(
-                set.intersection(
-                    *[
-                        paths
-                        for lang, paths in self.by_language.items()
-                        if lang not in UNSUPPORTED_EXT_IGNORE_LANGS
-                    ]
-                )
+        return frozenset(
+            set.intersection(
+                *[
+                    paths
+                    for lang, paths in self.by_language.items()
+                    if lang not in UNSUPPORTED_EXT_IGNORE_LANGS
+                ]
             )
             if self.by_language
-            else frozenset()
+            else set()
         )
 
     def __str__(self) -> str:

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -39,7 +39,7 @@ from attrs import Factory, frozen
 from wcmatch import glob as wcglob
 from boltons.iterutils import partition
 
-from semgrep.constants import Colors
+from semgrep.constants import Colors, UNSUPPORTED_EXT_IGNORE_LANGS
 from semgrep.error import FilesNotFoundError
 from semgrep.formatter.text import width
 from semgrep.ignores import FileIgnore
@@ -139,7 +139,7 @@ class FileTargetingLog:
                     *[
                         paths
                         for lang, paths in self.by_language.items()
-                        if lang != "generic"
+                        if lang not in UNSUPPORTED_EXT_IGNORE_LANGS
                     ]
                 )
             )

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -130,6 +130,23 @@ class FileTargetingLog:
             }
         )
 
+    @property
+    def unsupported_lang_paths(self) -> FrozenSet[Path]:
+        # paths of all files that were ignored by ALL non-generic langs
+        return (
+            frozenset(
+                set.intersection(
+                    *[
+                        paths
+                        for lang, paths in self.by_language.items()
+                        if lang != "generic"
+                    ]
+                )
+            )
+            if self.by_language
+            else frozenset()
+        )
+
     def __str__(self) -> str:
         limited_fragments = []
         skip_fragments = []

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
@@ -14,6 +14,9 @@
   },
   "event_id": "00000000-0000-0000-0000-000000000000",
   "fix_rate": {},
+  "ignores": {
+    "unsupported_exts": {}
+  },
   "performance": {
     "fileStats": [
       {

--- a/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
+++ b/cli/tests/e2e/snapshots/test_metrics/test_metrics_payload/metrics-payload.json
@@ -14,9 +14,6 @@
   },
   "event_id": "00000000-0000-0000-0000-000000000000",
   "fix_rate": {},
-  "ignores": {
-    "unsupported_exts": {}
-  },
   "performance": {
     "fileStats": [
       {
@@ -76,6 +73,7 @@
       "c3f79a06bc39dcd0d7ed1e1b676934d1d9fa628d5631ecd666fc204e3d811089": 0,
       "f19cada0143903df62f6b421917d325fbbcc5ff6a7c423818030cdf64c828731": 0,
       "f4692285ae22ee62c58c95675c490c445348fdf6d8bce37b696c75f868c8ae40": 1
-    }
+    },
+    "unsupportedExts": {}
   }
 }


### PR DESCRIPTION
Closes APP-1354. This PR adds new reporting of file extensions that do not match any enabled language except `generic`. File extension here is defined as `os.path.splitext` defines it:

> Split the pathname path into a pair (root, ext) such that root + ext == path, and the extension, ext, is empty or begins with a period and contains at most one period.

This does not report anything for files without an extension, including hidden files without an extensions such as `.semgrepignore`. 

For each file extension, it reports the number of files that were ignored with that extension.

PR checklist:

- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [ ] Change has no security implications (otherwise, ping security team)
