### PR TITLE
Disable Bloom filter optimization by default

### DIFF
--- a/changelog.d/pa-1927.changed
+++ b/changelog.d/pa-1927.changed
@@ -1,0 +1,4 @@
+Disabled Bloom filter optimization by default, due to undesired interactions with
+constant and symbolic propagation, while it appears to not provide a net major
+performance benefit (nowadays). If you do notice a significant drop in performance
+after this change, please let us know.

--- a/semgrep-core/src/core/Flag_semgrep.ml
+++ b/semgrep-core/src/core/Flag_semgrep.ml
@@ -24,8 +24,30 @@ let filter_irrelevant_patterns = ref false
  * the regexp *)
 let filter_irrelevant_rules = ref false
 
-(* check for identifiers before attempting to match a stmt or stmt list *)
-let use_bloom_filter = ref true
+(* check for identifiers before attempting to match a stmt or stmt list
+ *
+ * We disabled the Bloom filter optimization by default in 0.116.0 due to its
+ * bad interaction with const-prop and sym-prop, and because nowadays it appears
+ * to only have a marginal benefit on performance. If we don't notice any major
+ * perf regressions, we could completely drop the optimization in the future.
+ *
+ * For an example of how it interacts badly with const-prop see GH #4670, and for
+ * an example of how it interacts badly with sym-prop see PA-1920 (or GH PR #6179).
+ * Regarding performance, we ran Semgrep with and without this optimization on
+ * nine of the repos in our stress-test monorepo (using p/default):
+ *
+ * - In four cases (elasticsearch, maven, metabase, and kubernetes) using the
+ *   Bloom filter was about 4-5% slower.
+ * - In four cases (hadoop, mypy, react, mediawiki) using the Bloom filter was an
+ *   average of 9.5% faster, with the largest effect seen on mypy (15% faster).
+ * - In the remaining case (flask) there was no meaningful difference.
+ *
+ * That said take these %'s with a grain of salt, since we only did one run each,
+ * and it was done on a laptop with other stuff running on the bakground, so there
+ * was noise. And the absolute difference in seconds between runs was less than
+ * 8 seconds, with an average (and also median) of 4 seconds.
+ *)
+let use_bloom_filter = ref false
 
 (* opt = optimization *)
 let with_opt_cache = ref true

--- a/semgrep-core/tests/python/cp_concat.py
+++ b/semgrep-core/tests/python/cp_concat.py
@@ -1,0 +1,4 @@
+#ERROR:
+x = ("pass"
+    "word")
+

--- a/semgrep-core/tests/python/cp_concat.sgrep
+++ b/semgrep-core/tests/python/cp_concat.sgrep
@@ -1,0 +1,1 @@
+"password"


### PR DESCRIPTION
It conflicts with const-prop and sym-prop and appears not to provide a major net benefit nowadays.

To close #4670 we still need to tackle filter-irrelevant-rules interaction with const-prop.

Helps #4670
Helps PR #6179
Closes PA-1927

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
