### PR TITLE
chore: reduce log level of metrics failure message

### DIFF
--- a/changelog.d/app-1398.changed
+++ b/changelog.d/app-1398.changed
@@ -1,0 +1,5 @@
+Previously, the following error message appears when metrics are not uploaded within the set timeout timeframe:
+
+Error in send: HTTPSConnectionPool(host='metrics.semgrep.dev', port=443): Read timed out. (read timeout=3)
+
+As this causes users confusion when running the CLI, the log level of the message is reduced to appear for development and debugging purposes only. Note that metrics are still successfully uploaded, but the success status is not sent in time for the curent timeout set.

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -152,7 +152,8 @@ def suppress_errors(func: Callable[..., None]) -> Callable[..., None]:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
-        except Exception:
+        except Exception as e:
+            logger.debug(f"Error in {func.__name__}: {e}")
             return None
 
     return wrapper

--- a/cli/src/semgrep/metrics.py
+++ b/cli/src/semgrep/metrics.py
@@ -152,8 +152,7 @@ def suppress_errors(func: Callable[..., None]) -> Callable[..., None]:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
-        except Exception as e:
-            logger.error(f"Error in {func.__name__}: {e}")
+        except Exception:
             return None
 
     return wrapper


### PR DESCRIPTION
What: 
`Error in send: HTTPSConnectionPool(host='metrics.semgrep.dev', port=443): Read timed out. (read timeout=3)` appears when metrics are not uploaded within the set timeout timeframe. 

Why: 
Causing users confusion when they run the CLI.

How: 
Remove error messaging. Note: Metrics are still successfully uploaded, but success status is not sent in time for current timeout set.  

PR checklist:

- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

Fixes APP-1398