### PR TITLE
fixed(typo): fixed typo in dump ast

### DIFF
--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -538,7 +538,7 @@ and vof_type_kind = function
   | TyRecordAnon (v0, v1) ->
       let v0 = vof_class_kind v0 in
       let v1 = vof_bracket (OCaml.vof_list vof_field) v1 in
-      OCaml.VSum ("TyRecordAnd", [ v0; v1 ])
+      OCaml.VSum ("TyRecordAnon", [ v0; v1 ])
   | TyOr (v1, v2, v3) ->
       let v1 = vof_type_ v1 in
       let v2 = vof_tok v2 in


### PR DESCRIPTION
**What:**
It's `TyRecordAnon`, not `TyRecordAnd` :P 

**Why:**
Clarity!

**Test plan:**
Can reproduce via `sc -dump_ast`.

PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
