### PR TITLE
Prototype a utility for pattern parse stats

### DIFF
--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -208,6 +208,7 @@ let json_of_v (v : OCaml.v) =
 
 let dump_v_to_format (v : OCaml.v) =
   match !output_format with
+  | No_output -> ""
   | Text -> OCaml.string_of_v v
   | Json -> J.string_of_json (json_of_v v)
 
@@ -382,6 +383,12 @@ let all_actions () =
           Test_parsing.parsing_stats
             (Xlang.lang_of_opt_xlang !lang)
             ~json:(!output_format = Json) ~verbose:true xs) );
+    ( "-pattern_parsing_stats",
+      " <files or dirs> generate pattern parsing statistics",
+      Common.mk_action_n_arg (fun xs ->
+          Pattern_parse_stats.get_pattern_parse_stats mk_config
+            (Xlang.lang_of_opt_xlang !lang)
+            xs) );
     (* the dumpers *)
     ( "-dump_extensions",
       " print file extension to language mapping",

--- a/semgrep-core/src/experiments/synthesizing/Pattern_parse_stats.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pattern_parse_stats.ml
@@ -1,0 +1,117 @@
+open Common
+module G = AST_generic
+module V = Visitor_AST
+module Set = Set_
+
+type result = Success | No_matches of string | Parse_failure of string
+
+let add_opt x set_ref =
+  let set = !set_ref in
+  let set' =
+    match x with
+    | Some x -> Set.add x set
+    | None -> set
+  in
+  set_ref := set'
+
+let show_pattern file pattern =
+  match Visitor_AST.range_of_any_opt pattern with
+  | Some (start, end_) ->
+      let { Range.start; end_ } = Range.range_of_token_locations start end_ in
+      Some (String.sub file start (end_ - start + 1))
+  | None -> None
+
+let generate_patterns file ast =
+  let patterns = ref Set.empty in
+  let visitor =
+    V.mk_visitor
+      {
+        V.default_visitor with
+        V.kexpr =
+          (fun (k, _) x ->
+            add_opt (show_pattern file (G.E x)) patterns;
+            k x);
+      }
+  in
+  visitor ast;
+  !patterns
+
+let run_semgrep config lang pattern file =
+  let generate_rule pattern lang =
+    spf
+      "rules:\n\
+       - id: generated\n\
+      \  pattern: |\n\
+      \       %s\n\
+      \  message: MATCH\n\
+      \  languages: [%s]\n\
+      \  severity: WARNING" pattern (Lang.to_string lang)
+  in
+  let rule = generate_rule pattern lang in
+  Common2.with_tmp_dir (fun dir ->
+      Common2.with_tmp_file ~str:rule ~ext:"txt" (fun rules_file ->
+          let config =
+            {
+              config with
+              Runner_config.lang = Some (Xlang.of_lang lang);
+              rules_file;
+              output_format = No_output;
+              roots = [ file ];
+              error_recovery = true;
+              parsing_cache_dir = dir;
+            }
+          in
+          let exn, res, _files =
+            Run_semgrep.semgrep_with_raw_results_and_exn_handler config
+          in
+          match (exn, res.matches) with
+          | None, [] ->
+              No_matches
+                (spf "-------- %s: No matches\n`%s`\n--------\n" file pattern)
+          | Some _exn, _ ->
+              Parse_failure
+                (spf "-------- %s: Parse failure\n%s\n--------\n" file pattern)
+          | _ -> Success))
+
+let count_parsed_patterns config lang patterns files =
+  let check_pattern (successes, no_matches, parse_failures) pattern =
+    match run_semgrep config lang pattern files with
+    | Success -> (successes + 1, no_matches, parse_failures)
+    | No_matches x ->
+        pr x;
+        (successes, no_matches + 1, parse_failures)
+    | Parse_failure x ->
+        pr x;
+        (successes, no_matches, parse_failures + 1)
+  in
+  List.fold_left check_pattern (0, 0, 0) patterns
+
+(* Entry point *)
+
+let get_pattern_parse_stats mk_config lang roots =
+  let config = mk_config () in
+  let roots =
+    roots |> Common.map Run_semgrep.replace_named_pipe_by_regular_file
+  in
+  let files, _skipped = Find_target.files_of_dirs_or_files (Some lang) roots in
+  let patterns_parse_rate file =
+    let file_str = Common.read_file file in
+    let { Parse_target.ast; skipped_tokens = _; _ } =
+      Parse_target.just_parse_with_lang lang file
+    in
+    let patterns = generate_patterns file_str (G.Ss ast) |> Set.elements in
+    count_parsed_patterns config lang patterns file
+  in
+  let successes, no_matches, parse_failures =
+    List.fold_left
+      (fun (acc_s, acc_nm, acc_pf) file ->
+        pr2 file;
+        let s, nm, pf = patterns_parse_rate file in
+        (acc_s + s, acc_nm + nm, acc_pf + pf))
+      (0, 0, 0) files
+  in
+  let total = successes + no_matches + parse_failures in
+  let percent = successes * 100 / total in
+  pr
+    (spf "Success rate: %d / %d (%d%%), %d didn't match, %d failed to parse"
+       successes total percent no_matches parse_failures)

--- a/semgrep-core/src/experiments/synthesizing/Pattern_parse_stats.mli
+++ b/semgrep-core/src/experiments/synthesizing/Pattern_parse_stats.mli
@@ -1,0 +1,2 @@
+val get_pattern_parse_stats :
+  (unit -> Runner_config.t) -> Lang.t -> string list -> unit

--- a/semgrep-core/src/experiments/synthesizing/dune
+++ b/semgrep-core/src/experiments/synthesizing/dune
@@ -9,6 +9,7 @@
    pfff-lang_GENERIC
 
    semgrep_core
+   semgrep_running
    semgrep_parsing
    semgrep_matching
    semgrep_engine ; just for match_any_any

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -194,7 +194,7 @@ let semgrep_check config metachecks rules =
       config with
       Runner_config.lang = Some (Xlang.of_lang Yaml);
       rules_file = metachecks;
-      output_format = Json;
+      output_format = No_output;
       (* the targets are actually the rules! metachecking! *)
       roots = rules;
     }
