### PR TITLE
Guard removal of rules and targets files

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -908,8 +908,16 @@ class CoreRunner:
                     parsing_data.add_error(err)
             errors.extend(parsed_errors)
 
-        os.remove(rule_file_name)
-        os.remove(target_file_name)
+        try:
+            # We use NamedTemporaryFile for the rules and targets files to
+            # create files with random names, but because of how we open
+            # the files we need to remove them ourselves. However, we are
+            # not guaranteed that a different implementation would not
+            # remove the file. Therefore, we wrap this in a try-except
+            os.remove(rule_file_name)
+            os.remove(target_file_name)
+        except FileNotFoundError:
+            logger.warning("Rules and targets file already removed")
 
         return (
             outputs,

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -912,19 +912,19 @@ class CoreRunner:
                     parsing_data.add_error(err)
             errors.extend(parsed_errors)
 
+        # We use NamedTemporaryFile for the rules and targets files to
+        # create files with random names, but because of how we open
+        # the files we need to remove them ourselves. However, we are
+        # not guaranteed that a different implementation would not
+        # remove the file. Therefore, we wrap these in try-except.
         try:
-            # We use NamedTemporaryFile for the rules and targets files to
-            # create files with random names, but because of how we open
-            # the files we need to remove them ourselves. However, we are
-            # not guaranteed that a different implementation would not
-            # remove the file. Therefore, we wrap this in a try-except.
-
-            # This assumes that the files are removed together, which we
-            # currently deem a reasonable assumption
             os.remove(rule_file_name)
+        except FileNotFoundError:
+            logger.warning(f"Rules file {rule_file_name} already removed")
+        try:
             os.remove(target_file_name)
         except FileNotFoundError:
-            logger.warning("Rules and targets file already removed")
+            logger.warning(f"Targets file {target_file_name} already removed")
 
         return (
             outputs,

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -727,6 +727,10 @@ class CoreRunner:
         profiling_data: ProfilingData = ProfilingData()
         parsing_data: ParsingData = ParsingData()
 
+        # Note: temporary file behavior varies based on OS according to
+        # https://docs.python.org/3/library/tempfile.html. In the future
+        # if we support Windows semgrep-core may not be able to open
+        # these files
         rule_file_name = (
             str(state.env.user_data_folder / "semgrep_rules.json")
             if dump_command_for_core
@@ -913,7 +917,10 @@ class CoreRunner:
             # create files with random names, but because of how we open
             # the files we need to remove them ourselves. However, we are
             # not guaranteed that a different implementation would not
-            # remove the file. Therefore, we wrap this in a try-except
+            # remove the file. Therefore, we wrap this in a try-except.
+
+            # This assumes that the files are removed together, which we
+            # currently deem a reasonable assumption
             os.remove(rule_file_name)
             os.remove(target_file_name)
         except FileNotFoundError:


### PR DESCRIPTION
Semgrep creates temporary rules and targets files to send to semgrep-core. These files may not be removed by the temporary file system. To avoid undefined behavior, we try to manually remove the file but do not crash if we fail.

Related to https://github.com/returntocorp/semgrep/issues/5996

Test plan: make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
