### PR TITLE
feat(swift): most of swift parsing

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1100,6 +1100,8 @@ and other_stmt_with_stmt_operator =
   | OSWS_UncheckedBlock
   (* C/C++/cpp *)
   | OSWS_Iterator
+  (* Closures in Swift *)
+  | OSWS_Closure
   (* e.g., Assembly in Solidity *)
   | OSWS_Todo
 
@@ -1322,7 +1324,7 @@ and keyword_attribute =
   (* Rust *)
   | Unsafe
   | DefaultImpl (* Rust unstable, RFC 1210 *)
-  (* Scala *)
+  (* Scala and Swift *)
   | Lazy
   (* Swift *)
   | Throws

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -785,6 +785,7 @@ and vof_other_stmt_with_stmt_operator = function
   | OSWS_CheckedBlock -> OCaml.VSum ("OSWS_CheckedBlock", [])
   | OSWS_UncheckedBlock -> OCaml.VSum ("OSWS_UncheckedBlock", [])
   | OSWS_Iterator -> OCaml.VSum ("OSWS_Iterator", [])
+  | OSWS_Closure -> OCaml.VSum ("OSWS_Closure", [])
   | OSWS_Todo -> OCaml.VSum ("OSWS_Todo", [])
 
 and vof_label_ident = function

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -29,9 +29,64 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* Helpers *)
 (*****************************************************************************)
 
+module SMap = Map.Make (String)
+module IMap = Map.Make (Int)
+
+type mode = Searching | Finding
+
+(* Global store, because I don't want to pass it through a bunch of func calls.
+ *)
+let store = ref []
+
+let process_exn () =
+  let rec process mode (lines : string list) =
+    match lines with
+    | [] -> "failure"
+    | line :: rest -> (
+        (* Sue me. *)
+        let tokens = Common.split " " line in
+        match (mode, tokens) with
+        | Searching, "Called" :: "from" :: _ -> process Finding rest
+        | Searching, _ -> process Searching rest
+        | ( Finding,
+            "Called" :: "from" :: funcname :: _in :: _file :: _filename
+            :: "line" :: linenum :: _ ) ->
+            funcname ^ ":" ^ linenum
+            (* There should be at least one `Called from` after the first... *)
+        | Finding, _ -> failwith "bad")
+  in
+  let res =
+    Printexc.get_backtrace ()
+    |> Common.split (Str.quote "\n")
+    |> process Searching
+  in
+  store := res :: !store;
+  ()
+
 let print_exn file e =
   let trace = Printexc.get_backtrace () in
+  process_exn ();
   pr2 (spf "%s: exn = %s\n%s" file (Common.exn_to_s e) trace)
