### PR TITLE
fix(cli): Add git url parser and use for building repo url and repo name, add fallback when not defined

### DIFF
--- a/changelog.d/cli-280.fixed
+++ b/changelog.d/cli-280.fixed
@@ -1,0 +1,1 @@
+Semgrep CI now accepts more formats of git url for metadata provided to semgrep.dev and lets the user provide a fallback for repo name (SEMGREP_REPO_NAME) and repo url (SEMGREP_REPO_URL) if they are undefined by CI.

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -1,0 +1,115 @@
+# This file is copied from https://github.com/coala/git-url-parse/blob/master/giturlparse/parser.py
+# MIT license here: https://github.com/coala/git-url-parse/blob/master/LICENSE
+
+# Copyright (c) 2017 John Dewey
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#  DEALINGS IN THE SOFTWARE.
+
+import collections
+import re
+from typing import List
+
+Parsed = collections.namedtuple('Parsed', [
+    'pathname',
+    'protocols',
+    'protocol',
+    'href',
+    'resource',
+    'user',
+    'port',
+    'name',
+    'owner',
+])
+
+POSSIBLE_REGEXES = (
+    re.compile(r'^(?P<protocol>https?|git|ssh|rsync)\://'
+               r'(?:(?P<user>.+)@)*'
+               r'(?P<resource>[a-z0-9_.-]*)'
+               r'[:/]*'
+               r'(?P<port>[\d]+){0,1}'
+               r'(?P<pathname>\/((?P<owner>[\w\-]+)\/)?'
+               r'((?P<name>[\w\-\.]+?)(\.git|\/)?)?)$'),
+    re.compile(r'(git\+)?'
+               r'((?P<protocol>\w+)://)'
+               r'((?P<user>\w+)@)?'
+               r'((?P<resource>[\w\.\-]+))'
+               r'(:(?P<port>\d+))?'
+               r'(?P<pathname>(\/(?P<owner>\w+)/)?'
+               r'(\/?(?P<name>[\w\-]+)(\.git|\/)?)?)$'),
+    re.compile(r'^(?:(?P<user>.+)@)*'
+               r'(?P<resource>[a-z0-9_.-]*)[:]*'
+               r'(?P<port>[\d]+){0,1}'
+               r'(?P<pathname>\/?(?P<owner>.+)/(?P<name>.+).git)$'),
+    re.compile(r'((?P<user>\w+)@)?'
+               r'((?P<resource>[\w\.\-]+))'
+               r'[\:\/]{1,2}'
+               r'(?P<pathname>((?P<owner>\w+)/)?'
+               r'((?P<name>[\w\-]+)(\.git|\/)?)?)$'),
+)
+
+
+class ParserError(Exception):
+    """ Error raised when a URL can't be parsed. """
+    pass
+
+
+class Parser(str):
+    """
+    A class responsible for parsing a GIT URL and return a `Parsed` object.
+    """
+
+    def __init__(self, url: str):
+        self._url: str = url
+
+    def parse(self) -> Parsed:
+        """
+        Parses a GIT URL and returns an object.  Raises an exception on invalid
+        URL.
+        :returns: Parsed object
+        :raise: :class:`.ParserError`
+        """
+        d = {
+            'pathname': None,
+            'protocols': self._get_protocols(),
+            'protocol': 'ssh',
+            'href': self._url,
+            'resource': None,
+            'user': None,
+            'port': None,
+            'name': None,
+            'owner': None,
+        }
+        for regex in POSSIBLE_REGEXES:
+            match = regex.search(self._url)
+            if match:
+                d.update(match.groupdict())
+                break
+        else:
+            msg = "Invalid URL '{}'".format(self._url)
+            raise ParserError(msg)
+
+        return Parsed(**d)
+
+    def _get_protocols(self) -> List[str]:
+        try:
+            index = self._url.index('://')
+        except ValueError:
+            return []
+
+        return self._url[:index].split('+')

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -75,7 +75,10 @@ class Parser(str):
     """
 
     def __init__(self, url: str):
+        # to fix an open bug with trailing slashes: https://github.com/coala/git-url-parse/issues/46
         self._url: str = url
+        if url[-1] == "/":
+          self._url = url[:-1]
 
     def parse(self) -> Parsed:
         """

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
@@ -1,0 +1,11 @@
+{
+  "exit_code": 1,
+  "stats": {
+    "findings": 9,
+    "errors": [],
+    "total_time": 0.5,
+    "unsupported_exts": {
+      ".txt": 1
+    }
+  }
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
@@ -1,0 +1,170 @@
+{
+  "token": null,
+  "gitlab_token": null,
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    x == 2"
+      ]
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "__r2c-internal-cai_eqeq",
+      "path": "foo.py",
+      "line": 21,
+      "column": 5,
+      "end_line": 21,
+      "end_column": 16,
+      "message": "useless comparison to 3",
+      "severity": 0,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "985498b46aff45ebdffe6a26af8524ab",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    }
+  ],
+  "searched_paths": [
+    "foo.py"
+  ],
+  "rule_ids": [
+    "eqeq-bad",
+    "eqeq-five",
+    "eqeq-four"
+  ],
+  "cai_ids": [
+    "__r2c-internal-cai_eqeq"
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/ignores.json
@@ -1,0 +1,93 @@
+{
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 13,
+      "column": 5,
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 16,
+      "column": 5,
+      "end_line": 16,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0",
+      "fixed_lines": [
+        "    y == 2  # nosemgrep"
+      ]
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 18,
+      "column": 5,
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+    }
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "semgrep_version": "<sanitized version>",
+    "repository": "a/repo/name",
+    "repo_url": "https://random.url.org/some/path",
+    "branch": "some/branch-name",
+    "ci_job_url": "https://jenkins.build.url",
+    "commit": "sanitized",
+    "commit_author_email": "test_environment@test.r2c.dev",
+    "commit_author_name": "Environment Test",
+    "commit_author_username": null,
+    "commit_author_image_url": null,
+    "commit_title": "Some other commit/ message",
+    "on": "unknown",
+    "pull_request_author_username": null,
+    "pull_request_author_image_url": null,
+    "pull_request_id": null,
+    "pull_request_title": null,
+    "scan_environment": "jenkins",
+    "is_full_scan": true,
+    "is_sca_scan": false
+  }
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -1,5 +1,5 @@
 === command
-JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="some/branch-name" BUILD_URL="https://jenkins.build.url" GIT_COMMIT="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci
+JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGREP_REPO_NAME="a/repo/name" GIT_BRANCH="some/branch-name" BUILD_URL="https://jenkins.build.url" GIT_COMMIT="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci
 === end of command
 
 === exit code
@@ -26,7 +26,7 @@ Findings:
         useless comparison to 5
 
          ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
+         15┆ x == 2
           ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -1,5 +1,5 @@
 === command
-JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git" GIT_BRANCH="some/branch-name" BUILD_URL="https://jenkins.build.url" GIT_COMMIT="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci
+JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="some/branch-name" BUILD_URL="https://jenkins.build.url" GIT_COMMIT="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci
 === end of command
 
 === exit code

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
@@ -1,0 +1,11 @@
+{
+  "exit_code": 1,
+  "stats": {
+    "findings": 9,
+    "errors": [],
+    "total_time": 0.5,
+    "unsupported_exts": {
+      ".txt": 1
+    }
+  }
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
@@ -1,0 +1,167 @@
+{
+  "token": null,
+  "gitlab_token": null,
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "__r2c-internal-cai_eqeq",
+      "path": "foo.py",
+      "line": 21,
+      "column": 5,
+      "end_line": 21,
+      "end_column": 16,
+      "message": "useless comparison to 3",
+      "severity": 0,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "985498b46aff45ebdffe6a26af8524ab",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    }
+  ],
+  "searched_paths": [
+    "foo.py"
+  ],
+  "rule_ids": [
+    "eqeq-bad",
+    "eqeq-five",
+    "eqeq-four"
+  ],
+  "cai_ids": [
+    "__r2c-internal-cai_eqeq"
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/ignores.json
@@ -1,0 +1,90 @@
+{
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 13,
+      "column": 5,
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 16,
+      "column": 5,
+      "end_line": 16,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 18,
+      "column": 5,
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+    }
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
@@ -1,0 +1,23 @@
+{
+  "meta": {
+    "semgrep_version": "<sanitized version>",
+    "repository": "a/repo/name",
+    "repo_url": "https://random.url.org/some/path",
+    "branch": "some/branch-name",
+    "ci_job_url": "https://jenkins.build.url",
+    "commit": "sanitized",
+    "commit_author_email": "test_environment@test.r2c.dev",
+    "commit_author_name": "Environment Test",
+    "commit_author_username": null,
+    "commit_author_image_url": null,
+    "commit_title": "Some other commit/ message",
+    "on": "unknown",
+    "pull_request_author_username": null,
+    "pull_request_author_image_url": null,
+    "pull_request_id": null,
+    "pull_request_title": null,
+    "scan_environment": "jenkins",
+    "is_full_scan": true,
+    "is_sca_scan": false
+  }
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -1,5 +1,5 @@
 === command
-JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="some/branch-name" BUILD_URL="https://jenkins.build.url" GIT_COMMIT="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci
+JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGREP_REPO_NAME="a/repo/name" GIT_BRANCH="some/branch-name" BUILD_URL="https://jenkins.build.url" GIT_COMMIT="<MASKED>" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci
 === end of command
 
 === exit code

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -258,7 +258,14 @@ def mock_autofix(request, mocker):
         },
         {  # Jenkins
             "JENKINS_URL": "some_url",
-            "GIT_URL": "https://github.com/org/repo.git",
+            "GIT_URL": "https://github.com/org/repo.git/",
+            "GIT_BRANCH": BRANCH_NAME,
+            "BUILD_URL": "https://jenkins.build.url",
+        },
+        {  # Jenkins, not defined GIT_URL
+            "JENKINS_URL": "some_url",
+            "SEMGREP_REPO_URL": "https://random.url.org/some/path",
+            "SEMGREP_REPO_NAME": "a/repo/name",
             "GIT_BRANCH": BRANCH_NAME,
             "BUILD_URL": "https://jenkins.build.url",
         },
@@ -310,6 +317,7 @@ def mock_autofix(request, mocker):
         "gitlab-push",
         "circleci",
         "jenkins",
+        "jenkins-missing-vars",
         "bitbucket",
         "azure-pipelines",
         "buildkite",


### PR DESCRIPTION
PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
