### PR TITLE
style(CLI): modify output to separate non-blocking and blocking findings

### DIFF
--- a/changelog.d/app-2306.added
+++ b/changelog.d/app-2306.added
@@ -1,0 +1,1 @@
+Modify the CLI output to separate non-blocking and blocking findings and show a list of the blocking rules that fired.

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -584,7 +584,10 @@ class TextFormatter(BaseFormatter):
         if first_party_blocking_rules:
             formatted_first_party_blocking_rules = [
                 with_color(Colors.foreground, rule_id, bold=True)
-                for rule_id in set(first_party_blocking_rules)
+                for rule_id in sorted(
+                    set(first_party_blocking_rules),
+                    key=first_party_blocking_rules.index,
+                )
             ]
             first_party_blocking_rules_output = (
                 [

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -500,7 +500,7 @@ class TextFormatter(BaseFormatter):
                     first_party_blocking.append(match)
                     rule_id = match.match.rule_id.value
                     # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -.
-                    # The short rule is ran in the command-line and has no associated rule_id
+                    # The rule is ran in the command-line and has no associated rule_id
                     if rule_id != "-":
                         first_party_blocking_rules.append(rule_id)
                 else:

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -499,6 +499,7 @@ class TextFormatter(BaseFormatter):
                 if match.is_blocking:
                     first_party_blocking.append(match)
                     rule_id = match.match.rule_id.value
+                    # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -
                     if rule_id != "-":
                         first_party_blocking_rules.append(rule_id)
                 else:

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -582,7 +582,7 @@ class TextFormatter(BaseFormatter):
         first_party_blocking_rules_output = []
         # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -.
         # The short rule is ran in the command-line and has no associated rule_id
-        if first_party_blocking_rules and first_party_blocking_rules != ["-"]:
+        if first_party_blocking_rules and "-" not in first_party_blocking_rules:
             formatted_first_party_blocking_rules = [
                 with_color(Colors.foreground, rule_id, bold=True)
                 for rule_id in sorted(

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -499,7 +499,7 @@ class TextFormatter(BaseFormatter):
                 if match.is_blocking:
                     first_party_blocking.append(match)
                     rule_id = match.match.rule_id.value
-                    if rule_id not in first_party_blocking_rules and rule_id != "-":
+                    if rule_id != "-":
                         first_party_blocking_rules.append(rule_id)
                 else:
                     first_party_nonblocking.append(match)
@@ -584,7 +584,7 @@ class TextFormatter(BaseFormatter):
         if first_party_blocking_rules:
             formatted_first_party_blocking_rules = [
                 with_color(Colors.foreground, rule_id, bold=True)
-                for rule_id in first_party_blocking_rules
+                for rule_id in set(first_party_blocking_rules)
             ]
             first_party_blocking_rules_output = (
                 [

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -582,7 +582,7 @@ class TextFormatter(BaseFormatter):
         first_party_blocking_rules_output = []
         # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -.
         # The short rule is ran in the command-line and has no associated rule_id
-        if first_party_blocking_rules != ["-"]:
+        if first_party_blocking_rules and first_party_blocking_rules != ["-"]:
             formatted_first_party_blocking_rules = [
                 with_color(Colors.foreground, rule_id, bold=True)
                 for rule_id in sorted(

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -499,7 +499,10 @@ class TextFormatter(BaseFormatter):
                 if match.is_blocking:
                     first_party_blocking.append(match)
                     rule_id = match.match.rule_id.value
-                    first_party_blocking_rules.append(rule_id)
+                    # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -.
+                    # The short rule is ran in the command-line and has no associated rule_id
+                    if rule_id != "-":
+                        first_party_blocking_rules.append(rule_id)
                 else:
                     first_party_nonblocking.append(match)
             elif match.extra["sca_info"].reachable:
@@ -580,9 +583,7 @@ class TextFormatter(BaseFormatter):
             )
 
         first_party_blocking_rules_output = []
-        # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -.
-        # The short rule is ran in the command-line and has no associated rule_id
-        if first_party_blocking_rules and "-" not in first_party_blocking_rules:
+        if first_party_blocking_rules:
             formatted_first_party_blocking_rules = [
                 with_color(Colors.foreground, rule_id, bold=True)
                 for rule_id in sorted(

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -499,9 +499,7 @@ class TextFormatter(BaseFormatter):
                 if match.is_blocking:
                     first_party_blocking.append(match)
                     rule_id = match.match.rule_id.value
-                    # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -
-                    if rule_id != "-":
-                        first_party_blocking_rules.append(rule_id)
+                    first_party_blocking_rules.append(rule_id)
                 else:
                     first_party_nonblocking.append(match)
             elif match.extra["sca_info"].reachable:
@@ -582,7 +580,9 @@ class TextFormatter(BaseFormatter):
             )
 
         first_party_blocking_rules_output = []
-        if first_party_blocking_rules:
+        # When ephemeral rules are run with the -e or --pattern flag in the command-line, the rule_id is set to -.
+        # The short rule is ran in the command-line and has no associated rule_id
+        if first_party_blocking_rules != ["-"]:
             formatted_first_party_blocking_rules = [
                 with_color(Colors.foreground, rule_id, bold=True)
                 for rule_id in sorted(

--- a/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
          15┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           7┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   baz.py 
           1┆ baz = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   foo.py 
           3┆ foo = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stdout.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_symlink_changed/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_symlink_changed/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   dir_one/foo.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   file_or_dir.py/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   definitely_a_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   definitely_a_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_intersection/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_intersection/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_one_commit_with_baseline/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_one_commit_with_baseline/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   dir_new/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   dir_new/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
         201┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   Foo.py 
         201┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink/output.txt
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   symlink_or_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/full.out
@@ -1,5 +1,5 @@
 
-Findings:
+Blocking Findings:
 
   symlink_or_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -23,6 +23,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return a + b == a + b
+
+Blocking Rules Fired:
+   rules.eqeq-is-bad   
+   rules.javascript-basic-eqeq-bad
 
 === end of stdout - plain
 
@@ -48,7 +52,7 @@ Ran 4 rules on 14 files: 2 findings.
 
 === stdout - color
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -63,6 +67,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
+
+Blocking Rules Fired:
+   [1m[24mrules.eqeq-is-bad[0m   
+   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -23,6 +23,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return a + b == a + b
+
+Blocking Rules Fired:
+   rules.eqeq-is-bad   
+   rules.javascript-basic-eqeq-bad
 
 === end of stdout - plain
 
@@ -42,7 +46,7 @@ Ran 4 rules on 14 files: 2 findings.
 
 === stdout - color
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -57,6 +61,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
+
+Blocking Rules Fired:
+   [1m[24mrules.eqeq-is-bad[0m   
+   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -24,6 +24,10 @@ Findings:
 
           3┆ return a + b == a + b
 
+Blocking Rules Fired:
+   rules.eqeq-is-bad   
+   rules.javascript-basic-eqeq-bad
+
 === end of stdout - plain
 
 === stderr - plain
@@ -32,7 +36,7 @@ Findings:
 
 === stdout - color
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -47,6 +51,10 @@ Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
+
+Blocking Rules Fired:
+   [1m[24mrules.eqeq-is-bad[0m   
+   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -8,7 +8,16 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -8,7 +8,16 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -8,7 +8,16 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -8,7 +8,16 @@ CI="true" GITLAB_CI="true" CI_PROJECT_PATH="project_name/project_name" CI_PIPELI
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -22,12 +31,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -37,6 +40,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -32,12 +41,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -47,6 +50,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -18,7 +18,19 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+          ⋮┆----------------------------------------
+         ▶▶┆ Autofix ▶ y == 2
+         16┆ y == 5  # nosemgrep
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -42,15 +54,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
-         ▶▶┆ Autofix ▶ y == 2
-         16┆ y == 5  # nosemgrep
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -62,6 +65,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -18,7 +18,19 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+          ⋮┆----------------------------------------
+         ▶▶┆ Autofix ▶ y == 2
+         16┆ y == 5  # nosemgrep
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -42,15 +54,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
-         ▶▶┆ Autofix ▶ y == 2
-         16┆ y == 5  # nosemgrep
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -62,6 +65,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -18,7 +18,16 @@ Unreachable Supply Chain Findings:
         found a dependency
 
 
-First-Party Findings:
+First-Party Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+First-Party Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -36,12 +45,6 @@ First-Party Findings:
           ⋮┆----------------------------------------
          24┆ a == a # Triage ignored by match_based_id
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -51,6 +54,11 @@ First-Party Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+First-Party Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/results.txt
@@ -8,7 +8,7 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
 
   bar.py 
      eqeq-five

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
@@ -1,11 +1,14 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[x.xxx == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m
 
 ============================[ summary ]============================
 Total time: x.xxxs Config time: x.xxxs Core time: x.xxxs

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[x.xxx == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[24m1 == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[24m1 == 1[0m)
+
+Blocking Rules Fired:
+   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
@@ -1,8 +1,11 @@
 
-Findings:
+Blocking Findings:
 
   targets/cli_test/basic/basic.py 
      rules.cli_test.basic.basic-test
         Basic test
 
           2┆ print(1 == 1)
+
+Blocking Rules Fired:
+   rules.cli_test.basic.basic-test

--- a/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
@@ -17,7 +17,7 @@ Unreachable Supply Chain Findings:
         oh no
 
 
-First-Party Findings:
+First-Party Blocking Findings:
 
   targets/dependency_aware/monorepo/build.js 
      rules.dependency_aware.js-other
@@ -31,3 +31,6 @@ First-Party Findings:
         this is always bad
 
           1┆ bad()
+
+First-Party Blocking Rules Fired:
+   rules.dependency_aware.js-other

--- a/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/results.txt
+++ b/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERS
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   stupid.py 
           3┆ return a + b == a + b

--- a/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/results.txt
+++ b/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERS
 
 === stdout - plain
 
-Findings:
+Blocking Findings:
 
   stupid.py 
           3┆ return a + b == a + b


### PR DESCRIPTION
This PR modifies the CLI output such that now findings are separating into blocking and non-blocking findings. Additionally, if there are blocking findings, we also show a list of blocking rules that were fired. 

<img width="686" alt="image" src="https://user-images.githubusercontent.com/109543197/190835484-bbbde573-0aee-4c1d-b6e8-12e19f65751d.png">

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

Closes APP-2306