### PR TITLE
fix(debug): make dump-il more cohesive

### DIFF
--- a/changelog.d/dump-il.fixed
+++ b/changelog.d/dump-il.fixed
@@ -1,1 +1,0 @@
-Changed it such that `dump-il` prints out all the top-level IL statements of a program, rather than individually printing out all of the statements in each function.

--- a/changelog.d/dump-il.fixed
+++ b/changelog.d/dump-il.fixed
@@ -1,0 +1,1 @@
+Changed it such that `dump-il` prints out all the top-level IL statements of a program, rather than individually printing out all of the statements in each function.

--- a/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
@@ -70,25 +70,8 @@ let dump_il file =
   let lang = List.hd (Lang.langs_of_filename file) in
   let ast = Parse_target.parse_program file in
   Naming_AST.resolve lang ast;
-
-  let v =
-    V.mk_visitor
-      {
-        V.default_visitor with
-        V.kfunction_definition =
-          (fun (_k, _) def ->
-            let s =
-              AST_generic.show_any (G.S (H.funcbody_to_stmt def.G.fbody))
-            in
-            pr2 s;
-            pr2 "==>";
-
-            let _, xs = AST_to_IL.function_definition lang def in
-            let s = IL.show_any (IL.Ss xs) in
-            pr2 s);
-      }
-  in
-  v (G.Pr ast)
+  let xs = AST_to_IL.stmt lang (G.stmt1 ast) in
+  List.iter (fun stmt -> pr2 (IL.show_stmt stmt)) xs
   [@@action]
 
 (*****************************************************************************)

--- a/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
@@ -62,19 +62,6 @@ module D = Datalog_fact
 type env = { facts : Datalog_fact.t list ref }
 
 (*****************************************************************************)
-(* Dumper *)
-(*****************************************************************************)
-
-(* mostly a copy paste of pfff/lang_GENERIC/analyze/Test_analyze_generic.ml *)
-let dump_il file =
-  let lang = List.hd (Lang.langs_of_filename file) in
-  let ast = Parse_target.parse_program file in
-  Naming_AST.resolve lang ast;
-  let xs = AST_to_IL.stmt lang (G.stmt1 ast) in
-  List.iter (fun stmt -> pr2 (IL.show_stmt stmt)) xs
-  [@@action]
-
-(*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 let add env x = Common.push x env.facts

--- a/semgrep-core/src/experiments/datalog/Datalog_experiment.mli
+++ b/semgrep-core/src/experiments/datalog/Datalog_experiment.mli
@@ -2,6 +2,3 @@
  * and output the varpointto info for the file.
  *)
 val gen_facts : Common.filename -> Common.dirname -> unit
-
-(* to debug the IL *)
-val dump_il : Common.filename -> unit


### PR DESCRIPTION
**What:**
Currently, `dump-il` uses `Visitor_AST` to separately visit each function definition, and then print the IL stmts contained within. Notably, this means that it misses top-level statements, including the functions themselves.

**Why:**
If you use `dump-il` on the following program:
```py
x = "ls"

def foo():
  x = 5

def bar():
  x = True
```

it will display something like:
```
(S
   { s =
     (Block
        ((),
         [{ s =
            (ExprStmt (
               { e =
                 (Assign (
                    { e =
                      (N
                         (Id (("x", ()),
                            { id_resolved = ref ((Some (LocalVar, 2)));
                              id_type = ref (None); id_svalue = ref (None);
                              id_hidden = false; id_info_id = 2 }
                            )));
                      e_id = 0; e_range = None },
                    (),
                    { e = (L (Int ((Some 5), ()))); e_id = 0; e_range = None
                      }
                    ));
                 e_id = 0; e_range = None },
               ()));
            ...)
==>
(Ss
   [{ s =
      (Instr
         { i =
           (Assign (
              { base =
                (Var
                   { IL.ident = ("x", ()); sid = 2;
                     id_info =
                     { id_resolved = ref ((Some (LocalVar, 2)));
                       id_type = ref (None); id_svalue = ref (None);
                       id_hidden = false; id_info_id = 2 }
                     });
                offset = NoOffset },
              { e = (Literal (Int ((Some 5), ())));
                eorig = ...
                }
              ));
           iorig = ...
      }
     ])
(S
   { s =
     (Block
        ((),
         [{ s =
            (ExprStmt (
               { e =
                 (Assign (
                    { e =
                      (N
                         (Id (("x", ()),
                            { id_resolved = ref ((Some (LocalVar, 3)));
                              id_type = ref (None); id_svalue = ref (None);
                              id_hidden = false; id_info_id = 4 }
                            )));
                      e_id = 0; e_range = None },
                    (),
                    { e = (L (Bool (true, ()))); e_id = 0; e_range = None }));
                 e_id = 0; e_range = None },
               ...)
==>
(Ss
   [{ s =
      (Instr
         { i =
           (Assign (
              { base =
                (Var
                   { IL.ident = ("x", ()); sid = 3;
                     id_info =
                     { id_resolved = ref ((Some (LocalVar, 3)));
                       id_type = ref (None); id_svalue = ref (None);
                       id_hidden = false; id_info_id = 4 }
                     });
                offset = NoOffset },
              { e = (Literal (Bool (true, ())));
                eorig = ...
                }
              ));
           iorig = ...
      }
     ])
```
This is pretty misleading in my opinion, and looks like all the `x` assigns exist in the same top-level or something. The distinction between these functions is not super clear, and in any case, the actual function nodes themselves are completely missing, despite the fact that the IL really looks something like `DefStmt (x) -> MiscStmt (foo) -> MiscStmt (bar)`.

I think it would be nicer for debugging purposes to not obfuscate the IL's form.

**How:**
I changed `dump-il` such that we no longer use `Visitor_AST`, and instead just convert the AST to a series of IL statements, and then print the statements.

Also, I added a new `dump-il-functions` command, which will explicitly go and print out (as before) all top-level functions. It has effectively the same functionality as what `dump-il` currently is. It also prints out function names, if possible.

**Test plan:**
Try it out yourself.

**PR checklist:**

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)