### PR TITLE
pre-commit: add semgrep with local semgrep.yml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,6 +117,23 @@ repos:
         types: [python]
         exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
         args: ["--config", "https://semgrep.dev/p/bandit", "--error"]
+      #coupling: ran also in .circleci/config.yml
+      - id: semgrep
+        name: Semgrep with local semgrep.yml
+        args:
+          [
+            "--config",
+            "semgrep.yml",
+            "--error",
+            "--exclude",
+            "tests",
+            "--exclude",
+            "TODO",
+            "--exclude",
+            "_build",
+            "--autofix",
+            ".",
+          ]
 
   - repo: local
     hooks:

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -91,7 +91,7 @@ let is_in_scope env s =
 (*****************************************************************************)
 let id x = x
 let option = Option.map
-let list = List.map
+let list = Common.map
 let vref f x = ref (f !x)
 let string = id
 let bool = id
@@ -121,11 +121,11 @@ let module_name env (v1, dots) =
   | Some toks ->
       let count =
         toks
-        |> List.map Parse_info.str_of_info
+        |> Common.map Parse_info.str_of_info
         |> String.concat "" |> String.length
       in
       let tok = List.hd toks in
-      let elems = v1 |> List.map fst in
+      let elems = v1 |> Common.map fst in
       let prefixes =
         match count with
         | 1 -> [ "." ]
@@ -194,7 +194,7 @@ let rec expr env (x : expr) =
           |> G.e,
           ( v1,
             xs
-            |> List.map (fun x ->
+            |> Common.map (fun x ->
                    let x = expr env x in
                    G.Arg x),
             v3 ) )
@@ -205,7 +205,7 @@ let rec expr env (x : expr) =
           |> G.e,
           fb
             (xs
-            |> List.map (fun x ->
+            |> Common.map (fun x ->
                    let x = expr env x in
                    G.Arg x)) )
       |> G.e
@@ -243,7 +243,7 @@ let rec expr env (x : expr) =
        | l1, [ x ], l2 -> slice1 env e (l1, x, l2)
        | l1, xs, _ ->
            let xs = list (slice env e) xs in
-           G.OtherExpr (("Slices", l1), xs |> List.map (fun x -> G.E x)))
+           G.OtherExpr (("Slices", l1), xs |> Common.map (fun x -> G.E x)))
       |> G.e
   | Attribute (v1, t, v2, v3) ->
       let v1 = expr env v1
@@ -272,12 +272,12 @@ let rec expr env (x : expr) =
       G.Comprehension (G.Dict, (l, e1, r)) |> G.e
   | BoolOp ((v1, tok), v2) ->
       let v1 = boolop v1 and v2 = list (expr env) v2 in
-      G.Call (G.IdSpecial (G.Op v1, tok) |> G.e, fb (v2 |> List.map G.arg))
+      G.Call (G.IdSpecial (G.Op v1, tok) |> G.e, fb (v2 |> Common.map G.arg))
       |> G.e
   | BinOp (v1, (v2, tok), v3) ->
       let v1 = expr env v1 and v2 = operator v2 and v3 = expr env v3 in
       G.Call
-        (G.IdSpecial (G.Op v2, tok) |> G.e, fb ([ v1; v3 ] |> List.map G.arg))
+        (G.IdSpecial (G.Op v2, tok) |> G.e, fb ([ v1; v3 ] |> Common.map G.arg))
       |> G.e
   | UnaryOp ((v1, tok), v2) ->
       let op = unaryop v1 and v2 = expr env v2 in
@@ -287,15 +287,16 @@ let rec expr env (x : expr) =
       match (v2, v3) with
       | [ (op, tok) ], [ e ] ->
           G.Call
-            (G.IdSpecial (G.Op op, tok) |> G.e, fb ([ v1; e ] |> List.map G.arg))
+            ( G.IdSpecial (G.Op op, tok) |> G.e,
+              fb ([ v1; e ] |> Common.map G.arg) )
           |> G.e
       | _ ->
           let anyops =
             v2
