### PR TITLE
fix: don't parse ts patterns to `Pr`

### DIFF
--- a/changelog.d/pa-1910.fixed
+++ b/changelog.d/pa-1910.fixed
@@ -1,0 +1,1 @@
+Added a fix for a bug involving parsing of TS imports.

--- a/changelog.d/pa-1910.fixed
+++ b/changelog.d/pa-1910.fixed
@@ -1,1 +1,1 @@
-Added a fix for a bug involving parsing of TS imports.
+Added a fix for a bug involving parsing of TS imports, where they were not allowed to appear as patterns to a rule.

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -3225,4 +3225,6 @@ let parse_pattern str =
     (fun cst ->
       let file = "<pattern>" in
       let env = { H.file; conv = Hashtbl.create 0; extra = () } in
-      program env cst)
+      match program env cst with
+      | Program ss -> Stmts ss
+      | other -> other)

--- a/semgrep-core/tests/OTHER/rules/parse_pattern_as_stmt.ts
+++ b/semgrep-core/tests/OTHER/rules/parse_pattern_as_stmt.ts
@@ -1,0 +1,2 @@
+// ruleid: program-pattern
+import i = require('foo')

--- a/semgrep-core/tests/OTHER/rules/parse_pattern_as_stmt.yaml
+++ b/semgrep-core/tests/OTHER/rules/parse_pattern_as_stmt.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: program-pattern 
+    pattern: |
+      import $I = $FOO; 
+    message: "This should not parse as a Program, or it will break the matching." 
+    languages:
+      - typescript
+    severity: ERROR


### PR DESCRIPTION
**What:**
This PR implements a change which parses TS/JS in a way that pattern parsing does not lead to the `Pr` constructor being used.

**Why:**
Someone pulled up in the community slack with this issue:
https://r2c-community.slack.com/archives/C018NJRRCJ0/p1663850040935109

Basically, the pattern 
```
import $K = require('aws-cdk-lib/aws-rds')
...
```
was being parsed to a `Pr`. However, the engine in `Match_patterns` only deals with a few variants of `any`, and namely `Pr` is not one of them. So it just `failwith`s.

**How:**
In the parsing of the pattern, I add a `match` which converts any `Pr` to an `Ss`. This only happens in `parse_pattern`, so there's no risk of it affecting target parsing.

**Comments:**
I'm not in love with the fact that there's this distinction between `Pr` and `Ss`, because I don't really see why there ought to be. We have to insert logic converting between the other (in several places), when really I don't know of a time when we have to dispatch on that information in a meaningful way. Unless there is a strong reason to keep it, I would be inclined towards refactoring to eliminate this variant.

Another solution that was considered was to add a case to `Match_patterns` which handles `Pr`, but we decided not to go for that approach.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
