### PR TITLE
Add support for named pipes to spacegrep CLI

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -5,6 +5,10 @@
 # Set environment variables used by dune files to locate the
 # C headers and libraries of the tree-sitter runtime library.
 # This file is created by ocaml-tree-sitter-core's configure script.
+#
+# Because of these required environment variables, we can't call dune directly
+# to build semgrep-core.
+#
 include src/ocaml-tree-sitter-core/tree-sitter-config.mk
 
 .PHONY: all
@@ -67,6 +71,11 @@ dev:
 	rm -f ../cli/src/semgrep/bin/semgrep_bridge_python.so
 	ln -s ../../../../semgrep-core/bin/semgrep_bridge_python.so \
 	  ../cli/src/semgrep/bin/semgrep_bridge_python.so
+
+# Run utop with all the semgrep-core libraries loaded.
+.PHONY: utop
+utop:
+	dune utop
 
 .PHONY: e2etest
 e2etest:

--- a/semgrep-core/src/spacegrep/src/lib/Find_files.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Find_files.ml
@@ -79,7 +79,9 @@ let fold_one ~accept_file_name ~accept_dir_name visit_tracker f acc root =
               |> Common.map (fun name -> Filename.concat path name)
             in
             List.fold_left fold acc children
-      | Some Unix.S_REG -> if accept_file_name name then f acc path else acc
+      | Some Unix.S_REG
+      | Some Unix.S_FIFO ->
+          if accept_file_name name then f acc path else acc
       | None
       | Some _ ->
           (* leave broken symlinks and special files alone *)

--- a/semgrep-core/src/spacegrep/src/lib/Src_file.ml
+++ b/semgrep-core/src/spacegrep/src/lib/Src_file.ml
@@ -68,10 +68,14 @@ let of_file ?source ?max_len file =
     | None -> File file
     | Some x -> x
   in
-  let ic = open_in_bin file in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> of_channel ~source ?max_len ic)
+  (* This needs to work on named pipes such as those created by bash with
+     so-called "process substitution" (for those, 'in_channel_length' returns
+     but then we can't read the file again).
+     It's convenient for testing using the spacegrep command line:
+     $ spacegrep hello <(echo 'hello')
+  *)
+  let contents = Common.read_file ?max_len file in
+  { source; contents }
 
 let to_lexbuf x = Lexing.from_string x.contents
 

--- a/semgrep-core/src/utils/SPcre.ml
+++ b/semgrep-core/src/utils/SPcre.ml
@@ -47,6 +47,11 @@ let exec_all ?iflags ?flags ?rex ?pos ?callout subj =
   | Not_found -> Ok [||]
   | Pcre.Error err -> Error err
 
+let exec_to_strings ?iflags ?flags ?rex ?pos ?callout subj =
+  match exec_all ?iflags ?flags ?rex ?pos ?callout subj with
+  | Ok a -> Ok (Array.map Pcre.get_substrings a)
+  | Error _ as e -> e
+
 let split ?iflags ?flags ?rex ?pos ?max ?callout subj =
   try Ok (Pcre.split ?iflags ?flags ?rex ?pos ?max ?callout subj) with
   | Pcre.Error err -> Error err

--- a/semgrep-core/src/utils/SPcre.mli
+++ b/semgrep-core/src/utils/SPcre.mli
@@ -84,6 +84,17 @@ val exec_all :
   string ->
   (Pcre.substrings array, Pcre.error) result
 
+(* Return all captured subgroups as strings.
+   This is useful for debugging in utop. *)
+val exec_to_strings :
+  ?iflags:Pcre.irflag ->
+  ?flags:Pcre.rflag list ->
+  ?rex:Pcre.regexp ->
+  ?pos:int ->
+  ?callout:Pcre.callout ->
+  string ->
+  (string array array, Pcre.error) result
+
 (* Return '[| |]' in case of a PCRE error. The error is logged. *)
 val exec_all_noerr :
   ?iflags:Pcre.irflag ->


### PR DESCRIPTION
I use this for troubleshooting spacegrep (generic mode). This relies on https://github.com/returntocorp/pfff/pull/551

test plan:
```
$ spacegrep hello <(echo 'hello world')
```
should return a match on `hello`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change (these changes are not user-facing since the `spacegrep` command is not distributed or documented)
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
