### PR TITLE
chore: enforce submodule commits to be on default branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -511,20 +511,24 @@ jobs:
       - name: Check semgrep-interfaces
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "${GITHUB_WORKSPACE}/cli/src/semgrep/semgrep_interfaces"
+          # Looks like this uses the value from
+          # git config --file .gitmodules --name-only --get-regexp path
+          # (per https://github.com/jtmullen/submodule-branch-check-action/blob/6c6f99f42640ce5247e478880be431940ad3c515/entrypoint.sh#L94)
+          # instead of the actual path?
+          path: cli/src/semgrep/semgrep-interfaces
           branch: main
       - name: Check semgrep-langs
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "${GITHUB_WORKSPACE}/cli/src/semgrep/lang"
+          path: cli/src/semgrep/lang
           branch: main
       - name: Check ocaml-tree-sitter-core
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "${GITHUB_WORKSPACE}/semgrep-core/src/ocaml-tree-sitter-core"
+          path: semgrep-core/src/ocaml-tree-sitter-core
           branch: main
       - name: Check pfff
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "${GITHUB_WORKSPACE}/semgrep-core/src/pfff"
+          path: semgrep-core/src/pfff
           branch: develop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -511,20 +511,20 @@ jobs:
       - name: Check semgrep-interfaces
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: ./cli/src/semgrep/semgrep_interfaces
+          path: "${GITHUB_WORKSPACE}/cli/src/semgrep/semgrep_interfaces"
           branch: main
       - name: Check semgrep-langs
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: ./cli/src/semgrep/lang
+          path: "${GITHUB_WORKSPACE}/cli/src/semgrep/lang"
           branch: main
       - name: Check ocaml-tree-sitter-core
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: ./semgrep-core/src/ocaml-tree-sitter-core
+          path: "${GITHUB_WORKSPACE}/semgrep-core/src/ocaml-tree-sitter-core"
           branch: main
       - name: Check pfff
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: ./semgrep-core/src/pfff
+          path: "${GITHUB_WORKSPACE}/semgrep-core/src/pfff"
           branch: develop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -511,20 +511,20 @@ jobs:
       - name: Check semgrep-interfaces
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "cli/src/semgrep/semgrep_interfaces"
-          branch: "main"
+          path: ./cli/src/semgrep/semgrep_interfaces
+          branch: main
       - name: Check semgrep-langs
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "cli/src/semgrep/lang"
-          branch: "main"
+          path: ./cli/src/semgrep/lang
+          branch: main
       - name: Check ocaml-tree-sitter-core
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "semgrep-core/src/ocaml-tree-sitter-core"
-          branch: "main"
+          path: ./semgrep-core/src/ocaml-tree-sitter-core
+          branch: main
       - name: Check pfff
         uses: jtmullen/submodule-branch-check-action@v1
         with:
-          path: "semgrep-core/src/pfff"
-          branch: "develop"
+          path: ./semgrep-core/src/pfff
+          branch: develop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -501,3 +501,30 @@ jobs:
         with:
           name: semgrep-ubuntu-16.04-${{ github.sha }}
           path: artifacts.tar.gz
+
+  check-submodules:
+    name: check submodule branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check semgrep-interfaces
+        uses: jtmullen/submodule-branch-check-action@v1
+        with:
+          path: "cli/src/semgrep/semgrep_interfaces"
+          branch: "main"
+      - name: Check semgrep-langs
+        uses: jtmullen/submodule-branch-check-action@v1
+        with:
+          path: "cli/src/semgrep/lang"
+          branch: "main"
+      - name: Check ocaml-tree-sitter-core
+        uses: jtmullen/submodule-branch-check-action@v1
+        with:
+          path: "semgrep-core/src/ocaml-tree-sitter-core"
+          branch: "main"
+      - name: Check pfff
+        uses: jtmullen/submodule-branch-check-action@v1
+        with:
+          path: "semgrep-core/src/pfff"
+          branch: "develop"


### PR DESCRIPTION
PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

---

This PR adds a new github actions workflow to enforce that the major submodules (i.e., [pfff](https://github.com/returntocorp/pfff), [semgrep-langs](https://github.com/returntocorp/semgrep-langs), [semgrep-interfaces](https://github.com/returntocorp/semgrep-interfaces), and [ocaml-tree-sitter-core](https://github.com/returntocorp/ocaml-tree-sitter-core); excludes the various auto-updated semgrep-$LANG submodules) point to a commit on the default branch (either `develop` or `main`).

This has the benefit of avoiding possible merge conflicts which can arise when a commit makes in onto develop here. Moreover, it avoids the potential issue of commits in the upstream submodule being gc'd.
