### PR TITLE
fix(CI): Do not overwrite Jenkins SEMGREP_REPO_NAME environment variable with autodetection

### DIFF
--- a/changelog.d/app-2331.fixed
+++ b/changelog.d/app-2331.fixed
@@ -1,0 +1,1 @@
+Change default behavior of Jenkins CI configurations. If the SEMGREP_REPO_NAME environment variable is set, use it. Otherwise, default autodetection.

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -199,7 +199,7 @@ class ScanHandler:
         logger.debug("Starting scan")
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/deployments/scans",
-            json={"meta": meta, "policy": self._policy_names},
+            json={"meta": meta, "policy_names": self._policy_names},
         )
 
         if response.status_code == 404:

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -587,6 +587,9 @@ class JenkinsMeta(GitMeta):
         This assumes that the url is in the github format.
         """
         name = get_repo_name_from_repo_url(os.getenv("GIT_URL"))
+        repo_name = os.getenv("SEMGREP_REPO_NAME")
+        if repo_name:
+            return repo_name
         return name if name else super().repo_name
 
     @property

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": false,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
@@ -22,7 +22,7 @@
     "start_sha": null,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
@@ -22,7 +22,7 @@
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": false,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
@@ -22,7 +22,7 @@
     "start_sha": null,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
@@ -22,7 +22,7 @@
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -330,6 +330,13 @@ def mock_autofix(request, mocker):
             "GIT_BRANCH": BRANCH_NAME,
             "BUILD_URL": "https://jenkins.build.url",
         },
+        {  # Jenkins overwrite repo_name
+            "JENKINS_URL": "some_url",
+            "SEMGREP_REPO_NAME": "a/repo/name",
+            "GIT_URL": "https://github.com/org/repo.git/",
+            "GIT_BRANCH": BRANCH_NAME,
+            "BUILD_URL": "https://jenkins.build.url",
+        },
         {  # Jenkins, not defined GIT_URL
             "JENKINS_URL": "some_url",
             "SEMGREP_REPO_URL": "https://random.url.org/some/path",


### PR DESCRIPTION
PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)

Closes APP-2331