+
+let report_counts () =
+  let counts =
+    List.fold_left
+      (fun map x ->
+        SMap.update x
+          (function
+            | None -> Some 1
+            | Some x -> Some (x + 1))
+          map)
+      SMap.empty !store
+    |> SMap.to_seq
+    |> Seq.map (fun (x, y) -> (y, x))
+    |> IMap.of_seq |> IMap.to_rev_seq |> List.of_seq
+  in
+  pr2 "\nTODO statistics:";
+  List.fold_left
+    (fun acc (count, filename) -> acc ^ Common.spf "\n%s -> %d" filename count)
+    "" counts
+  |> pr2
 
 let dump_and_print_errors dumper (res : 'a Tree_sitter_run.Parsing_result.t) =
   (match res.program with
@@ -417,6 +472,7 @@ let parse_projects ~verbose lang project_dirs =
 
 let parsing_stats ?(json = false) ?(verbose = false) lang project_dirs =
   let stat_list = parse_projects ~verbose lang project_dirs in
+  report_counts ();
   if json then print_json lang stat_list
   else
     let flat_stat = List.concat_map snd stat_list in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -80,13 +80,13 @@ let map_function_modifier (env : env) (x : CST.function_modifier) =
   match x with
   | `Infix tok ->
       (* "infix" *)
-      G.unhandled_keywordattr ("Infix", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Post tok ->
       (* "postfix" *)
-      G.unhandled_keywordattr ("Postfix", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Prefix tok ->
       (* "prefix" *)
-      G.unhandled_keywordattr ("Prefix", token env tok)
+      G.unhandled_keywordattr (str env tok)
 
 let map_binding_pattern_kind (env : env) (x : CST.binding_pattern_kind) :
     G.ident list =
@@ -143,16 +143,16 @@ let map_ownership_modifier (env : env) (x : CST.ownership_modifier) =
   match x with
   | `Weak tok ->
       (* "weak" *)
-      G.unhandled_keywordattr ("Weak", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Unow_7c8c304 tok ->
       (* "unowned" *)
-      G.unhandled_keywordattr ("Unowned", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Unow_e455cde tok ->
       (* "unowned(safe)" *)
-      G.unhandled_keywordattr ("UnownedSafe", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Unow_8fda70e tok ->
       (* "unowned(unsafe)" *)
-      G.unhandled_keywordattr ("UnownedUnsafe", token env tok)
+      G.unhandled_keywordattr (str env tok)
 
 let map_import_kind (env : env) (x : CST.import_kind) =
   match x with
@@ -218,10 +218,10 @@ let map_member_modifier (env : env) (x : CST.member_modifier) =
       G.attr G.Override (token env tok)
   | `Conv tok ->
       (* "convenience" *)
-      G.unhandled_keywordattr ("Convenience", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Requ tok ->
       (* "required" *)
-      G.unhandled_keywordattr ("Required", token env tok)
+      G.unhandled_keywordattr (str env tok)
 
 let map_try_operator (env : env) (x : CST.try_operator) =
   match x with
@@ -231,18 +231,13 @@ let map_try_operator (env : env) (x : CST.try_operator) =
 
 let map_special_literal (env : env) (x : CST.special_literal) =
   (match x with
-  | `HASH_36725ee tok -> (* "#file" *) G.OtherExpr (("File", token env tok), [])
-  | `HASH_ee0b998 tok ->
-      (* "#fileID" *) G.OtherExpr (("FileID", token env tok), [])
-  | `HASH_bd759bd tok ->
-      (* "#filePath" *) G.OtherExpr (("FilePath", token env tok), [])
-  | `HASH_709af6a tok -> (* "#line" *) G.OtherExpr (("Line", token env tok), [])
-  | `HASH_be35129 tok ->
-      (* "#column" *) G.OtherExpr (("Column", token env tok), [])
-  | `HASH_96a7ced tok ->
-      (* "#function" *) G.OtherExpr (("Function", token env tok), [])
-  | `HASH_4d47dbe tok ->
-      (* "#dsohandle" *) G.OtherExpr (("Dsohandle", token env tok), []))
+  | `HASH_36725ee tok -> (* "#file" *) G.OtherExpr (str env tok, [])
+  | `HASH_ee0b998 tok -> (* "#fileID" *) G.OtherExpr (str env tok, [])
+  | `HASH_bd759bd tok -> (* "#filePath" *) G.OtherExpr (str env tok, [])
+  | `HASH_709af6a tok -> (* "#line" *) G.OtherExpr (str env tok, [])
+  | `HASH_be35129 tok -> (* "#column" *) G.OtherExpr (str env tok, [])
+  | `HASH_96a7ced tok -> (* "#function" *) G.OtherExpr (str env tok, [])
+  | `HASH_4d47dbe tok -> (* "#dsohandle" *) G.OtherExpr (str env tok, []))
   |> G.e
 
 let map_integer_literal (env : env) (tok : CST.integer_literal) : G.literal =
@@ -253,10 +248,10 @@ let map_mutation_modifier (env : env) (x : CST.mutation_modifier) =
   match x with
   | `Muta tok ->
       (* "mutating" *)
-      G.unhandled_keywordattr ("Mutating", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Nonm tok ->
       (* "nonmutating" *)
-      G.unhandled_keywordattr ("Nonmutating", token env tok)
+      G.unhandled_keywordattr (str env tok)
 
 let map_property_modifier (env : env) (x : CST.property_modifier) =
   match x with
@@ -266,14 +261,14 @@ let map_property_modifier (env : env) (x : CST.property_modifier) =
   (* Has to do with the Obj-C runtime... probably not important *)
   | `Dyna tok ->
       (* "dynamic" *)
-      G.unhandled_keywordattr ("Dynamic", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `Opt tok ->
       (* Seems close enough to other Optional field uses.*)
       (* "optional" *)
       G.attr G.Optional (token env tok)
   | `Class tok ->
       (* "class" *)
-      G.unhandled_keywordattr ("Class", token env tok)
+      G.unhandled_keywordattr (str env tok)
 
 let map_parameter_modifier (env : env) (x : CST.parameter_modifier) =
   (* TODO? I don't think any of these will actually matter.
@@ -283,13 +278,13 @@ let map_parameter_modifier (env : env) (x : CST.parameter_modifier) =
   match x with
   | `Inout tok ->
       (* "inout" *)
-      G.unhandled_keywordattr ("Inout", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `ATes tok ->
       (* "@escaping" *)
-      G.unhandled_keywordattr ("Escaping", token env tok)
+      G.unhandled_keywordattr (str env tok)
   | `ATau tok ->
       (* "@autoclosure" *)
-      G.unhandled_keywordattr ("Autoclosure", token env tok)
+      G.unhandled_keywordattr (str env tok)
 
 let map_throws (env : env) (x : CST.throws) =
   match x with
@@ -1107,8 +1102,7 @@ and map_bodyless_function_declaration (env : env) ~in_class
     match v2 with
     | Some tok ->
         (* "class" *)
-        let _todo = token env tok in
-        ()
+        token env tok |> todo env
     | None -> ()
   in
   let v3 =
@@ -1386,7 +1380,7 @@ and map_enum_entry (env : env) ((v1, v2, v3, v4, v5, v6, _v7) : CST.enum_entry)
       match v2 with
       | Some tok ->
           (* "indirect" *)
-          [ G.unhandled_keywordattr ("Indirect", token env tok) ]
+          [ G.unhandled_keywordattr (str env tok) ]
       | None -> []
     in
     (match v1 with
@@ -1817,7 +1811,6 @@ and map_lambda_function_type_parameters (env : env)
 and map_lambda_literal (env : env) ((v1, v2, v3, v4, v5) : CST.lambda_literal) :
     G.expr =
   let v1 = (* "{" *) token env v1 in
-  (* TODO include captures *)
   let captures =
     match v2 with
     | Some x -> map_capture_list env x
@@ -1841,6 +1834,10 @@ and map_lambda_literal (env : env) ((v1, v2, v3, v4, v5) : CST.lambda_literal) :
     (* Fake brackets here since the brackets delimit the lambda expression as a
      * whole, not just the statements *)
     (* TODO consider using `in` and the closing bracket as the delimiters *)
+    (* We inject into an `OtherStmtWithStmt` here because we needed somewhere for the
+       capture list to go. This is not permitted with just a regular statement, so there is
+       a new variant `OSWS_Closure` to signify this.
+    *)
     G.FBStmt
       (G.OtherStmtWithStmt
          ( G.OSWS_Closure,
@@ -1877,7 +1874,7 @@ and map_lambda_parameter (env : env) ((v1, v2) : CST.lambda_parameter) :
         let _v1 =
           match v1 with
           | Some x ->
-              let _todo = map_simple_identifier env x in
+              map_simple_identifier env x |> ignore;
               ()
           | None -> ()
         in
@@ -2050,7 +2047,7 @@ and map_modifierless_class_declaration (env : env) (attrs : G.attribute list)
           match v1 with
           | Some tok ->
               (* "indirect" *)
-              [ G.unhandled_keywordattr ("Indirect", token env tok) ]
+              [ G.unhandled_keywordattr (str env tok) ]
           | None -> []
         in
         indirect_kw @ [ G.KeywordAttr (G.EnumClass, v2) ] @ attrs
@@ -2950,27 +2947,26 @@ and map_type_constraint (env : env) (x : CST.type_constraint) =
   | `Inhe_cons (v1, v2, v3, v4) ->
       let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_identifier env v2 in
-      let v3 = (* ":" *) token env v3 in
       let v4 = map_possibly_implicitly_unwrapped_type env v4 in
       let base_type = G.ArgType (G.TyN (H2.name_of_ids v2) |> G.t) in
       let conformed_protocol = G.ArgType v4 in
       G.NamedAttr
-        ( v3,
-          H2.name_of_id ("ConformsTo", v3),
+        ( token env v3,
+          H2.name_of_id (str env v3),
           G.fake_bracket [ base_type; conformed_protocol ] )
   | `Equa_cons (v1, v2, v3, v4) ->
       let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_identifier env v2 in
       let first_type = G.ArgType (G.TyN (H2.name_of_ids v2) |> G.t) in
-      let v3 =
+      let ((_, v3_tok) as v3_str) =
         match v3 with
-        | `Equal_sign tok -> (* eq_custom *) token env tok
-        | `Eq_eq tok -> (* eq_eq_custom *) token env tok
+        | `Equal_sign tok -> (* eq_custom *) str env tok
+        | `Eq_eq tok -> (* eq_eq_custom *) str env tok
       in
       let v4 = map_type_ env v4 in
       G.NamedAttr
-        ( v3,
-          H2.name_of_id ("EqualTypes", v3),
+        ( v3_tok,
+          H2.name_of_id v3_str,
           G.fake_bracket [ first_type; G.ArgType v4 ] )
 
 and map_type_constraints (env : env) ((v1, v2, v3) : CST.type_constraints) =
@@ -3078,18 +3074,15 @@ and map_unannotated_type (env : env) (x : CST.unannotated_type) =
       let v2 = (* "." *) token env v2 in
       let v3 =
         match v3 with
-        | `Type tok ->
-            (* "Type" *) G.unhandled_keywordattr ("Type", token env tok)
-        | `Prot tok ->
-            (* "Protocol" *) G.unhandled_keywordattr ("Protocol", token env tok)
+        | `Type tok -> (* "Type" *) G.unhandled_keywordattr (str env tok)
+        | `Prot tok -> (* "Protocol" *) G.unhandled_keywordattr (str env tok)
       in
       { v1 with G.t_attrs = v3 :: v1.G.t_attrs }
   | `Opaque_type (v1, v2) ->
-      let v1 = (* "some" *) token env v1 in
       let v2 = map_user_type env v2 in
       {
         v2 with
-        G.t_attrs = G.unhandled_keywordattr ("Some", v1) :: v2.G.t_attrs;
+        G.t_attrs = G.unhandled_keywordattr (str env v1) :: v2.G.t_attrs;
       }
   | `Prot_comp_type (v1, v2) ->
       let v1 = map_unannotated_type env v1 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -146,11 +146,20 @@ let map_assignment_and_operator (env : env) (x : CST.assignment_and_operator) =
   | `EQ tok -> (None, (* "=" *) token env tok)
 
 let map_ownership_modifier (env : env) (x : CST.ownership_modifier) =
+  (* These have to do with garbage collection and probably do not matter. *)
   match x with
-  | `Weak tok -> (* "weak" *) token env tok
-  | `Unow_7c8c304 tok -> (* "unowned" *) token env tok
-  | `Unow_e455cde tok -> (* "unowned(safe)" *) token env tok
-  | `Unow_8fda70e tok -> (* "unowned(unsafe)" *) token env tok
+  | `Weak tok ->
+      (* "weak" *)
+      G.unhandled_keywordattr ("Weak", token env tok)
+  | `Unow_7c8c304 tok ->
+      (* "unowned" *)
+      G.unhandled_keywordattr ("Unowned", token env tok)
+  | `Unow_e455cde tok ->
+      (* "unowned(safe)" *)
+      G.unhandled_keywordattr ("UnownedSafe", token env tok)
+  | `Unow_8fda70e tok ->
+      (* "unowned(unsafe)" *)
+      G.unhandled_keywordattr ("UnownedUnsafe", token env tok)
 
 let map_import_kind (env : env) (x : CST.import_kind) =
   match x with
@@ -169,9 +178,22 @@ let map_optionally_valueful_control_keyword (env : env)
   | `Ret tok ->
       let tok = (* "return" *) token env tok in
       G.Return (tok, expr, semi) |> G.s
-  | `Cont tok -> (* "continue" *) token env tok |> todo env
-  | `Brk tok -> (* "break" *) token env tok |> todo env
-  | `Yield tok -> (* "yield" *) token env tok |> todo env
+  | `Cont tok -> (
+      let tok = (* "continue" *) token env tok in
+      match expr with
+      | Some { G.e = N (Id (id, _)); _ } ->
+          G.Continue (tok, LId id, semi) |> G.s
+      | Some { G.e = _; _ } -> raise Common.Impossible
+      | None -> G.Continue (tok, LNone, semi) |> G.s)
+  | `Brk tok -> (
+      let tok = (* "break" *) token env tok in
+      match expr with
+      | Some { G.e = N (Id (id, _)); _ } -> G.Break (tok, LId id, semi) |> G.s
+      | Some { G.e = _; _ } -> raise Common.Impossible
+      | None -> G.Break (tok, LNone, semi) |> G.s)
+  | `Yield tok ->
+      let tok = (* "yield" *) token env tok in
+      G.ExprStmt (G.Yield (tok, expr, false) |> G.e, semi) |> G.s
 
 let map_multiplicative_operator (env : env) (x : CST.multiplicative_operator) :
     G.operator * G.tok =
@@ -182,7 +204,7 @@ let map_multiplicative_operator (env : env) (x : CST.multiplicative_operator) :
 
 let map_inheritance_modifier (env : env) (x : CST.inheritance_modifier) =
   match x with
-  | `Final tok -> (* "final" *) token env tok
+  | `Final tok -> (* "final" *) G.attr G.Final (token env tok)
 
 let map_boolean_literal (env : env) (x : CST.boolean_literal) =
   match x with
@@ -195,9 +217,15 @@ let map_boolean_literal (env : env) (x : CST.boolean_literal) =
 
 let map_member_modifier (env : env) (x : CST.member_modifier) =
   match x with
-  | `Over tok -> (* "override" *) token env tok
-  | `Conv tok -> (* "convenience" *) token env tok
-  | `Requ tok -> (* "required" *) token env tok
+  | `Over tok ->
+      (* "override" *)
+      G.attr G.Override (token env tok)
+  | `Conv tok ->
+      (* "convenience" *)
+      G.unhandled_keywordattr ("Convenience", token env tok)
+  | `Requ tok ->
+      (* "required" *)
+      G.unhandled_keywordattr ("Required", token env tok)
 
 let map_try_operator (env : env) (x : CST.try_operator) =
   match x with
@@ -206,14 +234,20 @@ let map_try_operator (env : env) (x : CST.try_operator) =
   | `TryQ tok -> (* "try?" *) token env tok
 
 let map_special_literal (env : env) (x : CST.special_literal) =
-  match x with
-  | `HASH_36725ee tok -> (* "#file" *) token env tok
-  | `HASH_ee0b998 tok -> (* "#fileID" *) token env tok
-  | `HASH_bd759bd tok -> (* "#filePath" *) token env tok
-  | `HASH_709af6a tok -> (* "#line" *) token env tok
-  | `HASH_be35129 tok -> (* "#column" *) token env tok
-  | `HASH_96a7ced tok -> (* "#function" *) token env tok
-  | `HASH_4d47dbe tok -> (* "#dsohandle" *) token env tok
+  (match x with
+  | `HASH_36725ee tok -> (* "#file" *) G.OtherExpr (("File", token env tok), [])
+  | `HASH_ee0b998 tok ->
+      (* "#fileID" *) G.OtherExpr (("FileID", token env tok), [])
+  | `HASH_bd759bd tok ->
+      (* "#filePath" *) G.OtherExpr (("FilePath", token env tok), [])
+  | `HASH_709af6a tok -> (* "#line" *) G.OtherExpr (("Line", token env tok), [])
+  | `HASH_be35129 tok ->
+      (* "#column" *) G.OtherExpr (("Column", token env tok), [])
+  | `HASH_96a7ced tok ->
+      (* "#function" *) G.OtherExpr (("Function", token env tok), [])
+  | `HASH_4d47dbe tok ->
+      (* "#dsohandle" *) G.OtherExpr (("Dsohandle", token env tok), []))
+  |> G.e
 
 let map_integer_literal (env : env) (tok : CST.integer_literal) : G.literal =
   let s, t = str env tok in
@@ -232,22 +266,34 @@ let map_property_modifier (env : env) (x : CST.property_modifier) =
   match x with
   | `Static tok ->
       (* "static" *)
-      todo env tok
+      G.attr G.Static (token env tok)
+  (* Has to do with the Obj-C runtime... probably not important *)
   | `Dyna tok ->
       (* "dynamic" *)
-      todo env tok
+      G.unhandled_keywordattr ("Dynamic", token env tok)
   | `Opt tok ->
+      (* Seems close enough to other Optional field uses.*)
       (* "optional" *)
-      todo env tok
+      G.attr G.Optional (token env tok)
   | `Class tok ->
       (* "class" *)
       G.unhandled_keywordattr ("Class", token env tok)
 
 let map_parameter_modifier (env : env) (x : CST.parameter_modifier) =
+  (* TODO? I don't think any of these will actually matter.
+   * `inout` potentially can have ramifications for constant propagation...
+   * but I don't think we have the machinery to deal with that right now.
+   *)
   match x with
-  | `Inout tok -> (* "inout" *) token env tok
-  | `ATes tok -> (* "@escaping" *) token env tok
-  | `ATau tok -> (* "@autoclosure" *) token env tok
+  | `Inout tok ->
+      (* "inout" *)
+      G.unhandled_keywordattr ("Inout", token env tok)
+  | `ATes tok ->
+      (* "@escaping" *)
+      G.unhandled_keywordattr ("Escaping", token env tok)
+  | `ATau tok ->
+      (* "@autoclosure" *)
+      G.unhandled_keywordattr ("Autoclosure", token env tok)
 
 let map_throws (env : env) (x : CST.throws) =
   match x with
@@ -268,7 +314,7 @@ let map_locally_permitted_modifier (env : env)
     (x : CST.locally_permitted_modifier) =
   match x with
   | `Owne_modi x -> map_ownership_modifier env x
-  | `Prop_beha_modi tok -> (* "lazy" *) token env tok
+  | `Prop_beha_modi tok -> (* "lazy" *) G.attr G.Lazy (token env tok)
   | `Inhe_modi x -> map_inheritance_modifier env x
 
 let map_custom_operator (env : env) ((v1, v2) : CST.custom_operator) =
@@ -286,30 +332,30 @@ let map_setter_specifier (env : env) ((v1, v2) : CST.setter_specifier) =
     | None -> ()
   in
   let v2 = (* "set" *) token env v2 in
-  (v2, `Set)
+  v2
 
 let map_modify_specifier (env : env) ((v1, v2) : CST.modify_specifier) =
   let v1 =
     match v1 with
-    | Some x -> map_mutation_modifier env x
-    | None -> todo env ()
+    | Some x -> map_mutation_modifier env x |> todo env
+    | None -> ()
   in
   let v2 = (* "_modify" *) token env v2 in
-  todo env (v1, v2)
+  v2
 
 let map_constructor_function_decl (env : env)
     ((v1, v2) : CST.constructor_function_decl) =
   (* TODO special-case the constructor somehow? *)
   let v1 = (* "init" *) str env v1 in
-  let v2 =
+  let is_quest =
     match v2 with
     | Some x -> (
         match x with
-        | `Quest tok -> (* "?" *) token env tok |> todo env
-        | `Bang tok -> (* bang *) token env tok |> todo env)
-    | None -> ()
+        | `Quest tok -> (* "?" *) true
+        | `Bang tok -> (* bang *) false)
+    | None -> false
   in
-  v1
+  (is_quest, v1)
 
 let map_additive_operator (env : env) (x : CST.additive_operator) :
     G.operator * G.tok =
@@ -324,7 +370,7 @@ let map_additive_operator (env : env) (x : CST.additive_operator) :
 let map_non_local_scope_modifier (env : env) (x : CST.non_local_scope_modifier)
     =
   match x with
-  | `Member_modi x -> map_member_modifier env x |> todo env
+  | `Member_modi x -> map_member_modifier env x
   | `Visi_modi (v1, v2) -> (
       let attr =
         G.KeywordAttr
@@ -346,7 +392,7 @@ let map_non_local_scope_modifier (env : env) (x : CST.non_local_scope_modifier)
   | `Func_modi x -> map_function_modifier env x
   | `Muta_modi x -> map_mutation_modifier env x
   | `Prop_modi x -> map_property_modifier env x
-  | `Param_modi x -> map_parameter_modifier env x |> todo env
+  | `Param_modi x -> map_parameter_modifier env x
 
 let map_parameter_modifiers (env : env) (xs : CST.parameter_modifiers) =
   Common.map (map_parameter_modifier env) xs
@@ -489,14 +535,25 @@ let map_navigation_suffix (env : env) ((v1, v2) : CST.navigation_suffix) :
 
 let map_precedence_group_attribute (env : env)
     ((v1, v2, v3) : CST.precedence_group_attribute) =
-  let v1 = map_simple_identifier env v1 in
+  let name = map_simple_identifier env v1 |> H2.name_of_id in
   let v2 = (* ":" *) token env v2 in
   let v3 =
     match v3 with
-    | `Simple_id x -> map_simple_identifier env x
-    | `Bool_lit x -> map_boolean_literal env x |> todo env
+    | `Simple_id x ->
+        G.NamedAttr
+          ( v2,
+            name,
+            G.fake_bracket
+              [
+                G.Arg (G.N (map_simple_identifier env x |> H2.name_of_id) |> G.e);
+              ] )
+    | `Bool_lit x ->
+        G.NamedAttr
+          ( v2,
+            name,
+            G.fake_bracket [ G.Arg (G.L (map_boolean_literal env x) |> G.e) ] )
   in
-  todo env (v1, v2, v3)
+  G.At v3
 
 let map_tuple_type_item_identifier (env : env)
     ((v1, v2, v3) : CST.tuple_type_item_identifier) =
@@ -512,15 +569,41 @@ let map_tuple_type_item_identifier (env : env)
 
 let map_referenceable_operator (env : env) (x : CST.referenceable_operator) =
   match x with
-  | `Custom_op x -> map_custom_operator env x |> todo env
-  | `Comp_op x -> map_comparison_operator env x |> todo env
-  | `Addi_op x -> map_additive_operator env x |> todo env
-  | `Mult_op x -> map_multiplicative_operator env x |> todo env
-  | `Equa_op x -> map_equality_operator env x |> todo env
-  | `PLUSPLUS tok -> (* "++" *) token env tok
-  | `DASHDASH tok -> (* "--" *) token env tok
-  | `Bang tok -> (* bang *) token env tok
-  | `TILDE tok -> (* "~" *) token env tok
+  | `Custom_op x ->
+      let ((s, tok) as ident) = map_custom_operator env x in
+      (tok, G.N (H2.name_of_id ident))
+  | `Comp_op x ->
+      let op, tok = map_comparison_operator env x in
+      (tok, G.IdSpecial (G.Op op, tok))
+  | `Addi_op x ->
+      let op, tok = map_additive_operator env x in
+      (tok, G.IdSpecial (G.Op op, tok))
+  | `Mult_op x ->
+      let op, tok = map_multiplicative_operator env x in
+      (tok, G.IdSpecial (G.Op op, tok))
+  | `Equa_op x ->
+      let op, tok = map_equality_operator env x in
+      (tok, G.IdSpecial (G.Op op, tok))
+  (* TODO There is no good reason for these to be postfix, but this is not determinable right now.
+     Fix later.
+  *)
+  | `PLUSPLUS tok ->
+      (* "++" *)
+      let tok = token env tok in
+      (tok, G.IdSpecial (G.IncrDecr (G.Incr, G.Postfix), tok))
+  | `DASHDASH tok ->
+      (* "--" *)
+      let tok = token env tok in
+
+      (tok, G.IdSpecial (G.IncrDecr (G.Decr, G.Postfix), tok))
+  | `Bang tok ->
+      (* bang *)
+      let tok = token env tok in
+      (tok, G.IdSpecial (G.Op G.Not, tok))
+  | `TILDE tok ->
+      (* "~" *)
+      let tok = token env tok in
+      (tok, G.IdSpecial (G.Op G.BitNot, tok))
 
 let map_multi_line_string_content (env : env)
     (x : CST.multi_line_string_content) =
@@ -552,8 +635,12 @@ let map_non_constructor_function_decl (env : env)
   let v2 =
     match v2 with
     | `Simple_id x -> map_simple_identifier env x
-    | `Refe_op x -> map_referenceable_operator env x |> todo env
-    | `Bitw_bin_op x -> map_bitwise_binary_operator env x |> todo env
+    | `Refe_op x ->
+        map_referenceable_operator env x |> fst |> fun x -> (PI.str_of_info x, x)
+    | `Bitw_bin_op x ->
+        (* Maybe come back and do this better? *)
+        let _, tok = map_bitwise_binary_operator env x in
+        (PI.str_of_info tok, tok)
   in
   v2
 
@@ -569,9 +656,10 @@ let map_getter_specifier (env : env) ((v1, v2, v3) : CST.getter_specifier) =
     | Some x -> map_getter_effects env x |> todo env
     | None -> ()
   in
-  (v2, `Get)
+  v2
 
 let map_availability_argument (env : env) (x : CST.availability_argument) =
+  (* This does not seem important semantically. *)
   match x with
   | `Id_int_lit_rep_DOT_int_lit (v1, v2, v3) ->
       let v1 = map_identifier env v1 in
@@ -581,11 +669,15 @@ let map_availability_argument (env : env) (x : CST.availability_argument) =
           (fun (v1, v2) ->
             let v1 = (* "." *) token env v1 in
             let v2 = (* integer_literal *) token env v2 in
-            todo env (v1, v2))
+            G.Tk v2)
           v3
       in
-      todo env (v1, v2, v3)
-  | `STAR tok -> (* "*" *) token env tok
+      G.OtherExpr (("AvailableId", v2), G.Di v1 :: G.Tk v2 :: v3) |> G.e
+  | `STAR tok ->
+      (* "*" *)
+      G.OtherExpr
+        (("AvailableStar", G.fake "AvailableStar"), [ G.Tk (token env tok) ])
+      |> G.e
 
 let map_precedence_group_declaration (env : env)
     ((v1, v2, v3, v4, v5) : CST.precedence_group_declaration) =
@@ -595,10 +687,10 @@ let map_precedence_group_declaration (env : env)
   let v4 =
     match v4 with
     | Some x -> map_precedence_group_attributes env x
-    | None -> todo env ()
+    | None -> []
   in
   let v5 = (* "}" *) token env v5 in
-  todo env (v1, v2, v3, v4, v5)
+  G.OtherStmt (G.OS_Todo, G.I v2 :: v4) |> G.s
 
 let map_protocol_property_requirements (env : env)
     ((v1, v2, v3) : CST.protocol_property_requirements) =
@@ -681,32 +773,53 @@ and map_type_casting_pattern (env : env) (x : CST.type_casting_pattern) =
   | `Is_type (v1, v2) ->
       let v1 = (* "is" *) token env v1 in
       let v2 = map_type_ env v2 in
-      todo env (v1, v2)
+      G.PatType v2
   | `Bind_pat_no_expr_as_type (v1, v2, v3) ->
       let v1 = map_binding_pattern_no_expr env v1 in
       let v2 = (* as_custom *) token env v2 in
       let v3 = map_type_ env v3 in
-      todo env (v1, v2, v3)
+      (* This is only kind of correct. It's actually a subclassing thing. *)
+      PatTyped (v1, v3)
 
 and map_computed_getter (env : env) ((v1, v2, v3) : CST.computed_getter) =
   let v1 = Common.map (map_attribute env) v1 in
   let v2 = map_getter_specifier env v2 in
+  (* Yes, I know, but I want them in the same order.
+   *)
+  let attrs = v1 @ [ G.unhandled_keywordattr ("Get", v2) ] in
   let v3 =
     match v3 with
-    | Some x -> map_function_body env x
-    | None -> todo env ()
+    | Some x -> G.FBStmt (map_function_body env x)
+    | None -> G.FBNothing
   in
-  todo env (v1, v2, v3)
+  G.DefStmt
+    ( { G.name = G.OtherEntity (("Get", v2), []); attrs = []; tparams = [] },
+      G.FuncDef
+        {
+          G.fkind = (G.Method, v2);
+          G.fparams = [];
+          G.frettype = None;
+          G.fbody = v3;
+        } )
+  |> G.s
 
 and map_computed_modify (env : env) ((v1, v2, v3) : CST.computed_modify) =
   let v1 = Common.map (map_attribute env) v1 in
   let v2 = map_modify_specifier env v2 in
-  let v3 =
+  (* Yes, I know, but I want them in the same order.
+   *)
+  let attrs = v1 @ [ G.unhandled_keywordattr ("Modify", v2) ] in
+  let fbody =
     match v3 with
-    | Some x -> map_function_body env x
-    | None -> todo env ()
+    | Some x -> G.FBStmt (map_function_body env x)
+    | None -> G.FBNothing
   in
-  todo env (v1, v2, v3)
+  G.DefStmt
+    ( { G.name = G.OtherEntity (("Modify", v2), []); attrs; tparams = [] },
+      G.FuncDef
+        { G.fkind = (G.Method, v2); G.fparams = []; G.frettype = None; G.fbody }
+    )
+  |> G.s
 
 and map_computed_property (env : env) ((v1, v2, v3) : CST.computed_property) =
   let v1 = (* "{" *) token env v1 in
@@ -718,7 +831,7 @@ and map_computed_property (env : env) ((v1, v2, v3) : CST.computed_property) =
         | Some x -> map_statements env x
         | _ -> []
       in
-      G.StmtExpr (G.Block (v1, stmts, v3) |> G.s) |> G.e
+      G.Block (v1, stmts, v3) |> G.s
   | `Rep_choice_comp_getter xs ->
       let getters_setters =
         Common.map
@@ -729,26 +842,37 @@ and map_computed_property (env : env) ((v1, v2, v3) : CST.computed_property) =
             | `Comp_modify x -> map_computed_modify env x)
           xs
       in
-      G.StmtExpr (G.Block (v1, getters_setters, v3) |> G.s) |> G.e
+      G.Block (v1, getters_setters, v3) |> G.s
 
 and map_computed_setter (env : env) ((v1, v2, v3, v4) : CST.computed_setter) =
   let v1 = Common.map (map_attribute env) v1 in
   let v2 = map_setter_specifier env v2 in
-  let v3 =
+  (* Yes, I know, but I want them in the same order.
+   *)
+  let attrs = v1 @ [ G.unhandled_keywordattr ("Set", v2) ] in
+  (* TODO? There's some weird semantics here about a name for the argument to
+     pass in to willSet and didSet.
+     I'm gonna say these don't matter for now.
+  *)
+  let fparams =
     match v3 with
     | Some (v1, v2, v3) ->
         let v1 = (* "(" *) token env v1 in
         let v2 = map_simple_identifier env v2 in
         let v3 = (* ")" *) token env v3 in
-        todo env (v1, v2, v3)
-    | None -> todo env ()
+        [ G.Param (G.param_of_id v2) ]
+    | None -> []
   in
-  let v4 =
+  let fbody =
     match v4 with
-    | Some x -> map_function_body env x
-    | None -> todo env ()
+    | Some x -> G.FBStmt (map_function_body env x)
+    | None -> G.FBNothing
   in
-  todo env (v1, v2, v3, v4)
+  G.DefStmt
+    ( { G.name = G.OtherEntity (("Set", v2), []); attrs; tparams = [] },
+      G.FuncDef
+        { G.fkind = (G.Method, v2); G.fparams; G.frettype = None; G.fbody } )
+  |> G.s
 
 and map_array_type (env : env) ((v1, v2, v3) : CST.array_type) : G.type_ =
   let v1 = (* "[" *) token env v1 in
@@ -758,35 +882,43 @@ and map_array_type (env : env) ((v1, v2, v3) : CST.array_type) : G.type_ =
 
 and map_associatedtype_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.associatedtype_declaration) =
-  let v1 =
-    match v1 with
-    | Some x -> map_modifiers env x
-    | None -> todo env ()
-  in
   let v2 = (* "associatedtype" *) token env v2 in
-  let v3 = map_simple_identifier env v3 in
-  let v4 =
+  (* a default value for the associated type is a modifier on the actual
+     definition
+  *)
+  let modifiers =
+    let default =
+      match v6 with
+      | Some (v1, ty) ->
+          let v1 = (* eq_custom *) token env v1 in
+          let ty = map_type_ env ty in
+          [ G.OtherAttribute (("DefaultType", v2), [ G.T ty ]) ]
+      | None -> []
+    in
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> [])
+    @ default
+  in
+  let id = map_simple_identifier env v3 in
+  (* however, type constraints are modifiers on the type *)
+  let protocol =
+    let tconstraints =
+      match v5 with
+      | Some x -> map_type_constraints env x
+      | None -> []
+    in
     match v4 with
     | Some (v1, v2) ->
         let v1 = (* ":" *) token env v1 in
         let v2 = map_type_ env v2 in
-        todo env (v1, v2)
-    | None -> todo env ()
+        [ G.T { v2 with G.t_attrs = tconstraints @ v2.G.t_attrs } ]
+    | None -> []
   in
-  let v5 =
-    match v5 with
-    | Some x -> map_type_constraints env x
-    | None -> todo env ()
-  in
-  let v6 =
-    match v6 with
-    | Some (v1, v2) ->
-        let v1 = (* eq_custom *) token env v1 in
-        let v2 = map_type_ env v2 in
-        todo env (v1, v2)
-    | None -> todo env ()
-  in
-  todo env (v1, v2, v3, v4, v5, v6)
+  G.DefStmt
+    ( G.basic_entity ~attrs:modifiers id,
+      G.TypeDef { tbody = G.OtherTypeKind (("Protocol", v2), protocol) } )
+  |> G.s
 
 and map_attribute_argument (env : env) (x : CST.attribute_argument) =
   match x with
@@ -794,16 +926,19 @@ and map_attribute_argument (env : env) (x : CST.attribute_argument) =
       let v1 = map_bound_identifier env v1 in
       let v2 = (* ":" *) token env v2 in
       let v3 = map_expression env v3 in
-      todo env (v1, v2, v3)
-  | `Exp x -> map_expression env x
+      G.OtherArg (("AttrArgIdExp", v2), [ G.I v1; G.E v3 ])
+  | `Exp x ->
+      G.OtherArg
+        (("AttrArgExp", G.fake "AttrArgExp"), [ G.E (map_expression env x) ])
   | `Rep1_simple_id_COLON xs ->
-      Common.map
-        (fun (v1, v2) ->
-          let v1 = map_bound_identifier env v1 in
-          let v2 = (* ":" *) token env v2 in
-          todo env (v1, v2))
-        xs
-      |> todo env
+      G.OtherArg
+        ( ("AttrBoundIds", G.fake "AttrBoundIds"),
+          Common.map
+            (fun (v1, v2) ->
+              let v1 = map_bound_identifier env v1 in
+              let v2 = (* ":" *) token env v2 in
+              G.I v1)
+            xs )
   | `Rep1_simple_id_int_lit_rep_DOT_int_lit (v1, v2, v3) ->
       let v1 = Common.map (map_bound_identifier env) v1 in
       let v2 = (* integer_literal *) token env v2 in
@@ -812,10 +947,11 @@ and map_attribute_argument (env : env) (x : CST.attribute_argument) =
           (fun (v1, v2) ->
             let v1 = (* "." *) token env v1 in
             let v2 = (* integer_literal *) token env v2 in
-            todo env (v1, v2))
+            G.Tk v2)
           v3
       in
-      todo env (v1, v2, v3)
+      G.OtherArg
+        (("AttrBoundIdAndInts", G.fake "AttrBoundIdAndInts"), G.Tk v2 :: v3)
 
 and map_attribute (env : env) ((v1, v2, v3) : CST.attribute) =
   let at_tok = (* "@" *) token env v1 in
@@ -830,11 +966,11 @@ and map_attribute (env : env) ((v1, v2, v3) : CST.attribute) =
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 = map_attribute_argument env v2 in
-              todo env (v1, v2))
+              v2)
             v3
         in
         let v4 = (* ")" *) token env v4 in
-        (v1, Common.map (fun x -> G.Arg x) (v2 :: v3), v4)
+        (v1, v2 :: v3, v4)
     | None -> G.fake_bracket []
   in
   G.NamedAttr (at_tok, attr_name, args)
@@ -938,9 +1074,15 @@ and map_binding_pattern_with_expr (env : env)
         | G.L lit -> G.PatLiteral lit
         | _ -> todo env ())
   in
+  (* As elsewhere, it looks like this question mark isn't important right now.
+     See `map_expression`.
+  *)
   let v2 =
     match v2 with
-    | Some tok -> (* "?" *) token env tok |> todo env
+    | Some tok ->
+        (* "?" *)
+        let todo = token env tok in
+        ()
     | None -> ()
   in
   v1
@@ -967,7 +1109,10 @@ and map_bodyless_function_declaration (env : env) ~in_class
   *)
   let v2 =
     match v2 with
-    | Some tok -> (* "class" *) token env tok |> todo env
+    | Some tok ->
+        (* "class" *)
+        let _todo = token env tok in
+        ()
     | None -> ()
   in
   let v3 =
@@ -1008,7 +1153,8 @@ and map_call_suffix (env : env) (v1 : CST.call_suffix) : G.arguments =
       in
       anon_arg :: labeled_args |> G.fake_bracket
 
-and map_capture_list (env : env) ((v1, v2, v3, v4, v5) : CST.capture_list) =
+and map_capture_list (env : env) ((v1, v2, v3, v4, v5) : CST.capture_list) :
+    G.parameter list =
   let v1 = Common.map (map_attribute env) v1 in
   let v2 = (* "[" *) token env v2 in
   let v3 = map_capture_list_item env v3 in
@@ -1016,32 +1162,32 @@ and map_capture_list (env : env) ((v1, v2, v3, v4, v5) : CST.capture_list) =
     Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
-        let v2 = map_capture_list_item env v2 in
-        todo env (v1, v2))
+        map_capture_list_item env v2)
       v4
   in
   let v5 = (* "]" *) token env v5 in
-  todo env (v1, v2, v3, v4, v5)
+  v3 :: v4
 
 and map_capture_list_item (env : env) (x : CST.capture_list_item) =
   match x with
-  | `Self_exp tok -> (* "self" *) token env tok
-  | `Opt_owne_modi_simple_id_opt_equal_sign_exp (v1, v2, v3) ->
-      let v1 =
+  | `Self_exp tok ->
+      (* "self" *) G.Param (G.param_of_id ("self", token env tok))
+  | `Opt_owne_modi_simple_id_opt_equal_sign_exp (v1, v2_tok, v3) ->
+      let pattrs =
         match v1 with
-        | Some x -> map_ownership_modifier env x
-        | None -> todo env ()
+        | Some x -> [ map_ownership_modifier env x ]
+        | None -> []
       in
-      let v2 = map_simple_identifier env v2 in
-      let v3 =
+      let id = map_simple_identifier env v2_tok in
+      let pdefault =
         match v3 with
         | Some (v1, v2) ->
+            let expr = G.N (H2.name_of_id id) |> G.e in
             let v1 = (* eq_custom *) token env v1 in
-            let v2 = map_expression env v2 in
-            todo env (v1, v2)
-        | None -> todo env ()
+            Some (map_expression env v2)
+        | None -> None
       in
-      todo env (v1, v2, v3)
+      G.Param (G.param_of_id ~pattrs ~pdefault id)
 
 and map_catch_block (env : env) ((v1, v2, v3, v4) : CST.catch_block) =
   let catch_tok = (* catch_keyword *) token env v1 in
@@ -1134,12 +1280,12 @@ and map_control_transfer_statement (env : env)
 and map_deinit_declaration (env : env) ((v1, v2, v3) : CST.deinit_declaration) =
   let v1 =
     match v1 with
-    | Some x -> map_modifiers env x |> todo env
-    | None -> ()
+    | Some x -> map_modifiers env x
+    | None -> []
   in
   let v2 = (* "deinit" *) str env v2 in
   let v3 = map_function_body env v3 in
-  let entity = G.basic_entity v2 in
+  let entity = G.basic_entity ~attrs:v1 v2 in
   let definition_kind =
     G.FuncDef
       {
@@ -1271,17 +1417,21 @@ and map_enum_class_body (is_raw : bool) (enum_ident : G.ident) (env : env)
 and map_enum_entry_raw (env : env)
     ((v1, v2, v3, v4, v5, v6, _v7) : CST.enum_entry) : G.stmt list =
   let modifiers =
-    match v1 with
-    | Some x -> map_modifiers env x |> todo env
-    | None -> []
+    let v2 =
+      match v2 with
+      | Some tok ->
+          (* "indirect" *)
+          [ G.unhandled_keywordattr ("Indirect", token env tok) ]
+      | None -> []
+    in
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> [])
+    @ v2
   in
-  let v2 =
-    match v2 with
-    | Some tok -> (* "indirect" *) token env tok |> todo env
-    | None -> []
-  in
+
   let mk_variant id suffix_opt =
-    let ent = G.basic_entity (map_simple_identifier env v4) in
+    let ent = G.basic_entity ~attrs:modifiers (map_simple_identifier env v4) in
     match v5 with
     | Some x -> map_enum_entry_suffix_raw env ent x
     | None ->
@@ -1294,16 +1444,24 @@ and map_enum_entry_raw (env : env)
 
 and map_enum_entry_union (env : env)
     ((v1, v2, v3, v4, v5, v6, _v7) : CST.enum_entry) : G.or_type_element list =
+  (* This is weird... theoretically these modifiers should only apply to the variants
+     listed directly afterwards, but our generic AST can't really represent that
+     within an OrType without applying to the whole definition.
+  *)
   let modifiers =
-    match v1 with
-    | Some x -> map_modifiers env x |> todo env
-    | None -> []
+    let v2 =
+      match v2 with
+      | Some tok ->
+          (* "indirect" *)
+          [ G.unhandled_keywordattr ("Indirect", token env tok) ]
+      | None -> []
+    in
+    (match v1 with
+    | Some x -> map_modifiers env x
+    | None -> [])
+    @ v2
   in
-  let v2 =
-    match v2 with
-    | Some tok -> (* "indirect" *) token env tok |> todo env
-    | None -> []
-  in
+
   let mk_variant id suffix_opt =
     let ident = map_simple_identifier env v4 in
     match v5 with
@@ -1401,26 +1559,30 @@ and map_function_declaration (env : env) ~in_class
 
 and map_function_type (env : env) ((v1, v2, v3, v4, v5) : CST.function_type) =
   let v1 = map_tuple_type env v1 in
-  let v2 =
-    match v2 with
-    | Some tok -> (* async_keyword_custom *) token env tok
-    | None -> todo env ()
-  in
-  let v3 =
-    match v3 with
-    | Some x -> map_throws env x
-    | None -> todo env ()
+  let attrs =
+    let v2 =
+      match v2 with
+      | Some tok ->
+          (* async_keyword_custom *) [ G.attr G.Async (token env tok) ]
+      | None -> []
+    in
+    let v3 =
+      match v3 with
+      | Some x -> [ map_throws env x ]
+      | None -> []
+    in
+    v2 @ v3
   in
   let v4 = (* arrow_operator_custom *) token env v4 in
   let v5 = map_type_ env v5 in
-  todo env (v1, v2, v3, v4, v5)
+  G.TyFun ([ G.Param (G.param_of_type ~pattrs:attrs v1) ], v5) |> G.t
 
 and map_function_value_parameter (env : env)
     ((v1, v2, v3) : CST.function_value_parameter) : G.parameter =
-  let v1 =
+  let modifiers =
     match v1 with
-    | Some x -> map_attribute env x |> todo env
-    | None -> ()
+    | Some x -> [ map_attribute env x ]
+    | None -> []
   in
   let v3 =
     match v3 with
@@ -1430,7 +1592,7 @@ and map_function_value_parameter (env : env)
         Some v2
     | None -> None
   in
-  map_parameter env v2 v3
+  map_parameter env v2 v3 ~attrs:modifiers
 
 and map_function_value_parameters (env : env)
     ((v1, v2, v3) : CST.function_value_parameters) : G.parameters =
@@ -1455,6 +1617,8 @@ and map_function_value_parameters (env : env)
 
 and map_guard_statement (env : env) ((v1, v2, v3, v4, v5) : CST.guard_statement)
     =
+  (* A guard statement seems to be semantically equivalent to an "if not".
+   *)
   let v1 = (* "guard" *) token env v1 in
   let v2 = map_if_condition_sequence_item env v2 in
   let v3 =
@@ -1462,22 +1626,32 @@ and map_guard_statement (env : env) ((v1, v2, v3, v4, v5) : CST.guard_statement)
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_if_condition_sequence_item env v2 in
-        todo env (v1, v2))
+        v2)
       v3
   in
-  let v4 = (* else *) token env v4 in
-  let v5 = map_function_body env v5 in
-  todo env (v1, v2, v3, v4, v5)
+  let cond = combine_conds v2 v3 in
+  let body = map_function_body env v5 in
+  G.If (v1, G.Cond (G.special (G.Op G.Not, G.fake "not") [ cond ]), body, None)
+  |> G.s
+
+and combine_conds cond conds =
+  List.fold_left
+    (fun acc x ->
+      G.Call
+        ( G.IdSpecial (G.Op G.And, G.fake "&&") |> G.e,
+          G.fake_bracket [ G.Arg acc; G.Arg x ] )
+      |> G.e)
+    cond conds
 
 and map_if_condition_sequence_item (env : env)
-    (x : CST.if_condition_sequence_item) : G.condition =
+    (x : CST.if_condition_sequence_item) : G.expr =
   match x with
   | `If_let_bind (v1, v2, v3) ->
       let v1 = map_direct_or_indirect_binding env v1 in
       let v2 = (* eq_custom *) token env v2 in
       let v3 = map_expression env v3 in
-      G.Cond (G.LetPattern (v1, v3) |> G.e)
-  | `Exp x -> G.Cond (map_expression env x)
+      G.LetPattern (v1, v3) |> G.e
+  | `Exp x -> map_expression env x
   | `Avai_cond (v1, v2, v3, v4, v5) ->
       let v1 = (* "#available" *) token env v1 in
       let v2 = (* "(" *) token env v2 in
@@ -1487,13 +1661,13 @@ and map_if_condition_sequence_item (env : env)
           (fun (v1, v2) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_availability_argument env v2 in
-            todo env (v1, v2))
+            v2)
           v4
       in
       let v5 = (* ")" *) token env v5 in
       (* See `map_repeat_while_statement` if this returns a non-`Cond`.
        *)
-      todo env (v1, v2, v3, v4, v5)
+      combine_conds v3 v4
 
 and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
   let v1 = (* "if" *) token env v1 in
@@ -1506,9 +1680,10 @@ and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_if_condition_sequence_item env v2 in
-        todo env (v1, v2))
+        v2)
       v3
   in
+  let cond = combine_conds v2 v3 in
   let v4 = map_block env v4 in
   let v5 =
     match v5 with
@@ -1518,14 +1693,14 @@ and map_if_statement (env : env) ((v1, v2, v3, v4, v5) : CST.if_statement) =
         Some v2
     | None -> None
   in
-  G.If (v1, v2, v4, v5) |> G.s
+  G.If (v1, G.Cond cond, v4, v5) |> G.s
 
 and map_import_declaration (env : env)
     ((v1, v2, v3, v4) : CST.import_declaration) =
-  let v1 =
+  let attrs =
     match v1 with
-    | Some x -> map_modifiers env x |> todo env
-    | None -> ()
+    | Some x -> map_modifiers env x
+    | None -> []
   in
   let v2 = (* "import" *) token env v2 in
   let v3 =
@@ -1537,13 +1712,16 @@ and map_import_declaration (env : env)
   let v4 = map_identifier env v4 in
   (* TODO Use ImportFrom for `import foo.bar.baz`? *)
   G.DirectiveStmt
-    (G.ImportAll (v2, G.DottedName v4, PI.unsafe_fake_info "") |> G.d)
+    {
+      G.d = G.ImportAll (v2, G.DottedName v4, PI.unsafe_fake_info "");
+      d_attrs = attrs;
+    }
   |> G.s
 
 and map_inheritance_specifier (env : env) (x : CST.inheritance_specifier) =
   match x with
   | `User_type x -> map_user_type env x
-  | `Func_type x -> map_function_type env x |> todo env
+  | `Func_type x -> map_function_type env x
 
 and map_inheritance_specifiers (env : env)
     ((v1, v2) : CST.inheritance_specifiers) =
@@ -1605,15 +1783,15 @@ and map_arguments (env : env) ((v1, v2) : CST.interpolation_contents) :
   in
   v1 @ v2
 
-and map_key_path_component (env : env) (x : CST.key_path_component) =
+and _map_key_path_component (env : env) (x : CST.key_path_component) =
   match x with
   | `Simple_id_rep_key_path_postfs (v1, v2) ->
       let v1 = map_simple_identifier env v1 in
-      let v2 = Common.map (map_key_path_postfixes env) v2 in
+      let v2 = Common.map (_map_key_path_postfixes env) v2 in
       todo env (v1, v2)
-  | `Rep1_key_path_postfs xs -> Common.map (map_key_path_postfixes env) xs
+  | `Rep1_key_path_postfs xs -> Common.map (_map_key_path_postfixes env) xs
 
-and map_key_path_postfixes (env : env) (x : CST.key_path_postfixes) =
+and _map_key_path_postfixes (env : env) (x : CST.key_path_postfixes) =
   match x with
   | `QMARK tok -> (* "?" *) token env tok
   | `Bang tok -> (* bang *) token env tok
@@ -1650,9 +1828,11 @@ and map_labeled_statement (env : env) ((v1, v2) : CST.labeled_statement) =
   | None -> v2
   | Some ident -> G.Label (ident, v2) |> G.s
 
+(* This is a misleading name, it has nothing to do with the lambda's type... *)
 and map_lambda_function_type (env : env)
-    ((v1, v2, v3, v4) : CST.lambda_function_type) : G.parameter list =
-  let v1 =
+    ((v1, v2, v3, v4) : CST.lambda_function_type) :
+    G.parameter list * G.type_ option =
+  let params =
     match v1 with
     | `Lambda_func_type_params x -> map_lambda_function_type_parameters env x
     | `LPAR_opt_lambda_func_type_params_RPAR (v1, v2, v3) ->
@@ -1660,31 +1840,34 @@ and map_lambda_function_type (env : env)
         let v2 =
           match v2 with
           | Some x -> map_lambda_function_type_parameters env x
-          | None -> todo env ()
+          | None -> []
         in
         let v3 = (* ")" *) token env v3 in
-        todo env (v1, v2, v3)
+        v2
   in
-  let v2 =
-    match v2 with
-    | Some tok -> (* async_keyword_custom *) token env tok |> todo env
-    | None -> None
+  let attrs =
+    let v2 =
+      match v2 with
+      | Some tok ->
+          (* async_keyword_custom *) [ G.attr G.Async (token env tok) ]
+      | None -> []
+    in
+    let v3 =
+      match v3 with
+      | Some x -> [ map_throws env x ]
+      | None -> []
+    in
+    v2 @ v3
   in
-  let v3 =
-    match v3 with
-    | Some x -> map_throws env x |> todo env
-    | None -> None
-  in
-  let v4 =
+  let rettype =
     match v4 with
     | Some (v1, v2) ->
         let v1 = (* arrow_operator_custom *) token env v1 in
         let v2 = map_possibly_implicitly_unwrapped_type env v2 in
-        todo env (v1, v2)
+        Some { v2 with G.t_attrs = attrs @ v2.G.t_attrs }
     | None -> None
   in
-  (* TODO return info other than paremeter list *)
-  v1
+  (params, rettype)
 
 and map_lambda_function_type_parameters (env : env)
     ((v1, v2) : CST.lambda_function_type_parameters) : G.parameter list =
@@ -1702,22 +1885,18 @@ and map_lambda_literal (env : env) ((v1, v2, v3, v4, v5) : CST.lambda_literal) :
     G.expr =
   let v1 = (* "{" *) token env v1 in
   (* TODO include captures *)
-  let _captures =
+  let captures =
     match v2 with
     | Some x -> map_capture_list env x
     | None -> []
   in
-  let params =
+  let params, rettype =
     match v3 with
-    | Some (v1, v2) ->
-        let v1 =
-          match v1 with
-          | Some x -> map_lambda_function_type env x
-          | None -> []
-        in
-        let _in = (* "in" *) token env v2 in
-        v1
-    | None -> []
+    | Some (v1, v2) -> (
+        match v1 with
+        | Some x -> map_lambda_function_type env x
+        | None -> ([], None))
+    | None -> ([], None)
   in
   let body =
     let stmts =
@@ -1729,15 +1908,19 @@ and map_lambda_literal (env : env) ((v1, v2, v3, v4, v5) : CST.lambda_literal) :
     (* Fake brackets here since the brackets delimit the lambda expression as a
      * whole, not just the statements *)
     (* TODO consider using `in` and the closing bracket as the delimiters *)
-    G.FBStmt (G.Block (G.fake_bracket stmts) |> G.s)
+    G.FBStmt
+      (G.OtherStmtWithStmt
+         ( G.OSWS_Closure,
+           Common.map (fun x -> G.Pa x) captures,
+           G.Block (G.fake_bracket stmts) |> G.s )
+      |> G.s)
   in
   let v5 = (* "}" *) token env v5 in
   let def =
     {
       G.fkind = (G.LambdaKind, v1);
       fparams = params;
-      (* TODO include return type if provided *)
-      frettype = None;
+      frettype = rettype;
       fbody = body;
     }
   in
@@ -1745,31 +1928,36 @@ and map_lambda_literal (env : env) ((v1, v2, v3, v4, v5) : CST.lambda_literal) :
 
 and map_lambda_parameter (env : env) ((v1, v2) : CST.lambda_parameter) :
     G.parameter =
-  let v1 =
+  let attrs =
     match v1 with
-    | Some x -> map_attribute env x |> todo env
-    | None -> None
+    | Some x -> [ map_attribute env x ]
+    | None -> []
   in
   let v2 =
     match v2 with
-    | `Self_exp tok -> (* "self" *) token env tok |> todo env
-    | `Simple_id x -> G.Param (map_simple_identifier env x |> G.param_of_id)
+    | `Self_exp tok -> (* "self" *) G.OtherParam (("Self", token env tok), [])
+    | `Simple_id x ->
+        G.Param (map_simple_identifier env x |> G.param_of_id ~pattrs:attrs)
     | `Opt_simple_id_simple_id_COLON_opt_param_modifs_poss_impl_unwr_type
         (v1, v2, v3, v4, v5) ->
-        let v1 =
+        (* TODO As with `map_parameter`, we only support internal names right now. *)
+        let _v1 =
           match v1 with
-          | Some x -> map_simple_identifier env x
-          | None -> todo env ()
+          | Some x ->
+              let _todo = map_simple_identifier env x in
+              ()
+          | None -> ()
         in
         let v2 = map_simple_identifier env v2 in
         let v3 = (* ":" *) token env v3 in
-        let v4 =
+        let attrs =
           match v4 with
           | Some x -> map_parameter_modifiers env x
-          | None -> todo env ()
+          | None -> []
         in
         let v5 = map_possibly_implicitly_unwrapped_type env v5 in
-        todo env (v1, v2, v3, v4, v5)
+        let ty = { v5 with G.t_attrs = attrs @ v5.G.t_attrs } in
+        G.Param (G.param_of_id ~ptype:(Some ty) ~pattrs:attrs v2)
   in
   v2
 
@@ -1784,26 +1972,26 @@ and map_local_declaration (env : env) (x : CST.local_declaration) : G.stmt list
       in
       map_modifierless_property_declaration env modifiers v2
   | `Local_typeas_decl (v1, v2) ->
-      let v1 =
+      let modifiers =
         match v1 with
-        | Some x -> map_locally_permitted_modifiers env x |> todo env
+        | Some x -> map_locally_permitted_modifiers env x
         | None -> []
       in
-      [ map_modifierless_typealias_declaration env v2 ]
+      [ map_modifierless_typealias_declaration env modifiers v2 ]
   | `Local_func_decl (v1, v2) ->
       let v1 =
         match v1 with
-        | Some x -> map_locally_permitted_modifiers env x |> todo env
+        | Some x -> map_locally_permitted_modifiers env x
         | None -> []
       in
-      map_modifierless_function_declaration env v2
+      map_modifierless_function_declaration env v1 v2
   | `Local_class_decl (v1, v2) ->
       let modifiers =
         match v1 with
-        | Some x -> map_locally_permitted_modifiers env x |> todo env
+        | Some x -> map_locally_permitted_modifiers env x
         | None -> []
       in
-      map_modifierless_class_declaration env [] v2 |> todo env
+      [ map_modifierless_class_declaration env modifiers v2 ]
 
 and map_semi (env : env) (semi : CST.semi option) : G.sc =
   match semi with
@@ -1831,7 +2019,7 @@ and map_locally_permitted_modifiers (env : env)
     (fun x ->
       match x with
       | `Attr x -> map_attribute env x
-      | `Loca_perm_modi x -> map_locally_permitted_modifier env x |> todo env)
+      | `Loca_perm_modi x -> map_locally_permitted_modifier env x)
     xs
 
 and construct_class_def :
@@ -1840,12 +2028,13 @@ and construct_class_def :
       ?kind:G.class_kind ->
       G.tok ->
       'inheritance_specifiers ->
+      G.entity ->
       CST.type_constraints option ->
       'body ->
       (env -> 'body -> G.field list G.bracket) ->
-      G.definition_kind =
- fun env ?(kind = G.Class) class_token inheritance_specifiers type_constraints
-     body map_body ->
+      G.stmt =
+ fun env ?(kind = G.Class) class_token inheritance_specifiers ent
+     type_constraints body map_body ->
   let extends =
     (* Swift allows classes to have at most one superclass, followed by a list
      * of protocols that the class implements. If there is a superclass, it must
@@ -1866,8 +2055,8 @@ and construct_class_def :
      * parameters in the current definition, or to other type parameters in
      * scope. *)
     match type_constraints with
-    | Some x -> map_type_constraints env x |> todo env
-    | None -> ()
+    | Some x -> map_type_constraints env x
+    | None -> []
   in
   let body = map_body env body in
   let definition_kind =
@@ -1880,7 +2069,8 @@ and construct_class_def :
       cbody = body;
     }
   in
-  G.ClassDef definition_kind
+  let entity = { ent with G.attrs = type_constraints @ ent.G.attrs } in
+  G.DefStmt (entity, G.ClassDef definition_kind) |> G.s
 
 (* TODO?: probably not complete, but that's OK *)
 and is_raw_type env s =
@@ -1913,8 +2103,7 @@ and map_modifierless_class_declaration (env : env) (attrs : G.attribute list)
         | None -> []
       in
       let entity = G.basic_entity ~tparams ~attrs v2 in
-      let classdef = construct_class_def env v1 v4 v5 v6 map_class_body in
-      G.DefStmt (entity, classdef) |> G.s
+      construct_class_def env v1 v4 entity v5 v6 map_class_body
   | `Exte_user_type_opt_type_params_opt_COLON_inhe_specis_opt_type_consts_class_body
       (v1, v2, v3, v4, v5, v6) ->
       let v1 = (* "extension" *) token env v1 in
@@ -1930,8 +2119,7 @@ and map_modifierless_class_declaration (env : env) (attrs : G.attribute list)
        * generic AST, but an ordinary class is probably the closest.
        *
        * https://docs.swift.org/swift-book/LanguageGuide/Extensions.html *)
-      let classdef = construct_class_def env v1 v4 v5 v6 map_class_body in
-      G.DefStmt (entity, classdef) |> G.s
+      construct_class_def env v1 v4 entity v5 v6 map_class_body
   | `Opt_indi_enum_simple_id_opt_type_params_opt_COLON_inhe_specis_opt_type_consts_enum_class_body
       (v1, v2, v3, v4, v5, v6, v7) ->
       let v2 = (* "enum" *) token env v2 in
@@ -1958,28 +2146,24 @@ and map_modifierless_class_declaration (env : env) (attrs : G.attribute list)
       *)
       let is_raw =
         match v5 with
-        | None -> false
-        (* Yeah, I know, but this should cover the use cases that matter.
-         *)
-        | Some (_, (([], `User_type ((bid, None), [])), [])) ->
-            let s, _ = map_bound_identifier env bid in
-            is_raw_type env s
+        | Some (_, (spec, _)) -> (
+            match (map_annotated_inheritance_specifier env spec).G.t with
+            | G.TyN (Id ((s, _), _)) -> is_raw_type env s
+            | _ -> false)
         | _ -> false
       in
       let entity = G.basic_entity ~attrs ~tparams v3 in
-      let classdef =
-        construct_class_def env v2 v5 v6 v7 (map_enum_class_body is_raw v3)
-      in
-      G.DefStmt (entity, classdef) |> G.s
+      construct_class_def env v2 v5 entity v6 v7 (map_enum_class_body is_raw v3)
 
-and map_modifierless_function_declaration (env : env)
+and map_modifierless_function_declaration (env : env) (attrs : G.attribute list)
     ((v1, v2) : CST.modifierless_function_declaration) =
   let v2 = map_function_body env v2 in
   let in_class = todo env () in
   let v1 =
-    map_modifierless_function_declaration_no_body env ~in_class v1 (G.FBStmt v2)
+    map_modifierless_function_declaration_no_body env ~in_class ~attrs v1
+      (G.FBStmt v2)
   in
-  todo env (v1, v2)
+  [ v1 ]
 
 and map_type_with_modifiers env ty attrs =
   { ty with G.t_attrs = ty.G.t_attrs @ attrs }
@@ -1988,10 +2172,10 @@ and map_modifierless_function_declaration_no_body (env : env) ~in_class
     ?(attrs = [])
     ((v1, v2, v3, v4, v5, v6, v7) :
       CST.modifierless_function_declaration_no_body) (body : G.function_body) =
-  let v1 =
+  let is_quest, v1 =
     match v1 with
     | `Cons_func_decl x -> map_constructor_function_decl env x
-    | `Non_cons_func_decl x -> map_non_constructor_function_decl env x
+    | `Non_cons_func_decl x -> (false, map_non_constructor_function_decl env x)
   in
   let v2 =
     match v2 with
@@ -2013,26 +2197,28 @@ and map_modifierless_function_declaration_no_body (env : env) ~in_class
     in
     v4 @ v5
   in
-  let v6 =
-    match v6 with
-    | Some (v1, v2) ->
-        let _ = (* arrow_operator_custom *) token env v1 in
-        let ty = map_possibly_implicitly_unwrapped_type env v2 in
-        let res = map_type_with_modifiers env ty rettype_attrs in
-        Some res
-    | None -> None
-  in
   let type_constraints =
     match v7 with
     | Some x -> map_type_constraints env x
     | None -> []
   in
-  let attrs = type_constraints @ attrs in
+  let frettype =
+    match v6 with
+    | Some (v1, v2) ->
+        let _ = (* arrow_operator_custom *) token env v1 in
+        let ty = map_possibly_implicitly_unwrapped_type env v2 in
+        let res =
+          map_type_with_modifiers env ty (type_constraints @ rettype_attrs)
+        in
+        Some (if is_quest then G.TyQuestion (res, G.fake "?") |> G.t else res)
+    | None -> None
+  in
+
+  let attrs = attrs in
   let entity = G.basic_entity ~tparams:v2 ~attrs v1 in
   let kind = if in_class then G.Method else G.Function in
   let definition_kind =
-    G.FuncDef
-      { fkind = (kind, snd v1); fparams = v3; frettype = v6; fbody = body }
+    G.FuncDef { fkind = (kind, snd v1); fparams = v3; frettype; fbody = body }
   in
   G.DefStmt (entity, definition_kind) |> G.s
 
@@ -2042,15 +2228,15 @@ and map_single_modifierless_property_declaration (env : env)
       CST.single_modifierless_property_declaration) : G.stmt =
   let pat = map_no_expr_pattern_already_bound env pat in
   let entity = entity_of_pattern ~attrs pat in
-  let tannot =
-    match tannot with
-    | Some x -> Some (map_type_annotation env x)
-    | None -> None
-  in
   let tconstraints =
     match tconstraints with
-    | Some x -> map_type_constraints env x |> todo env
-    | None -> ()
+    | Some x -> map_type_constraints env x
+    | None -> []
+  in
+  let tannot =
+    match tannot with
+    | Some x -> Some (map_type_annotation ~attrs:tconstraints env x)
+    | None -> None
   in
   let init =
     match init with
@@ -2061,7 +2247,7 @@ and map_single_modifierless_property_declaration (env : env)
               let v1 = (* eq_custom *) token env v1 in
               let v2 = map_expression env v2 in
               v2
-          | `Comp_prop x -> map_computed_property env x
+          | `Comp_prop x -> G.StmtExpr (map_computed_property env x) |> G.e
         in
         Some x
     | None -> None
@@ -2083,6 +2269,7 @@ and map_modifierless_property_declaration (env : env) (attrs : G.attribute list)
   stmt1 :: stmts
 
 and map_modifierless_typealias_declaration (env : env)
+    (attrs : G.attribute list)
     ((v1, v2, v3, v4, v5) : CST.modifierless_typealias_declaration) =
   let v1 = (* "typealias" *) token env v1 in
   let v2 = map_simple_identifier env v2 in
@@ -2094,7 +2281,8 @@ and map_modifierless_typealias_declaration (env : env)
   let v4 = (* eq_custom *) token env v4 in
   let v5 = map_type_ env v5 in
   G.DefStmt
-    (G.basic_entity ~tparams:v3 v2, G.TypeDef { G.tbody = G.AliasType v5 })
+    ( G.basic_entity ~tparams:v3 ~attrs v2,
+      G.TypeDef { G.tbody = G.AliasType v5 } )
   |> G.s
 
 and map_modifiers (env : env) (xs : CST.modifiers) =
@@ -2219,8 +2407,8 @@ and map_universally_allowed_pattern (env : env)
       in
       pat_init |> add_pat_args (G.Id (id, id_info)) |> add_pat_type
 
-and map_parameter (env : env) ((v1, v2, v3, v4, v5, v6) : CST.parameter) default
-    =
+and map_parameter (env : env) ((v1, v2, v3, v4, v5, v6) : CST.parameter)
+    ?(attrs = []) default =
   let v1 =
     (* If present, this is the externally-visible label for this parameter. In
      * this context, the local name will be more relevant, so since we can
@@ -2234,13 +2422,15 @@ and map_parameter (env : env) ((v1, v2, v3, v4, v5, v6) : CST.parameter) default
   in
   let v2 = map_simple_identifier env v2 in
   let v3 = (* ":" *) token env v3 in
-  let v4 =
-    match v4 with
-    | Some x -> map_parameter_modifiers env x |> todo env
-    | None -> ()
+  let attrs =
+    (match v4 with
+    | Some x -> map_parameter_modifiers env x
+    | None -> [])
+    @ attrs
   in
   let v5 = map_possibly_implicitly_unwrapped_type env v5 in
-  let param = G.param_of_id ~pdefault:default ~ptype:(Some v5) v2 in
+  let ptype = Some { v5 with G.t_attrs = attrs @ v5.G.t_attrs } in
+  let param = G.param_of_id ~pdefault:default ~ptype v2 in
   match v6 with
   | Some tok ->
       let dots = (* three_dot_operator_custom *) token env tok in
@@ -2257,30 +2447,36 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : G.expr =
   | `Tuple_exp x -> map_tuple_expression env x
   | `Basic_lit x -> map_basic_literal env x
   | `Lambda_lit x -> map_lambda_literal env x
-  | `Spec_lit x -> map_special_literal env x |> todo env
+  | `Spec_lit x -> map_special_literal env x
   | `Play_lit (v1, v2, v3, v4, v5, v6, v7) ->
       let v1 =
         match v1 with
-        | `HASH_38ce0d0 tok -> (* "#colorLiteral" *) token env tok
-        | `HASH_34ae46a tok -> (* "#fileLiteral" *) token env tok
-        | `HASH_71f9c0e tok -> (* "#imageLiteral" *) token env tok
+        | `HASH_38ce0d0 tok ->
+            (* "#colorLiteral" *)
+            G.OtherExpr (("ColorLiteral", token env tok), [])
+        | `HASH_34ae46a tok ->
+            (* "#fileLiteral" *) G.OtherExpr (("FileLiteral", token env tok), [])
+        | `HASH_71f9c0e tok ->
+            (* "#imageLiteral" *)
+            G.OtherExpr (("ImageLiteral", token env tok), [])
       in
+      let mk_arg ident exp = G.ArgKwd (ident, exp) in
       let v2 = (* "(" *) token env v2 in
       let v3 = map_simple_identifier env v3 in
       let v4 = (* ":" *) token env v4 in
       let v5 = map_expression env v5 in
-      let v6 =
+      let rest =
         Common.map
           (fun (v1, v2, v3, v4) ->
             let v1 = (* "," *) token env v1 in
             let v2 = map_simple_identifier env v2 in
             let v3 = (* ":" *) token env v3 in
             let v4 = map_expression env v4 in
-            todo env (v1, v2, v3, v4))
+            mk_arg v2 v4)
           v6
       in
       let v7 = (* ")" *) token env v7 in
-      todo env (v1, v2, v3, v4, v5, v6, v7)
+      G.Call (v1 |> G.e, (v2, mk_arg v3 v5 :: rest, v7)) |> G.e
   | `Array_lit (v1, v2, v3, v4) ->
       let v1 = (* "[" *) token env v1 in
       let v2 =
@@ -2355,37 +2551,40 @@ and map_primary_expression (env : env) (x : CST.primary_expression) : G.expr =
         | `Tern_exp x -> map_ternary_expression env x
       in
       G.Await (v1, v2) |> G.e
-  | `Refe_op x -> map_referenceable_operator env x |> todo env
+  | `Refe_op x -> map_referenceable_operator env x |> snd |> G.e
   | `Key_path_exp (v1, v2, v3) ->
-      let v1 = (* "\\" *) token env v1 in
-      let v2 =
-        match v2 with
-        | Some x -> (
-            match x with
-            | `Simple_user_type x ->
-                let id, targs = map_simple_user_type env x in
-                let name = H2.name_of_id id in
-                let name = H2.add_type_args_opt_to_name name targs in
-                G.TyN name |> G.t
-            | `Array_type x -> map_array_type env x
-            | `Dict_type x -> map_dictionary_type env x)
-        | None -> todo env ()
-      in
-      let v3 =
-        Common.map
-          (fun (v1, v2) ->
-            let v1 = (* "." *) token env v1 in
-            let v2 = map_key_path_component env v2 in
-            todo env (v1, v2))
-          v3
-      in
-      todo env (v1, v2, v3)
+      (*let v1 = (* "\\" *) token env v1 in
+        let v2 =
+          match v2 with
+          | Some x -> (
+              match x with
+              | `Simple_user_type x ->
+                  let id, targs = map_simple_user_type env x in
+                  let name = H2.name_of_id id in
+                  let name = H2.add_type_args_opt_to_name name targs in
+                  G.TyN name |> G.t
+              | `Array_type x -> map_array_type env x
+              | `Dict_type x -> map_dictionary_type env x)
+          | None -> todo env ()
+        in
+        let v3 =
+          Common.map
+            (fun (v1, v2) ->
+              let v1 = (* "." *) token env v1 in
+              let v2 = map_key_path_component env v2 in
+              todo env (v1, v2))
+            v3
+        in
+        todo env (v1, v2, v3)
+      *)
+      G.StmtExpr (G.Block (G.fake_bracket []) |> G.s) |> G.e
   | `Key_path_str_exp (v1, v2, v3, v4) ->
       let v1 = (* "#keyPath" *) token env v1 in
       let v2 = (* "(" *) token env v2 in
       let v3 = map_expression env v3 in
       let v4 = (* ")" *) token env v4 in
-      todo env (v1, v2, v3, v4)
+      G.Call (G.OtherExpr (("KeyPath", v1), []) |> G.e, (v2, [ G.Arg v3 ], v4))
+      |> G.e
   | `Three_dot_op tok ->
       let tok = (* three_dot_operator_custom *) token env tok in
       if in_pattern env then G.Ellipsis tok |> G.e
@@ -2433,10 +2632,7 @@ and map_protocol_declaration (env : env)
     | None -> None
   in
   let entity = G.basic_entity ~attrs:modifiers ?tparams v3 in
-  let classdef =
-    construct_class_def env ~kind:G.Interface v2 v5 v6 v7 map_protocol_body
-  in
-  G.DefStmt (entity, classdef) |> G.s
+  construct_class_def env ~kind:G.Interface v2 v5 entity v6 v7 map_protocol_body
 
 and map_protocol_member_declaration (env : env)
     (x : CST.protocol_member_declaration) : G.field =
@@ -2453,21 +2649,21 @@ and map_protocol_member_declaration (env : env)
   | `Prot_prop_decl (v1, v2, v3, v4, v5) ->
       let v1 =
         match v1 with
-        | Some x -> map_modifiers env x |> todo env
-        | None -> ()
+        | Some x -> map_modifiers env x
+        | None -> []
       in
       let kinds, pat = map_binding_kind_and_pattern env v2 in
       let pat = apply_pattern_kinds env pat kinds in
-      let entity = entity_of_pattern pat in
+      let entity = entity_of_pattern ~attrs:v1 pat in
+      let tconstraints =
+        match v4 with
+        | Some x -> map_type_constraints env x
+        | None -> []
+      in
       let v3 =
         match v3 with
-        | Some x -> Some (map_type_annotation env x)
+        | Some x -> Some (map_type_annotation ~attrs:tconstraints env x)
         | None -> None
-      in
-      let v4 =
-        match v4 with
-        | Some x -> map_type_constraints env x |> todo env
-        | None -> ()
       in
       (* TODO do something with these *)
       let v5 = map_protocol_property_requirements env v5 in
@@ -2521,15 +2717,7 @@ and map_repeat_while_statement (env : env)
     G.Block (left, stmts, right) |> G.s
   in
   let v5 = (* "while" *) token env v5 in
-  let expr =
-    match map_if_condition_sequence_item env v6 with
-    | Cond expr -> expr
-    (* TODO: For now, `map_if_condition_sequence_item` only returns a `Cond`. I
-       can imagine that the `Avail_cond` might not, when we implement it in the
-       future, however. When that happens, refactor this.
-    *)
-    | _ -> raise Common.Impossible
-  in
+  let expr = map_if_condition_sequence_item env v6 in
   (* TODO: multiple conds *)
   let v7 =
     Common.map
@@ -2539,7 +2727,8 @@ and map_repeat_while_statement (env : env)
         todo env (v1, v2))
       v7
   in
-  G.DoWhile (repeat_tok, stmt, expr) |> G.s
+  let cond = combine_conds expr v7 in
+  G.DoWhile (repeat_tok, stmt, cond) |> G.s
 
 and map_simple_user_type (env : env) ((v1, v2) : CST.simple_user_type) :
     G.ident * G.type_arguments option =
@@ -2602,33 +2791,40 @@ and map_string_literal (env : env) (x : CST.string_literal) : G.expr =
 
 and map_subscript_declaration (env : env)
     ((v1, v2, v3, v4, v5, v6, v7) : CST.subscript_declaration) =
-  let v1 =
+  let v2 = (* "subscript" *) token env v2 in
+  let attrs =
     match v1 with
     | Some x -> map_modifiers env x
-    | None -> todo env ()
+    | None -> []
   in
-  let v2 = (* "subscript" *) token env v2 in
-  let v3 =
+  let tparams =
     match v3 with
     | Some x -> map_type_parameters env x
-    | None -> todo env ()
+    | None -> []
   in
-  let v4 = map_function_value_parameters env v4 in
-  let v5 =
+  let fparams = map_function_value_parameters env v4 in
+  let frettype =
     match v5 with
     | Some (v1, v2) ->
         let v1 = (* arrow_operator_custom *) token env v1 in
         let v2 = map_possibly_implicitly_unwrapped_type env v2 in
-        todo env (v1, v2)
-    | None -> todo env ()
+        Some v2
+    | None -> None
   in
   let v6 =
     match v6 with
     | Some x -> map_type_constraints env x
-    | None -> todo env ()
+    | None -> []
+  in
+  let ent =
+    { G.name = G.OtherEntity (("Subscript", v2), []); attrs; tparams }
   in
   let v7 = map_computed_property env v7 in
-  todo env (v1, v2, v3, v4, v5, v6, v7)
+  G.DefStmt
+    ( ent,
+      G.FuncDef
+        { fkind = (G.Method, v2); fparams; frettype; fbody = G.FBStmt v7 } )
+  |> G.s
 
 and map_switch_entry (env : env) ((v1, v2, v3, v4, v5) : CST.switch_entry) =
   (* These are weird case-specific attributes... probably not important. *)
@@ -2775,46 +2971,53 @@ and map_tuple_type (env : env) ((v1, v2, v3) : CST.tuple_type) =
             (fun (v1, v2) ->
               let v1 = (* "," *) token env v1 in
               let v2 = map_tuple_type_item env v2 in
-              todo env (v1, v2))
+              v2)
             v2
         in
-        todo env (v1, v2)
-    | None -> todo env ()
+        List.map (fun x -> G.F x) (v1 :: v2)
+    | None -> []
   in
   let v3 = (* ")" *) token env v3 in
-  todo env (v1, v2, v3)
+  G.TyRecordAnon ((G.Class, v1), (v1, v2, v3)) |> G.t
 
 and map_tuple_type_item (env : env) ((v1, v2, v3) : CST.tuple_type_item) =
-  let v1 =
+  let ent =
     match v1 with
-    | Some x -> map_tuple_type_item_identifier env x
-    | None -> todo env ()
+    | Some x -> G.basic_entity (map_tuple_type_item_identifier env x)
+    | None ->
+        {
+          G.name =
+            G.OtherEntity (("AnonTupleField", G.fake "AnonTupleField"), []);
+          attrs = [];
+          tparams = [];
+        }
   in
   let v2 =
     match v2 with
-    | Some x -> map_parameter_modifiers env x
-    | None -> todo env ()
+    | Some x -> map_parameter_modifiers env x |> todo env
+    | None -> []
   in
   let v3 = map_type_ env v3 in
-  todo env (v1, v2, v3)
+  G.DefStmt (ent, G.FieldDefColon { vinit = None; vtype = Some v3 }) |> G.s
 
 and map_type_ (env : env) (x : CST.type_) : G.type_ =
   match x with
   | `Opt_type_modifs_unan_type (v1, v2) ->
-      let _v1 =
+      let v1 =
         match v1 with
-        | Some x -> map_type_modifiers env x |> todo env
-        | None -> None
+        | Some x -> map_type_modifiers env x
+        | None -> []
       in
       let v2 = map_unannotated_type env v2 in
       (* TODO include type modifiers *)
-      v2
+      { v2 with G.t_attrs = v1 @ v2.G.t_attrs }
   | `Semg_ellips tok -> (* "..." *) token env tok |> todo env
 
-and map_type_annotation (env : env) ((v1, v2) : CST.type_annotation) : G.type_ =
+and map_type_annotation (env : env) ?(attrs = [])
+    ((v1, v2) : CST.type_annotation) : G.type_ =
   let v1 = (* ":" *) token env v1 in
   let v2 = map_possibly_implicitly_unwrapped_type env v2 in
-  v2
+  map_type_with_modifiers env v2 attrs
 
 and map_type_arguments (env : env) ((v1, v2, v3, v4) : CST.type_arguments) :
     G.type_arguments =
@@ -2837,17 +3040,26 @@ and map_type_constraint (env : env) (x : CST.type_constraint) =
       let v2 = map_identifier env v2 in
       let v3 = (* ":" *) token env v3 in
       let v4 = map_possibly_implicitly_unwrapped_type env v4 in
-      todo env (v1, v2, v3, v4)
+      let base_type = G.ArgType (G.TyN (H2.name_of_ids v2) |> G.t) in
+      let conformed_protocol = G.ArgType v4 in
+      G.NamedAttr
+        ( v3,
+          H2.name_of_id ("ConformsTo", v3),
+          G.fake_bracket [ base_type; conformed_protocol ] )
   | `Equa_cons (v1, v2, v3, v4) ->
       let v1 = Common.map (map_attribute env) v1 in
       let v2 = map_identifier env v2 in
+      let first_type = G.ArgType (G.TyN (H2.name_of_ids v2) |> G.t) in
       let v3 =
         match v3 with
         | `Equal_sign tok -> (* eq_custom *) token env tok
         | `Eq_eq tok -> (* eq_eq_custom *) token env tok
       in
       let v4 = map_type_ env v4 in
-      todo env (v1, v2, v3, v4)
+      G.NamedAttr
+        ( v3,
+          H2.name_of_id ("EqualTypes", v3),
+          G.fake_bracket [ first_type; G.ArgType v4 ] )
 
 and map_type_constraints (env : env) ((v1, v2, v3) : CST.type_constraints) =
   let v1 = (* where_keyword *) token env v1 in
@@ -2857,10 +3069,10 @@ and map_type_constraints (env : env) ((v1, v2, v3) : CST.type_constraints) =
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
         let v2 = map_type_constraint env v2 in
-        todo env (v1, v2))
+        v2)
       v3
   in
-  todo env (v1, v2, v3)
+  v2 :: v3
 
 and map_type_level_declaration (env : env) (x : CST.type_level_declaration) :
     G.stmt list =
@@ -2876,7 +3088,7 @@ and map_type_level_declaration (env : env) (x : CST.type_level_declaration) :
       | `Deinit_decl x -> [ map_deinit_declaration env x ]
       | `Subs_decl x -> [ map_subscript_declaration env x ]
       | `Op_decl x -> [ map_operator_declaration env x ]
-      | `Prec_group_decl x -> map_precedence_group_declaration env x
+      | `Prec_group_decl x -> [ map_precedence_group_declaration env x ]
       | `Asso_decl x -> [ map_associatedtype_declaration env x ])
   | `Semg_ellips tok (* "..." *) ->
       let tok = (* three_dot_operator_custom *) token env tok in
@@ -2890,8 +3102,8 @@ and map_type_parameter (env : env) (x : CST.type_parameter) =
   | `Opt_type_param_modifs_simple_id_opt_COLON_type (v1, v2, v3) ->
       let v1 =
         match v1 with
-        | Some x -> map_type_parameter_modifiers env x |> todo env
-        | None -> ()
+        | Some x -> map_type_parameter_modifiers env x
+        | None -> []
       in
       let v2 = map_simple_identifier env v2 in
       let v3 =
@@ -2902,7 +3114,7 @@ and map_type_parameter (env : env) (x : CST.type_parameter) =
             [ v2 ]
         | None -> []
       in
-      G.tparam_of_id ~tp_bounds:v3 v2
+      G.tparam_of_id ~tp_attrs:v1 ~tp_bounds:v3 v2
   | `Semg_ellips tok -> (* "..." *) token env tok |> todo env
 
 and map_type_parameter_modifiers (env : env) (xs : CST.type_parameter_modifiers)
@@ -2925,13 +3137,12 @@ and map_type_parameters (env : env) ((v1, v2, v3, v4) : CST.type_parameters) =
 
 and map_typealias_declaration (env : env) ((v1, v2) : CST.typealias_declaration)
     =
-  let v1 =
+  let modifiers =
     match v1 with
-    | Some x -> map_modifiers env x |> todo env
-    | None -> ()
+    | Some x -> map_modifiers env x
+    | None -> []
   in
-  let v2 = map_modifierless_typealias_declaration env v2 in
-  v2
+  map_modifierless_typealias_declaration env modifiers v2
 
 and map_unannotated_type (env : env) (x : CST.unannotated_type) =
   match x with
@@ -2955,14 +3166,19 @@ and map_unannotated_type (env : env) (x : CST.unannotated_type) =
       let v2 = (* "." *) token env v2 in
       let v3 =
         match v3 with
-        | `Type tok -> (* "Type" *) token env tok
-        | `Prot tok -> (* "Protocol" *) token env tok
+        | `Type tok ->
+            (* "Type" *) G.unhandled_keywordattr ("Type", token env tok)
+        | `Prot tok ->
+            (* "Protocol" *) G.unhandled_keywordattr ("Protocol", token env tok)
       in
-      todo env (v1, v2, v3)
+      { v1 with G.t_attrs = v3 :: v1.G.t_attrs }
   | `Opaque_type (v1, v2) ->
       let v1 = (* "some" *) token env v1 in
       let v2 = map_user_type env v2 in
-      todo env (v1, v2)
+      {
+        v2 with
+        G.t_attrs = G.unhandled_keywordattr ("Some", v1) :: v2.G.t_attrs;
+      }
   | `Prot_comp_type (v1, v2) ->
       let v1 = map_unannotated_type env v1 in
       let v2 =
@@ -3003,17 +3219,22 @@ and map_unary_expression (env : env) (x : CST.unary_expression) : G.expr =
   | `Sele_exp (v1, v2, v3, v4, v5) ->
       let v1 = (* "#selector" *) token env v1 in
       let v2 = (* "(" *) token env v2 in
-      let v3 =
+      let add_label expr =
         match v3 with
-        | Some x -> (
-            match x with
-            | `Gett tok -> (* "getter:" *) token env tok
-            | `Sett tok -> (* "setter:" *) token env tok)
-        | None -> todo env ()
+        | Some x ->
+            (match x with
+            | `Gett tok ->
+                (* "getter:" *)
+                G.OtherExpr (("Getter", token env tok), [ G.E expr ])
+            | `Sett tok ->
+                (* "setter:" *)
+                G.OtherExpr (("Setter", token env tok), [ G.E expr ]))
+            |> G.e
+        | None -> expr
       in
-      let v4 = map_expression env v4 in
-      let v5 = (* ")" *) token env v5 in
-      todo env (v1, v2, v3, v4, v5)
+      G.OtherExpr
+        (("Selector", v1), [ G.E (map_expression env v4 |> add_label) ])
+      |> G.e
   | `Open_start_range_exp (v1, v2) ->
       let v1 = map_range_operator env v1 in
       let v2 = map_expression env v2 in
@@ -3049,7 +3270,7 @@ and map_value_argument (env : env) ((v1, v2) : CST.value_argument) :
     G.argument list =
   let v1 =
     match v1 with
-    | Some x -> Some (map_type_modifiers env x) |> todo env
+    | Some x -> Some (map_type_modifiers env x)
     | None -> None
   in
   let v2 =
@@ -3106,18 +3327,17 @@ and map_where_clause (env : env) ((v1, v2) : CST.where_clause) =
 and map_while_statement (env : env)
     ((v1, v2, v3, v4, v5, v6) : CST.while_statement) =
   let while_tok = (* "while" *) token env v1 in
-  let cond = map_if_condition_sequence_item env v2 in
   (* TODO: As with if: looks like we could desugar this to a bunch of And expressions, but
      * need to double-check semantics. For now just raise if we encounter this.
      * *)
-  let _v3 =
+  let v3 =
     Common.map
       (fun (v1, v2) ->
         let v1 = (* "," *) token env v1 in
-        let v2 = map_if_condition_sequence_item env v2 in
-        todo env (v1, v2))
+        map_if_condition_sequence_item env v2)
       v3
   in
+  let cond = combine_conds (map_if_condition_sequence_item env v2) v3 in
   let stmt =
     let left = (* "{" *) token env v4 in
     let right = (* "}" *) token env v6 in
@@ -3128,7 +3348,7 @@ and map_while_statement (env : env)
     in
     G.Block (left, stmts, right) |> G.s
   in
-  G.While (while_tok, cond, stmt) |> G.s
+  G.While (while_tok, G.Cond cond, stmt) |> G.s
 
 let map_global_declaration (env : env) (x : CST.global_declaration) :
     G.stmt list =
@@ -3140,7 +3360,7 @@ let map_global_declaration (env : env) (x : CST.global_declaration) :
   | `Class_decl x -> [ map_class_declaration env x ]
   | `Prot_decl x -> [ map_protocol_declaration env x ]
   | `Op_decl x -> [ map_operator_declaration env x ]
-  | `Prec_group_decl x -> map_precedence_group_declaration env x
+  | `Prec_group_decl x -> [ map_precedence_group_declaration env x ]
   | `Asso_decl x -> [ map_associatedtype_declaration env x ]
 
 let map_top_level_statement (env : env) (x : CST.top_level_statement)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -2886,7 +2886,7 @@ and map_tuple_type (env : env) ((v1, v2, v3) : CST.tuple_type) =
               v2)
             v2
         in
-        List.map (fun x -> G.F x) (v1 :: v2)
+        Common.map (fun x -> G.F x) (v1 :: v2)
     | None -> []
   in
   let v3 = (* ")" *) token env v3 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -1873,9 +1873,7 @@ and map_lambda_parameter (env : env) ((v1, v2) : CST.lambda_parameter) :
         (* TODO As with `map_parameter`, we only support internal names right now. *)
         let _v1 =
           match v1 with
-          | Some x ->
-              map_simple_identifier env x |> ignore;
-              ()
+          | Some x -> map_simple_identifier env x |> todo env
           | None -> ()
         in
         let v2 = map_simple_identifier env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -630,8 +630,7 @@ let map_non_constructor_function_decl (env : env)
     | `Refe_op x -> map_referenceable_operator env x |> fst
     | `Bitw_bin_op x ->
         (* Maybe come back and do this better? *)
-        let _, (s, tok) = map_bitwise_binary_operator env x in
-        (s, tok)
+        map_bitwise_binary_operator env x |> snd
   in
   v2
 
@@ -653,6 +652,7 @@ let map_availability_argument (env : env) (x : CST.availability_argument) =
   (* This does not seem important semantically.
      Availability arguments just allow code to be annotated with its availability
      with respect to certain macOS (and related) versions.
+     https://docs.swift.org/swift-book/ReferenceManual/Statements.html#grammar_availability-condition
   *)
   match x with
   | `Id_int_lit_rep_DOT_int_lit (v1, v2, v3) ->
@@ -2933,7 +2933,6 @@ and map_type_ (env : env) (x : CST.type_) : G.type_ =
         | None -> []
       in
       let v2 = map_unannotated_type env v2 in
-      (* TODO include type modifiers *)
       { v2 with G.t_attrs = v1 @ v2.G.t_attrs }
   | `Semg_ellips tok -> (* "..." *) token env tok |> todo env
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -962,6 +962,9 @@ and map_bodyless_function_declaration (env : env) ~in_class
     | Some x -> map_modifiers env x
     | None -> []
   in
+  (* I'm not sure this does anything. "class" is already a possible modifier
+     from the `map_modifiers` - it's a property modifier.
+  *)
   let v2 =
     match v2 with
     | Some tok -> (* "class" *) token env tok |> todo env

--- a/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml
@@ -589,6 +589,9 @@ and map_enum_entry_suffix_union (env : env) (ident : G.ident)
       let fields =
         match v2 with
         | Some (v1, v2, v3, v4) ->
+            (* This is like how CPP does it. If there's no name, the entity just
+               has an anonymous name.
+            *)
             let mk_field id_opt ty expr_opt =
               let name =
                 match id_opt with
@@ -616,6 +619,9 @@ and map_enum_entry_suffix_union (env : env) (ident : G.ident)
       G.TyRecordAnon ((G.Class, v1), (v1, fields, v3)) |> G.t
   | `Equal_sign_exp (v1, v2) -> raise Common.Impossible
 
+(* Similarly to how Java handles enum fields, each are parsed as an
+   EnumEntryDef.
+*)
 and map_enum_entry_suffix_raw (env : env) (ent : G.entity)
     (x : CST.enum_entry_suffix) : G.stmt =
   match x with
@@ -1187,7 +1193,9 @@ and map_enum_class_body (is_raw : bool) (enum_ident : G.ident) (env : env)
       fields
     else
       (* Get all of the enum variants, and put them at the front as an OrType declaration.
-     *)
+         This is because we can't really leave them strewn about and preserve ordering, if we're
+         gonna put them in an OrType.
+      *)
       let collect_entries entries =
         List.fold_right
           (fun entry (variants, decls) ->

--- a/semgrep-core/tests/swift/parsing/expressions.swift
+++ b/semgrep-core/tests/swift/parsing/expressions.swift
@@ -27,6 +27,15 @@ named(bar: baz:);
 // TODO figure out the type modifier part of a value argument
 
 closure { x in x };
+{ @foo [ self, x, y = 3]
+(self, name, externalname realname : inout @escaping @autoclosure Int ) -> Int in
+return 2
+};
+
+{ @foo [ self, x, y = 3]
+self, name, externalname realname : inout @escaping @autoclosure Int -> Int in
+return 2
+};
 
 // TODO this used to lead the parser into an infinite loop in CI. Test that it's
 // correctly parsed, even though that issue has been mitigated.
@@ -100,10 +109,9 @@ Thing<Int, String>.foo;
 
 // Selector expressions:
 
-// TODO handle selector expressions
-// #selector(5);
-// #selector(getter: 4);
-// #selector(setter: 4);
+#selector(5);
+#selector(getter: 4);
+#selector(setter: 4);
 
 // Open start range expressions:
 
@@ -233,7 +241,20 @@ nil;
 ({ x in x });
 ({});
 
-// TODO Special literals
+// Special literals
+#file;
+#fileID;
+#filePath;
+#line;
+#column;
+#function;
+#dsohandle;
+#colorLiteral(x : 5, y : 2);
+#fileLiteral(x : 5);
+#imageLiteral(x : 5);
+#keyPath(2 + 3);
+
+
 // TODO Playground literals
 
 // Array literals
@@ -297,3 +318,26 @@ foo?.bar;
 // aysnc ?
 
 async
+
+// Operators
+++;
+--;
+1 < 2;
+1 > 2;
+1 <= 2;
+1 >= 2;
+1 + 2;
+1 * 2;
+1 != 2;
+1 !== 2;
+1 === 2;
+1 == 2;
+!2;
+~2;
+
+// Declarations with operator names
+func +() {}
+func *() {}
+func ==() {}
+func /() {}
+func >>=() {}

--- a/semgrep-core/tests/swift/parsing/expressions.swift
+++ b/semgrep-core/tests/swift/parsing/expressions.swift
@@ -28,12 +28,12 @@ named(bar: baz:);
 
 closure { x in x };
 { @foo [ self, x, y = 3]
-(self, name, externalname realname : inout @escaping @autoclosure Int ) -> Int in
+(self, name, realname : inout @escaping @autoclosure Int ) -> Int in
 return 2
 };
 
 { @foo [ self, x, y = 3]
-self, name, externalname realname : inout @escaping @autoclosure Int -> Int in
+self, name, realname : inout @escaping @autoclosure Int -> Int in
 return 2
 };
 

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -105,6 +105,37 @@ extension bar { }
 
 // TODO test other varieties
 enum baz { }
+enum Error: Int {
+    case a = 1
+    case b
+}
+enum Error: String {
+    case a = "hi"
+    case b
+}
+enum Error: Character {
+    case a = "h"
+    case b
+}
+enum Error: Float {
+    case a = 0.0
+    func foo() { return 2 }
+    case b
+}
+enum SumType {
+  case a(Int, String)
+  case b
+}
+enum SumType<T> {
+  case a(Int, String)
+  case b(T)
+}
+enum SumTypeWithNames<T> {
+  case a(x: Int, String)
+  func foo() { return 2 }
+  case b(z: T)
+  case c(i: Int, Int, k: Character)
+}
 
 // For-in loops
 for x in collection {

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -36,6 +36,16 @@ var foo = 1;
 var bar: Int = 2;
 var baz: Int;
 
+var x {
+  var x = 2
+  var y = 3
+}
+
+var y { }
+
+// Type
+var x : Int? = 1
+
 // TODO computed variables
 // var computed: Int {
 //     get { 4 }
@@ -62,6 +72,28 @@ func foo(x y: Int) { }
 // func foo(x: inout Int) { }
 func foo(x: Int = 5) { }
 func foo(x: Int...) { }
+
+infix func foo() { }
+postfix func foo() { }
+prefix func foo() { }
+mutating func foo() { }
+nonmutating func foo() { }
+private func foo() { }
+public func foo() { }
+open func foo() { }
+fileprivate func foo() { }
+internal func foo() { }
+private(set) func foo() { }
+public(set) func foo() { }
+open(set) func foo() { }
+fileprivate(set) func foo() { }
+internal(set) func foo() { }
+@attr func foo ( ) { }
+
+infix postfix prefix mutating nonmutating private public open fileprivate 
+internal private(set) public(set) open(set) fileprivate(set) internal(set) 
+@attr 
+func foo () { }
 // TODO
 // func foo() throws { }
 // func foo() throws -> Int { }
@@ -93,6 +125,11 @@ class bar: foo { }
 class bar: foo, baz, asdf { }
 class foo<bar, baz> { }
 class foo<bar: baz> { }
+
+infix postfix prefix mutating nonmutating private public open fileprivate 
+internal private(set) public(set) open(set) fileprivate(set) internal(set) 
+@attr 
+class foo { }
 // TODO
 // class foo<bar> where bar: baz { }
 // class foo<bar> where bar: baz, bar: asdf { }
@@ -101,6 +138,11 @@ class foo<bar: baz> { }
 struct foo { }
 
 // TODO test other varieties
+infix postfix prefix mutating nonmutating private public open fileprivate 
+internal private(set) public(set) open(set) fileprivate(set) internal(set) 
+@attr 
+extension bar { }
+
 extension bar { }
 
 // TODO test other varieties
@@ -136,6 +178,11 @@ enum SumTypeWithNames<T> {
   case b(z: T)
   case c(i: Int, Int, k: Character)
 }
+
+infix postfix prefix mutating nonmutating private public open fileprivate 
+internal private(set) public(set) open(set) fileprivate(set) internal(set) 
+@attr indirect 
+enum bar { }
 
 // For-in loops
 for x in collection {
@@ -201,6 +248,13 @@ switch foo {
   case _:
     return 3
   default:
+}
+
+switch foo {
+  case true, false:
+    return 1
+  case true where true, false:
+    return 2
 }
 
 // Protocol

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -251,7 +251,8 @@ switch foo {
 }
 
 switch foo {
-  case true, false:
+  // Literal patterns
+  case 1, 2:
     return 1
   case true where true, false:
     return 2

--- a/semgrep-core/tests/swift/parsing/statements.swift
+++ b/semgrep-core/tests/swift/parsing/statements.swift
@@ -15,6 +15,9 @@ import protocol foo;
 import let foo;
 import var foo;
 import func foo;
+infix postfix prefix mutating nonmutating private public open fileprivate 
+internal private(set) public(set) open(set) fileprivate(set) internal(set) 
+import foo;
 
 // Constant
 
@@ -42,34 +45,51 @@ var x {
 }
 
 var y { }
+var x {
+  get { return 2 }
+  _modify { }
+  set { return () }
+}
+var x {
+  var y = 3
+  get { return 2 }
+  set (setter_name) { return () }
+  _modify { }
+}
+
+// Closures
+var x =
+  { @foo [ self, x, y = 3]
+    return 2
+  }
+var x =
+  { @foo(x : 3 + 4, 5, long:thing:here:, name 5 . 0 . 2 . 3) [ self, x, y = 3]
+    return 2
+  }
 
 // Type
 var x : Int? = 1
 
-// TODO computed variables
-// var computed: Int {
-//     get { 4 }
-//     set { }
-// }
-
 // Typealias
-
-// TODO include modifiers
 typealias foo = bar;
 typealias foo<baz> = bar;
+infix postfix prefix mutating nonmutating private public open fileprivate 
+internal private(set) public(set) open(set) fileprivate(set) internal(set) 
 typealias foo<baz: Int> = bar;
+
+// Associated types
+associatedtype foo : Protocol where foo : Bar = Int
+associatedtype foo : Protocol where foo == Bar = Int
 
 // Function
 
-// TODO include modifiers
 func foo() { }
 func foo() -> Int { return 5; }
 func foo(x: Int, y: Int) { }
 func foo(_: Int) { }
 func foo(_ x: Int) { }
 func foo(x y: Int) { }
-// TODO
-// func foo(x: inout Int) { }
+func foo(x: inout Int) { }
 func foo(x: Int = 5) { }
 func foo(x: Int...) { }
 
@@ -94,13 +114,15 @@ infix postfix prefix mutating nonmutating private public open fileprivate
 internal private(set) public(set) open(set) fileprivate(set) internal(set) 
 @attr 
 func foo () { }
-// TODO
-// func foo() throws { }
-// func foo() throws -> Int { }
-// func foo(f: () throws -> void) rethrows { }
-// func foo() async { }
-// func foo() async -> Int { return 5; }
-// func foo() async throws { }
+func foo() throws { }
+func foo() throws -> Int { }
+func foo(f: () throws -> void) rethrows { }
+func foo() async { }
+func foo() async -> Int { return 5; }
+func foo() async throws { }
+
+// deinit 
+deinit {}
 
 // Class etc.
 
@@ -119,6 +141,7 @@ class foo {
     class cla { }
     protocol prot { }
     deinit { }
+    associatedtype foo 
     // TODO others
 }
 class bar: foo { }
@@ -130,9 +153,8 @@ infix postfix prefix mutating nonmutating private public open fileprivate
 internal private(set) public(set) open(set) fileprivate(set) internal(set) 
 @attr 
 class foo { }
-// TODO
-// class foo<bar> where bar: baz { }
-// class foo<bar> where bar: baz, bar: asdf { }
+class foo<bar> where bar: baz { }
+class foo<bar> where bar: baz, bar: asdf { }
 
 // TODO test other varieties
 struct foo { }
@@ -145,7 +167,6 @@ extension bar { }
 
 extension bar { }
 
-// TODO test other varieties
 enum baz { }
 enum Error: Int {
     case a = 1
@@ -177,6 +198,10 @@ enum SumTypeWithNames<T> {
   func foo() { return 2 }
   case b(z: T)
   case c(i: Int, Int, k: Character)
+}
+indirect enum RecursiveType<T> {
+  case Base
+  indirect case Recur(RecursiveType, T, RecursiveType)
 }
 
 infix postfix prefix mutating nonmutating private public open fileprivate 
@@ -230,6 +255,14 @@ if true {}
 if true {} else {}
 if async let x = true {} else {}
 if case x = true {} else if case x = false {} else {}
+if #available(things2) {}
+if #available(things 1 . 2 . 3) {}
+if #available(things 2 . 3) {}
+if #available(*) {}
+
+// Guard statements
+guard true else {}
+guard async let x = true else {}
 
 // Switch statements
 switch foo {
@@ -256,6 +289,19 @@ switch foo {
     return 1
   case true where true, false:
     return 2
+  // Type casting patterns
+  case foo as Int: 
+    return 1
+  case is Int:
+    return 2
+}
+
+// Precedence group
+precedencegroup foo { } 
+precedencegroup foo {
+  bar : x
+  baz : argh
+  bank : true
 }
 
 // Protocol
@@ -276,8 +322,7 @@ protocol foo {
 protocol foo<T> { }
 protocol foo: bar { }
 protocol foo: bar, baz { }
-// TODO
-// protocol foo<T> where T: bar { }
+protocol foo<T> where T: bar { }
 
 foo: if 1 < 150 {
 }


### PR DESCRIPTION
**What:**
Added functionality for parsing Swift enums into the generic AST, along with modifiers, optional types, and literal patterns.

Then I also added most other things.

**Why:**
I pulled up a random Swift repo on Github, and the first thing that failed was that we couldn't parse enums. It's probably a healthy reason for why our parse rate is so abysmal - imagine trying to parse a random OCaml project without `type`.

I also went through more repos and found we couldn't parse them because of heavy use of modifiers like `public`, `private`, decorators, etc. I also found some other miscellaneous things like optional type sugar and casing on literals, so I fixed those too.

**How:**

----------------------------------------------------------------------------------------------------

**Enums:**

I went and handled the TODOs.

It's worth noting that Swift has both C-style enums where each variant is just an alias for some base-type constant, _and_ ML-style sum types. The real terrible thing going on here is that they both use the `enum` syntax.

For raw-style enums, I've mostly followed how Java does them, in that each `enum` entry defines an `EnumEntryDef`. For instance:
```swift
enum Foo: Int {
  case a = 1
  case b
}
```
parses to
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("Foo", ()),
                {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[KeywordAttr((EnumClass, ()))]; tparams=[]; },
      ClassDef(
        {ckind=(Class, ());
         cextends=[({t_attrs=[];
                     t=TyN(
                         Id(("Int", ()),
                           {id_info_id=2; id_hidden=false; id_resolved=Ref(
                            None); id_type=Ref(None); id_svalue=Ref(None); }));
                     },
                    None)];
         cimplements=[]; cmixins=[]; cparams=[];
         cbody=[F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("a", ()),
                               {id_info_id=3; id_hidden=false; id_resolved=Ref(
                                None); id_type=Ref(None); id_svalue=Ref(
                                None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef({ee_args=Some([Arg(L(Int((Some(1), ()))))]); ee_body=None; }))));
                F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("b", ()),
                               {id_info_id=4; id_hidden=false; id_resolved=Ref(
                                None); id_type=Ref(None); id_svalue=Ref(
                                None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef({ee_args=None; ee_body=None; }))))];
         })))])
```

Notably, this allows intermingling of regular fields with the actual enums themselves. This is intended.

What we're doing right now is that we just parse each as an `EnumEntryDef` anyways, even though it's not raw-style, and actually works as part of a sum type. This lets it intermingle with the other fields in the class.

Here's an example of parsing a union-style enum:
```
enum Foo {
  case a(Int)
  case b
}
```
goes to
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("Foo", ()),
                {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[KeywordAttr((EnumClass, ()))]; tparams=[]; },
      ClassDef(
        {ckind=(Class, ()); cextends=[]; cimplements=[]; cmixins=[]; cparams=[
         ];
         cbody=[F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("a", ()),
                               {id_info_id=2; id_hidden=false; id_resolved=Ref(
                                None); id_type=Ref(None); id_svalue=Ref(
                                None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef(
                       {
                        ee_args=Some([ArgType(
                                        {t_attrs=[];
                                         t=TyRecordAnon((Class, ()),
                                             [F(
                                                DefStmt(
                                                  ({name=OtherEntity(("AnonTupleField", ()), []); attrs=[]; tparams=[]; },
                                                   FieldDefColon(
                                                     {vinit=None;
                                                      vtype=Some({t_attrs=[
                                                                  ];
                                                                  t=TyN(
                                                                    Id((
                                                                    "Int", ()),
                                                                    {id_info_id=3; id_hidden=false;
                                                                    id_resolved=Ref(
                                                                    None); id_type=Ref(
                                                                    None); id_svalue=Ref(
                                                                    None); }));
                                                                  });
                                                      }))))]);
                                         })]);
                        ee_body=None; }))));
                F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("b", ()),
                               {id_info_id=4; id_hidden=false; id_resolved=Ref(
                                None); id_type=Ref(None); id_svalue=Ref(
                                None); }));
                      attrs=[]; tparams=[]; },
                     EnumEntryDef({ee_args=None; ee_body=None; }))))];
         })))])
