### PR TITLE
feat(swift): support modifierless function decls

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1324,6 +1324,9 @@ and keyword_attribute =
   | DefaultImpl (* Rust unstable, RFC 1210 *)
   (* Scala *)
   | Lazy
+  (* Swift *)
+  | Throws
+  | Rethrows
 
 (* By name application in Scala, via => T, in parameter *)
 

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -651,6 +651,8 @@ and vof_keyword_attribute = function
   | NotNull -> OCaml.VSum ("NotNull", [])
   | Unsafe -> OCaml.VSum ("Unsafe", [])
   | DefaultImpl -> OCaml.VSum ("DefaultImpl", [])
+  | Throws -> OCaml.VSum ("Throws", [])
+  | Rethrows -> OCaml.VSum ("Rethrows", [])
 
 and vof_attribute = function
   | KeywordAttr x ->

--- a/semgrep-core/src/experiments/api/AST_generic_to_v0.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v0.ml
@@ -621,6 +621,8 @@ and map_keyword_attribute = function
   | Setter -> Left `Setter
   | Unsafe -> Left `Unsafe
   | DefaultImpl -> Left `DefaultImpl
+  | Throws -> Left `Throws
+  | Rethrows -> Left `Rethrows
   (* new: *)
   | Lazy -> Right "lazy"
   | RecordClass -> Right "RecordClass"


### PR DESCRIPTION
This PR just cleans up a few TODOs for the Swift modifierless function declarations.

In particular, there are modifiers `Async`, `Throws`, and `Rethrows` which may be attached to a function signature. Also, where are `where` constraints on type parameters to a function.

**Test plan:**
Doing `sc -dump_ast test.swift -lang swift` on the following program:
```swift
func foo () async throws -> ty {}
```
produces
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("foo", ()),
                {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[]; tparams=[]; },
      FuncDef(
        {fkind=(Function, ()); fparams=[];
         frettype=Some({t_attrs=[KeywordAttr((Async, ())); KeywordAttr((Throws, ()))];
                        t=TyN(
                            Id(("ty", ()),
                              {id_info_id=1; id_hidden=false; id_resolved=Ref(
                               None); id_type=Ref(None); id_svalue=Ref(
                               None); }));
                        });
         fbody=FBStmt(Block([])); })))])
```

PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
