### PR TITLE
Define Code Owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,20 @@
+# Together with the correct GitHub project setting, this limits who can
+# approve pull requests.
+# It's also used by GitHub to suggest reviewers.
+
+# Default owners:
+# Program Analysis team at r2c
+* @returntocorp/pa
+
+# Python CLI code base.
+#
+# Too many people? Not enough people?
+# Consider updating GitHub teams rather than
+# adding individuals here.
+cli @returntocorp/pa @returntocorp/cli @returntocorp/sca
+
+# CI
+.github @returntocorp/devops @returntocorp/pa
+
+# CI not supported by DevOps
+.circleci @returntocorp/pa


### PR DESCRIPTION
This is similar to https://github.com/returntocorp/ocaml-tree-sitter-core/pull/49 but will affect more people. This setup will auto-assign PR reviewers and will require one approval from them.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
