### PR TITLE
Parse function-like language constructs as specials

### DIFF
--- a/changelog.d/gh-5382.changed
+++ b/changelog.d/gh-5382.changed
@@ -1,0 +1,1 @@
+Parse several built-in PHP functions in the same way in pfff and tree-sitter. This makes it possible to match exit, eval, empty and isset, even if the pattern is parsed with pfff and the PHP file with tree-sitter.

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -257,9 +257,7 @@ and expr e : G.expr =
   | Id v1 ->
       let v1 = name_of_qualified_ident v1 in
       G.N v1
-  | IdSpecial v1 ->
-      let v1 = wrap special v1 in
-      G.IdSpecial v1
+  | IdSpecial v1 -> special v1
   (* unify Id and Var, finally *)
   | Var v1 ->
       let v1 = var v1 in
@@ -448,11 +446,16 @@ and argument = function
   | ArgUnpack (tok, e) -> G.special (Spread, tok) [ expr e ] |> G.arg
   | ArgLabel (label, _tok, e) -> G.ArgKwd (label, expr e)
 
-and special = function
-  | This -> G.This
-  | Eval -> G.Eval
-  | Self -> G.Self
-  | Parent -> G.Parent
+and special (spec, tok) =
+  match spec with
+  | This -> G.IdSpecial (G.This, tok)
+  | Self -> G.IdSpecial (G.Self, tok)
+  | Parent -> G.IdSpecial (G.Parent, tok)
+  | FuncLike Empty -> G.N (G.Id (("empty", tok), G.empty_id_info ()))
+  | FuncLike Eval -> G.IdSpecial (G.Eval, tok)
+  | FuncLike Exit -> G.N (G.Id (("exit", tok), G.empty_id_info ()))
+  | FuncLike Isset -> G.IdSpecial (G.Defined, tok)
+  | FuncLike Unset -> G.N (G.Id (("unset", tok), G.empty_id_info ()))
 
 and foreach_pattern v =
   let v = expr v in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -1013,13 +1013,24 @@ and map_callable_variable (env : env) (x : CST.callable_variable) =
         match v1 with
         | `Name tok ->
             (* pattern [_a-zA-Z\u00A1-\u00ff][_a-zA-Z\u00A1-\u00ff\d]* *)
-            A.Id (map_name env tok)
+            map_function_name env tok
         | `Rese_id x -> map_reserved_identifier env x
         | `Qual_name x -> A.Id (map_qualified_name env x)
         | `Choice_choice_choice_dyna_var_name x -> map_callable_expression env x
       in
       let v2 = map_arguments env v2 in
       A.Call (v1, v2)
+
+and map_function_name env tok =
+  let id = _str env tok in
+  let str, tok = id in
+  match String.lowercase_ascii str with
+  | "empty" -> A.IdSpecial (A.FuncLike A.Empty, tok)
+  | "eval" -> A.IdSpecial (A.FuncLike A.Eval, tok)
+  | "exit" -> A.IdSpecial (A.FuncLike A.Exit, tok)
+  | "isset" -> A.IdSpecial (A.FuncLike A.Isset, tok)
+  | "unset" -> A.IdSpecial (A.FuncLike A.Unset, tok)
+  | _ -> A.Id [ id ]
 
 and map_catch_clause (env : env) ((v1, v2, v3, v4, v5, v6) : CST.catch_clause) :
     A.catch =
@@ -1976,7 +1987,8 @@ and map_statement (env : env) (x : CST.statement) =
       in
       let v5 = (* ")" *) token env v5 in
       let v6 = map_semicolon env v6 in
-      A.Expr (A.Call (A.Id [ (A.builtin "unset", v1) ], (v2, v3 :: v4, v5)), v6)
+      A.Expr
+        (A.Call (A.IdSpecial (A.FuncLike A.Unset, v1), (v2, v3 :: v4, v5)), v6)
   | `Const_decl x ->
       let consts = map_const_declaration_ env x in
       let consts = Common.map (fun c -> A.ConstantDef c) consts in


### PR DESCRIPTION
Primarily to reduce the differences between tree-sitter and pfff parsing.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
