### PR TITLE
Simplify (and comment more) Dockerfile thx to the new returntocorp/ocaml:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,7 @@ ENV SEMGREP_IN_DOCKER=1 \
 WORKDIR /src
 
 # semgrep is now available /usr/local/bin thx to the 'pip install' command
-# above, so let's remove /semgrep which is not needed anymore. 
+# above, so let's remove /semgrep which is not needed anymore.
 #
 # Note that this is only a cleanup. This does not reduce the size of
 # the Docker image. Indeed, this is how Docker images work. The state

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@
 # Step1: build semgrep-core
 ###############################################################################
 
-# The Docker image below (after the 'FROM') is prepackaged with OCaml, 'opam',
-# and lots of packages that are used by semgrep-core and installed in
+# The Docker image below (after the 'FROM') is prepackaged with 'ocamlc',
+# 'opam', and lots of packages that are used by semgrep-core and installed in
 # 'make setup' further below.
 # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine.sh
 # Thanks to this container, 'make setup' finishes very quickly because it's
@@ -25,10 +25,13 @@
 #    but building a Docker image would take longer because
 #    of all the necessary Semgrep dependencies installed in 'make setup'.
 #    Note also that ocaml/opam:alpine default user is 'opam', not 'root', which
-#    is not without problems when used inside GHA or even inside this Dockerfile.
+#    is not without problems when used inside Github actions (GHA) or even inside
+#    this Dockerfile.
 #
-#  - alpine, but installing opam/ocaml from scratch on Alpine would take
-#    longer (and is not trivial).
+#  - basic alpine, but this would require some extra 'apk' commands to install opam
+#    and extra commands to setup OCaml with this opam from scratch. This would take
+#    far longer, and is also not trivial as 'opam' itself requires lots of extra
+#    tools like gcc, make, which are not provided by default on Alpine.
 #
 # Note that the Docker base image below currently uses OCaml 4.14.0
 # coupling: if you modify the OCaml version there, you probably also need
@@ -40,7 +43,6 @@
 # Note that many .github/workflows/ use returntocorp/ocaml:alpine, which should
 # be the latest, but may differ from this one.
 FROM returntocorp/ocaml:alpine-2022-09-24 as semgrep-core-container
-
 
 # Here is why we need those apk packages below:
 # - pcre-dev: for ocaml-pcre now used in semgrep-core

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN make setup
 # Let's build just semgrep-core
 WORKDIR /src/semgrep/semgrep-core
 # An alternative to the eval is to use 'opam exec -- ...'
-RUN eval $(opam env) && make minimal-build &&\
+RUN eval "$(opam env)" && make minimal-build &&\
      # Sanity check
      /src/semgrep/semgrep-core/_build/default/src/cli/Main.exe -version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
 ###############################################################################
 # Overview
 ###############################################################################
-#
-# First, build a *static* 'semgrep-core' binary on Alpine because it comes set
-# up for it (requires using musl rather than glibc).
+# First, build a *static* 'semgrep-core' binary on Alpine
+# (requires using musl rather than glibc).
 #
 # Then 'semgrep-core' alone is copied to a container which takes care
-# of the 'semgrep-python' wrapping.
-#
+# of the 'semgrep-cli' Python wrapping.
 
 ###############################################################################
 # Step1: build semgrep-core
 ###############################################################################
-#
 # The docker base image below in the FROM currently uses OCaml 4.14.0
 # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/alpine.sh
-#
 # coupling: if you modify the OCaml version there, you probably also need
 # to modify:
 # - scripts/{osx-release,osx-m1-release,setup-m1-builder}.sh
@@ -23,74 +19,38 @@
 # - https://github.com/Homebrew/homebrew-core/blob/master/Formula/semgrep.rb
 # Note that many .github/workflows/ use returntocorp/ocaml:alpine, which should
 # be the latest, but may differ from this one.
-FROM returntocorp/ocaml:alpine-2022-06-09@sha256:99b453a838c9d94414991c0fd7be4711aa1bcc120f576e0f0653c7b921ea9718 as semgrep-core
+FROM returntocorp/ocaml:alpine-2022-09-24 as semgrep-core-container
 
-USER root
 # Here is why we need those apk packages:
 # - pcre-dev: for ocaml-pcre now used in semgrep-core
 # - python3: used during building for processing lang.json
 # - python3-dev: for the semgrep Python bridge to build Python C extensions
 # TODO: update root image to include python 3.9
 RUN apk add --no-cache pcre-dev python3 python3-dev &&\
