### PR TITLE
Add support for Jsonnet in the Semgrep Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,9 @@ COPY cli ./
 # Here is why we need the apk packages below:
 #  - build-base: ??
 #  - make, g++: to compile the jsonnet C++ library which is installed
-#    by 'pip install jsonnet'
+#    by 'pip install jsonnet'.
+#    TODO: at some point we should not need the 'pip install jsonnet' because
+#    jsonnet would be mentioned in the setup.py for semgrep as a dependency.
 # TODO? why the mkdir -p /tmp/.cache?
 # hadolint ignore=DL3013
 RUN apk add --no-cache --virtual=.build-deps build-base make g++ &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,12 +102,16 @@ COPY cli ./
 
 # Let's now simply use 'pip' to install semgrep.
 # Note the difference between .run-deps and .build-deps below.
-# TODO? what does --virtual= mean? why all in one command below?
+# We use a single command to install packages, install semgrep, and remove
+# packages to keep a small Docker image (classic Docker trick).
+# Here is why we need the apk packages below:
+#  - build-base: ??
+#  - make, g++: to compile the jsonnet C++ library which is installed
+#    by 'pip install jsonnet'
 # TODO? why the mkdir -p /tmp/.cache?
-# TODO: for jsonnet, you need for the build-deps before 'pip install jsonnet'
-#  'apk add g++ make'
 # hadolint ignore=DL3013
-RUN apk add --no-cache --virtual=.build-deps build-base &&\
+RUN apk add --no-cache --virtual=.build-deps build-base make g++ &&\
+     pip install jsonnet &&\
      SEMGREP_SKIP_BIN=true pip install /semgrep &&\
      # running this pre-compiles some python files for faster startup times
      semgrep --version &&\


### PR DESCRIPTION
test plan:
```
$ make build-docker
$ docker run --rm -v "${PWD}:/src" semgrep:latest semgrep --config
semgrep.jsonnet
...
Support for Jsonnet rules is experimental and currently meant for internal use only. The syntax may change or be removed at any point.
Semgrep rule registry URL is https://semgrep.dev/registry.

Scanning across multiple languages:
     ocaml | 41 rules × 362 files
    python |  5 rules × 224 files
...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)