### PR TITLE
feat(app-metrics): track unsupported file extensions for app users

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -290,7 +290,7 @@ The classes of scan data are:
 - Author identity (e.g., committer email)
 - Commit metadata (e.g., commit hash)
 - Review and review-requester identifying data (e.g., pull-request ID, branch, merge base, request author)
-- Scan metadata, including type of scan and scan parameters (e.g., paths scanned)
+- Scan metadata, including type of scan and scan parameters (e.g., paths scanned and extensions of ignored files)
 - Timing metrics (e.g., time taken to scan per-rule and per-path)
 - Semgrep environment (e.g., version, interpreter, timestamp)
 

--- a/changelog.d/app-1354.added
+++ b/changelog.d/app-1354.added
@@ -1,0 +1,1 @@
+Added metadata in App-connected scans to report extensions of files that do not match the language of any enabled rules in order to enable more effective language prioritization while developing new rules.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -1,6 +1,7 @@
 # Handle communication of findings / errors to semgrep.app
 import json
 import os
+from collections import Counter
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -158,6 +159,7 @@ class ScanHandler:
         errors: List[SemgrepError],
         rules: List[Rule],
         targets: Set[Path],
+        ignored_targets: Set[Path],
         total_time: float,
         commit_date: str,
     ) -> None:
@@ -196,6 +198,12 @@ class ScanHandler:
                 for match in new_ignored
             ],
         }
+
+        ignored_ext_freqs = Counter(
+            [os.path.splitext(path)[1] for path in ignored_targets]
+        )
+        ignored_ext_freqs.pop("", None)  # don't count files with no extension
+
         complete = {
             "exit_code": 1
             if any(match.is_blocking and not match.is_ignored for match in all_matches)
@@ -204,6 +212,7 @@ class ScanHandler:
                 "findings": len(new_matches),
                 "errors": [error.to_dict() for error in errors],
                 "total_time": total_time,
+                "unsupported_exts": ignored_ext_freqs,
             },
         }
 
@@ -248,6 +257,7 @@ class ScanHandler:
             raise Exception(f"API server returned this error: {response.text}")
 
         # mark as complete
+        print("sending 'complete' blob", complete)
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/complete",
             json=complete,

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -257,7 +257,6 @@ class ScanHandler:
             raise Exception(f"API server returned this error: {response.text}")
 
         # mark as complete
-        print("sending 'complete' blob", complete)
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/complete",
             json=complete,

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -212,7 +212,7 @@ class ScanHandler:
                 "findings": len(new_matches),
                 "errors": [error.to_dict() for error in errors],
                 "total_time": total_time,
-                "unsupported_exts": ignored_ext_freqs,
+                "unsupported_exts": dict(ignored_ext_freqs),
             },
         }
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -429,6 +429,7 @@ def ci(
             semgrep_errors,
             filtered_rules,
             all_targets,
+            ignore_log.unsupported_lang_paths,
             total_time,
             metadata.commit_datetime,
         )

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -24,6 +24,8 @@ FIXTEST_SUFFIX = ".fixed"
 
 RETURNTOCORP_LEVER_URL = "https://api.lever.co/v0/postings/returntocorp?mode=json"
 
+UNSUPPORTED_EXT_IGNORE_LANGS = {"generic", "regex"}
+
 
 class OutputFormat(Enum):
     TEXT = auto()

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -39,7 +39,7 @@ from attrs import Factory, frozen
 from wcmatch import glob as wcglob
 from boltons.iterutils import partition
 
-from semgrep.constants import Colors
+from semgrep.constants import Colors, UNSUPPORTED_EXT_IGNORE_LANGS
 from semgrep.error import FilesNotFoundError
 from semgrep.formatter.text import width
 from semgrep.ignores import FileIgnore
@@ -128,6 +128,21 @@ class FileTargetingLog:
                 *(rule_id for rule_id, skips in self.rule_includes.items() if skips),
                 *(rule_id for rule_id, skips in self.rule_excludes.items() if skips),
             }
+        )
+
+    @property
+    def unsupported_lang_paths(self) -> Set[Path]:
+        # paths of all files that were ignored by ALL non-generic langs
+        return (
+            set.intersection(
+                *[
+                    paths
+                    for lang, paths in self.by_language.items()
+                    if lang not in UNSUPPORTED_EXT_IGNORE_LANGS
+                ]
+            )
+            if self.by_language
+            else set()
         )
 
     def __str__(self) -> str:

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -314,7 +314,9 @@ Would have sent complete blob: {
         "findings": 9,
         "errors": [],
         "total_time": <MASKED>
-        "unsupported_exts": {}
+        "unsupported_exts": {
+            ".txt": 1
+        }
     }
 }
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -314,6 +314,7 @@ Would have sent complete blob: {
         "findings": 9,
         "errors": [],
         "total_time": <MASKED>
+        "unsupported_exts": {}
     }
 }
   Has findings for blocking rules so exiting with code 1

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
@@ -4,6 +4,8 @@
     "findings": 9,
     "errors": [],
     "total_time": 0.5,
