### PR TITLE
chore(ci): run macOS build tests on develop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -436,7 +436,7 @@ jobs:
     name: build macOS release
     runs-on: macos-10.15
     # there are too many PR events which deplete our macOS concurrency limit
-    if: (!contains(github.event_name, 'pull_request')) || contains(github.event.pull_request.head.ref, 'release-')
+    if: (!contains(github.event_name, 'pull_request')) || contains(github.event.pull_request.head.ref, 'release-') || github.ref == 'refs/heads/develop'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -460,7 +460,7 @@ jobs:
     name: test macOS release
     runs-on: macos-10.15
     # there are too many PR events which deplete our macOS concurrency limit
-    if: (!contains(github.event_name, 'pull_request')) || contains(github.event.pull_request.head.ref, 'release-')
+    if: (!contains(github.event_name, 'pull_request')) || contains(github.event.pull_request.head.ref, 'release-') || github.ref == 'refs/heads/develop'
     needs: [build-macos-release]
     steps:
       - name: download artifacts


### PR DESCRIPTION
Skipping tests on develop resulted in a red-X summary of CI

PR checklist:

- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
