### PR TITLE
chore: update to latest semgrep-rules and fix regressions

### DIFF
--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -643,8 +643,6 @@ let full_rule_semgrep_rules_regression_tests () =
                        =~ ".*/terraform/aws/security/aws-fsx-lustre-files-ystem.yaml"
                     (* TODO: parse error, weird *)
                     || s =~ ".*/unicode/security/bidi.yml"
-                    || s
-                       =~ ".*/javascript/audit/detect-replaceall-sanitization.yaml"
                     (* TODO many mismatches *)
                     || s =~ ".*/generic/ci/audit/changed-semgrepignore.*"
                     || s


### PR DESCRIPTION
The code in Unit_engine.ml was not handling the new .fixed.xxx files
that has been added recently (by Pieter I think).

This is hopefully one of the last manual update of semgrep-rules.
I've started to make a new github action workflow to automate it
so we can catch problems ASAP.

test plan:
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)