```

----------------------------------------------------------------------------------------------------

Here's some decisions I made for other stuff:

**Modifiers:** 

For modifiers, here's the dump on the choices I made. Consider a:
```swift
infix postfix prefix mutating nonmutating private public open fileprivate
internal private(set) public(set) open(set) fileprivate(set) internal(set)
weak unowned unowned(safe) unowned(unsafe) final override convenience required
static dynamic optional class inout @escaping @autoclosure lazy
@attr
func foo () { }
```
which is a common code pattern that Swift developers write in their everyday code.

This parses as:
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("foo", ()),
                {id_info_id=18; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[NamedAttr((),
                Id(("Infix", ()),
                  {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]);
              NamedAttr((),
                Id(("Postfix", ()),
                  {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]);
              NamedAttr((),
                Id(("Prefix", ()),
                  {id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]);
              NamedAttr((),
                Id(("Mutating", ()),
                  {id_info_id=4; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]);
              NamedAttr((),
                Id(("Nonmutating", ()),
                  {id_info_id=5; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]); KeywordAttr((Private, ())); KeywordAttr((Public, ()));
              KeywordAttr((Public, ())); KeywordAttr((Public, ())); KeywordAttr((Protected, ()));
              OtherAttribute(("Set", ()), [At(KeywordAttr((Private, ())))]);
              OtherAttribute(("Set", ()), [At(KeywordAttr((Public, ())))]);
              OtherAttribute(("Set", ()), [At(KeywordAttr((Public, ())))]);
              OtherAttribute(("Set", ()), [At(KeywordAttr((Public, ())))]);
              OtherAttribute(("Set", ()), [At(KeywordAttr((Protected, ())))]);
              NamedAttr((),
                Id(("Weak", ()),
                  {id_info_id=6; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]);
              NamedAttr((),
                Id(("Unowned", ()),
                  {id_info_id=7; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]);
              NamedAttr((),
                Id(("UnownedSafe", ()),
                  {id_info_id=8; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]);
              NamedAttr((),
                Id(("UnownedUnsafe", ()),
                  {id_info_id=9; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ]); KeywordAttr((Final, ())); KeywordAttr((Override, ()));
              NamedAttr((),
                Id(("Convenience", ()),
                  {id_info_id=10; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                []);
              NamedAttr((),
                Id(("Required", ()),
                  {id_info_id=11; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                []); KeywordAttr((Static, ()));
              NamedAttr((),
                Id(("Dynamic", ()),
                  {id_info_id=12; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                []); KeywordAttr((Optional, ()));
              NamedAttr((),
                Id(("Class", ()),
                  {id_info_id=13; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                []);
              NamedAttr((),
                Id(("Inout", ()),
                  {id_info_id=14; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                []);
              NamedAttr((),
                Id(("Escaping", ()),
                  {id_info_id=15; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                []);
              NamedAttr((),
                Id(("Autoclosure", ()),
                  {id_info_id=16; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                []); KeywordAttr((Lazy, ()));
              NamedAttr((),
                Id(("attr", ()),
                  {id_info_id=17; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }),
                [])];
       tparams=[]; },
      FuncDef({fkind=(Function, ()); fparams=[]; frettype=None; fbody=FBStmt(Block([])); })))])
```

