### PR TITLE
dataflow: Make the environment a parameter of the fixpoint function

### DIFF
--- a/semgrep-core/src/analyzing/Dataflow_svalue.mli
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.mli
@@ -1,4 +1,6 @@
-type mapping = AST_generic.svalue Dataflow_core.mapping
+(** Dataflow S-value analysis (constant and symbolic propagation) *)
+
+type mapping = AST_generic.svalue Dataflow_var_env.mapping
 
 (* Indicates guarantees on the return value of a function
  * We could also reuse AST_generic.Cst, but this will make it easier

--- a/semgrep-core/src/analyzing/Dataflow_var_env.ml
+++ b/semgrep-core/src/analyzing/Dataflow_var_env.ml
@@ -1,0 +1,96 @@
+(* Iain Proctor, Yoann Padioleau, Jiao Li
+ *
+ * Copyright (C) 2009-2010 Facebook
+ * Copyright (C) 2019-2022 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+module C = Dataflow_core
+module VarMap = Map.Make (String)
+module VarSet = Set.Make (String)
+
+(* The comparison function uses only the name of a variable (a string), so
+ * two variables at different positions in the code will be agglomerated
+ * correctly in the Set or Map.
+ *)
+type var = string
+type 'a t = 'a VarMap.t
+type 'a env = 'a t
+type 'a inout = 'a env C.inout
+type 'a mapping = 'a env C.mapping
+type 'a transfn = 'a mapping -> C.nodei -> 'a inout
+
+let empty_env () = VarMap.empty
+let empty_inout () = { C.in_env = empty_env (); out_env = empty_env () }
+
+(* the environment is polymorphic, so we require to pass an eq for 'a *)
+let eq_env eq env1 env2 = VarMap.equal eq env1 env2
+
+let (varmap_union : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t) =
+ fun union_op env1 env2 ->
+  let union _ x y = Some (union_op x y) in
+  VarMap.union union env1 env2
+
+let (varmap_diff : ('a -> 'a -> 'a) -> ('a -> bool) -> 'a t -> 'a t -> 'a t) =
+ fun diff_op is_empty env1 env2 ->
+  let merge _ opt_x opt_y =
+    match (opt_x, opt_y) with
+    | None, _ -> None
+    | Some x, None -> Some x
+    | Some x, Some y ->
+        let diff = diff_op x y in
+        if is_empty diff then None else Some diff
+  in
+  VarMap.merge merge env1 env2
+
+let (env_to_str : ('a -> string) -> 'a t -> string) =
+ fun val2str env ->
+  VarMap.fold (fun dn v s -> s ^ dn ^ ":" ^ val2str v ^ " ") env ""
+
+(*****************************************************************************)
+(* NodeiSet envs *)
+(*****************************************************************************)
+
+let (add_var_and_nodei_to_env :
+      var -> C.nodei -> C.NodeiSet.t t -> C.NodeiSet.t t) =
+ fun var ni env ->
+  let set =
+    try C.NodeiSet.add ni (VarMap.find var env) with
+    | Not_found -> C.NodeiSet.singleton ni
+  in
+  VarMap.add var set env
+
+let (add_vars_and_nodei_to_env :
+      VarSet.t -> C.nodei -> C.NodeiSet.t t -> C.NodeiSet.t t) =
+ fun varset ni env ->
+  let acc = env in
+  VarSet.fold (fun var acc -> add_var_and_nodei_to_env var ni acc) varset acc
+
+(* useful helpers when the environment maps to a set of Nodes, e.g.,
+ * for reaching definitions.
+ *)
+let (union_env : C.NodeiSet.t t -> C.NodeiSet.t t -> C.NodeiSet.t t) =
+ fun env1 env2 ->
+  let union _ x y = Some (C.NodeiSet.union x y) in
+  VarMap.union union env1 env2
+
+let (diff_env : C.NodeiSet.t t -> C.NodeiSet.t t -> C.NodeiSet.t t) =
+ fun env1 env2 ->
+  let merge _ opt_x opt_y =
+    match (opt_x, opt_y) with
+    | None, _ -> None
+    | Some x, None -> Some x
+    | Some x, Some y ->
+        let diff = C.NodeiSet.diff x y in
+        if C.NodeiSet.is_empty diff then None else Some diff
+  in
+  VarMap.merge merge env1 env2

--- a/semgrep-core/src/analyzing/Dataflow_var_env.mli
+++ b/semgrep-core/src/analyzing/Dataflow_var_env.mli
@@ -1,0 +1,47 @@
+(** Dataflow environments where the key is a simple variable name (a string) *)
+
+(* The comparison function uses only the name of a variable (a string), so
+ * two variables at different positions in the code will be agglomerated
+ * correctly in the Set or Map.
+ *)
+type var = string
+
+module VarMap : Map.S with type key = String.t
+module VarSet : Set.S with type elt = String.t
+
+type 'a t = 'a VarMap.t
+type 'a env = 'a t
+type 'a inout = 'a env Dataflow_core.inout
+type 'a mapping = 'a env Dataflow_core.mapping
+type 'a transfn = 'a mapping -> Dataflow_core.nodei -> 'a inout
+
+val empty_env : unit -> 'a env
+val empty_inout : unit -> 'a inout
+val eq_env : ('a -> 'a -> bool) -> 'a env -> 'a env -> bool
+val varmap_union : ('a -> 'a -> 'a) -> 'a env -> 'a env -> 'a env
+val varmap_diff : ('a -> 'a -> 'a) -> ('a -> bool) -> 'a env -> 'a env -> 'a env
+val env_to_str : ('a -> string) -> 'a env -> string
+
+(** {2 Variable to [Dataflow_core.NodeiSet] environments} *)
+
+val add_var_and_nodei_to_env :
+  var ->
+  Dataflow_core.nodei ->
+  Dataflow_core.NodeiSet.t env ->
+  Dataflow_core.NodeiSet.t env
+
+val add_vars_and_nodei_to_env :
+  VarSet.t ->
+  Dataflow_core.nodei ->
+  Dataflow_core.NodeiSet.t env ->
+  Dataflow_core.NodeiSet.t env
+
+val union_env :
+  Dataflow_core.NodeiSet.t env ->
+  Dataflow_core.NodeiSet.t env ->
+  Dataflow_core.NodeiSet.t env
+
+val diff_env :
+  Dataflow_core.NodeiSet.t env ->
+  Dataflow_core.NodeiSet.t env ->
+  Dataflow_core.NodeiSet.t env

--- a/semgrep-core/src/analyzing/Test_analyze_generic.ml
+++ b/semgrep-core/src/analyzing/Test_analyze_generic.ml
@@ -100,7 +100,8 @@ let test_dfg_svalue ~parse_program file =
             let mapping = Dataflow_svalue.fixpoint lang inputs flow in
             Dataflow_svalue.update_svalue flow mapping;
             DataflowY.display_mapping flow mapping
-              (Pretty_print_AST.svalue_to_string lang);
+              (Dataflow_var_env.env_to_str
+                 (Pretty_print_AST.svalue_to_string lang));
             let s = AST_generic.show_any (S (H.funcbody_to_stmt def.fbody)) in
             pr2 s);
       }

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -14,6 +14,7 @@
  *)
 
 module D = Dataflow_tainting
+module Var_env = Dataflow_var_env
 module G = AST_generic
 module H = AST_generic_helpers
 module V = Visitor_AST
@@ -501,7 +502,7 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
       |> Common.map (fun (x : _ D.tmatch) -> (x.pm, x.spec))
       |> T.taints_of_pms
     in
-    Dataflow_core.VarMap.add var taint env
+    Var_env.VarMap.add var taint env
   in
   let in_env =
     (* For each argument, check if it's a source and, if so, add it to the input
@@ -540,7 +541,7 @@ let check_fundef lang fun_env taint_config opt_ent fdef =
                 | _ -> env)
               env fields
         | _ -> env)
-      Dataflow_core.VarMap.empty fdef.G.fparams
+      Var_env.VarMap.empty fdef.G.fparams
   in
   let _, xs = AST_to_IL.function_definition lang fdef in
   let flow = CFG_build.cfg_of_stmts xs in

--- a/semgrep-core/src/engine/Match_tainting_mode.mli
+++ b/semgrep-core/src/engine/Match_tainting_mode.mli
@@ -16,7 +16,7 @@ val taint_config_of_rule :
   Rule.taint_rule ->
   (Dataflow_tainting.var option ->
   Taint.finding list ->
-  Taint.taints Dataflow_core.env ->
+  Taint.taints Dataflow_var_env.t ->
   unit) ->
   Dataflow_tainting.config * debug_taint * Matching_explanation.t list
 

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -31,18 +31,21 @@ let test_tainting lang file config def =
   Common.pr2 "\nDataflow";
   Common.pr2 "--------";
   let mapping = Dataflow_tainting.fixpoint config flow in
-  DataflowX.display_mapping flow mapping (fun taint ->
-      let show_taint t =
-        match t.Taint.orig with
-        | Taint.Src src ->
-            let tok1, tok2 = (fst (Taint.pm_of_trace src)).range_loc in
-            let r = Range.range_of_token_locations tok1 tok2 in
-            Range.content_at_range file r
-        | Taint.Arg i -> spf "arg %d" i
-      in
-      taint |> Taint.Taint_set.elements |> Common.map show_taint
-      |> String.concat ", "
-      |> fun str -> "{ " ^ str ^ " }")
+  let taint_to_str taint =
+    let show_taint t =
+      match t.Taint.orig with
+      | Taint.Src src ->
+          let tok1, tok2 = (fst (Taint.pm_of_trace src)).range_loc in
+          let r = Range.range_of_token_locations tok1 tok2 in
+          Range.content_at_range file r
+      | Taint.Arg i -> spf "arg %d" i
+    in
+    taint |> Taint.Taint_set.elements |> Common.map show_taint
+    |> String.concat ", "
+    |> fun str -> "{ " ^ str ^ " }"
+  in
+  DataflowX.display_mapping flow mapping
+    (Dataflow_var_env.env_to_str taint_to_str)
 
 let test_dfg_tainting rules_file file =
   let lang = List.hd (Lang.langs_of_filename file) in

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -1,4 +1,4 @@
-type var = Dataflow_core.var
+type var = Dataflow_var_env.var
 (** A string of the form "<source name>:<sid>". *)
 
 type overlap = float
@@ -61,7 +61,7 @@ type config = {
   handle_findings :
     var option (** function name ('None' if anonymous) *) ->
     Taint.finding list ->
-    Taint.taints Dataflow_core.env ->
+    Taint.taints Dataflow_var_env.t ->
     unit;
       (** Callback to report findings. *)
 }
@@ -70,7 +70,7 @@ type config = {
   * For a source to taint a sink, the bindings of both source and sink must be
   * unifiable. See 'unify_meta_envs'. *)
 
-type mapping = Taint.taints Dataflow_core.mapping
+type mapping = Taint.taints Dataflow_var_env.mapping
 (** Mapping from variables to taint sources (if the variable is tainted).
   * If a variable is not in the map, then it's not tainted. *)
 
@@ -86,7 +86,7 @@ val hook_function_taint_signature :
 (** Deep Semgrep *)
 
 val fixpoint :
-  ?in_env:Taint.taints Dataflow_core.VarMap.t ->
+  ?in_env:Taint.taints Dataflow_var_env.VarMap.t ->
   ?name:var ->
   ?fun_env:fun_env (** Poor-man's interprocedural HACK (TO BE DEPRECATED) *) ->
   config ->


### PR DESCRIPTION
In some cases like in PR #5697 we want to have a richer environment than
just a mapping from strings to X. This refactoring allows for arbitrary
environments to be used in dataflow analyses.

test plan:
make test

PR checklist:

- [x] Each source file starts with an up-to-date [summary of why it exists](https://semgrep.dev/docs/contributing/contributing-code/#explaining)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
