### PR TITLE
Write rules and targets to ~/.semgrep

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -727,16 +727,8 @@ class CoreRunner:
         profiling_data: ProfilingData = ProfilingData()
         parsing_data: ParsingData = ParsingData()
 
-        rule_file_name = (
-            str(state.env.user_data_folder / "semgrep_rules.json")
-            if dump_command_for_core
-            else tempfile.NamedTemporaryFile("w", suffix=".json").name
-        )
-        target_file_name = (
-            str(state.env.user_data_folder / "semgrep_targets.txt")
-            if dump_command_for_core
-            else tempfile.NamedTemporaryFile("w").name
-        )
+        rule_file_name = str(state.env.user_data_folder / "semgrep_rules.json")
+        target_file_name = str(state.env.user_data_folder / "semgrep_targets.txt")
 
         with open(rule_file_name, "w+") as rule_file, open(
             target_file_name, "w+"


### PR DESCRIPTION
Semgrep writes the rules and targets to temporary files, which are sent to semgrep-core. However, the temporary files are essentially just random names, since we still have to remove them ourselves. This was probably done earlier when we didn't use ~/.semgrep as much.

Now, since we already write to ~/.semgrep, there's no reason not to use this folder to write our rules and targets. In addition, it makes our code path simpler and avoids using implementation details of temporary files (e.g. there is nothing preventing Python from deleting the temporary file for us).

Alternatives considered: wrapping `os.remove` calls in a `try-except`. This would achieve the same purpose of avoiding the possibility of Python deciding to remove the temporary file before we remove it, and maintains the random name of the rules and targets, but makes the code more complicated.

Related to https://github.com/returntocorp/semgrep/issues/5996

The one potentially annoying consequence of this is that people using `-d` cannot rely on the generated `semgrep_rules.json` persisting when they run semgrep without `-d`, but that isn't good behavior to rely on anyway.

Test plan: make test. Also, print out the rule file name and target file name and check that they don't exist after the run.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
