### PR TITLE
cleanup: analysis: Factor out common function-definition visitor

### DIFF
--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -684,15 +684,8 @@ let propagate_dataflow lang ast =
       let flow = CFG_build.cfg_of_stmts xs in
       propagate_dataflow_one_function lang [] flow
   | _ ->
-      let v =
-        V.mk_visitor
-          {
-            V.default_visitor with
-            V.kfunction_definition =
-              (fun (_k, _) def ->
-                let inputs, xs = AST_to_IL.function_definition lang def in
-                let flow = CFG_build.cfg_of_stmts xs in
-                propagate_dataflow_one_function lang inputs flow);
-          }
-      in
-      v (Pr ast)
+      ast
+      |> Visit_function_defs.visit (fun _ent fdef ->
+             let inputs, xs = AST_to_IL.function_definition lang fdef in
+             let flow = CFG_build.cfg_of_stmts xs in
+             propagate_dataflow_one_function lang inputs flow)

--- a/semgrep-core/src/analyzing/Test_analyze_generic.ml
+++ b/semgrep-core/src/analyzing/Test_analyze_generic.ml
@@ -60,19 +60,12 @@ let test_cfg_il ~parse_program file =
   let ast = parse_program file in
   let lang = List.hd (Lang.langs_of_filename file) in
   Naming_AST.resolve lang ast;
-
-  let v =
-    V.mk_visitor
-      {
-        V.default_visitor with
-        V.kfunction_definition =
-          (fun (_k, _) def ->
-            let _, xs = AST_to_IL.function_definition lang def in
-            let cfg = CFG_build.cfg_of_stmts xs in
-            Display_IL.display_cfg cfg);
-      }
-  in
-  v (Pr ast)
+  Visit_function_defs.visit
+    (fun _ fdef ->
+      let _, xs = AST_to_IL.function_definition lang fdef in
+      let cfg = CFG_build.cfg_of_stmts xs in
+      Display_IL.display_cfg cfg)
+    ast
 
 module F2 = IL
 

--- a/semgrep-core/src/analyzing/Visit_function_defs.ml
+++ b/semgrep-core/src/analyzing/Visit_function_defs.ml
@@ -1,0 +1,46 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2022 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+
+module G = AST_generic
+module H = AST_generic_helpers
+module V = Visitor_AST
+
+(* Visit all function definitions in an AST. *)
+let visit (f : G.entity option -> G.function_definition -> unit)
+    (ast : G.program) : unit =
+  let v =
+    V.mk_visitor
+      {
+        V.default_visitor with
+        V.kdef =
+          (fun (k, v) ((ent, def_kind) as def) ->
+            match def_kind with
+            | G.FuncDef fdef ->
+                f (Some ent) fdef;
+                (* go into nested functions
+                   but do NOT revisit the function definition again
+                   with `kfunction_definition` below! *)
+                let body = H.funcbody_to_stmt fdef.G.fbody in
+                v (G.S body)
+            | __else__ -> k def);
+        V.kfunction_definition =
+          (fun (k, _v) def ->
+            f None def;
+            (* go into nested functions *)
+            k def);
+      }
+  in
+  (* Check each function definition. *)
+  v (G.Pr ast)

--- a/semgrep-core/src/cli-lib/Cli_lib.ml
+++ b/semgrep-core/src/cli-lib/Cli_lib.ml
@@ -264,11 +264,12 @@ let dump_il file =
   let lang = List.hd (Lang.langs_of_filename file) in
   let ast = Parse_target.parse_program file in
   Naming_AST.resolve lang ast;
-  let report_func_def_with_name fdef name =
+  let report_func_def_with_name ent_opt fdef =
     let name =
-      match name with
+      match ent_opt with
       | None -> "<lambda>"
-      | Some name -> G.show_name name
+      | Some { G.name = EN n; _ } -> G.show_name n
+      | Some _ -> "<entity>"
     in
     pr2 (spf "Function name: %s" name);
     let s =
@@ -282,24 +283,7 @@ let dump_il file =
     let s = IL.show_any (IL.Ss xs) in
     pr2 s
   in
-  let v =
-    V.mk_visitor
-      {
-        V.default_visitor with
-        V.kexpr =
-          (fun (_k, _) expr ->
-            match expr.e with
-            | Lambda fdef -> report_func_def_with_name fdef None
-            | _ -> ());
-        V.kdef =
-          (fun (_k, _) (ent, dkind) ->
-            match (ent, dkind) with
-            | { name = EN n; _ }, FuncDef fdef ->
-                report_func_def_with_name fdef (Some n)
-            | _ -> ());
-      }
-  in
-  v (AST_generic.Pr ast)
+  Visit_function_defs.visit report_func_def_with_name ast
 
 let dump_v0_json file =
   let file = Run_semgrep.replace_named_pipe_by_regular_file file in


### PR DESCRIPTION
We had a few definitions of this visitor, and they were not equivalent. In particular, `-dump_il` was missing some functions.

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
