### PR TITLE
fix(python): destroy final parsing todo

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
@@ -1139,7 +1139,6 @@ let map_decorator (env : env) ((v1, v2, v3) : CST.decorator) =
   let get_dotted_name x = List.rev (get_dotted_name_rev x) in
   let dotted_name, args =
     match v2 with
-    (* We won't support this for now. *)
     | `Call (e, `Gene_exp x) ->
         let x = map_generator_expression env x in
         (get_dotted_name e, Some (fb [ Arg x ]))

--- a/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
@@ -68,7 +68,7 @@ let single_or_tuple e xs =
 (* Disable warnings against unused variables *)
 [@@@warning "-26-27"]
 
-let todo (env : env) _ = failwith "not implemented"
+let _todo (env : env) _ = failwith "not implemented"
 let _complicated (env : env) _ = failwith "not implemented"
 
 let map_keyword_identifier (env : env) (x : CST.keyword_identifier) : name =
@@ -439,7 +439,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
       let v1 = map_type_ env v1 in
       let v2 = (* "as" *) token env v2 in
       let v3 = map_type_ env v3 in
-      todo env (v1, v2, v3)
+      invalid ()
 
 and map_expression_list (env : env) ((v1, v2) : CST.expression_list) : expr list
     =
@@ -1140,7 +1140,9 @@ let map_decorator (env : env) ((v1, v2, v3) : CST.decorator) =
   let dotted_name, args =
     match v2 with
     (* We won't support this for now. *)
-    | `Call (e, `Gene_exp _) -> todo env ()
+    | `Call (e, `Gene_exp x) ->
+        let x = map_generator_expression env x in
+        (get_dotted_name e, Some (fb [ Arg x ]))
     | `Call (e, `Arg_list args) ->
         (get_dotted_name e, Some (map_argument_list env args))
     | _ -> (get_dotted_name v2, None)


### PR DESCRIPTION
**What:**
There's like one `todo` I left in the Python tree-sitter parser, because the parse rate was pretty good and I didn't think it would come up. I probably also just forgot.

**Why:**
Python parse rate is 99.7%, which is very close to our promised GA parse rate. I'm making this change in the hopes that this is the reason for why it's not higher.

**How:**
Implemented the `todo`.

**Test plan:**
`make test`, and parse rate

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
