### PR TITLE
fix: Ensure the docker image uses the latest base packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,11 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=true \
     PYTHONUNBUFFERED=1
 
 
-# Update to the latest packages for the base image
+# Update to the latest packages for the base image.
+# This allows to get CVE fixes ASAP, without waiting for new builds of the base image
+# (see docker-library/python#761 for an example of such an issue in the past
+# where the time between the CVE was discovered and the package update was X days, but the new base
+# image was updated only after Y days).
 RUN apk update &&\
     apk upgrade
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,12 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=true \
     PYTHONIOENCODING=utf8 \
     PYTHONUNBUFFERED=1
 
+
+# Update to the latest packages for the base image
+RUN apk update &&\
+    apk upgrade
+
+
 # Here is why we need those apk packages below:
 # - bash: for entrypoint.sh (see below) and probably many other things
 # - git, git-lfs, openssh: so that the semgrep docker image can be used in

--- a/changelog.d/docker.fixed
+++ b/changelog.d/docker.fixed
@@ -1,0 +1,1 @@
+fix: Ensure the docker image uses the latest base packages


### PR DESCRIPTION
Tested with manually validating the steps:
```bash
podman run --rm  --security-opt label=disable  -it python:3.10-alpine /bin/sh
```
followed by:
```bash
/ # apk update
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
v3.16.2-221-ge7097e0782 [https://dl-cdn.alpinelinux.org/alpine/v3.16/main]
v3.16.2-230-g38caf0e9f8 [https://dl-cdn.alpinelinux.org/alpine/v3.16/community]
OK: 17036 distinct packages available
```
```bash
/ # apk upgrade
(1/4) Upgrading expat (2.4.8-r0 -> 2.4.9-r0)
(2/4) Upgrading alpine-baselayout-data (3.2.0-r22 -> 3.2.0-r23)
(3/4) Upgrading alpine-baselayout (3.2.0-r22 -> 3.2.0-r23)
Executing alpine-baselayout-3.2.0-r23.pre-upgrade
Executing alpine-baselayout-3.2.0-r23.post-upgrade
(4/4) Upgrading tzdata (2022a-r0 -> 2022c-r0)
Executing busybox-1.35.0-r17.trigger
OK: 14 MiB in 36 packages
```

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
