### PR TITLE
Quick-fix for regression in 0.107.0 after taint labels PR

### DIFF
--- a/changelog.d/pa-1724.fixed
+++ b/changelog.d/pa-1724.fixed
@@ -1,0 +1,4 @@
+Quick fix for a regression introduced in 0.107.0 (presumably by taint labels)
+that could cause some taint rules to crash Semgrep with:
+
+    Invalid_argument "output_value: abstract value (Custom)"

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -413,7 +413,18 @@ let pm_of_finding finding =
        * already expect Semgrep (and DeepSemgrep) to report the match on `sink(x)`.
        *)
       let taint_trace =
-        Some (lazy (taint_trace_of_src_to_sink source tokens sink))
+        Some
+          ((* FIXME: We replaced `lazy` with `Lazy.from_val` because, after
+              PR #5725 (taint labels), somewhow this prevents Semgrep-core from crashing
+              in some weird cases, see PA-1724. We don't understand why, yet. But it
+              requires -j 2 (so that Parmap is used) and -json (so that the lazy value
+              reaches Parmap unevaluated), and when Parmap tries to marshal this value
+              it crashes with:
+
+                  Invalid_argument "output_value: abstract value (Custom)"
+           *)
+           Lazy.from_val
+             (taint_trace_of_src_to_sink source tokens sink))
       in
       let sink_pm, _ = T.pm_of_trace sink in
       Some { sink_pm with env = merged_env; taint_trace }

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -177,6 +177,8 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
              in
              let res =
                try
+                 (* TODO: Maybe we should be using Run_semgrep running the same functions
+                    as for Semgrep CLI. *)
                  Match_rules.check
                    ~match_hook:(fun _ _ -> ())
                    ~timeout:0. ~timeout_threshold:0 (config, []) rules xtarget
@@ -185,6 +187,12 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
                    failwith
                      (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn))
              in
+             (* Check that the result can be marshalled, as this will be needed
+                 when using Parmap! See PA-1724. *)
+             (try Marshal.to_string res [ Marshal.Closures ] |> ignore with
+             | exn ->
+                 failwith
+                   (spf "exn on %s (exn = %s)" file (Common.exn_to_s exn)));
              let eres =
                try
                  Common.map

--- a/semgrep-core/tests/OTHER/rules/tainted-file-path.java
+++ b/semgrep-core/tests/OTHER/rules/tainted-file-path.java
@@ -1,0 +1,7 @@
+// PA-1724: This was a weird regression after merging taint labels (PR #5725)
+public class Foo {
+    public void bar(@RequestParam String path) {
+        //ruleid: tainted-file-path
+        File f = new File(path);
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/tainted-file-path.yaml
+++ b/semgrep-core/tests/OTHER/rules/tainted-file-path.yaml
@@ -1,0 +1,50 @@
+rules:
+  - id: tainted-file-path
+    languages:
+      - java
+    severity: ERROR
+    message: Detected user input controlling a file path. An attacker could control
+      the location of this file, to include going backwards in the directory
+      with '../'. To address this, ensure that user-controlled variables in file
+      paths are sanitized. You may also consider using a utility method such as
+      org.apache.commons.io.FilenameUtils.getName(...) to only retrieve the file
+      name from the path.
+    metadata:
+      cwe: "CWE-23: Relative Path Traversal"
+      owasp:
+        - A01:2021 - Broken Access Control
+        - A05:2017 - Broken Access Control
+      references:
+        - https://owasp.org/www-community/attacks/Path_Traversal
+      category: security
+      technology:
+        - java
+        - spring
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ($LOOKUP) $TYPE $SOURCE,...) {
+                    ...
+                  }
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ $TYPE $SOURCE,...) {
+                    ...
+                  }
+          - metavariable-regex:
+              metavariable: $REQ
+              regex: (RequestBody|PathVariable|RequestParam|RequestHeader|CookieValue)
+          - pattern: $SOURCE
+    pattern-sinks:
+      - pattern-either:
+          - pattern-either:
+              - pattern: new FileInputStream(...)
+              - pattern: new java.io.FileInputStream(...)
+              - pattern: new FileReader(...)
+              - pattern: new java.io.FileReader(...)
+              - pattern: new File(...)
+              - pattern: new java.io.File(...)
+              - pattern: $SOMETHING.getResourceAsStream(...)
+


### PR DESCRIPTION
Follows: 8f26fabe29a ("tainting: Add experimental taint labels feature (#5725)")

Helps CSE-116
Helps PA-1724

After PR #5725 (taint labels), we started to get reports of crashes like:

    (Invalid_argument "output_value: abstract value (Custom)")
    Raised by primitive operation at Parmap.marshal in file "src/parmap.ml", line 146, characters 10-48
    Called from Parmap.spawn_many.loop in file "src/parmap.ml", line 168, characters 8-23
    Called from Parmap.run_many in file "src/parmap.ml" (inlined), line 190, characters 16-45
    Called from Parmap.simplemapper in file "src/parmap.ml", line 208, characters 2-678
    Called from Run_semgrep.semgrep_with_rules in file "src/runner/Run_semgrep.ml", line 596, characters 4-1023
    Called from Run_semgrep.semgrep_with_raw_results_and_exn_handler in file "src/runner/Run_semgrep.ml", line 667, characters 21-58

This seems to happenn when Parmap tries to do the marshalling of the
taint trace. But it happens even with a fake empty taint trace! And it is
"fixed" if we force the taint-trace's lazy thunk before marshalling it
(presumably that is why it only crashes with -json, since in text mode
the match and trace are printed right away). It needs -j 2 or higher to
be reproduced, so that Parmap is used.

We do not yet understand why it happens, but e.g. in the added test, the
crash doesn't happen if we comment out the `metavariable-regex`. Taint
labels shouldn't be affecting the result returned by Semgrep-core in
these cases, and the match and the taint trace look identical when
compared with the commit before 8f26fabe29a.

Also, we now test that the result of `Match_rules.check` can be
marshalled. This does not seem to affect the runtime of `make test`.

test plan:
make test # added one test

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
