### PR TITLE
add an e2e test case for blocking findings

### DIFF
--- a/.github/workflows/e2e-semgrep-ci.yml
+++ b/.github/workflows/e2e-semgrep-ci.yml
@@ -82,6 +82,8 @@ jobs:
       - name: Run CI
         id: run-ci
         run: |
+          # If we get error code 0: unexpected, return an error. Otherwise, continue on.
+          # other tests ensure that error code >=2 are handled appropriately.
           if semgrep ci --suppress-errors; then
             exit 2
           else

--- a/.github/workflows/e2e-semgrep-ci.yml
+++ b/.github/workflows/e2e-semgrep-ci.yml
@@ -58,6 +58,36 @@ jobs:
       - name: Run CI
         run: semgrep ci --suppress-errors
 
+  semgrep-ci-fail-open-blocking-findings:
+    name: Semgrep CI Fail Open Blocking Findings
+    runs-on: ubuntu-22.04
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_E2E_APP_TOKEN }}
+      SEMGREP_USER_AGENT_APPEND: semgrep-ci-e2e
+    needs: get-inputs
+    container:
+      image: "returntocorp/semgrep:${{ needs.get-inputs.outputs.docker_tag }}"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Create code under test
+        id: create-code
+        run: |
+          cat > ./test.py <<- EOF
+          import click
+
+          # ruleid:use-click-secho
+          click.echo(click.style("foo"))
+          EOF
+      - name: Run CI
+        id: run-ci
+        run: |
+          if semgrep ci --suppress-errors; then
+            exit 2
+          else
+            exit 0
+          fi
+
   semgrep-ci-on-pr:
     name: Run Semgrep CI on a PR
     uses: ./.github/workflows/open-bump-pr.yml


### PR DESCRIPTION
We want to surface error code 1 when blocking findings are encountered via `semgrep ci`

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
