### PR TITLE
Simplify Dockerfile and fix Arch Linux failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,7 +135,15 @@ repos:
           - dockerfile
         exclude: "^dockerfiles/linuxbrew[.]Dockerfile$"
         entry: hadolint/hadolint:v2.8.0-alpine hadolint
-        args: ["--ignore", "DL3008", "--ignore", "DL3018"]
+        # Disabled checks:
+        # Pin versions in apt get install
+        #   https://github.com/hadolint/hadolint/wiki/DL3008
+        # Pin versions in apk add
+        #   https://github.com/hadolint/hadolint/wiki/DL3018
+        # Multiple consecutive RUN instructions. Consider
+        # consolidation.
+        #   https://github.com/hadolint/hadolint/wiki/DL3059
+        args: ["--ignore", "DL3008", "--ignore", "DL3018", "--ignore", "DL3059"]
 
   # Run develop semgrep. Only used in CI
   # To run locally use `pre-commit run --hook-stage manual semgrep-docker-develop`

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN apk add --no-cache --virtual=.run-deps bash git git-lfs openssh
 COPY cli ./
 
 RUN apk add --no-cache --virtual=.build-deps build-base
+
+# DL3013: Pin versions in pip.
+# hadolint ignore=DL3013
 RUN SEMGREP_SKIP_BIN=true pip install /semgrep
 # running this pre-compiles some python files for faster startup times
 RUN semgrep --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,8 @@ COPY cli ./
 RUN apk add --no-cache --virtual=.build-deps build-base
 RUN SEMGREP_SKIP_BIN=true pip install /semgrep
 # running this pre-compiles some python files for faster startup times
-RUN semgrep --version && apk del .build-deps && mkdir -p /tmp/.cache
-
+RUN semgrep --version
+RUN apk del .build-deps && mkdir -p /tmp/.cache
 # those files are not needed anymore
 RUN rm -rf /semgrep
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,40 +21,21 @@ FROM returntocorp/ocaml:alpine-2022-06-09@sha256:99b453a838c9d94414991c0fd7be471
 USER root
 # for ocaml-pcre now used in semgrep-core
 # TODO: update root image to include python 3.9
-RUN apk add --no-cache pcre-dev python3 python3-dev &&\
-     pip install --no-cache-dir pipenv==2022.6.7
+RUN apk add --no-cache pcre-dev python3 python3-dev
+RUN pip install --no-cache-dir pipenv==2022.6.7
 
 USER user
 
 ENV OPAMYES=true
 
-WORKDIR /semgrep/semgrep-core/src/ocaml-tree-sitter-core
-COPY --chown=user semgrep-core/src/ocaml-tree-sitter-core/ .
-RUN ./configure \
- && ./scripts/install-tree-sitter-lib
-
-WORKDIR /semgrep/semgrep-core/src/pfff
-COPY --chown=user semgrep-core/src/pfff/*.opam .
-WORKDIR /semgrep/semgrep-core/src/ocaml-tree-sitter-core
-COPY --chown=user semgrep-core/src/ocaml-tree-sitter-core/*.opam .
-WORKDIR /semgrep/semgrep-core
-COPY --chown=user semgrep-core/*.opam .
-
-RUN opam install --deps-only \
-     /semgrep/semgrep-core/src/pfff \
-     /semgrep/semgrep-core/src/ocaml-tree-sitter-core \
-     /semgrep/semgrep-core
-
+# TODO: why copy the current dir to /semgrep and run the command from there?
+COPY --chown=user . /semgrep
 WORKDIR /semgrep
-COPY --chown=user semgrep-core/ ./semgrep-core
-COPY --chown=user interfaces/ ./interfaces
-COPY --chown=user cli/src/semgrep/lang ./cli/src/semgrep/lang
-COPY --chown=user cli/src/semgrep/semgrep_interfaces ./cli/src/semgrep/semgrep_interfaces
+RUN make setup
 
 WORKDIR /semgrep/semgrep-core
 RUN opam exec -- make minimal-build
 
-WORKDIR /semgrep
 RUN /semgrep/semgrep-core/_build/default/src/cli/Main.exe -version
 
 #
@@ -74,18 +55,19 @@ RUN apk add --no-cache --virtual=.run-deps bash git git-lfs openssh
 COPY cli ./
 
 # hadolint ignore=DL3013
-RUN apk add --no-cache --virtual=.build-deps build-base && \
-     SEMGREP_SKIP_BIN=true pip install /semgrep && \
-     # running this pre-compiles some python files for faster startup times
-     semgrep --version && \
-     apk del .build-deps && \
-     mkdir -p /tmp/.cache
+RUN apk add --no-cache --virtual=.build-deps build-base
+RUN SEMGREP_SKIP_BIN=true pip install /semgrep
+# running this pre-compiles some python files for faster startup times
+RUN semgrep --version && apk del .build-deps && mkdir -p /tmp/.cache
+
+# those files are not needed anymore
+RUN rm -rf /semgrep
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Let the user know how their container was built
-COPY dockerfiles/semgrep.Dockerfile /Dockerfile
+COPY Dockerfile /Dockerfile
 
 COPY --from=semgrep-core /semgrep/semgrep-core/_build/default/src/cli/Main.exe /usr/local/bin/semgrep-core
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,13 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=true \
 RUN apk add --no-cache --virtual=.run-deps bash git git-lfs openssh
 COPY cli ./
 
-# hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base
 RUN SEMGREP_SKIP_BIN=true pip install /semgrep
 # running this pre-compiles some python files for faster startup times
 RUN semgrep --version
-RUN apk del .build-deps && mkdir -p /tmp/.cache
+# ??
+RUN mkdir -p /tmp/.cache
+RUN apk del .build-deps
 # those files are not needed anymore
 RUN rm -rf /semgrep
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ rebuild:
 #
 .PHONY: setup
 setup:
-	git submodule update --init
+	git submodule update --init || echo not a git repository
 	# Fetch, build and install the tree-sitter runtime library locally.
 	cd semgrep-core/src/ocaml-tree-sitter-core \
 	&& ./configure \


### PR DESCRIPTION
This closes #5715

The main issue was that WORKDIR does not honor the USER
directive on arch linux (it seems to do on macOS), so
the ocaml-tree-sitter-core directory itself (the '.') was
owned by root which prevented configure to create files
(e.g., tree-sitter-config.ml) in it.

By simplifying the Dockerfile and doing the COPY of
the parent dir, the ocaml-tree-sitter-core directory
is now owned by the user and so configure works.

I've also split some RUN command in 2 because they
were hard to read and I prefer to separate different
concerns in different RUN commands.

test plan:
docker build .


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)