### PR TITLE
Fix incorrect stripping of literal dollar sign in regexps

### DIFF
--- a/changelog.d/gh-5987.fixed
+++ b/changelog.d/gh-5987.fixed
@@ -1,0 +1,2 @@
+Fixed incorrect stripping of '\$' (literal dollar sign) in regexps used in the
+context of `metavariable-regex`.

--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -38,7 +38,7 @@ clean:
 test: all
 	# The test executable has a few options that can be useful
 	# in some contexts.
-	# The following ensures that we can call 'test.exe --help'
+	# The following command ensures that we can call 'test.exe --help'
 	# without having to chdir into the test data folder.
 	./_build/default/tests/test.exe --help 2>&1 >/dev/null
 	$(MAKE) -C src/spacegrep test

--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -36,8 +36,10 @@ clean:
 #
 .PHONY: test
 test: all
-	# ensure that '--help' is available and that we don't load test data
-	# until the tests need to run.
+	# The test executable has a few options that can be useful
+	# in some contexts.
+	# The following ensures that we can call 'test.exe --help'
+	# without having to chdir into the test data folder.
 	./_build/default/tests/test.exe --help 2>&1 >/dev/null
 	$(MAKE) -C src/spacegrep test
 	dune runtest -f --no-buffer

--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -36,6 +36,9 @@ clean:
 #
 .PHONY: test
 test: all
+	# ensure that '--help' is available and that we don't load test data
+	# until the tests need to run.
+	./_build/default/tests/test.exe --help 2>&1 >/dev/null
 	$(MAKE) -C src/spacegrep test
 	dune runtest -f --no-buffer
 

--- a/semgrep-core/src/utils/Unit_regexp_engine.ml
+++ b/semgrep-core/src/utils/Unit_regexp_engine.ml
@@ -16,6 +16,11 @@ let test_remove_eos_assertions () =
       ("AA", Some "AA");
       ("AAA", Some "AAA");
       ("AAAA", Some "AAAA");
+      ({|\$|}, Some {|\$|});
+      ({|A\$|}, Some {|A\$|});
+      ({|AA\$|}, Some {|AA\$|});
+      ({|AAA\$|}, Some {|AAA\$|});
+      ({|AAAA\$|}, Some {|AAAA\$|});
       ("^", Some "");
       ("$", Some "");
       ({|\A|}, Some "");
@@ -30,10 +35,10 @@ let test_remove_eos_assertions () =
       ("^AAA$", Some "AAA");
       ("^^", None);
       ("$$", None);
-      ({|A\A|}, None);
+      ({|A\A|}, Some {|A\A|});
       ("[$]*", None);
       ("(?:^)", None);
-      ({|\\A|}, None);
+      ({|\\A|}, Some {|\\A|});
       ({|(?<!.|\n)|}, None);
       (* DIY beginning-of-string assertion = \A *)
       ({|(?!.|\n)|}, None) (* DIY end-of-string assertion = \z *);

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -77,6 +77,9 @@ let tests () = List.flatten [
 (*
    This allows running the test program with '--help' from any folder
    without getting an error due to not being able to load test data.
+
+   See https://github.com/mirage/alcotest/issues/358 for a request
+   to allow what we want without this workaround.
 *)
 let tests_with_delayed_error () =
   try tests ()

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -74,8 +74,17 @@ let tests () = List.flatten [
 (* Entry point *)
 (*****************************************************************************)
 
+(*
+   This allows running the test program with '--help' from any folder
+   without getting an error due to not being able to load test data.
+*)
+let tests_with_delayed_error () =
+  try tests ()
+  with e ->
+     ["cannot load test data - not a real test", (fun () -> raise e)]
+
 let main () =
-  let alcotest_tests = Testutil.to_alcotest (tests ()) in
+  let alcotest_tests = Testutil.to_alcotest (tests_with_delayed_error ()) in
   Alcotest.run "semgrep-core" alcotest_tests
 
 let () = main ()


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/5987

I also fixed the issue that prevented us from calling `test.exe --help` from any folder. See https://github.com/mirage/alcotest/issues/358

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
