### PR TITLE
fixed(sym prop): added usage of sym prop as last resort

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1007,6 +1007,8 @@ and m_expr ?(is_root = false) a b =
   | G.OtherExpr (a1, a2), B.OtherExpr (b1, b2) ->
       m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.N (G.Id _ as a), B.N (B.IdQualified _ as b) -> m_name a b
+  | _, G.N (G.Id _) ->
+      m_with_symbolic_propagation ~is_root (fun b1 -> m_expr a b1) b
   | G.Container _, _
   | G.Comprehension _, _
   | G.Record _, _

--- a/semgrep-core/tests/OTHER/rules/sym_prop_non_literal.java
+++ b/semgrep-core/tests/OTHER/rules/sym_prop_non_literal.java
@@ -1,0 +1,8 @@
+public class test {
+    public static void main() {
+        Object a = x(); // x, y, z are a static function in class Hello
+        Object b = a.y();
+        // ruleid: sym_prop_non_literal 
+        Object d = b.z();
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/sym_prop_non_literal.yaml
+++ b/semgrep-core/tests/OTHER/rules/sym_prop_non_literal.yaml
@@ -1,0 +1,8 @@
+id: sym_prop_non_literal 
+options:
+  symbolic_propagation: true
+pattern: x(). ... .z()
+message: Semgrep found a match
+languages:
+  - java
+severity: WARNING


### PR DESCRIPTION
**What:**
Currently, when matching against a `N` (which may contain a propagated `svalue`), we allow some cases to reach `fail`, without trying to match with symbolic propagation (if enabled) first.

This means that we basically give up without using all the information we can.

**Why:**
We currently fail a test case due to this. See https://semgrep.dev/playground/s/7l6Q, where basically we end up matching a `DotAccessEllipsis` to a `N`, and then give up because `DotAccessEllipsis` was not explicitly stated as something which can unpack what is inside of a `N`.

**How:**
Added a case where if anything matches to an `N`, right before the failing case, we will try to match using symbolic propagation.

I don't see why this shouldn't be here, because if symbolic propagation is on, we might as well use it. Furthermore, there are several cases (for specific pattern variants) where we do essentially this, such as `Call`, `New` and `ArrayAccess`. Due to the fact that we've specifically whitelisted variants that can do this, we missed this case.

I added a catch-all case, but I would be down to delete the `Call`, `New`, and `ArrayAccess` cases, and fold them under this one. I just haven't done it yet in this PR, in case that's something we shouldn't do. Let me know.

**Test plan:**
`make test`

Closes PA-1829.
Closes #6003.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
