### PR TITLE
Remove unnecessary dependency on the semgrep_core library, for now

### DIFF
--- a/semgrep-core/src/parsing/pfff/dune
+++ b/semgrep-core/src/parsing/pfff/dune
@@ -10,7 +10,7 @@
    dyp
 
    commons commons_core
-   semgrep_core
+
    pfff-config pfff-h_program-lang
 
    pfff-lang_GENERIC_base

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -17,7 +17,6 @@ open Ast_ruby
 module G = AST_generic
 module H = AST_generic_helpers
 module PI = Parse_info
-module MV = Metavariable
 
 (*****************************************************************************)
 (* Prelude *)


### PR DESCRIPTION
We don't need to depend on the `Metavariable` module for now so I'm removing the dependency.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
