### PR TITLE
fix(ci): semgrep-rules qa tests were not running correctly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Fetch semgrep-cli submodules
-        run: git submodule update --init --recursive --recommend-shallow cli/src/semgrep/lang cli/src/semgrep/semgrep_interfaces
+        run: git submodule update --init --recursive --recommend-shallow cli/src/semgrep/lang cli/src/semgrep/semgrep_interfaces semgrep-core/tests/semgrep-rules
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -298,10 +298,12 @@ jobs:
 
   # These tests aren't run by default by pytest.
   # To reproduce errors locally, use:
-  #   pipenv run pytest -k test_whatever tests/qa
+  #   $ cd cli/tests
+  #   $ make qa
   #
-  # TODO: explain why the code below is so complicated (and reject all
-  # PRs that don't explain things)
+  # TODO: if you know this, please explain what the code below is meant
+  #       to achieve and how to make sure it works.
+  #
   test-qa:
     name: quality assurance on semgrep
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Fetch semgrep-cli submodules
-        run: git submodule update --init --recursive --recommend-shallow cli/src/semgrep/lang cli/src/semgrep/semgrep_interfaces semgrep-core/tests/semgrep-rules
+        run: git submodule update --init --recursive --recommend-shallow cli/src/semgrep/lang cli/src/semgrep/semgrep_interfaces
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -314,7 +314,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Fetch semgrep-cli submodules
-        run: git submodule update --init --recursive --recommend-shallow cli/src/semgrep/lang cli/src/semgrep/semgrep_interfaces
+        run: git submodule update --init --recursive --recommend-shallow cli/src/semgrep/lang cli/src/semgrep/semgrep_interfaces semgrep-core/tests/semgrep-rules
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/cli/tests/qa/test_semgrep_rules_repo.py
+++ b/cli/tests/qa/test_semgrep_rules_repo.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -25,8 +26,9 @@ def in_semgrep_rules_repo(tmpdir_factory):
     # since it's a shared resource. If writes are necessary, make a copy
     # of the folder to create a safe read-write workspace.
     #
-    # Remove subdir that doesnt contain rules
-    # shutil.rmtree(repo_dir / "stats")
+    # Remove subdir that contains yaml files that are not rules, causing
+    # 'semgrep scan --validate --config=.' to fail.
+    shutil.rmtree(repo_dir / "stats")
     monkeypatch.chdir(repo_dir)
     if not os.listdir("."):
         raise Exception(

--- a/cli/tests/qa/test_semgrep_rules_repo.py
+++ b/cli/tests/qa/test_semgrep_rules_repo.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -27,6 +28,10 @@ def in_semgrep_rules_repo(tmpdir_factory):
     # Remove subdir that doesnt contain rules
     # shutil.rmtree(repo_dir / "stats")
     monkeypatch.chdir(repo_dir)
+    if not os.listdir("."):
+        raise Exception(
+            "The semgrep-rules folder is empty. Was it properly checked out as a git submodule?"
+        )
     yield
     monkeypatch.undo()
 

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -267,8 +267,13 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
              |> List.iter (fun (res : RP.partial_profiling RP.match_result) ->
                     res.matches |> List.iter JSON_report.match_to_error);
              if not (Report.ErrorSet.is_empty res.errors) then
-               failwith (spf "parsing error on %s" file);
-
+               let errors =
+                 Report.ErrorSet.elements res.errors
+                 |> Common.map Semgrep_error_code.show_error
+                 |> String.concat "-----\n"
+               in
+               failwith (spf "parsing error(s) on %s:\n%s" file errors)
+             else ();
              let actual_errors = !E.g_errors in
              actual_errors
              |> List.iter (fun e ->


### PR DESCRIPTION
https://github.com/returntocorp/semgrep/pull/5917/files pointed the qa rules to a submodule but the CI job running
the test didn't fetch that submodule causing tests to not be run

PR checklist:

- [x] Each source file starts with an up-to-date [summary of why it exists](https://semgrep.dev/docs/contributing/contributing-code/#explaining)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
