### PR TITLE
refactor(terraform): kill terraform module il changes, avoid mistranslation of records in IL

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -867,7 +867,7 @@ and record env ((_tok, origfields, _) as record_def) =
   let e_gen = G.Record record_def |> G.e in
   let fields =
     origfields
-    |> Common.map (function
+    |> Common.map_filter (function
          | G.F
              {
                s =
@@ -884,7 +884,7 @@ and record env ((_tok, origfields, _) as record_def) =
                | ___else___ -> todo (G.E e_gen)
              in
              let field_def = expr env fdeforig in
-             Field (id, field_def)
+             Some (Field (id, field_def))
          | G.F
              {
                s =
@@ -898,7 +898,10 @@ and record env ((_tok, origfields, _) as record_def) =
                      _ );
                _;
              } ->
-             Spread (expr env e)
+             Some (Spread (expr env e))
+         | _ when is_hcl env.lang ->
+             logger#warning "Skipping HCL record field during IL translation";
+             None
          | G.F _ -> todo (G.E e_gen))
   in
   mk_e (Record fields) (SameAs e_gen)

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -225,70 +225,11 @@ let is_hcl lang =
   | Lang.Hcl -> true
   | _ -> false
 
-let rec hcl_translate_module_call env void (e, args, fields) =
-  (* bTERRAFORM:
-      Terraform modules are translated in the form of `Call`, but we would like to
-      interpret them as actual function calls to fake function definitions.
-      This step in the translation to IL just manufactures that fake function
-      definition.
-      This function is named the same as the "module name" for a given module,
-      which is of the form `dir/module_name` for a module at directory `dir`.
-      The parameters are all of the `variable` blocks.
-
-      We have to translate into an actual IL Call construct with the correct
-      name so that we can let the taint engine do the work.
-  *)
-  let mod_sources, _, mod_args =
-    Common.partition_either3
-      (function
-        | G.F
-            {
-              s =
-                DefStmt
-                  ( {
-                      name =
-                        EN
-                          (Id
-                             ( ("source", _),
-                               {
-                                 id_resolved =
-                                   { contents = Some (G.ResolvedName _, _); _ };
-                                 _;
-                               } ) as name);
-                      _;
-                    },
-                    VarDef _ );
-              _;
-            } ->
-            Left3 (G.N name |> G.e)
-        | G.F
-            {
-              s =
-                DefStmt
-                  ( { name = EN (Id (arg_id, _)); _ },
-                    VarDef { vinit = Some arg_exp; _ } );
-              _;
-            } ->
-            Right3 (G.ArgKwd (arg_id, arg_exp))
-        | _ ->
-            (* bTODO: Ignore all other cases. They correspond neither to the module's name, or its arguments. *)
-            Middle3 ())
-      fields
-  in
-  let tok = G.fake "call" in
-  match mod_sources with
-  | [ mod_source ] ->
-      call_generic env ~void tok mod_source (G.fake_bracket mod_args)
-  | _ ->
-      (* Don't know how to interpret multiple sources. Just let this go to the wildcard case.
-        *)
-      logger#warning "Translating Terraform module with multiple/no sources";
-      call_generic env ~void tok e args
-
 (*****************************************************************************)
 (* lvalue *)
 (*****************************************************************************)
-and lval env eorig =
+
+let rec lval env eorig =
   match eorig.G.e with
   | G.N n -> name env n
   | G.IdSpecial (G.This, tok) -> lval_of_base (VarSpecial (This, tok))
@@ -607,11 +548,6 @@ and expr_aux env ?(void = false) e_gen =
        * interpolated strings, but we do not have an use for it yet during
        * semantic analysis, so in the IL we just unwrap the expression. *)
       expr env e
-  | G.Call
-      ( ({ e = N (Id (("module", _), _)); _ } as e),
-        ((_, [ _; G.Arg { e = Record (_, fields, _); _ } ], _) as args) )
-    when is_hcl env.lang ->
-      hcl_translate_module_call env void (e, args, fields)
   | G.New (tok, ty, args) ->
       (* TODO: lift up New in IL like we did in AST_generic *)
       let special = (New, tok) in

--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -900,6 +900,10 @@ and record env ((_tok, origfields, _) as record_def) =
              } ->
              Some (Spread (expr env e))
          | _ when is_hcl env.lang ->
+             (* For HCL constructs such as `lifecycle` blocks within a module call, the
+                IL translation engine will brick the whole record if it is encountered.
+                To avoid this, we will just ignore any unrecognized fields for HCL specifically.
+             *)
              logger#warning "Skipping HCL record field during IL translation";
              None
          | G.F _ -> todo (G.E e_gen))

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -132,8 +132,8 @@ let map_string_lit (env : env) ((v1, v2, v3) : CST.string_lit) =
   let v2 = map_template_literal env v2 in
   let v3 = (* quoted_template_end *) token env v3 in
   match v2 with
