### PR TITLE
Parse $this as IdSpecial in PHP tree-sitter parser

### DIFF
--- a/changelog.d/gh-5594.fixed
+++ b/changelog.d/gh-5594.fixed
@@ -1,0 +1,1 @@
+When parsing PHP with tree-sitter, parse `$this` similar to pfff, as an IdSpecial. This makes it possible to match `$this` when the pattern is parsed with pfff and the program with tree-sitter.

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -2445,7 +2445,11 @@ and map_variable (env : env) (x : CST.variable) =
 and map_variable_name_ (env : env) (x : CST.variable_name_) : A.expr =
   match x with
   | `Dyna_var_name x -> map_dynamic_variable_name env x
-  | `Var_name x -> A.Id [ map_variable_name env x ]
+  | `Var_name x -> (
+      let str, tok = map_variable_name env x in
+      match str with
+      | "$this" -> IdSpecial (A.This, tok)
+      | _ -> A.Id [ (str, tok) ])
 
 and map_variadic_unpacking (env : env) ((v1, v2) : CST.variadic_unpacking) =
   let v1 = (* "..." *) token env v1 in

--- a/semgrep-core/tests/php/gh_5594.php
+++ b/semgrep-core/tests/php/gh_5594.php
@@ -1,0 +1,7 @@
+<?php
+
+$arr = [3, 4, 5];
+$newArr = array_filter($arr, fn($item) => $item > 3);
+
+//ERROR: match
+$this->logger->info('Removing network bond');

--- a/semgrep-core/tests/php/gh_5594.sgrep
+++ b/semgrep-core/tests/php/gh_5594.sgrep
@@ -1,0 +1,1 @@
+$this->logger->info(...);


### PR DESCRIPTION
Related to #5382. Closes #5594.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
