### PR TITLE
fix(cli): Support optional org in repo url

### DIFF
--- a/changelog.d/app-2202.fixed
+++ b/changelog.d/app-2202.fixed
@@ -1,0 +1,1 @@
+Update git url parser to support optional "org" after hostname. Example: https://some.enterprise.scm/myorg/owner/repo.

--- a/cli/src/semgrep/external/git_url_parser.py
+++ b/cli/src/semgrep/external/git_url_parser.py
@@ -1,4 +1,4 @@
-# This file is copied from https://github.com/coala/git-url-parse/blob/master/giturlparse/parser.py
+# This file is forked from https://github.com/coala/git-url-parse/blob/master/giturlparse/parser.py
 # MIT license here: https://github.com/coala/git-url-parse/blob/master/LICENSE
 
 # Copyright (c) 2017 John Dewey
@@ -56,6 +56,11 @@ POSSIBLE_REGEXES = (
                r'(?P<resource>[a-z0-9_.-]*)[:]*'
                r'(?P<port>[\d]+){0,1}'
                r'(?P<pathname>\/?(?P<owner>.+)/(?P<name>.+).git)$'),
+    re.compile(r'((?P<user>\w+)@)?'
+                r'((?P<resource>[\w\.\-]+))'
+                r'[\:\/]{1,2}'
+                r'(?P<pathname>((?P<owner>([\w\-]+\/)?\w+)/)?'
+                r'((?P<name>[\w\-]+)(\.git|\/)?)?)$'),
     re.compile(r'((?P<user>\w+)@)?'
                r'((?P<resource>[\w\.\-]+))'
                r'[\:\/]{1,2}'

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -35,7 +35,7 @@ def get_url_from_sstp_url(sstp_url: Optional[str]) -> Optional[str]:
     p = Parser(sstp_url)
     result = p.parse()
     protocol = result.protocol
-    if protocol != "http" and protocol != "http":
+    if protocol != "http" and protocol != "https":
         # let's just pick https
         protocol = "https"
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
@@ -1,0 +1,23 @@
+{
+  "exit_code": 1,
+  "stats": {
+    "findings": 10,
+    "errors": [],
+    "total_time": 0.5,
+    "unsupported_exts": {
+      ".txt": 1
+    },
+    "lockfile_scan_info": {
+      "poetry.lock": 1,
+      "yarn.lock": 1
+    },
+    "parse_rate": {
+      "python": {
+        "targets_parsed": 1,
+        "num_targets": 1,
+        "bytes_parsed": 366,
+        "num_bytes": 366
+      }
+    }
+  }
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -1,0 +1,336 @@
+{
+  "token": null,
+  "gitlab_token": null,
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    x == 2"
+      ]
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": false,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
+    }
+  ],
+  "searched_paths": [
+    "foo.py"
+  ],
+  "rule_ids": [
+    "eqeq-bad",
+    "eqeq-five",
+    "eqeq-four",
+    "taint-test",
+    "supply-chain1",
+    "supply-chain2"
+  ],
+  "ignores": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 13,
+      "column": 5,
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 16,
+      "column": 5,
+      "end_line": 16,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0",
+      "fixed_lines": [
+        "    y == 2  # nosemgrep"
+      ]
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 18,
+      "column": 5,
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+    }
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "semgrep_version": "<sanitized version>",
+    "repository": "org_name/project_name/project_name",
+    "repo_url": "https://some.enterprise.url.com/org_name/project_name/project_name",
+    "branch": "some/branch-name",
+    "ci_job_url": null,
+    "commit": "sanitized",
+    "commit_author_email": "test_environment@test.r2c.dev",
+    "commit_author_name": "Environment Test",
+    "commit_author_username": null,
+    "commit_author_image_url": null,
+    "commit_title": "Some other commit/ message",
+    "on": "pull_request",
+    "pull_request_author_username": null,
+    "pull_request_author_image_url": null,
+    "pull_request_id": "35",
+    "pull_request_title": null,
+    "scan_environment": "git",
+    "is_full_scan": true,
+    "is_sca_scan": false
+  },
+  "policy": [
+    "audit",
+    "comment",
+    "block"
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -1,0 +1,71 @@
+=== command
+CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_URL="https://some.enterprise.url.com/org_name/project_name/project_name" SEMGREP_PR_ID="35" SEMGREP_BRANCH="some/branch-name" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
+
+  foo.py 
+     eqeq-bad
+        useless comparison
+
+          4┆ a == a
+          ⋮┆----------------------------------------
+          5┆ a == a
+          ⋮┆----------------------------------------
+          7┆ a == a
+          ⋮┆----------------------------------------
+         11┆ y == y
+          ⋮┆----------------------------------------
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+          ⋮┆----------------------------------------
+     eqeq-four
+        useless comparison to 4
+
+         19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
+
+=== end of stdout - plain
+
+=== stderr - plain
+Scan environment:
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is pull_request
+  server      - https://semgrep.dev
+
+Fetching configuration from semgrep.dev
+Authenticated as org_name
+Scanning 1 file with 4 python rules.
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 8 findings (6 blocking) from 6 rules.
+  Uploading findings to Semgrep App.
+  Has findings for blocking rules so exiting with code 1
+
+=== end of stderr - plain

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
@@ -1,0 +1,23 @@
+{
+  "exit_code": 1,
+  "stats": {
+    "findings": 10,
+    "errors": [],
+    "total_time": 0.5,
+    "unsupported_exts": {
+      ".txt": 1
+    },
+    "lockfile_scan_info": {
+      "poetry.lock": 1,
+      "yarn.lock": 1
+    },
+    "parse_rate": {
+      "python": {
+        "targets_parsed": 1,
+        "num_targets": 1,
+        "bytes_parsed": 366,
+        "num_bytes": 366
+      }
+    }
+  }
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings.json
@@ -1,0 +1,261 @@
+{
+  "token": null,
+  "gitlab_token": null,
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "__r2c-internal-cai_eqeq",
+      "path": "foo.py",
+      "line": 21,
+      "column": 5,
+      "end_line": 21,
+      "end_column": 16,
+      "message": "useless comparison to 3",
+      "severity": 0,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "985498b46aff45ebdffe6a26af8524ab",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "428d340d1be54b3f1fbc781d56aef28eb2092d3f140cab3a5d03ad7a769e21803c79eb728c18dce723226b7f224e8f688395081ca05d48bc2c1590d312d26fca_0"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": false,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
+    }
+  ],
+  "searched_paths": [
+    "foo.py"
+  ],
+  "rule_ids": [
+    "eqeq-bad",
+    "eqeq-five",
+    "eqeq-four",
+    "taint-test",
+    "supply-chain1",
+    "supply-chain2"
+  ],
+  "cai_ids": [
+    "__r2c-internal-cai_eqeq"
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -1,0 +1,330 @@
+{
+  "token": null,
+  "gitlab_token": null,
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "taint-test",
+      "path": "foo.py",
+      "line": 27,
+      "column": 5,
+      "end_line": 27,
+      "end_column": 13,
+      "message": "unsafe use of danger",
+      "severity": 1,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "05a6d6793a6242a49ff83113ef4a83b3",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e160d5d9982bc004e18272a890af8fc2539063a06782d2f509b2c2d9b7e58c5b095443b568847f7c9ab25f68f9b5c7a1dea764e514d0480bab7b12dca08f4a57_0",
+      "dataflow_trace": {
+        "taint_source": {
+          "location": {
+            "path": "foo.py",
+            "start": {
+              "line": 26,
+              "col": 10,
+              "offset": 346
+            },
+            "end": {
+              "line": 26,
+              "col": 16,
+              "offset": 352
+            }
+          },
+          "content": "danger"
+        },
+        "intermediate_vars": [
+          {
+            "location": {
+              "path": "foo.py",
+              "start": {
+                "line": 26,
+                "col": 5,
+                "offset": 341
+              },
+              "end": {
+                "line": 26,
+                "col": 7,
+                "offset": 343
+              }
+            },
+            "content": "d2"
+          }
+        ]
+      }
+    },
+    {
+      "check_id": "supply-chain1",
+      "path": "poetry.lock",
+      "line": 0,
+      "column": 0,
+      "end_line": 0,
+      "end_column": 0,
+      "message": "found a dependency",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "ff8806e5d262f88aeebbc15b80d84f12",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": false,
+      "match_based_id": "2c4ff12fcdf80ef1c00dd0f566ae102d792c7ba68e560d70f111aae3b3216c0b1b943e74d2ce29c0361f1fbc37bd4e9aafd32c3435a36c61b8bd3963efe0d7a1_0",
+      "sca_info": {
+        "reachable": false,
+        "reachability_rule": false,
+        "sca_finding_schema": 20220818,
+        "dependency_match": {
+          "dependency_pattern": {
+            "ecosystem": "pypi",
+            "package": "badlib",
+            "semver_range": "== 1.0.0"
+          },
+          "found_dependency": {
+            "package": "badlib",
+            "version": "1.0.0",
+            "ecosystem": "pypi",
+            "allowed_hashes": {}
+          },
+          "lockfile": "poetry.lock"
+        }
+      }
+    }
+  ],
+  "searched_paths": [
+    "foo.py"
+  ],
+  "rule_ids": [
+    "eqeq-bad",
+    "eqeq-five",
+    "eqeq-four",
+    "taint-test",
+    "supply-chain1",
+    "supply-chain2"
+  ],
+  "ignores": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 13,
+      "column": 5,
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 16,
+      "column": 5,
+      "end_line": 16,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 18,
+      "column": 5,
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+    }
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/ignores.json
@@ -1,0 +1,90 @@
+{
+  "findings": [
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 13,
+      "column": 5,
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 16,
+      "column": 5,
+      "end_line": 16,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "6ed37cfa23475cee444f54947efb9da4",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 18,
+      "column": 5,
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+    }
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "semgrep_version": "<sanitized version>",
+    "repository": "org_name/project_name/project_name",
+    "repo_url": "https://some.enterprise.url.com/org_name/project_name/project_name",
+    "branch": "some/branch-name",
+    "ci_job_url": null,
+    "commit": "sanitized",
+    "commit_author_email": "test_environment@test.r2c.dev",
+    "commit_author_name": "Environment Test",
+    "commit_author_username": null,
+    "commit_author_image_url": null,
+    "commit_title": "Some other commit/ message",
+    "on": "pull_request",
+    "pull_request_author_username": null,
+    "pull_request_author_image_url": null,
+    "pull_request_id": "35",
+    "pull_request_title": null,
+    "scan_environment": "git",
+    "is_full_scan": true,
+    "is_sca_scan": false
+  },
+  "policy": [
+    "audit",
+    "comment",
+    "block"
+  ]
+}

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -1,0 +1,71 @@
+=== command
+CI="true" SEMGREP_REPO_NAME="org_name/project_name/project_name" SEMGREP_REPO_URL="https://some.enterprise.url.com/org_name/project_name/project_name" SEMGREP_PR_ID="35" SEMGREP_BRANCH="some/branch-name" SEMGREP_APP_TOKEN="fake-key-from-tests" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep ci --no-suppress-errors
+=== end of command
+
+=== exit code
+1
+=== end of exit code
+
+=== stdout - plain
+
+SCA Summary: 0 Reachable findings, 1 Unreachable finding
+
+
+Unreachable SCA Findings:
+
+  poetry.lock 
+     supply-chain1
+        found a dependency
+
+
+First-Party Findings:
+
+  foo.py 
+     eqeq-bad
+        useless comparison
+
+          4┆ a == a
+          ⋮┆----------------------------------------
+          5┆ a == a
+          ⋮┆----------------------------------------
+          7┆ a == a
+          ⋮┆----------------------------------------
+         11┆ y == y
+          ⋮┆----------------------------------------
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+          ⋮┆----------------------------------------
+     eqeq-four
+        useless comparison to 4
+
+         19┆ baz == 4
+          ⋮┆----------------------------------------
+     taint-test
+        unsafe use of danger
+
+         27┆ sink(d2)
+
+=== end of stdout - plain
+
+=== stderr - plain
+Scan environment:
+  versions    - semgrep <MASKED> on python <MASKED>
+  environment - running in environment git, triggering event is pull_request
+  server      - https://semgrep.dev
+
+Fetching configuration from semgrep.dev
+Authenticated as org_name
+Scanning 1 file with 4 python rules.
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+CI scan completed successfully.
+  Found 8 findings (6 blocking) from 6 rules.
+  Uploading findings to Semgrep App.
+  Has findings for blocking rules so exiting with code 1
+
+=== end of stderr - plain

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -382,7 +382,6 @@ def mock_autofix(request, mocker):
             # Sent in metadata but no functionality change
             "SEMGREP_PR_ID": "35",
             "SEMGREP_BRANCH": BRANCH_NAME,
