### PR TITLE
refactor: Add rendered_fix to semgrep-core output

### DIFF
--- a/cli/src/semgrep/autofix.py
+++ b/cli/src/semgrep/autofix.py
@@ -67,6 +67,10 @@ def _get_match_context(
 def _basic_fix(
     rule_match: RuleMatch, file_offsets: FileOffsets, fix: str
 ) -> Tuple[Fix, FileOffsets]:
+
+    if rule_match.match.extra.rendered_fix:
+        fix = rule_match.match.extra.rendered_fix
+
     p = rule_match.path
     lines = _get_lines(p)
 

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -171,6 +171,8 @@ let unsafe_match_to_match (x : Pattern_match.t) : Out.core_match =
         message = Some x.rule_id.message;
         metavars = x.env |> Common.map (metavars startp);
         dataflow_trace;
+        (* TODO compute autofixes *)
+        rendered_fix = None;
       };
   }
 


### PR DESCRIPTION
This allows semgrep-core to compute autofixes and pass them to the CLI for application, rather than the CLI computing the fix. This allows us to use information exclusive to semgrep-core when rendering an autofix to text. Specifically, we plan to manipulate the AST rather than manipulating text directly.

Test plan:

* Existing automated tests
* Manual test: Replace the `None` with `Some` and an arbitrary string. Run Semgrep with an autofix rule and confirm that the written string appears in the target file instead of the real autofix.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
