### PR TITLE
sym-prop: Fix propagatation of New expressions

### DIFF
--- a/changelog.d/gh-6161.fixed
+++ b/changelog.d/gh-6161.fixed
@@ -1,0 +1,3 @@
+Fixed symbolic propagation of the `new` operator, that had been broken since
+version 0.98.0. You can again e.g. use the pattern `new A().foo()` to match
+`a.foo()`, with `a = new A()`.

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -527,15 +527,17 @@ let transfer :
               update_env_with inp' var ccall
         | CallSpecial
             (Some { base = Var var; rev_offset = [] }, (special, _), args) ->
+            let args = Common.map IL_helpers.exp_of_arg args in
             let cexp =
-              (* We try to evalaute the special function. *)
+              (* We try to evaluate the special function, if we know how. *)
               if special = Concat then
                 (* var = concat(args) *)
-                args |> Common.map IL_helpers.exp_of_arg |> eval_concat inp'
+                eval_concat inp' args
               else G.NotCst
             in
             let cexp =
-              (* If we could not evaluate it, then we do sym-prop. *)
+              (* If we don't know how to evaluate this function, or if the
+               * evaluation fails, then we do sym-prop. *)
               if cexp = G.NotCst then sym_prop instr.iorig else cexp
             in
             update_env_with inp' var cexp

--- a/semgrep-core/tests/OTHER/rules/sym_prop_new.java
+++ b/semgrep-core/tests/OTHER/rules/sym_prop_new.java
@@ -1,0 +1,7 @@
+class h {
+    void f(){
+        A a = new B();
+        //ruleid: test
+        a.test();
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/sym_prop_new.yaml
+++ b/semgrep-core/tests/OTHER/rules/sym_prop_new.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: test
+    options:
+      symbolic_propagation: true
+    pattern: new B().test(...)
+    message: Semgrep found a match
+    languages:
+      - java
+    severity: WARNING
+


### PR DESCRIPTION
Fixes: 995163b526d ("fix(js): Parse `New` as a separate construct from `Call` (#5510)")

PR #5510 made `new` expressions different from function calls, thus breaking symbolic propagation of `new`.

Closes #6161
Closes PA-1911

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
