### PR TITLE
chore(debt): remove unique_id from the JSON output of cli and core

### DIFF
--- a/changelog.d/unique-id-json.changed
+++ b/changelog.d/unique-id-json.changed
@@ -1,0 +1,2 @@
+Removed the unique_id field from the semgrep (and semgrep-core) JSON output
+for metavariables.

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -78,7 +78,6 @@ def _clean_output_json(output_json: str, clean_fingerprint: bool = False) -> str
 
     masked_keys = [
         "tool.driver.semanticVersion",
-        "results.extra.metavars.*.unique_id.md5sum",
         "results.*.checks.*.matches",
     ]
     for path in masked_keys:

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-dryrun/results.json
@@ -36,10 +36,6 @@
               "col": 3,
               "line": 5,
               "offset": 45
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           },
           "$KEY": {
@@ -53,10 +49,6 @@
               "col": 10,
               "line": 5,
               "offset": 52
-            },
-            "unique_id": {
-              "sid": 2,
-              "type": "id"
             }
           }
         },
@@ -98,10 +90,6 @@
               "col": 6,
               "line": 6,
               "offset": 64
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           },
           "$KEY": {
@@ -115,10 +103,6 @@
               "col": 13,
               "line": 6,
               "offset": 71
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixautofix.yaml-autofixautofix.py-not-dryrun/results.json
@@ -33,10 +33,6 @@
               "col": 3,
               "line": 5,
               "offset": 45
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           },
           "$KEY": {
@@ -50,10 +46,6 @@
               "col": 10,
               "line": 5,
               "offset": 52
-            },
-            "unique_id": {
-              "sid": 2,
-              "type": "id"
             }
           }
         },
