### PR TITLE
style(CLI): Modify CLI output to separate blocking and non-blocking findings

### DIFF
--- a/changelog.d/app-2306.added
+++ b/changelog.d/app-2306.added
@@ -1,0 +1,1 @@
+Modify the CLI output to separate non-blocking and blocking findings and show a list of the blocking rules that fired.

--- a/changelog.d/gh-5686.added
+++ b/changelog.d/gh-5686.added
@@ -1,0 +1,4 @@
+Fixes https://github.com/returntocorp/semgrep/issues/5686.
+You can now have multiple metavariables under `focus-metavariable`, which allows Semgrep to highlight the
+values matched by multiple metavariables more easily in certain circumstances.
+See the gist in the description of the original issue for an example.

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -586,10 +586,17 @@ class TextFormatter(BaseFormatter):
                 with_color(Colors.foreground, rule_id, bold=True)
                 for rule_id in first_party_blocking_rules
             ]
-            first_party_blocking_rules_output = [
-                "\nBlocking Rules Fired:\n   "
-                + "   \n   ".join(formatted_first_party_blocking_rules)
-            ]
+            first_party_blocking_rules_output = (
+                [
+                    "\nFirst-Party Blocking Rules Fired:\n   "
+                    + "   \n   ".join(formatted_first_party_blocking_rules)
+                ]
+                if (reachable or unreachable)
+                else [
+                    "\nBlocking Rules Fired:\n   "
+                    + "   \n   ".join(formatted_first_party_blocking_rules)
+                ]
+            )
 
         return "\n".join(
             [

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -560,10 +560,10 @@ class TextFormatter(BaseFormatter):
                 extra["dataflow_traces"],
             )
             findings_output.append(
-                "\nFirst-Party Non-blocking Findings:\n"
+                "\nFirst-Party Non-Blocking Findings:\n"
                 + "\n".join(first_party_nonblocking_output)
             ) if (reachable or unreachable) else findings_output.append(
-                "\nNon-blocking Findings:\n" + "\n".join(first_party_nonblocking_output)
+                "\nNon-Blocking Findings:\n" + "\n".join(first_party_nonblocking_output)
             )
         if first_party_blocking:
             first_party_blocking_output = self._build_text_output(

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -499,7 +499,7 @@ class TextFormatter(BaseFormatter):
                 if match.is_blocking:
                     first_party_blocking.append(match)
                     rule_id = match.match.rule_id.value
-                    if rule_id not in first_party_blocking_rules:
+                    if rule_id not in first_party_blocking_rules and rule_id != "-":
                         first_party_blocking_rules.append(rule_id)
                 else:
                     first_party_nonblocking.append(match)

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -491,10 +491,18 @@ class TextFormatter(BaseFormatter):
     ) -> str:
         reachable = []
         unreachable = []
-        first_party = []
+        first_party_blocking = []
+        first_party_nonblocking = []
+        first_party_blocking_rules = []
         for match in rule_matches:
             if "sca_info" not in match.extra:
-                first_party.append(match)
+                if match.is_blocking:
+                    first_party_blocking.append(match)
+                    rule_id = match.match.rule_id
+                    if rule_id not in first_party_blocking_rules:
+                        first_party_blocking_rules.append(rule_id)
+                else:
+                    first_party_nonblocking.append(match)
             elif match.extra["sca_info"].reachable:
                 reachable.append(match)
             else:
@@ -543,26 +551,34 @@ class TextFormatter(BaseFormatter):
                 + "\n".join(unreachable_output)
             )
 
