### PR TITLE
fix: Use unique home directory for test_api

### DIFF
--- a/changelog.d/app-2166.fixed
+++ b/changelog.d/app-2166.fixed
@@ -1,0 +1,2 @@
+Fixed nondeterministic failure of test_api test due to invalid settings file by
+configuring home directory to temporary directory.

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -359,6 +359,12 @@ def _run_semgrep(
     return result
 
 
+@pytest.fixture()
+def unique_home_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    yield tmp_path
+
+
 @pytest.fixture
 def run_semgrep():
     yield partial(_run_semgrep, strict=False, target_name=None, output_format=None)

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -361,6 +361,9 @@ def _run_semgrep(
 
 @pytest.fixture()
 def unique_home_dir(monkeypatch, tmp_path):
+    """
+    Assign the home directory to a unique temporary directory.
+    """
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     yield tmp_path
 

--- a/cli/tests/e2e/test_api.py
+++ b/cli/tests/e2e/test_api.py
@@ -10,6 +10,8 @@ from semgrep.semgrep_main import invoke_semgrep
 @pytest.mark.slow
 def test_api(unique_home_dir, capsys, run_semgrep_in_tmp):
     # Test that exposed python API works and prints out nothing to stderr or stdout
+    # unique_home_dir is used to ensure that the test runs with it's own
+    # settings.yaml file to avoid reading one corrupted by another concurrent test run.
     output = invoke_semgrep(
         Path("rules/eqeq.yaml"),
         [Path("targets/bad/invalid_python.py"), Path("targets/basic/stupid.py")],

--- a/cli/tests/e2e/test_api.py
+++ b/cli/tests/e2e/test_api.py
@@ -8,7 +8,7 @@ from semgrep.semgrep_main import invoke_semgrep
 
 
 @pytest.mark.slow
-def test_api(capsys, run_semgrep_in_tmp):
+def test_api(unique_home_dir, capsys, run_semgrep_in_tmp):
     # Test that exposed python API works and prints out nothing to stderr or stdout
     output = invoke_semgrep(
         Path("rules/eqeq.yaml"),


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
