### PR TITLE
extract-mode: fix the "too many open files" errors

### DIFF
--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -275,7 +275,6 @@ let extract_and_concat erule_table xtarget rule_ids matches =
          |> List.rev
          (* Read the extracted text from the source file *)
          |> Common.map (fun { start_pos; start_line; start_col; end_pos } ->
-                let _x = open_in_bin xtarget.Xtarget.file in
                 let contents =
                   Common.with_open_infile xtarget.Xtarget.file (fun chan ->
                       let extract_size = end_pos - start_pos in

--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -275,10 +275,13 @@ let extract_and_concat erule_table xtarget rule_ids matches =
          |> List.rev
          (* Read the extracted text from the source file *)
          |> Common.map (fun { start_pos; start_line; start_col; end_pos } ->
-                let source_file = open_in_bin xtarget.Xtarget.file in
-                let extract_size = end_pos - start_pos in
-                seek_in source_file start_pos;
-                let contents = really_input_string source_file extract_size in
+                let _x = open_in_bin xtarget.Xtarget.file in
+                let contents =
+                  Common.with_open_infile xtarget.Xtarget.file (fun chan ->
+                      let extract_size = end_pos - start_pos in
+                      seek_in chan start_pos;
+                      really_input_string chan extract_size)
+                in
                 logger#trace
                   "Extract rule %s extracted the following from %s at bytes \
                    %d-%d\n\
@@ -366,10 +369,12 @@ let extract_as_separate erule_table xtarget rule_ids matches =
                    None
              in
              (* Read the extracted text from the source file *)
-             let source_file = open_in_bin m.file in
-             let extract_size = end_extract_pos - start_extract_pos in
-             seek_in source_file start_extract_pos;
-             let contents = really_input_string source_file extract_size in
+             let contents =
+               Common.with_open_infile m.file (fun chan ->
+                   let extract_size = end_extract_pos - start_extract_pos in
+                   seek_in chan start_extract_pos;
+                   really_input_string chan extract_size)
+             in
              logger#trace
                "Extract rule %s extracted the following from %s at bytes %d-%d\n\
                 %s"

--- a/semgrep-core/src/metachecking/Translate_rule.ml
+++ b/semgrep-core/src/metachecking/Translate_rule.ml
@@ -34,10 +34,10 @@ let rec expr_to_string expr =
   let { AST_generic.e_range; _ } = expr in
   match e_range with
   | Some (start, end_) ->
-      let source_file = open_in_bin start.file in
-      let extract_size = end_.charpos - start.charpos in
-      seek_in source_file start.charpos;
-      really_input_string source_file extract_size
+      Common.with_open_infile start.file (fun chan ->
+          let extract_size = end_.charpos - start.charpos in
+          seek_in chan start.charpos;
+          really_input_string chan extract_size)
   | None -> failwith "invalid source/sink requires"
 
 and translate_metavar_cond cond : [> `O of (string * Yaml.value) list ] =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml
@@ -41,35 +41,33 @@ type 'a env = {
 
 (* mostly a copy-paste of Parse_info.full_charpos_to_pos_large *)
 let line_col_to_pos file =
-  let chan = open_in_bin file in
   let size = Common2.filesize file + 2 in
-
-  let charpos = ref 0 in
-  let line = ref 0 in
   let h = Hashtbl.create size in
+  Common.with_open_infile file (fun chan ->
+      let charpos = ref 0 in
+      let line = ref 0 in
 
-  let full_charpos_to_pos_aux () =
-    try
-      while true do
-        let s = input_line chan in
-        incr line;
+      let full_charpos_to_pos_aux () =
+        try
+          while true do
+            let s = input_line chan in
+            incr line;
 
-        (* '... +1 do'  cos input_line dont return the trailing \n *)
-        for i = 0 to String.length s - 1 + 1 do
-          Hashtbl.add h (!line, i) (!charpos + i)
-        done;
-        charpos := !charpos + String.length s + 1
-      done
-    with
-    | End_of_file ->
-        (* bugfix: this is wrong:  Hashtbl.add h (!line, 0) !charpos;
-         * because an ident on the last line would get
-         * the last charpos.
-         *)
-        ()
-  in
-  full_charpos_to_pos_aux ();
-  close_in chan;
+            (* '... +1 do'  cos input_line dont return the trailing \n *)
+            for i = 0 to String.length s - 1 + 1 do
+              Hashtbl.add h (!line, i) (!charpos + i)
+            done;
+            charpos := !charpos + String.length s + 1
+          done
+        with
+        | End_of_file ->
+            (* bugfix: this is wrong:  Hashtbl.add h (!line, 0) !charpos;
+             * because an ident on the last line would get
+             * the last charpos.
+             *)
+            ()
+      in
+      full_charpos_to_pos_aux ());
   h
 
 let token env (tok : Tree_sitter_run.Token.t) =

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -23,6 +23,7 @@ module In = Input_to_core_j
 module Out = Output_from_core_j
 
 let logger = Logging.get_logger [ __MODULE__ ]
+let debug_extract_mode = ref false
 
 (*****************************************************************************)
 (* Purpose *)
@@ -526,8 +527,8 @@ let extract_targets_of_config config rule_ids extractors =
   in
   let extract_targets = extract_target_info.target_mappings in
   let match_hook str match_ =
-    if config.output_format = Text then (
-      print_string "extracted content from ";
+    if !debug_extract_mode && config.output_format = Text then (
+      pr2 "extracted content from ";
       print_match ~str config match_ Metavariable.ii_of_mval)
   in
   logger#info "extracting nested content from %d files, skipping %d files"

--- a/semgrep-core/src/targeting/Guess_lang.ml
+++ b/semgrep-core/src/targeting/Guess_lang.ml
@@ -90,10 +90,7 @@ let is_executable =
   Or (has_extension [ ".exe" ], Test_path f)
 
 let get_first_line path =
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
+  Common.with_open_infile path (fun ic ->
       try input_line ic with
       | End_of_file -> (* empty file *) "")
 
@@ -102,10 +99,7 @@ let get_first_line path =
    a single filesystem block.
 *)
 let get_first_block ?(block_size = 4096) path =
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
+  Common.with_open_infile path (fun ic ->
       let len = min block_size (in_channel_length ic) in
       really_input_string ic len)
 

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -1,12 +1,25 @@
-# See pfff/semgrep.yml for more information.
-# Put semgrep-specific rules here. More general OCaml or Python rules should
-# go in the semgrep-rules repository under ocaml/ or python/.
+# This file contains Semgrep rules.
+# See https://semgrep.dev for more information.
+#
+# You can use this file locally either with:
+#  - docker run --rm -v "${PWD}:/home/repo" returntocorp/semgrep:develop --config semgrep.yml
+# or if you have already installed semgrep:
+#  - semgrep --config semgrep.yml .
+#
+# This file is also used in CI, see .circleci/config.yml
+#
+# Put semgrep-specific rules here.
+# Put general OCaml or Python rules in the semgrep-rules repository
+# under ocaml/ or python/.
+# Use semgrep-core/src/pfff/semgrep.yml for rules related to using pfff
+# libraries.
 
 rules:
   - id: no-print-in-semgrep
     patterns:
       - pattern-either:
           - pattern: pr ...
+          - pattern: print_string ...
       - pattern-not-inside: |
           if !Flag.debug
           then ...
@@ -31,6 +44,17 @@ rules:
         - runner/*.ml
         - experiments/*
         - Check_*.ml
+
+  #TODO: this could be moved in pfff/semgrep.yml at some point
+  - id: no-open-in
+    pattern-either:
+      - pattern: open_in_bin ...
+      - pattern: open_in ...
+    message: >-
+      It is easy to forget to close `open_in` with `close_in`.
+      Use `Common.with_open_infile()` instead.
+    languages: [ocaml]
+    severity: ERROR
 
   - id: use-pytest-mock
     pattern: import unittest.mock


### PR DESCRIPTION
This will help #6180

We forgot to use close_in.

I've also added a new semgrep rule to detect those bugs.

test plan:
in the stress-test-monorepo, in the discourse subdirectory,
run:
semgrep --config=~/extract-ruby-from-erb.yaml --config "p/ruby"

with the extract rules described in 6180


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)