### PR TITLE
AST_to_IL: Require fresh variables to have fake tokens

### DIFF
--- a/changelog.d/pa-1672.fixed
+++ b/changelog.d/pa-1672.fixed
@@ -1,0 +1,6 @@
+taint-mode: Taint traces (`--dataflow-traces`) should no longer report "strange"
+intermediate variables when there are record accesses involved. This happened e.g.
+if `foo` was a tainted record and the code accessed some of its fields as in
+`foo.bar.baz`. This was related to the use of auxiliary variables in the Dataflow IL.
+These variables got tainted, but they had real tokens attached corresponding to the
+dot `.` operator. Now we do not include these variables in the taint trace.

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -100,6 +100,12 @@ let fixme_stmt kind gany =
 (* Helpers *)
 (*****************************************************************************)
 let fresh_var ?(str = "_tmp") _env tok =
+  let tok =
+    (* We don't want "fake" auxiliary variables to have non-fake tokens, otherwise
+       we confuse ourselves! E.g. during taint-tracking we don't want to add these
+       variables to the taint trace. *)
+    if Parse_info.is_fake tok then tok else Parse_info.fake_info tok str
+  in
   let i = H.gensym () in
   { ident = (str, tok); sid = i; id_info = G.empty_id_info () }
 


### PR DESCRIPTION
Previously we created fresh auxiliary variables with real tokens attached
to them. This makes it hard to distinguish the "real" code variables from
the "fake" auxiliary variables introduced during AST-to-IL translation.
Taint-tracking uses the token attached to a variable to decide whether to
include it in the taint trace or not, so here we force all auxiliary
variables to carry fake tokens.

Closes PA-1672

test plan:
Run this rule:

    rules:
      - id: test
        languages:
          - python
        message: bad
        mode: taint
        pattern-sinks:
          - pattern: '"bad" + ...'
        pattern-sources:
          - pattern: foo.bar.$ANYTHING
        severity: WARNING

on this .py file:

    def asdf():
        bad = "bad"
        bad + foo.bar.baz.f()

Check that there are no more weird intermediate variables being reported
in the taint trace.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