@@ -92,10 +84,6 @@
               "col": 6,
               "line": 6,
               "offset": 64
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           },
           "$KEY": {
@@ -109,10 +97,6 @@
               "col": 13,
               "line": 6,
               "offset": 71
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-dryrun/results.json
@@ -48,10 +48,6 @@
               "col": 9,
               "line": 62,
               "offset": 2376
-            },
-            "unique_id": {
-              "sid": 18,
-              "type": "id"
             }
           },
           "$VAR": {
@@ -65,10 +61,6 @@
               "col": 9,
               "line": 60,
               "offset": 2269
-            },
-            "unique_id": {
-              "sid": 20,
-              "type": "id"
             }
           },
           "$W": {
@@ -82,10 +74,6 @@
               "col": 32,
               "line": 60,
               "offset": 2292
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$X": {
@@ -99,10 +87,6 @@
               "col": 41,
               "line": 60,
               "offset": 2301
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -163,10 +147,6 @@
               "col": 9,
               "line": 71,
               "offset": 2687
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MODEL": {
@@ -193,10 +173,6 @@
               "col": 9,
               "line": 79,
               "offset": 2977
-            },
-            "unique_id": {
-              "sid": 25,
-              "type": "id"
             }
           },
           "$VAR": {
@@ -210,10 +186,6 @@
               "col": 34,
               "line": 71,
               "offset": 2712
-            },
-            "unique_id": {
-              "sid": 24,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixdjango-none-password-default.yaml-autofixdjango-none-password-default.py-not-dryrun/results.json
@@ -42,10 +42,6 @@
               "col": 9,
               "line": 62,
               "offset": 2376
-            },
-            "unique_id": {
-              "sid": 18,
-              "type": "id"
             }
           },
           "$VAR": {
@@ -59,10 +55,6 @@
               "col": 9,
               "line": 60,
               "offset": 2269
-            },
-            "unique_id": {
-              "sid": 20,
-              "type": "id"
             }
           },
           "$W": {
@@ -76,10 +68,6 @@
               "col": 32,
               "line": 60,
               "offset": 2292
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$X": {
@@ -93,10 +81,6 @@
               "col": 41,
               "line": 60,
               "offset": 2301
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -144,10 +128,6 @@
               "col": 9,
               "line": 71,
               "offset": 2687
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MODEL": {
@@ -174,10 +154,6 @@
               "col": 9,
               "line": 79,
               "offset": 2977
-            },
-            "unique_id": {
-              "sid": 25,
-              "type": "id"
             }
           },
           "$VAR": {
@@ -191,10 +167,6 @@
               "col": 34,
               "line": 71,
               "offset": 2712
-            },
-            "unique_id": {
-              "sid": 24,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-dryrun/results.json
@@ -40,10 +40,6 @@
               "col": 5,
               "line": 7,
               "offset": 95
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -89,10 +85,6 @@
               "col": 5,
               "line": 15,
               "offset": 259
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixflask-use-jsonify.yaml-autofixflask-use-jsonify.py-not-dryrun/results.json
@@ -37,10 +37,6 @@
               "col": 5,
               "line": 7,
               "offset": 95
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -83,10 +79,6 @@
               "col": 5,
               "line": 15,
               "offset": 259
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-dryrun/results.json
@@ -36,10 +36,6 @@
               "col": 16,
               "line": 3,
               "offset": 49
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -81,10 +77,6 @@
               "col": 22,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixjava-string-wrap.yaml-autofixjava-string-wrap.java-not-dryrun/results.json
@@ -33,10 +33,6 @@
               "col": 16,
               "line": 3,
               "offset": 49
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -75,10 +71,6 @@
               "col": 22,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-dryrun/results.json
@@ -36,10 +36,6 @@
               "col": 27,
               "line": 1,
               "offset": 26
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -81,10 +77,6 @@
               "col": 27,
               "line": 3,
               "offset": 66
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -126,10 +118,6 @@
               "col": 29,
               "line": 5,
               "offset": 110
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -171,10 +159,6 @@
               "col": 29,
               "line": 7,
               "offset": 167
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixocaml_paren_expr.yaml-autofixocaml_paren_expr.ml-not-dryrun/results.json
@@ -33,10 +33,6 @@
               "col": 27,
               "line": 1,
               "offset": 26
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -75,10 +71,6 @@
               "col": 27,
               "line": 3,
               "offset": 66
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -117,10 +109,6 @@
               "col": 29,
               "line": 5,
               "offset": 110
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -159,10 +147,6 @@
               "col": 29,
               "line": 7,
               "offset": 167
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-dryrun/results.json
@@ -36,10 +36,6 @@
               "col": 11,
               "line": 2,
               "offset": 21
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -81,10 +77,6 @@
               "col": 11,
               "line": 5,
               "offset": 48
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-assert-statement.yaml-autofixpython-assert-statement.py-not-dryrun/results.json
@@ -33,10 +33,6 @@
               "col": 11,
               "line": 2,
               "offset": 21
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -75,10 +71,6 @@
               "col": 11,
               "line": 5,
               "offset": 48
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-dryrun/results.json
@@ -46,10 +46,6 @@
               "col": 26,
               "line": 1,
               "offset": 25
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -101,10 +97,6 @@
               "col": 26,
               "line": 6,
               "offset": 136
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixterraform-ec2-instance-metadata-options.yaml-autofixterraform-ec2-instance-metadata-options.hcl-not-dryrun/results.json
@@ -36,10 +36,6 @@
               "col": 26,
               "line": 1,
               "offset": 25
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -81,10 +77,6 @@
               "col": 26,
               "line": 6,
               "offset": 136
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_basic_rule__absolute/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_basic_rule__local/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_basic_rule__relative/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_cdn_ruleset_resolution/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_cdn_ruleset_resolution/results.json
@@ -55,10 +55,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -104,10 +100,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_deduplication/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_deduplication/results.json
@@ -56,10 +56,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -121,10 +117,6 @@
               "col": 5,
               "line": 8,
               "offset": 168
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -186,10 +178,6 @@
               "col": 12,
               "line": 12,
               "offset": 260
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_deduplication_different_message/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_deduplication_different_message/results.json
@@ -32,10 +32,6 @@
               "col": 1,
               "line": 1,
               "offset": 0
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$Y": {
@@ -49,10 +45,6 @@
               "col": 5,
               "line": 1,
               "offset": 4
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -90,10 +82,6 @@
               "col": 1,
               "line": 1,
               "offset": 0
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$Y": {
@@ -107,10 +95,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_deduplication_same_message/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_deduplication_same_message/results.json
@@ -32,10 +32,6 @@
               "col": 1,
               "line": 1,
               "offset": 0
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$Y": {
@@ -49,10 +45,6 @@
               "col": 5,
               "line": 1,
               "offset": 4
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_default_rule__file/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_default_rule__folder/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_hidden_rule__explicit/results.json
@@ -45,10 +45,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -86,10 +82,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule/results.json
@@ -42,10 +42,6 @@
               "col": 30,
               "line": 2,
               "offset": 62
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_base/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_base/results.json
@@ -42,10 +42,6 @@
               "col": 35,
               "line": 1,
               "offset": 34
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_strip/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_comparison_rule_strip/results.json
@@ -42,10 +42,6 @@
               "col": 36,
               "line": 1,
               "offset": 35
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_multi_regex_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_multi_regex_rule/results.json
@@ -42,10 +42,6 @@
               "col": 25,
               "line": 1,
               "offset": 24
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$Y": {
@@ -59,10 +55,6 @@
               "col": 33,
               "line": 1,
               "offset": 32
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_propagation_comparison/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_propagation_comparison/results.json
@@ -32,10 +32,6 @@
               "col": 9,
               "line": 7,
               "offset": 65
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -73,10 +69,6 @@
               "col": 9,
               "line": 12,
               "offset": 111
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_propagation_regex/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_propagation_regex/results.json
@@ -32,10 +32,6 @@
               "col": 5,
               "line": 1,
               "offset": 4
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -73,10 +69,6 @@
               "col": 5,
               "line": 4,
               "offset": 29
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_regex_multi_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_regex_multi_rule/results.json
@@ -42,10 +42,6 @@
               "col": 29,
               "line": 3,
               "offset": 73
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_metavariable_regex_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_metavariable_regex_rule/results.json
@@ -42,10 +42,6 @@
               "col": 25,
               "line": 1,
               "offset": 24
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -83,10 +79,6 @@
               "col": 25,
               "line": 2,
               "offset": 56
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
@@ -47,10 +47,6 @@
               "col": 9,
               "line": 7,
               "offset": 115
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multiple_configs_different_origins/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -129,10 +121,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -170,10 +158,6 @@
               "col": 5,
               "line": 8,
               "offset": 168
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -211,10 +195,6 @@
               "col": 12,
               "line": 12,
               "offset": 260
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multiple_configs_file/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_nested_pattern_either_rule/results.json
@@ -103,10 +103,6 @@
               "col": 26,
               "line": 5,
               "offset": 148
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_nested_patterns_rule/results.json
@@ -34,10 +34,6 @@
               "col": 26,
               "line": 2,
               "offset": 43
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -75,10 +71,6 @@
               "col": 26,
               "line": 3,
               "offset": 78
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_noextension_filtering/results.json
@@ -34,10 +34,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_noextension_filtering_optimizations/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_noextension_filtering_optimizations/results.json
@@ -34,10 +34,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_regex_rule__not/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_regex_rule__not/results.json
@@ -32,10 +32,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_regex_rule__not2/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_regex_rule__not2/results.json
@@ -32,10 +32,6 @@
               "col": 2,
               "line": 1,
               "offset": 1
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -73,10 +69,6 @@
               "col": 2,
               "line": 2,
               "offset": 33
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -114,10 +106,6 @@
               "col": 2,
               "line": 7,
               "offset": 128
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -155,10 +143,6 @@
               "col": 6,
               "line": 14,
               "offset": 338
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -196,10 +180,6 @@
               "col": 2,
               "line": 16,
               "offset": 367
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_registry_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_registry_rule/results.json
@@ -55,10 +55,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -104,10 +100,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_script/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_script/results.json
@@ -34,10 +34,6 @@
               "col": 1,
               "line": 3,
               "offset": 20
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_check/test_url_rule/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_url_rule/results.json
@@ -42,10 +42,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -83,10 +79,6 @@
               "col": 5,
               "line": 8,
               "offset": 168
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -124,10 +116,6 @@
               "col": 12,
               "line": 12,
               "offset": 260
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -41,10 +41,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 4,
               "offset": 37
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -82,10 +78,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 5,
               "offset": 48
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -123,10 +115,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 7,
               "offset": 83
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -164,10 +152,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 11,
               "offset": 120
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -209,10 +193,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 19,
               "offset": 219
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -256,10 +236,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 15,
               "offset": 157
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -41,10 +41,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 4,
               "offset": 37
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -82,10 +78,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 5,
               "offset": 48
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -123,10 +115,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 7,
               "offset": 83
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -164,10 +152,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 11,
               "offset": 120
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -209,10 +193,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 19,
               "offset": 219
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -253,10 +233,6 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "col": 5,
               "line": 15,
               "offset": 157
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4shell.java/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarelog4shell.yaml-dependency_awarelog4shell.java/results.txt
@@ -72,10 +72,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "col": 26,
               "line": 33,
               "offset": 1027
-            },
-            "unique_id": {
-              "sid": 7,
-              "type": "id"
             }
           },
           "$LOGGER": {
@@ -102,10 +98,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "col": 13,
               "line": 33,
               "offset": 1014
-            },
-            "unique_id": {
-              "sid": 10,
-              "type": "id"
             }
           },
           "$METHOD": {
@@ -119,10 +111,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "col": 20,
               "line": 33,
               "offset": 1021
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$PKG": {
@@ -136,10 +124,6 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "col": 33,
               "line": 9,
               "offset": 225
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-include/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude-and-include/results.json
@@ -45,10 +45,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude0/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude0/results.json
@@ -46,10 +46,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -100,10 +96,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude1/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/exclude1/results.json
@@ -46,10 +46,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -100,10 +96,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-exclude/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-exclude/results.json
@@ -45,10 +45,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include0/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include0/results.json
@@ -48,10 +48,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -102,10 +98,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -156,10 +148,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -210,10 +198,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include1/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include-and-include1/results.json
@@ -48,10 +48,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -102,10 +98,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -156,10 +148,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -210,10 +198,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include0/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include0/results.json
@@ -46,10 +46,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -100,10 +96,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include1/results.json
+++ b/cli/tests/e2e/snapshots/test_exclude_include/test_exclude_include/include1/results.json
@@ -46,10 +46,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -100,10 +96,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_ignores/test_default_semgrepignore/results.json
+++ b/cli/tests/e2e/snapshots/test_ignores/test_default_semgrepignore/results.json
@@ -32,10 +32,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_ignores/test_internal_explicit_semgrepignore/results.json
+++ b/cli/tests/e2e/snapshots/test_ignores/test_internal_explicit_semgrepignore/results.json
@@ -36,10 +36,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -77,10 +73,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -118,10 +110,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -159,10 +147,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -200,10 +184,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_ignores/test_semgrepignore/results.json
+++ b/cli/tests/e2e/snapshots/test_ignores/test_semgrepignore/results.json
@@ -33,10 +33,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -74,10 +70,6 @@
               "col": 9,
               "line": 1,
               "offset": 8
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesinlineinline-rules.yaml-join_rulesuser-input-with-unescaped-extension/results.json
+++ b/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesinlineinline-rules.yaml-join_rulesuser-input-with-unescaped-extension/results.json
@@ -30,10 +30,6 @@
               "col": 39,
               "line": 9,
               "offset": 143
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesinlinetaint.yaml-join_rulesuser-input-with-unescaped-extension/results.json
+++ b/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesinlinetaint.yaml-join_rulesuser-input-with-unescaped-extension/results.json
@@ -30,10 +30,6 @@
               "col": 39,
               "line": 9,
               "offset": 143
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesmultiple-rules.yaml-join_rulesuser-input-with-unescaped-extension/results.json
+++ b/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesmultiple-rules.yaml-join_rulesuser-input-with-unescaped-extension/results.json
@@ -55,10 +55,6 @@
               "col": 38,
               "line": 9,
               "offset": 142
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-escaped-with-safe.yaml-join_rulesuser-input-escaped-with-safe/results.json
+++ b/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-escaped-with-safe.yaml-join_rulesuser-input-escaped-with-safe/results.json
@@ -32,10 +32,6 @@
               "col": 28,
               "line": 19,
               "offset": 437
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-with-unescaped-extension.yaml-join_rulesuser-input-with-unescaped-extension/results.json
+++ b/cli/tests/e2e/snapshots/test_join_rules/test_join_rules/rulesjoin_rulesuser-input-with-unescaped-extension.yaml-join_rulesuser-input-with-unescaped-extension/results.json
@@ -30,10 +30,6 @@
               "col": 38,
               "line": 9,
               "offset": 142
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_join_rules/test_recursive_join_rules/rulesjoin_rulesrecursiveflask-deep-stored-xss-exampleflask-stored-xss.yaml-join_rulesrecursiveflask-deep-stored-xss-example/results.json
+++ b/cli/tests/e2e/snapshots/test_join_rules/test_recursive_join_rules/rulesjoin_rulesrecursiveflask-deep-stored-xss-exampleflask-stored-xss.yaml-join_rulesrecursiveflask-deep-stored-xss-example/results.json
@@ -30,10 +30,6 @@
               "col": 7,
               "line": 2,
               "offset": 34
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_join_rules/test_recursive_join_rules/rulesjoin_rulesrecursivejava-callgraph-examplevulnado-sqli.yaml-join_rulesrecursivejava-callgraph-examplevulnado/results.json
+++ b/cli/tests/e2e/snapshots/test_join_rules/test_recursive_join_rules/rulesjoin_rulesrecursivejava-callgraph-examplevulnado-sqli.yaml-join_rulesrecursivejava-callgraph-examplevulnado/results.json
@@ -30,10 +30,6 @@
               "col": 22,
               "line": 43,
               "offset": 1140
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$PARAMETER": {
@@ -47,10 +43,6 @@
               "col": 65,
               "line": 51,
               "offset": 1423
-            },
-            "unique_id": {
-              "sid": 23,
-              "type": "id"
             }
           },
           "$RETURNTYPE": {
@@ -64,10 +56,6 @@
               "col": 17,
               "line": 43,
               "offset": 1135
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$SQLSTATEMENT": {
@@ -81,10 +69,6 @@
               "col": 23,
               "line": 51,
               "offset": 1381
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$TYPE": {
@@ -98,10 +82,6 @@
               "col": 28,
               "line": 43,
               "offset": 1146
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_lsp/test_lsp_diagnostics/diagnostics.json
+++ b/cli/tests/e2e/snapshots/test_lsp/test_lsp_diagnostics/diagnostics.json
@@ -19,10 +19,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "aca68f1483a3c0badcd1b2f72d3954d7",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_match_based_id/test_duplicate_matches_indexing/results.json
+++ b/cli/tests/e2e/snapshots/test_match_based_id/test_duplicate_matches_indexing/results.json
@@ -33,10 +33,6 @@
               "col": 4,
               "line": 1,
               "offset": 3
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -74,10 +70,6 @@
               "col": 4,
               "line": 4,
               "offset": 34
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -115,10 +107,6 @@
               "col": 4,
               "line": 1,
               "offset": 3
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -156,10 +144,6 @@
               "col": 4,
               "line": 4,
               "offset": 34
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -197,10 +181,6 @@
               "col": 4,
               "line": 1,
               "offset": 3
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -238,10 +218,6 @@
               "col": 4,
               "line": 4,
               "offset": 34
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -279,10 +255,6 @@
               "col": 4,
               "line": 1,
               "offset": 3
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -320,10 +292,6 @@
               "col": 4,
               "line": 4,
               "offset": 34
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1MB/results.json
+++ b/cli/tests/e2e/snapshots/test_max_target_bytes/test_max_target_bytes/1MB/results.json
@@ -47,10 +47,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -88,10 +84,6 @@
               "col": 13,
               "line": 3,
               "offset": 61
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside.py/results.json
@@ -32,10 +32,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -49,10 +45,6 @@
               "col": 9,
               "line": 2,
               "offset": 19
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -66,10 +58,6 @@
               "col": 15,
               "line": 3,
               "offset": 38
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -107,10 +95,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -124,10 +108,6 @@
               "col": 9,
               "line": 5,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -141,10 +121,6 @@
               "col": 15,
               "line": 6,
               "offset": 74
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -182,10 +158,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -199,10 +171,6 @@
               "col": 9,
               "line": 8,
               "offset": 90
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -216,10 +184,6 @@
               "col": 15,
               "line": 9,
               "offset": 109
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -257,10 +221,6 @@
               "col": 7,
               "line": 14,
               "offset": 151
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -274,10 +234,6 @@
               "col": 9,
               "line": 15,
               "offset": 164
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -291,10 +247,6 @@
               "col": 15,
               "line": 16,
               "offset": 183
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationmulti-pattern-inside.yaml-message_interpolationmulti_pattern_inside_nested.py/results.json
@@ -32,10 +32,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -49,10 +45,6 @@
               "col": 9,
               "line": 2,
               "offset": 19
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -66,10 +58,6 @@
               "col": 19,
               "line": 4,
               "offset": 59
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -107,10 +95,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -124,10 +108,6 @@
               "col": 13,
               "line": 3,
               "offset": 36
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -141,10 +121,6 @@
               "col": 19,
               "line": 4,
               "offset": 59
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -182,10 +158,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -199,10 +171,6 @@
               "col": 9,
               "line": 6,
               "offset": 76
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -216,10 +184,6 @@
               "col": 15,
               "line": 7,
               "offset": 95
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -257,10 +221,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -274,10 +234,6 @@
               "col": 9,
               "line": 6,
               "offset": 76
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -291,10 +247,6 @@
               "col": 19,
               "line": 9,
               "offset": 137
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -332,10 +284,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -349,10 +297,6 @@
               "col": 13,
               "line": 8,
               "offset": 114
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -366,10 +310,6 @@
               "col": 19,
               "line": 9,
               "offset": 137
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -407,10 +347,6 @@
               "col": 7,
               "line": 11,
               "offset": 152
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -424,10 +360,6 @@
               "col": 9,
               "line": 12,
               "offset": 165
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$MSG": {
@@ -441,10 +373,6 @@
               "col": 15,
               "line": 13,
               "offset": 184
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-either.yaml-message_interpolationpattern_either_basic.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-either.yaml-message_interpolationpattern_either_basic.py/results.json
@@ -32,10 +32,6 @@
               "col": 5,
               "line": 1,
               "offset": 4
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -73,10 +69,6 @@
               "col": 5,
               "line": 4,
               "offset": 30
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -114,10 +106,6 @@
               "col": 5,
               "line": 7,
               "offset": 56
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_basic.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_basic.py/results.json
@@ -32,10 +32,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -49,10 +45,6 @@
               "col": 9,
               "line": 2,
               "offset": 19
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -90,10 +82,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -107,10 +95,6 @@
               "col": 9,
               "line": 5,
               "offset": 54
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_complex.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-inside.yaml-message_interpolationpattern_inside_complex.py/results.json
@@ -32,10 +32,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -49,10 +45,6 @@
               "col": 9,
               "line": 2,
               "offset": 19
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -90,10 +82,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -107,10 +95,6 @@
               "col": 9,
               "line": 5,
               "offset": 54
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -148,10 +132,6 @@
               "col": 7,
               "line": 8,
               "offset": 87
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$FUNC": {
@@ -165,10 +145,6 @@
               "col": 9,
               "line": 9,
               "offset": 100
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_basic.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_basic.py/results.json
@@ -32,10 +32,6 @@
               "col": 5,
               "line": 8,
               "offset": 85
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_complex.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpattern-not-inside.yaml-message_interpolationpattern_not_inside_complex.py/results.json
@@ -32,10 +32,6 @@
               "col": 5,
               "line": 12,
               "offset": 128
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpropagated-constant.yaml-message_interpolationpropagated_constant.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpropagated-constant.yaml-message_interpolationpropagated_constant.py/results.json
@@ -32,10 +32,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$X": {
@@ -62,10 +58,6 @@
               "col": 15,
               "line": 4,
               "offset": 51
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -103,10 +95,6 @@
               "col": 7,
               "line": 1,
               "offset": 6
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$X": {
@@ -120,10 +108,6 @@
               "col": 15,
               "line": 7,
               "offset": 87
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
+++ b/cli/tests/e2e/snapshots/test_metavariable_matching/test_equivalence/results.json
@@ -55,10 +55,6 @@
               "col": 10,
               "line": 4,
               "offset": 91
-            },
-            "unique_id": {
-              "sid": 2,
-              "type": "id"
             }
           }
         },