-    "unsupported_exts": {}
+    "unsupported_exts": {
+      ".txt": 1
+    }
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
@@ -3,6 +3,7 @@
   "stats": {
     "findings": 9,
     "errors": [],
-    "total_time": 0.5
+    "total_time": 0.5,
+    "unsupported_exts": {}
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -231,6 +231,7 @@ Sending complete blob: {
         "findings": 1,
         "errors": [],
         "total_time":<MASKED>
+        "unsupported_exts": {}
     }
 }
   No blocking findings so exiting with code 0

--- a/cli/tests/e2e/targets/unsupported_langs/test.rkt
+++ b/cli/tests/e2e/targets/unsupported_langs/test.rkt
@@ -1,0 +1,7 @@
+#lang racket/safe
+
+(println "this is a test file")
+
+(if (= 2 2)
+  (println "always true")
+  (println ":("))

--- a/cli/tests/e2e/targets/unsupported_langs/test.rkt
+++ b/cli/tests/e2e/targets/unsupported_langs/test.rkt
@@ -1,7 +1,0 @@
-#lang racket/safe
-
-(println "this is a test file")
-
-(if (= 2 2)
-  (println "always true")
-  (println ":("))

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -885,38 +885,3 @@ def test_git_failure(run_semgrep, git_tmp_path_with_commit, mocker):
         assert_exit_code=2,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
     )
-
-
-@pytest.mark.kinda_slow
-def test_unsupported_langs(git_tmp_path, run_semgrep_in_tmp, mocker, snapshot):
-    mocker.patch("semgrep.app.auth.is_valid_token", return_value=True)
-    mocker.patch.object(AppSession, "post")
-
-    env = {"SEMGREP_APP_TOKEN": "fake_api_token"}
-
-    shutil.copy(
-        Path(__file__).parent.parent
-        / "e2e"
-        / "targets"
-        / "unsupported_langs"
-        / "test.rkt",
-        git_tmp_path / "test.rkt",
-    )
-    subprocess.run(["git", "add", "."], check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "dummy commit"],
-        check=True,
-        capture_output=True,
-    )
-
-    result = run_semgrep_in_tmp(
-        target_name=None, options=["ci"], strict=False, env=env, assert_exit_code=None
-    )
-
-    post_calls = AppSession.post.call_args_list  # type: ignore
-    findings_json = post_calls[(len(post_calls) // 2) + 1].kwargs["json"]
-
-    snapshot.assert_match(
-        findings_json,
-        "results.txt",
-    )

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -881,3 +881,37 @@ def test_git_failure(run_semgrep, git_tmp_path_with_commit, mocker):
         assert_exit_code=2,
         env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
     )
+
+
+@pytest.mark.kinda_slow
+def test_unsupported_langs(git_tmp_path, run_semgrep_in_tmp, mocker):
+    mocker.patch("semgrep.app.auth.is_valid_token", return_value=True)
+    mocker.patch.object(AppSession, "post")
+
+    env = {"SEMGREP_APP_TOKEN": "fake_api_token"}
+
+    shutil.copy(
+        Path(__file__).parent.parent
+        / "e2e"
+        / "targets"
+        / "unsupported_langs"
+        / "test.rkt",
+        git_tmp_path / "test.rkt",
+    )
+    subprocess.run(["git", "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "dummy commit"],
+        check=True,
+        capture_output=True,
+    )
+
+    result = run_semgrep_in_tmp(
+        target_name=None, options=["ci"], strict=False, env=env, assert_exit_code=None
+    )
+
+    post_calls = AppSession.post.call_args_list  # type: ignore
+    # print("post     calls:", post_calls)
+    findings_json = post_calls[(len(post_calls) // 2) + 1].kwargs["json"]
+    unsupported_exts = findings_json["stats"]["unsupported_exts"]
+
+    assert unsupported_exts == {".rkt": 1}


### PR DESCRIPTION
Closes APP-1354. This PR adds new reporting of file extensions that do not match any enabled language except generic. Note that this will still return file extensions of languages that _semgrep_ supports if none of the enabled rules support that language. File extension here is defined as `os.path.splitext` defines it:

> Split the pathname path into a pair (root, ext) such that root + ext == path, and the extension, ext, is empty or begins with a period and contains at most one period.

This does not report anything for files without an extension, including hidden files without an extensions such as .semgrepignore. Unlike the previous version #5802, these metrics are added as part of Scan metadata (only for App users). 

PR checklist:

- [ ] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
