### PR TITLE
fix: Mark all unreachable supply chain findings as non-blocking

### DIFF
--- a/changelog.d/sca-block-bug.fix
+++ b/changelog.d/sca-block-bug.fix
@@ -1,0 +1,1 @@
+Fixed bug where unreachable supply chain findings could be marked blocking

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -417,7 +417,11 @@ def ci(
                 else blocking_matches_by_rule
                 # if an SCA finding is unreachable, it always goes in non-blocking
                 if rule.is_blocking
-                and ("sca_info" in match.extra and match.extra["sca_info"].reachable)
+                and (
+                    match.extra["sca_info"].reachable
+                    if "sca_info" in match.extra
+                    else True
+                )
                 else nonblocking_matches_by_rule
             )
             applicable_result_set[rule].append(match)

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -416,7 +416,8 @@ def ci(
                 if "r2c-internal-cai" in rule.id
                 else blocking_matches_by_rule
                 # if an SCA finding is unreachable, it always goes in non-blocking
-                if rule.is_blocking and not match.extra.get("dependency_match_only")
+                if rule.is_blocking
+                and ("sca_info" in match.extra and match.extra["sca_info"].reachable)
                 else nonblocking_matches_by_rule
             )
             applicable_result_set[rule].append(match)

--- a/cli/src/semgrep/formatter/emacs.py
+++ b/cli/src/semgrep/formatter/emacs.py
@@ -26,7 +26,7 @@ class EmacsFormatter(BaseFormatter):
             str(rule_match.start.line),
             str(rule_match.start.col),
             severity,
-            rule_match.lines[0].rstrip(),
+            rule_match.lines[0].rstrip() if rule_match.lines else "",
             rule_match.message,
         ]
 

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -283,7 +283,11 @@ class RuleMatch:
         """
         Returns if this finding indicates it should block CI
         """
-        return "block" in self.metadata.get("dev.semgrep.actions", ["block"])
+        blocking = "block" in self.metadata.get("dev.semgrep.actions", ["block"])
+        if "sca_info" in self.extra:
+            return blocking and self.extra["sca_info"].reachable
+        else:
+            return blocking
 
     @property
     def dataflow_trace(self) -> Optional[core.CliMatchDataflowTrace]:

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -58,7 +68,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 9 findings (8 blocking) from 6 rules.
+  Found 10 findings (8 blocking) from 6 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -58,7 +68,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 9 findings (8 blocking) from 6 rules.
+  Found 10 findings (8 blocking) from 6 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -289,7 +289,7 @@ Would have sent findings blob: {
                     "block"
                 ]
             },
-            "is_blocking": true,
+            "is_blocking": false,
             "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
             "sca_info": {
                 "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -54,7 +64,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
 Would have sent findings blob: {
     "token": null,
@@ -261,6 +271,45 @@ Would have sent findings blob: {
                     }
                 ]
             }