-        if (reachable or unreachable) and first_party:
-            first_party_output = self._build_text_output(
-                first_party,
+        if first_party_nonblocking:
+            first_party_nonblocking_output = self._build_text_output(
+                first_party_nonblocking,
                 extra.get("color_output", False),
                 extra["per_finding_max_lines_limit"],
                 extra["per_line_max_chars_limit"],
                 extra["dataflow_traces"],
             )
             findings_output.append(
-                "\nFirst-Party Findings:\n" + "\n".join(first_party_output)
+                "\nFirst-Party Non-blocking Findings:\n"
+                + "\n".join(first_party_nonblocking_output)
+            ) if (reachable or unreachable) else findings_output.append(
+                "\nNon-blocking Findings:\n" + "\n".join(first_party_nonblocking_output)
             )
-        elif first_party:
-            first_party_output = self._build_text_output(
-                first_party,
+        if first_party_blocking:
+            first_party_blocking_output = self._build_text_output(
+                first_party_blocking,
                 extra.get("color_output", False),
                 extra["per_finding_max_lines_limit"],
                 extra["per_line_max_chars_limit"],
                 extra["dataflow_traces"],
             )
-            findings_output.append("\nFindings:\n" + "\n".join(first_party_output))
+            findings_output.append(
+                "\nFirst-Party Blocking Findings:\n"
+                + "\n".join(first_party_blocking_output)
+            ) if (reachable or unreachable) else findings_output.append(
+                "\nBlocking Findings:\n" + "\n".join(first_party_blocking_output)
+            )
 
         return "\n".join(
             [

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -498,7 +498,7 @@ class TextFormatter(BaseFormatter):
             if "sca_info" not in match.extra:
                 if match.is_blocking:
                     first_party_blocking.append(match)
-                    rule_id = match.match.rule_id
+                    rule_id = match.match.rule_id.value
                     if rule_id not in first_party_blocking_rules:
                         first_party_blocking_rules.append(rule_id)
                 else:
@@ -580,9 +580,21 @@ class TextFormatter(BaseFormatter):
                 "\nBlocking Findings:\n" + "\n".join(first_party_blocking_output)
             )
 
+        first_party_blocking_rules_output = []
+        if first_party_blocking_rules:
+            formatted_first_party_blocking_rules = [
+                with_color(Colors.foreground, rule_id, bold=True)
+                for rule_id in first_party_blocking_rules
+            ]
+            first_party_blocking_rules_output = [
+                "\nBlocking Rules Fired:\n   "
+                + "   \n   ".join(formatted_first_party_blocking_rules)
+            ]
+
         return "\n".join(
             [
                 *findings_output,
+                *first_party_blocking_rules_output,
                 *timing_output,
             ]
         )

--- a/cli/tests/e2e/rules/multi-focus-metavariable.yaml
+++ b/cli/tests/e2e/rules/multi-focus-metavariable.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: multi-focus-metavariable
+    pattern-either:
+      - patterns:
+        - pattern: foo($X, ..., $Y)
+        - focus-metavariable:
+          - $X
+          - $Y
+      - patterns:
+        - pattern: goo($A, $B)
+        - focus-metavariable: $A
+        - focus-metavariable: $B
+    message: Test for multiple metavariables
+    languages:
+      - py
+    severity: ERROR

--- a/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
          15┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           7┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   baz.py 
           1┆ baz = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   foo.py 
           3┆ foo = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_symlink_changed/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_symlink_changed/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   dir_one/foo.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   definitely_a_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   definitely_a_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_intersection/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_intersection/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_one_commit_with_baseline/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_one_commit_with_baseline/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   dir_new/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   dir_new/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
         201┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   Foo.py 
         201┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   symlink_or_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   symlink_or_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -23,6 +23,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return a + b == a + b
+
+Blocking Rules Fired:
+   rules.eqeq-is-bad   
+   rules.javascript-basic-eqeq-bad
 
 === end of stdout - plain
 
@@ -48,7 +52,7 @@ Ran 4 rules on 14 files: 2 findings.
 
 === stdout - color
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -63,6 +67,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
+
+Blocking Rules Fired:
+   [1m[24mrules.eqeq-is-bad[0m   
+   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -23,6 +23,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return a + b == a + b
+
+Blocking Rules Fired:
+   rules.eqeq-is-bad   
+   rules.javascript-basic-eqeq-bad
 
 === end of stdout - plain
 
@@ -42,7 +46,7 @@ Ran 4 rules on 14 files: 2 findings.
 
 === stdout - color
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -57,6 +61,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
+
+Blocking Rules Fired:
+   [1m[24mrules.eqeq-is-bad[0m   
+   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -24,6 +24,10 @@ Findings:
 
           3┆ return a + b == a + b
 
+Blocking Rules Fired:
+   rules.eqeq-is-bad   
+   rules.javascript-basic-eqeq-bad
+
 === end of stdout - plain
 
 === stderr - plain
@@ -32,7 +36,7 @@ Findings:
 
 === stdout - color
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -47,6 +51,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
+
+Blocking Rules Fired:
+   [1m[24mrules.eqeq-is-bad[0m   
+   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Non-blocking Findings:
+Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -8,7 +8,16 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -8,7 +8,16 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Findings:
+Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -8,7 +8,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Non-blocking Findings:
+Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Non-blocking Findings:
+Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -8,7 +8,16 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -8,7 +8,16 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Findings:
+Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -8,7 +8,7 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Non-blocking Findings:
+Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Non-blocking Findings:
+Non-Blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -18,7 +18,19 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+          ⋮┆----------------------------------------
+         ▶▶┆ Autofix ▶ y == 2
+         16┆ y == 5  # nosemgrep
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -42,15 +54,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
-         ▶▶┆ Autofix ▶ y == 2
-         16┆ y == 5  # nosemgrep
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -62,6 +65,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -18,7 +18,19 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+          ⋮┆----------------------------------------
+         ▶▶┆ Autofix ▶ y == 2
+         16┆ y == 5  # nosemgrep
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -42,15 +54,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
-         ▶▶┆ Autofix ▶ y == 2
-         16┆ y == 5  # nosemgrep
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -62,6 +65,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -18,7 +18,7 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Non-blocking Findings:
+First-Party Non-Blocking Findings:
 
   foo.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Non-blocking Findings:
+Non-Blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Non-blocking Findings:
+Non-Blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
@@ -1,11 +1,14 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[x.xxx == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m
 
 ============================[ summary ]============================
 Total time: x.xxxs Config time: x.xxxs Core time: x.xxxs

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[x.xxx == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[24m1 == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[24m1 == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
   targets/cli_test/basic/basic.py 
      rules.cli_test.basic.basic-test
         Basic test
 
           2┆ print(1 == 1)
+
+Blocking Rules Fired:
+   rules.cli_test.basic.basic-test

--- a/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
@@ -17,7 +17,7 @@ Unreachable Supply Chain Findings:
         oh no
 
 
-First-Party Findings:
+First-Party Blocking Findings:
 
   targets/dependency_aware/monorepo/build.js 
      rules.dependency_aware.js-other
@@ -31,3 +31,6 @@ First-Party Findings:
         this is always bad
 
           1┆ bad()
+
+Blocking Rules Fired:
+   rules.dependency_aware.js-other

--- a/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/results.txt
+++ b/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERS
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   stupid.py 
           3┆ return a + b == a + b

--- a/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/results.txt
+++ b/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERS
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   stupid.py 
           3┆ return a + b == a + b

--- a/cli/tests/e2e/targets/multi-focus-metavariable.py
+++ b/cli/tests/e2e/targets/multi-focus-metavariable.py
@@ -1,0 +1,17 @@
+foo (
+	# match: multi-focus-metavariable
+	1
+	,
+	# ok: multi-focus-metavariable
+	2
+	,
+	# ok: multi-focus-metavariable
+	3
+	,
+	# match: multi-focus-metavariable
+	4
+)
+
+# ok: multi-focus-metavariable
+goo (1, 2)
+

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -730,3 +730,16 @@ def test_experiment_finding_output(run_semgrep_in_tmp, snapshot):
         ).stderr,
         "output.txt",
     )
+
+
+@pytest.mark.quick
+def multi_focus_metavariable(run_semgrep_in_tmp, snapshot):
+    snapshot.assert_match(
+        run_semgrep_in_tmp(
+            "rules/multi-focus-metavariable.yaml",
+            target_name="targets/multi-focus-metavariable.py",
+            strict=False,
+            output_format=OutputFormat.TEXT,
+        ).stderr,
+        "output.txt",
+    )

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -39,8 +39,7 @@
 (* The locations of variables which taint propagates through *)
 type tainted_tokens = Parse_info.t list [@@deriving show]
 
-(* The tokens associated with a single pattern match involved in a taint trace
- * *)
+(* The tokens associated with a single pattern match involved in a taint trace *)
 type pattern_match_tokens = Parse_info.t list [@@deriving show]
 
 (* Simplified version of Taint.source_to_sink meant for finding reporting *)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -73,6 +73,10 @@ type formula =
    *)
   | Inside of tok * formula
 
+(* Represents all of the metavariables that are being focused by a single
+   `focus-metavariable`. *)
+and focus_mv_list = tok * MV.mvar list [@@deriving show]
+
 (* The conjunction must contain at least
  * one positive "term" (unless it's inside a CondNestedFormula, in which
  * case there is not such a restriction).
@@ -84,7 +88,7 @@ and conjunction = {
   (* metavariable-xyz:'s *)
   conditions : (tok * metavar_cond) list;
   (* focus-metavariable:'s *)
-  focus : (tok * MV.mvar) list;
+  focus : focus_mv_list list;
 }
 
 and metavar_cond =

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -140,7 +140,10 @@ let unknown_metavar_in_comparison env f =
                | CondAnalysis (mv, _) ->
                    if not (Set.mem mv mvs) then mv_error mv t);
         focus
-        |> List.iter (fun (t, mv) -> if not (Set.mem mv mvs) then mv_error mv t);
+        |> List.iter (fun (t, mv_list) ->
+               mv_list
+               |> List.iter (fun mv ->
+                      if not (Set.mem mv mvs) then mv_error mv t));
         mvs
   in
   let _ = collect_metavars f in

--- a/semgrep-core/src/metachecking/Translate_rule.ml
+++ b/semgrep-core/src/metachecking/Translate_rule.ml
@@ -91,8 +91,15 @@ and translate_formula f : [> `O of (string * Yaml.value) list ] =
                 (Common.map
                    (fun (_, cond) -> translate_metavar_cond cond)
                    conditions
-                @ Common.map (fun (_, mv) -> `O [ ("focus", `String mv) ]) focus
-                ) );
+                @ Common.map
+                    (fun (_, mv_list) ->
+                      `O
+                        [
+                          ( "focus",
+                            `A (Common.map (fun mvar -> `String mvar) mv_list)
+                          );
+                        ])
+                    focus) );
           ]))
   | Or (_, fs) ->
       `O [ ("or", `A (Common.map translate_formula fs :> Yaml.value list)) ]

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable1.py
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable1.py
@@ -1,4 +1,4 @@
-# ruleid: test
+# ruleid: focus_metavariable1
 foo (1 + 2,
 # OK: test
 	1)

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable1.yaml
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable1.yaml
@@ -1,5 +1,5 @@
 rules:
-  - id: test
+  - id: focus_metavariable1
     patterns:
       - pattern-inside: foo($X, ...)
       - focus-metavariable: $X

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable2.py
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable2.py
@@ -1,0 +1,16 @@
+foo (
+	# ruleid: focus_metavariable2
+	1
+	,
+	# ok: focus_metavariable2
+	2
+	,
+	# ok: focus_metavariable2
+	3
+	,
+	# ruleid: focus_metavariable2
+	4
+)
+
+# ok: focus_metavariable2
+goo (1, 2)

--- a/semgrep-core/tests/OTHER/rules/focus_metavariable2.yaml
+++ b/semgrep-core/tests/OTHER/rules/focus_metavariable2.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: focus_metavariable2
+    pattern-either:
+      - patterns:
+        - pattern: foo($X, ..., $Y)
+        - focus-metavariable:
+          - $X
+          - $Y
+      - patterns:
+        - pattern: goo($A, $B)
+        - focus-metavariable: $A
+        - focus-metavariable: $B
+    message: Test for multiple metavariables
+    languages:
+      - py
+    severity: ERROR
+

--- a/semgrep-core/tests/tainting_rules/go/command-injection.go
+++ b/semgrep-core/tests/tainting_rules/go/command-injection.go
@@ -1,0 +1,46 @@
+func (a *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+
+  	username, _, _ := r.BasicAuth()
+
+  	fmt.Printf("Path Sink:\n")
+  	cmd := &exec.Cmd {
+  	  // Path is the path of the command to run.
+  	  // MATCH: net-http-command-injection-taint
+  	  Path: username,
+  	  // Args holds command line arguments, including the command as Args[0].
+  	  Args: []string{ "tr", "--help" },
+  	  Stdout: os.Stdout,
+  	  Stderr: os.Stderr,
+  	}
+
+  	fmt.Printf("Args Sink:\n")
+  	cmd2 := &exec.Cmd {
+  	  // Path is the path of the command to run.
+  	  Path: "/usr/bin/tr",
+  	  // Args holds command line arguments, including the command as Args[0].
+  	  // MATCH: net-http-command-injection-taint
+  	  Args: []string{ username, "--help" },
+  	  Stdout: os.Stdout,
+  	  Stderr: os.Stderr,
+  	}
+
+  	cmd3 := &exec.Cmd {
+  	  // Path is the path of the command to run.
+  	  Path: "/usr/bin/tr",
+  	  // Args holds command line arguments, including the command as Args[0].
+  	  Args: []string{ "--help" },
+  	  // ok: net-http-command-injection-taint
+  	  Something: username,
+  	  Stdout: os.Stdout,
+  	  Stderr: os.Stderr,
+  	}
+
+  	// MATCH: net-http-command-injection-taint
+  	syscall.Exec(username, []string{"-a", "-l", "-h"})
+
+  	// ok: net-http-command-injection-taint
+  	syscall.Exec("ls", []string{"-a", "-l", "-h"}, username)
+}
+

--- a/semgrep-core/tests/tainting_rules/go/command-injection.yaml
+++ b/semgrep-core/tests/tainting_rules/go/command-injection.yaml
@@ -1,0 +1,36 @@
+rules:
+  - id: command-injection
+    message:
+      This test confirms that taint works with multiple focus-metavariables
+    languages:
+      - go
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  ($REQ : http.Request).$FIELD
+              - pattern: |
+                  ($REQ : *http.Request).$FIELD()
+          - metavariable-regex:
+              metavariable: $FIELD
+              regex: ^(BasicAuth|Body|Cookie|Cookies|Form|FormValue|GetBody|Host|MultipartReader|ParseForm|ParseMultipartForm|PostForm|PostFormValue|Referer|RequestURI|Trailer|TransferEncoding|URL|UserAgent)$
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: syscall.Exec($PATH, $ARGS, ...)
+              - pattern-inside: syscall.ForkExec($PATH, $ARGS, ...)
+              - pattern-inside: |
+                  &exec.Cmd {$PATH, $ARGS, ...}
+              - patterns:
+                  - pattern-inside: |
+                      &exec.Cmd { ... }
+                  - pattern-either:
+                      - pattern-inside: |
+                          Path: $PATH
+                      - pattern-inside: |
+                          Args: $ARGS
+          - focus-metavariable:
+              - $PATH
+              - $ARGS


### PR DESCRIPTION
This PR modifies the CLI output such that now findings are separating into blocking and non-blocking findings. Additionally, if there are blocking findings, we also show a list of blocking rules that were fired. 

<img width="686" alt="image" src="https://user-images.githubusercontent.com/109543197/190835484-bbbde573-0aee-4c1d-b6e8-12e19f65751d.png">

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

Closes APP-2306