### PR TITLE
feat(swift): Handle extensions and protocols

### DIFF
--- a/semgrep-core/tests/swift/class_variants.sgrep
+++ b/semgrep-core/tests/swift/class_variants.sgrep
@@ -1,0 +1,1 @@
+class Foo {}

--- a/semgrep-core/tests/swift/class_variants.swift
+++ b/semgrep-core/tests/swift/class_variants.swift
@@ -1,0 +1,8 @@
+// We parse all of these as classes, so they all match a class pattern
+
+// MATCH:
+class Foo {}
+// MATCH:
+struct Foo {}
+// MATCH:
+extension Foo {}

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -96,3 +96,33 @@ class foo<bar: baz> { }
 // TODO
 // class foo<bar> where bar: baz { }
 // class foo<bar> where bar: baz, bar: asdf { }
+
+// TODO test other varieties
+struct foo { }
+
+// TODO test other varieties
+extension bar { }
+
+// TODO test other varieties
+enum baz { }
+
+// Protocol
+
+protocol foo {
+    // The grammar allows bodies for functions/initializers/deinitializers but
+    // Swift actually does not.
+    //
+    // The grammar allows deinits here but Swift does not.
+    func foo()
+    init()
+    var foo: Int { get }
+    var foo: Int { get set }
+    var foo: Int { set get }
+    // TODO other options
+}
+
+protocol foo<T> { }
+protocol foo: bar { }
+protocol foo: bar, baz { }
+// TODO
+// protocol foo<T> where T: bar { }


### PR DESCRIPTION
Test plan: Automated tests plus manual inspection of some parse trees,
for example:

`$ semgrep-core -lang swift -dump_ast test.swift`

`protocol foo<T>: bar, baz { }`

```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("foo", ()),
                {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[]; tparams=[TP({tp_id=("T", ()); tp_attrs=[]; tp_bounds=[]; tp_default=None; tp_variance=None; })]; },
      ClassDef(
        {ckind=(Interface, ());
         cextends=[({t_attrs=[];
                     t=TyN(
                         Id(("bar", ()),
                           {id_info_id=2; id_hidden=false; id_resolved=Ref(
                            None); id_type=Ref(None); id_svalue=Ref(None); }));
                     },
                    None);
                   ({t_attrs=[];
                     t=TyN(
                         Id(("baz", ()),
                           {id_info_id=3; id_hidden=false; id_resolved=Ref(
                            None); id_type=Ref(None); id_svalue=Ref(None); }));
                     },
                    None)];
         cimplements=[]; cmixins=[]; cparams=[]; cbody=[]; })))])
```

As I noted in the `construct_class_def` function, it's not possible in
general to tell which inheritance specifiers are for superclasses and
which are for protocols. For protocol definitions, all inheritance
specifiers must also be protocols, but for consistency with classes I
think it's better to leave them all in `cextends`.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