-            |> List.map (function arith, tok ->
+            |> Common.map (function arith, tok ->
                    G.E (G.IdSpecial (G.Op arith, tok) |> G.e))
           in
-          let anys = anyops @ (v3 |> List.map (fun e -> G.E e)) in
+          let anys = anyops @ (v3 |> Common.map (fun e -> G.E e)) in
           G.OtherExpr (("CmpOps", unsafe_fake ""), anys) |> G.e)
   | Call (v1, v2) ->
       let v1 = expr env v1 in
@@ -461,7 +462,7 @@ and param_pattern env = function
 
 and parameters env xs =
   xs
-  |> List.map (function
+  |> Common.map (function
        | ParamDefault ((n, topt), e) ->
            let n = name env n in
            let topt = option (type_ env) topt in
@@ -597,7 +598,7 @@ and stmt_aux env x =
           cimplements = [];
           cmixins = [];
           cparams = [];
-          cbody = fb (v3 |> List.map (fun x -> fieldstmt x));
+          cbody = fb (v3 |> Common.map (fun x -> fieldstmt x));
         }
       in
       [ G.DefStmt (ent, G.ClassDef def) |> G.s ]
@@ -606,7 +607,7 @@ and stmt_aux env x =
       [ G.Return (t, v1, G.sc) |> G.s ]
   | Delete (_t, v1) ->
       let v1 = list (expr env) v1 in
-      [ G.OtherStmt (G.OS_Delete, v1 |> List.map (fun x -> G.E x)) |> G.s ]
+      [ G.OtherStmt (G.OS_Delete, v1 |> Common.map (fun x -> G.E x)) |> G.s ]
   | If (t, v1, v2, v3) ->
       let v1 = expr env v1
       and v2 = list_stmt1 env v2
@@ -626,7 +627,7 @@ and stmt_aux env x =
                  [
                    G.While (t, G.Cond v1, v2) |> G.s;
                    G.OtherStmt
-                     (G.OS_WhileOrElse, v3 |> List.map (fun x -> G.S x))
+                     (G.OS_WhileOrElse, v3 |> Common.map (fun x -> G.S x))
                    |> G.s;
                  ])
             |> G.s;
@@ -646,7 +647,7 @@ and stmt_aux env x =
                  [
                    G.For (t, header, body) |> G.s;
                    G.OtherStmt
-                     (G.OS_ForOrElse, orelse |> List.map (fun x -> G.S x))
+                     (G.OS_ForOrElse, orelse |> Common.map (fun x -> G.S x))
                    |> G.s;
                  ])
             |> G.s;
@@ -775,7 +776,7 @@ and stmt_aux env x =
                  [
                    G.Try (t, v1, v2, None) |> G.s;
                    G.OtherStmt
-                     (G.OS_TryOrElse, orelse |> List.map (fun x -> G.S x))
+                     (G.OS_TryOrElse, orelse |> Common.map (fun x -> G.S x))
                    |> G.s;
                  ])
             |> G.s;
@@ -787,7 +788,7 @@ and stmt_aux env x =
   | Assert (t, v1, v2) ->
       let v1 = expr env v1 and v2 = option (expr env) v2 in
       let es = v1 :: Option.to_list v2 in
-      let args = es |> List.map G.arg in
+      let args = es |> Common.map G.arg in
       [ G.Assert (t, fb args, G.sc) |> G.s ]
   | ImportAs (t, v1, v2) ->
       let mname = module_name env v1
@@ -798,7 +799,7 @@ and stmt_aux env x =
       [ G.DirectiveStmt (G.ImportAll (t, mname, v2) |> G.d) |> G.s ]
   | ImportFrom (t, v1, v2) ->
       let v1 = module_name env v1 and v2 = list (alias env) v2 in
-      List.map
+      Common.map
         (fun (a, b) ->
           G.DirectiveStmt (G.ImportFrom (t, v1, a, b) |> G.d) |> G.s)
         v2
@@ -806,7 +807,7 @@ and stmt_aux env x =
   | NonLocal (t, v1) ->
       let v1 = list (name env) v1 in
       v1
