### PR TITLE
fix!: allowed other matching to use m_todo_kind

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -2467,7 +2467,7 @@ and m_pattern a b =
   | G.PatWhen (a1, a2), B.PatWhen (b1, b2) ->
       m_pattern a1 b1 >>= fun () -> m_expr a2 b2
   | G.OtherPat (a1, a2), B.OtherPat (b1, b2) ->
-      m_other_pattern_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.PatId _, _
   | G.PatLiteral _, _
   | G.PatConstructor _, _
@@ -2487,8 +2487,6 @@ and m_pattern a b =
 and m_field_pattern a b =
   match (a, b) with
   | (a1, a2), (b1, b2) -> m_dotted_name a1 b1 >>= fun () -> m_pattern a2 b2
-
-and m_other_pattern_operator = m_other_xxx
 
 (*****************************************************************************)
 (* Definitions *)

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1917,14 +1917,13 @@ and m_attribute a b =
       (* 'm_name' handles aliasing for attributes! *)
       m_name a1 b1 >>= fun () -> m_bracket m_list__m_argument a2 b2
   | G.OtherAttribute (a1, a2), B.OtherAttribute (b1, b2) ->
-      m_other_attribute_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.KeywordAttr _, _
   | G.NamedAttr _, _
   | G.OtherAttribute _, _ ->
       fail ()
 
 and m_attributes a b = m_list_in_any_order ~less_is_ok:true m_attribute a b
-and m_other_attribute_operator = m_other_xxx
 
 (*****************************************************************************)
 (* Statement list *)
@@ -2840,7 +2839,7 @@ and m_type_definition_kind a b =
       (* TODO: m_list__m_type_ ? *)
       (m_list m_type_) a2 b2
   | G.OtherTypeKind (a1, a2), B.OtherTypeKind (b1, b2) ->
-      m_other_type_kind_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.AbstractType a1, B.AbstractType b1 -> m_tok a1 b1
   | G.OrType _, _
   | G.AndType _, _
@@ -2865,8 +2864,6 @@ and m_or_type a b =
   | G.OrEnum _, _
   | G.OrUnion _, _ ->
       fail ()
-
-and m_other_type_kind_operator = m_other_xxx
 
 and _m_list__m_type_ (xsa : G.type_ list) (xsb : G.type_ list) =
   m_list_with_dots m_type_
@@ -2990,13 +2987,11 @@ and m_module_definition_kind a b =
   | G.ModuleStruct (a1, a2), B.ModuleStruct (b1, b2) ->
       (m_option m_dotted_name) a1 b1 >>= fun () -> (m_list m_item) a2 b2
   | G.OtherModule (a1, a2), B.OtherModule (b1, b2) ->
-      m_other_module_operator a1 b1 >>= fun () -> (m_list m_any) a2 b2
+      m_todo_kind a1 b1 >>= fun () -> (m_list m_any) a2 b2
   | G.ModuleAlias _, _
   | G.ModuleStruct _, _
   | G.OtherModule _, _ ->
       fail ()
-
-and m_other_module_operator = m_other_xxx
 
 (* ------------------------------------------------------------------------- *)
 (* Macro definition *)

--- a/semgrep-core/tests/swift/if_let.sgrep
+++ b/semgrep-core/tests/swift/if_let.sgrep
@@ -1,0 +1,1 @@
+if let foo = bar { }

--- a/semgrep-core/tests/swift/if_let.swift
+++ b/semgrep-core/tests/swift/if_let.swift
@@ -1,0 +1,2 @@
+// MATCH:
+if let foo = bar { }


### PR DESCRIPTION
**What:**
Currently, `OtherPat` matching, when matching the contained `todo_kind`, uses `m_other_pattern_operator`, which is a wrapper for `m_other_xxx`, a physical equality check. Physical equality on tokens is going to return false a lot of the time, because they contain sensitive location data. We should use `m_todo_kind` instead, like `m_expr` does for matching `OtherExpr`s.

**Why:**
This causes silly matching bugs, like https://semgrep.dev/s/ZL97

**How:**
Updated to use `m_todo_kind`.

I also then updated a few more instances of `m_other_xxx` for a `todo_kind`.

Closes PA-1836.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
