### PR TITLE
fix!: fix regression related to inside patterns

### DIFF
--- a/changelog.d/gh-6059.fixed
+++ b/changelog.d/gh-6059.fixed
@@ -1,0 +1,1 @@
+Fixed a regression introduced with the previous release, involving a bug with `pattern-inside`.

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -383,7 +383,9 @@ let visit_new_formula f formula =
     | P p -> f p !bref
     | Inside (_, formula) ->
         bref := true;
-        visit_new_formula f formula
+        let res = visit_new_formula f formula in
+        bref := false;
+        res
     | Not (_, x) -> visit_new_formula f x
     | Or (_, xs)
     | And (_, { conjuncts = xs; _ }) ->

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -382,10 +382,7 @@ let visit_new_formula f formula =
     match formula with
     | P p -> f p !bref
     | Inside (_, formula) ->
-        bref := true;
-        let res = visit_new_formula f formula in
-        bref := false;
-        res
+        Common.save_excursion bref true (fun () -> visit_new_formula f formula)
     | Not (_, x) -> visit_new_formula f x
     | Or (_, xs)
     | And (_, { conjuncts = xs; _ }) ->

--- a/semgrep-core/tests/OTHER/rules/inside_test.go
+++ b/semgrep-core/tests/OTHER/rules/inside_test.go
@@ -1,0 +1,9 @@
+// We don't want findings! If we produce a finding, that means something is wrong with `inside`.
+func foo() {
+
+	x := 5 
+
+	if cond { }
+
+	return 0 
+}

--- a/semgrep-core/tests/OTHER/rules/inside_test.yaml
+++ b/semgrep-core/tests/OTHER/rules/inside_test.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: inside-test 
+  languages:
+    - go
+  message: inside should work properly here! 
+  patterns:
+    - pattern-inside: func $FUNCNAME(...) { ... }
+    - pattern-either:
+        - pattern: |
+            x := $VALUE
+            ...
+            if cond { ... }
+    - pattern-not: |
+        x = $OTHERVALUE
+        ...
+  severity: WARNING


### PR DESCRIPTION
**What:**
We got a regression due to the rules PR. This PR aims to fix that.

**Why:**
Regressions are bad. We should solve this so that we don't lose existing behavior.

**How:**
I didn't set a ref back to false when I should have. This PR uses `save_excursion` to manage the boolean reference cell.

Not doing so results in later patterns always being assumed to be underneath an `inside`, which causes issues with ranges that overlap.

Closes #6059 

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
