### PR TITLE
test: Test autofixes in semgrep-core

### DIFF
--- a/semgrep-core/tests/python/fix_ellipsis_metavar.fix
+++ b/semgrep-core/tests/python/fix_ellipsis_metavar.fix
@@ -1,0 +1,1 @@
+foo($...BEFORE, bar =  False, $...AFTER)

--- a/semgrep-core/tests/python/fix_ellipsis_metavar.fixed
+++ b/semgrep-core/tests/python/fix_ellipsis_metavar.fixed
@@ -1,0 +1,15 @@
+# MATCH:
+foo(bar =  False), foo(bar =  False)
+
+foo(bar=False)
+
+foo(baz=True)
+
+# MATCH:
+foo(bar =  False)
+
+# These should work, but end up with overlapping fixes. See
+# https://github.com/returntocorp/semgrep/issues/4963
+
+# foo(x, bar=True)
+# foo(x, bar=True, y)

--- a/semgrep-core/tests/python/fix_ellipsis_metavar.py
+++ b/semgrep-core/tests/python/fix_ellipsis_metavar.py
@@ -1,0 +1,15 @@
+# MATCH:
+foo(bar=True), foo(bar=True)
+
+foo(bar=False)
+
+foo(baz=True)
+
+# MATCH:
+foo(  bar   =    True  )
+
+# These should work, but end up with overlapping fixes. See
+# https://github.com/returntocorp/semgrep/issues/4963
+
+# foo(x, bar=True)
+# foo(x, bar=True, y)

--- a/semgrep-core/tests/python/fix_ellipsis_metavar.sgrep
+++ b/semgrep-core/tests/python/fix_ellipsis_metavar.sgrep
@@ -1,0 +1,1 @@
+foo($...BEFORE, bar=True, $...AFTER)


### PR DESCRIPTION
This extends the existing semgrep-core test runner that we use to test matches so that it can also test autofix. The format is pretty simple: add a `.fix` file with the fix pattern and a `.fixed` file with the expected contents of the target after fixes are applied.

There are existing end-to-end tests which test autofix on the CLI side. Unfortunately, modifying them involves updating a large snapshot file, and maintaining any large quantity of them would be onerous. Additionally, it's not easy to adapt tests from our large existing test suite in semgrep-core to also exercise autofix.

Semgrep's `--test` flag can also test autofix (#5190), but it has the same problems as the existing autofix e2e tests for these purposes.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
