### PR TITLE
feat: parsing todo statistics

### DIFF
--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -29,9 +29,64 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* Helpers *)
 (*****************************************************************************)
 
+module SMap = Map.Make (String)
+module IMap = Map.Make (Int)
+
+type mode = Searching | Finding
+
+(* Global store, because I don't want to pass it through a bunch of func calls.
+ *)
+let store = ref []
+
+let process_exn () =
+  let rec process mode (lines : string list) =
+    match lines with
+    | [] -> "failure"
+    | line :: rest -> (
+        (* Sue me. *)
+        let tokens = Common.split " " line in
+        match (mode, tokens) with
+        | Searching, "Called" :: "from" :: _ -> process Finding rest
+        | Searching, _ -> process Searching rest
+        | ( Finding,
+            "Called" :: "from" :: funcname :: _in :: _file :: _filename
+            :: "line" :: linenum :: _ ) ->
+            funcname ^ ":" ^ linenum
+            (* There should be at least one `Called from` after the first... *)
+        | Finding, _ -> failwith "bad")
+  in
+  let res =
+    Printexc.get_backtrace ()
+    |> Common.split (Str.quote "\n")
+    |> process Searching
+  in
+  store := res :: !store;
+  ()
+
 let print_exn file e =
   let trace = Printexc.get_backtrace () in
+  process_exn ();
   pr2 (spf "%s: exn = %s\n%s" file (Common.exn_to_s e) trace)
+
+let report_counts () =
+  let counts =
+    List.fold_left
+      (fun map x ->
+        SMap.update x
+          (function
+            | None -> Some 1
+            | Some x -> Some (x + 1))
+          map)
+      SMap.empty !store
+    |> SMap.to_seq
+    |> Seq.map (fun (x, y) -> (y, x))
+    |> IMap.of_seq |> IMap.to_rev_seq |> List.of_seq
+  in
+  pr2 "\nTODO statistics:";
+  List.fold_left
+    (fun acc (count, filename) -> acc ^ Common.spf "\n%s -> %d" filename count)
+    "" counts
+  |> pr2
 
 let dump_and_print_errors dumper (res : 'a Tree_sitter_run.Parsing_result.t) =
   (match res.program with
@@ -417,6 +472,7 @@ let parse_projects ~verbose lang project_dirs =
 
 let parsing_stats ?(json = false) ?(verbose = false) lang project_dirs =
   let stat_list = parse_projects ~verbose lang project_dirs in
+  report_counts ();
   if json then print_json lang stat_list
   else
     let flat_stat = List.concat_map snd stat_list in


### PR DESCRIPTION
**What:**
It's real rough when you're trying to add a new language to Semgrep. There's like a billion TODOs around, and you gotta fix all of them. The thing is though, although we can get parsing statistics as to what files we have difficulty parsing, and our percentage of parse rate, they aren't actually directed towards where in the translation process that we failed; they just count the frequency of failure on a repository basis.

This PR adds parsing TODO statistics, which count up the places where `todo` was called from within the parser, and then reports them in descending order. That way, you can focus on TODOs which are more prevalent, and make changes which have maximal impact in getting parse rate up.

**Why**:
We should be able to write translations in a more directed fashion, prioritizing those parts of the language which are most common.

**How:**
I parse the exception backtrace for each failed test, for the first instance of a non-`todo`-named function. I save the line number too. Then, I concatenate them together, and order them in descending order, and print to the relevant `stats.log` file. This hooks into the `./run-lang <lang>` parse rate estimator.

So, for instance, with our current 2% parse rate Swift parser, I ran the `./run-lang swift` command, and then the end of the `stats.log` that is produced has the following:

```
TODO statistics:

Parse_swift_tree_sitter.map_non_local_scope_modifier:302, -> 133
Parse_swift_tree_sitter.map_attribute:790, -> 26
Parse_swift_tree_sitter.map_value_argument:2931, -> 10
Parse_swift_tree_sitter.map_call_expression:927, -> 9
Parse_swift_tree_sitter.map_property_declaration:2281, -> 4
Parse_swift_tree_sitter.map_binding_pattern_with_expr:890, -> 3
Parse_swift_tree_sitter.map_type_constraints:2719, -> 2
Parse_swift_tree_sitter.map_type_arguments:2687, -> 1
```
This tells us that the largest source of parse errors is on line 302 in `map_non_local_scope_modifier`, tripping a whole 133 times. This means that we should fix that one next, in order to get parse rate up.

PR checklist:

- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
