### PR TITLE
chore: add not-in to eval op

### DIFF
--- a/changelog.d/gh-6072.fixed
+++ b/changelog.d/gh-6072.fixed
@@ -1,0 +1,1 @@
+Allowed metavariable-comparison to make use of the `not in` operator.

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -281,6 +281,10 @@ and eval_op op values code =
       match v2 with
       | List xs -> Bool (List.mem v1 xs)
       | _ -> Bool false)
+  | G.NotIn, [ v1; v2 ] -> (
+      match v2 with
+      | List xs -> Bool (not (List.mem v1 xs))
+      | _ -> Bool false)
   (* less: it would be better to show the actual values not handled,
    * rather than the code, because this may differ as the code does not
    * contained the resolved content of metavariables *)

--- a/semgrep-core/tests/OTHER/rules/eval_not_in.py
+++ b/semgrep-core/tests/OTHER/rules/eval_not_in.py
@@ -1,0 +1,4 @@
+
+def foo():
+    # ruleid: eval-not-in
+    foo(5)

--- a/semgrep-core/tests/OTHER/rules/eval_not_in.yaml
+++ b/semgrep-core/tests/OTHER/rules/eval_not_in.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: eval-not-in 
+  languages:
+    - python
+  message: found a metavariable not in the desired list 
+  patterns:
+    - pattern-inside: |
+        def $FUNCNAME(...):
+          ...
+    - pattern: foo($SINGULAR)
+    - metavariable-comparison:
+        comparison: $SINGULAR not in [150, 312]
+        metavariable: $SINGULAR
+  severity: ERROR


### PR DESCRIPTION
**What:**
We do not currently do evaluation of the `not in` operator, which appears in Python. So for instance, using this clause:
```
  - metavariable-comparison:
      comparison: $ARG not in [443, 80]
      metavariable: $ARG
```
will not properly match if `$ARG` is bound to `5`, for instance.

**Why:**
This is just a regular bug we should fix. This was brought to our attention as something that a user was trying to do via the community slack.

**How:**
Added it to the list of supported operators.

**Test plan:**
`make test`

Closes #6072 

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
