### PR TITLE
feat!: allow lvalue comparison to unknown `sid`s

### DIFF
--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -22,6 +22,11 @@ open IL
 let compare_name x y =
   let ident_cmp = String.compare (fst x.ident) (fst y.ident) in
   if ident_cmp <> 0 then ident_cmp
+    (* If their names match, and either of the names have an unresolved sid,
+       then let's just say that they are the same.
+       In particular, this will help with Terraform, where we purposefully introduce
+       unresolved names as the parameters to fake functions.
+    *)
   else if x.sid = -1 || y.sid = -1 then 0
   else Int.compare x.sid y.sid
 

--- a/semgrep-core/src/core/il/IL_lvalue_helpers.ml
+++ b/semgrep-core/src/core/il/IL_lvalue_helpers.ml
@@ -21,7 +21,9 @@ open IL
 
 let compare_name x y =
   let ident_cmp = String.compare (fst x.ident) (fst y.ident) in
-  if ident_cmp <> 0 then ident_cmp else Int.compare x.sid y.sid
+  if ident_cmp <> 0 then ident_cmp
+  else if x.sid = -1 || y.sid = -1 then 0
+  else Int.compare x.sid y.sid
 
 let rexps_of_instr x =
   match x.i with


### PR DESCRIPTION
## What:
This PR adds the ability to say that any lvalue with matching names are the same, if one of them has an unresolved `sid`.

## Why:
In implementing Terraform changes, I had to construct a fake function definition for each module. In particular, I had to add parameters for the function, after the naming stage, which necessarily have `sid`s as `-1`. When comparing variables for comparison in taint analysis, it will automatically reject them if they have the same name, as long as they don't have the same `sid`s. I would like this functionality so that, even if we don't resolve the name of a variable, we go by identifier matching to say that they are the same.

## How:
Changed the comparison function for names which is used for lvalue comparison.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
