### PR TITLE
Compute correct exit code for autofix tests

### DIFF
--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -579,7 +579,13 @@ def generate_test_results(
         for file_results in results_output.values()
         for check_results in file_results["checks"].values()
     )
-    exit_code = int(strict_error or any_failures)
+
+    any_fixtest_failures = any(
+        not fixtest_file_results["passed"]
+        for fixtest_file_results in fixtest_results_output.values()
+    )
+
+    exit_code = int(strict_error or any_failures or any_fixtest_failures)
 
     if json_output:
         print(json.dumps(output, indent=4, separators=(",", ": ")))

--- a/cli/tests/e2e/test_fixtest.py
+++ b/cli/tests/e2e/test_fixtest.py
@@ -64,6 +64,7 @@ def test_fixtest_test3_no_json(run_semgrep_in_tmp, snapshot):
         target_name="fixtest/test3.py",
         options=["--test"],
         output_format=OutputFormat.TEXT,
+        assert_exit_code=1,
     )
 
     snapshot.assert_match(
@@ -79,6 +80,7 @@ def test_fixtest_test3_json(run_semgrep_in_tmp, snapshot):
         target_name="fixtest/test3.py",
         options=["--test"],
         output_format=OutputFormat.JSON,
+        assert_exit_code=1,
     )
     snapshot.assert_match(stdout, "test-results.json")
 


### PR DESCRIPTION
I noticed that the exit code for `semgrep --test` was incorrect when autofix tests were failing.
See this run for a PR in `semgrep-rules`: https://github.com/returntocorp/semgrep-rules/runs/7560053759?check_suite_focus=true#step:6:1532
The run is reported as "success" but there are failing autofix tests.