### PR TITLE
feat: lockfile line numbers in supply chain findings for python/js

### DIFF
--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -120,7 +120,7 @@ def parse_yarn(
             allowed_hashes=extract_npm_lockfile_hash(integrity) if integrity else {},
             resolved_url=resolved,
             transitivity=transitivity,
-            line_number=int(line_number),
+            line_number=int(line_number) + 1,
         )
 
 
@@ -173,7 +173,7 @@ def parse_package_lock(
             allowed_hashes=extract_npm_lockfile_hash(integrity) if integrity else {},
             resolved_url=resolved_url,
             transitivity=transitivity,
-            line_number=int(line_number) if line_number else None,
+            line_number=int(line_number) + 1 if line_number else None,
         )
 
 
@@ -228,7 +228,7 @@ def parse_pipfile(
                     if "hashes" in dep_blob
                     else {},
                     transitivity=transitivity,
-                    line_number=int(line_number) if line_number else None,
+                    line_number=int(line_number) + 1 if line_number else None,
                 )
 
     as_json = json.loads(lockfile_text)
@@ -454,7 +454,7 @@ def parse_poetry(
             resolved_url=None,
             allowed_hashes={},
             transitivity=transitivity,
-            line_number=int(line_number),
+            line_number=int(line_number) + 1,
         )
 
     lockfile_text = "\n".join(

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -74,14 +74,15 @@ def parse_yarn(
     def remove_trailing_octothorpe(s: str) -> str:
         return "#".join(s.split("#")[:-1]) if "#" in s else s
 
-    def remove_quotes(s: str) -> str:
-        return s[1:-1]
-
     if manifest_text:
         manifest = json.loads(manifest_text)
         manifest_deps = manifest["dependencies"]
     else:
         manifest_deps = None
+    lockfile_text = "\n".join(
+        line + f" {i}" if line.strip().startswith("version") else line
+        for i, line in enumerate(lockfile_text.split("\n"))
+    )
     _comment, all_deps_text = lockfile_text.split("\n\n\n")
     dep_texts = all_deps_text.split("\n\n")
     if dep_texts == [""]:  # No dependencies
@@ -89,11 +90,10 @@ def parse_yarn(
     for dep_text in dep_texts:
         lines = dep_text.split("\n")
         package_name, constraints = version_sources(lines[0])
-        version = remove_quotes(lines[1].split()[1])
+        _, version, line_number = lines[1].split()
+        version = version.strip('" ')
         if len(lines) >= 3 and lines[2].strip().startswith("resolved"):
-            resolved = remove_trailing_octothorpe(
-                remove_quotes(lines[2].split()[1]).strip()
-            )
+            resolved = remove_trailing_octothorpe(lines[2].split()[1].strip('" '))
         else:
             resolved = None
         integrity = (
@@ -120,12 +120,17 @@ def parse_yarn(
             allowed_hashes=extract_npm_lockfile_hash(integrity) if integrity else {},
             resolved_url=resolved,
             transitivity=transitivity,
+            line_number=int(line_number),
         )
 
 
 def parse_package_lock(
     lockfile_text: str, manifest_text: Optional[str]
 ) -> Generator[FoundDependency, None, None]:
+    lockfile_text = "\n".join(
+        line + f'"line_number": {i},' if line.strip().startswith('"version"') else line
+        for i, line in enumerate(lockfile_text.split("\n"))
+    )
     as_json = json.loads(lockfile_text)
     # Newer versions of NPM (>= v7) use 'packages'
     # But 'dependencies' is kept up to date, and 'packages' uses relative, not absolute names
@@ -149,7 +154,7 @@ def parse_package_lock(
         except InvalidVersion:
             logger.info(f"no version for dependency: {dep}")
             continue
-
+        line_number = dep_blob.get("line_number")
         if manifest_deps:
             transitivity = (
                 Transitivity(Direct())
@@ -168,6 +173,7 @@ def parse_package_lock(
             allowed_hashes=extract_npm_lockfile_hash(integrity) if integrity else {},
             resolved_url=resolved_url,
             transitivity=transitivity,
+            line_number=int(line_number) if line_number else None,
         )
 
 

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -291,7 +291,8 @@ Would have sent findings and ignores blob: {
                         "version": "1.0.0",
                         "ecosystem": "pypi",
                         "allowed_hashes": {},
-                        "transitivity": "unknown"
+                        "transitivity": "unknown",
+                        "line_number": 2
                     },
                     "lockfile": "poetry.lock"
                 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -225,7 +225,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -222,7 +222,8 @@
             "version": "1.0.0",
             "ecosystem": "pypi",
             "allowed_hashes": {},
-            "transitivity": "unknown"
+            "transitivity": "unknown",
+            "line_number": 2
           },
           "lockfile": "poetry.lock"
         }

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -362,6 +362,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "pypi",
+              "line_number": 2,
               "package": "badlib",
               "transitivity": "unknown",
               "version": "1.0.0"

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -359,6 +359,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "pypi",
+              "line_number": 2,
               "package": "badlib",
               "transitivity": "unknown",
               "version": "1.0.0"

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
@@ -52,7 +52,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "npm",
-              "line_number": 17,
+              "line_number": 18,
               "package": "ansi-html",
               "resolved_url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz",
               "transitivity": "transitive",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
@@ -52,6 +52,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "npm",
+              "line_number": 17,
               "package": "ansi-html",
               "resolved_url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz",
               "transitivity": "transitive",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
@@ -45,7 +45,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -94,7 +94,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -143,7 +143,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -192,7 +192,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -241,7 +241,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -290,7 +290,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -339,7 +339,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -388,7 +388,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
-              "line_number": 34,
+              "line_number": 35,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
@@ -45,6 +45,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -93,6 +94,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -141,6 +143,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -189,6 +192,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -237,6 +241,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -285,6 +290,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -333,6 +339,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"
@@ -381,6 +388,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "pypi",
+              "line_number": 34,
               "package": "awscli",
               "transitivity": "unknown",
               "version": "1.11.82"

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaregeneric-sca.yaml-dependency_awaregeneric/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaregeneric-sca.yaml-dependency_awaregeneric/results.txt
@@ -45,7 +45,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "npm",
-              "line_number": 46,
+              "line_number": 47,
               "package": "@types/jquery",
               "resolved_url": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
               "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaregeneric-sca.yaml-dependency_awaregeneric/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaregeneric-sca.yaml-dependency_awaregeneric/results.txt
@@ -45,6 +45,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "npm",
+              "line_number": 46,
               "package": "@types/jquery",
               "resolved_url": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
               "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
@@ -44,7 +44,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "npm",
-              "line_number": 46,
+              "line_number": 47,
               "package": "@types/jquery",
               "resolved_url": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
               "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
@@ -44,6 +44,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "npm",
+              "line_number": 46,
               "package": "@types/jquery",
               "resolved_url": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
               "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.txt
@@ -42,7 +42,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "npm",
-              "line_number": 10,
+              "line_number": 11,
               "package": "bad-lib",
               "resolved_url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz",
               "transitivity": "unknown",
@@ -87,7 +87,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "npm",
-              "line_number": 5,
+              "line_number": 6,
               "package": "bad-lib",
               "resolved_url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz",
               "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.txt
@@ -42,6 +42,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "npm",
+              "line_number": 10,
               "package": "bad-lib",
               "resolved_url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz",
               "transitivity": "unknown",
@@ -86,6 +87,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "npm",
+              "line_number": 5,
               "package": "bad-lib",
               "resolved_url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz",
               "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry/results.txt
@@ -40,7 +40,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "pypi",
-              "line_number": 16,
+              "line_number": 17,
               "package": "faker",
               "transitivity": "direct",
               "version": "13.11.1"

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry/results.txt
@@ -40,6 +40,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "found_dependency": {
               "allowed_hashes": {},
               "ecosystem": "pypi",
+              "line_number": 16,
               "package": "faker",
               "transitivity": "direct",
               "version": "13.11.1"


### PR DESCRIPTION
Adds the line numbers to dependencies parsed from python/js lockfiles. The line number points to the version specifier. This is done very hackily, by inserting line number information into the lockfile text before parsing it.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
