### PR TITLE
chore: reraise-timeout Semgrep rule

### DIFF
--- a/semgrep.yml
+++ b/semgrep.yml
@@ -147,6 +147,18 @@ rules:
     paths:
       include:
         - cli/src/*
+  - id: reraise-timeout
+    patterns:
+      - pattern: try ... with | $X -> ...
+      - pattern-not: try ... with | Timeout _ as e -> ...
+      - pattern-not: try ... with | Timeout $X -> ...
+    message: >-
+      Catch and re-raise Timeout exceptions to avoid swallowing them
+    languages: [ocaml]
+    severity: ERROR
+    paths:
+      include:
+        - semgrep-core/src/*
 # not ready yet
 #  - id: no-exit-in-semgrep
 #    pattern: |


### PR DESCRIPTION
As suggested in #5980

This rule has 100 findings. Based on some spot checking, this seems to
be working as intended. However, I'm not sure whether we actually want
to enforce that for every `try`, we catch and reraise `Timeout`. Some of
the findings are on simple things like
`try Hashtbl.find ... with Not_found -> ...`. It would be annoying to
have to catch and reraise `Timeout` there, but maybe worth it to have
the guarantees of this rule? I'd love to hear what others think.

If people would like to move forward with this, I can go through and fix
the existing findings before committing this.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
