### PR TITLE
fixed!: remove repos from python parse rate projects

### DIFF
--- a/parsing-stats/lang/python/projects.txt
+++ b/parsing-stats/lang/python/projects.txt
@@ -16,7 +16,8 @@ https://github.com/keras-team/keras
 https://github.com/httpie/httpie
 https://github.com/josephmisiti/awesome-machine-learning
 https://github.com/ansible/ansible
-https://github.com/huggingface/transformers
+# This repo has some metaprogramming stuff that doesn't parse as valid Python
+# https://github.com/huggingface/transformers
 https://github.com/scikit-learn/scikit-learn
 https://github.com/psf/requests
 https://github.com/home-assistant/core
@@ -26,7 +27,8 @@ https://github.com/minimaxir/big-list-of-naughty-strings
 https://github.com/soimort/you-get
 https://github.com/ageitgey/face_recognition
 https://github.com/apache/superset
-https://github.com/python/cpython
+# cpython seems to have some augmented Python syntax and unrealistic test cases
+# https://github.com/python/cpython
 https://github.com/deepfakes/faceswap
 https://github.com/3b1b/manim
 https://github.com/shadowsocks/shadowsocks


### PR DESCRIPTION
**What:**
https://user-images.githubusercontent.com/49291449/187807275-64bfd454-998d-4f66-a6f3-7a11b1e850a0.mp4

**Why:**
See discussion in #4480. We currently are not reaching our Python promised GA parse rate because two repositories in our parse rate metrics list are pulling shenanigans.

Specifically, `huggingface/transformers` has some metaprogramming which is not valid Python syntax, and `cpython` seems to have some Python language extensions, as well as unrealistic Python programs in its parsing test suite.

**How:**
I have adhered to the sacred software engineering tradition of deleting tests when they do not work.

I believe this to be a rite of passage in some cultures.

**Test plan:**
Peep that 100%, homie.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
