### PR TITLE
Fix metrics reporting for LSP to hash rules to hash rules

### DIFF
--- a/changelog.d/lsp-metrixs.fixed
+++ b/changelog.d/lsp-metrixs.fixed
@@ -1,0 +1,1 @@
+Rules reported for LSP metrics now are hashed before sending

--- a/cli/src/semgrep/lsp/metrics.py
+++ b/cli/src/semgrep/lsp/metrics.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import List
 from typing import MutableMapping
 from typing import Optional
@@ -39,12 +40,13 @@ class LSPMetrics:
 
     def update(self, rule_id: str, opened: int, closed: int) -> None:
         """Update the metrics with the given rule and count."""
-        self.rule_seen_max_map[rule_id] = max(
-            self.rule_seen_max_map.get(rule_id, 0), opened
+        rule_hash = hashlib.sha256(rule_id.encode("utf-8")).hexdigest()
+        self.rule_seen_max_map[rule_hash] = max(
+            self.rule_seen_max_map.get(rule_hash, 0), opened
         )
-        self.rules_seen_last_map[rule_id] = opened
-        self.rule_seen_closed_map[rule_id] = closed + self.rule_seen_closed_map.get(
-            rule_id, 0
+        self.rules_seen_last_map[rule_hash] = opened
+        self.rule_seen_closed_map[rule_hash] = closed + self.rule_seen_closed_map.get(
+            rule_hash, 0
         )
 
     def send(

--- a/cli/tests/e2e/test_lsp.py
+++ b/cli/tests/e2e/test_lsp.py
@@ -167,5 +167,15 @@ def test_lsp_metrics_measurement(lsp, tmp_path, mocker):
     lsp.m_shutdown()
 
     payload = json.loads(mock_post.call_args.kwargs["data"])
-    assert payload["fix_rate"]["lowerLimits"]["rules.eqeq-is-bad"] == 1
-    assert payload["fix_rate"]["upperLimits"]["rules.eqeq-is-bad"] == 1
+    assert (
+        payload["fix_rate"]["lowerLimits"][
+            "eed07adc473fcdbff2e7970162c5b82d039a83e720f1dbdabbc55783ac91021c"
+        ]
+        == 1
+    )
+    assert (
+        payload["fix_rate"]["upperLimits"][
+            "eed07adc473fcdbff2e7970162c5b82d039a83e720f1dbdabbc55783ac91021c"
+        ]
+        == 1
+    )


### PR DESCRIPTION
PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
