### PR TITLE
feat(js): allow decorated class fields as patterns

### DIFF
--- a/changelog.d/pa-1677.fixed
+++ b/changelog.d/pa-1677.fixed
@@ -1,1 +1,1 @@
-JS: Allowed decorators to appear in Semgrep patterns for class methods.
+JS: Allowed decorators to appear in Semgrep patterns for class methods and fields.

--- a/semgrep-core/tests/OTHER/rules/decorated_field_pattern.ts
+++ b/semgrep-core/tests/OTHER/rules/decorated_field_pattern.ts
@@ -1,0 +1,10 @@
+class Foo {
+    // ruleid: decorated-field-pattern 
+    @Input() bar: string;
+    // ruleid: decorated-field-pattern 
+    @Input bar: string;
+
+    @Input bar(): string {
+        return 5
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/decorated_field_pattern.yaml
+++ b/semgrep-core/tests/OTHER/rules/decorated_field_pattern.yaml
@@ -1,0 +1,12 @@
+id: decorated-field-pattern 
+message: Matched a decorated field
+languages:
+  - typescript
+severity: WARNING
+patterns:
+  - pattern-inside: |
+      class $CLASSNAME {
+        ...
+      }
+  - pattern: |
+      @$DEC() $INPUT: string


### PR DESCRIPTION
**What:**
This PR adds functionality for patterns of the form `<decorators> <id> : <type>`, which lets you search for decorated class fields.

**Why:**
This is something we should be able to do.

**How:**
Updated the `pfff` parser.

**Test plan:**
`make test`

**Fixes:**
PA-1677

PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