@@ -96,10 +92,6 @@
               "col": 10,
               "line": 14,
               "offset": 260
-            },
-            "unique_id": {
-              "sid": 6,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_metavariable_regex_const_prop/test_metavariable_regex_const_prop/results.json
+++ b/cli/tests/e2e/snapshots/test_metavariable_regex_const_prop/test_metavariable_regex_const_prop/results.json
@@ -42,10 +42,6 @@
               "col": 9,
               "line": 4,
               "offset": 53
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -93,10 +89,6 @@
               "col": 9,
               "line": 11,
               "offset": 170
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_nosemgrep/test_regex_rule__nosemgrep/results.json
+++ b/cli/tests/e2e/snapshots/test_nosemgrep/test_regex_rule__nosemgrep/results.json
@@ -35,10 +35,6 @@
               "col": 1,
               "line": 3,
               "offset": 44
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$3": {
@@ -52,10 +48,6 @@
               "col": 5,
               "line": 3,
               "offset": 48
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$4": {
@@ -69,10 +61,6 @@
               "col": 13,
               "line": 3,
               "offset": 56
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$6": {
@@ -86,10 +74,6 @@
               "col": 15,
               "line": 3,
               "offset": 58
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_output/test_output_format/--json/results.out
+++ b/cli/tests/e2e/snapshots/test_output/test_output_format/--json/results.out
@@ -34,10 +34,6 @@
               "col": 12,
               "line": 3,
               "offset": 55
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_paths/test_paths/results.json
+++ b/cli/tests/e2e/snapshots/test_paths/test_paths/results.json
@@ -47,10 +47,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -101,10 +97,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -155,10 +147,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -209,10 +197,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -263,10 +247,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -317,10 +297,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -371,10 +347,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -425,10 +397,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -479,10 +447,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -533,10 +497,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -587,10 +547,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -641,10 +597,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -695,10 +647,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },
@@ -749,10 +697,6 @@
               "col": 13,
               "line": 3,
               "offset": 24