-  | Some (s, t) -> G.String (s, PI.combine_infos v1 [ t; v3 ])
-  | None -> G.String ("", PI.combine_infos v1 [ v3 ])
+  | Some (s, t) -> (s, PI.combine_infos v1 [ t; v3 ])
+  | None -> ("", PI.combine_infos v1 [ v3 ])
 
 let map_variable_expr (env : env) (x : CST.variable_expr) = map_identifier env x
 
@@ -149,7 +149,7 @@ let map_literal_value (env : env) (x : CST.literal_value) : literal =
   | `Nume_lit x -> map_numeric_lit env x
   | `Bool_lit x -> Bool (map_bool_lit env x)
   | `Null_lit tok -> (* "null" *) Null (token env tok)
-  | `Str_lit x -> map_string_lit env x
+  | `Str_lit x -> String (map_string_lit env x)
 
 let rec map_anon_choice_get_attr_7bbf24f (env : env)
     (x : CST.anon_choice_get_attr_7bbf24f) =
@@ -566,7 +566,7 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
         match x with
         | `Str_lit x ->
             let x = map_string_lit env x in
-            L x |> G.e
+            N (Id (x, empty_id_info ())) |> G.e
         | `Id tok ->
             let id = (* identifier *) map_identifier env tok in
             let n = H2.name_of_id id in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -127,12 +127,12 @@ let map_identifier (env : env) (x : CST.identifier) : ident =
       (* tok_choice_pat_3e8fcfc_rep_choice_pat_71519dc *) str env tok
   | `Semg_meta tok -> (* semgrep_metavariable *) str env tok
 
-let map_string_lit (env : env) ((v1, v2, v3) : CST.string_lit) =
+let map_string_lit ~with_quotes (env : env) ((v1, v2, v3) : CST.string_lit) =
   let v1 = (* quoted_template_start *) token env v1 in
   let v2 = map_template_literal env v2 in
   let v3 = (* quoted_template_end *) token env v3 in
   match v2 with
-  | Some (s, t) -> (s, PI.combine_infos v1 [ t; v3 ])
+  | Some (s, t) -> (s, if with_quotes then PI.combine_infos v1 [ t; v3 ] else t)
   | None -> ("", PI.combine_infos v1 [ v3 ])
 
 let map_variable_expr (env : env) (x : CST.variable_expr) = map_identifier env x
@@ -149,7 +149,7 @@ let map_literal_value (env : env) (x : CST.literal_value) : literal =
   | `Nume_lit x -> map_numeric_lit env x
   | `Bool_lit x -> Bool (map_bool_lit env x)
   | `Null_lit tok -> (* "null" *) Null (token env tok)
-  | `Str_lit x -> String (map_string_lit env x)
+  | `Str_lit x -> String (map_string_lit ~with_quotes:true env x)
 
 let rec map_anon_choice_get_attr_7bbf24f (env : env)
     (x : CST.anon_choice_get_attr_7bbf24f) =
@@ -566,7 +566,7 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
         match x with
         | `Str_lit x ->
             (* Parse this to a name as it has the same semantics. *)
-            let x = map_string_lit env x in
+            let x = map_string_lit ~with_quotes:false env x in
             N (Id (x, empty_id_info ())) |> G.e
         | `Id tok ->
             let id = (* identifier *) map_identifier env tok in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml
@@ -565,6 +565,7 @@ let rec map_block (env : env) ((v1, v2, v3, v4, v5) : CST.block) : G.expr =
       (fun x ->
         match x with
         | `Str_lit x ->
+            (* Parse this to a name as it has the same semantics. *)
             let x = map_string_lit env x in
             N (Id (x, empty_id_info ())) |> G.e
         | `Id tok ->


### PR DESCRIPTION
## What:
A [little bit ago](https://github.com/returntocorp/semgrep/pull/6164), I added some Terraform module stuff in the AST IL translation. This is now no longer needed.

Also, we are now ignoring unknown fields within a record for HCL programs during IL translation. This saves us from bricking the analysis when we don't have to.

## Why:
I do a postprocessing step on the AST, making it already get translated to a proper `Call`. So we don't need to special case this anymore.

I changed it so unknown records in a field are ignored for only HCL programs during IL translation, such as `lifecycle` blocks. These aren't really relevant to our dataflow, but shouldn't stop the analysis.

## How:
Deleted the irrelevant stuff.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