The important thing to note is that for most of these, we don't have a matching `KeywordAttr` that describes them, so I just made them `NamedAttr`s.

For the access modifiers `public`, `private`, `fileprivate`, `open`, and `internal`, it's a little more complicated. Those modifiers are described [here](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html).

`open` and `public` allow code to be used throughout any file, and only differ in subclassing behavior, so I've made them both `Public`. I figure that we don't really care about name resolution for subclassing at the moment.

`fileprivate` only allows access within the current file, and since Semgrep only does single-file analysis right now, I marked that as `Public` too.

`internal` only allows access from within the defining module, and I wasn't sure of how that interacts with subclassing. Because of that, by analogy to Java, I just marked it as `Protected` behavior to me.

`private` is the most private setting, so it's `Private`. It doesn't allow usage outside of the current declaration.

Also worth noting is that each of these access levels has a suffix `(set)` that may be added, to denote that it is only a modifier on the setting privileges of these variables. I decided to just inject it into an `OtherAttr`, which wraps the particular access level attribute.

It's worth noting that there isn't really anything distinguishing a Swift attribute (something like `@attr`) from a non-Swift attribute which is named `attr`.

----------------------------------------------------------------------------------------------------

**Switches and Patterns:**

Here's also an example of a `switch` using a `where` clause, along with a literal pattern:
```swift
switch true {
  case 1:
    var x = 2
  case true where true == true, 2:
    var x = 2
}
```
goes to
```
Pr(
  [Switch((), Some(Cond(L(Bool((true, ()))))),
     [CasesAndBody([Case((), PatLiteral(Int((Some(1), ()))))],
        Block(
          [DefStmt(
             ({
               name=EN(
                      Id(("x", ()),
                        {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
               attrs=[NamedAttr((),
                        Id(("Var", ()),
                          {id_info_id=1; id_hidden=false; id_resolved=Ref(
                           None); id_type=Ref(None); id_svalue=Ref(None); }), [
                        ])];
               tparams=[]; },
              VarDef({vinit=Some(L(Int((Some(2), ())))); vtype=None; })))]));
      CasesAndBody(
        [Case((),
           PatDisj(
             PatWhen(PatLiteral(Bool((true, ()))),
               Call(IdSpecial((Op(Eq), ())), [Arg(L(Bool((true, ())))); Arg(L(Bool((true, ()))))])),
             PatLiteral(Int((Some(2), ())))))],
        Block(
          [DefStmt(
             ({
               name=EN(
                      Id(("x", ()),
                        {id_info_id=4; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
               attrs=[NamedAttr((),
                        Id(("Var", ()),
                          {id_info_id=3; id_hidden=false; id_resolved=Ref(
                           None); id_type=Ref(None); id_svalue=Ref(None); }), [
                        ])];
               tparams=[]; },
              VarDef({vinit=Some(L(Int((Some(2), ())))); vtype=None; })))]))])])
```

