### PR TITLE
Write deep-semgrep is proprietary warning to stderr

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -806,8 +806,8 @@ class CoreRunner:
             # TODO: use exact same command-line arguments so just
             # need to replace the SemgrepCore.path() part.
             if deep:
-                print("!!!This is a proprietary extension of semgrep.!!!")
-                print("!!!You must be logged in to access this extension!!!")
+                logger.error("!!!This is a proprietary extension of semgrep.!!!")
+                logger.error("!!!You must be logged in to access this extension!!!")
                 targets = target_manager.targets
                 if len(targets) == 1 and targets[0].path.is_dir():
                     root = str(targets[0].path)


### PR DESCRIPTION
We have a warning that deep-semgrep is proprietary. Since this warning is on stdout, it interferes with JSON ingestion. Instead we will log it to stderr.

Alternatives considered: only log the warning when `--json` is passed. I can do this if someone feels strongly, it would just make the code more complicated.

Test plan: `semgrep --config <anything> . --deep 2> deep_stderr.txt`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
