### PR TITLE
cleanup some projects.txt parsing-stat and add few projects

### DIFF
--- a/parsing-stats/lang/c/projects.txt
+++ b/parsing-stats/lang/c/projects.txt
@@ -2,25 +2,25 @@
 # Top C projects from GitHub, sorted by stars.
 # Created by ../../scripts/most-starred-for-language.
 #
-
-# Linux is 20M lines of .c files, 7M of .h files, which is more than necessary.
-# It's also possibly too homogenous.
-# https://github.com/torvalds/linux
-
 https://github.com/coolsnowwolf/lede
 https://github.com/FFmpeg/FFmpeg
 https://github.com/php/php-src
 https://github.com/arendst/Tasmota
-https://github.com/openssl/openssl
 https://github.com/Awesome-HarmonyOS/HarmonyOS
 https://github.com/netdata/netdata
-https://github.com/git/git
 https://github.com/taosdata/TDengine
 https://github.com/obsproject/obs-studio
-https://github.com/curl/curl
 https://github.com/ventoy/Ventoy
 https://github.com/redis/redis
 https://github.com/mpv-player/mpv
+# Linux is 20M lines of .c files, 7M of .h files, which is more than necessary.
+# It's also possibly too homogenous.
+# https://github.com/torvalds/linux
+
+# popular and used by R2C
+https://github.com/git/git
+https://github.com/curl/curl
+https://github.com/openssl/openssl
 
 #TODO: get some hard-to-recover out of memory error, so skipped for now
 #https://github.com/radareorg/radare2

--- a/parsing-stats/lang/cpp/projects.txt
+++ b/parsing-stats/lang/cpp/projects.txt
@@ -8,13 +8,11 @@ https://github.com/microsoft/terminal
 https://github.com/apple/swift
 https://github.com/opencv/opencv
 https://github.com/bitcoin/bitcoin
-https://github.com/protocolbuffers/protobuf
 https://github.com/pytorch/pytorch
 https://github.com/tesseract-ocr/tesseract
 https://github.com/godotengine/godot
 https://github.com/x64dbg/x64dbg
 https://github.com/BVLC/caffe
-https://github.com/grpc/grpc
 https://github.com/ariya/phantomjs
 https://github.com/ocornut/imgui
 https://github.com/rethinkdb/rethinkdb
@@ -32,3 +30,7 @@ https://github.com/mongodb/mongo
 https://github.com/apache/incubator-mxnet
 https://github.com/facebook/rocksdb
 https://github.com/ApolloAuto/apollo
+
+# popular and used by R2C
+https://github.com/protocolbuffers/protobuf
+https://github.com/grpc/grpc

--- a/parsing-stats/lang/go/projects.txt
+++ b/parsing-stats/lang/go/projects.txt
@@ -1,11 +1,20 @@
-#TODO? skip the compiler as it may contain lots of test files?
-https://github.com/golang/go.git
-https://github.com/kubernetes/kubernetes.git
-https://github.com/moby/moby.git
-https://github.com/gohugoio/hugo.git
-https://github.com/gin-gonic/gin.git
-https://github.com/fatedier/frp.git
-https://github.com/astaxie/build-web-application-with-golang.git
-https://github.com/gogs/gogs.git
-https://github.com/v2ray/v2ray-core.git
-https://github.com/syncthing/syncthing.git
+
+# Popular projects
+# TODO? should we skip the compiler as it may contain lots of test files?
+https://github.com/golang/go
+https://github.com/gohugoio/hugo
+https://github.com/gin-gonic/gin
+https://github.com/fatedier/frp
+https://github.com/astaxie/build-web-application-with-golang
+https://github.com/gogs/gogs
+https://github.com/v2ray/v2ray-core
+https://github.com/syncthing/syncthing
+
+# Popular and used by R2C
+https://github.com/kubernetes/kubernetes
+https://github.com/moby/moby
+
+# Used by R2C
+https://github.com/github/hub
+https://github.com/argoproj/argo-cd
+https://github.com/hashicorp/terraform

--- a/parsing-stats/lang/hack/projects.txt
+++ b/parsing-stats/lang/hack/projects.txt
@@ -5,7 +5,6 @@
 # files, so the parsing line count is only at 8000 right now, even with
 # all those projects
 https://github.com/facebookarchive/hack-example-site.git
-# https://github.com/titon/framework.git
 https://github.com/facebookarchive/oss-performance.git
 https://github.com/igorw/reasoned-php.git
 https://github.com/hacktx/nucleus.git
@@ -20,7 +19,6 @@ https://github.com/ivivian/EchartSample.git
 https://github.com/JarJarBernie/jimmybox5.git
 https://github.com/XinLiangCoder/web_barrage.git
 https://github.com/wangzhenjjcn/WZ_WEB_ENGINE.git
-# https://github.com/nuxed/framework.git
 https://github.com/hhvm/type-assert.git
 https://github.com/pauloamgomes/BackupAndRestore.git
 https://github.com/iamcal/grant-pattishall-award.com.git
