### PR TITLE
fix(metrics): incorrect handling of generated targets for parsing statistics

### DIFF
--- a/cli/src/semgrep/parsing_data.py
+++ b/cli/src/semgrep/parsing_data.py
@@ -52,7 +52,15 @@ class ParsingData:
         registered from the original plan with `add_targets`.
         """
         path = err.location.path
-        (lang, no_error_yet) = self._file_info[path]
+        try:
+            (lang, no_error_yet) = self._file_info[path]
+        except KeyError:
+            # We may be told to register an error for a file we didn't know
+            # about from the plan. This can occur due to rules that involve
+            # generating new targets, namely ones involving extract mode or
+            # metavariable-pattern. In this case, just don't report the parsing
+            # statistics for this right now.
+            return
         lang_parse_data = self._parse_errors_by_lang[lang]
         if no_error_yet:
             lang_parse_data.targets_with_errors += 1


### PR DESCRIPTION
Currently the parsing statistics metrics creates a dictionary of targets
to help track the number of files which have errors. In the event that a
parse error is reported in a file not registered in the original plan,
however, this causes a KeyError due to a lookup failure in the
dictionary. This commit resolves this by ignoring parse errors reported
in generated files (which would originate either from a
metavariable-pattern or an extract mode rule) and simply discarding
them.

In the future we could restructure this to allow core to register
additional specific targets, or handle the parsing statistics directly,
but as it currently stands the cli doesn't have a way to determine what
these targets would be ahead of time, as this requires matching logic.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
