### PR TITLE
fix!: multiline tokens range reporting

### DIFF
--- a/cli/tests/e2e/rules/multiline.yaml
+++ b/cli/tests/e2e/rules/multiline.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: assign-multiline-comment
+    message: found an assignment of a multiline comment
+    severity: WARNING
+    languages: [python]
+    pattern: $X = """$MULTILINE"""
+  - id: eqeq-is-bad
+    patterns:
+      - pattern-not-inside: |
+          def __eq__(...):
+              ...
+      - pattern-not-inside: assert(...)
+      - pattern-not-inside: assertTrue(...)
+      - pattern-not-inside: assertFalse(...)
+      - pattern-either:
+          - pattern: $X == $X
+          - pattern: $X != $X
+          - patterns:
+              - pattern-inside: |
+                  def __init__(...):
+                      ...
+              - pattern: self.$X == self.$X
+      - pattern-not: 1 == 1
+    message: "useless comparison operation `$X == $X` or `$X != $X`; possible bug?"
+    languages: [python]
+    severity: ERROR
+    metadata:
+      shortlink: https://sg.run/xyz1

--- a/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_multiline/results.json
@@ -8,6 +8,56 @@
   },
   "results": [
     {
+      "check_id": "rules.assign-multiline-comment",
+      "end": {
+        "col": 4,
+        "line": 14,
+        "offset": 248
+      },
+      "extra": {
+        "fingerprint": "9d1118226495e3021eba55e101363e71d9c9f13e15ea40d11864a747896a602c3e62e3ddae1bd8fc1100668730628116751075c5ccc20f774d3bbe1641fde13f_0",
+        "is_ignored": false,
+        "lines": "x = \"\"\"\n    abc\n    def\n\"\"\"",
+        "message": "found an assignment of a multiline comment",
+        "metadata": {},
+        "metavars": {
+          "$MULTILINE": {
+            "abstract_content": "\n    abc\n    def\n",
+            "end": {
+              "col": 1,
+              "line": 14,
+              "offset": 245
+            },
+            "start": {
+              "col": 8,
+              "line": 11,
+              "offset": 228
+            }
+          },
+          "$X": {
+            "abstract_content": "x",
+            "end": {
+              "col": 2,
+              "line": 11,
+              "offset": 222
+            },
+            "start": {
+              "col": 1,
+              "line": 11,
+              "offset": 221
+            }
+          }
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/multiline/stupid.py",
+      "start": {
+        "col": 1,
+        "line": 11,
+        "offset": 221
+      }
+    },
+    {
       "check_id": "rules.eqeq-is-bad",
       "end": {
         "col": 55,

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
@@ -39,7 +39,7 @@ Files skipped:
 
   [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
 
-   • [36m[22m[24mtargets/bad/invalid_python.py (1 lines skipped)[0m
+   • [36m[22m[24mtargets/bad/invalid_python.py (2 lines skipped)[0m
 
 
 Some files were skipped or only partially analyzed.

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
@@ -8,8 +8,8 @@
       "spans": [
         {
           "end": {
-            "col": 60,
-            "line": 1
+            "col": 49,
+            "line": 2
           },
           "file": "targets/bad/invalid_python.py",
           "start": {

--- a/cli/tests/e2e/targets/multiline/stupid.py
+++ b/cli/tests/e2e/targets/multiline/stupid.py
@@ -7,3 +7,8 @@ def foo(a, b):
         SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK
         == SUPER_LONG_CONSTANT_TO_TRIGGER_A_LINE_BREAK
     )
+
+x = """
+    abc
+    def
+"""

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -222,7 +222,7 @@ def test_multi_subshell_input(snapshot):
 @pytest.mark.kinda_slow
 def test_multiline(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(
-        run_semgrep_in_tmp("rules/eqeq.yaml", target_name="multiline").stdout,
+        run_semgrep_in_tmp("rules/multiline.yaml", target_name="multiline").stdout,
         "results.json",
     )
 

--- a/semgrep-core/src/core/Output_from_core_util.ml
+++ b/semgrep-core/src/core/Output_from_core_util.ml
@@ -18,7 +18,7 @@ let position_of_token_location loc =
   }
 
 let position_range min_loc max_loc =
-  let len_max = String.length max_loc.PI.str in
+  let end_loc = PI.mk_end_token_location max_loc in
   (* alt: could call position_of_token_location but more symetric like that*)
   ( {
       line = min_loc.PI.line;
@@ -26,9 +26,9 @@ let position_range min_loc max_loc =
       offset = min_loc.PI.charpos;
     },
     {
-      line = max_loc.PI.line;
-      col = adjust_column (max_loc.PI.column + len_max);
-      offset = max_loc.PI.charpos + len_max;
+      line = end_loc.line;
+      col = adjust_column end_loc.column;
+      offset = end_loc.charpos;
     } )
 
 let location_of_token_location loc =

--- a/semgrep-core/src/core/Output_from_core_util.ml
+++ b/semgrep-core/src/core/Output_from_core_util.ml
@@ -18,18 +18,14 @@ let position_of_token_location loc =
   }
 
 let position_range min_loc max_loc =
-  let end_loc = PI.mk_end_token_location max_loc in
+  let end_line, end_col, end_charpos = PI.get_token_end_info max_loc in
   (* alt: could call position_of_token_location but more symetric like that*)
   ( {
       line = min_loc.PI.line;
       col = adjust_column min_loc.PI.column;
       offset = min_loc.PI.charpos;
     },
-    {
-      line = end_loc.line;
-      col = adjust_column end_loc.column;
-      offset = end_loc.charpos;
-    } )
+    { line = end_line; col = adjust_column end_col; offset = end_charpos } )
 
 let location_of_token_location loc =
   let start, end_ = position_range loc loc in

--- a/semgrep-core/src/reporting/Matching_report.ml
+++ b/semgrep-core/src/reporting/Matching_report.ml
@@ -61,10 +61,11 @@ let rec join_with_space_if_needed xs =
 let print_match ?(format = Normal) ?(str = "") ?(spaces = 0) ii =
   try
     let mini, maxi = PI.min_max_ii_by_pos ii in
+    let endi = PI.fix_token_location PI.mk_end_token_location maxi in
     let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
     let prefix = spf "%s:%d" file line in
     let arr = Common2.cat_array file in
-    let lines = Common2.enum (PI.line_of_info mini) (PI.line_of_info maxi) in
+    let lines = Common2.enum (PI.line_of_info mini) (PI.line_of_info endi) in
 
     match format with
     | Normal ->

--- a/semgrep-core/src/reporting/Matching_report.ml
+++ b/semgrep-core/src/reporting/Matching_report.ml
@@ -61,11 +61,13 @@ let rec join_with_space_if_needed xs =
 let print_match ?(format = Normal) ?(str = "") ?(spaces = 0) ii =
   try
     let mini, maxi = PI.min_max_ii_by_pos ii in
-    let endi = PI.fix_token_location PI.mk_end_token_location maxi in
+    let end_line, _, _ =
+      PI.get_token_end_info (PI.unsafe_token_location_of_info maxi)
+    in
     let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
     let prefix = spf "%s:%d" file line in
     let arr = Common2.cat_array file in
-    let lines = Common2.enum (PI.line_of_info mini) (PI.line_of_info endi) in
+    let lines = Common2.enum (PI.line_of_info mini) end_line in
 
     match format with
     | Normal ->


### PR DESCRIPTION
**What:**
Currently, multiline tokens (like multiline strings) do not report their ranges correctly.

**Why:**
This causes bugs in the playground, such as the following: 
https://semgrep.dev/playground/s/Jg2y

**How:**
I added a helper function which "flips" a token. For the most part, we use tokens to denote the data of the start of the token - the line, column, and charpos all correspond to that beginning, with the `str` field denoting the actual contents.

There are two places in our code where we are instead interested in the _end_ of a token (specifically, the line and column of the end of a token). This is when we start reporting ranges.

The code currently makes an incorrect assumption that the line and column of a token that it receives is correctly on the same line as the end of the token. This is not the case, however, for all tokens. This causes weird ranges.

The fix was to make a helper that just "flips" a `token_location`. It does so by reading the contents of the string, and by counting the number of newlines, it can synthesize the end line and column from the beginning line and column.

**Alternatives Considered**
I considered using `charpos_to_pos`, but it is expensive, so it would need to be called at the file-level to maximize performance.

Unfortunately, the amount of logic between when Semgrep is considering things as files, and when it is considering the specific tokens it needs to flip, is about as wide as the Gulf of Mexico. I attempted this, but gave up due to the sheer amount of refactoring it required.

This solution is slightly ugly, but it works.

**Test plan:**
`make test`

Closes #5750 (still thinking of you, Ben!)

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