@@ -33,3 +31,5 @@ https://github.com/usox/hackttp.git
 https://github.com/nazg-hack/framework.git
 https://github.com/philsinatra/IDM231.git
 https://github.com/jesseschalken/hack-utils.git
+# https://github.com/titon/framework.git
+# https://github.com/nuxed/framework.git

--- a/parsing-stats/lang/java/projects.txt
+++ b/parsing-stats/lang/java/projects.txt
@@ -1,15 +1,15 @@
 #
 # Collection of public git repositories of java code.
 #
-https://github.com/elastic/elasticsearch.git
-https://github.com/spring-projects/spring-boot.git
-https://github.com/ReactiveX/RxJava.git
-https://github.com/google/guava.git
+https://github.com/elastic/elasticsearch
+https://github.com/spring-projects/spring-boot
+https://github.com/ReactiveX/RxJava
+https://github.com/google/guava
 # okhttp seems more kotlin than Java
-https://github.com/square/okhttp.git
-https://github.com/square/retrofit.git
+https://github.com/square/okhttp
+https://github.com/square/retrofit
 https://github.com/PhilJay/MPAndroidChart
 # project in "maintenance-mode"
-https://github.com/zxing/zxing.git
+https://github.com/zxing/zxing
 # last update was 1 year ago, seems dead
-https://github.com/crossoverJie/JCSprout.git
+https://github.com/crossoverJie/JCSprout

--- a/parsing-stats/lang/javascript/projects.txt
+++ b/parsing-stats/lang/javascript/projects.txt
@@ -25,3 +25,6 @@ https://github.com/hakimel/reveal.js.git
 # a preprocessor over each file to turn it into standard javascript.
 #
 #https://github.com/nodejs/node.git
+
+# Used by R2C
+https://github.com/getredash/redash

--- a/parsing-stats/lang/lua/projects.txt
+++ b/parsing-stats/lang/lua/projects.txt
@@ -1,7 +1,5 @@
 # TODO? should we skip the interpreter? it may contain lots of test files.
 https://github.com/lua/lua
-#RPC error at clone so skipped for now
-#https://git.net-core.org/tome/t-engine4.git
 https://github.com/EmmyLua/VSCode-EmmyLua
 https://github.com/EvandroLG/pegasus.lua
 https://github.com/Kong/kong
@@ -29,3 +27,5 @@ https://github.com/openresty/lua-resty-redis
 https://github.com/rxi/json.lua
 https://github.com/rxi/lite
 https://github.com/Ruin0x11/OpenNefia
+#RPC error at clone so skipped for now
+#https://git.net-core.org/tome/t-engine4.git

--- a/parsing-stats/lang/ocaml/projects.txt
+++ b/parsing-stats/lang/ocaml/projects.txt
@@ -1,35 +1,37 @@
 # Git URLs of publicly-accessible projects to be used for parsing stats,
 # one per line.
-#
 
-# r2c's ocaml projects
-https://github.com/returntocorp/semgrep.git
+# R2C'S OCaml projects
+https://github.com/returntocorp/semgrep
 https://github.com/returntocorp/pfff
 
-#
 # Projects with more than 1000 stars on GitHub.
 # (we could add more, we're looking for large amounts of handwritten
 # code rather than popularity)
 #
-# TODO? should we skip the compiler repo? it contains lots of test files.
-# https://github.com/ocaml/ocaml.git
-https://github.com/facebook/flow.git
-https://github.com/reasonml/reason.git
-https://github.com/facebook/pyre-check.git
-https://github.com/astrada/google-drive-ocamlfuse.git
-https://github.com/batsh-dev-team/Batsh.git
-https://github.com/coq/coq.git
-https://github.com/fastpack/fastpack.git
-https://github.com/bcpierce00/unison.git
-https://github.com/mirage/mirage.git
-https://github.com/mirage/irmin.git
-https://github.com/BinaryAnalysisPlatform/bap.git
-https://github.com/tomprimozic/type-systems.git
-https://github.com/ocaml/merlin.git
-https://github.com/MLstate/opalang.git
-https://github.com/airbus-seclab/bincat.git
-https://github.com/ocaml/dune.git
+https://github.com/facebook/flow
+https://github.com/reasonml/reason
+https://github.com/facebook/pyre-check
+https://github.com/astrada/google-drive-ocamlfuse
+https://github.com/batsh-dev-team/Batsh
+https://github.com/coq/coq
+https://github.com/fastpack/fastpack
+https://github.com/bcpierce00/unison
+https://github.com/mirage/mirage
+https://github.com/mirage/irmin
+https://github.com/BinaryAnalysisPlatform/bap
+https://github.com/tomprimozic/type-systems
+https://github.com/MLstate/opalang
+https://github.com/airbus-seclab/bincat
+
+# popular and used by R2C
+https://github.com/ocaml/dune
+https://github.com/ocaml/merlin
+
+# We currently skip the compiler repo because it contains lots of test files
+# which are not representative of regular OCaml code
+# https://github.com/ocaml/ocaml
 
 # this contains a 22MB whole_compiler.ml file that requires 4GB