@@ -260,6 +260,7 @@ let check_files mk_config fparser input =
     | metachecks :: xs -> run_checks config fparser metachecks xs
   in
   match config.output_format with
+  | No_output -> ()
   | Text -> List.iter (fun err -> pr2 (E.string_of_error err)) errors
   | Json ->
       let res = { RP.empty_final_result with errors } in

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -682,6 +682,7 @@ let semgrep_with_rules_and_formatted_output config =
    * Common2.write_value matches "/tmp/debug_matches";
    *)
   match config.output_format with
+  | No_output -> ()
   | Json -> (
       let res = JSON_report.match_results_of_matches_and_errors files res in
       (*
@@ -770,6 +771,7 @@ let semgrep_with_one_pattern config =
   let pattern, pattern_string = pattern_of_config lang config in
 
   match config.output_format with
+  | No_output -> ()
   | Json ->
       let rule, rules_parse_time =
         Common.with_time (fun () -> rule_of_pattern lang pattern_string pattern)

--- a/semgrep-core/src/runner/Runner_config.ml
+++ b/semgrep-core/src/runner/Runner_config.ml
@@ -4,7 +4,8 @@ open Common
    Type definitions, mostly.
 *)
 
-type output_format = Text | Json [@@deriving show]
+(* No_output is for internal utilities that wrap semgrep *)
+type output_format = No_output | Text | Json [@@deriving show]
 
 type t = {
   (* Debugging/profiling/logging flags *)


### PR DESCRIPTION
It can be frustrating to write rules because it's hard to get a pattern that
even works. Sometimes the pattern extension isn't supported (e.g. `$X. ...$Y`).
Sometimes you don't understand what is required for a pattern (and sometimes
we allow partial expressions only for specific languages). Sometimes there's
just a pattern parse error. This makes it hard for users to write rules and
especially for new users to learn the tool.

One idea I had was to at least enforce that the patterns that are supposed
to parse, do parse. The ultimate goal of this utility would be to generate
valid patterns from a file's AST, including ones that require substituting
ellipses or other semgrep extensions, and running them as rules to see how
many parse. This would be a lot of work though and would generate a LOT of
patterns unless we found a solution (one idea: only generate one for each
AST construct?).

In the meantime, this is a quick experiment that just extracts expressions
from a target AST and tries to use those as patterns. This already takes a
fair amount of time because currently a single bad pattern makes Semgrep stop
trying to parse a file, so I run each pattern as an individual rule. Also, a
significant proportion of expressions that don't parse are missing tokens; if
the expression were correctly dumped it would probably parse. That might also
be a useful thing to measure, though!

Anyway, wanted to put up the PR so people could know what I was talking about
and give ideas. It's entirely possible to me that this doesn't make sense as
an approach. I didn't even bother to put up a file-level comment yet. It was
cool for me to explore though and just see what our rates looked like.

To run:

```
semgrep-core -lang <LANG> -pattern_parsing_stats <file/dir>
```

e.g.

```
semgrep-core -lang python -pattern_parsing_stats cli/src/semgrep/commands/
...
Success rate: 1689 / 2008 (84%), 38 didn't match, 281 failed to parse
```

(The patterns are expected to match the code they're taken from, in addition to parsing)

PR checklist:

- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
