### PR TITLE
feat(terraform): parse block names consistently, avoid mistranslation of records in IL

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -867,7 +867,7 @@ and record env ((_tok, origfields, _) as record_def) =
   let e_gen = G.Record record_def |> G.e in
   let fields =
     origfields
-    |> Common.map (function
+    |> Common.map_filter (function
          | G.F
              {
                s =
@@ -884,7 +884,7 @@ and record env ((_tok, origfields, _) as record_def) =
                | ___else___ -> todo (G.E e_gen)
              in
              let field_def = expr env fdeforig in
-             Field (id, field_def)
+             Some (Field (id, field_def))
          | G.F
              {
                s =
@@ -898,7 +898,10 @@ and record env ((_tok, origfields, _) as record_def) =
                      _ );
                _;
              } ->
-             Spread (expr env e)
+             Some (Spread (expr env e))
+         | _ when is_hcl env.lang ->
+             logger#warning "Skipping HCL record field during IL translation";
+             None
          | G.F _ -> todo (G.E e_gen))
   in
   mk_e (Record fields) (SameAs e_gen)

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -900,6 +900,10 @@ and record env ((_tok, origfields, _) as record_def) =
              } ->
              Some (Spread (expr env e))
          | _ when is_hcl env.lang ->
+             (* For HCL constructs such as `lifecycle` blocks within a module call, the
+                IL translation engine will brick the whole record if it is encountered.
+                To avoid this, we will just ignore any unrecognized fields for HCL specifically.
+             *)
              logger#warning "Skipping HCL record field during IL translation";
              None
          | G.F _ -> todo (G.E e_gen))

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -132,8 +132,8 @@ let map_string_lit (env : env) ((v1, v2, v3) : CST.string_lit) =
   let v2 = map_template_literal env v2 in
   let v3 = (* quoted_template_end *) token env v3 in
   match v2 with
-  | Some (s, t) -> G.String (s, PI.combine_infos v1 [ t; v3 ])
-  | None -> G.String ("", PI.combine_infos v1 [ v3 ])
+  | Some (s, t) -> (s, PI.combine_infos v1 [ t; v3 ])
+  | None -> ("", PI.combine_infos v1 [ v3 ])
 
 let map_variable_expr (env : env) (x : CST.variable_expr) = map_identifier env x
 
@@ -149,7 +149,7 @@ let map_literal_value (env : env) (x : CST.literal_value) : literal =
   | `Nume_lit x -> map_numeric_lit env x
   | `Bool_lit x -> Bool (map_bool_lit env x)
   | `Null_lit tok -> (* "null" *) Null (token env tok)
-  | `Str_lit x -> map_string_lit env x
+  | `Str_lit x -> String (map_string_lit env x)
 
 let rec map_anon_choice_get_attr_7bbf24f (env : env)
     (x : CST.anon_choice_get_attr_7bbf24f) =
@@ -566,7 +566,7 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
         match x with
         | `Str_lit x ->
             let x = map_string_lit env x in
-            L x |> G.e
+            N (Id (x, empty_id_info ())) |> G.e
         | `Id tok ->
             let id = (* identifier *) map_identifier env tok in
             let n = H2.name_of_id id in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -127,12 +127,12 @@ let map_identifier (env : env) (x : CST.identifier) : ident =
       (* tok_choice_pat_3e8fcfc_rep_choice_pat_71519dc *) str env tok
   | `Semg_meta tok -> (* semgrep_metavariable *) str env tok
 
-let map_string_lit (env : env) ((v1, v2, v3) : CST.string_lit) =
+let map_string_lit ~with_quotes (env : env) ((v1, v2, v3) : CST.string_lit) =
   let v1 = (* quoted_template_start *) token env v1 in
   let v2 = map_template_literal env v2 in
   let v3 = (* quoted_template_end *) token env v3 in
   match v2 with
-  | Some (s, t) -> (s, PI.combine_infos v1 [ t; v3 ])
+  | Some (s, t) -> (s, if with_quotes then PI.combine_infos v1 [ t; v3 ] else t)
   | None -> ("", PI.combine_infos v1 [ v3 ])
 
 let map_variable_expr (env : env) (x : CST.variable_expr) = map_identifier env x
@@ -149,7 +149,7 @@ let map_literal_value (env : env) (x : CST.literal_value) : literal =
   | `Nume_lit x -> map_numeric_lit env x
   | `Bool_lit x -> Bool (map_bool_lit env x)
   | `Null_lit tok -> (* "null" *) Null (token env tok)
-  | `Str_lit x -> String (map_string_lit env x)
+  | `Str_lit x -> String (map_string_lit ~with_quotes:true env x)
 
 let rec map_anon_choice_get_attr_7bbf24f (env : env)
     (x : CST.anon_choice_get_attr_7bbf24f) =
@@ -566,7 +566,7 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
         match x with
         | `Str_lit x ->
             (* Parse this to a name as it has the same semantics. *)
-            let x = map_string_lit env x in
+            let x = map_string_lit ~with_quotes:false env x in
             N (Id (x, empty_id_info ())) |> G.e
         | `Id tok ->
             let id = (* identifier *) map_identifier env tok in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -565,6 +565,7 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
       (fun x ->
         match x with
         | `Str_lit x ->
+            (* Parse this to a name as it has the same semantics. *)
             let x = map_string_lit env x in
             N (Id (x, empty_id_info ())) |> G.e
         | `Id tok ->


### PR DESCRIPTION
## What:
This PR adds in two things. One is the parsing of block names in a consistent way, due to these names being able to be presented in either a string literal, or as a standalone identifier. Two is ignoring unknown fields within a record for HCL programs during IL translation.

## Why:
The first will allow us to avoid being unable to produce findings due to naming issues on blocks, because blocks are expected to have names, instead of string literals.

The second will allow us to avoid being unable to produce findings due to failing at IL translation time. This is because there may be certain constructs within a `resource` block, such as a `lifecycle` block, which does not translate to a `DefStmt`, but an `ExprStmt`. The IL translation engine doesn't know what to do with this though, so it currently just makes the entire module call into a `Fixme`. To avoid that, we will opt to just ignore such fields when translating HCL programs specifically.

## How:
This was achieved via just altering the HCL parser to parse string literals as block names to real names, and to change the mapping of records during IL translation to a `map_filter` which only triggers on parsing an HCL AST.

## Test plan:
`make test` still succeeds. I can't really write a more in-depth test demonstrating the effect on DeepSemgrep, but I have tested this manually, and it matters.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