-# of memory to parse.
-https://github.com/rescript-lang/rescript-compiler.git
+# of memory to parse, which is a good stress test for semgrep
+https://github.com/rescript-lang/rescript-compiler

--- a/parsing-stats/lang/python/projects.txt
+++ b/parsing-stats/lang/python/projects.txt
@@ -10,14 +10,10 @@ https://github.com/vinta/awesome-python
 https://github.com/ytdl-org/youtube-dl
 https://github.com/tensorflow/models
 https://github.com/nvbn/thefuck
-https://github.com/django/django
-https://github.com/pallets/flask
 https://github.com/keras-team/keras
 https://github.com/httpie/httpie
 https://github.com/josephmisiti/awesome-machine-learning
 https://github.com/ansible/ansible
-# This repo has some metaprogramming stuff that doesn't parse as valid Python
-# https://github.com/huggingface/transformers
 https://github.com/scikit-learn/scikit-learn
 https://github.com/psf/requests
 https://github.com/home-assistant/core
@@ -27,10 +23,21 @@ https://github.com/minimaxir/big-list-of-naughty-strings
 https://github.com/soimort/you-get
 https://github.com/ageitgey/face_recognition
 https://github.com/apache/superset
-# cpython seems to have some augmented Python syntax and unrealistic test cases
-# https://github.com/python/cpython
 https://github.com/deepfakes/faceswap
 https://github.com/3b1b/manim
 https://github.com/shadowsocks/shadowsocks
 https://github.com/tiangolo/fastapi
 https://github.com/fighting41love/funNLP
+# This repo has some metaprogramming stuff that doesn't parse as valid Python
+# https://github.com/huggingface/transformers
+# cpython seems to have some augmented Python syntax and unrealistic test cases
+# https://github.com/python/cpython
+
+# popular and used by R2C
+https://github.com/django/django
+https://github.com/pallets/flask
+
+# used by R2C
+https://github.com/python/mypy
+https://github.com/getredash/redash
+https://github.com/getsentry/sentry

--- a/parsing-stats/lang/ruby/projects.txt
+++ b/parsing-stats/lang/ruby/projects.txt
@@ -30,7 +30,6 @@ https://github.com/jekyll/jekyll
 https://github.com/discourse/discourse
 https://github.com/fastlane/fastlane
 https://github.com/gitlabhq/gitlabhq
-https://github.com/Homebrew/brew
 https://github.com/heartcombo/devise
 https://github.com/hashicorp/vagrant
 https://github.com/diaspora/diaspora
@@ -46,7 +45,6 @@ https://github.com/activeadmin/activeadmin
 https://github.com/faker-ruby/faker
 https://github.com/kaminari/kaminari
 https://github.com/heartcombo/simple_form
-https://github.com/Homebrew/homebrew-core
 https://github.com/thoughtbot/factory_bot
 https://github.com/lewagon/setup
 https://github.com/realm/jazzy
@@ -54,3 +52,7 @@ https://github.com/chef/chef
 https://github.com/puma/puma
 https://github.com/pry/pry
 https://github.com/github-changelog-generator/github-changelog-generator
+
+# Popular and used by R2C
+https://github.com/Homebrew/brew
+https://github.com/Homebrew/homebrew-core

--- a/parsing-stats/lang/rust/projects.txt
+++ b/parsing-stats/lang/rust/projects.txt
@@ -34,3 +34,6 @@ https://github.com/BurntSushi/ripgrep
 https://github.com/sharkdp/fd
 https://github.com/diem/diem
 https://github.com/Ruin0x11/adieu
+
+# used by r2c
+https://github.com/tree-sitter/tree-sitter

--- a/parsing-stats/lang/typescript/projects.txt
+++ b/parsing-stats/lang/typescript/projects.txt
@@ -10,7 +10,6 @@
 
 https://github.com/ant-design/ant-design
 https://github.com/angular/angular
-https://github.com/microsoft/vscode
 https://github.com/ionic-team/ionic
 https://github.com/angular/angular-cli
 https://github.com/akveo/ngx-admin
@@ -32,6 +31,12 @@ https://github.com/swimlane/ngx-datatable
 https://github.com/NativeScript/NativeScript
 https://github.com/ant-design/ant-design-mobile
 https://github.com/basarat/typescript-book
+
+# popular and used by R2C
+https://github.com/microsoft/vscode
+
+# Used by R2C
+https://github.com/getsentry/sentry
 
 # Too many weird test cases in the following:
 # https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
I've mostly added projects that we use at R2C (e.g., sentry,
terraform, hub)

test plan:
./test-lang python
wait for circle CI to finish


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)