-     pip install --no-cache-dir pipenv==2022.6.7 &&\
-     # This mkdir/chown is needed on Arch Linux where the WORKDIR command does not honor
-     # the USER directive and all the directories are created as root
-     # (as it should be according to the spec, see https://github.com/moby/moby/issues/36677)
-     # The COPY --chown=user below are correctly adjusting the permissions of the files
-     # except the enclosing directory itself which would be owned by root. This would then
-     # prevent some commands (e.g., install-tree-sitter-lib, dune) to create files
-     # in the enclosing directory.
-     mkdir -p /semgrep/semgrep-core/src/ocaml-tree-sitter-core &&\
-     chown -R user /semgrep
+     pip install --no-cache-dir pipenv==2022.6.7
 
-USER user
+WORKDIR /src/semgrep
+COPY . .
+#TODO? git clean -dfX?
+RUN make setup
 
-ENV OPAMYES=true
-
-#TODO? we could reduce this to
-# COPY --chown=user . /semgrep
-# RUN make setup
-WORKDIR /semgrep/semgrep-core/src/ocaml-tree-sitter-core
-COPY --chown=user semgrep-core/src/ocaml-tree-sitter-core/ .
-RUN ./configure \
- && ./scripts/install-tree-sitter-lib
-
-WORKDIR /semgrep/semgrep-core/src/pfff
-COPY --chown=user semgrep-core/src/pfff/*.opam ./
-WORKDIR /semgrep/semgrep-core/src/ocaml-tree-sitter-core
-COPY --chown=user semgrep-core/src/ocaml-tree-sitter-core/*.opam ./
-WORKDIR /semgrep/semgrep-core
-COPY --chown=user semgrep-core/*.opam ./
-
-RUN opam install --deps-only \
-     /semgrep/semgrep-core/src/pfff \
-     /semgrep/semgrep-core/src/ocaml-tree-sitter-core \
-     /semgrep/semgrep-core
-
-# Copy all the source files needed to build semgrep-core
-WORKDIR /semgrep
-COPY --chown=user semgrep-core/ ./semgrep-core
-COPY --chown=user interfaces/ ./interfaces
-COPY --chown=user cli/src/semgrep/lang ./cli/src/semgrep/lang
-COPY --chown=user cli/src/semgrep/semgrep_interfaces ./cli/src/semgrep/semgrep_interfaces
-
-# Let's build it
-WORKDIR /semgrep/semgrep-core
-RUN opam exec -- make minimal-build &&\
+# Let's build just semgrep-core
+WORKDIR /src/semgrep/semgrep-core
+# An alternative to the eval is to use 'opam exec -- ...'
+RUN eval $(opam env) && make minimal-build &&\
      # Sanity check
-     /semgrep/semgrep-core/_build/default/src/cli/Main.exe -version
+     /src/semgrep/semgrep-core/_build/default/src/cli/Main.exe -version
 
 ###############################################################################
 # Step2: Build the final docker image with Python wrapper and semgrep-core bin
 ###############################################################################
-#
 # We change container, bringing the 'semgrep-core' binary with us.
-#
 
 FROM python:3.10-alpine AS semgrep-cli
 
 WORKDIR /semgrep
 
+#???
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true \
      PIP_NO_CACHE_DIR=true \
      PYTHONIOENCODING=utf8 \
@@ -99,13 +59,20 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=true \
 # Here is why we need those apk packages:
 # - bash: for entrypoint.sh (see below) and probably many other things
 # - git, git-lfs, openssh: so that the semgrep docker image can be used in
-#   github actions and get git submodules and use ssh to get those submodules
+#   Github actions and get git submodules and use ssh to get those submodules
 # - libstdc++: for the Python jsonnet binding now used in the semgrep CLI
 #   note: do not put libstdc++6, you'll get 'missing library' or 'unresolved
 #   symbol' errors
 RUN apk add --no-cache --virtual=.run-deps bash git git-lfs openssh libstdc++
+
+# We just need the Python code in cli/.
+# The semgrep-core stuff would be copied from the other container
 COPY cli ./
 
+# Use pip to install semgrep
+# Note the difference between .run-deps and .build-deps below.
+# TODO? what does --virtual= mean? why all in one command below?
+# TODO? why the mkdir -p /tmp/.cache?
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base && \
      SEMGREP_SKIP_BIN=true pip install /semgrep && \
@@ -114,6 +81,7 @@ RUN apk add --no-cache --virtual=.build-deps build-base && \
      apk del .build-deps && \
      mkdir -p /tmp/.cache
 
+# TODO: we should remove this (we were supposed to get rid of it in June 2022)
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
@@ -121,17 +89,16 @@ RUN chmod +x /entrypoint.sh
 COPY Dockerfile /Dockerfile
 
 # Get semgrep-core from step1
-COPY --from=semgrep-core /semgrep/semgrep-core/_build/default/src/cli/Main.exe /usr/local/bin/semgrep-core
+COPY --from=semgrep-core-container /src/semgrep/semgrep-core/_build/default/src/cli/Main.exe /usr/local/bin/semgrep-core
 
+# ???
 ENV SEMGREP_IN_DOCKER=1 \
      SEMGREP_VERSION_CACHE_PATH=/tmp/.cache/semgrep_version \
      SEMGREP_USER_AGENT_APPEND="Docker"
 
-WORKDIR /src
-
 # /semgrep is not needed anymore;
 # semgrep is now available /usr/local/bin thx to the 'pip install' command above
-# (this weirdly does not reduce the size of the docker image though)
+# TODO: this weirdly does not reduce the size of the docker image though
 RUN rm -rf /semgrep
 
 # In case of problems, if you need to debug the docker image, run 'docker build .',

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 # Thanks to this container, 'make setup' finishes very quickly because it's
 # mostly a noop. Alternative base container candidates are:
 #
-#  - 'ocaml/opam:alpine', the official OCaml/opam Docker image, 
+#  - 'ocaml/opam:alpine', the official OCaml/opam Docker image,
 #    but building our Docker image would take longer because
 #    of all the necessary Semgrep dependencies installed in 'make setup'.
 #

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,45 @@
 ###############################################################################
 # This Makefile is targeted at developers.
 # For a one-shot production build, look into Dockerfile.
+# 
+# This Makefile assumes some commands have been run before to install
+# the correct development environment supporting the different languages
+# used for semgrep development: 
+#  - for C: the classic 'gcc', 'ld', but also some C libraries like PCRE
+#  - for Python: 'python3', 'pip', 'pipenv', 'python-config'
+#  - for OCaml: 'opam' and the right OCaml switch (currently 4.14)
+# You will also need obviously 'make', but also 'git', and many other
+# common dev tools (e.g., 'docker').
+#
+# Once this basic development environment has been setup
+# (either via apk commands in a Dockerfile, or with some steps: apt-get
+# in GHA, or with your own brew/apt-get/pacman/whatever on your own machine),
+# you can then use:
+#
+#     $ make setup
+#
+# to install the dependencies proper to semgrep (e.g., the necessary OPAM
+# packages used by semgrep-core).
+# Then to compile semgrep simply type:
+#
+#     $ make
+#
+# See INSTALL.md for more information
+# See also https://semgrep.dev/docs/contributing/contributing-code/
 
 ###############################################################################
 # Portability tricks
 ###############################################################################
+
+# This Makefile should work equally under Linux (Alpine, Ubuntu, Arch linux),
+# macOS, or from a Dockerfile, and hopefully also under Windows WSL.
+# This is why you should avoid to use platform-specific commands like
+# package managers (e.g., apk, apt-get, brew) here. Instead you should
+# put those system-wide installation commands in the Dockerfile, or
+# in GHA workflows, or in scripts/ (e.g., scripts/install-alpine-semgrep-core).
+
+# If you really have to use platform-specific commands or flags, try to use
+# macros like the one below to make the Makefile portable.
 
 # Used to select commands with different usage under GNU/Linux and *BSD/Darwin
 # such as 'sed'.

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 ###############################################################################
 # This Makefile is targeted at developers.
 # For a one-shot production build, look into Dockerfile.
-# 
+#
 # This Makefile assumes some commands have been run before to install
 # the correct development environment supporting the different languages
-# used for semgrep development: 
+# used for semgrep development:
 #  - for C: the classic 'gcc', 'ld', but also some C libraries like PCRE
 #  - for Python: 'python3', 'pip', 'pipenv', 'python-config'
 #  - for OCaml: 'opam' and the right OCaml switch (currently 4.14)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-#
-# This makefile is targeted at developers.
+###############################################################################
+# Prelude
+###############################################################################
+# This Makefile is targeted at developers.
 # For a one-shot production build, look into Dockerfile.
-#
+
+###############################################################################
+# Portability tricks
+###############################################################################
 
 # Used to select commands with different usage under GNU/Linux and *BSD/Darwin
 # such as 'sed'.
@@ -18,10 +23,13 @@ else
   SED = sed -i ''
 endif
 
+###############################################################################
+# Build (and clean) targets
+###############################################################################
+
 # Routine build. It assumes all dependencies and configuration are already
 # in place and correct. It should be fast since it's called often during
 # development.
-#
 .PHONY: build
 build:
 	$(MAKE) build-core
@@ -29,18 +37,12 @@ build:
 	cd cli && pipenv install --dev
 	$(MAKE) -C cli build
 
-.PHONY: install
-install:
-	$(MAKE) -C semgrep-core install
-	python3 -m pip install semgrep
-
 .PHONY: build-core
 build-core:
 	$(MAKE) -C semgrep-core
 	$(MAKE) -C semgrep-core install
 
 # Update and rebuild everything within the project.
-#
 .PHONY: rebuild
 rebuild:
 	git submodule update --init
@@ -54,19 +56,42 @@ rebuild:
 build-docker:
 	docker build -t semgrep .
 
+# Remove from the project tree everything that's not under source control
+# and was not created by 'make setup'.
+#
+.PHONY: clean
+clean:
+	-$(MAKE) -C semgrep-core clean
+	-$(MAKE) -C cli clean
+
+###############################################################################
+# Install targets
+###############################################################################
+
+.PHONY: install
+install:
+	$(MAKE) -C semgrep-core install
+	python3 -m pip install semgrep
+
+###############################################################################
+# Setup targets
+###############################################################################
 
 # This is a best effort to install some external dependencies.
 # Should run infrequently.
-#
+# This target is portable and should work equally on Linux (Alpine and Ubuntu),
+# macOS, and inside Docker.
+# It only assumes you have 'git' and 'opam' installed, and a working
+# Python (e.g., python3, pip, pipenv, python-config) and OCaml (e.g., ocamlc).
+# Note that 'make setup' is now called from our Dockerfile so do not
+# run 'opam update' below to not slow down things.
 .PHONY: setup
 setup:
-	git submodule update --init
 	# Fetch, build and install the tree-sitter runtime library locally.
 	cd semgrep-core/src/ocaml-tree-sitter-core \
 	&& ./configure \
 	&& ./scripts/install-tree-sitter-lib
 	# Install OCaml dependencies (globally).
-	opam update -y
 	opam install -y --deps-only ./semgrep-core/src/pfff
 	opam install -y --deps-only ./semgrep-core/src/ocaml-tree-sitter-core
 	opam install -y --deps-only ./semgrep-core
@@ -94,20 +119,20 @@ homebrew-setup:
 	opam install -y --deps-only --no-depexts ./semgrep-core/src/ocaml-tree-sitter-core
 	opam install -y --deps-only --no-depexts ./semgrep-core
 
+###############################################################################
+# Developer targets
+###############################################################################
+
+.PHONY: update
+update:
+	git submodule update --init
+	opam update -y
+
 # Install development dependencies in addition to build dependencies.
-#
 .PHONY: dev-setup
 dev-setup:
 	$(MAKE) setup
 	opam install -y --deps-only ./semgrep-core/dev
-
-# Remove from the project tree everything that's not under source control
-# and was not created by 'make setup'.
-#
-.PHONY: clean
-clean:
-	-$(MAKE) -C semgrep-core clean
-	-$(MAKE) -C cli clean
 
 # Same as 'make clean' but may remove additional files, such as external
 # libraries installed locally.


### PR DESCRIPTION
Now that the returntocorp/ocaml:alpine use the 'user=root' default,
like most Docker images for languages (e.g., Golang, Rust),
the Dockerfile can be simpler.
See also https://github.com/returntocorp/ocaml-layer/pull/14
and
https://returntocorp.slack.com/archives/C01NXGX2EHZ/p1663937723277069
for a recent discussion on this topic.

test plan:
$ make build-docker
$ docker images # semgrep:latest still at 226MB (before compression)


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)