### PR TITLE
fix(extract): regression in mk_rule_table

### DIFF
--- a/changelog.d/pa-1786.fixed
+++ b/changelog.d/pa-1786.fixed
@@ -1,0 +1,2 @@
+Extract mode: fixed a possible exception in normal usage introduced due to
+changes in handling of search/taint rules.

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -432,9 +432,15 @@ let mk_rule_table rules list_of_rule_ids =
   let rule_pairs = Common.map (fun r -> (fst r.R.id, r)) rules in
   let rule_table = Common.hash_of_list rule_pairs in
   let id_pairs =
-    List.mapi
-      (fun i rule_id -> (i, Hashtbl.find rule_table rule_id))
-      list_of_rule_ids
+    list_of_rule_ids
+    |> List.mapi (fun i x -> (i, x))
+    (* We filter out rules here if they don't exist, because we might have a
+     * rule_id for an extract mode rule, but extract mode rules won't appear in
+     * rule pairs, because they won't be in the table we make for search
+     * because we don't want to run them at this stage.
+     *)
+    |> List.filter_map (fun (i, rule_id) ->
+           Hashtbl.find_opt rule_table rule_id >>= fun x -> Some (i, x))
   in
   Common.hash_of_list id_pairs
 


### PR DESCRIPTION
Due to a changes in for memory consumption the logic for making the
rule table in Run_semgrep changed. However, this relies on the
assumption that rule_pairs and list_of_rule_ids should contain the exact
same rules/rule_ids. When running with extract mode rules, this is
intentionally not the case.

This commit fixes this, by filtering out any unpaired rule_ids present
in these lists. These filtered rule_ids comprise the extract mode rules
which were used to target that file, but which should not be run against
it in search mode.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
