### PR TITLE
fix: [APP-2379] Pass SEMGREP_SETTINGS_FILE to subprocess

### DIFF
--- a/changelog.d/app-2379.fixed
+++ b/changelog.d/app-2379.fixed
@@ -1,0 +1,2 @@
+Fixed nondeterministic failure of test_api test (again) by splitting out the
+subprocess call into a separate test and passing SEMGREP_SETTINGS_FILE env var.

--- a/changelog.d/app-2379.fixed
+++ b/changelog.d/app-2379.fixed
@@ -1,2 +1,0 @@
-Fixed nondeterministic failure of test_api test (again) by splitting out the
-subprocess call into a separate test and passing SEMGREP_SETTINGS_FILE env var.

--- a/cli/tests/e2e/test_api.py
+++ b/cli/tests/e2e/test_api.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -24,7 +25,12 @@ def test_api(unique_home_dir, capsys, run_semgrep_in_tmp):
     assert captured.out == ""
     assert captured.err == ""
 
+
+@pytest.mark.slow
+def test_api_via_cli(unique_home_dir, run_semgrep_in_tmp):
     # Check that logging code isnt handled by default root handler and printed to stderr
+    env = os.environ.copy()
+    env["SEMGREP_SETTINGS_FILE"] = str(unique_home_dir / ".semgrep/settings.yaml")
     x = subprocess.run(
         [
             sys.executable,
@@ -33,6 +39,7 @@ def test_api(unique_home_dir, capsys, run_semgrep_in_tmp):
         ],
         encoding="utf-8",
         capture_output=True,
+        env=env,
     )
     assert x.stdout == ""
     assert x.stderr == ""

--- a/cli/tests/e2e/test_api.py
+++ b/cli/tests/e2e/test_api.py
@@ -29,7 +29,10 @@ def test_api(unique_home_dir, capsys, run_semgrep_in_tmp):
 @pytest.mark.slow
 def test_api_via_cli(unique_home_dir, run_semgrep_in_tmp):
     # Check that logging code isnt handled by default root handler and printed to stderr
+    # This is run as a separate test from the one above so that it has a separate, temp directory
     env = os.environ.copy()
+    # Assign env var for settings.yaml to the per-test unique home directory
+    # so it doesn't use the default (~/.semgrep/settings.yaml)
     env["SEMGREP_SETTINGS_FILE"] = str(unique_home_dir / ".semgrep/settings.yaml")
     x = subprocess.run(
         [


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
