### PR TITLE
Update ocaml-tree-sitter-core with additional options to the configure script

### DIFF
--- a/changelog.d/gh-5944.added
+++ b/changelog.d/gh-5944.added
@@ -1,0 +1,2 @@
+Add configuration options for using a tree-sitter library installed anywhere
+on the system.


### PR DESCRIPTION
This was motivated by homebrew packaging which uses a tree-sitter library installed globally, but I don't think it's needed for that use case. It will be useful in other scenarios, such as trying out a patched version of tree-sitter.

test plan: CI build should succeed as before. See also the original PR https://github.com/returntocorp/ocaml-tree-sitter-core/pull/47

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
