### PR TITLE
GHA cleanup part 1 (lint.yml), use new returntocorp/ocaml:ubuntu

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,7 @@ jobs:
           # coupling: must be the same than in semgrep-core/dev/dev.opam
           sudo opam install -y ocamlformat.0.21.0
           #TODO? why do we need that?
-          #sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
           #   fatal: detected dubious ownership in repository at '/__w/semgrep/semgrep'
           #   To add an exception for this directory, call:
           #         git config --global --add safe.directory /__w/semgrep/semgrep

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,18 +69,17 @@ jobs:
     # hence the ugly use of sudo below (an alternative is to prefix some commands
     # with HOME=root ...
     steps:
-      - run: |
-          ls -al /root
-          which opam
-          which ocamlc
+      - name: Check environment variable tampering
+        run: |
+          pwd
           echo $HOME
-          HOME=/root opam exec -- opam env
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |
           pwd
-          #TODO? why do we need that?
-          sudo -u root git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          echo $HOME
           # coupling: must be the same than in semgrep-core/dev/dev.opam
-          sudo -u root opam install -y ocamlformat.0.21.0
-          sudo -u root opam exec -- pre-commit run --verbose --all lint-ocaml
+          sudo opam install -y ocamlformat.0.21.0
+          #TODO? why do we need that?
+          sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          sudo opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,17 +70,23 @@ jobs:
     # with HOME=root ...
     steps:
       - name: Check environment variable tampering
+        env: HOME:/root
         run: |
           pwd
           echo $HOME
       - uses: actions/checkout@v3
       - name: Check OCaml code
+        env: HOME:/root
         run: |
           # coupling: must be the same than in semgrep-core/dev/dev.opam
           sudo opam install -y ocamlformat.0.21.0
           #TODO? why do we need that?
           #sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          #   fatal: detected dubious ownership in repository at '/__w/semgrep/semgrep'
+          #   To add an exception for this directory, call:
+          #         git config --global --add safe.directory /__w/semgrep/semgrep
           pwd
           ls -al .
           echo $GITHUB_WORKSPACE
-          sudo opam exec -- pre-commit run --verbose --all lint-ocaml || cat /root/.cache/pre-commit/pre-commit.log
+          sudo opam exec -- pre-commit run --verbose --all lint-ocaml
+          #sudo opam exec -- pre-commit run --verbose --all lint-ocaml || cat /root/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,11 +64,14 @@ jobs:
     # Custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in semgrep-core/dev/dev.opam)
     container: returntocorp/ocaml:ubuntu-2022-09-24
+    # HOME is tampered by GHA and modified from /root to /home/github
+    # which then confuses opam which can not find its ~/.opam
     steps:
       - run: |
           ls -al /root
           which opam
           which ocamlc
+          echo $HOME
           opam exec -- opam env
       - uses: actions/checkout@v3
       - name: Check OCaml code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,9 +65,13 @@ jobs:
     # OCaml code (must be the same than the one in semgrep-core/dev/dev.opam)
     container: returntocorp/ocaml:ubuntu-2022-09-24
     steps:
+      - run: |
+          ls -al /root
+          opam info
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |
+          ls -al /root
           #TODO? why do we need that?
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # coupling: must be the same than in semgrep-core/dev/dev.opam

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,9 +79,8 @@ jobs:
       - name: Check OCaml code
         run: |
           pwd
-          ls -l /home/github
           #TODO? why do we need that?
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          sudo -u root git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # coupling: must be the same than in semgrep-core/dev/dev.opam
-          sudo opam install -y ocamlformat.0.21.0
-          sudo opam exec -- pre-commit run --verbose --all lint-ocaml
+          sudo -u root opam install -y ocamlformat.0.21.0
+          sudo -u root opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
     # OCaml code (must be the same than the one in semgrep-core/dev/dev.opam)
     container: returntocorp/ocaml:ubuntu-2022-09-24
     # HOME is tampered by GHA and modified from /root to /home/github
-    # which then confuses opam which can not find its ~/.opam
+    # which then confuses opam which can not find its ~/.opam (which is at /root/.opam)
     steps:
       - run: |
           ls -al /root
@@ -80,5 +80,5 @@ jobs:
           #TODO? why do we need that?
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # coupling: must be the same than in semgrep-core/dev/dev.opam
-          HOME=/root opam install -y ocamlformat.0.21.0
-          HOME=/root opam exec -- pre-commit run --verbose --all lint-ocaml
+          sudo opam install -y ocamlformat.0.21.0
+          sudo pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
           ls -al /root
           which opam
           which ocamlc
