### PR TITLE
chore: Update reference to LICENSE file

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open IL

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open IL
 module F = IL (* to be even more similar to controlflow_build.ml *)

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open AST_generic
 module G = AST_generic

--- a/semgrep-core/src/analyzing/Dataflow_core.ml
+++ b/semgrep-core/src/analyzing/Dataflow_core.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open IL

--- a/semgrep-core/src/analyzing/Dataflow_var_env.ml
+++ b/semgrep-core/src/analyzing/Dataflow_var_env.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 module C = Dataflow_core

--- a/semgrep-core/src/core/Equivalence.ml
+++ b/semgrep-core/src/core/Equivalence.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (*****************************************************************************)

--- a/semgrep-core/src/core/Hooks.ml
+++ b/semgrep-core/src/core/Hooks.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (*****************************************************************************)

--- a/semgrep-core/src/core/Matching_explanation.ml
+++ b/semgrep-core/src/core/Matching_explanation.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module Out = Output_from_core_j

--- a/semgrep-core/src/core/Metavariable.ml
+++ b/semgrep-core/src/core/Metavariable.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module G = AST_generic

--- a/semgrep-core/src/core/Mini_rule.ml
+++ b/semgrep-core/src/core/Mini_rule.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (*****************************************************************************)

--- a/semgrep-core/src/core/Pattern.ml
+++ b/semgrep-core/src/core/Pattern.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 

--- a/semgrep-core/src/core/Pattern_match.ml
+++ b/semgrep-core/src/core/Pattern_match.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (*****************************************************************************)

--- a/semgrep-core/src/core/Range.ml
+++ b/semgrep-core/src/core/Range.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module G = AST_generic

--- a/semgrep-core/src/core/Rule_match.ml
+++ b/semgrep-core/src/core/Rule_match.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 type t = Pattern_match.t

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -4,12 +4,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/core/Target.ml
+++ b/semgrep-core/src/core/Target.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 (*****************************************************************************)
 (* Prelude *)

--- a/semgrep-core/src/core/Xpattern.ml
+++ b/semgrep-core/src/core/Xpattern.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (*****************************************************************************)

