### PR TITLE
chore: Remove failing cdn test

### DIFF
--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -706,14 +706,6 @@ def test_pattern_regex_empty_file(run_semgrep_in_tmp, snapshot):
     )
 
 
-@pytest.mark.slow
-def test_cdn_ruleset_resolution(run_semgrep_in_tmp, snapshot):
-    snapshot.assert_match(
-        run_semgrep_in_tmp("p/ci").stdout,
-        "results.json",
-    )
-
-
 @pytest.mark.kinda_slow
 def test_inventory_finding_output(run_semgrep_in_tmp, snapshot):
     snapshot.assert_match(


### PR DESCRIPTION
This test is failing because of unrelated changes to p/ci. It is no longer relevant because we deleted the cdn, so let's remove the test.

Test plan: actions

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
