### PR TITLE
Kotlin: support ellipsis in method chaining

### DIFF
--- a/changelog.d/gh-5819.added
+++ b/changelog.d/gh-5819.added
@@ -1,0 +1,1 @@
+Kotlin: support for ellipsis in field access (e.g., `obj. ... .bar()`)

--- a/semgrep-core/tests/kotlin/dots_method_chaining.kt
+++ b/semgrep-core/tests/kotlin/dots_method_chaining.kt
@@ -1,0 +1,17 @@
+class Foo {
+
+  fun test() {
+
+    //ERROR: match
+    f = this.foo().m().h().bar().z();
+
+    //ERROR: match
+    f = this.foo().bar();
+
+    f = this.foo().m().h().z();
+
+    //ERROR: match $O can match o.before()
+    f = this.before().foo().m().h().bar().z();
+  }
+}
+


### PR DESCRIPTION
This closes #5819

test plan:
test file included


PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)