### PR TITLE
tests: Update snapshots

### DIFF
--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/meta.json
@@ -24,7 +24,7 @@
       "tag_key:tag_val"
     ]
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -11,7 +11,16 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 2
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -25,12 +34,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 2
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -40,6 +43,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/meta.json
@@ -24,7 +24,7 @@
       "tag_key:tag_val"
     ]
   },
-  "policy": [
+  "policy_names": [
     "audit",
     "comment",
     "block"

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -11,7 +11,16 @@ CI="true" GITHUB_ACTIONS="true" GITHUB_EVENT_NAME="pull_request" GITHUB_REPOSITO
 
 === stdout - plain
 
-Findings:
+Non-Blocking Findings:
+
+  foo.py 
+     eqeq-five
+        useless comparison to 5
+
+         ▶▶┆ Autofix ▶ x == 2
+         15┆ x == 5
+
+Blocking Findings:
 
   foo.py 
      eqeq-bad
@@ -25,12 +34,6 @@ Findings:
           ⋮┆----------------------------------------
          11┆ y == y
           ⋮┆----------------------------------------
-     eqeq-five
-        useless comparison to 5
-
-         ▶▶┆ Autofix ▶ x == 2
-         15┆ x == 5
-          ⋮┆----------------------------------------
      eqeq-four
         useless comparison to 4
 
@@ -40,6 +43,11 @@ Findings:
         unsafe use of danger
 
          27┆ sink(d2)
+
+Blocking Rules Fired:
+   eqeq-bad   
+   eqeq-four   
+   taint-test
 
 === end of stdout - plain
 


### PR DESCRIPTION
https://github.com/returntocorp/semgrep/pull/6102 broke the snapshot tests. That PR was based on an old revision, and it wasn't rebased over some recent changes to the CLI output before merging. So, the tests were green, and the merge succeeded, but now the tests fail.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
