### PR TITLE
update links for contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
    this file would be a symlink.
 -->
 
-[Contribution guidelines can be found in `doc/`](https://semgrep.dev/docs/contributing/how-to-contribute/).
+[Contribution guidelines can be found in here](https://semgrep.dev/docs/contributing/contributing/).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,4 +56,4 @@ $ docker build -t semgrep .
 
 Contribution guidelines and developer documentation
 are [available from Semgrep's documentation
-website](https://semgrep.dev/docs/contributing/how-to-contribute/).
+website](https://semgrep.dev/docs/contributing/contributing/).

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To disable Registry rule metrics, use `--metrics=off`.
 ### More
 
 - [Frequently asked questions (FAQs)](https://semgrep.dev/docs/faq/)
-- [Contributing](https://semgrep.dev/docs/contributing/how-to-contribute/)
+- [Contributing](https://semgrep.dev/docs/contributing/contributing/)
 - [Build instructions for developers](INSTALL.md)
 - [Ask questions in the r2c Community Slack](https://r2c.dev/slack)
 - [CLI reference and exit codes](https://semgrep.dev/docs/cli-usage)


### PR DESCRIPTION
No changelog item needed - this addresses issues pointed out in #5890 

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
