### PR TITLE
fix: add backwards compatibility with old endpoints

### DIFF
--- a/changelog.d/gh-6098.added
+++ b/changelog.d/gh-6098.added
@@ -1,0 +1,1 @@
+Adds backwards-compatibility with older versions of semgrep-app. Only relevant for customers with on-prem versions of the app.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -332,8 +332,12 @@ class ScanHandler:
             json=findings_and_ignores,
         )
         # TODO: delete this once all on-prem app instances are gone
-        if response.status_code == 404:
-            response = state.app_session.post(
+        if (
+            response.status_code == 404
+            and state.env.semgrep_url != "https://semgrep.dev"
+        ):
+            # order matters here - findings sends back errors but ignores doesn't
+            ignores_response = state.app_session.post(
                 f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/ignores",
                 json={"findings": ignores},
             )

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -116,6 +116,47 @@ class ScanHandler:
                 f"API server at {state.env.semgrep_url} returned type '{type(response.json())}'. Expected a dictionary."
             )
 
+    def fetch_config_and_start_scan_old(self, meta: Dict[str, Any]) -> None:
+        """
+        Get configurations for scan and create scan object
+        Backwards-compatible with versions of semgrep-app from before Aug 2022
+        TODO: Delete once all old, on-prem instances have been deprecated
+        """
+        state = get_state()
+
+        logger.debug("Getting deployment information")
+        get_deployment_url = f"{state.env.semgrep_url}/api/agent/deployments/current"
+        body = self._get_scan_config_from_app(get_deployment_url)
+        self._deployment_id = body["deployment"]["id"]
+        self._deployment_name = body["deployment"]["name"]
+
+        logger.debug("Creating scan")
+        create_scan_url_old = (
+            f"{state.env.semgrep_url}/api/agent/deployments/{self.deployment_id}/scans"
+        )
+        response = state.app_session.post(
+            create_scan_url_old,
+            json={"meta": meta},
+        )
+        try:
+            response.raise_for_status()
+        except requests.RequestException:
+            raise Exception(
+                f"API server at {state.env.semgrep_url} returned this error: {response.text}"
+            )
+        body = response.json()
+        self.scan_id = body["scan"]["id"]
+        self._policy_names = body["policy"]
+        self._autofix = body.get("autofix") or False
+        self._skipped_syntactic_ids = body.get("triage_ignored_syntactic_ids") or []
+        self._skipped_match_based_ids = body.get("triage_ignored_match_based_ids") or []
+
+        logger.debug("Getting rules file")
+        get_rules_url = (
+            f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/rules.yaml"
+        )
+        self._rules = get_rules_url
+
     def fetch_and_init_scan_config(self, meta: Dict[str, Any]) -> None:
         """
         Get configurations for scan
@@ -218,7 +259,7 @@ class ScanHandler:
         """
         state = get_state()
         all_ids = [r.id for r in rules]
-
+        cai_ids, rule_ids = partition(all_ids, lambda r_id: "r2c-internal-cai" in r_id)
         all_matches = [
             match
             for matches_of_rule in matches_by_rule.values()
@@ -228,21 +269,21 @@ class ScanHandler:
             all_matches,
             lambda match: bool(match.is_ignored),
         )
-
+        findings = [
+            match.to_app_finding_format(commit_date).to_json() for match in new_matches
+        ]
+        ignores = [
+            match.to_app_finding_format(commit_date).to_json() for match in new_ignored
+        ]
         findings_and_ignores = {
             # send a backup token in case the app is not available
             "token": os.getenv("GITHUB_TOKEN"),
             "gitlab_token": os.getenv("GITLAB_TOKEN"),
-            "findings": [
-                match.to_app_finding_format(commit_date).to_json()
-                for match in new_matches
-            ],
+            "findings": findings,
             "searched_paths": [str(t) for t in targets],
-            "rule_ids": all_ids,
-            "ignores": [
-                match.to_app_finding_format(commit_date).to_json()
-                for match in new_ignored
-            ],
+            "rule_ids": rule_ids,
+            "cai_ids": cai_ids,
+            "ignores": ignores,
         }
 
         ignored_ext_freqs = Counter(
@@ -290,6 +331,16 @@ class ScanHandler:
             f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/findings_and_ignores",
             json=findings_and_ignores,
         )
+        # TODO: delete this once all on-prem app instances are gone
+        if response.status_code == 404:
+            response = state.app_session.post(
+                f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/ignores",
+                json={"findings": ignores},
+            )
+            response = state.app_session.post(
+                f"{state.env.semgrep_url}/api/agent/scans/{self.scan_id}/findings",
+                json=findings_and_ignores,
+            )
         try:
             response.raise_for_status()
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -300,8 +300,13 @@ def ci(
                     try:
                         scan_handler.fetch_and_init_scan_config(metadata_dict)
                         scan_handler.start_scan(metadata_dict)
-                    except Exception:
-                        scan_handler.fetch_config_and_start_scan_old(metadata_dict)
+                    except Exception as e:
+                        if (
+                            state.env.semgrep_url != "https://semgrep.dev"
+                        ):  # support old on-prem apps
+                            scan_handler.fetch_config_and_start_scan_old(metadata_dict)
+                        else:
+                            raise e
                     logger.info(f"Authenticated as {scan_handler.deployment_name}")
                     config = (scan_handler.rules,)
             except Exception as e:

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -297,8 +297,11 @@ def ci(
                 # Note this needs to happen within fix_head_if_github_action
                 # so that metadata of current commit is correct
                 if scan_handler:
-                    scan_handler.fetch_and_init_scan_config(metadata_dict)
-                    scan_handler.start_scan(metadata_dict)
+                    try:
+                        scan_handler.fetch_and_init_scan_config(metadata_dict)
+                        scan_handler.start_scan(metadata_dict)
+                    except Exception:
+                        scan_handler.fetch_config_and_start_scan_old(metadata_dict)
                     logger.info(f"Authenticated as {scan_handler.deployment_name}")
                     config = (scan_handler.rules,)
             except Exception as e:

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -310,6 +310,7 @@ Would have sent findings and ignores blob: {
         "supply-chain1",
         "supply-chain2"
     ],
+    "cai_ids": [],
     "ignores": [
         {
             "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -203,6 +203,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -203,6 +203,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -244,6 +244,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -200,6 +200,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -200,6 +200,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -241,6 +241,7 @@
     "supply-chain1",
     "supply-chain2"
   ],
+  "cai_ids": [],
   "ignores": [
     {
       "check_id": "eqeq-bad",

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -228,6 +228,7 @@ Sending findings and ignores blob: {
         "supply-chain1",
         "supply-chain2"
     ],
+    "cai_ids": [],
     "ignores": []
 }
 Sending complete blob: {


### PR DESCRIPTION
We have a customer still running a version of semgrep-app from March 2022 on-prem. These changes give backwards-compatibility with that version of the app for that customer specifically.

Test plan:

Tested against version of semgrep-app from Aug 3, 2022 before the refactor on app. To do this, I downgraded the migrations back through Aug 1, then checked out develop from that date (git checkout `git rev-list -n 1 --before="2022-08-03 13:37" develop`) then ran:

`SEMGREP_APP_URL="http://localhost:5000" SEMGREP_APP_TOKEN=<secret> python -m semgrep ci`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