-      |> List.map (fun x ->
+      |> Common.map (fun x ->
              let ent = G.basic_entity x in
              G.DefStmt (ent, G.UseOuterDecl t) |> G.s)
   | ExprStmt v1 ->
@@ -829,7 +830,7 @@ and stmt_aux env x =
   | Print (tok, _dest, vals, _nl) ->
       let id = Name (("print", tok), Load, ref NotResolved) in
       stmt_aux env
-        (ExprStmt (Call (id, fb (vals |> List.map (fun e -> Arg e)))))
+        (ExprStmt (Call (id, fb (vals |> Common.map (fun e -> Arg e)))))
   | Exec (tok, e, _eopt, _eopt2) ->
       let id = Name (("exec", tok), Load, ref NotResolved) in
       stmt_aux env (ExprStmt (Call (id, fb [ Arg e ])))

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -184,7 +184,7 @@ and expr e =
   | ConcatString xs ->
       G.Call
         ( G.IdSpecial (G.ConcatString G.SequenceConcat, unsafe_fake " ") |> G.e,
-          fb (xs |> List.map (fun x -> G.Arg (G.L (G.String x) |> G.e))) )
+          fb (xs |> Common.map (fun x -> G.Arg (G.L (G.String x) |> G.e))) )
       |> G.e
   | Defined (t, id) ->
       let e = G.N (G.Id (id, G.empty_id_info ())) |> G.e in
@@ -272,7 +272,7 @@ and expr e =
       G.Record v1 |> G.e
   | GccConstructor (v1, v2) ->
       let v1 = type_ v1 and v2 = expr v2 in
-      G.New (unsafe_fake "new", v1, fb ([ v2 ] |> List.map G.arg)) |> G.e
+      G.New (unsafe_fake "new", v1, fb ([ v2 ] |> Common.map G.arg)) |> G.e
   | TypedMetavar (v1, v2) ->
       let v1 = name v1 in
       let v2 = type_ v2 in
@@ -293,7 +293,7 @@ let rec stmt st =
   | CaseStmt x ->
       (* should not happen, should only appear in Switch *)
       let case, st = case_and_body x in
-      let anys = [ case ] |> List.map (fun cs -> G.Cs cs) in
+      let anys = [ case ] |> Common.map (fun cs -> G.Cs cs) in
       G.OtherStmtWithStmt (OSWS_Todo, anys, st)
   | ExprSt (v1, t) ->
       let v1 = expr v1 in
@@ -308,7 +308,7 @@ let rec stmt st =
       let v0 = info v0 in
       let v1 = expr v1 and v2 = list case_and_body v2 in
       let cases =
-        v2 |> List.map (fun (case, body) -> G.CasesAndBody ([ case ], body))
+        v2 |> Common.map (fun (case, body) -> G.CasesAndBody ([ case ], body))
       in
       G.Switch (v0, Some (G.Cond v1), cases)
   | While (t, v1, v2) ->
@@ -342,10 +342,10 @@ let rec stmt st =
       G.Goto (t, v1, G.sc)
   | Vars v1 ->
       let v1 = list var_decl v1 in
-      (G.stmt1 (v1 |> List.map (fun v -> G.s (G.DefStmt v)))).G.s
+      (G.stmt1 (v1 |> Common.map (fun v -> G.s (G.DefStmt v)))).G.s
   | Asm v1 ->
       let v1 = list expr v1 in
-      G.OtherStmt (G.OS_Asm, v1 |> List.map (fun e -> G.E e)))
+      G.OtherStmt (G.OS_Asm, v1 |> Common.map (fun e -> G.E e)))
   |> G.s
 
 and expr_or_vars v1 =
@@ -403,12 +403,12 @@ and struct_def { s_name; s_kind; s_flds } =
   match s_kind with
   | Struct ->
       let fields =
-        bracket (List.map (fun (n, t) -> G.basic_field n None (Some t))) v3
+        bracket (Common.map (fun (n, t) -> G.basic_field n None (Some t))) v3
       in
       (entity, G.TypeDef { G.tbody = G.AndType fields })
   | Union ->
       let ctors =