-            "GIT_ENV": "true",
         },
     ],
     ids=[

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -22,6 +22,7 @@ from semgrep.meta import GitMeta
 
 pytestmark = pytest.mark.kinda_slow
 
+REPO_ORG_NAME = "org_name"
 REPO_DIR_NAME = "project_name"
 AUTHOR_EMAIL = "test_environment@test.r2c.dev"
 AUTHOR_NAME = "Environment Test"
@@ -374,6 +375,15 @@ def mock_autofix(request, mocker):
             "TRAVIS_PULL_REQUEST": "35",
             "TRAVIS_COMMIT_MESSAGE": COMMIT_MESSAGE,
         },
+        {  # Special SCM with org in path
+            "CI": "true",
+            "SEMGREP_REPO_NAME": f"{REPO_ORG_NAME}/{REPO_DIR_NAME}/{REPO_DIR_NAME}",
+            "SEMGREP_REPO_URL": f"https://some.enterprise.url.com/{REPO_ORG_NAME}/{REPO_DIR_NAME}/{REPO_DIR_NAME}",
+            # Sent in metadata but no functionality change
+            "SEMGREP_PR_ID": "35",
+            "SEMGREP_BRANCH": BRANCH_NAME,
+            "GIT_ENV": "true",
+        },
     ],
     ids=[
         "local",
@@ -389,6 +399,7 @@ def mock_autofix(request, mocker):
         "azure-pipelines",
         "buildkite",
         "travis",
+        "self-hosted",
     ],
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
This change improves support for self-hosted SCMs where the url follows a pattern similar to:

```https://some.enterprise.scm/myorg/owner/repo```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
