### PR TITLE
feat(swift): Parse operator declarations

### DIFF
--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -130,3 +130,10 @@ protocol foo: bar, baz { }
 // Throws
 throw badthing
 throw badthingagain;
+
+// Operator
+
+prefix operator !!!;
+infix operator !!!;
+postfix operator !!!;
+prefix operator !!!: precedence;


### PR DESCRIPTION
I don't think there's an AST node that is a good match for this
construct. The operator declaration doesn't define its behavior, it just
tells Swift how to parse it. The definition of an operator's behavior
uses the syntax of an ordinary function declaration.

Test plan: Automated tests plus manual test below

```
semgrep-core -lang swift -dump_ast test.swift
```

```
prefix operator !!!;
infix operator !!!;
postfix operator !!!;
prefix operator !!!: precedence;
```

```
Pr(
  [OtherStmt(OS_Todo, [I(("prefix", ())); I(("!!!", ()))]); OtherStmt(OS_Todo, [I(("infix", ())); I(("!!!", ()))]);
   OtherStmt(OS_Todo, [I(("postfix", ())); I(("!!!", ()))]);
   OtherStmt(OS_Todo, [I(("prefix", ())); I(("!!!", ())); I(("precedence", ()))])])
```

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
