### PR TITLE
remove old version of semgrep before running

### DIFF
--- a/.github/workflows/homebrew-core-head.yml
+++ b/.github/workflows/homebrew-core-head.yml
@@ -21,6 +21,8 @@ jobs:
         run: brew install semgrep --HEAD
       - name: Check installed correctly
         run: brew test semgrep --HEAD
+      - name: Clean up semgrep installation
+        run: brew uninstall semgrep
 
   notify-failure:
     needs: [brew-build]

--- a/.github/workflows/homebrew-core-head.yml
+++ b/.github/workflows/homebrew-core-head.yml
@@ -11,6 +11,10 @@ jobs:
     name: Build Semgrep via Brew from `returntocorp/semgrep:develop`
     runs-on: ["self-hosted", "macOS", "X64"]
     steps:
+      - name: Uninstall semgrep
+        # This is sub-optimal - our workflows shouldn't have to conform to their environment.
+        # However, on the runner side, we can't hook into the workflow run to clean up after.
+        run: brew uninstall semgrep || true
       - name: Brew update
         run: brew update
       - name: Brew Install


### PR DESCRIPTION
Because we now re-use infra, the `brew install semgrep` wasn't doing anything - leading to a de-sync and failing brew tests. This is sub-optimal (ideally we don't change our workflows to suit the infra) but we don't have a good way (or really any way) to hook into the workflow and do this on the runner. 

Maybe we ought to investigate docker-izing the runner, but even then, we have a) figure out how to run the container not in the linux VM that docker uses by default (very difficult, in my estimation) and b) figure out how to spawn a new one on each run (not trivial).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