I just used `PatLiteral` and `PatWhen` here. I also turned all the comma-separated patterns into `PatDisj`s, because they seem to be disjunctive patterns.

It's also interesting to note that the tree-sitter parser for Swift is wrong. It only allows `where` clauses on the first disjunctive pattern, but it's actually possible to have them on all of them. Swift playground confirms this. This makes me mildly upset, get off my lawn, grrr.

----------------------------------------------------------------------------------------------------

**Question Mark Types:**

I also implemented support for optional type syntactic sugar. So for instance:
```swift
var x : Int? = 2
```
goes to
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("x", ()),
                {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[NamedAttr((),
                Id(("Var", ()),
                  {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }), [
                ])];
       tparams=[]; },
      VarDef(
        {vinit=Some(L(Int((Some(2), ()))));
         vtype=Some({t_attrs=[];
                     t=TyQuestion((),
                         {t_attrs=[];
                          t=TyN(
                              Id(("Int", ()),
                                {id_info_id=3; id_hidden=false; id_resolved=Ref(
                                 None); id_type=Ref(None); id_svalue=Ref(
                                 None); }));
                          });
                     });
         })))])
```

(I used `TyQuestion`, which was conveniently existent)

----------------------------------------------------------------------------------------------------
**Closures**:

Probably the next most important thing I did was for closures.

So for instance, the closure
```
{ @foo [ self, x, y = 3]
(self, name, externalname realname : inout @escaping @autoclosure Int ) -> Int in
return 2
};
```
parses to

```
Pr(
  [ExprStmt(
     Lambda(
       {fkind=(LambdaKind, ());
        fparams=[OtherParam(("Self", ()), []);
                 Param(
                   {pname=Some(("name", ())); pdefault=None; ptype=None; pattrs=[
                    ];
                    pinfo={id_info_id=6; id_hidden=false; id_resolved=Ref(
                           Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                           None); };
                    });
                 Param(
                   {pname=Some(("realname", ())); pdefault=None;
                    ptype=Some({
                                t_attrs=[NamedAttr((),
                                           Id(("Inout", ()),
                                             {id_info_id=7; id_hidden=false; id_resolved=Ref(
                                              None); id_type=Ref(None); id_svalue=Ref(
                                              None); }), []);
                                         NamedAttr((),
                                           Id(("Escaping", ()),
                                             {id_info_id=8; id_hidden=false; id_resolved=Ref(
                                              None); id_type=Ref(None); id_svalue=Ref(
                                              None); }), []);
                                         NamedAttr((),
                                           Id(("Autoclosure", ()),
                                             {id_info_id=9; id_hidden=false; id_resolved=Ref(
                                              None); id_type=Ref(None); id_svalue=Ref(
                                              None); }), [])];
                                t=TyN(
                                    Id(("Int", ()),
                                      {id_info_id=10; id_hidden=false; id_resolved=Ref(
                                       None); id_type=Ref(None); id_svalue=Ref(
                                       None); }));
                                });
                    pattrs=[NamedAttr((),
                              Id(("Inout", ()),
                                {id_info_id=7; id_hidden=false; id_resolved=Ref(
                                 None); id_type=Ref(None); id_svalue=Ref(
                                 None); }), []);
                            NamedAttr((),
                              Id(("Escaping", ()),
                                {id_info_id=8; id_hidden=false; id_resolved=Ref(
                                 None); id_type=Ref(None); id_svalue=Ref(
                                 None); }), []);
                            NamedAttr((),
                              Id(("Autoclosure", ()),
                                {id_info_id=9; id_hidden=false; id_resolved=Ref(
                                 None); id_type=Ref(None); id_svalue=Ref(
                                 None); }), [])];
                    pinfo={id_info_id=11; id_hidden=false; id_resolved=Ref(
                           Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                           None); };
                    })];
        frettype=Some({t_attrs=[];
                       t=TyN(
                           Id(("Int", ()),
                             {id_info_id=12; id_hidden=false; id_resolved=Ref(
                              None); id_type=Ref(None); id_svalue=Ref(
                              None); }));
                       });
        fbody=FBStmt(
                OtherStmtWithStmt(OSWS_Closure,
                  [Pa(
                     Param(
                       {pname=Some(("self", ())); pdefault=None; ptype=None; pattrs=[
                        ];
                        pinfo={id_info_id=2; id_hidden=false; id_resolved=Ref(
                               Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                               None); };
                        }));
                   Pa(
                     Param(
                       {pname=Some(("x", ())); pdefault=None; ptype=None; pattrs=[
                        ];
                        pinfo={id_info_id=3; id_hidden=false; id_resolved=Ref(
                               Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                               None); };
                        }));
                   Pa(
                     Param(
                       {pname=Some(("y", ())); pdefault=Some(L(Int((Some(3), ())))); ptype=None; pattrs=[
                        ];
                        pinfo={id_info_id=5; id_hidden=false; id_resolved=Ref(
                               Some((Parameter, -1))); id_type=Ref(None); id_svalue=Ref(
                               None); };
                        }))], Block([Return((), Some(L(Int((Some(2), ())))), ())])));
        }), ())])
