### PR TITLE
fix: core_runner: Do not compete with NamedTemporaryFile objects for temp file removal.

### DIFF
--- a/changelog.d/gh-6100.fixed
+++ b/changelog.d/gh-6100.fixed
@@ -1,0 +1,7 @@
+Hold references to `NamedTemporaryFile` objects while their corresponding
+temporary files are still in use by the core runner. Failure to explicitly hold
+references to these objects on some Python implementations, such as PyPy,
+results in them sometimes being garbage-collected during processing. This,
+in turn, triggers removal of the temp files while they are still in use by
+the core runner or the worker subprocesses, resulting in various crashes and
+processing failures.

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -1,7 +1,7 @@
 import asyncio
 import collections
+import contextlib
 import json
-import os
 import resource
 import shlex
 import subprocess
@@ -727,24 +727,25 @@ class CoreRunner:
         profiling_data: ProfilingData = ProfilingData()
         parsing_data: ParsingData = ParsingData()
 
-        # Note: temporary file behavior varies based on OS according to
-        # https://docs.python.org/3/library/tempfile.html. In the future
-        # if we support Windows semgrep-core may not be able to open
-        # these files
-        rule_file_name = (
-            str(state.env.user_data_folder / "semgrep_rules.json")
+        # Create an exit stack context manager to properly handle closing
+        # either the temp files for an actual run or else the dump files for
+        # a future direct run of semgrep-core. This method of file management
+        # is OS-agnostic and should be portable across POSIX and Windows
+        # systems. It also ensures that NamedTemporaryFile objects will delete
+        # their corresponding temp files after closing streams to them.
+        exit_stack = contextlib.ExitStack()
+        rule_file = exit_stack.enter_context(
+            (state.env.user_data_folder / "semgrep_rules.json").open("w+")
             if dump_command_for_core
-            else tempfile.NamedTemporaryFile("w", suffix=".json").name
+            else tempfile.NamedTemporaryFile("w+", suffix=".json")
         )
-        target_file_name = (
-            str(state.env.user_data_folder / "semgrep_targets.txt")
+        target_file = exit_stack.enter_context(
+            (state.env.user_data_folder / "semgrep_targets.txt").open("w+")
             if dump_command_for_core
-            else tempfile.NamedTemporaryFile("w").name
+            else tempfile.NamedTemporaryFile("w+")
         )
 
-        with open(rule_file_name, "w+") as rule_file, open(
-            target_file_name, "w+"
-        ) as target_file:
+        with exit_stack:
 
             plan = self._plan_core_run(rules, target_manager, all_targets)
             plan.log()
@@ -897,20 +898,6 @@ class CoreRunner:
                 ):
                     parsing_data.add_error(err)
             errors.extend(parsed_errors)
-
-        # We use NamedTemporaryFile for the rules and targets files to
-        # create files with random names, but because of how we open
-        # the files we need to remove them ourselves. However, we are
-        # not guaranteed that a different implementation would not
-        # remove the file. Therefore, we wrap these in try-except.
-        try:
-            os.remove(rule_file_name)
-        except FileNotFoundError:
-            logger.warning(f"Rules file {rule_file_name} already removed")
-        try:
-            os.remove(target_file_name)
-        except FileNotFoundError:
-            logger.warning(f"Targets file {target_file_name} already removed")
 
         return (
             outputs,


### PR DESCRIPTION
re: #5996 (cc: @emjin)

What this fix addresses is described in the changelog entry.
tldr; References to `NamedTemporaryFile` objects were not being maintained while processing occurred with their corresponding temp files. This allowed them to be garbage-collected during processing, which caused the temp files to disappear while workers or the core runner were trying to use them. And bad things would happen as a result.

Tested manually and fix seems good. (20 iterations with PyPy and not a single worker crash. Used updated code in an existing installation.)

Also built Docker image and ran a container from it:
```
$ git submodule update --init
$ make build-docker
$ docker run -it -v $(pwd):/src semgrep /bin/bash
```
Inside container, installed Pytest and some other dependencies and then ran Pytest:
```
$ apk add make
$ pip install pytest-snapshot pytest-xdist pytest-mock pytest-freezegun pytest-split pytest-rerunfailures
$ pytest -n auto --snapshot-update --allow-snapshot-deletion tests
$ pytest
...
============================================================================================== short test summary info ==============================================================================================
FAILED tests/e2e/test_check.py::test_hidden_rule__implicit - AssertionError: value does not match the expected value in snapshot /src/cli/tests/e2e/snapshots/test_check/test_hidden_rule__implicit/error.txt
FAILED tests/e2e/test_ci.py::test_full_run[autofix-github-pr] - AssertionError: value does not match the expected value in snapshot /src/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete....
FAILED tests/e2e/test_ci.py::test_full_run[autofix-gitlab] - AssertionError: value does not match the expected value in snapshot /src/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
FAILED tests/e2e/test_ci.py::test_full_run[noautofix-azure-pipelines] - AssertionError: value does not match the expected value in snapshot /src/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pip...
============================================================================= 4 failed, 1145 passed, 2322 warnings in 220.23s (0:03:40) =============================================================================
```
Mostly passed. Failures don't seem to be related to anything under my control or related to my changes.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
