### PR TITLE
fix(CLI): change key in start_scan from policy to policy_name to be consistent with the app

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -199,7 +199,7 @@ class ScanHandler:
         logger.debug("Starting scan")
         response = state.app_session.post(
             f"{state.env.semgrep_url}/api/agent/deployments/scans",
-            json={"meta": meta, "policy": self._policy_names},
+            json={"meta": meta, "policy_names": self._policy_names},
         )
 
         if response.status_code == 404:

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": false,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/meta.json
@@ -22,7 +22,7 @@
     "start_sha": null,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/meta.json
@@ -22,7 +22,7 @@
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": false,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/meta.json
@@ -22,7 +22,7 @@
     "start_sha": null,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/meta.json
@@ -22,7 +22,7 @@
     "start_sha": "unused-commit-test-placeholder",
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/meta.json
@@ -20,7 +20,7 @@
     "is_full_scan": true,
     "is_sca_scan": false
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"


### PR DESCRIPTION
PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
