### PR TITLE
Docker: fix Arch Linux failure for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ USER root
 RUN apk add --no-cache pcre-dev python3 python3-dev &&\
      pip install --no-cache-dir pipenv==2022.6.7
 
+RUN mkdir -p /semgrep/semgrep-core/src/ocaml-tree-sitter-core 
+RUN chown -R user /semgrep
+
 USER user
 
 ENV OPAMYES=true
@@ -34,11 +37,11 @@ RUN ./configure \
  && ./scripts/install-tree-sitter-lib
 
 WORKDIR /semgrep/semgrep-core/src/pfff
-COPY --chown=user semgrep-core/src/pfff/*.opam .
+COPY --chown=user semgrep-core/src/pfff/*.opam ./
 WORKDIR /semgrep/semgrep-core/src/ocaml-tree-sitter-core
-COPY --chown=user semgrep-core/src/ocaml-tree-sitter-core/*.opam .
+COPY --chown=user semgrep-core/src/ocaml-tree-sitter-core/*.opam ./
 WORKDIR /semgrep/semgrep-core
-COPY --chown=user semgrep-core/*.opam .
+COPY --chown=user semgrep-core/*.opam ./
 
 RUN opam install --deps-only \
      /semgrep/semgrep-core/src/pfff \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,9 @@ USER root
 # for ocaml-pcre now used in semgrep-core
 # TODO: update root image to include python 3.9
 RUN apk add --no-cache pcre-dev python3 python3-dev &&\
-     pip install --no-cache-dir pipenv==2022.6.7
-
-RUN mkdir -p /semgrep/semgrep-core/src/ocaml-tree-sitter-core 
-RUN chown -R user /semgrep
+     pip install --no-cache-dir pipenv==2022.6.7 &&\
+     mkdir -p /semgrep/semgrep-core/src/ocaml-tree-sitter-core &&\
+     chown -R user /semgrep
 
 USER user
 


### PR DESCRIPTION
This closes #5715

This is a simplification of
https://github.com/returntocorp/semgrep/pull/6019
which introduced some regressions in the size of
docker image (from 64MB to 127MB).

test plan:
docker build .
docker images and control the size (223MB uncompressed,
when it was 408MB after 6019)


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)