### PR TITLE
re-enable macos tests on all PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -447,8 +447,6 @@ jobs:
   build-macos-release:
     name: build macOS release
     runs-on: ["self-hosted", "macOS", "X64"]
-    # there are too many PR events which deplete our macOS concurrency limit
-    if: (!contains(github.event_name, 'pull_request'))
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -471,8 +469,6 @@ jobs:
   test-macos-release:
     name: test macOS release
     runs-on: ["self-hosted", "macOS", "X64"]
-    # there are too many PR events which deplete our macOS concurrency limit
-    if: (!contains(github.event_name, 'pull_request'))
     needs: [build-macos-release]
     steps:
       - name: download artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -448,7 +448,7 @@ jobs:
     name: build macOS release
     runs-on: ["self-hosted", "macOS", "X64"]
     # there are too many PR events which deplete our macOS concurrency limit
-    if: (!contains(github.event_name, 'pull_request')) || contains(github.event.pull_request.head.ref, 'release-')
+    if: (!contains(github.event_name, 'pull_request'))
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -472,7 +472,7 @@ jobs:
     name: test macOS release
     runs-on: ["self-hosted", "macOS", "X64"]
     # there are too many PR events which deplete our macOS concurrency limit
-    if: (!contains(github.event_name, 'pull_request')) || contains(github.event.pull_request.head.ref, 'release-')
+    if: (!contains(github.event_name, 'pull_request'))
     needs: [build-macos-release]
     steps:
       - name: download artifacts


### PR DESCRIPTION
Re-enable MacOS build/test on all PRs to increase stability and decrease release-time errors encountered.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
