### PR TITLE
tainting: Restore ArgToSink findings after taint labels

### DIFF
--- a/changelog.d/pa-1750.fixed
+++ b/changelog.d/pa-1750.fixed
@@ -1,0 +1,3 @@
+Fixed a regression in DeepSemgrep after the experimental taint labels feature
+was introduced in 0.106.0. This prevented DeepSemgrep from reporting taint
+findings when e.g. the sink was wrapped by another function.

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -217,26 +217,28 @@ let findings_of_tainted_sink env taints (sink : T.sink) : T.finding list =
   let labels = labels_in_taint taints in
   let sink_pm, ts = T.pm_of_trace sink in
   let req = eval_label_requires ~labels ts.requires in
-  if req then
-    (* TODO: With taint labels it's less clear what is "the source",
+  (* TODO: With taint labels it's less clear what is "the source",
      * in fact, there could be many sources, each one providing a
      * different label. Here these would be reported as different
-     * findings... We would need to compute subsets of taints satisfying
-     * the `requires`, and then have multiple sources in `SrcToSink`! *)
-    taints |> Taints.elements
-    |> List.filter_map (fun (taint : T.taint) ->
-           let tokens = List.rev taint.tokens in
-           match taint.orig with
-           | Arg i ->
-               (* We need to check unifiability at the call site. *)
-               Some (T.ArgToSink (i, tokens, sink))
-           | Src source ->
+     * findings... We would need to have multiple sources in `SrcToSink`!
+     * And `ArgtoSink` needs to carry the other taint that reaches the
+     * sink besides the argument. *)
+  taints |> Taints.elements
+  |> List.filter_map (fun (taint : T.taint) ->
+         let tokens = List.rev taint.tokens in
+         match taint.orig with
+         | Arg i ->
+             (* We need to check the label and unifiability requirements
+                at the call site. *)
+             Some (T.ArgToSink (i, tokens, sink))
+         | Src source ->
+             if req then
                let src_pm, _ = T.pm_of_trace source in
                let* merged_env =
                  merge_source_sink_mvars env sink_pm.PM.env src_pm.PM.env
                in
-               Some (T.SrcToSink { source; tokens; sink; merged_env }))
-  else []
+               Some (T.SrcToSink { source; tokens; sink; merged_env })
+             else None)
 
 (* Produces a finding for every unifiable source-sink pair. *)
 let findings_of_tainted_sinks env taints sinks : T.finding list =

--- a/semgrep-core/tests/OTHER/rules/taint_labels1.py
+++ b/semgrep-core/tests/OTHER/rules/taint_labels1.py
@@ -1,6 +1,11 @@
 def foo():
   a = source()
-  if cond():
-     b = a
+  b = a
+  #OK: tainting
+  sink(b)
+
+def bar(x):
+  a = source()
+  b = a + x
   #OK: tainting
   sink(b)


### PR DESCRIPTION
With taint labels we stopped producing certain ArgToSink findings because
the `requires` label-formula of the sink always evaluates to false, if
the only taint we have is "polymorphic taint" coming from an argument.
Instead, the `requires` should always evaluate to true for arguments!

This is still not a proper implementation of taint labels for
DeepSemgrep, but at least it allows us to fix the regressions that
8f26fabe29a introduced.

Fixes: 8f26fabe29a ("tainting: Add experimental taint labels feature (#5725)")

Closes PA-1750

test plan:
DeepSemgrep tests pass

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