-            },
-            "unique_id": {
-              "sid": 1,
-              "type": "id"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepdockerfile.yaml-spacegreproot.Dockerfile/results.json
+++ b/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepdockerfile.yaml-spacegreproot.Dockerfile/results.json
@@ -32,10 +32,6 @@
               "col": 6,
               "line": 3,
               "offset": 39
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -73,10 +69,6 @@
               "col": 6,
               "line": 7,
               "offset": 107
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
+++ b/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrephttpresponse.yaml-spacegrephttpresponse.txt/results.json
@@ -32,10 +32,6 @@
               "col": 14,
               "line": 1,
               "offset": 13
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           },
           "$STATUS": {
@@ -49,10 +45,6 @@
               "col": 10,
               "line": 1,
               "offset": 9
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
+++ b/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmarkdown.yaml-spacegrepmarkdown.md/results.json
@@ -32,10 +32,6 @@
               "col": 4,
               "line": 62,
               "offset": 2584
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -73,10 +69,6 @@
               "col": 4,
               "line": 97,
               "offset": 3694
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -114,10 +106,6 @@
               "col": 4,
               "line": 145,
               "offset": 8838
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -155,10 +143,6 @@
               "col": 4,
               "line": 159,
               "offset": 9237
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -196,10 +180,6 @@
               "col": 4,
               "line": 188,
               "offset": 9793
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },
@@ -237,10 +217,6 @@
               "col": 4,
               "line": 203,
               "offset": 10936
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmulti-lines.yaml-spacegrepmulti-lines.java/results.json
+++ b/cli/tests/e2e/snapshots/test_spacegrep/test_spacegrep/rulesspacegrepmulti-lines.yaml-spacegrepmulti-lines.java/results.json
@@ -32,10 +32,6 @@
               "col": 5,
               "line": 4,
               "offset": 45
-            },
-            "unique_id": {
-              "md5sum": "<masked in tests>",
-              "type": "AST"
             }
           }
         },

--- a/perf/run-benchmarks
+++ b/perf/run-benchmarks
@@ -69,10 +69,6 @@ class SemgrepResult:
             if "lines" in dict2["extra"]:
                 dict2["extra"]["lines"] = "<masked in benchmarks>"
             if "metavars" in dict2["extra"]:
-                # TODO: spacegrep/../Semgrep.ml uses a different unique_id
-                for _, v in dict2["extra"]["metavars"].items():
-                    if "unique_id" in v:
-                        v["unique_id"] = "<masked in benchmarks>"
                 # TODO: core_runner.py dedup_output() depends on the order
                 # of the elements in the list to remove similar findings
                 # but with different metavars


### PR DESCRIPTION
This field was useful back in the day when the semgrep
engine was split between semgrep-core and semgrep-cli.
Now all the logic is in semgrep-core so there is no
need anymore for this unique_id field.

test plan:
make test


PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)