### PR TITLE
fix(python): typed expression translation bug

### DIFF
--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -735,6 +735,13 @@ and stmt_aux env x =
   | AugAssign (v1, (v2, tok), v3) ->
       let v1 = expr env v1 and v2 = operator v2 and v3 = expr env v3 in
       [ G.exprstmt (G.AssignOp (v1, (v2, tok), v3) |> G.e) ]
+  | Cast (Name (id, _kind, _ref), _tok, ty) ->
+      (* no need to guard with assign_to_vardef here *)
+      let id = name env id in
+      let ty = type_ env ty in
+      let ent = G.basic_entity id in
+      let def = G.VarDef { G.vtype = Some ty; vinit = None } in
+      [ G.DefStmt (ent, def) |> G.s ]
   | Cast (e, tok, ty) ->
       [ G.exprstmt (G.Cast (type_ env ty, info tok, expr env e) |> G.e) ]
   | Raise (t, v1) -> (

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -736,6 +736,13 @@ and stmt_aux env x =
       let v1 = expr env v1 and v2 = operator v2 and v3 = expr env v3 in
       [ G.exprstmt (G.AssignOp (v1, (v2, tok), v3) |> G.e) ]
   | Cast (Name (id, _kind, _ref), _tok, ty) ->
+      (* In the following example, `x : int` is not a type cast but a variable
+       * declaration:
+       *
+       *      class Test:
+       *        x : int
+       *        ...
+       *)
       (* no need to guard with assign_to_vardef here *)
       let id = name env id in
       let ty = type_ env ty in


### PR DESCRIPTION
**What:**
A little while ago, I made the PR #5949, which introduces a regression which only a DeepSemgrep test catches. Essentially, sole standalone casted expressions are no longer parsed as `DefStmt`s, which has semantic meaning in DeepSemgrep.

**Why:**
This is not the desired behavior, and makes it so that naming fails for class fields, which rely on the `DefStmt`. See the following file:
`self_ex.py`
```
class Ex:
    #DEF: Ex.fld1
    fld1: int
    fld2_dead_ok: int
    fld3: int = 42

    #DEF: Ex.bar
    def bar():
        return 1

    def other_dead_ok():
        return 1

    #DEF: Ex.foo
    def foo():
        #USE: Ex.fld1
        x = self.fld1
        #USE: Ex.bar
        self.bar(x)
        return 0

    
def test_dead_ok():
    #USE: Ex.foo
    Ex().foo();
```
This test makes `fld1` invisible to DeepSemgrep.

**How:**
Made it so that `Cast`s of `Name`s are properly translated to `DefStmt`s, as they were before.

**Test plan:**
`make test` in DeepSemgrep (I've tested that this fixes the regression).

Closes PA-1881.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
