### PR TITLE
chore(fail-open): Update fail-open message body

### DIFF
--- a/changelog.d/pm-194.fixed
+++ b/changelog.d/pm-194.fixed
@@ -1,0 +1,1 @@
+Changed the fail-open message body

--- a/cli/src/semgrep/app/session.py
+++ b/cli/src/semgrep/app/session.py
@@ -147,7 +147,5 @@ class AppSession(requests.Session):
         if response.ok:
             error_handler.pop_request()
         else:
-            error_handler.append_request(
-                status_code=response.status_code, response_json=response.json()
-            )
+            error_handler.append_request(status_code=response.status_code)
         return response


### PR DESCRIPTION
PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