-          opam env
+          opam exec -- opam env
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |
@@ -77,5 +77,5 @@ jobs:
           #TODO? why do we need that?
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # coupling: must be the same than in semgrep-core/dev/dev.opam
-          opam install -y ocamlformat.0.21.0
+          opam exec -- opam install -y ocamlformat.0.21.0
           opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,4 +82,5 @@ jobs:
           #sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pwd
           ls -al .
-          sudo opam exec -- pre-commit run --verbose --all lint-ocaml
+          echo $GITHUB_WORKSPACE
+          sudo opam exec -- pre-commit run --verbose --all lint-ocaml || cat /root/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,13 +70,13 @@ jobs:
     # with HOME=root ...
     steps:
       - name: Check environment variable tampering
-        env: HOME:/root
+        env:
+          HOME: /root
         run: |
           pwd
           echo $HOME
       - uses: actions/checkout@v3
       - name: Check OCaml code
-        env: HOME:/root
         run: |
           # coupling: must be the same than in semgrep-core/dev/dev.opam
           sudo opam install -y ocamlformat.0.21.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,7 @@ jobs:
           ls -al /root
           which opam
           which ocamlc
+          opam env
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,11 +36,11 @@ jobs:
       - uses: pre-commit/action@v3.0.0
 
   # This is mostly a copy-paste of the pre-commit job above. The only difference
-  # is the extra_args: directive, which runs semgrep/.pre-commit-config.yaml#L150,
+  # is the 'extra_args:' directive, which runs semgrep/.pre-commit-config.yaml#L150,
   # which runs Semgrep Bandit and Semgrep Python, which we don't run on normal pre-commit
   # since they would slow down pre-commit on local development.
-  # We could add the last step of this job in the pre-commit job above, but jobs can run
-  # in parallel, hence the copy-paste.
+  # An alternative would be to add the last step of this job in the pre-commit job above,
+  # but jobs can run in parallel, hence the copy-paste to speed things up.
   # The intention is a test that runs semgrep-pre-commit.
   # (TODO: actually it looks like we also run Semgrep Bandit/Python in normal pre-commit)
   # TODO? should we split this out to a different config?
@@ -57,17 +57,20 @@ jobs:
         with:
           extra_args: --hook-stage manual
 
+  # Running the ocamlformat part of pre-commit, which requires a special container
   pre-commit-ocaml:
-    # Even if there's a container: below, we still need a runs-on:, to say which VM will
-    # run the docker container. See https://github.com/orgs/community/discussions/25534
+    # Even if there's a 'container:' below, we still need a 'runs-on:', to say which VM will
+    # run the Docker container. See https://github.com/orgs/community/discussions/25534
+    # This is not necessary in Circle CI which has sane defaults.
     runs-on: ubuntu-latest
-    # Custom image provides 'ocamlformat' with a specific version needed to check
+    # This custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in semgrep-core/dev/dev.opam)
+    # See https://github.com/returntocorp/ocaml-layer/blob/master/configs/ubuntu.sh
     container: returntocorp/ocaml:ubuntu-2022-09-24
     # HOME in the container is tampered by GHA and modified from /root to /home/github
-    # which then confuses opam which can not find its ~/.opam (which is at /root/.opam)
-    # hence the ugly use of sudo below (an alternative is to prefix some commands
-    # with HOME=root ...
+    # which then confuses opam below which can not find its ~/.opam (which is at /root/.opam)
+    # hence the ugly use of 'env: HOME ...' below.
+    # An alternative would be to run commands with 'sudo' or prefixed with 'HOME=root ...'
     steps:
       - uses: actions/checkout@v3
       - name: Check OCaml code
@@ -76,10 +79,15 @@ jobs:
         run: |
           # coupling: must be the same than in semgrep-core/dev/dev.opam
           opam install -y ocamlformat.0.21.0
-          #TODO? why do we need that?
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          # Without this 'git config' command below, we would get this error in CI:
           #   fatal: detected dubious ownership in repository at '/__w/semgrep/semgrep'
           #   To add an exception for this directory, call:
           #         git config --global --add safe.directory /__w/semgrep/semgrep
+          # This is probably because the files are owned by root and git
+          # by default returns an error. The 'safe.directory' directive just whitelists
+          # the directory so pre-commit below (which internally runs some 'git' commands)
+          # does not fail.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           opam exec -- pre-commit run --verbose --all lint-ocaml
-          #sudo opam exec -- pre-commit run --verbose --all lint-ocaml || cat /root/.cache/pre-commit/pre-commit.log
+          # to debug errors in pre-commit, use instead:
+          # opam exec -- pre-commit run --verbose --all lint-ocaml || cat /root/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,7 +67,8 @@ jobs:
     steps:
       - run: |
           ls -al /root
-          opam info
+          which opam
+          which ocamlc
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,20 +63,13 @@ jobs:
     runs-on: ubuntu-latest
     # Custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in semgrep-core/dev/dev.opam)
