### PR TITLE
fix: make symbol prop matching less redundant

### DIFF
--- a/changelog.d/pa-1772.fixed
+++ b/changelog.d/pa-1772.fixed
@@ -1,4 +1,5 @@
-Changed symbolic propagation such that "redundant" matches are no longer reported as findings. For instance:
+Changed symbolic propagation such that "redundant" matches are no
+longer reported as findings. For instance:
 
 ```py
 def foo():
@@ -6,7 +7,8 @@ def foo():
   f(x)
 ```
 
-If we are looking for the pattern `g(5)`, we should not match on line 3, since we will match on line 2 anyways,
-and this is just repeating information that we already know.
+If we are looking for the pattern `g(5)`, we should not match on line 3,
+since we will match on line 2 anyways, and this is just repeating information that
+we already know.
 
 This patch changes it so that we do not match on line 3 anymore.

--- a/changelog.d/pa-1772.fixed
+++ b/changelog.d/pa-1772.fixed
@@ -1,0 +1,12 @@
+Changed symbolic propagation such that "redundant" matches are no longer reported as findings. For instance:
+
+```py
+def foo():
+  x = g(5)
+  f(x)
+```
+
+If we are looking for the pattern `g(5)`, we should not match on line 3, since we will match on line 2 anyways,
+and this is just repeating information that we already know.
+
+This patch changes it so that we do not match on line 3 anymore.

--- a/semgrep-core/src/matching/Apply_equivalences.ml
+++ b/semgrep-core/src/matching/Apply_equivalences.ml
@@ -37,7 +37,7 @@ let match_e_e_for_equivalences _ruleid lang a b =
       in
       let cache = None in
       let env = Matching_generic.empty_environment cache lang config in
-      Generic_vs_generic.m_expr a b env)
+      Generic_vs_generic.m_expr_root a b env)
 
 (*****************************************************************************)
 (* Substituters *)

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -364,9 +364,12 @@ let m_deep (deep_fun : G.expr Matching_generic.matcher)
       in
       b |> sub_fun |> aux)
 
-let m_with_symbolic_propagation f b =
+let m_with_symbolic_propagation ~is_root f b =
   if_config
