### PR TITLE
fix(python): Include start and end tokens of Python f strings

### DIFF
--- a/changelog.d/gh-2995.fixed
+++ b/changelog.d/gh-2995.fixed
@@ -1,0 +1,1 @@
+Fix an incorrect autofix application when the fix includes Python f strings

--- a/cli/tests/e2e/rules/autofix/python-ranges.yaml
+++ b/cli/tests/e2e/rules/autofix/python-ranges.yaml
@@ -1,0 +1,7 @@
+rules:
+- id: range-test
+  message: change it
+  pattern: foo($E)
+  fix: bar($E)
+  languages: [python]
+  severity: ERROR

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-dryrun/autofix/python-ranges.py-dryrun
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-dryrun/autofix/python-ranges.py-dryrun
@@ -1,0 +1,5 @@
+foo('abc')
+foo("abc")
+foo("""abc""")
+foo(r"abc")
+foo(f"abc")

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-dryrun/results.json
@@ -1,0 +1,217 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/autofix/python-ranges.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 11,
+        "line": 1,
+        "offset": 10
+      },
+      "extra": {
+        "fingerprint": "e79279649b452bbbf7d0ed45b41c4306c7ae447ec18dff9fb9533164cca8cb739c6125cfe75b8132ef06a64daa3a3e792a54f815e4e13fe1620390ce4635eee7_0",
+        "fix": "bar('abc')",
+        "fixed_lines": [
+          "bar('abc')"
+        ],
+        "is_ignored": false,
+        "lines": "foo('abc')",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "'abc'",
+            "end": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "start": {
+              "col": 5,
+              "line": 1,
+              "offset": 4
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 11,
+        "line": 2,
+        "offset": 21
+      },
+      "extra": {
+        "fingerprint": "f76e5da0c5286b980c16e4cb70edfd8c8d36f5971f05289d7436504d3f523e6181581f057708c5497eefbe00f7e0c0700e129ebfe625bd28b8511abb12c21ad2_0",
+        "fix": "bar(\"abc\")",
+        "fixed_lines": [
+          "bar(\"abc\")"
+        ],
+        "is_ignored": false,
+        "lines": "foo(\"abc\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "\"abc\"",
+            "end": {
+              "col": 10,
+              "line": 2,
+              "offset": 20
+            },
+            "start": {
+              "col": 5,
+              "line": 2,
+              "offset": 15
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 2,
+        "offset": 11
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 15,
+        "line": 3,
+        "offset": 36
+      },
+      "extra": {
+        "fingerprint": "81532d03c4025559cb90654aa03c73def58102d74b319def22897ab0a1f951106a13277f2be0879fd3aa52d3d72c0ee09388879e961aef12af65d60d5ef6268f_0",
+        "fix": "bar(\"\"\"abc\"\"\")",
+        "fixed_lines": [
+          "bar(\"\"\"abc\"\"\")"
+        ],
+        "is_ignored": false,
+        "lines": "foo(\"\"\"abc\"\"\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "\"\"\"abc\"\"\"",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 35
+            },
+            "start": {
+              "col": 5,
+              "line": 3,
+              "offset": 26
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 3,
+        "offset": 22
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 12,
+        "line": 4,
+        "offset": 48
+      },
+      "extra": {
+        "fingerprint": "1b483609b2d923053bf48d8e2c4a8f4268b1b56115eadcdd4d03c9f04048fe4ab38c7286384a067c18e771fbd62ca47060e793d4ab51bb064dcd1edf71918bc1_0",
+        "fix": "bar(r\"abc\")",
+        "fixed_lines": [
+          "bar(r\"abc\")"
+        ],
+        "is_ignored": false,
+        "lines": "foo(r\"abc\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "r\"abc\"",
+            "end": {
+              "col": 11,
+              "line": 4,
+              "offset": 47
+            },
+            "start": {
+              "col": 5,
+              "line": 4,
+              "offset": 41
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 4,
+        "offset": 37
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 12,
+        "line": 5,
+        "offset": 60
+      },
+      "extra": {
+        "fingerprint": "06ff9a5e1a4aa4daf35c58f780d854fc712eea26b9028ce7df5be64264072da0bd45abf96ad9143e5d24aacf6dfcc93f3f7f88d0ef0d6ea86ab713dd69962fc7_0",
+        "fix": "bar(f\"abc\")",
+        "fixed_lines": [
+          "bar(f\"abc\")"
+        ],
+        "is_ignored": false,
+        "lines": "foo(f\"abc\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "f\"abc\"",
+            "end": {
+              "col": 11,
+              "line": 5,
+              "offset": 59
+            },
+            "start": {
+              "col": 5,
+              "line": 5,
+              "offset": 53
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 5,
+        "offset": 49
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-not-dryrun/autofix/python-ranges.py-fixed
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-not-dryrun/autofix/python-ranges.py-fixed
@@ -1,0 +1,5 @@
+bar('abc')
+bar("abc")
+bar("""abc""")
+bar(r"abc")
+bar(f"abc")

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-not-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixpython-ranges.yaml-autofixpython-ranges.py-not-dryrun/results.json
@@ -1,0 +1,202 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/autofix/python-ranges.py"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 11,
+        "line": 1,
+        "offset": 10
+      },
+      "extra": {
+        "fingerprint": "e79279649b452bbbf7d0ed45b41c4306c7ae447ec18dff9fb9533164cca8cb739c6125cfe75b8132ef06a64daa3a3e792a54f815e4e13fe1620390ce4635eee7_0",
+        "fix": "bar('abc')",
+        "is_ignored": false,
+        "lines": "foo('abc')",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "'abc'",
+            "end": {
+              "col": 10,
+              "line": 1,
+              "offset": 9
+            },
+            "start": {
+              "col": 5,
+              "line": 1,
+              "offset": 4
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 1,
+        "offset": 0
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 11,
+        "line": 2,
+        "offset": 21
+      },
+      "extra": {
+        "fingerprint": "f76e5da0c5286b980c16e4cb70edfd8c8d36f5971f05289d7436504d3f523e6181581f057708c5497eefbe00f7e0c0700e129ebfe625bd28b8511abb12c21ad2_0",
+        "fix": "bar(\"abc\")",
+        "is_ignored": false,
+        "lines": "foo(\"abc\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "\"abc\"",
+            "end": {
+              "col": 10,
+              "line": 2,
+              "offset": 20
+            },
+            "start": {
+              "col": 5,
+              "line": 2,
+              "offset": 15
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 2,
+        "offset": 11
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 15,
+        "line": 3,
+        "offset": 36
+      },
+      "extra": {
+        "fingerprint": "81532d03c4025559cb90654aa03c73def58102d74b319def22897ab0a1f951106a13277f2be0879fd3aa52d3d72c0ee09388879e961aef12af65d60d5ef6268f_0",
+        "fix": "bar(\"\"\"abc\"\"\")",
+        "is_ignored": false,
+        "lines": "foo(\"\"\"abc\"\"\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "\"\"\"abc\"\"\"",
+            "end": {
+              "col": 14,
+              "line": 3,
+              "offset": 35
+            },
+            "start": {
+              "col": 5,
+              "line": 3,
+              "offset": 26
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 3,
+        "offset": 22
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 12,
+        "line": 4,
+        "offset": 48
+      },
+      "extra": {
+        "fingerprint": "1b483609b2d923053bf48d8e2c4a8f4268b1b56115eadcdd4d03c9f04048fe4ab38c7286384a067c18e771fbd62ca47060e793d4ab51bb064dcd1edf71918bc1_0",
+        "fix": "bar(r\"abc\")",
+        "is_ignored": false,
+        "lines": "foo(r\"abc\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "r\"abc\"",
+            "end": {
+              "col": 11,
+              "line": 4,
+              "offset": 47
+            },
+            "start": {
+              "col": 5,
+              "line": 4,
+              "offset": 41
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 4,
+        "offset": 37
+      }
+    },
+    {
+      "check_id": "rules.autofix.range-test",
+      "end": {
+        "col": 12,
+        "line": 5,
+        "offset": 60
+      },
+      "extra": {
+        "fingerprint": "06ff9a5e1a4aa4daf35c58f780d854fc712eea26b9028ce7df5be64264072da0bd45abf96ad9143e5d24aacf6dfcc93f3f7f88d0ef0d6ea86ab713dd69962fc7_0",
+        "fix": "bar(f\"abc\")",
+        "is_ignored": false,
+        "lines": "foo(f\"abc\")",
+        "message": "change it",
+        "metadata": {},
+        "metavars": {
+          "$E": {
+            "abstract_content": "f\"abc\"",
+            "end": {
+              "col": 11,
+              "line": 5,
+              "offset": 59
+            },
+            "start": {
+              "col": 5,
+              "line": 5,
+              "offset": 53
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/autofix/python-ranges.py",
+      "start": {
+        "col": 1,
+        "line": 5,
+        "offset": 49
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/autofix/python-ranges.py
+++ b/cli/tests/e2e/targets/autofix/python-ranges.py
@@ -1,0 +1,5 @@
+foo('abc')
+foo("abc")
+foo("""abc""")
+foo(r"abc")
+foo(f"abc")

--- a/cli/tests/e2e/test_autofix.py
+++ b/cli/tests/e2e/test_autofix.py
@@ -27,6 +27,7 @@ import pytest
         ("rules/autofix/two-autofixes.yaml", "autofix/two-autofixes.txt"),
         ("rules/autofix/three-autofixes.yaml", "autofix/three-autofixes.py"),
         ("rules/autofix/ocaml_paren_expr.yaml", "autofix/ocaml_paren_expr.ml"),
+        ("rules/autofix/python-ranges.yaml", "autofix/python-ranges.py"),
     ],
 )
 @pytest.mark.kinda_slow

--- a/perf/snapshots/benchmark_findings.json
+++ b/perf/snapshots/benchmark_findings.json
@@ -497,11 +497,11 @@
             "severity": "WARNING"
           },
           "path": "<masked in benchmarks>/semgrep/perf/bench/pallets/input/flask/src/flask/debughelpers.py",
-          "start": { "col": 15, "line": 23, "offset": 645 }
+          "start": { "col": 13, "line": 23, "offset": 643 }
         },
         {
           "check_id": "semgrep.perf.bench.rules_cache.pallets.python.lang.correctness.common-mistakes.string-concat-in-list.string-concat-in-list",
-          "end": { "col": 35, "line": 53, "offset": 1895 },
+          "end": { "col": 36, "line": 53, "offset": 1896 },
           "extra": {
             "fingerprint": "<masked in benchmarks>",
             "is_ignored": false,
@@ -512,7 +512,7 @@
             "severity": "WARNING"
           },
           "path": "<masked in benchmarks>/semgrep/perf/bench/pallets/input/flask/src/flask/debughelpers.py",
-          "start": { "col": 15, "line": 51, "offset": 1736 }
+          "start": { "col": 13, "line": 51, "offset": 1734 }
         },
         {
           "check_id": "semgrep.perf.bench.rules_cache.pallets.python.lang.correctness.common-mistakes.is-comparison-string.identical-is-comparison",

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -187,16 +187,17 @@ let rec expr env (x : expr) =
         ( G.IdSpecial (G.EncodedString pre, fake (snd v1) "") |> G.e,
           fb [ G.Arg (G.L (G.String v1) |> G.e) ] )
       |> G.e
-  | InterpolatedString xs ->
+  | InterpolatedString (v1, xs, v3) ->
       G.Call
         (* Python interpolated strings are always of the form f"...", we need to support arbitary strings in the generic AST because Scala has custom interpolators *)
         ( G.IdSpecial (G.ConcatString (G.FString "f"), unsafe_fake "concat")
           |> G.e,
-          fb
-            (xs
+          ( v1,
+            xs
             |> List.map (fun x ->
                    let x = expr env x in
-                   G.Arg x)) )
+                   G.Arg x),
+            v3 ) )
       |> G.e
   | ConcatenatedString xs ->
       G.Call


### PR DESCRIPTION
This ensures that the start and end tokens are included in the AST node
representing f strings. It's generally good practice to make sure that
all of the tokens that make up a specific construct are included, but in
particular this addresses an issue with autofix that led to the quotes
and `f` of an f string getting dropped.

Fixes #2995

Test plan: Automated tests

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