-    container: returntocorp/ocaml:ubuntu-2022-06-09
+    container: returntocorp/ocaml:ubuntu-2022-09-24
     steps:
-      # Apparently GHA when running a container: does a bunch of
-      # `docker create` on /github and /__w but with the wrong permissions
-      # (all of this after it pulled the custom container), hence the chmod below.
-      # I wish we could have a .github/pre-gha-checkout to factorize and document
-      # this mess, but we're before the checkout@v3 so there is no .github yet :)
-      - name: Pre-checkout GHA fixes
-        run: sudo chmod -R 777 /github /__w
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |
           #TODO? why do we need that?
-          sudo -u user git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # coupling: must be the same than in semgrep-core/dev/dev.opam
-          sudo -u user opam install -y ocamlformat.0.21.0
-          sudo -u user opam exec -- pre-commit run --verbose --all lint-ocaml
+          opam install -y ocamlformat.0.21.0
+          opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,8 @@ jobs:
     container: returntocorp/ocaml:ubuntu-2022-09-24
     # HOME is tampered by GHA and modified from /root to /home/github
     # which then confuses opam which can not find its ~/.opam (which is at /root/.opam)
+    # hence the ugly use of sudo below (an alternative is to prefix some commands
+    # with HOME=root ...
     steps:
       - run: |
           ls -al /root
@@ -76,9 +78,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |
-          ls -al /root
+          pwd
+          ls -l /home/github
           #TODO? why do we need that?
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # coupling: must be the same than in semgrep-core/dev/dev.opam
           sudo opam install -y ocamlformat.0.21.0
-          sudo pre-commit run --verbose --all lint-ocaml
+          sudo opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
           which opam
           which ocamlc
           echo $HOME
-          opam exec -- opam env
+          HOME=/root opam exec -- opam env
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |
@@ -80,5 +80,5 @@ jobs:
           #TODO? why do we need that?
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           # coupling: must be the same than in semgrep-core/dev/dev.opam
-          opam exec -- opam install -y ocamlformat.0.21.0
-          opam exec -- pre-commit run --verbose --all lint-ocaml
+          HOME=/root opam install -y ocamlformat.0.21.0
+          HOME=/root opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,10 +76,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check OCaml code
         run: |
-          pwd
-          echo $HOME
           # coupling: must be the same than in semgrep-core/dev/dev.opam
           sudo opam install -y ocamlformat.0.21.0
           #TODO? why do we need that?
-          sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          #sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          pwd
+          ls -al .
           sudo opam exec -- pre-commit run --verbose --all lint-ocaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,29 +64,22 @@ jobs:
     # Custom image provides 'ocamlformat' with a specific version needed to check
     # OCaml code (must be the same than the one in semgrep-core/dev/dev.opam)
     container: returntocorp/ocaml:ubuntu-2022-09-24
-    # HOME is tampered by GHA and modified from /root to /home/github
+    # HOME in the container is tampered by GHA and modified from /root to /home/github
     # which then confuses opam which can not find its ~/.opam (which is at /root/.opam)
     # hence the ugly use of sudo below (an alternative is to prefix some commands
     # with HOME=root ...
     steps:
-      - name: Check environment variable tampering
+      - uses: actions/checkout@v3
+      - name: Check OCaml code
         env:
           HOME: /root
         run: |
-          pwd
-          echo $HOME
-      - uses: actions/checkout@v3
-      - name: Check OCaml code
-        run: |
           # coupling: must be the same than in semgrep-core/dev/dev.opam
-          sudo opam install -y ocamlformat.0.21.0
+          opam install -y ocamlformat.0.21.0
           #TODO? why do we need that?
-          sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           #   fatal: detected dubious ownership in repository at '/__w/semgrep/semgrep'
           #   To add an exception for this directory, call:
           #         git config --global --add safe.directory /__w/semgrep/semgrep
-          pwd
-          ls -al .
-          echo $GITHUB_WORKSPACE
-          sudo opam exec -- pre-commit run --verbose --all lint-ocaml
+          opam exec -- pre-commit run --verbose --all lint-ocaml
           #sudo opam exec -- pre-commit run --verbose --all lint-ocaml || cat /root/.cache/pre-commit/pre-commit.log


### PR DESCRIPTION
Now that returntocorp/ocaml:ubuntu use the 'user=root' default,
things can be simplified.

See
https://returntocorp.slack.com/archives/C01NXGX2EHZ/p1663937723277069
for more context

test plan:
wait for CI to kick in observe if errors
modify Main.ml with bad indentation, git commit -a -m"xxx" --no-verify
push and see if ocamlformat complains correctly during the
pre-commit-ocaml GHA workflow


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)