### PR TITLE
tainting: Track taint inside if's conditions and throw's

### DIFF
--- a/changelog.d/pa-1933.fixed
+++ b/changelog.d/pa-1933.fixed
@@ -1,0 +1,2 @@
+taint-mode: Fixed a bug that made Semgrep miss taint findings when the sink was
+located inside an `if` condition or a `throw` (aka `raise`) expression/statement.

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -720,6 +720,10 @@ let (transfer :
             (* Either we cannot obtain a simple dotted lvalue to track, or the
              * instruction returns 'void'. *)
             lval_env')
+    | NCond (_tok, e)
+    | NThrow (_tok, e) ->
+        let _, lval_env' = check_tainted_expr env e in
+        lval_env'
     | NReturn (tok, e) -> (
         (* TODO: Move most of this to check_tainted_return. *)
         let taints, lval_env' = check_tainted_return env tok e in
@@ -743,7 +747,15 @@ let (transfer :
                  Hashtbl.replace fun_env str (Taints.union pmatches tained'));
             lval_env'
         | None -> lval_env')
-    | _ -> in'
+    | NGoto _
+    | Enter
+    | Exit
+    | TrueNode
+    | FalseNode
+    | Join
+    | NOther _
+    | NTodo _ ->
+        in'
   in
   { D.in_env = in'; out_env = out' }
 

--- a/semgrep-core/tests/OTHER/rules/taint_if_cond_sink.c
+++ b/semgrep-core/tests/OTHER/rules/taint_if_cond_sink.c
@@ -1,0 +1,10 @@
+int bad_code3(){
+    struct NAME *var;
+    var = malloc(sizeof(auth));
+    free(var);
+    // ruleid: use-after-free-taint
+    if(var->auth){
+        printf("you have logged in already");
+    }
+    return 0;
+}

--- a/semgrep-core/tests/OTHER/rules/taint_if_cond_sink.yaml
+++ b/semgrep-core/tests/OTHER/rules/taint_if_cond_sink.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: use-after-free-taint
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: free($VAR);
+          - focus-metavariable: $VAR
+    pattern-sinks:
+      - patterns:
+        - pattern: |
+            $VAR->$ACCESSOR
+        - focus-metavariable: $VAR
+    pattern-sanitizers:
+      - patterns:
+          - pattern: |
+              $VAR = NULL;
+          - focus-metavariable: $VAR
+    message: Variable '$VAR' was used after being freed. This can lead to undefined
+      behavior.
+    metadata:
+      cwe: "CWE-416: Use After Free"
+      references:
+        - https://cwe.mitre.org/data/definitions/416.html
+        - https://ctf-wiki.github.io/ctf-wiki/pwn/linux/glibc-heap/use_after_free/
+      category: security
+      technology:
+        - c
+      confidence: MEDIUM
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    languages:
+      - c
+    severity: WARNING
+


### PR DESCRIPTION
We were only checking inside `NInstr` and `NReturn` nodes and we forgot about `NCond` and `NThrow` ones! As a result, if there was a sink within one of those two kinds of node, we missed it. We would also miss sources that add taint to variables by side-effect.

This is the problem with using `| _ -> ...` !

Closes PA-1933

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
