### PR TITLE
infra: add a quick way to re-point the semgrep docker image latest tag

### DIFF
--- a/.github/workflows/revert-semgrep-docker-image.yml
+++ b/.github/workflows/revert-semgrep-docker-image.yml
@@ -1,0 +1,32 @@
+name: Revert Semgrep Docker Image
+on:
+  workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: "Docker Tag to point 'latest' to, example: 0.100.0"
+        required: true
+
+jobs:
+  rollback-docker-image:
+    name: Rollback returntocorp/semgrep Docker Image
+    runs-on: ubuntu-22.04
+    env:
+      DOCKER_IMAGE_REPO: returntocorp/semgrep
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - id: pull
+        name: Pull Image to Retag as Latest
+        run: |
+          docker pull ${{ env.DOCKER_IMAGE_REPO }}:${{ inputs.docker_tag }}
+      - id: retag
+        name: Re-Tag Docker Image
+        run: |
+          docker tag ${{ env.DOCKER_IMAGE_REPO }}:${{ inputs.docker_tag }} ${{ env.DOCKER_IMAGE_REPO }}:latest
+      - id: push
+        name: Push New Latest Tag
+        run: |
+          docker push ${{ env.DOCKER_IMAGE_REPO }}:latest


### PR DESCRIPTION
No changelog entry needed (not user facing). 

This allows a quick way to re-point the latest docker tag, and give us time to fail forward there. Once this is approved/merged, I'll update our internal docs to reflect this. 

We may also want to expand this to rollback the version of `returntocorp/semgrep-action`, as well. 

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
