### PR TITLE
AST_to_IL: Fix translation of `"some string".concat(E)` exprs

### DIFF
--- a/changelog.d/pa-1787.fixed
+++ b/changelog.d/pa-1787.fixed
@@ -1,0 +1,3 @@
+taint-mode: Fixed the translation from Generic to IL for expressions like
+`"some string".concat(x)`. Previously, when `x` was tainted, the `concat`
+expression was not recognized as tainted and this caused false negatives.

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -502,15 +502,16 @@ and expr_aux env ?(void = false) e_gen =
         args ) ->
       (* obj.concat(args) *)
       (* NOTE: Often this will be string concatenation but not necessarily! *)
-      let obj' = lval env obj in
-      let obj_arg' = mk_e (Fetch obj') (SameAs obj) in
+      let obj_arg' = expr env obj in
       let args' = arguments env args in
       let res =
         match env.lang with
         (* Ruby's concat method is side-effectful and updates the object. *)
         (* TODO: The lval in the LHs should have a differnt svalue than the
          * one in the RHS. *)
-        | Lang.Ruby -> obj'
+        | Lang.Ruby -> (
+            try lval env obj with
+            | Fixme _ -> fresh_lval ~str:"Fixme" env tok)
         | _ -> fresh_lval env tok
       in
       add_instr env

--- a/semgrep-core/src/cli/Main.ml
+++ b/semgrep-core/src/cli/Main.ml
@@ -246,7 +246,7 @@ let dump_ast ?(naming = false) lang file =
         Runner_exit.(exit_semgrep False)))
 
 (* mostly a copy paste of pfff/lang_GENERIC/analyze/Test_analyze_generic.ml *)
-let dump_il file =
+let dump_il_all file =
   let lang = List.hd (Lang.langs_of_filename file) in
   let ast = Parse_target.parse_program file in
   Naming_AST.resolve lang ast;
@@ -254,10 +254,9 @@ let dump_il file =
   List.iter (fun stmt -> pr2 (IL.show_stmt stmt)) xs
   [@@action]
 
-module G = AST_generic
-module V = Visitor_AST
-
-let dump_il_functions file =
+let dump_il file =
+  let module G = AST_generic in
+  let module V = Visitor_AST in
   let lang = List.hd (Lang.langs_of_filename file) in
   let ast = Parse_target.parse_program file in
   Naming_AST.resolve lang ast;
@@ -456,8 +455,8 @@ let all_actions () =
         Common.mk_action_1_arg
           (dump_ast ~naming:true (Xlang.lang_of_opt_xlang !lang))
           file );
+    ("-dump_il_all", " <file>", Common.mk_action_1_arg dump_il_all);
     ("-dump_il", " <file>", Common.mk_action_1_arg dump_il);
