### PR TITLE
Zach/fail open exclude blocking

### DIFF
--- a/changelog.d/app-2073.fixed
+++ b/changelog.d/app-2073.fixed
@@ -1,0 +1,1 @@
+Skip fail-open for exit code 1

--- a/cli/src/semgrep/error_handler.py
+++ b/cli/src/semgrep/error_handler.py
@@ -8,6 +8,8 @@ from attr import define
 from attr import Factory
 from attr import field
 
+from semgrep.error import FINDINGS_EXIT_CODE
+from semgrep.error import OK_EXIT_CODE
 from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
@@ -57,7 +59,11 @@ class ErrorHandler:
 
         state = get_state()
 
-        if not self.is_enabled or exit_code == 0:
+        if (
+            not self.is_enabled
+            or exit_code == OK_EXIT_CODE
+            or exit_code == FINDINGS_EXIT_CODE
+        ):
             return exit_code
 
         import traceback

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -934,6 +934,25 @@ def test_bad_config_error_handler(run_semgrep, mocker, git_tmp_path_with_commit)
     mock_send.assert_called_once_with(mocker.ANY, 7)
 
 
+def test_fail_scan_findings(run_semgrep, mocker, git_tmp_path_with_commit):
+    """
+    Test failure with findings has exit code == 1.
+
+    Asserts that error logs are NOT sent to fail-open
+    """
+    mock_send = mocker.spy(ErrorHandler, "send")
+    mock_request_post = mocker.patch("semgrep.error_handler.requests.post")
+    run_semgrep(
+        options=["ci", "--suppress-errors"],
+        target_name=None,
+        strict=False,
+        assert_exit_code=1,
+        env={"SEMGREP_APP_TOKEN": "fake-key-from-tests"},
+    )
+    mock_send.assert_called_once_with(mocker.ANY, 1)
+    mock_request_post.assert_not_called()
+
+
 def test_fail_finish_scan(run_semgrep, mocker, git_tmp_path_with_commit):
     """
     Test failure to send findings has exit code > 1


### PR DESCRIPTION
PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
