### PR TITLE
tainting: Allow this.x to be a source of taint

### DIFF
--- a/changelog.d/pa-1929.fixed
+++ b/changelog.d/pa-1929.fixed
@@ -1,0 +1,1 @@
+taint-mode: It is now possible for `this` or `this.x` to be a source of taint.

--- a/semgrep-core/tests/OTHER/rules/taint_this.js
+++ b/semgrep-core/tests/OTHER/rules/taint_this.js
@@ -1,0 +1,4 @@
+function foo() {
+  //ruleid: test
+  this.window.eval("a");
+}

--- a/semgrep-core/tests/OTHER/rules/taint_this.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_this.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: this.$X
+    pattern-sinks:
+      - patterns:
+          - pattern: $X.eval(...)
+    languages:
+      - typescript
+      - javascript
+    message: |
+      Semgrep found a match
+    severity: WARNING


### PR DESCRIPTION
This a quick-fix for an SR request, I will reconsider the solution as part of fixing PA-1928.

Closes PA-1929

test plan:
make test # added one test

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
