### PR TITLE
update m1 osx script

### DIFF
--- a/scripts/osx-m1-release.sh
+++ b/scripts/osx-m1-release.sh
@@ -12,14 +12,15 @@ set -eux
 # everything every time
 
 brew update # Needed to sidestep bintray brownout
-brew install opam pkg-config coreutils pcre
-opam init --no-setup --bare;
+
 #coupling: this should be the same version than in our Dockerfile
-opam switch create 4.14.0
 opam switch 4.14.0
 git submodule update --init --recursive --depth 1
 
 eval "$(opam env)"
+
+# Needed so we don't make config w/ sudo
+export HOMEBREW_SYSTEM=1
 
 make setup
 


### PR DESCRIPTION
We had a few changes that went in that broke our self-hosted M1 builder - this undoes the breaking changes.

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
