### PR TITLE
Fix tests failing on develop

### DIFF
--- a/cli/tests/e2e/snapshots/test_check/test_cdn_ruleset_resolution/results.json
+++ b/cli/tests/e2e/snapshots/test_check/test_cdn_ruleset_resolution/results.json
@@ -4,6 +4,7 @@
     "_comment": "<add --verbose for a list of skipped paths>",
     "scanned": [
       "targets/basic/inside.py",
+      "targets/basic/md5.go",
       "targets/basic/metavariable-comparison-bad-content.py",
       "targets/basic/metavariable-comparison-base.py",
       "targets/basic/metavariable-comparison-strip.py",
@@ -23,106 +24,90 @@
   },
   "results": [
     {
-      "check_id": "javascript.lang.correctness.useless-eqeq.eqeq-is-bad",
+      "check_id": "go.lang.security.audit.crypto.bad_imports.insecure-module-used",
       "end": {
-        "col": 19,
-        "line": 3,
-        "offset": 67
+        "col": 24,
+        "line": 10,
+        "offset": 116
       },
       "extra": {
-        "fingerprint": "26682c31d5fdf7711c4a49e58af66f7c86c6c4e01fe08ef91caf88aad21785fe536057f2c0de5f0a6069c5dc04f79db545397194cf6a49be3d51019ff3d8c7dc_0",
+        "fingerprint": "ea9697b1d3899319ee7f703949739bbe449cd0a3318a2354e0d9663eb469309b1701d5cbbf54adb51d00fe3a0dbd9ba0dd80cef0a45bb24b814edc2f677fe431_0",
         "is_ignored": false,
-        "lines": "console.log(x == x)",
-        "message": "Detected a useless comparison operation `x == x` or `x != x`. This operation is always true. If testing for floating point NaN, use `math.isnan`, or `cmath.isnan` if the number is complex.",
+        "lines": "    hasher := md5.New()",
+        "message": "Detected use of an insecure cryptographic hashing method. This method is known to be broken and easily compromised. Use SHA256 or SHA3 instead.",
         "metadata": {
-          "category": "correctness",
+          "category": "security",
+          "confidence": "MEDIUM",
+          "cwe": "CWE-327: Use of a Broken or Risky Cryptographic Algorithm",
           "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
-          "shortlink": "https://sg.run/Kl6n",
-          "source": "https://semgrep.dev/r/javascript.lang.correctness.useless-eqeq.eqeq-is-bad",
+          "owasp": "A9: Using Components with Known Vulnerabilities",
+          "references": [
+            "https://godoc.org/golang.org/x/crypto/sha3"
+          ],
+          "shortlink": "https://sg.run/l2gj",
+          "source": "https://semgrep.dev/r/go.lang.security.audit.crypto.bad_imports.insecure-module-used",
+          "source-rule-url": "https://github.com/securego/gosec",
           "technology": [
-            "javascript"
+            "go"
           ]
         },
         "metavars": {
-          "$X": {
-            "abstract_content": "x",
+          "$FUNC": {
+            "abstract_content": "New",
             "end": {
-              "col": 14,
-              "line": 3,
-              "offset": 62
-            },
-            "propagated_value": {
-              "svalue_abstract_content": "window.prompt()",
-              "svalue_end": {
-                "col": 24,
-                "line": 1,
-                "offset": 23
-              },
-              "svalue_start": {
-                "col": 9,
-                "line": 1,
-                "offset": 8
-              }
+              "col": 22,
+              "line": 10,
+              "offset": 114
             },
             "start": {
-              "col": 13,
-              "line": 3,
-              "offset": 61
+              "col": 19,
+              "line": 10,
+              "offset": 111
             }
           }
         },
-        "severity": "ERROR"
+        "severity": "WARNING"
       },
-      "path": "targets/basic/stupid.js",
+      "path": "targets/basic/md5.go",
       "start": {
-        "col": 13,
-        "line": 3,
-        "offset": 61
+        "col": 15,
+        "line": 10,
+        "offset": 107
       }
     },
     {
-      "check_id": "python.lang.correctness.useless-eqeq.useless-eqeq",
+      "check_id": "go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5",
       "end": {
-        "col": 26,
-        "line": 3,
-        "offset": 69
+        "col": 24,
+        "line": 10,
+        "offset": 116
       },
       "extra": {
-        "fingerprint": "604a9137e4fb9b559395f8e30003b1e2c5df02173bd602e4732e00d4a5a4ef001e11194aec68bb030f8dc37d9a8f72588fcf3ea5f8acce46fe824e6e4e1abfdc_0",
+        "fingerprint": "9691c668f70ea82285e857e2fe212abfc93038c4d8fde8d653df8e5c099d0a0938b1b96ab236c9d62ee1ee2f0a35ac25646f928cb34df534da5624775fac1e9a_0",
         "is_ignored": false,
-        "lines": "    return a + b == a + b",
-        "message": "This expression is always True: `a + b == a + b` or `a + b != a + b`. If testing for floating point NaN, use `math.isnan(a + b)`, or `cmath.isnan(a + b)` if the number is complex.",
+        "lines": "    hasher := md5.New()",
+        "message": "Detected MD5 hash algorithm which is considered insecure. MD5 is not collision resistant and is therefore not suitable as a cryptographic signature. Use SHA256 or SHA3 instead.",
         "metadata": {
-          "category": "correctness",
+          "category": "security",
+          "confidence": "MEDIUM",
+          "cwe": "CWE-327: Use of a Broken or Risky Cryptographic Algorithm",
           "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
-          "shortlink": "https://sg.run/GeAp",
-          "source": "https://semgrep.dev/r/python.lang.correctness.useless-eqeq.useless-eqeq",
+          "owasp": "A9: Using Components with Known Vulnerabilities",
+          "shortlink": "https://sg.run/2xB5",
+          "source": "https://semgrep.dev/r/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5",
+          "source-rule-url": "https://github.com/securego/gosec#available-rules",
           "technology": [
-            "python"
+            "go"
           ]
         },
-        "metavars": {
-          "$X": {
-            "abstract_content": "a+b",
-            "end": {
-              "col": 17,
-              "line": 3,
-              "offset": 60
-            },
-            "start": {
-              "col": 12,
-              "line": 3,
-              "offset": 55
-            }
-          }
-        },
-        "severity": "INFO"
+        "metavars": {},
+        "severity": "WARNING"
       },
-      "path": "targets/basic/stupid.py",
+      "path": "targets/basic/md5.go",
       "start": {
-        "col": 12,
-        "line": 3,
-        "offset": 55
+        "col": 15,
+        "line": 10,
+        "offset": 107
       }
     }
   ],

--- a/cli/tests/e2e/targets/basic/md5.go
+++ b/cli/tests/e2e/targets/basic/md5.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+    "crypto/md5"
+)
+
+func main() {
+    var str string = "hello world"
+
+    hasher := md5.New()
+    hasher.Write([]byte(str))
+}


### PR DESCRIPTION
The test_cdn_ruleset_resolution test relies on p/ci, which was modified by https://github.com/returntocorp/semgrep-rule-packs/commit/7c064e3334427d745ce066bfba236cd8525199fe

This PR modifies our test targets to cause a result by a different rule. I'm not certain what this test is for; perhaps it should be mocked instead. For now, let's make develop green.

Test plan: python tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
