### PR TITLE
fix set intersection null case

### DIFF
--- a/changelog.d/gh-6093.fixed
+++ b/changelog.d/gh-6093.fixed
@@ -1,0 +1,2 @@
+Fixes bug where set.intersection() was being called witho no argument and throwing an error.
+Handles null case where user scans only with generic languages like regex rules.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -5,6 +5,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 from typing import Dict
+from typing import FrozenSet
 from typing import List
 from typing import Optional
 from typing import Set
@@ -160,7 +161,7 @@ class ScanHandler:
         errors: List[SemgrepError],
         rules: List[Rule],
         targets: Set[Path],
-        ignored_targets: Set[Path],
+        ignored_targets: FrozenSet[Path],
         parse_rate: ParsingData,
         total_time: float,
         commit_date: str,

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -116,6 +116,8 @@ class FileTargetingLog:
     # "None" indicates that all lines were skipped
     core_failure_lines_by_file: Mapping[Path, Optional[int]] = Factory(dict)
 
+    # Indicates which files were NOT scanned by each language
+    # e.g. for python, should be a list of all non-python-compatible files
     by_language: Dict[Union[Language, PackageManagers], Set[Path]] = Factory(
         lambda: defaultdict(set)
     )
@@ -138,18 +140,24 @@ class FileTargetingLog:
         )
 
     @property
-    def unsupported_lang_paths(self) -> Set[Path]:
-        # paths of all files that were ignored by ALL non-generic langs
-        return (
-            set.intersection(
-                *[
-                    paths
-                    for lang, paths in self.by_language.items()
-                    if lang not in UNSUPPORTED_EXT_IGNORE_LANGS
-                ]
-            )
+    def unsupported_lang_paths(self) -> FrozenSet[Path]:
+        """
+        RETURNS: paths of all files that were ignored by ALL non-generic langs
+        Note: if only generic languages were scanned, returns all file paths
+        """
+        unsupported_lang_paths = (
+            [
+                unsupported_paths
+                for lang, unsupported_paths in self.by_language.items()
+                if lang not in UNSUPPORTED_EXT_IGNORE_LANGS
+            ]
             if self.by_language
-            else set()
+            else []
+        )
+        return (
+            frozenset(set.intersection(*unsupported_lang_paths))
+            if unsupported_lang_paths
+            else self.target_manager.get_all_files()
         )
 
     def __str__(self) -> str:
@@ -655,6 +663,10 @@ class TargetManager:
         return FilteredFiles(frozenset(kept), frozenset(removed))
 
     @lru_cache(maxsize=None)
+    def get_all_files(self) -> FrozenSet[Path]:
+        return frozenset(f for target in self.targets for f in target.files())
+
+    @lru_cache(maxsize=None)
     def get_files_for_language(
         self, lang: Union[Language, PackageManagers]
     ) -> FilteredFiles:
@@ -667,7 +679,7 @@ class TargetManager:
 
         Note also filters out any directory and descendants of `.git`
         """
-        all_files = frozenset(f for target in self.targets for f in target.files())
+        all_files = self.get_all_files()
 
         files = self.filter_by_language(lang, candidates=all_files)
         self.ignore_log.by_language[lang].update(files.removed)

--- a/cli/tests/unit/targeting/test_target_manager.py
+++ b/cli/tests/unit/targeting/test_target_manager.py
@@ -399,3 +399,38 @@ def test_unsupported_lang_paths(tmp_path, monkeypatch):
     assert_path_sets_equal(
         target_manager.ignore_log.unsupported_lang_paths, expected_unsupported
     )
+
+
+@pytest.mark.quick
+def test_unsupported_lang_paths_2(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    targets: List[str] = []
+
+    # we will "scan" only for generic and regex
+    paths = {
+        ".": ["a.rb", "b.erb"],
+        "dir": ["c.erb", "d.rkt"],
+    }
+
+    expected_unsupported = set()
+
+    for dir_name in paths:
+        dir = tmp_path
+        if not dir_name == ".":
+            dir = tmp_path / dir_name
+            dir.mkdir()
+        for file_name in paths[dir_name]:
+            path = dir / file_name
+            path.touch()
+            targets.append(str(path))
+            expected_unsupported.add(path)
+
+    target_manager = TargetManager(targets)
+
+    target_manager.get_files_for_language(LANG_GENERIC)
+    target_manager.get_files_for_language(LANG_REGEX)
+
+    assert_path_sets_equal(
+        target_manager.ignore_log.unsupported_lang_paths, expected_unsupported
+    )


### PR DESCRIPTION
Fixes APP-2274

Handles null case where user scans with only generic languages

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
