### PR TITLE
modified docker run command in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ brew install semgrep
 $ python3 -m pip install semgrep
 
 # To try Semgrep without installation run via Docker
-$ docker run --rm -v "${PWD}:/src" returntocorp/semgrep
+$ docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep
 ```
 
 Once installed, Semgrep can run with single rules or entire rulesets. Visit [Docs > Running rules](https://semgrep.dev/docs/running-rules/) to learn more or try the following:


### PR DESCRIPTION
README file has been updated so that the docker run command is no longer using the custom entrypoint, which was planned to be removed in June 2022.
No other files are affected and it has no security implications, since it's only updating the instructions on how to run semgrep using Docker.