+        },
+        {
+            "check_id": "supply-chain1",
+            "path": "poetry.lock",
+            "line": 0,
+            "column": 0,
+            "end_line": 0,
+            "end_column": 0,
+            "message": "found a dependency",
+            "severity": 2,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+            "metadata": {
+                "dev.semgrep.actions": [
+                    "block"
+                ]
+            },
+            "is_blocking": true,
+            "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+            "sca_info": {
+                "reachable": false,
+                "reachability_rule": false,
+                "sca_finding_schema": 20220818,
+                "dependency_match": {
+                    "dependency_pattern": {
+                        "ecosystem": "pypi",
+                        "package": "badlib",
+                        "semver_range": "== 1.0.0"
+                    },
+                    "found_dependency": {
+                        "package": "badlib",
+                        "version": "1.0.0",
+                        "ecosystem": "pypi",
+                        "allowed_hashes": {}
+                    },
+                    "lockfile": "poetry.lock"
+                }
+            }
         }
     ],
     "searched_paths": [
@@ -371,7 +420,7 @@ Would have sent ignores blob: {
 Would have sent complete blob: {
     "exit_code": 1,
     "stats": {
-        "findings": 10,
+        "findings": 11,
         "errors": [],
         "total_time": <MASKED>
         "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -8,7 +8,17 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -8,7 +8,17 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -8,7 +8,17 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -8,7 +8,17 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -8,7 +8,17 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -8,7 +8,17 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -8,7 +8,17 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -8,7 +8,17 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -8,7 +8,17 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings.json
@@ -206,6 +206,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings.json
@@ -224,7 +224,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -8,7 +8,17 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -8,7 +8,17 @@ BUILD_BUILDID="some_id" BUILD_REPOSITORY_URI="https://github.com/project_name/pr
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -8,7 +8,17 @@ CI="true" BITBUCKET_BUILD_NUMBER="hi" BITBUCKET_REPO_FULL_NAME="project_name/pro
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -8,7 +8,17 @@ BUILDKITE="true" BUILDKITE_REPO="git@github.com/project_name/project_name.git" B
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -8,7 +8,17 @@ CI="true" CIRCLECI="true" CIRCLE_PROJECT_USERNAME="project_name" CIRCLE_PROJECT_
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -8,7 +8,17 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -8,7 +8,17 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="push" GITHUB_REPOSITORY="proj
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -8,7 +8,17 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -8,7 +8,17 @@ JENKINS_URL="some_url" SEMGREP_REPO_URL="https://random.url.org/some/path" SEMGR
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -8,7 +8,17 @@ JENKINS_URL="some_url" GIT_URL="https://github.com/org/repo.git/" GIT_BRANCH="so
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGR
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
@@ -1,7 +1,7 @@
 {
   "exit_code": 1,
   "stats": {
-    "findings": 10,
+    "findings": 11,
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings.json
@@ -221,7 +221,7 @@
           "block"
         ]
       },
-      "is_blocking": true,
+      "is_blocking": false,
       "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
       "sca_info": {
         "reachable": false,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings.json
@@ -203,6 +203,45 @@
           }
         ]
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
     }
   ],
   "searched_paths": [

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -8,7 +8,17 @@ CI="true" TRAVIS="true" TRAVIS_REPO_SLUG="project_name/project_name" TRAVIS_PULL
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -55,7 +65,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -69,7 +79,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 14 findings (12 blocking) from 6 rules.
+  Found 15 findings (12 blocking) from 6 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -58,7 +68,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 9 findings (8 blocking) from 6 rules.
+  Found 10 findings (8 blocking) from 6 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -69,7 +79,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 14 findings (12 blocking) from 6 rules.
+  Found 15 findings (12 blocking) from 6 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -8,7 +8,17 @@ SEMGREP_APP_TOKEN="" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<
 
 === stdout - plain
 
-Findings:
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
 
   foo.py 
      eqeq-bad
@@ -58,7 +68,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 9 findings (8 blocking) from 6 rules.
+  Found 10 findings (8 blocking) from 6 rules.
   Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
@@ -3,10 +3,18 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 === end of command
 
 === exit code
-2
+1
 === end of exit code
 
 === stdout - plain
+foo.py:4:5:error(eqeq-bad):    a == a:useless comparison
+foo.py:5:5:error(eqeq-bad):    a == a:useless comparison
+foo.py:7:5:error(eqeq-bad):    a == a:useless comparison
+foo.py:11:5:error(eqeq-bad):    y == y:useless comparison
+foo.py:15:5:error(eqeq-five):    x == 5:useless comparison to 5
+foo.py:19:5:error(eqeq-four):    baz == 4:useless comparison to 4
+foo.py:27:5:warning(taint-test):    sink(d2):unsafe use of danger
+poetry.lock:0:0:error(supply-chain1)::found a dependency
 
 === end of stdout - plain
 
@@ -20,24 +28,13 @@ Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
 Scanning 1 file with 5 python rules.
-list index out of range
-Traceback (most recent call last):
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/wrapper.py", line 35, in wrapper
-    func(*args, **kwargs)
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/ci.py", line 428, in ci
-    output_handler.output(
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 347, in output
-    output = self._build_output()
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 461, in _build_output
-    return self.formatter.output(
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/base.py", line 28, in output
-    return self.format(
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in format
-    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in <genexpr>
-    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 29, in _get_parts
-    rule_match.lines[0].rstrip(),
-IndexError: list index out of range
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 8 findings (6 blocking) from 6 rules.
+  Uploading findings to Semgrep App.
+  Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
@@ -3,17 +3,10 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 === end of command
 
 === exit code
-1
+2
 === end of exit code
 
 === stdout - plain
-foo.py:4:5:error(eqeq-bad):    a == a:useless comparison
-foo.py:5:5:error(eqeq-bad):    a == a:useless comparison
-foo.py:7:5:error(eqeq-bad):    a == a:useless comparison
-foo.py:11:5:error(eqeq-bad):    y == y:useless comparison
-foo.py:15:5:error(eqeq-five):    x == 5:useless comparison to 5
-foo.py:19:5:error(eqeq-four):    baz == 4:useless comparison to 4
-foo.py:27:5:warning(taint-test):    sink(d2):unsafe use of danger
 
 === end of stdout - plain
 
@@ -27,13 +20,24 @@ Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
 Scanning 1 file with 5 python rules.
-
-Some files were skipped or only partially analyzed.
-  Scan was limited to files tracked by git.
-
-CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings to Semgrep App.
-  Has findings for blocking rules so exiting with code 1
+list index out of range
+Traceback (most recent call last):
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/wrapper.py", line 35, in wrapper
+    func(*args, **kwargs)
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/ci.py", line 428, in ci
+    output_handler.output(
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 347, in output
+    output = self._build_output()
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 461, in _build_output
+    return self.formatter.output(
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/base.py", line 28, in output
+    return self.format(
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in format
+    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in <genexpr>
+    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 29, in _get_parts
+    rule_match.lines[0].rstrip(),
+IndexError: list index out of range
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
@@ -206,6 +206,34 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         }
       },
       "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "cve": "poetry.lock:f53a023eedfa3fbf2925ec7dc76eecdc954ea94b7e47065393dbad519613dc89:supply-chain1",
+      "id": "ff8806e5-d262-f88a-eebb-c15b80d84f12",
+      "identifiers": [
+        {
+          "name": "Semgrep - supply-chain1",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/supply-chain1",
+          "value": "supply-chain1"
+        }
+      ],
+      "location": {
+        "end_line": 0,
+        "file": "poetry.lock",
+        "start_line": 0
+      },
+      "message": "found a dependency",
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "High"
     }
   ]
 }
@@ -226,7 +254,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
@@ -255,6 +255,39 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         }
       },
       "severity": "High"
+    },
+    {
+      "category": "secret_detection",
+      "commit": {
+        "date": "1970-01-01T00:00:00Z",
+        "sha": "0000000"
+      },
+      "confidence": "High",
+      "cve": "poetry.lock:f53a023eedfa3fbf2925ec7dc76eecdc954ea94b7e47065393dbad519613dc89:supply-chain1",
+      "id": "ff8806e5-d262-f88a-eebb-c15b80d84f12",
+      "identifiers": [
+        {
+          "name": "Semgrep - supply-chain1",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/supply-chain1",
+          "value": "supply-chain1"
+        }
+      ],
+      "location": {
+        "end_line": 0,
+        "file": "poetry.lock",
+        "start_line": 0
+      },
+      "message": "found a dependency",
+      "raw_source_code_extract": [],
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "High"
     }
   ]
 }
