### PR TITLE
feat(terraform): IL translation of module calls and variable usages

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -566,9 +566,7 @@ and expr_aux env ?(void = false) e_gen =
                                         ( _,
                                           {
                                             id_resolved =
-                                              Some
-                                                ( G.ResolvedName (dotted_id, _),
-                                                  _ );
+                                              { contents = Some _; _ };
                                             _;
                                           } )) as name;
                                   _;
@@ -582,22 +580,24 @@ and expr_aux env ?(void = false) e_gen =
                 {
                   s =
                     DefStmt
-                      ( { name = EN (Id ((arg_name, _), _)); _ },
+                      ( { name = EN (Id (arg_id, _)); _ },
                         VarDef { vinit = Some arg_exp; _ } );
                   _;
                 } ->
-                Right3 (arg_name, arg_exp)
+                Right3 (G.ArgKwd (arg_id, arg_exp))
             | _ ->
                 (* bTODO: Ignore all other cases. They correspond neither to the module's name, or its arguments. *)
                 Middle3 ())
           fields
       in
+      let tok = G.fake "call" in
       match mod_sources with
-      | [ mod_source ] -> call_generic env ~void tok
+      | [ mod_source ] ->
+          call_generic env ~void tok (mod_source |> G.e)
+            (G.fake_bracket mod_args)
       | _ ->
           (* Don't know how to interpret multiple sources. Just let this go to the wildcard case.
          *)
-          let tok = G.fake "call" in
           call_generic env ~void tok e args)
   | G.New (tok, ty, args) ->
       (* TODO: lift up New in IL like we did in AST_generic *)


### PR DESCRIPTION
## What:
This PR has to do with changing all module declarations in Terraform to "fake function calls", which will sync up with work done in previous PRs.

## Why:
See the current scope doc [here](https://docs.google.com/document/d/1yoHq0RNvVhhlH51PyMPzzSvUFIYlmoMavCV2LzRy2d4/edit?usp=sharing). Basically, we are modeling module instantiation as the calling of a fake module function. As such, module definitions have to be translated during IL translation into function calls, with parameters as specified in the declaration. This will hook into the existing taint engine logic.

## How:
We changed module declarations here to be real function calls. The parameters will all have fake `sid`s, though, which will muck with the lvalue matching process. This can be fixed at a later date by changing the lvalue comparison function.

## Test plan:
Since this is having to do with DeepSemgrep, I necessarily cannot test these changes here. It will be testable upon consolidation with other PRs.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
