### PR TITLE
fix(cli): Fix join+taint regression

### DIFF
--- a/changelog.d/gh-5839.fixed
+++ b/changelog.d/gh-5839.fixed
@@ -1,0 +1,1 @@
+Fixed a crash that occurred when reporting results when join mode and taint mode were used together


### PR DESCRIPTION
Join mode uses the output from Semgrep in a way that defeats the type
safety provided by ATD and mypy. When I split out the dataflow trace
types into a core version and a CLI version in #5765, I didn't realize
that join mode relies on the `extra` field of the CLI output being
compatible with the `extra` field of the core output, mypy was not able
to warn me, and there were apparently no tests exercising this behavior.

This changes the join mode code to explicitly convert the `extra` field
from the CLI match version to the core match version. Because this
conversion is now done explicitly, mypy will be able to flag
incompatibilities caused by future changes to the extra datatypes, but
there are still a lot of other places in this file where there is
minimal type safety.

At some point, it would be nice to:
* Add an automated test exercising join+taint mode
* Refactor so that join mode doesn't need to convert from the semgrep
output back to a datatype used earlier in the pipeline
* Refactor so that mypy can check the join mode code

Fixes #5839

Test plan: Automated tests, mypy, and manual testing of the issue as reported
in #5839

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