@@ -275,7 +308,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -333,6 +333,52 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "line": 15,
         "offset": 157
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "end": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      },
+      "extra": {
+        "fingerprint": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+        "is_ignored": false,
+        "lines": "",
+        "message": "found a dependency",
+        "metadata": {
+          "dev.semgrep.actions": [
+            "block"
+          ]
+        },
+        "metavars": {},
+        "sca_info": {
+          "dependency_match": {
+            "dependency_pattern": {
+              "ecosystem": "pypi",
+              "package": "badlib",
+              "semver_range": "== 1.0.0"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "ecosystem": "pypi",
+              "package": "badlib",
+              "version": "1.0.0"
+            },
+            "lockfile": "poetry.lock"
+          },
+          "reachability_rule": false,
+          "reachable": false,
+          "sca_finding_schema": 20220818
+        },
+        "severity": "ERROR"
+      },
+      "path": "poetry.lock",
+      "start": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      }
     }
   ],
   "version": "0.42"
@@ -354,7 +400,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -396,6 +396,31 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "kind": "inSource"
             }
           ]
+        },
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "poetry.lock",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 0,
+                  "endLine": 0,
+                  "snippet": {
+                    "text": ""
+                  },
+                  "startColumn": 0,
+                  "startLine": 0
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found a dependency"
+          },
+          "ruleId": "supply-chain1"
         }
       ],
       "tool": {
@@ -455,6 +480,23 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             },
             {
               "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "found a dependency"
+              },
+              "id": "supply-chain1",
+              "name": "supply-chain1",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "found a dependency"
+              }
+            },
+            {
+              "defaultConfiguration": {
                 "level": "warning"
               },
               "fullDescription": {
@@ -495,7 +537,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 12 findings (10 blocking) from 6 rules.
+  Found 13 findings (10 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---vim/results.txt
@@ -14,6 +14,7 @@ foo.py:11:5:E:eqeq-bad:useless comparison
 foo.py:19:5:E:eqeq-four:useless comparison to 4
 foo.py:27:5:W:taint-test:unsafe use of danger
 foo.py:15:5:E:eqeq-five:useless comparison to 5
+poetry.lock:0:0:E:supply-chain1:found a dependency
 
 === end of stdout - plain
 
@@ -32,7 +33,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
@@ -3,10 +3,18 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 === end of command
 
 === exit code
-2
+1
 === end of exit code
 
 === stdout - plain
+foo.py:4:5:error(eqeq-bad):    a == a:useless comparison
+foo.py:5:5:error(eqeq-bad):    a == a:useless comparison
+foo.py:7:5:error(eqeq-bad):    a == a:useless comparison
+foo.py:11:5:error(eqeq-bad):    y == y:useless comparison
+foo.py:15:5:error(eqeq-five):    x == 5:useless comparison to 5
+foo.py:19:5:error(eqeq-four):    baz == 4:useless comparison to 4
+foo.py:27:5:warning(taint-test):    sink(d2):unsafe use of danger
+poetry.lock:0:0:error(supply-chain1)::found a dependency
 
 === end of stdout - plain
 
@@ -20,24 +28,13 @@ Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
 Scanning 1 file with 5 python rules.
-list index out of range
-Traceback (most recent call last):
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/wrapper.py", line 35, in wrapper
-    func(*args, **kwargs)
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/ci.py", line 428, in ci
-    output_handler.output(
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 347, in output
-    output = self._build_output()
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 461, in _build_output
-    return self.formatter.output(
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/base.py", line 28, in output
-    return self.format(
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in format
-    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in <genexpr>
-    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
-  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 29, in _get_parts
-    rule_match.lines[0].rstrip(),
-IndexError: list index out of range
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 8 findings (6 blocking) from 6 rules.
+  Uploading findings to Semgrep App.
+  Has findings for blocking rules so exiting with code 1
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
@@ -3,17 +3,10 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
 === end of command
 
 === exit code
-1
+2
 === end of exit code
 
 === stdout - plain
-foo.py:4:5:error(eqeq-bad):    a == a:useless comparison
-foo.py:5:5:error(eqeq-bad):    a == a:useless comparison
-foo.py:7:5:error(eqeq-bad):    a == a:useless comparison
-foo.py:11:5:error(eqeq-bad):    y == y:useless comparison
-foo.py:15:5:error(eqeq-five):    x == 5:useless comparison to 5
-foo.py:19:5:error(eqeq-four):    baz == 4:useless comparison to 4
-foo.py:27:5:warning(taint-test):    sink(d2):unsafe use of danger
 
 === end of stdout - plain
 
@@ -27,13 +20,24 @@ Fetching configuration from semgrep.dev
 Adding ignore patterns configured on semgrep.dev as `--exclude` options: ()
 Fetching rules from https://semgrep.dev/registry.
 Scanning 1 file with 5 python rules.
-
-Some files were skipped or only partially analyzed.
-  Scan was limited to files tracked by git.
-
-CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
-  Uploading findings to Semgrep App.
-  Has findings for blocking rules so exiting with code 1
+list index out of range
+Traceback (most recent call last):
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/wrapper.py", line 35, in wrapper
+    func(*args, **kwargs)
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/commands/ci.py", line 428, in ci
+    output_handler.output(
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 347, in output
+    output = self._build_output()
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/output.py", line 461, in _build_output
+    return self.formatter.output(
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/base.py", line 28, in output
+    return self.format(
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in format
+    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 42, in <genexpr>
+    return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)
+  File "/Users/matthewmcquaid/semgrep/cli/src/semgrep/formatter/emacs.py", line 29, in _get_parts
+    rule_match.lines[0].rstrip(),
+IndexError: list index out of range
 
 === end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
@@ -206,6 +206,34 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         }
       },
       "severity": "High"
+    },
+    {
+      "category": "sast",
+      "confidence": "High",
+      "cve": "poetry.lock:f53a023eedfa3fbf2925ec7dc76eecdc954ea94b7e47065393dbad519613dc89:supply-chain1",
+      "id": "ff8806e5-d262-f88a-eebb-c15b80d84f12",
+      "identifiers": [
+        {
+          "name": "Semgrep - supply-chain1",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/supply-chain1",
+          "value": "supply-chain1"
+        }
+      ],
+      "location": {
+        "end_line": 0,
+        "file": "poetry.lock",
+        "start_line": 0
+      },
+      "message": "found a dependency",
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "High"
     }
   ]
 }
@@ -226,7 +254,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
@@ -255,6 +255,39 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         }
       },
       "severity": "High"
+    },
+    {
+      "category": "secret_detection",
+      "commit": {
+        "date": "1970-01-01T00:00:00Z",
+        "sha": "0000000"
+      },
+      "confidence": "High",
+      "cve": "poetry.lock:f53a023eedfa3fbf2925ec7dc76eecdc954ea94b7e47065393dbad519613dc89:supply-chain1",
+      "id": "ff8806e5-d262-f88a-eebb-c15b80d84f12",
+      "identifiers": [
+        {
+          "name": "Semgrep - supply-chain1",
+          "type": "semgrep_type",
+          "url": "https://semgrep.dev/r/supply-chain1",
+          "value": "supply-chain1"
+        }
+      ],
+      "location": {
+        "end_line": 0,
+        "file": "poetry.lock",
+        "start_line": 0
+      },
+      "message": "found a dependency",
+      "raw_source_code_extract": [],
+      "scanner": {
+        "id": "semgrep",
+        "name": "Semgrep",
+        "vendor": {
+          "name": "Semgrep"
+        }
+      },
+      "severity": "High"
     }
   ]
 }
