### PR TITLE
Implement templated rules

### DIFF
--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -445,6 +445,7 @@ def parse_config_string(
             f"Empty configuration file {filename}", code=UNPARSEABLE_YAML_EXIT_CODE
         )
     try:
+        # Emma note: this is where configs are wrapped to YAML
         # we pretend it came from YAML so we can keep later code simple
         data = YamlTree.wrap(json.loads(contents), EmptySpan)
         return {config_id: data}

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -49,11 +49,11 @@ from semgrep.semgrep_types import LANGUAGE
 from semgrep.semgrep_types import Language
 from semgrep.state import get_state
 from semgrep.target_manager import TargetManager
+from semgrep.template_resolver import resolve_template_urls
+from semgrep.template_resolver import TemplateDirectory
 from semgrep.util import sub_check_output
 from semgrep.util import unit_str
 from semgrep.verbose_logging import getLogger
-from semgrep.template_resolver import resolve_template_urls
-from semgrep.template_resolver import TemplateDirectory
 
 logger = getLogger(__name__)
 
@@ -621,11 +621,11 @@ class CoreRunner:
             else tempfile.NamedTemporaryFile("w").name
         )
         # template_dir = (
-            # TODO use custom context manager for dump_command_for_core
-            # option
-            # tempfile.TemporaryDirectory(prefix="templates")
+        # TODO use custom context manager for dump_command_for_core
+        # option
+        # tempfile.TemporaryDirectory(prefix="templates")
         # )
-        
+
         with open(rule_file_name, "w+") as rule_file, open(
             target_file_name, "w+"
         ) as target_file, TemplateDirectory(dump_command_for_core) as template_dir:
@@ -638,7 +638,7 @@ class CoreRunner:
             target_file.flush()
 
             # Rules are dumped as JSON for two reasons:
-            # 1. Performance: JSON is faster to parse 
+            # 1. Performance: JSON is faster to parse
             # 2. Templated rules: currently, semgrep-core only supports
             #    templated rules for JSON files. If this is changed to
             #    dump rules using YAML, templated rules will fail to parse

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -52,6 +52,8 @@ from semgrep.target_manager import TargetManager
 from semgrep.util import sub_check_output
 from semgrep.util import unit_str
 from semgrep.verbose_logging import getLogger
+from semgrep.template_resolver import resolve_template_urls
+from semgrep.template_resolver import TemplateDirectory
 
 logger = getLogger(__name__)
 
@@ -618,10 +620,16 @@ class CoreRunner:
             if dump_command_for_core
             else tempfile.NamedTemporaryFile("w").name
         )
-
+        # template_dir = (
+            # TODO use custom context manager for dump_command_for_core
+            # option
+            # tempfile.TemporaryDirectory(prefix="templates")
+        # )
+        
         with open(rule_file_name, "w+") as rule_file, open(
             target_file_name, "w+"
-        ) as target_file:
+        ) as target_file, TemplateDirectory(dump_command_for_core) as template_dir:
+            resolve_template_urls(rules, Path(template_dir.name))
 
             plan = self._plan_core_run(rules, target_manager, all_targets)
             plan.log()
@@ -629,6 +637,11 @@ class CoreRunner:
             target_file.write(json.dumps(plan.to_json()))
             target_file.flush()
 
