### PR TITLE
feat(swift): added swift labeled statements for parsing

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -85,8 +85,8 @@ let map_function_modifier (env : env) (x : CST.function_modifier) =
 let map_binding_pattern_kind (env : env) (x : CST.binding_pattern_kind) :
     (string * PI.t) list =
   match x with
-  | `Var tok -> (* "var" *) [ ("Var", token env tok) ]
-  | `Let tok -> (* "let" *) [ ("Let", token env tok) ]
+  | `Var tok -> (* "var" *) [ str env tok ]
+  | `Let tok -> (* "let" *) [ str env tok ]
 
 let map_possibly_async_binding_pattern_kind (env : env)
     ((v1, v2) : CST.possibly_async_binding_pattern_kind) =
@@ -94,7 +94,7 @@ let map_possibly_async_binding_pattern_kind (env : env)
     match v1 with
     | Some tok ->
         (* async_modifier *)
-        [ ("async", token env tok) ]
+        [ str env tok ]
     | None -> []
   in
   async @ map_binding_pattern_kind env v2

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -1503,11 +1503,13 @@ and map_key_path_postfixes (env : env) (x : CST.key_path_postfixes) =
       let v3 = (* "]" *) token env v3 in
       todo env (v1, v2, v3)
 
-and map_labeled_statement (env : env) ((v1, v2) : CST.labeled_statement) =
+and map_labeled_statement (env : env) ((v1_orig, v2) : CST.labeled_statement) =
   let v1 =
-    match v1 with
-    | Some tok -> (* statement_label *) token env tok |> todo env
-    | None -> ()
+    let ident_of x =
+      let tok = token env x in
+      (PI.str_of_info tok, tok)
+    in
+    Option.map ident_of v1_orig
   in
   let v2 =
     match v2 with
@@ -1519,7 +1521,9 @@ and map_labeled_statement (env : env) ((v1, v2) : CST.labeled_statement) =
     | `Guard_stmt x -> map_guard_statement env x
     | `Switch_stmt x -> map_switch_statement env x
   in
