### PR TITLE
fix(git): Ignore pending changes in submodule

### DIFF
--- a/changelog.d/cli-272.fixed
+++ b/changelog.d/cli-272.fixed
@@ -1,0 +1,1 @@
+Fixed issue when scan fails due to pending changes in submodule.

--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -190,7 +190,9 @@ class BaselineHandler:
             return self._dirty_paths_by_status
 
         logger.debug("Initializing dirty paths")
-        git_status_output = git_check_output(["git", "status", "--porcelain", "-z"])
+        git_status_output = git_check_output(
+            ["git", "status", "--porcelain", "-z", "--ignore-submodules"]
+        )
         logger.debug(f"Git status output: {git_status_output}")
         output = zsplit(git_status_output)
         logger.debug("finished getting dirty paths")


### PR DESCRIPTION
PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

## Testing:
- Reproduced issue in test repo
   - Add submodule to repo (commit X)
   - Remove or update submodule in repo (commit Y)
   - Create PR forked from commit X
- Ran semgrep CI locally: `semgrep ci --verbose`

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
