### PR TITLE
fix(SSC): package-lock parse error

### DIFF
--- a/changelog.d/sca-parse-error.fix
+++ b/changelog.d/sca-parse-error.fix
@@ -1,0 +1,1 @@
+Fixed a parser error in some package-lock.json files

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -128,7 +128,13 @@ def parse_package_lock(
     lockfile_text: str, manifest_text: Optional[str]
 ) -> Generator[FoundDependency, None, None]:
     lockfile_text = "\n".join(
-        line + f'"line_number": {i},' if line.strip().startswith('"version"') else line
+        (
+            line + f'"line_number": {i},'
+            if line.strip().endswith(",")
+            else f'"line_number": {i},' + line
+        )
+        if line.strip().startswith('"version"')
+        else line
         for i, line in enumerate(lockfile_text.split("\n"))
     )
     as_json = json.loads(lockfile_text)

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
@@ -44,7 +44,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
                 ]
               },
               "ecosystem": "npm",
-              "line_number": 47,
+              "line_number": 41,
               "package": "@types/jquery",
               "resolved_url": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
               "transitivity": "unknown",

--- a/cli/tests/e2e/targets/dependency_aware/js/package-lock.json
+++ b/cli/tests/e2e/targets/dependency_aware/js/package-lock.json
@@ -23,13 +23,7 @@
           }
         },
         "node_modules/@babel/code-frame": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-          "dev": true,
-          "dependencies": {
-            "@babel/highlight": "^7.10.4"
-          }
+          "version": "7.12.11"
         }
     },
     "dependencies": {


### PR DESCRIPTION
We track line numbers in `package-lock.json` files by adding a `line_number` field after every `version` field. This strategy assumed `version` would never be the last field in an object, but in fact this can happen.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