-  v2
+  match v1 with
+  | None -> v2
+  | Some ident -> G.Label (ident, v2) |> G.s
 
 and map_lambda_function_type (env : env)
     ((v1, v2, v3, v4) : CST.lambda_function_type) : G.parameter list =

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -120,6 +120,12 @@ for try! await x in collection {
 for x in collection where true == true {
 }
 
+// While loops
+while true {}
+while case x = true {}
+while async let x = true {}
+while async var x : true = true {}
+
 // Protocol
 
 protocol foo {

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -126,3 +126,7 @@ protocol foo: bar { }
 protocol foo: bar, baz { }
 // TODO
 // protocol foo<T> where T: bar { }
+
+foo: if 1 < 150 {
+    var thing = 122
+}

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -106,6 +106,20 @@ extension bar { }
 // TODO test other varieties
 enum baz { }
 
+// For-in loops
+for x in collection {
+}
+for await x in collection {
+}
+for try await x in collection {
+}
+for try? await x in collection {
+}
+for try! await x in collection {
+}
+for x in collection where true == true {
+}
+
 // Protocol
 
 protocol foo {
@@ -128,5 +142,7 @@ protocol foo: bar, baz { }
 // protocol foo<T> where T: bar { }
 
 foo: if 1 < 150 {
-    var thing = 122
+}
+
+bar: for x in collection {
 }

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -147,6 +147,12 @@ do {
 } catch {
 }
 
+// If-statements
+if true {}
+if true {} else {}
+if async let x = true {} else {}
+if case x = true {} else if case x = false {} else {}
+
 // Protocol
 
 protocol foo {

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -153,6 +153,25 @@ if true {} else {}
 if async let x = true {} else {}
 if case x = true {} else if case x = false {} else {}
 
+// Switch statements
+switch foo {
+}
+
+switch foo {
+  case y:
+    var x = 2
+    var x = 3
+  case x where true == true:
+    return 2
+  case let x where true == true:
+    return 2
+  case var x:
+    return 2
+  case _:
+    return 3
+  default:
+}
+
 // Protocol
 
 protocol foo {

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -131,6 +131,22 @@ repeat {} while true
 repeat {} while case x = true
 repeat {} while async let x = 1
 
+// Do-statements
+do {
+  var x = 2
+} catch foo {}
+
+do {
+  var x = 2
+} catch {}
+
+do {
+  var x = 2
+} catch foo {
+} catch bar where true == true {
+} catch {
+}
+
 // Protocol
 
 protocol foo {

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -126,6 +126,11 @@ while case x = true {}
 while async let x = true {}
 while async var x : true = true {}
 
+// Repeat-while loops
+repeat {} while true
+repeat {} while case x = true
+repeat {} while async let x = 1
+
 // Protocol
 
 protocol foo {

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -198,3 +198,11 @@ foo: if 1 < 150 {
 
 bar: for x in collection {
 }
+
+baz: while async let x = true {}
+
+qux: do { var x = 2 } catch {}
+
+corn: switch foo {}
+
+learn: repeat {} while true


### PR DESCRIPTION
**What:**
Added ability to parse Swift labeled statements to Generic AST.

This entails also being able to parse a bunch of statements, notably:
- `for-in` statements
- `while` statements
- `if` statements
- `repeat-while` statements
- `switch` statements
- `do` statements

This PR adds functionality for doing that.

**Why:**
These are common constructs in the Swift language and should be a good step towards increasing our parse rate.

**How:**
So, notably, Swift has a bunch of random things that I decided to just make `OtherPat`s and the like. For instance:
- `try` and `await` patterns
- `?` patterns
- `var` and `let` in conditions

Let me know if I handled these strangely.

Here's some examples of `OtherPat`:
```swift
for try await x in collection {
}
```
parses to
```
Pr(
  [For((),
     ForEach(
       (OtherPat(("Await", ()),
          [P(
             OtherPat(("Try", ()),
               [P(
                  PatId(("x", ()),
                    {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }))]))]),
        (),
        N(
          Id(("collection", ()),
            {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))),
     Block([]))])
```

This is because the `x` is a pattern which is ranging over the collection, and the `try` and `await` tokens seem to be modifying the pattern. So I stuck them in an `OtherPat`.

Here's another example:
```swift
if async let x = true {} else {}
```
parses to
```
Pr(
  [If((),
     Cond(
       LetPattern(
         OtherPat(("async", ()),
           [P(
              OtherPat(("let", ()),
                [P(
                   PatId(("x", ()),
                     {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }))]))]),
         L(Bool((true, ()))))), Block([]), Some(Block([])))])
```

This is because this `if` is interesting, in that it binds a variable in the conditional. I was looking for an `expr` which seemed like it did that, and the closest thing I could find was `LetPattern`, so I flagged it under that.

Similarly, `let` and `async` seem to be modifiers on the pattern, so I just put them there.

Finally:
```swift
switch foo {
  case let x where true == true:
    return 2
  case var x:
    return 2
}
```
parses to
```
Pr(
  [Switch((),
     Some(Cond(
            N(
              Id(("foo", ()),
                {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })))),
     [CasesAndBody(
        [Case((),
           PatWhen(
             OtherPat(("let", ()),
               [P(
                  PatId(("x", ()),
                    {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }))]),
             Call(IdSpecial((Op(Eq), ())), [Arg(L(Bool((true, ())))); Arg(L(Bool((true, ()))))])))],
        Block([Return((), Some(L(Int((Some(2), ())))), ())]));
      CasesAndBody(
        [Case((),
           OtherPat(("var", ()),
             [P(
                PatId(("x", ()),
                  {id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }))]))],
        Block([Return((), Some(L(Int((Some(2), ())))), ())]))])])
```

This is pretty much the same thing.

**Test plan:**
`make test`

PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
