### PR TITLE
refactor: Generic machinery to try multiple pattern parsers

### DIFF
--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -44,6 +44,46 @@ let extract_pattern_from_tree_sitter_result
                pr2 (Tree_sitter_run.Tree_sitter_error.to_string ~color:true err));
       failwith "error parsing the pattern"
 
+type 'ast parser =
+  | Pfff of (string -> 'ast)
+  | TreeSitter of (string -> 'ast Tree_sitter_run.Parsing_result.t)
+
+let run_parser ~print_errors p str =
+  let parse () =
+    match p with
+    | Pfff f -> f str
+    | TreeSitter f ->
+        let res = f str in
+        extract_pattern_from_tree_sitter_result res print_errors
+  in
+  try Ok (parse ()) with
+  | Timeout _ as e -> Exception.catch_and_reraise e
+  | exn -> Error (Exception.catch exn)
+
+(* This is a simplified version of run_either in Parse_target.ml. We don't need
+ * most of the logic there when we're parsing patterns, so it doesn't make sense
+ * to reuse it. *)
+let run_either ~print_errors parsers program =
+  let rec f parsers =
+    match parsers with
+    | [] ->
+        Error
+          (Exception.trace
+             (Failure "internal error: No pattern parser available"))
+    | p :: xs -> (
+        match run_parser ~print_errors p program with
+        | Ok res -> Ok res
+        | Error e -> (
+            match f xs with
+            | Ok res -> Ok res
+            | Error _ ->
+                (* Return the error from the first parser. *)
+                Error e))
+  in
+  match f parsers with
+  | Ok res -> res
+  | Error e -> Exception.reraise e
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -98,20 +138,13 @@ let parse_pattern lang ?(print_errors = false) str =
     | Lang.Ts
     | Lang.Js
     | Lang.Vue ->
-        (* This is a simplified version of run_either in Parse_target.ml. We
-         * don't need most of the logic there when we're parsing patterns, so it
-         * doesn't make sense to reuse it. However, we should abstract this out
-         * if we start using fallback parsers for patterns in other languages.
-         * *)
         let js_ast =
-          try Parse_js.any_of_string str with
-          | Timeout _ as e -> Exception.catch_and_reraise e
-          | exn -> (
-              let e = Exception.catch exn in
-              let res = Parse_typescript_tree_sitter.parse_pattern str in
-              match (res.program, res.errors) with
-              | Some p, [] -> p
-              | _ -> Exception.reraise e)
+          str
+          |> run_either ~print_errors
+               [
+                 Pfff Parse_js.any_of_string;
+                 TreeSitter Parse_typescript_tree_sitter.parse_pattern;
+               ]
         in
         Js_to_generic.any js_ast
     | Lang.Json ->


### PR DESCRIPTION
In #5980, I introduced logic to first try the pfff parser when parsing
patterns for JS/TS, and then the tree sitter parser, rather than relying
solely on the pfff parser as we had been doing previously. Now I find
myself wanting to do this for Java as well, so it is time to make this
logic more generic.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
