### PR TITLE
chore(java): Upgrade semgrep-java

### DIFF
--- a/changelog.d/gh-6051.fixed
+++ b/changelog.d/gh-6051.fixed
@@ -1,0 +1,1 @@
+Java: Correctly parse ellipsis in the body of top-level constructor patterns with privacy modifiers (e.g. public Foo() { ... })

--- a/semgrep-core/tests/java/misc_constructor_public.sgrep
+++ b/semgrep-core/tests/java/misc_constructor_public.sgrep
@@ -1,1 +1,1 @@
-public MyJavaClass() { }
+public MyJavaClass() { ... }


### PR DESCRIPTION
In particular, this pulls in https://github.com/returntocorp/ocaml-tree-sitter-semgrep/commit/278bae677938ccd03f33bcc0e09c98e3204d21a5

That commit allows `...` as a standalone statement. Previously, when using the tree sitter parser for Java patterns, `...` in a statement context would have required a semicolon. That commmit also adds tests for various contexts in which someone might want to use `...`.

The tree sitter parser still is not typically used for pattern parsing. It is only used as a fallback when the pfff parser fails.

Fixes #6051

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
