### PR TITLE
test(taint): Test taint finding output from ci subcommand

### DIFF
--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -36,6 +36,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -47,13 +52,13 @@ Scan environment:
 
 Fetching configuration from semgrep.dev
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 8 findings (7 blocking) from 3 rules.
+  Found 9 findings (8 blocking) from 4 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -36,6 +36,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -47,13 +52,13 @@ Scan environment:
 
 Fetching configuration from semgrep.dev
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 8 findings (7 blocking) from 3 rules.
+  Found 9 findings (8 blocking) from 4 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -43,13 +48,13 @@ Scan environment:
 
 Fetching configuration from semgrep.dev
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
 Would have sent findings blob: {
     "token": null,
@@ -204,6 +209,58 @@ Would have sent findings blob: {
             "metadata": {},
             "is_blocking": true,
             "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+        },
+        {
+            "check_id": "taint-test",
+            "path": "foo.py",
+            "line": 27,
+            "column": 5,
+            "end_line": 27,
+            "end_column": 13,
+            "message": "unsafe use of danger",
+            "severity": 1,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+            "dataflow_trace": {
+                "taint_source": {
+                    "location": {
+                        "path": "foo.py",
+                        "start": {
+                            "line": 26,
+                            "col": 10,
+                            "offset": 346
+                        },
+                        "end": {
+                            "line": 26,
+                            "col": 16,
+                            "offset": 352
+                        }
+                    },
+                    "content": "danger"
+                },
+                "intermediate_vars": [
+                    {
+                        "location": {
+                            "path": "foo.py",
+                            "start": {
+                                "line": 26,
+                                "col": 5,
+                                "offset": 341
+                            },
+                            "end": {
+                                "line": 26,
+                                "col": 7,
+                                "offset": 343
+                            }
+                        },
+                        "content": "d2"
+                    }
+                ]
+            }
         }
     ],
     "searched_paths": [
@@ -212,7 +269,8 @@ Would have sent findings blob: {
     "rule_ids": [
         "eqeq-bad",
         "eqeq-five",
-        "eqeq-four"
+        "eqeq-four",
+        "taint-test"
     ],
     "cai_ids": [
         "__r2c-internal-cai_eqeq"
@@ -311,7 +369,7 @@ Would have sent ignores blob: {
 Would have sent complete blob: {
     "exit_code": 1,
     "stats": {
-        "findings": 9,
+        "findings": 10,
         "errors": [],
         "total_time": <MASKED>
         "unsupported_exts": {
@@ -321,8 +379,8 @@ Would have sent complete blob: {
             "python": {
                 "targets_parsed": 1,
                 "num_targets": 1,
-                "bytes_parsed": 336,
-                "num_bytes": 336
+                "bytes_parsed": 366,
+                "num_bytes": 366
             }
         }
     }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
@@ -9,8 +9,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -47,21 +52,21 @@ Using <MASKED> as the merge-base of <MASKED> and <MASKED>
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
-  Current version has 14 findings.
+Scanning 1 file with 5 python rules.
+  Current version has 15 findings.
 
 Switching repository to baseline commit '<MASKED>'.
   Will report findings introduced by these commits:
     * <MASKED> Some other commit/ message
 
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 Returning to original head revision <MASKED>
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
@@ -9,8 +9,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,20 +49,20 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
-  Current version has 14 findings.
+Scanning 1 file with 5 python rules.
+  Current version has 15 findings.
 
 Switching repository to baseline commit '<MASKED>'.
   Will report findings introduced by these commits:
     * <MASKED> Some other commit/ message
 
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings.json
@@ -154,6 +154,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -162,7 +214,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
@@ -9,8 +9,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -47,21 +52,21 @@ Using <MASKED> as the merge-base of <MASKED> and <MASKED>
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
-  Current version has 14 findings.
+Scanning 1 file with 5 python rules.
+  Current version has 15 findings.
 
 Switching repository to baseline commit '<MASKED>'.
   Will report findings introduced by these commits:
     * <MASKED> Some other commit/ message
 
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 Returning to original head revision <MASKED>
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
@@ -9,8 +9,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,20 +49,20 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
-  Current version has 14 findings.
+Scanning 1 file with 5 python rules.
+  Current version has 15 findings.
 
 Switching repository to baseline commit '<MASKED>'.
   Will report findings introduced by these commits:
     * <MASKED> Some other commit/ message
 
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 9,
+    "findings": 10,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {
@@ -11,8 +11,8 @@
       "python": {
         "targets_parsed": 1,
         "num_targets": 1,
-        "bytes_parsed": 336,
-        "num_bytes": 336
+        "bytes_parsed": 366,
+        "num_bytes": 366
       }
     }
   }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings.json
@@ -151,6 +151,58 @@
       "metadata": {},
       "is_blocking": true,
       "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
     }
   ],
   "searched_paths": [
@@ -159,7 +211,8 @@
   "rule_ids": [
     "eqeq-bad",
     "eqeq-five",
-    "eqeq-four"
+    "eqeq-four",
+    "taint-test"
   ],
   "cai_ids": [
     "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -32,6 +32,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -44,13 +49,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -46,7 +46,7 @@ Fetching rules from https://semgrep.dev<MASKED>
 trying to download from https://semgrep.dev<MASKED>
 finished downloading from https://semgrep.dev<MASKED>
 loaded 1 configs in<MASKED>
-running 4 rules from 1 config remote-url_0
+running 5 rules from 1 config remote-url_0
 Initializing git status
 Running git diff
 Finished git diff. Parsing git status output
@@ -66,8 +66,9 @@ Rules:
 - eqeq-bad
 - eqeq-five
 - eqeq-four
+- taint-test
 Passing whole rules directly to semgrep_core
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 Running semgrep-core with command:
 /<MASKED>/semgrep-core -json -rules <MASKED>-json_time -fast --debug
 --- semgrep-core stderr ---
@@ -120,6 +121,25 @@ Running semgrep-core with command:
       "message": "useless comparison to 3",
       "pattern": "$X == 3",
       "severity": "INFO"
+    },
+    {
+      "id": "taint-test",
+      "languages": [
+        "python"
+      ],
+      "message": "unsafe use of danger",
+      "mode": "taint",
+      "pattern-sinks": [
+        {
+          "pattern": "sink($X)"
+        }
+      ],
+      "pattern-sources": [
+        {
+          "pattern": "danger"
+        }
+      ],
+      "severity": "WARNING"
     }
   ]
 }
@@ -134,9 +154,12 @@ Running semgrep-core with command:
 <MASKED>
 <MASKED>
 <MASKED>
+<MASKED>
+<MASKED>
 --- end semgrep-core stderr ---
+skipped 'bar.py' [rule RuleId(value='taint-test')]: SkipReason(value=IrrelevantRule()): No need to perform deeper matching because target does not contain some elements necessary for the rule to match 'taint-test'
 semgrep ran in <MASKED> on 1 files
-findings summary: 1 error, 0 info
+findings summary: 1 error, 0 info, 0 warning
   Current version has 1 finding.
 
 Skipping baseline scan, because all current findings are in files that didn't exist in the baseline commit.
@@ -182,7 +205,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 1 finding (0 blocking) from 3 rules.
+  Found 1 finding (0 blocking) from 4 rules.
   Uploading findings to Semgrep App.
 Sending findings blob: {
     "token": null,
@@ -216,7 +239,8 @@ Sending findings blob: {
     "rule_ids": [
         "eqeq-bad",
         "eqeq-five",
-        "eqeq-four"
+        "eqeq-four",
+        "taint-test"
     ],
     "cai_ids": [
         "__r2c-internal-cai_eqeq"

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -47,6 +47,11 @@ Findings:
          18┆ baz == 4  # nosemgrep
           ⋮┆----------------------------------------
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -58,13 +63,13 @@ Scan environment:
 
 Fetching configuration from semgrep.dev
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 13 findings (11 blocking) from 3 rules.
+  Found 14 findings (12 blocking) from 4 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -36,6 +36,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -47,13 +52,13 @@ Scan environment:
 
 Fetching configuration from semgrep.dev
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 8 findings (7 blocking) from 3 rules.
+  Found 9 findings (8 blocking) from 4 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -47,6 +47,11 @@ Findings:
          18┆ baz == 4  # nosemgrep
           ⋮┆----------------------------------------
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -58,13 +63,13 @@ Scan environment:
 
 Fetching configuration from semgrep.dev
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 13 findings (11 blocking) from 3 rules.
+  Found 14 findings (12 blocking) from 4 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -36,6 +36,11 @@ Findings:
         useless comparison to 4
 
          19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
 
 === end of stdout - plain
 
@@ -47,13 +52,13 @@ Scan environment:
 
 Fetching configuration from semgrep.dev
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 8 findings (7 blocking) from 3 rules.
+  Found 9 findings (8 blocking) from 4 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
@@ -13,6 +13,7 @@ foo.py:7:5:error(eqeq-bad):    a == a:useless comparison
 foo.py:11:5:error(eqeq-bad):    y == y:useless comparison
 foo.py:15:5:error(eqeq-five):    x == 5:useless comparison to 5
 foo.py:19:5:error(eqeq-four):    baz == 4:useless comparison to 4
+foo.py:27:5:warning(taint-test):    sink(d2):unsafe use of danger
 
 === end of stdout - plain
 
@@ -25,13 +26,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
@@ -154,6 +154,34 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
     {
       "category": "sast",
       "confidence": "High",
+      "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:taint-test",
+      "id": "05a6d679-3a62-42a4-9ff8-3113ef4a83b3",
+      "identifiers": [
+        {
+          "name": "Semgrep - taint-test",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/taint-test",
+          "value": "taint-test"
+        }
+      ],
+      "location": {
+        "end_line": 27,
+        "file": "foo.py",
+        "start_line": 27
+      },
+      "message": "unsafe use of danger",
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "Medium"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
       "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:eqeq-five",
       "id": "8646a2df-c020-9136-0696-9dcfe84e53c0",
       "identifiers": [
@@ -192,13 +220,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
@@ -193,6 +193,41 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "sha": "0000000"
       },
       "confidence": "High",
+      "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:taint-test",
+      "id": "05a6d679-3a62-42a4-9ff8-3113ef4a83b3",
+      "identifiers": [
+        {
+          "name": "Semgrep - taint-test",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/taint-test",
+          "value": "taint-test"
+        }
+      ],
+      "location": {
+        "end_line": 27,
+        "file": "foo.py",
+        "start_line": 27
+      },
+      "message": "unsafe use of danger",
+      "raw_source_code_extract": [
+        "    sink(d2)\n"
+      ],
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "Medium"
+    },
+    {
+      "category": "secret_detection",
+      "commit": {
+        "date": "1970-01-01T00:00:00Z",
+        "sha": "0000000"
+      },
+      "confidence": "High",
       "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:eqeq-five",
       "id": "8646a2df-c020-9136-0696-9dcfe84e53c0",
       "identifiers": [
@@ -234,13 +269,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -206,6 +206,92 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
       }
     },
     {
+      "check_id": "taint-test",
+      "end": {
+        "col": 13,
+        "line": 27,
+        "offset": 365
+      },
+      "extra": {
+        "dataflow_trace": {
+          "intermediate_vars": [
+            {
+              "content": "d2",
+              "location": {
+                "end": {
+                  "col": 7,
+                  "line": 26,
+                  "offset": 343
+                },
+                "path": "foo.py",
+                "start": {
+                  "col": 5,
+                  "line": 26,
+                  "offset": 341
+                }
+              }
+            }
+          ],
+          "taint_source": {
+            "content": "danger",
+            "location": {
+              "end": {
+                "col": 16,
+                "line": 26,
+                "offset": 352
+              },
+              "path": "foo.py",
+              "start": {
+                "col": 10,
+                "line": 26,
+                "offset": 346
+              }
+            }
+          }
+        },
+        "fingerprint": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+        "is_ignored": false,
+        "lines": "    sink(d2)",
+        "message": "unsafe use of danger",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "d2",
+            "end": {
+              "col": 12,
+              "line": 27,
+              "offset": 364
+            },
+            "propagated_value": {
+              "svalue_abstract_content": "danger",
+              "svalue_end": {
+                "col": 16,
+                "line": 26,
+                "offset": 352
+              },
+              "svalue_start": {
+                "col": 10,
+                "line": 26,
+                "offset": 346
+              }
+            },
+            "start": {
+              "col": 10,
+              "line": 27,
+              "offset": 362
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "foo.py",
+      "start": {
+        "col": 5,
+        "line": 27,
+        "offset": 357
+      }
+    },
+    {
       "check_id": "eqeq-five",
       "end": {
         "col": 11,
@@ -262,13 +348,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -264,6 +264,31 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
           "ruleId": "eqeq-four"
         },
         {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "foo.py",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 13,
+                  "endLine": 27,
+                  "snippet": {
+                    "text": "    sink(d2)"
+                  },
+                  "startColumn": 5,
+                  "startLine": 27
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "unsafe use of danger"
+          },
+          "ruleId": "taint-test"
+        },
+        {
           "fixes": [
             {
               "artifactChanges": [
@@ -427,6 +452,23 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "shortDescription": {
                 "text": "useless comparison to 4"
               }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "fullDescription": {
+                "text": "unsafe use of danger"
+              },
+              "id": "taint-test",
+              "name": "taint-test",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "unsafe use of danger"
+              }
             }
           ],
           "semanticVersion": "placeholder"
@@ -447,13 +489,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 11 findings (9 blocking) from 3 rules.
+  Found 12 findings (10 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
@@ -12,6 +12,7 @@ foo.py:5:5:E:eqeq-bad:useless comparison
 foo.py:7:5:E:eqeq-bad:useless comparison
 foo.py:11:5:E:eqeq-bad:useless comparison
 foo.py:19:5:E:eqeq-four:useless comparison to 4
+foo.py:27:5:W:taint-test:unsafe use of danger
 foo.py:15:5:E:eqeq-five:useless comparison to 5
 
 === end of stdout - plain
@@ -25,13 +26,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
@@ -13,6 +13,7 @@ foo.py:7:5:error(eqeq-bad):    a == a:useless comparison
 foo.py:11:5:error(eqeq-bad):    y == y:useless comparison
 foo.py:15:5:error(eqeq-five):    x == 5:useless comparison to 5
 foo.py:19:5:error(eqeq-four):    baz == 4:useless comparison to 4
+foo.py:27:5:warning(taint-test):    sink(d2):unsafe use of danger
 
 === end of stdout - plain
 
@@ -25,13 +26,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
@@ -154,6 +154,34 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
     {
       "category": "sast",
       "confidence": "High",
+      "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:taint-test",
+      "id": "05a6d679-3a62-42a4-9ff8-3113ef4a83b3",
+      "identifiers": [
+        {
+          "name": "Semgrep - taint-test",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/taint-test",
+          "value": "taint-test"
+        }
+      ],
+      "location": {
+        "end_line": 27,
+        "file": "foo.py",
+        "start_line": 27
+      },
+      "message": "unsafe use of danger",
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "Medium"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
       "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:eqeq-five",
       "id": "8646a2df-c020-9136-0696-9dcfe84e53c0",
       "identifiers": [
@@ -192,13 +220,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
@@ -193,6 +193,41 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "sha": "0000000"
       },
       "confidence": "High",
+      "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:taint-test",
+      "id": "05a6d679-3a62-42a4-9ff8-3113ef4a83b3",
+      "identifiers": [
+        {
+          "name": "Semgrep - taint-test",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/taint-test",
+          "value": "taint-test"
+        }
+      ],
+      "location": {
+        "end_line": 27,
+        "file": "foo.py",
+        "start_line": 27
+      },
+      "message": "unsafe use of danger",
+      "raw_source_code_extract": [
+        "    sink(d2)\n"
+      ],
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "Medium"
+    },
+    {
+      "category": "secret_detection",
+      "commit": {
+        "date": "1970-01-01T00:00:00Z",
+        "sha": "0000000"
+      },
+      "confidence": "High",
       "cve": "foo.py:b08fd7a517303ab07cfa211f74d03c1a4c2e64b3b0656d84ff32ecb449b785d2:eqeq-five",
       "id": "8646a2df-c020-9136-0696-9dcfe84e53c0",
       "identifiers": [
@@ -234,13 +269,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -206,6 +206,92 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
       }
     },
     {
+      "check_id": "taint-test",
+      "end": {
+        "col": 13,
+        "line": 27,
+        "offset": 365
+      },
+      "extra": {
+        "dataflow_trace": {
+          "intermediate_vars": [
+            {
+              "content": "d2",
+              "location": {
+                "end": {
+                  "col": 7,
+                  "line": 26,
+                  "offset": 343
+                },
+                "path": "foo.py",
+                "start": {
+                  "col": 5,
+                  "line": 26,
+                  "offset": 341
+                }
+              }
+            }
+          ],
+          "taint_source": {
+            "content": "danger",
+            "location": {
+              "end": {
+                "col": 16,
+                "line": 26,
+                "offset": 352
+              },
+              "path": "foo.py",
+              "start": {
+                "col": 10,
+                "line": 26,
+                "offset": 346
+              }
+            }
+          }
+        },
+        "fingerprint": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+        "is_ignored": false,
+        "lines": "    sink(d2)",
+        "message": "unsafe use of danger",
+        "metadata": {},
+        "metavars": {
+          "$X": {
+            "abstract_content": "d2",
+            "end": {
+              "col": 12,
+              "line": 27,
+              "offset": 364
+            },
+            "propagated_value": {
+              "svalue_abstract_content": "danger",
+              "svalue_end": {
+                "col": 16,
+                "line": 26,
+                "offset": 352
+              },
+              "svalue_start": {
+                "col": 10,
+                "line": 26,
+                "offset": 346
+              }
+            },
+            "start": {
+              "col": 10,
+              "line": 27,
+              "offset": 362
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "foo.py",
+      "start": {
+        "col": 5,
+        "line": 27,
+        "offset": 357
+      }
+    },
+    {
       "check_id": "eqeq-five",
       "end": {
         "col": 11,
@@ -259,13 +345,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -272,6 +272,31 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
+                  "endColumn": 13,
+                  "endLine": 27,
+                  "snippet": {
+                    "text": "    sink(d2)"
+                  },
+                  "startColumn": 5,
+                  "startLine": 27
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "unsafe use of danger"
+          },
+          "ruleId": "taint-test"
+        },
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "foo.py",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
                   "endColumn": 11,
                   "endLine": 15,
                   "snippet": {
@@ -373,6 +398,23 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "shortDescription": {
                 "text": "useless comparison to 4"
               }
+            },
+            {
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "fullDescription": {
+                "text": "unsafe use of danger"
+              },
+              "id": "taint-test",
+              "name": "taint-test",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "unsafe use of danger"
+              }
             }
           ],
           "semanticVersion": "placeholder"
@@ -393,13 +435,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 11 findings (9 blocking) from 3 rules.
+  Found 12 findings (10 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
@@ -12,6 +12,7 @@ foo.py:5:5:E:eqeq-bad:useless comparison
 foo.py:7:5:E:eqeq-bad:useless comparison
 foo.py:11:5:E:eqeq-bad:useless comparison
 foo.py:19:5:E:eqeq-four:useless comparison to 4
+foo.py:27:5:W:taint-test:unsafe use of danger
 foo.py:15:5:E:eqeq-five:useless comparison to 5
 
 === end of stdout - plain
@@ -25,13 +26,13 @@ Scan environment:
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
 
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 6 findings (5 blocking) from 3 rules.
+  Found 7 findings (6 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -39,7 +39,7 @@ Using b903231925961ac9d787ae53ee0bd15ec156e689 as the merge-base of 81af3f0c528f
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 2 files with 4 python rules.
+Scanning 2 files with 5 python rules.
   Current version has 3 findings.
 
 Switching repository to baseline commit 'b903231925961ac9d787ae53ee0bd15ec156e689'.
@@ -54,7 +54,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 2 findings (0 blocking) from 3 rules.
+  Found 2 findings (0 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   No blocking findings so exiting with code 0
 

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -31,7 +31,7 @@ Using 5b37988ae28e701bc9fd48d651db9e4e67936bcc as the merge-base of 81af3f0c528f
 Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
-Scanning 1 file with 4 python rules.
+Scanning 1 file with 5 python rules.
   Current version has 1 finding.
 
 Skipping baseline scan, because all current findings are in files that didn't exist in the baseline commit.
@@ -41,7 +41,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 1 finding (0 blocking) from 3 rules.
+  Found 1 finding (0 blocking) from 4 rules.
   Uploading findings to Semgrep App.
   No blocking findings so exiting with code 0
 

--- a/cli/tests/e2e/targets/ci/foo.py
+++ b/cli/tests/e2e/targets/ci/foo.py
@@ -22,3 +22,6 @@ def bar():
 
     b == b # Triage ignored by syntactic_id
     a == a # Triage ignored by match_based_id
+
+    d2 = danger
+    sink(d2)

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -153,6 +153,15 @@ def automocks(mocker):
           message: "useless comparison to 3"
           languages: [python]
           severity: INFO
+        - id: taint-test
+          message: "unsafe use of danger"
+          languages: [python]
+          severity: WARNING
+          mode: taint
+          pattern-sources:
+            - pattern: danger
+          pattern-sinks:
+            - pattern: sink($X)
         """
     ).lstrip()
 


### PR DESCRIPTION
Specifically, this is meant to test the JSON output for dataflow traces
generated from the CI command, but it tests quite a bit more. This was
requested in the review of #5694.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