-        v3 |> G.unbracket |> List.map (fun (n, t) -> G.OrUnion (n, t))
+        v3 |> G.unbracket |> Common.map (fun (n, t) -> G.OrUnion (n, t))
       in
       (entity, G.TypeDef { G.tbody = G.OrType ctors })
 
@@ -427,7 +427,7 @@ and enum_def { e_name = v1; e_consts = v2 } =
       v2
   in
   let entity = G.basic_entity v1 in
-  let ors = v2 |> List.map (fun (n, eopt) -> G.OrEnum (n, eopt)) in
+  let ors = v2 |> Common.map (fun (n, eopt) -> G.OrEnum (n, eopt)) in
   (entity, G.TypeDef { G.tbody = G.OrType ors })
 
 and type_def { t_name = v1; t_type = v2 } =

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -30,7 +30,7 @@ module H = AST_generic_helpers
 (*****************************************************************************)
 let id x = x
 let string = id
-let list = List.map
+let list = Common.map
 let option = Option.map
 let either = OCaml.map_of_either
 let arithmetic_operator = id
@@ -64,7 +64,7 @@ let return_type_of_results results =
       Some
         (G.TyTuple
            (xs
-           |> List.map (function
+           |> Common.map (function
                 | G.Param { G.ptype = Some t; _ } -> t
                 | G.Param { G.ptype = None; _ } -> raise Impossible
                 | G.ParamEllipsis t -> G.TyEllipsis t |> G.t
@@ -267,7 +267,7 @@ let top_func () =
         and v3 = expr v3 in
         G.Call
           ( G.IdSpecial (G.Op (H.conv_op v2), tok) |> G.e,
-            fb ([ v1; v3 ] |> List.map G.arg) )
+            fb ([ v1; v3 ] |> Common.map G.arg) )
     | CompositeLit (v1, v2) ->
         let v1 = type_ v1
         and l, v2, r = bracket (list init_for_composite_lit) v2 in
@@ -531,7 +531,7 @@ let top_func () =
             G.ForEach (pattern, v2, v3)
         | Some (xs, _tokEqOrColonEqTODO) ->
             let pattern =
-              G.PatTuple (xs |> List.map H.expr_to_pattern |> G.fake_bracket)
+              G.PatTuple (xs |> Common.map H.expr_to_pattern |> G.fake_bracket)
             in
             G.ForEach (pattern, v2, v3))
   and case_clause = function
@@ -550,12 +550,12 @@ let top_func () =
         | Right t -> G.PatType t)
   and case_kind = function
     | CaseExprs (tok, v1) ->
-        v1 |> List.map (fun x -> G.Case (tok, expr_or_type_to_pattern x))
+        v1 |> Common.map (fun x -> G.Case (tok, expr_or_type_to_pattern x))
     | CaseAssign (tok, v1, v2, v3) ->
         let v1 = list expr_or_type v1 and v3 = expr v3 in
         let v1 =
           v1
-          |> List.map (function
+          |> Common.map (function
                | Left e -> e
                | Right _ -> error tok "TODO: Case Assign with Type?")
         in

--- a/semgrep-core/src/parsing/pfff/json_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/json_to_generic.ml
@@ -45,7 +45,7 @@ let expr ?(unescape_strings = false) x =
             | Record (lp, xs, rp) ->
                 let ys =
                   xs
-                  |> List.map (function
+                  |> Common.map (function
                        | G.F
                            {
                              s =
@@ -63,7 +63,7 @@ let expr ?(unescape_strings = false) x =
                 in
                 let zs =
                   ys
-                  |> List.map (function
+                  |> Common.map (function
                        | Left (id, e) ->
                            let key =
                              (* we don't want $FLD: 1 to be transformed

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -30,7 +30,7 @@ module H = AST_generic_helpers
 (*****************************************************************************)
 let id x = x
 let option = Option.map
-let list = List.map
+let list = Common.map
 let string = id
 let bool = id
 
@@ -69,7 +69,7 @@ let mk_var_or_func tlet params tret body =
 
 let defs_of_bindings tlet attrs xs =
   xs
-  |> List.map (function
+  |> Common.map (function
        | Left (ent, params, tret, body) ->
            let ent = add_attrs ent attrs in
            G.DefStmt (ent, mk_var_or_func tlet params tret body) |> G.s
@@ -132,14 +132,14 @@ and type_kind = function
       G.TyFun ([ G.Param (G.param_of_type v1) ], v2)
   | TyApp (v1, v2) ->
       let v1 = list type_ v1 and v2 = name v2 in
-      G.TyApply (G.TyN v2 |> G.t, fb (v1 |> List.map (fun t -> G.TA t)))
+      G.TyApply (G.TyN v2 |> G.t, fb (v1 |> Common.map (fun t -> G.TA t)))
   | TyTuple v1 ->
       let v1 = list type_ v1 in
       G.TyTuple (fb v1)
   | TyTodo (t, v1) ->
       let t = todo_category t in
       let v1 = list type_ v1 in
-      G.OtherType (t, List.map (fun x -> G.T x) v1)
+      G.OtherType (t, Common.map (fun x -> G.T x) v1)
 
 and expr_body e : G.stmt = stmt e
 
@@ -164,7 +164,7 @@ and stmt e : G.stmt =
       let v1 = stmt v1 and v2 = list match_case v2 in
       let catches =
         v2
-        |> List.map (fun (pat, e) ->
+        |> Common.map (fun (pat, e) ->
                (fake "catch", G.CatchPattern pat, G.exprstmt e))
       in
       G.Try (t, v1, catches, None) |> G.s
@@ -378,7 +378,7 @@ and expr e =
   | ExprTodo (t, xs) ->
       let t = todo_category t in
       let xs = list expr xs in
-      G.OtherExpr (t, List.map (fun x -> G.E x) xs)
+      G.OtherExpr (t, Common.map (fun x -> G.E x) xs)
   | If _
   | Try _
   | For _
@@ -495,7 +495,7 @@ and pattern = function
   | PatTodo (t, xs) ->
       let t = todo_category t in
       let xs = list pattern xs in
-      G.OtherPat (t, List.map (fun x -> G.P x) xs)
+      G.OtherPat (t, Common.map (fun x -> G.P x) xs)
 
 and let_binding = function
   | LetClassic v1 ->
@@ -601,7 +601,7 @@ and module_expr = function
   | ModuleTodo (t, xs) ->
       let t = todo_category t in
       let xs = list module_expr xs in
-      G.OtherModule (t, List.map (fun x -> G.ModDk x) xs)
+      G.OtherModule (t, Common.map (fun x -> G.ModDk x) xs)
 
 and attributes xs = list attribute xs
 
@@ -628,7 +628,7 @@ and item { i; iattrs } =
   | Type (_t, v1) ->
       let xs = list type_declaration v1 in
       xs
-      |> List.map (function
+      |> Common.map (function
            | Left (ent, def) ->
                (* add attrs to all mutual type decls *)
                let ent = add_attrs ent attrs in
@@ -671,12 +671,12 @@ and item { i; iattrs } =
         G.OtherStmt
           ( G.OS_Todo,
             [ G.TodoK t ]
-            @ List.map (fun x -> G.S x) xs
-            @ List.map (fun x -> G.At x) attrs )
+            @ Common.map (fun x -> G.S x) xs
+            @ Common.map (fun x -> G.At x) attrs )
         |> G.s;
       ]
 
-and program xs = List.map item xs |> List.flatten
+and program xs = List.concat_map item xs
 
 and partial = function
   | PartialIf (t, e) ->

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -37,7 +37,7 @@ module PI = Parse_info
 (*****************************************************************************)
 let id x = x
 let option = Option.map
-let list = List.map
+let list = Common.map
 let bool = id
 let string = id
 let fake tok s = Parse_info.fake_info tok s
@@ -128,7 +128,7 @@ let rec expr e =
           in
           G.DotAccess (e, t, fld))
   | Splat (t, eopt) ->
-      let xs = option expr eopt |> Option.to_list |> List.map G.arg in
+      let xs = option expr eopt |> Option.to_list |> Common.map G.arg in
       let special = G.IdSpecial (G.Spread, t) |> G.e in
       G.Call (special, fb xs)
   | CodeBlock ((t1, _, t2), params_opt, xs) ->
@@ -339,7 +339,7 @@ and interpolated_string (t1, xs, t2) : G.expr_kind =
   let xs = list (string_contents t1) xs in
   G.Call
     ( G.IdSpecial (G.ConcatString G.InterpolatedConcat, t1) |> G.e,
-      (t1, xs |> List.map (fun e -> G.Arg e), t2) )
+      (t1, xs |> Common.map (fun e -> G.Arg e), t2) )
 
 and string_contents tok = function
   | StrChars s -> G.L (G.String s) |> G.e
@@ -593,14 +593,14 @@ and stmt st =
         | Some e -> Some (G.Cond e)
       in
       G.Switch
-        (t, condopt, whens @ default |> List.map (fun x -> G.CasesAndBody x))
+        (t, condopt, whens @ default |> Common.map (fun x -> G.CasesAndBody x))
       |> G.s
   | ExnBlock b -> body_exn b
 
 and when_clause (t, pats, sts) =
   let pats = list pattern pats in
   let st = list_stmt1 sts in
-  (pats |> List.map (fun pat -> G.Case (t, pat)), st)
+  (pats |> Common.map (fun pat -> G.Case (t, pat)), st)
 
 and args_to_label_ident xs = xs |> args_to_exprs |> exprs_to_label_ident
 

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -41,7 +41,7 @@ let v_string = id
 let v_int = id
 let v_float = id
 let v_bool = id
-let v_list = List.map
+let v_list = Common.map
 let v_option = Option.map
 
 let cases_to_lambda lb cases : G.function_definition =
@@ -141,7 +141,7 @@ and v_import_spec = function
       let v1 = (v_list v_import_selector) v1 in
       fun tk path ->
         v1
-        |> List.map (fun (id, opt) ->
+        |> Common.map (fun (id, opt) ->
                let alias =
                  match opt with
                  | None -> None
@@ -185,7 +185,7 @@ let rec v_literal = function
       in
       let args =
         v2
-        |> List.map (function
+        |> Common.map (function
              | Left lit -> G.Arg (G.L lit |> G.e)
              | Right e ->
                  let special =
@@ -227,12 +227,12 @@ and v_type_kind = function
   | TyApplied (v1, v2) -> (
       let v1 = v_type_ v1 and v2 = v_bracket (v_list v_type_) v2 in
       let lp, xs, rp = v2 in
-      let args = xs |> List.map (fun x -> G.TA x) in
+      let args = xs |> Common.map (fun x -> G.TA x) in
       match v1.t with
       | G.TyN n -> G.TyApply (G.TyN n |> G.t, (lp, args, rp))
       | _ ->
           todo_type "TyAppliedComplex"
-            (G.T v1 :: (xs |> List.map (fun x -> G.T x))))
+            (G.T v1 :: (xs |> Common.map (fun x -> G.T x))))
   | TyInfix (v1, v2, v3) ->
       let v1 = v_type_ v1 and v2 = v_ident v2 and v3 = v_type_ v3 in
       G.TyApply (G.TyN (H.name_of_ids [ v2 ]) |> G.t, fb [ G.TA v1; G.TA v3 ])
@@ -244,7 +244,7 @@ and v_type_kind = function
       and _v2 = v_tok v2
       and v3 = v_type_ v3 in
       let ts =
-        v1 |> G.unbracket |> List.map (fun t -> G.Param (G.param_of_type t))
+        v1 |> G.unbracket |> Common.map (fun t -> G.Param (G.param_of_type t))
       in
       G.TyFun (ts, v3)
   | TyTuple v1 ->
@@ -266,12 +266,13 @@ and v_type_kind = function
         ((match v1 with
          | None -> []
          | Some t -> [ G.T t ])
-        @ (defs |> List.map (fun def -> G.Def def)))
+        @ (defs |> Common.map (fun def -> G.Def def)))
   | TyExistential (v1, v2, v3) ->
       let v1 = v_type_ v1 in
       let _v2 = v_tok v2 in
       let _lb, defs, _rb = v_refinement v3 in
-      todo_type "TyExistential" (G.T v1 :: (defs |> List.map (fun x -> G.Def x)))
+      todo_type "TyExistential"
+        (G.T v1 :: (defs |> Common.map (fun x -> G.Def x)))
   | TyWith (v1, v2, v3) ->
       let v1 = v_type_ v1 and v2 = v_tok v2 and v3 = v_type_ v3 in
       G.TyAnd (v1, v2, v3)
@@ -391,7 +392,7 @@ and v_expr e : G.expr =
       todo_expr "ExprUnderscore" [ G.Tk v1 ]
   | InstanciatedExpr (v1, v2) ->
       let v1 = v_expr v1 and _, v2, _ = v_bracket (v_list v_type_) v2 in
-      todo_expr "InstanciatedExpr" (G.E v1 :: List.map (fun t -> G.T t) v2)
+      todo_expr "InstanciatedExpr" (G.E v1 :: Common.map (fun t -> G.T t) v2)
   | TypedExpr (v1, v2, v3) ->
       let v1 = v_expr v1 and v2 = v_tok v2 and v3 = v_ascription v3 in
       G.Cast (v3, v2, v1) |> G.e
@@ -627,9 +628,9 @@ and v_catch_clause (v1, v2) : G.catch list =
   let v1 = v_tok v1 in
   match v2 with
   | CatchCases (_lb, xs, _rb) ->
-      let actions = List.map v_case_clause xs in
+      let actions = Common.map v_case_clause xs in
       actions
-      |> List.map (fun (icase, pat, st) -> (icase, G.CatchPattern pat, st))
+      |> Common.map (fun (icase, pat, st) -> (icase, G.CatchPattern pat, st))
   | CatchExpr e ->
       let e = v_expr e in
       let pat = G.PatUnderscore v1 in
@@ -645,10 +646,10 @@ and v_block_stat x : G.item list =
   match x with
   | D v1 ->
       let v1 = v_definition v1 in
-      v1 |> List.map (fun def -> G.DefStmt def |> G.s)
+      v1 |> Common.map (fun def -> G.DefStmt def |> G.s)
   | I v1 ->
       let v1 = v_import v1 in
-      v1 |> List.map (fun dir -> G.DirectiveStmt dir |> G.s)
+      v1 |> Common.map (fun dir -> G.DirectiveStmt dir |> G.s)
   | E v1 ->
       let v1 = v_expr_for_stmt v1 in
       [ v1 ]
@@ -690,7 +691,7 @@ and v_modifier_kind = function
 
 and v_annotation (v1, v2, v3) : G.attribute =
   let v1 = v_tok v1 and v2 = v_type_ v2 and v3 = v_list v_arguments v3 in
-  let args = v3 |> List.map G.unbracket |> List.flatten in
+  let args = v3 |> Common.map G.unbracket |> List.flatten in
   match v2.t with
   | TyN name -> G.NamedAttr (v1, name, fb args)
   | _ ->
@@ -876,7 +877,7 @@ and v_template_definition
   let cbody =
     match body with
     | None -> G.empty_body
-    | Some (lb, xs, rb) -> (lb, xs |> List.map (fun st -> G.F st), rb)
+    | Some (lb, xs, rb) -> (lb, xs |> Common.map (fun st -> G.F st), rb)
   in
   { G.ckind; cextends; cmixins; cimplements = []; cparams; cbody }
 


### PR DESCRIPTION
Before this PR, you would get many semgrep errors at CI time (e.g., about List.map
that should be replaced by Common.map).
It's better to get them ASAP, at pre-commit time.

test plan:
pre-commit run semgrep

note that pre-commit run -a semgrep currently returns some weird
error messages.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)