### PR TITLE
C++: switch to tree-sitter for parsing the pattern

### DIFF
--- a/changelog.d/gh-1923.fixed
+++ b/changelog.d/gh-1923.fixed
@@ -1,0 +1,1 @@
+C++: support ellipsis in right-hand-side of an assignment

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -155,8 +155,16 @@ let parse_pattern lang ?(print_errors = false) str =
         let any = Parse_c.any_of_string str in
         C_to_generic.any any
     | Lang.Cpp ->
-        (* TODO: use tree-sitter-cpp at some point, probably more robust *)
-        let any = Parse_cpp.any_of_string Flag_parsing_cpp.Cplusplus str in
+        let any =
+          str
+          |> run_either ~print_errors
+               [
+                 Pfff
+                   (fun x ->
+                     Parse_cpp.any_of_string Flag_parsing_cpp.Cplusplus x);
+                 TreeSitter Parse_cpp_tree_sitter.parse_pattern;
+               ]
+        in
         Cpp_to_generic.any any
     | Lang.Java ->
         let any =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.mli
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.mli
@@ -1,1 +1,2 @@
 val parse : Common.filename -> Ast_cpp.program Tree_sitter_run.Parsing_result.t
+val parse_pattern : string -> Ast_cpp.any Tree_sitter_run.Parsing_result.t

--- a/semgrep-core/tests/cpp/dots_rhs.cpp
+++ b/semgrep-core/tests/cpp/dots_rhs.cpp
@@ -1,0 +1,4 @@
+void main() {
+  //ERROR: match
+  foo->bar = 2;
+}

--- a/semgrep-core/tests/cpp/dots_rhs.sgrep
+++ b/semgrep-core/tests/cpp/dots_rhs.sgrep
@@ -1,0 +1,3 @@
+// this actually requires the tree-sitter-cpp parser
+// it does not parse with parser_cpp.mly
+$VAR->$MEMBER = ...;


### PR DESCRIPTION
Support also ellipsis in RHS of assign as doing the switch.

This closes #1923

test plan:
test file included
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)