### PR TITLE
Only import jsonnet when necessary

### DIFF
--- a/cli/Pipfile
+++ b/cli/Pipfile
@@ -44,6 +44,5 @@ typing_extensions = "*"
 importlib_resources = ">=1.4.0"
 
 [packages]
-semgrep = {editable = true,path = "."}
 jsonschema = "==4.6.1"
-jsonnet = "*"
+semgrep = {editable = true, extras = ["experiments"], path = "."}

--- a/cli/Pipfile.lock
+++ b/cli/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4c342605864f6c3d90dfa1a604b9fe1671e6c99c26a1951b60ceb699313777f2"
+            "sha256": "f9622178b3aa1743275f53693d6e31a87bbdee4e325b819fdee1ef068065a6f7"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -111,7 +111,6 @@
             "hashes": [
                 "sha256:4ccd13427e9097b6b7d6d38f78f638a55ab8b452a257639e8e9af2178ec235d4"
             ],
-            "index": "pypi",
             "version": "==0.18.0"
         },
         "jsonschema": {
@@ -232,15 +231,18 @@
         },
         "semgrep": {
             "editable": true,
+            "extras": [
+                "experiments"
+            ],
             "path": "."
         },
         "tqdm": {
             "hashes": [
-                "sha256:40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d",
-                "sha256:74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6"
+                "sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4",
+                "sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.64.0"
+            "version": "==4.64.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -501,11 +503,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
-                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
+                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
             "index": "pypi",
-            "version": "==7.1.2"
+            "version": "==7.1.3"
         },
         "pytest-forked": {
             "hashes": [
@@ -573,11 +575,11 @@
         },
         "readme-renderer": {
             "hashes": [
-                "sha256:07b7ea234e03e58f77cc222e206e6abb8f4c0435becce5104794ee591f9301c5",
-                "sha256:9fa416704703e509eeb900696751c908ddeb2011319d93700d8f18baff887a69"
+                "sha256:16c914ca7731fd062a316a2a8e5434a175ee34661a608af771a60c881f528a34",
+                "sha256:96768c069729f69176f514477e57f2f8cd543fbb2cd7bad372976249fa509a0c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==37.0"
+            "version": "==37.1"
         },
         "setuptools": {
             "hashes": [
@@ -699,11 +701,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1",
-                "sha256:d86ea0bb50e06252d79e6c241507cb904fcd66090c3271381372d6221a3970f9"
+                "sha256:014f766e4134d0008dcaa1f95bafa0fb0f575795d07cae50b1bee514185d6782",
+                "sha256:035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==20.16.3"
+            "version": "==20.16.4"
         },
         "webencodings": {
             "hashes": [

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -126,7 +126,6 @@ install_requires = [
     "tqdm~=4.46",
     "packaging~=21.0",
     "jsonschema~=4.6",
-    "jsonnet~=0.18",
     "wcmatch~=8.3",
     "peewee~=3.14",
     "defusedxml~=0.7.1",
@@ -134,6 +133,8 @@ install_requires = [
     "typing-extensions~=4.2",
     "python-lsp-jsonrpc~=1.0.0",
 ]
+
+extras_require = {"experiments": ["jsonnet~=0.18"]}
 
 setuptools.setup(
     name="semgrep",
@@ -143,6 +144,7 @@ setuptools.setup(
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",
     cmdclass=cmdclass,
     install_requires=install_requires,
+    extras_require=extras_require,
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/returntocorp/semgrep",

--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -16,7 +16,6 @@ from typing import Tuple
 from urllib.parse import urlencode
 from urllib.parse import urlparse
 
-import _jsonnet  # type: ignore
 import requests
 import ruamel.yaml
 from ruamel.yaml import YAMLError
@@ -572,6 +571,17 @@ def parse_config_string(
         logger.error(
             "Support for Jsonnet rules is experimental and currently meant for internal use only. The syntax may change or be removed at any point."
         )
+
+        # Importing jsonnet here so that people who aren't using
+        # jsonnet rules don't need to deal with jsonnet as a
+        # dependency, especially while this is internal.
+        try:
+            import _jsonnet  # type: ignore
+        except ImportError:
+            logger.error(
+                "Running jsonnet rules requires the python jsonnet library. Please run `pip install jsonnet` and try again."
+            )
+
         contents = _jsonnet.evaluate_snippet(
             filename, contents, import_callback=import_callback
         )


### PR DESCRIPTION
Since jsonnet rules are an internal experiment for now, let's
not require users to have the jsonnet dependency. People who
want to try out jsonnet rules can `pip install jsonnet`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
