### PR TITLE
dogfood: override message for bad-reraise rule

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_dart_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_dart_tree_sitter.ml
@@ -2999,5 +2999,6 @@ let parse file =
         (* TODO: to delete once todo() has been removed *)
       with
       | Failure "not implemented" as exn ->
+          let e = Exception.catch exn in
           H.debug_sexp_cst_after_error (CST.sexp_of_program cst);
-          raise exn)
+          Exception.reraise e)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.ml
@@ -624,8 +624,9 @@ let parse file =
       with
       (* TODO: to delete once todo() has been removed *)
       | Failure "not implemented" as exn ->
+          let e = Exception.catch exn in
           H.debug_sexp_cst_after_error (CST.sexp_of_document cst);
-          raise exn)
+          Exception.reraise e)
 
 let parse_pattern str =
   H.wrap_parser

--- a/semgrep-core/src/parsing/tree_sitter/Parse_julia_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_julia_tree_sitter.ml
@@ -1204,8 +1204,9 @@ let parse file =
       with
       (* TODO: to delete once todo() has been removed *)
       | Failure "not implemented" as exn ->
+          let e = Exception.catch exn in
           H.debug_sexp_cst_after_error (CST.sexp_of_source_file cst);
-          raise exn)
+          Exception.reraise e)
 
 let parse_pattern str =
   H.wrap_parser


### PR DESCRIPTION
Can give better advice in semgrep/pfff context because
of Exception.ml

test plan:
semgrep --config semgrep.jsonnet --error --exclude tests


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)