@@ -275,7 +308,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -330,6 +330,52 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
         "line": 15,
         "offset": 157
       }
+    },
+    {
+      "check_id": "supply-chain1",
+      "end": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      },
+      "extra": {
+        "fingerprint": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+        "is_ignored": false,
+        "lines": "",
+        "message": "found a dependency",
+        "metadata": {
+          "dev.semgrep.actions": [
+            "block"
+          ]
+        },
+        "metavars": {},
+        "sca_info": {
+          "dependency_match": {
+            "dependency_pattern": {
+              "ecosystem": "pypi",
+              "package": "badlib",
+              "semver_range": "== 1.0.0"
+            },
+            "found_dependency": {
+              "allowed_hashes": {},
+              "ecosystem": "pypi",
+              "package": "badlib",
+              "version": "1.0.0"
+            },
+            "lockfile": "poetry.lock"
+          },
+          "reachability_rule": false,
+          "reachable": false,
+          "sca_finding_schema": 20220818
+        },
+        "severity": "ERROR"
+      },
+      "path": "poetry.lock",
+      "start": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      }
     }
   ],
   "version": "0.42"
@@ -351,7 +397,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -342,6 +342,31 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "kind": "inSource"
             }
           ]
+        },
+        {
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "poetry.lock",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 0,
+                  "endLine": 0,
+                  "snippet": {
+                    "text": ""
+                  },
+                  "startColumn": 0,
+                  "startLine": 0
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found a dependency"
+          },
+          "ruleId": "supply-chain1"
         }
       ],
       "tool": {
@@ -401,6 +426,23 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             },
             {
               "defaultConfiguration": {
+                "level": "error"
+              },
+              "fullDescription": {
+                "text": "found a dependency"
+              },
+              "id": "supply-chain1",
+              "name": "supply-chain1",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "found a dependency"
+              }
+            },
+            {
+              "defaultConfiguration": {
                 "level": "warning"
               },
               "fullDescription": {
@@ -441,7 +483,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 12 findings (10 blocking) from 6 rules.
+  Found 13 findings (10 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
@@ -14,6 +14,7 @@ foo.py:11:5:E:eqeq-bad:useless comparison
 foo.py:19:5:E:eqeq-four:useless comparison to 4
 foo.py:27:5:W:taint-test:unsafe use of danger
 foo.py:15:5:E:eqeq-five:useless comparison to 5
+poetry.lock:0:0:E:supply-chain1:found a dependency
 
 === end of stdout - plain
 
@@ -32,7 +33,7 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
 CI scan completed successfully.
-  Found 7 findings (6 blocking) from 6 rules.
+  Found 8 findings (6 blocking) from 6 rules.
   Uploading findings to Semgrep App.
   Has findings for blocking rules so exiting with code 1
 

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -70,9 +70,9 @@ def git_tmp_path_with_commit(monkeypatch, tmp_path, mocker):
     lockfile1.write_text(
         dedent(
             """[[package]]
-    name = "tomli"
-    version = "2.0.1"
-    description = "A lil' TOML parser"
+    name = "badlib"
+    version = "1.0.0"
+    description = "it's bad"
     category = "dev"
     optional = false
     python-versions = ">=3.7"
@@ -199,6 +199,8 @@ def automocks(mocker):
             namespace: pypi
             package: badlib
             version: == 1.0.0
+          metadata:
+            dev.semgrep.actions: [block]
         - id: supply-chain2
           message: "found a dependency"
           languages: [js]


### PR DESCRIPTION
Updates `ci.py` to use the new supply chain finding schema. Also adds an explicitly blocking rule with an unreachable finding to the ci tests, which is correctly marked as non-blocking in the results.
PR checklist:

- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] `changelog.d/<issue>.<type>` is a file with the _what_, _why_, and _how_ of the change.
  - \<issue> is `pa-312` (Linear ticket), `gh-1234` (GitHub issue), or `new-gizmo` (unique semantic name)
  - \<type> is `added`, `changed`, `fixed`, or `infra`.
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Changelog guidelines](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry)
- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
