### PR TITLE
feat(semgrep-core cli): added implicit rules key

### DIFF
--- a/changelog.d/implicit-rules-sc-core.added
+++ b/changelog.d/implicit-rules-sc-core.added
@@ -1,0 +1,1 @@
+Changed `semgrep-core` so that it can now be run with `-rules` on `.yaml` files which do not have a top-level `rules: ...` key. This means you can now copy paste from the playground editor directly into a `.yaml` file for use with `semgrep-core`.

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -980,7 +980,9 @@ let parse_generic ?(error_recovery = false) file ast =
         (* it's also ok to not have the toplevel rules:, anyway we never
          * used another toplevel key
          *)
+        | G.Container (G.Dict, (l, _, _)) -> (l, [ e ])
         | G.Container (G.Array, (l, rules, _r)) -> (l, rules)
+        (* otherwise, it's bad, and complain *)
         | _ ->
             let loc = PI.first_loc_of_file file in
             yaml_error (PI.mk_info_of_loc loc)


### PR DESCRIPTION
**What:**
`semgrep-core` with the `-rules` option takes in a `.yaml` file, which must have a `rules: ...` at the top level. This PR just makes it so that the `rules: ...` is inserted implicitly if it is not found.

**Why:**
This is annoying, because sometimes I want to copy-paste from the Semgrep playground, which does not require a `rules: ...` (and in fact, does not allow it). This leads to precious seconds of developer time being wasted by me having to write `rules:` on the first line, and the indent the rest.

**How:**
If it doesn't match the `rules: ...`, but it otherwise looks like the format of the Semgrep playground, parse it anyways.

**Test plan:** Try it on the CLI. You can do `sc -rules test.yaml test.py -lang python`, for instance, with a `.yaml` file that looks like:
```
id: java-private-property-track
message: The XML parser $PARSER is not securely configured.
severity: ERROR
languages:
  - java
patterns:
  - pattern: |
      $FACTORY = javax.xml.parsers.DocumentBuilderFactory.newInstance()
  - pattern-inside: |
      $FACTORY = ...;
      ...
      $PARSER = $FACTORY.newDocumentBuilder();
```


PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
