### PR TITLE
Run metachecking rules by default

### DIFF
--- a/cli/src/semgrep/commands/publish.py
+++ b/cli/src/semgrep/commands/publish.py
@@ -155,7 +155,7 @@ def _upload_rule(
         test_code_file: optional test case to attach with the rule
     """
     state = get_state()
-    config, errors = get_config(None, None, [str(rule_file)], project_url=None)
+    config, errors, _ = get_config(None, None, [str(rule_file)], project_url=None)
 
     if errors:
         click.echo(

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -771,7 +771,10 @@ def scan(
                     f"Nothing to validate, use the --config or --pattern flag to specify a rule"
                 )
             else:
-                resolved_configs, config_errors = semgrep.config_resolver.get_config(
+                # TODO this codepath is now very much
+                # duplicated by the normal validation.
+                # Figure out what to do with it
+                resolved_configs, config_errors, _ = semgrep.config_resolver.get_config(
                     pattern, lang, config or [], project_url=get_project_url()
                 )
 
@@ -785,7 +788,7 @@ def scan(
                             timeout_threshold=timeout_threshold,
                             optimizations=optimizations,
                             core_opts_str=core_opts,
-                        ).validate_configs(config)
+                        ).validate_configs(list(config))
                     except SemgrepError as e:
                         metacheck_errors = [e]
 
@@ -797,7 +800,7 @@ def scan(
                     f"Configuration is {valid_str} - found {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
                 )
                 if config_errors:
-                    output_handler.handle_semgrep_errors(config_errors)
+                    output_handler.handle_metacheck_errors(config_errors)
                     output_handler.output({}, all_targets=set(), filtered_rules=[])
                     raise SemgrepError("Please fix the above errors and try again.")
         else:

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -824,10 +824,11 @@ class CoreRunner:
 
         return (findings_by_rule, errors, all_targets, profiling_data, parsing_data)
 
-    def validate_configs(self, configs: Tuple[str, ...]) -> Sequence[SemgrepError]:
-        metachecks = Config.from_config_list(["p/semgrep-rule-lints"], None)[
-            0
-        ].get_rules(True)
+    def validate_configs(self, configs: List[str]) -> Sequence[SemgrepError]:
+        # TODO allow users to configure this
+        metachecks = Config.from_config_list(
+            ["../semgrep-core/tests/semgrep-rules/yaml/semgrep"], None
+        )[0].get_rules(True)
 
         parsed_errors = []
 
@@ -846,7 +847,7 @@ class CoreRunner:
                     "-check_rules",
                     rule_file.name,
                 ]
-                + list(configs)
+                + configs
             )
 
             runner = StreamingSemgrepCore(cmd, 1)  # only scanning combined rules

--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -25,6 +25,7 @@ import semgrep.output_from_core as core
 import semgrep.semgrep_main
 from semgrep.config_resolver import Config
 from semgrep.config_resolver import ConfigPath
+from semgrep.config_resolver import ConfigType
 from semgrep.constants import RuleSeverity
 from semgrep.error import ERROR_MAP
 from semgrep.error import FATAL_EXIT_CODE
@@ -232,10 +233,19 @@ def create_config_map(semgrep_config_strings: List[str]) -> Dict[str, Rule]:
     """
     config = {}
     for config_string in semgrep_config_strings:
-        resolved = ConfigPath(config_string, get_project_url()).resolve_config()
+        project_url = get_project_url()
+        resolved = ConfigPath(config_string, project_url).resolve_config()
+        resolved_with_path = {
+            k: (v, (ConfigType.REGISTRY, project_url if project_url else ""))
+            for (k, v) in resolved.items()
+        }
         # Some code-fu to get single rules
         config.update(
-            {config_string: list(Config._validate(resolved)[0].values())[0][0]}
+            {
+                config_string: list(Config._validate(resolved_with_path)[0].values())[
+                    0
+                ][0]
+            }
         )
     return config
 

--- a/cli/src/semgrep/lsp/config.py
+++ b/cli/src/semgrep/lsp/config.py
@@ -176,7 +176,9 @@ class LSPConfig:
         return self._settings
 
     def _rules(self, configs: List[str]) -> List[Rule]:
-        configs_obj, _ = get_config(None, None, configs, project_url=self.project_url)
+        configs_obj, _, _ = get_config(
+            None, None, configs, project_url=self.project_url
+        )
         all_rules = configs_obj.get_rules(True)
         filtered_rules = [
             rule for rule in all_rules if rule.severity.value in self.severity

--- a/cli/tests/unit/test_metric_manager.py
+++ b/cli/tests/unit/test_metric_manager.py
@@ -82,7 +82,7 @@ def test_rules_hash(first, second, is_equal) -> None:
     with NamedTemporaryFile() as tf1:
         tf1.write(config1.encode("utf-8"))
         tf1.flush()
-        config, errors = Config.from_config_list([tf1.name], None)
+        config, errors, _ = Config.from_config_list([tf1.name], None)
         assert not errors
         rules = config.get_rules(True)
         assert len(rules) == 3

--- a/cli/tests/unit/test_yaml_parsing.py
+++ b/cli/tests/unit/test_yaml_parsing.py
@@ -87,7 +87,7 @@ def test_multiple_configs():
         tf1.flush()
         tf2.flush()
         config_list = [tf1.name, tf2.name]
-        config, errors = Config.from_config_list(config_list, None)
+        config, errors, _ = Config.from_config_list(config_list, None)
         assert not errors
         rules = config.get_rules(True)
         assert len(rules) == 3

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -99,6 +99,8 @@ and rule_id = {
   message : string;
   (* used for debugging (could be removed at some point) *)
   pattern_string : string;
+  (* used for metachecker to save severity of match *)
+  severity : Output_from_core_t.core_severity;
 }
 [@@deriving show, eq]
 

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -323,6 +323,11 @@ let partition_rules (rules : rules) :
 (* Error Management *)
 (*****************************************************************************)
 
+let core_severity_of_severity severity =
+  match severity with
+  | Error -> Output_from_core_t.Error
+  | _ -> Output_from_core_t.Warning
+
 (* This is used to let the user know which rule the engine was using when
  * a Timeout or OutOfMemory exn occured.
  *)

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -41,7 +41,7 @@ type error = {
 [@@deriving show]
 
 (* TODO: define also in Output_from_core.atd *)
-type severity = Error | Warning
+type severity = Out.core_severity
 
 let g_errors = ref []
 
@@ -182,20 +182,22 @@ let string_of_error err =
 
 let severity_of_error typ =
   match typ with
-  | Out.SemgrepMatchFound -> Error
-  | Out.MatchingError -> Warning
-  | Out.TooManyMatches -> Warning
-  | Out.LexicalError -> Warning
-  | Out.ParseError -> Warning
-  | Out.PartialParsing _ -> Warning
-  | Out.SpecifiedParseError -> Warning
-  | Out.AstBuilderError -> Error
-  | Out.RuleParseError -> Error
-  | Out.PatternParseError _ -> Error
-  | Out.InvalidYaml -> Warning
-  | Out.FatalError -> Error
-  | Out.Timeout -> Warning
-  | Out.OutOfMemory -> Warning
+  | Out.SemgrepMatchFound -> Out.Error
+  | Out.MetacheckMatchInternal severity -> severity
+  | Out.MetacheckMatch -> Out.Warning
+  | Out.MatchingError -> Out.Warning
+  | Out.TooManyMatches -> Out.Warning
+  | Out.LexicalError -> Out.Warning
+  | Out.ParseError -> Out.Warning
+  | Out.PartialParsing _ -> Out.Warning
+  | Out.SpecifiedParseError -> Out.Warning
+  | Out.AstBuilderError -> Out.Error
+  | Out.RuleParseError -> Out.Error
+  | Out.PatternParseError _ -> Out.Error
+  | Out.InvalidYaml -> Out.Warning
+  | Out.FatalError -> Out.Error
+  | Out.Timeout -> Out.Warning
+  | Out.OutOfMemory -> Out.Warning
 
 (*****************************************************************************)
 (* Try with error *)

--- a/semgrep-core/src/core/Semgrep_error_code.mli
+++ b/semgrep-core/src/core/Semgrep_error_code.mli
@@ -16,7 +16,7 @@ type error = {
 }
 [@@deriving show]
 
-type severity = Error | Warning
+type severity = Output_from_core_t.core_severity
 
 val g_errors : error list ref
 

--- a/semgrep-core/src/engine/Match_env.ml
+++ b/semgrep-core/src/engine/Match_env.ml
@@ -34,6 +34,11 @@ type pattern_id = Xpattern.pattern_id
 (* !This hash table uses the Hashtbl.find_all property! *)
 type id_to_match_results = (pattern_id, Pattern_match.t) Hashtbl.t
 
+type minimal_env = {
+  config : Config_semgrep.t * Equivalence.equivalences;
+  severity : Rule.severity;
+}
+
 type env = {
   (* less: we might want to get rid of equivalences at some point as
    * they are not exposed to the user anymore. *)
@@ -66,4 +71,9 @@ let error env msg =
 
 (* this will be adjusted later in range_to_pattern_match_adjusted *)
 let fake_rule_id (id, str) =
-  { PM.id = string_of_int id; pattern_string = str; message = "" }
+  {
+    PM.id = string_of_int id;
+    pattern_string = str;
+    message = "";
+    severity = Output_from_core_t.Warning;
+  }

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -94,7 +94,13 @@ module DataflowY = Dataflow_core.Make (struct
   let short_string_of_node n = Display_IL.short_string_of_node_kind n.F2.n
 end)
 
-let convert_rule_id (id, _tok) = { PM.id; message = ""; pattern_string = id }
+let convert_rule_id (id, _tok) severity =
+  {
+    PM.id;
+    message = "";
+    pattern_string = id;
+    severity = Rule.core_severity_of_severity severity;
+  }
 
 let option_bind_list opt f =
   match opt with
@@ -563,7 +569,10 @@ let check_rule rule match_hook (default_config, equivs) xtarget =
                   let str = Common.spf "with rule %s" m.rule_id.id in
                   match_hook str m))
     |> Common.map (fun m ->
-           { m with PM.rule_id = convert_rule_id rule.Rule.id })
+           {
+             m with
+             PM.rule_id = convert_rule_id rule.Rule.id rule.Rule.severity;
+           })
   in
   let errors = Parse_target.errors_from_skipped_tokens skipped_tokens in
   ( RP.make_match_result matches errors

--- a/semgrep-core/src/matching/Match_patterns.ml
+++ b/semgrep-core/src/matching/Match_patterns.ml
@@ -136,6 +136,10 @@ let (rule_id_of_mini_rule : Mini_rule.t -> Pattern_match.rule_id) =
     PM.id = mr.Mini_rule.id;
     message = mr.Mini_rule.message;
     pattern_string = mr.Mini_rule.pattern_string;
+    severity =
+      (match mr.Mini_rule.severity with
+      | Error -> Output_from_core_t.Error
+      | _ -> Output_from_core_t.Warning);
   }
 
 let match_rules_and_recurse lang config (file, hook, matches) rules matcher k

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -73,7 +73,15 @@ let error env t s =
   let loc = Parse_info.unsafe_token_location_of_info t in
   let _check_idTODO = "semgrep-metacheck-builtin" in
   let rule_id, _ = env.r.id in
-  let err = E.mk_error ~rule_id:(Some rule_id) loc s Out.SemgrepMatchFound in
+  let severity =
+    match env.r.severity with
+    | Error -> Out.Error
+    | _ -> Out.Warning
+  in
+  let err =
+    E.mk_error ~rule_id:(Some rule_id) loc s
+      (Out.MetacheckMatchInternal severity)
+  in
   Common.push err env.errors
 
 (*****************************************************************************)
@@ -187,8 +195,10 @@ let semgrep_check config metachecks rules =
     let s = m.rule_id.message in
     let _check_id = m.rule_id.id in
     (* TODO: why not set ~rule_id here?? bug? *)
-    E.mk_error ~rule_id:None loc s Out.SemgrepMatchFound
+    E.mk_error ~rule_id:None loc s
+      (Out.MetacheckMatchInternal m.P.rule_id.severity)
   in
+
   let config =
     {
       config with

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -197,13 +197,17 @@ let match_to_match x =
  *)
 let error_to_error err =
   let severity_of_severity = function
-    | E.Error -> SJ.Error
-    | E.Warning -> SJ.Warning
+    | Out.Error -> SJ.Error
+    | Out.Warning -> SJ.Warning
   in
   let file = err.E.loc.PI.file in
   let startp, endp = OutH.position_range err.E.loc err.E.loc in
   let rule_id = err.E.rule_id in
-  let error_type = err.E.typ in
+  let error_type =
+    match err.E.typ with
+    | Out.MetacheckMatchInternal _ -> Out.MetacheckMatch
+    | e -> e
+  in
   let severity = severity_of_severity (E.severity_of_error err.E.typ) in
   let message = err.E.msg in
   let details = err.E.details in


### PR DESCRIPTION
We have a bunch of useful rules in `--validate`, but most people currently
don't use it. To minimally annoy people, we

- link the rules to the semgrep-rules submodule instead of pulling from the
  registry (so that validating doesn't slow down the parsing stage)
- distinguish between errors and warning (this reads from the severity
  field in the rule). Only errors cause the run to abort, unless run with
  strict mode, though both are outputted
- only validate when run with Text and a local config. The assumption is that
  people running with local configs are writing rules, while people running
  with registry rules are running them. Additionally, rules pulled from the
  registry should already be validated (this is TODO), so we can skip that
  extra run

Test plan: create files
```
➜  semgrep git:(emma/metachecker-by-default) ✗ cat semgrep-core/no_metadata.yaml
rules:
  - id: unchecked-subprocess-call
    patterns:
      - pattern: |
          subprocess.call(...)
      - pattern-not-inside: |
          $S = subprocess.call(...)
      - pattern-not-inside: |
          subprocess.call(...) == $X
    message: >-
      blah
    severity: WARNING
    fix: subprocess.check_call(...)
    languages: [python]
➜  semgrep git:(emma/metachecker-by-default) ✗ cat semgrep-core/unsatisfiable.yaml
rules:
  - id: unchecked-subprocess-call
    patterns:
      - pattern: |
          subprocess.call(...)
      # ruleid: unsatisfiable-rule
      - pattern-not: |
          subprocess.call(...)
      - pattern-not-inside: |
          $S = subprocess.call(...)
      - pattern-not-inside: |
          subprocess.call(...) == $X
    message: >-
      blah
    severity: WARNING
    fix: subprocess.check_call(...)
    languages: [python]
```

semgrep --config [rule]

One should fail with an error and two warnings, the other should still
run but emit two warnings.

PR checklist:

- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
