### PR TITLE
chore: update c# parser

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1372,7 +1372,7 @@ and expression (env : env) (x : CST.expression) : G.expr =
       let v3 = pattern env v3 in
       LetPattern (v3, v1) |> G.e
   | `Lambda_exp (v1, _vTODO, v2, v3, v4) ->
-      let _v1TODO = List.map (attribute_list env) v1 in
+      let _v1TODO = Common.map (attribute_list env) v1 in
       let v2 =
         match v2 with
         | `Param_list x -> parameter_list env x
@@ -2138,7 +2138,7 @@ and pattern (env : env) (x : CST.pattern) : G.pattern =
         | Some (v1, v2, _v3) ->
             let v1 = map_anon_choice_pat_29be9ad env v1 in
             let v2 =
-              List.map
+              Common.map
                 (fun (v1, v2) ->
                   let _v1 = (* "," *) token env v1 in
                   map_anon_choice_pat_29be9ad env v2)


### PR DESCRIPTION
## What:
Updated the C# parser.

## Why:
Our parse rate isn't 99.9% as promised by GA.

## How:
Followed the standard procedure to update the language.

## Test plan:
`make test`
Our `parsing-stats` metric for `./run-lang csharp` says that our parse rate is now 97.8%. Notably, this is no different than our current parse rate. It's `tree-sitter`'s fault.
PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
