### PR TITLE
fix: Use semgrep-core's rendered fix when constructing RuleMatch

### DIFF
--- a/cli/src/semgrep/autofix.py
+++ b/cli/src/semgrep/autofix.py
@@ -68,9 +68,6 @@ def _basic_fix(
     rule_match: RuleMatch, file_offsets: FileOffsets, fix: str
 ) -> Tuple[Fix, FileOffsets]:
 
-    if rule_match.match.extra.rendered_fix:
-        fix = rule_match.match.extra.rendered_fix
-
     p = rule_match.path
     lines = _get_lines(p)
 

--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -156,11 +156,12 @@ def core_matches_to_rule_matches(
         rule = rule_table[match.rule_id.value]
         matched_values, propagated_values = read_metavariables(match)
         message = interpolate(rule.message, matched_values, propagated_values)
-        fix = (
-            interpolate(rule.fix, matched_values, propagated_values)
-            if rule.fix
-            else None
-        )
+        if match.extra.rendered_fix:
+            fix = match.extra.rendered_fix
+        elif rule.fix:
+            fix = interpolate(rule.fix, matched_values, propagated_values)
+        else:
+            fix = None
         fix_regex = None
 
         # this validation for fix_regex code was in autofix.py before


### PR DESCRIPTION
Previously, the fix from semgrep-core would get applied, but the CLI would display the autofix that it computed.

Doing this earlier in the pipeline means that the CLI displays the same fix that it applies. It also just seems cleaner.

I don't think this needs a changelog entry because this code won't actually be exercised until #6143 is merged, so it's fixing something that no user could have experienced.

Test plan:

* Automated tests
* Manual test with test case given in #4964, along with the code in #6143. Verify that the CLI displays the correct autofix in the match result in addition to applying the correct autofix.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