-    (fun x -> x.Config.constant_propagation && x.Config.symbolic_propagation)
+    (* If we are not at the root, then we permit recursing into substituted values. *)
+      (fun x ->
+      x.Config.constant_propagation && x.Config.symbolic_propagation
+      && not is_root)
     ~then_:
       (match b.G.e with
       | G.N (G.Id (_, { id_svalue = { contents = Some (G.Sym b1) }; _ })) ->
@@ -647,14 +650,14 @@ and m_id_info a b =
 (* Expression *)
 (*****************************************************************************)
 
-(* Deep expression matching extracts sub-expressions without decomposing on the pattern,
-   meaning that matching those sub-expressions should be considered as the root.
-*)
 and m_expr_deep a b tin =
   let symbolic_propagation = tin.config.Config.symbolic_propagation in
   let subexprs_of_expr =
     SubAST_generic.subexprs_of_expr ~symbolic_propagation
   in
+  (* Deep expression matching extracts sub-expressions without decomposing on the pattern,
+     meaning that matching those sub-expressions should be considered as the root.
+  *)
   m_deep m_expr_deep m_expr_root subexprs_of_expr a b tin
 
 (* possibly go deeper. When someone writes a pattern like
@@ -674,35 +677,32 @@ and m_expr_deep a b tin =
  *   - <call>(<exprs).
  * see SubAST_generic.subexprs_of_expr_implicit
  *
- * Also matches sub-expressions without decomposing, meaning it should match as the root.
  *)
 and m_expr_deep_implict a b tin =
   let symbolic_propagation = tin.config.Config.symbolic_propagation in
   let subexprs_of_expr =
     SubAST_generic.subexprs_of_expr_implicit ~symbolic_propagation
   in
+  (* Deep expression matching extracts sub-expressions without decomposing on the pattern,
+     meaning that matching those sub-expressions should be considered as the root.
+  *)
   m_deep m_expr_deep_implict m_expr_root subexprs_of_expr a b tin
 
-(* This is allows the matching of expressions, where we are considered to not be
+(* This just calls `m_expr_inner` as the root. This is exposed, so that exterior uses will
+   properly register as the root, and should only be called at the start of matching.
+*)
+and m_expr_root a b = m_expr ~is_root:true a b
+
+(* This allows the matching of expressions, where we are considered to not be
    at the "root" of the pattern.
    This is because, for most of the other mutually recursive uses of `m_expr`, we are
    usually having already decomposed on the pattern, meaning that it is safe to
    use `m_expr`.
 *)
-and m_expr a b = m_expr_inner ~is_root:false a b
-
-(* This just calls `m_expr_inner` as the root. This is exposed, so that exterior uses will
-   properly register as the root, and should only be called at the start of matching.
-*)
-and m_expr_root a b = m_expr_inner ~is_root:true a b
-
-(* A wrapper for `m_expr`, which allows an `is_root` flag.
-   Any subsequent calls to `m_expr` will set it to false.
-*)
 (* coupling: if you add special sgrep hooks here, you should probably
  * also add them in m_pattern
  *)
-and m_expr_inner ~is_root a b =
+and m_expr ?(is_root = false) a b =
   Trace_matching.(if on then print_expr_pair a b);
   match (a.G.e, b.G.e) with
   (* the order of the matches matters! take care! *)
@@ -773,9 +773,7 @@ and m_expr_inner ~is_root a b =
       (match H.name_of_dot_access a with
       | None -> fail ()
       | Some a1 -> m_name a1 b1)
-      >||> m_with_symbolic_propagation
-             (fun b1 -> if is_root then fail () else m_expr a b1)
-             b
+      >||> m_with_symbolic_propagation ~is_root (fun b1 -> m_expr a b1) b
   (* $X should not match an IdSpecial in a call context,
    * otherwise $X(...) would match a+b because this is transformed in a
    * Call(IdSpecial Plus, ...).
@@ -800,9 +798,7 @@ and m_expr_inner ~is_root a b =
    *)
   | G.N (G.Id _ as na), B.N (B.Id _ as nb) ->
       m_name na nb
-      >||> m_with_symbolic_propagation
-             (fun b1 -> if is_root then m_expr a b1 else fail ())
-             b
+      >||> m_with_symbolic_propagation ~is_root (fun b1 -> m_expr a b1) b
   | G.N (G.Id ((str, tok), _id_info)), _b when MV.is_metavar_name str ->
       envf (str, tok) (MV.E b)
   (* metavar: typed! *)
@@ -892,10 +888,9 @@ and m_expr_inner ~is_root a b =
       m_expr a1 b1 >>= fun () -> m_arguments a2 b2
   | G.New (_a0, a1, a2), B.New (_b0, b1, b2) ->
       m_type_ a1 b1 >>= fun () -> m_arguments a2 b2
-  | G.Call _, _ when not is_root ->
-      m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
-  | G.New _, _ when not is_root ->
-      m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
+  | G.Call _, _ ->
+      m_with_symbolic_propagation ~is_root (fun b1 -> m_expr a b1) b
+  | G.New _, _ -> m_with_symbolic_propagation ~is_root (fun b1 -> m_expr a b1) b
   | G.Assign (a1, at, a2), B.Assign (b1, bt, b2) -> (
       m_expr a1 b1
       >>= (fun () -> m_tok at bt >>= fun () -> m_expr a2 b2)
@@ -948,8 +943,8 @@ and m_expr_inner ~is_root a b =
       aux candidates
   | G.ArrayAccess (a1, a2), B.ArrayAccess (b1, b2) ->
       m_expr a1 b1 >>= fun () -> m_bracket m_expr a2 b2
-  | G.ArrayAccess _, _ when not is_root ->
-      m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
+  | G.ArrayAccess _, _ ->
+      m_with_symbolic_propagation ~is_root (fun b1 -> m_expr a b1) b
   | G.Record a1, B.Record b1 -> (m_bracket m_fields) a1 b1
   | G.Constructor (a1, a2), B.Constructor (b1, b2) ->
       m_name a1 b1 >>= fun () -> m_bracket (m_list m_expr) a2 b2

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -647,12 +647,15 @@ and m_id_info a b =
 (* Expression *)
 (*****************************************************************************)
 
+(* Deep expression matching extracts sub-expressions without decomposing on the pattern,
+   meaning that matching those sub-expressions should be considered as the root.
+*)
 and m_expr_deep a b tin =
   let symbolic_propagation = tin.config.Config.symbolic_propagation in
   let subexprs_of_expr =
     SubAST_generic.subexprs_of_expr ~symbolic_propagation
   in
-  m_deep m_expr_deep m_expr subexprs_of_expr a b tin
+  m_deep m_expr_deep m_expr_root subexprs_of_expr a b tin
 
 (* possibly go deeper. When someone writes a pattern like
  *   'bar();'
@@ -670,18 +673,36 @@ and m_expr_deep a b tin =
  *   - x = <expr>,
  *   - <call>(<exprs).
  * see SubAST_generic.subexprs_of_expr_implicit
+ *
+ * Also matches sub-expressions without decomposing, meaning it should match as the root.
  *)
 and m_expr_deep_implict a b tin =
   let symbolic_propagation = tin.config.Config.symbolic_propagation in
   let subexprs_of_expr =
     SubAST_generic.subexprs_of_expr_implicit ~symbolic_propagation
   in
-  m_deep m_expr_deep_implict m_expr subexprs_of_expr a b tin
+  m_deep m_expr_deep_implict m_expr_root subexprs_of_expr a b tin
 
+(* This is allows the matching of expressions, where we are considered to not be
+   at the "root" of the pattern.
+   This is because, for most of the other mutually recursive uses of `m_expr`, we are
+   usually having already decomposed on the pattern, meaning that it is safe to
+   use `m_expr`.
+*)
+and m_expr a b = m_expr_inner ~is_root:false a b
+
+(* This just calls `m_expr_inner` as the root. This is exposed, so that exterior uses will
+   properly register as the root, and should only be called at the start of matching.
+*)
+and m_expr_root a b = m_expr_inner ~is_root:true a b
+
+(* A wrapper for `m_expr`, which allows an `is_root` flag.
+   Any subsequent calls to `m_expr` will set it to false.
+*)
 (* coupling: if you add special sgrep hooks here, you should probably
  * also add them in m_pattern
  *)
-and m_expr a b =
+and m_expr_inner ~is_root a b =
   Trace_matching.(if on then print_expr_pair a b);
   match (a.G.e, b.G.e) with
   (* the order of the matches matters! take care! *)
@@ -752,7 +773,9 @@ and m_expr a b =
       (match H.name_of_dot_access a with
       | None -> fail ()
       | Some a1 -> m_name a1 b1)
-      >||> m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
+      >||> m_with_symbolic_propagation
+             (fun b1 -> if is_root then fail () else m_expr a b1)
+             b
   (* $X should not match an IdSpecial in a call context,
    * otherwise $X(...) would match a+b because this is transformed in a
    * Call(IdSpecial Plus, ...).
@@ -776,7 +799,10 @@ and m_expr a b =
    * TODO: should be B.N (B.Id _ | B.IdQualified _)?
    *)
   | G.N (G.Id _ as na), B.N (B.Id _ as nb) ->
-      m_name na nb >||> m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
+      m_name na nb
+      >||> m_with_symbolic_propagation
+             (fun b1 -> if is_root then m_expr a b1 else fail ())
+             b
   | G.N (G.Id ((str, tok), _id_info)), _b when MV.is_metavar_name str ->
       envf (str, tok) (MV.E b)
   (* metavar: typed! *)
@@ -866,8 +892,10 @@ and m_expr a b =
       m_expr a1 b1 >>= fun () -> m_arguments a2 b2
   | G.New (_a0, a1, a2), B.New (_b0, b1, b2) ->
       m_type_ a1 b1 >>= fun () -> m_arguments a2 b2
-  | G.Call _, _ -> m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
-  | G.New _, _ -> m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
+  | G.Call _, _ when not is_root ->
+      m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
+  | G.New _, _ when not is_root ->
+      m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
   | G.Assign (a1, at, a2), B.Assign (b1, bt, b2) -> (
       m_expr a1 b1
       >>= (fun () -> m_tok at bt >>= fun () -> m_expr a2 b2)
@@ -920,7 +948,8 @@ and m_expr a b =
       aux candidates
   | G.ArrayAccess (a1, a2), B.ArrayAccess (b1, b2) ->
       m_expr a1 b1 >>= fun () -> m_bracket m_expr a2 b2
-  | G.ArrayAccess _, _ -> m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
+  | G.ArrayAccess _, _ when not is_root ->
+      m_with_symbolic_propagation (fun b1 -> m_expr a b1) b
   | G.Record a1, B.Record b1 -> (m_bracket m_fields) a1 b1
   | G.Constructor (a1, a2), B.Constructor (b1, b2) ->
       m_name a1 b1 >>= fun () -> m_bracket (m_list m_expr) a2 b2
@@ -967,6 +996,9 @@ and m_expr a b =
   | G.OtherExpr (a1, a2), B.OtherExpr (b1, b2) ->
       m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.N (G.Id _ as a), B.N (B.IdQualified _ as b) -> m_name a b
+  | G.Call _, _
+  | G.New _, _
+  | G.ArrayAccess _, _
   | G.Container _, _
   | G.Comprehension _, _
   | G.Record _, _
@@ -2106,7 +2138,7 @@ and m_stmt a b =
         if_config
           (fun x -> x.implicit_deep_exprstmt)
           ~then_:(m_expr_deep_implict a1 b1)
-          ~else_:(m_expr a1 b1)
+          ~else_:(m_expr_root a1 b1)
       in
       m_tok a2 b2
   (* opti: specialization to avoid going in the deep stmt matching!
@@ -2164,7 +2196,7 @@ and m_stmt a b =
         ~then_:
           (let resolved = Some (G.LocalVar, G.sid_TODO) in
            let b1 = H.funcdef_to_lambda (ent, fdef) resolved in
-           m_expr a1 b1)
+           m_expr_root a1 b1)
         ~else_:(fail ())
   (* equivalence: *)
   | G.ExprStmt (a1, _), B.Return (_, Some b1, _) -> m_expr_deep a1 b1

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -991,9 +991,6 @@ and m_expr ?(is_root = false) a b =
   | G.OtherExpr (a1, a2), B.OtherExpr (b1, b2) ->
       m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.N (G.Id _ as a), B.N (B.IdQualified _ as b) -> m_name a b
-  | G.Call _, _
-  | G.New _, _
-  | G.ArrayAccess _, _
   | G.Container _, _
   | G.Comprehension _, _
   | G.Record _, _

--- a/semgrep-core/src/matching/Generic_vs_generic.mli
+++ b/semgrep-core/src/matching/Generic_vs_generic.mli
@@ -1,5 +1,5 @@
 (* entry points, used in the sgrep_generic visitors *)
-val m_expr : AST_generic.expr Matching_generic.matcher
+val m_expr_root : AST_generic.expr Matching_generic.matcher
 val m_stmt : AST_generic.stmt Matching_generic.matcher
 
 val m_stmts_deep :

--- a/semgrep-core/src/matching/Match_patterns.ml
+++ b/semgrep-core/src/matching/Match_patterns.ml
@@ -63,7 +63,7 @@ let set_last_matched_rule rule f =
 
 let match_e_e rule a b env =
   Common.profile_code ("rule:" ^ rule.MR.id) (fun () ->
-      set_last_matched_rule rule (fun () -> GG.m_expr a b env))
+      set_last_matched_rule rule (fun () -> GG.m_expr_root a b env))
   [@@profiling]
 
 let match_st_st rule a b env =

--- a/semgrep-core/tests/OTHER/rules/symbol_prop_redundancy.py
+++ b/semgrep-core/tests/OTHER/rules/symbol_prop_redundancy.py
@@ -1,5 +1,5 @@
 # the function is only necessary because propagation only runs inside of functions at the moment
 def foo():
-  # ruleid: symbol_prop_redundancy: 
+  # ruleid: symbol_prop_redundancy
   x = g(5)
   f(x)

--- a/semgrep-core/tests/OTHER/rules/symbol_prop_redundancy.py
+++ b/semgrep-core/tests/OTHER/rules/symbol_prop_redundancy.py
@@ -1,0 +1,5 @@
+# the function is only necessary because propagation only runs inside of functions at the moment
+def foo():
+  # ruleid: symbol_prop_redundancy: 
+  x = g(5)
+  f(x)

--- a/semgrep-core/tests/OTHER/rules/symbol_prop_redundancy.yaml
+++ b/semgrep-core/tests/OTHER/rules/symbol_prop_redundancy.yaml
@@ -1,0 +1,9 @@
+id: symbol_prop_redundancy 
+options:
+  symbolic_propagation: true
+pattern: |
+  g(5)
+message: a match was found or something idk im not an engineer
+languages:
+  - python
+severity: WARNING


### PR DESCRIPTION
**What**:
Currently, symbolic propagation results in redundant matches, which leads to it being disabled by default.

Consider the following Python program:

```py
def foo():
  x = g(5)
  f(x)
```

If we wanted to match this to the following rule:

```yaml
id: i-cant-be-bothered-to-think-of-a-name-for-this-rule-so-ill-put-this-except-ironically-this-ends-up-significantly-longer-than-if-i-had-just-not-bothered-to-type-this-at-all
options:
  symbolic_propagation: true
pattern: |
  g(5)
message: a match was found or something idk im not an engineer
languages:
  - python
severity: WARNING
```

we get the following matches:

```
test2.py:3 with rule i-cant-be-bothered-to-think-of-a-name-for-this-rule-so-ill-put-this-except-ironically-this-ends-up-significantly-longer-than-if-i-had-just-not-bothered-to-type-this-at-all
   f(x)
test2.py:2 with rule i-cant-be-bothered-to-think-of-a-name-for-this-rule-so-ill-put-this-except-ironically-this-ends-up-significantly-longer-than-if-i-had-just-not-bothered-to-type-this-at-all
   x = g(5)
```

Notably, the first match (on the third line of the program) is extraneous, because it's not particularly useful to match to every instance of x, because we already produced a match at the time that we declared x. Every future match to x is just reiterating information we already know.

However, consider the following case:

```yaml
id: i-cant-be-bothered-to-think-of-a-name-for-this-rule-so-ill-put-this-except-ironically-this-ends-up-significantly-longer-than-if-i-had-just-not-bothered-to-type-this-at-all
options:
  symbolic_propagation: true
pattern: |
  f(g(5))
message: a match was found or something idk im not an engineer
languages:
  - python
severity: WARNING
```
with program
```py
def foo():
  x = g(5)
  // MATCH: 
  f(x)
```
In this case, we do care to use the propagated definition of x - this is a useful match to produce. The distinction is that in the latter case, we had to "do work" to get to the identifier x. The issue that we should not care to produce matches to propagated identifiers if they are at the "top-level", that is, not resulting from decomposing on the target pattern. 

So if we start out with something of the form x ~ <pat>, we should always fail - even if we produce a match, this would inevitably be reiterating some information we already knew at the time of binding x. If we have something like f(x) ~ f(<pat>), it's totally fair game to use the definition of x, though. More generally, any time that we recurse into a code snippet (taking a layer off the pattern), then we should want to use the symbolic propagation information.

**Why:**
We should avoid redundant matches so that we can have symbolic propagation be the default, since it's quite handy to have.

**How:**
I added a wrapper for `m_expr`, effectively allowing it to either take in an `is_root : bool` argument or not. Almost all existing cases where `m_expr` is called is with `is_root` set to `false` - this is because we usually reach `m_expr` from recursing on an existing pattern, meaning we are not at the root.

Notably exceptions include `m_expr_deep`, which just finds a list of sub-expressions, and matches to all of them. This is done with the original pattern, meaning it should be considered to be at the root of the pattern.

Also, `m_expr` was exposed, and I have changed it so that both `m_expr_root` is exposed and used, since from outside the matching engine itself, this is used at the top-level of a pattern.

**Fixes:** PA-1772

PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
