### PR TITLE
feat(swift): allow ellipses in class patterns

### DIFF
--- a/changelog.d/pa-1689.added
+++ b/changelog.d/pa-1689.added
@@ -1,0 +1,4 @@
+Swift: Added parsing for ellipses in class declarations for patterns.
+
+So like:
+class $CLASS { ... }

--- a/changelog.d/pa-1689.added
+++ b/changelog.d/pa-1689.added
@@ -1,4 +1,0 @@
-Swift: Added parsing for ellipses in class declarations for patterns.
-
-So like:
-class $CLASS { ... }

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -2660,17 +2660,22 @@ and map_type_constraints (env : env) ((v1, v2, v3) : CST.type_constraints) =
 and map_type_level_declaration (env : env) (x : CST.type_level_declaration) :
     G.stmt list =
   match x with
-  | `Import_decl x -> [ map_import_declaration env x ]
-  | `Prop_decl x -> map_property_declaration env x
-  | `Typeas_decl x -> [ map_typealias_declaration env x ]
-  | `Func_decl x -> [ map_function_declaration env ~in_class:true x ]
-  | `Class_decl x -> [ map_class_declaration env x ]
-  | `Prot_decl x -> [ map_protocol_declaration env x ]
-  | `Deinit_decl x -> [ map_deinit_declaration env x ]
-  | `Subs_decl x -> [ map_subscript_declaration env x ]
-  | `Op_decl x -> map_operator_declaration env x
-  | `Prec_group_decl x -> map_precedence_group_declaration env x
-  | `Asso_decl x -> [ map_associatedtype_declaration env x ]
+  | `Choice_import_decl x -> (
+      match x with
+      | `Import_decl x -> [ map_import_declaration env x ]
+      | `Prop_decl x -> map_property_declaration env x
+      | `Typeas_decl x -> [ map_typealias_declaration env x ]
+      | `Func_decl x -> [ map_function_declaration env ~in_class:true x ]
+      | `Class_decl x -> [ map_class_declaration env x ]
+      | `Prot_decl x -> [ map_protocol_declaration env x ]
+      | `Deinit_decl x -> [ map_deinit_declaration env x ]
+      | `Subs_decl x -> [ map_subscript_declaration env x ]
+      | `Op_decl x -> map_operator_declaration env x
+      | `Prec_group_decl x -> map_precedence_group_declaration env x
+      | `Asso_decl x -> [ map_associatedtype_declaration env x ])
+  | `Semg_ellips tok (* "..." *) ->
+      let tok = (* three_dot_operator_custom *) token env tok in
+      [ G.ExprStmt (G.Ellipsis tok |> G.e, G.sc) |> G.s ]
 
 and map_type_modifiers (env : env) (x : CST.type_modifiers) =
   map_type_parameter_modifiers env x

--- a/semgrep-core/tests/swift/class_ellipsis.sgrep
+++ b/semgrep-core/tests/swift/class_ellipsis.sgrep
@@ -1,0 +1,1 @@
+class $CLASS { ... }

--- a/semgrep-core/tests/swift/class_ellipsis.swift
+++ b/semgrep-core/tests/swift/class_ellipsis.swift
@@ -1,0 +1,4 @@
+// MATCH: 
+class Foo {
+    var x = 1
+}


### PR DESCRIPTION
**What:**
This PR updates the `semgrep-swift` repo to allow class patterns to contain ellipses.

**Why:**
This is a useful thing to be able to do.

**How:**
Updated the grammar, updated the submodule, and updated the generic conversion.

**Test plan:**
`make test`

**Fixes:** PA-1689

PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
