### PR TITLE
update -rpath= to -rpath,

### DIFF
--- a/changelog.d/gh-5979.fixed
+++ b/changelog.d/gh-5979.fixed
@@ -1,1 +1,0 @@
-Releases were broken, as evidenced by our nightly homebrew tests. This fixes those linker errors so we can start releases.

--- a/changelog.d/gh-5979.fixed
+++ b/changelog.d/gh-5979.fixed
@@ -1,0 +1,1 @@
+Releases were broken, as evidenced by our nightly homebrew tests. This fixes those linker errors so we can start releases.

--- a/semgrep-core/src/cli-bridge/bridge_design.txt
+++ b/semgrep-core/src/cli-bridge/bridge_design.txt
@@ -68,7 +68,7 @@ Finding shared libraries
 In the Python CLI, the existing logic for locating semgrep-core has been
 adapted to also locate semgrep_bridge_python.so.  That file then looks
 for semgrep_bridge_core.so in whatever directory it was loaded from by
-taking advantage of the "-Wl,-rpath=$ORIGIN" linker option.
+taking advantage of the "-Wl,-rpath,$ORIGIN" linker option.
 
 
 Analysis runs in a forked child

--- a/semgrep-core/src/cli-bridge/dune
+++ b/semgrep-core/src/cli-bridge/dune
@@ -69,7 +69,7 @@
   (action
     ; "$ORIGIN" is a special rpath that means to load from the directory
     ; where the referring object was loaded from.
-    (run %{cc} -shared -o %{target} %{deps} -Wl,-rpath=$ORIGIN
+    (run %{cc} -shared -o %{target} %{deps} -Wl,-rpath,$ORIGIN
            %{read-lines:python3-config-cflags.txt})
   )
 )

--- a/semgrep-core/tests/cli-bridge/dune
+++ b/semgrep-core/tests/cli-bridge/dune
@@ -12,7 +12,7 @@
       -I ../../src/cli-bridge
 
       ; Avoid the need to specify LD_LIBRARY_PATH in the test below.
-      -Wl,-rpath=../../src/cli-bridge
+      -Wl,-rpath,../../src/cli-bridge
 
       -ldl -lm)
   )


### PR DESCRIPTION
Our nightly homebrew test (which builds off develop) [started to fail last night](https://github.com/returntocorp/semgrep/runs/8012842603?check_suite_focus=true) - we won't be able to release until this gets fixed.

Test plan:
a) name branch `*release-*` to ensure that macos build occurs
b) will re-run develop homebrew nightly test once this is merged

PR checklist:

- [x] Each source file starts with an up-to-date [summary of why it exists](https://semgrep.dev/docs/contributing/contributing-code/#explaining)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