-    ("-dump_il_functions", " <file>", Common.mk_action_1_arg dump_il_functions);
     ("-dump_rule", " <file>", Common.mk_action_1_arg dump_rule);
     ( "-dump_equivalences",
       " <file> (deprecated)",

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -2,7 +2,9 @@ open IL
 
 let string_of_lval x =
   (match x.base with
-  | Var n -> str_of_name n
+  | Var n ->
+      (* coupling: Dataflow_xyz.str_of_name *)
+      Common.spf "%s:%d" (fst n.ident) n.sid
   | VarSpecial _ -> "<varspecial>"
   | Mem _ -> "<Mem>")
   ^
@@ -36,7 +38,13 @@ let short_string_of_node_kind nkind =
       match x.i with
       | Assign (lval, exp) -> string_of_lval lval ^ " = " ^ string_of_exp exp
       | AssignAnon _ -> " ... = <lambda|class>"
-      | Call (_lopt, exp, _) -> string_of_exp exp ^ "(...)"
+      | Call (lval_opt, exp, _) ->
+          let lval_str =
+            match lval_opt with
+            | None -> ""
+            | Some lval -> string_of_lval lval ^ " = "
+          in
+          lval_str ^ string_of_exp exp ^ "(...)"
       | CallSpecial (lval_opt, (call_special, _tok), _args) ->
           let lval_str =
             match lval_opt with

--- a/semgrep-core/tests/OTHER/rules/taint_ruby_concat.rb
+++ b/semgrep-core/tests/OTHER/rules/taint_ruby_concat.rb
@@ -1,0 +1,115 @@
+require 'pg'
+
+def bad1()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age=" + params['age']
+    # ruleid: ruby-pg-sqli
+    con.exec query
+end
+
+def bad2(user_input)
+    age = params[user_input]
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age="
+    query += age
+    # ruleid: ruby-pg-sqli
+    con.exec query
+end
+
+def bad3(userinput)
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age="
+    query.concat(cookies[userinput])
+    # ruleid: ruby-pg-sqli
+    con.exec query
+end
+
+def bad4(userinput)
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age="
+    query << params[userinput]
+    # ruleid: ruby-pg-sqli
+    con.exec(query)
+end
+
+def bad5()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    # ruleid: ruby-pg-sqli
+    con.exec_params("SELECT name FROM users WHERE age=" + params['age'])
+end
+
+def bad6()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    # ruleid: ruby-pg-sqli
+    con.exec_params("SELECT name FROM users WHERE age=".concat(params['age']))
+end
+
+def bad7(userinput)
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    # ruleid: ruby-pg-sqli
+    con.exec_params("SELECT name FROM users WHERE age=" << params[userinput])
+end
+
+def ok1()
+    conn = PG.connect(:dbname => 'db1')
+    conn.prepare('statement1', 'insert into table1 (id, name, profile) values ($1, $2, $3)')
+    # ok: ruby-pg-sqli
+    conn.exec_prepared('statement1', [ 11, 'J.R. "Bob" Dobbs', 'Too much is always better than not enough.' ])
+end
+
+def ok2()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age=" + "3"
+    # ok: ruby-pg-sqli
+    con.exec query
+end
+
+def ok3()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age="
+    query += "3"
+    # ok: ruby-pg-sqli
+    con.exec query
+end
+
+def ok4(userinput)
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age="
+    query.concat("hello")
+    # ok: ruby-pg-sqli
+    con.exec query
+end
+
+def ok5(userinput)
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    query = "SELECT name FROM users WHERE age="
+    query << "hello"
+    # ok: ruby-pg-sqli
+    con.exec query
+end
+
+def ok6()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    stm = "SELECT $1::int AS a, $2::int AS b, $3::int AS c"
+    # ok: ruby-pg-sqli
+    con.exec_params(stm, [1, 2, 3])
+end
+
+def ok7()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    # ok: ruby-pg-sqli
+    con.exec("SELECT name FROM users WHERE age=" + "3")
+end
+
+def ok8()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    # ok: ruby-pg-sqli
+    con.exec("SELECT * FROM users WHERE email=hello;".concat("hello"))
+end
+
+def ok9()
+    con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
+    # ok: ruby-pg-sqli
+    con.exec("SELECT * FROM users WHERE email=hello;" << "hello")
+end
+

--- a/semgrep-core/tests/OTHER/rules/taint_ruby_concat.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_ruby_concat.yaml
@@ -1,0 +1,50 @@
+id: ruby-pg-sqli
+mode: taint
+pattern-sources:
+  - pattern-either:
+      - pattern: |
+          params
+      - pattern: |
+          cookies
+pattern-propagators:
+  - pattern: $D << $S
+    from: $S
+    to: $D
+pattern-sinks:
+  - patterns:
+      - pattern-either:
+          - pattern-inside: |
+              $CON = PG.connect(...)
+              ...
+          - pattern-inside: |
+              $CON = PG::Connection.open(...)
+              ...
+          - pattern-inside: |
+              $CON = PG::Connection.new(...)
+              ...
+      - pattern-either:
+          - pattern: |
+              $CON.$METHOD($X,...)
+          - pattern: |
+              $CON.$METHOD $X, ...
+      - focus-metavariable: $X
+      - metavariable-regex:
+          metavariable: $METHOD
+          regex: ^(exec|exec_params)$
+languages:
+  - ruby
+message: "Detected string concatenation with a non-literal variable in a pg Ruby
+  SQL statement. This could lead to SQL injection if the variable is
+  user-controlled and not properly sanitized. In order to prevent SQL injection,
+  used parameterized queries or prepared statements instead. You can use
+  parameterized queries like so: `conn.exec_params('SELECT $1 AS a, $2 AS b, $3
+  AS c', [1, 2, nil])` And you can use prepared statements with
+  `exec_prepared`."
+metadata:
+  references:
+    - https://www.rubydoc.info/gems/pg/PG/Connection
+  category: security
+  technology:
+    - rails
+severity: WARNING
+


### PR DESCRIPTION
Because `"some string"` is not a valid l-value the whole thing was
translated into a Fixme node, and taint wouldn't propagate correctly.

Helps PA-1787

test plan:
make test # added one test

PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