--- a/semgrep-core/src/core/Xtarget.ml
+++ b/semgrep-core/src/core/Xtarget.ml
@@ -4,12 +4,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (* eXtended target.

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (*****************************************************************************)

--- a/semgrep-core/src/core/ast/AST_generic_helpers.ml
+++ b/semgrep-core/src/core/ast/AST_generic_helpers.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open AST_generic

--- a/semgrep-core/src/core/ast/Lang.ml.j2
+++ b/semgrep-core/src/core/ast/Lang.ml.j2
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module FT = File_type
 

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open OCaml
 open AST_generic

--- a/semgrep-core/src/core/ast/Pretty_print_AST.ml
+++ b/semgrep-core/src/core/ast/Pretty_print_AST.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open AST_generic

--- a/semgrep-core/src/core/ast/Type_generic.ml
+++ b/semgrep-core/src/core/ast/Type_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module G = AST_generic
 

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open OCaml
 open AST_generic

--- a/semgrep-core/src/core/il/CFG.ml
+++ b/semgrep-core/src/core/il/CFG.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 type nodei = Ograph_extended.nodei

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module G = AST_generic
 

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open IL
 

--- a/semgrep-core/src/engine/Eval_generic.ml
+++ b/semgrep-core/src/engine/Eval_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module G = AST_generic

--- a/semgrep-core/src/engine/Match_env.ml
+++ b/semgrep-core/src/engine/Match_env.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module E = Semgrep_error_code
 module PI = Parse_info

--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module In = Input_to_core_j

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 open Common

--- a/semgrep-core/src/engine/Match_search_mode.ml
+++ b/semgrep-core/src/engine/Match_search_mode.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module R = Rule

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module D = Dataflow_tainting

--- a/semgrep-core/src/engine/Metavariable_analysis.ml
+++ b/semgrep-core/src/engine/Metavariable_analysis.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module MV = Metavariable
 module G = AST_generic

--- a/semgrep-core/src/engine/Metavariable_pattern.ml
+++ b/semgrep-core/src/engine/Metavariable_pattern.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Match_env

--- a/semgrep-core/src/engine/Test_comby.ml
+++ b/semgrep-core/src/engine/Test_comby.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Comby_kernel

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module FT = File_type

--- a/semgrep-core/src/engine/Xpattern_match_comby.ml
+++ b/semgrep-core/src/engine/Xpattern_match_comby.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Xpattern_matcher

--- a/semgrep-core/src/engine/Xpattern_match_regexp.ml
+++ b/semgrep-core/src/engine/Xpattern_match_regexp.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Xpattern_matcher

--- a/semgrep-core/src/engine/Xpattern_match_spacegrep.ml
+++ b/semgrep-core/src/engine/Xpattern_match_spacegrep.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Xpattern_matcher
 module PI = Parse_info

--- a/semgrep-core/src/engine/Xpattern_matcher.ml
+++ b/semgrep-core/src/engine/Xpattern_matcher.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module MV = Metavariable

--- a/semgrep-core/src/experiments/api/AST_generic_to_v0.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v0.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open OCaml (* map_of_string, ... *)

--- a/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_experiment.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open IL

--- a/semgrep-core/src/experiments/datalog/Datalog_fact.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_fact.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 

--- a/semgrep-core/src/experiments/datalog/Datalog_io.ml
+++ b/semgrep-core/src/experiments/datalog/Datalog_io.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module D = Datalog_fact

--- a/semgrep-core/src/experiments/lsp/LSP_client.ml
+++ b/semgrep-core/src/experiments/lsp/LSP_client.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 open Common

--- a/semgrep-core/src/experiments/synthesizing/Pattern_from_Code.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pattern_from_Code.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open AST_generic
 module G = AST_generic

--- a/semgrep-core/src/experiments/synthesizing/Pattern_from_Targets.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pattern_from_Targets.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module Set = Set_

--- a/semgrep-core/src/experiments/synthesizing/Pretty_print_pattern.ml
+++ b/semgrep-core/src/experiments/synthesizing/Pretty_print_pattern.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open AST_generic

--- a/semgrep-core/src/experiments/synthesizing/Range_to_AST.ml
+++ b/semgrep-core/src/experiments/synthesizing/Range_to_AST.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 open Common

--- a/semgrep-core/src/experiments/synthesizing/Test_synthesizing.ml
+++ b/semgrep-core/src/experiments/synthesizing/Test_synthesizing.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module J = JSON

--- a/semgrep-core/src/matching/Apply_equivalences.ml
+++ b/semgrep-core/src/matching/Apply_equivalences.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open AST_generic

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 

--- a/semgrep-core/src/matching/Match_patterns.ml
+++ b/semgrep-core/src/matching/Match_patterns.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open AST_generic
 module V = Visitor_AST

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module B = AST_generic

--- a/semgrep-core/src/matching/Normalize_generic.ml
+++ b/semgrep-core/src/matching/Normalize_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common (* >>= *)
 open AST_generic

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 open AST_generic

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module FT = File_type

--- a/semgrep-core/src/metachecking/Test_metachecking.ml
+++ b/semgrep-core/src/metachecking/Test_metachecking.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module FT = File_type

--- a/semgrep-core/src/metachecking/Translate_rule.ml
+++ b/semgrep-core/src/metachecking/Translate_rule.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module FT = File_type

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open AST_generic

--- a/semgrep-core/src/optimizing/Analyze_pattern.ml
+++ b/semgrep-core/src/optimizing/Analyze_pattern.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open AST_generic
 module V = Visitor_AST

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module R = Rule

--- a/semgrep-core/src/optimizing/Bloom_annotation.ml
+++ b/semgrep-core/src/optimizing/Bloom_annotation.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module V = Visitor_AST
 module Set = Set_

--- a/semgrep-core/src/optimizing/Mini_rules_filter.ml
+++ b/semgrep-core/src/optimizing/Mini_rules_filter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module Flag = Flag_semgrep
 module R = Mini_rule

--- a/semgrep-core/src/parsing/Parse_equivalences.ml
+++ b/semgrep-core/src/parsing/Parse_equivalences.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module Eq = Equivalence

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module J = JSON

--- a/semgrep-core/src/parsing/Parse_target.ml
+++ b/semgrep-core/src/parsing/Parse_target.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 open Common

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 module Y = Yaml

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open AST_python

--- a/semgrep-core/src/parsing/pfff/c_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/c_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module G = AST_generic

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module H = AST_generic_helpers

--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Ast_go

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Ast_java

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Ast_js

--- a/semgrep-core/src/parsing/pfff/json_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/json_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Ast_json

--- a/semgrep-core/src/parsing/pfff/ml_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ml_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Ast_ml

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Ast_php

--- a/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/ruby_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Ast_ruby

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open AST_scala

--- a/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module AST = Ast_c

--- a/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_c_sharp.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_dart_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_dart_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module CST = Tree_sitter_dart.CST
 module H = Parse_tree_sitter_helpers

--- a/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_elixir.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module AST = Ast_go

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 (*
    Map a Hack CST obtained from the tree-sitter parser directly to the generic

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module CST = Tree_sitter_html.CST
 module H = Parse_tree_sitter_helpers

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module AST = Ast_java

--- a/semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_jsonnet.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_julia_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_julia_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_julia.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml
@@ -6,12 +6,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_kotlin.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_lua.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 (*
 open Common

--- a/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 module CST = Tree_sitter_python.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 module CST = Tree_sitter_r.CST
 module H = Parse_tree_sitter_helpers

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module AST = Ast_ruby

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_rust.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_solidity.CST

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module CST = Tree_sitter_vue.CST

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module StrSet = Common2.StringSet

--- a/semgrep-core/src/reporting/Matching_report.ml
+++ b/semgrep-core/src/reporting/Matching_report.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 module PI = Parse_info

--- a/semgrep-core/src/reporting/Statistics_report.ml
+++ b/semgrep-core/src/reporting/Statistics_report.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 open Common

--- a/semgrep-core/src/runner/Parse_with_caching.ml
+++ b/semgrep-core/src/runner/Parse_with_caching.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open Runner_config

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 open Common
 open IL

--- a/semgrep-core/src/tainting/Taint.ml
+++ b/semgrep-core/src/tainting/Taint.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 module G = AST_generic

--- a/semgrep-core/src/tainting/Taint_lval_env.ml
+++ b/semgrep-core/src/tainting/Taint_lval_env.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 module T = Taint

--- a/semgrep-core/src/utils/Regexp_engine.ml
+++ b/semgrep-core/src/utils/Regexp_engine.ml
@@ -5,12 +5,12 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
+ * special exception on linking described in file LICENSE.
  *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
+ * LICENSE for more details.
  *)
 
 (*****************************************************************************)


### PR DESCRIPTION
A quick codemod with `find` and `sed`. The license headers refer to `license.txt`, but the license file at the root of the repo is actually `LICENSE`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