```

This closure supports attributes, capture lists, arguments with attributes, and closure signatures. 

Notably, we ignore the external name for an argument, and also the capture list needed somewhere to go, so I put it in an `OtherStmtWithStmt`.  I added a new `other_stmt_with_stmt_operator` `OSWS_Closure`, and put the capture list as a list of parameters in there. Then the statement enclosed is just the body of the lambda.

----------------------------------------------------------------------------------------------------

**FINAL NOTES:**

Functions whose names are operators don’t have any special names, they’re just identifiers whose names are the same as that of the operator.

++ and — are parsed to Incrdecr ops, with default fixity of postfix. There's no reason for this, but I just needed to put something.

`get`, `set`, and `modify` methods have names which are just those keywords.

I and’ed all the sequences of conditions together.

A tuple type is a TyRecordAnon, the entries of which are FieldDefColons. This is because Swift tuples are allowed to have both entries which have names and do not have names.

Type protocol conforming constraints and equal type constraints are just named attributes on the type.

Things which are OtherExprs:
- #fileID
- #filePath
- #column
- #function
- #dsohandle
- #colorLiteral
- #fileLiteral
- #imageLiteral
- Getter
- setter

A large amount of modifiers are currently handled as just NamedAttributes.
These include:
- Infix
- Postfix
- Prefix
- Weak
- Unowned
- UnownedSafe
- UnownedUnsafe
- Mutating
- Nonmutating
- Class
- Inout
- @escaping
- @autoclosure
- Set
- Indirect
- Type
- Protocol
- Dynamic

Usages of keyword attributes (from Swift to generic AST) are:
- Var -> Mutable
- Let -> Const
- Async -> Async
- Final -> Final
- Lazy -> Lazy
- Visibility modifiers, which warrant further inspection. See Parse_swift_tree_sitter.ml:374
- Optional -> optional
- Static -> static

I also added in a random thing which does reporting for the place in code where TODOs are tripped, and prints them out to the `.log` when running the parse statistics, and sorts them by most frequent. This helps in doing more targeted generic AST conversion, to make sure that we handle the TODOs that are most common.

-----------------------------------------------------------------------------------------------

**Test plan:**
Look at the above, and check whether I'm doing stuff correctly.

Also, `make test`.



PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
