### PR TITLE
add a workflow to check for old PRs and send slack msgs

### DIFF
--- a/.github/workflows/find-old-brew-prs.yml
+++ b/.github/workflows/find-old-brew-prs.yml
@@ -1,0 +1,49 @@
+# Check if we have old Homebrew PRs hanging around unmerged
+name: Check for Old Homebrew PRs
+
+on:
+  workflow_dispatch:
+  # Fire at 08:27 PDT
+  schedule:
+    - cron: "27 15 * * *"
+
+jobs:
+  old-prs:
+    name: Check for old PRs in brew core
+    runs-on: ubuntu-22.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Check for Old PRs
+        run: |
+          getPrsOlderThanOneDay() {
+              gh --repo homebrew/homebrew-core pr list --state open -S semgrep --json number,createdAt,title --jq '(now - 86400) as $date | .[] | select (.createdAt | fromdateiso8601 < $date)'
+          }
+
+          NUM_OLD_PRS=$(getPrsOlderThanOneDay | wc -l)
+
+          if test "${NUM_OLD_PRS}" -gt "0"; then
+              echo "found PRs - see below for more info!"
+              getPrsOlderThanOneDay
+              exit 1
+          else
+              echo "No old PRs."
+              exit 0
+          fi
+
+  notify-failure:
+    needs: [old-prs]
+    name: Notify of Failure
+    runs-on: ubuntu-22.04
+    if: failure()
+    steps:
+      - name: Notify Failure
+        run: |
+          curl --request POST \
+          --url  ${{ secrets.OLD_PRS_NOTIFICATIONS_URL }} \
+          --header 'content-type: application/json' \
+          --data '{
+            "pr-numbers": "0"
+          }'


### PR DESCRIPTION
This change does the following:
- looks for PRs in `homebrew/homebrew-core` for the semgrep formula that are older than 24hr and have failed tests (sometimes running the tests take longer, and they have to wait to put our builds on special machines)
- message out in slack if this is the case

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