+            # Rules are dumped as JSON for two reasons:
+            # 1. Performance: JSON is faster to parse 
+            # 2. Templated rules: currently, semgrep-core only supports
+            #    templated rules for JSON files. If this is changed to
+            #    dump rules using YAML, templated rules will fail to parse
             rule_file.write(
                 json.dumps(
                     {"rules": [rule._raw for rule in rules]}, indent=2, sort_keys=True

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -1,6 +1,5 @@
 import json
 import time
-import requests
 from io import StringIO
 from os import environ
 from pathlib import Path

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -1,5 +1,6 @@
 import json
 import time
+import requests
 from io import StringIO
 from os import environ
 from pathlib import Path

--- a/cli/src/semgrep/template_resolver.py
+++ b/cli/src/semgrep/template_resolver.py
@@ -1,45 +1,47 @@
-from contextlib import contextmanager
-from typing import List
-from typing import Dict
-from urllib import request
 import os
 import shutil
-
-from semgrep.util import is_url
-from semgrep.rule import Rule
 from pathlib import Path
-
 from tempfile import TemporaryDirectory
+from typing import Dict
+from typing import List
+from urllib import request
+
 from semgrep.core_runner import get_state
+from semgrep.rule import Rule
+from semgrep.util import is_url
 
 template_file_id = 0
+
 
 def uniq_id() -> int:
     global template_file_id
     template_file_id += 1
     return template_file_id
 
-def resolve_template_urls(rules : List[Rule], template_dir : Path) -> None:
+
+def resolve_template_urls(rules: List[Rule], template_dir: Path) -> None:
     """
-     TODO: local files can download templates. This should mutate metrics
-           state
-     TODO: templates break the invariant the registry rules will not cause
-           latest semgrep to error because they could error after being
-           compiled. In particular, even if the rule initially is valid, it
-           could become broken after a template is changed. This error will
-           be extremely hard to parse
+    TODO: local files can download templates. This should mutate metrics
+          state
+    TODO: templates break the invariant the registry rules will not cause
+          latest semgrep to error because they could error after being
+          compiled. In particular, even if the rule initially is valid, it
+          could become broken after a template is changed. This error will
+          be extremely hard to parse
     """
     # Retrieve the paths to any templates used by the rules
 
-    template_defs = [ rule._raw["uses"] if "uses" in rule._raw else [] for rule in rules ]
+    template_defs = [rule._raw["uses"] if "uses" in rule._raw else [] for rule in rules]
 
-    template_paths = { path for uses in template_defs for use_def in uses for path in use_def.values() }
+    template_paths = {
+        path for uses in template_defs for use_def in uses for path in use_def.values()
+    }
 
     # Download the templates as needed; write back the name of the file
     # so that the rule sent to semgrep-core will reference the file
 
     """
-     TODO: pulling templates is going to be slow. Instead of 
+     TODO: pulling templates is going to be slow. Instead of
      delivering them through the registry, perhaps we should
      deliver them as a package that people can install. This
      also improves the versioning problem, though it unfortunately
@@ -49,7 +51,10 @@ def resolve_template_urls(rules : List[Rule], template_dir : Path) -> None:
     template_mappings = {}
     for path in template_paths:
         if is_url(path):
-            filepath = str(template_dir / ("template_" + str(uniq_id()) + "_" + os.path.basename(path)))
+            filepath = str(
+                template_dir
+                / ("template_" + str(uniq_id()) + "_" + os.path.basename(path))
+            )
             request.urlretrieve(path, filepath)
             template_mappings[path] = filepath
         else:
@@ -57,23 +62,29 @@ def resolve_template_urls(rules : List[Rule], template_dir : Path) -> None:
             # to put the equivalent libsonnet file in. A bit wasteful, but
             # this will also be nice for debugging
             _dirname, basename = os.path.split(path)
-            filepath = str(template_dir / ("template_" + str(uniq_id()) + "_" + basename))
+            filepath = str(
+                template_dir / ("template_" + str(uniq_id()) + "_" + basename)
+            )
             shutil.copyfile(path, filepath, follow_symlinks=True)
             template_mappings[path] = filepath
 
-    def replace_urls_in_place(uses : List[Dict[str, str]]) -> int:
+    def replace_urls_in_place(uses: List[Dict[str, str]]) -> int:
         for use in uses:
             for (template_id, template_path) in use.items():
                 use[template_id] = template_mappings[template_path]
-        return 0 # for mypy, since this intentionally uses mutation
+        return 0  # for mypy, since this intentionally uses mutation
 
-    [ replace_urls_in_place(rule._raw["uses"]) if "uses" in rule._raw else () for rule in rules ]
+    [
+        replace_urls_in_place(rule._raw["uses"]) if "uses" in rule._raw else ()
+        for rule in rules
+    ]
+
 
 class TemplateDirectory(TemporaryDirectory):
     temporary = True
     name = ""
 
-    def __init__(self, command_for_core : bool):
+    def __init__(self, command_for_core: bool):
         self.temporary = not command_for_core
         if self.temporary:
             super().__init__()

--- a/cli/src/semgrep/template_resolver.py
+++ b/cli/src/semgrep/template_resolver.py
@@ -1,0 +1,98 @@
+from contextlib import contextmanager
+from typing import List
+from typing import Dict
+from urllib import request
+import os
+import shutil
+
+from semgrep.util import is_url
+from semgrep.rule import Rule
+from pathlib import Path
+
+from tempfile import TemporaryDirectory
+from semgrep.core_runner import get_state
+
+template_file_id = 0
+
+def uniq_id() -> int:
+    global template_file_id
+    template_file_id += 1
+    return template_file_id
+
+def resolve_template_urls(rules : List[Rule], template_dir : Path) -> None:
+    """
+     TODO: local files can download templates. This should mutate metrics
+           state
+     TODO: templates break the invariant the registry rules will not cause
+           latest semgrep to error because they could error after being
+           compiled. In particular, even if the rule initially is valid, it
+           could become broken after a template is changed. This error will
+           be extremely hard to parse
+    """
+    # Retrieve the paths to any templates used by the rules
+
+    template_defs = [ rule._raw["uses"] if "uses" in rule._raw else [] for rule in rules ]
+
+    template_paths = { path for uses in template_defs for use_def in uses for path in use_def.values() }
+
+    # Download the templates as needed; write back the name of the file
+    # so that the rule sent to semgrep-core will reference the file
+
+    """
+     TODO: pulling templates is going to be slow. Instead of 
+     delivering them through the registry, perhaps we should
+     deliver them as a package that people can install. This
+     also improves the versioning problem, though it unfortunately
+     puts the burden of installing on users
+    """
+
+    template_mappings = {}
+    for path in template_paths:
+        if is_url(path):
+            filepath = str(template_dir / ("template_" + str(uniq_id()) + "_" + os.path.basename(path)))
+            request.urlretrieve(path, filepath)
+            template_mappings[path] = filepath
+        else:
+            # Copy local files so that later semgrep-core knows which folder
+            # to put the equivalent libsonnet file in. A bit wasteful, but
+            # this will also be nice for debugging
+            _dirname, basename = os.path.split(path)
+            filepath = str(template_dir / ("template_" + str(uniq_id()) + "_" + basename))
+            shutil.copyfile(path, filepath, follow_symlinks=True)
+            template_mappings[path] = filepath
+
+    def replace_urls_in_place(uses : List[Dict[str, str]]) -> int:
+        for use in uses:
+            for (template_id, template_path) in use.items():
+                use[template_id] = template_mappings[template_path]
+        return 0 # for mypy, since this intentionally uses mutation
+
+    [ replace_urls_in_place(rule._raw["uses"]) if "uses" in rule._raw else () for rule in rules ]
+
+class TemplateDirectory(TemporaryDirectory):
+    temporary = True
+    name = ""
+
+    def __init__(self, command_for_core : bool):
+        self.temporary = not command_for_core
+        if self.temporary:
+            super().__init__()
+
+    def __enter__(self):
+        if self.temporary:
+            name = super().__enter__()
+            self.name = name
+            return self
+        else:
+            # Create a directory
+            state = get_state()
+            self.name = state.env.user_data_folder / "semgrep_templates"
+            if not os.path.isdir(self.name):
+                os.mkdir(self.name)
+            return self
+
+    def __exit__(self, exc, value, tb):
+        if self.temporary:
+            return super().__exit__(exc, value, tb)
+        else:
+            return

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1162,11 +1162,7 @@ let create_imports libsonnet_defs =
   let create_import (name, path) = spf "local %s = import '%s';" name path in
   let imported_folder =
     match libsonnet_defs with
-    | [] ->
-        failwith
-          "No import definitions (given by the uses key) even though we are \
-           creating imports for the import definitions. This should be \
-           impossible"
+    | [] -> (* It will never be used so doesn't matter *) ""
     | (_, path) :: _ -> Filename.dirname path
   in
   let imports = String.concat "\n" (List.map create_import libsonnet_defs) in

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1125,12 +1125,13 @@ let parse_template file template_ast =
                take_no_env td (fun k e -> generic_to_json env k e) "contents"
              in
              match content_json with
-             | Array _ | Object _ -> 
+             | Array _
+             | Object _ ->
                  (* interpret as the json object *)
-                  JSON.string_of_json content_json
-             | String x -> 
+                 JSON.string_of_json content_json
+             | String x ->
                  (* interpret as pure jsonnet *)
-                 x 
+                 x
              | _ -> failwith "Not valid json format"
            in
            spf "   %s :: %s,\n" declaration contents)

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1347,7 +1347,9 @@ let parse_possibly_templated_rules error_recovery file ast =
      tokens for each rule are real, but they will be bad for levels above.
      This should be fine but needs to be tested *)
   let parsed_templated_rules, templated_errors =
-    parse_templated_rules templated_rules ("rules", t) |> parse_generic file
+    if templated_rules != [] then
+      parse_templated_rules templated_rules ("rules", t) |> parse_generic file
+    else ([], [])
   in
   let parsed_normal_rules, normal_errors =
     parse_generic ~error_recovery file recreated_normal_rules


### PR DESCRIPTION
What: Adds a new kind of file, a "template", which can be used to build a
"rule"

Why: rules often get repetitive. For instance, for a given framework, there
is usually a fixed set of sinks. These sinks get reused in every rule. When
the set is updated, each rule has to be updated. We want to be able to
factorize out those sinks.

How: We add a very simple syntax for templates and two extra fields, `uses`
and `ref`, to rules.

For templates: a template consists of a (declaration, contents) pair. The
declaration determines how the template may be invoked. When a template is
invoked, it is replaced with its contents, evaluating any variables. A
template file is a list of templates.

For rules: use `uses` to import a template. Use `ref` to call a template

Example:

Rule:
```
rules:
  - id: printing
    uses:
      - python_lib: python-lib.yaml
    patterns:
      - ref: python_lib.print()
    message: we printed!
    languages: [python]
    severity: ERROR
```

Template:
```
templates:
  - declaration: print()
    contents:
       pattern: print(...)
```

Under the hood, this works by converting the rules to jsonnet and then using
jsonnet to generate a json rule. In this case, the libsonnet template is:

```
{
   print() :: {"pattern":"print(...)"},
}
```

The jsonnet rule is:
```
local python_lib = import '/Users/emma/.semgrep/semgrep_templates/template_2_python-lib.libsonnet';
[{"id":"printing","languages":["python"],"message":"we printed!","patterns":[python_lib.print()],"severity":"ERROR"}]%
```

And the final json rule, compiled using jsonnet, is

```
[
   {
      "id": "printing",
      "languages": [
         "python"
      ],
      "message": "we printed!",
      "patterns": [
         {
            "pattern": "print(...)"
         }
      ],
      "severity": "ERROR"
   }
]
```

PR checklist:

- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
