### PR TITLE
fix: semgrep blocking on triaged issues

### DIFF
--- a/changelog.d/gh-6090.fixed
+++ b/changelog.d/gh-6090.fixed
@@ -1,0 +1,3 @@
+Fix CI behavior with ignored blocking findings. These findings should not block the build since they were ignored.
+Bug was in the interface definition, so this is another place where typed interfaces would have saved us. The
+variable name in semgrep-app did not match the name expected by semgrep CLI.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -139,8 +139,8 @@ class ScanHandler:
         self._policy_names = body["policy_names"]
         self._rules = body["rule_config"]
         self._autofix = body.get("autofix") or False
-        self._skipped_syntactic_ids = body.get("triage_ignored_syntactic_ids") or []
-        self._skipped_match_based_ids = body.get("triage_ignored_match_based_ids") or []
+        self._skipped_syntactic_ids = body.get("skipped_syntactic_ids") or []
+        self._skipped_match_based_ids = body.get("skipped_match_based_ids") or []
         self.ignore_patterns = body.get("ignored_files") or []
 
     def start_scan(self, meta: Dict[str, Any]) -> None:


### PR DESCRIPTION
DO NOT MERGE: I am considering whether to instead change this on the app side. If semgrep CLI has consistently used these other variable names, then by changing the app instead we could fix older as well as current/future versions of semgrep.

----------

Here's another place where true, typed interfaces would have saved us. 

Since we don't have that yet, I am also trying to figure out a setup in pytest that will mock the /deployments/scans/config response and verify that ScanConfig has the correct properties as a result.

So far, I have tested this manually. I verified that a blocking finding locally returned status code 1. Then I triaged it to ignored and verified that it still had status code 1. Then I made these code changes and verified that it returned status code 0.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

Closes APP-2149