### PR TITLE
fix(autofix): Abort on failure to replace metavar in string literal

### DIFF
--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -53,6 +53,7 @@ type visitor_in = {
   kid_info : (id_info -> unit) * visitor_out -> id_info -> unit;
   ksvalue : (svalue -> unit) * visitor_out -> svalue -> unit;
   kargument : (argument -> unit) * visitor_out -> argument -> unit;
+  klit : (literal -> unit) * visitor_out -> literal -> unit;
 }
 
 and visitor_out = any -> unit
@@ -96,6 +97,7 @@ let default_visitor =
         ());
     ksvalue = (fun (k, _) x -> k x);
     kargument = (fun (k, _) x -> k x);
+    klit = (fun (k, _) x -> k x);
   }
 
 let v_id _ = ()
@@ -424,45 +426,48 @@ let (mk_visitor :
     | OtherEntity (v1, v2) ->
         let v1 = v_todo_kind v1 and v2 = v_list v_any v2 in
         ()
-  and v_literal = function
-    | Unit v1 ->
-        let v1 = v_tok v1 in
-        ()
-    | Bool v1 ->
-        let v1 = v_wrap v_bool v1 in
-        ()
-    | Int v1 ->
-        let v1 = v_wrap v_id v1 in
-        ()
-    | Float v1 ->
-        let v1 = v_wrap v_id v1 in
-        ()
-    | Imag v1 ->
-        let v1 = v_wrap v_string v1 in
-        ()
-    | Ratio v1 ->
-        let v1 = v_wrap v_string v1 in
-        ()
-    | Atom (v0, v1) ->
-        let v0 = v_tok v0 in
-        let v1 = v_wrap v_string v1 in
-        ()
-    | Char v1 ->
-        let v1 = v_wrap v_string v1 in
-        ()
-    | String v1 ->
-        let v1 = v_wrap v_string v1 in
-        ()
-    | Regexp (v1, v2) ->
-        let v1 = v_bracket (v_wrap v_string) v1 in
-        let v2 = v_option (v_wrap v_string) v2 in
-        ()
-    | Null v1 ->
-        let v1 = v_tok v1 in
-        ()
-    | Undefined v1 ->
-        let v1 = v_tok v1 in
-        ()
+  and v_literal x =
+    let k = function
+      | Unit v1 ->
+          let v1 = v_tok v1 in
+          ()
+      | Bool v1 ->
+          let v1 = v_wrap v_bool v1 in
+          ()
+      | Int v1 ->
+          let v1 = v_wrap v_id v1 in
+          ()
+      | Float v1 ->
+          let v1 = v_wrap v_id v1 in
+          ()
+      | Imag v1 ->
+          let v1 = v_wrap v_string v1 in
+          ()
+      | Ratio v1 ->
+          let v1 = v_wrap v_string v1 in
+          ()
+      | Atom (v0, v1) ->
+          let v0 = v_tok v0 in
+          let v1 = v_wrap v_string v1 in
+          ()
+      | Char v1 ->
+          let v1 = v_wrap v_string v1 in
+          ()
+      | String v1 ->
+          let v1 = v_wrap v_string v1 in
+          ()
+      | Regexp (v1, v2) ->
+          let v1 = v_bracket (v_wrap v_string) v1 in
+          let v2 = v_option (v_wrap v_string) v2 in
+          ()
+      | Null v1 ->
+          let v1 = v_tok v1 in
+          ()
+      | Undefined v1 ->
+          let v1 = v_tok v1 in
+          ()
+    in
+    vin.klit (k, all_functions) x
   and v_const_type = function
     | Cbool -> ()
     | Cint -> ()

--- a/semgrep-core/src/core/ast/Visitor_AST.mli
+++ b/semgrep-core/src/core/ast/Visitor_AST.mli
@@ -30,6 +30,7 @@ type visitor_in = {
   kid_info : (id_info -> unit) * visitor_out -> id_info -> unit;
   ksvalue : (svalue -> unit) * visitor_out -> svalue -> unit;
   kargument : (argument -> unit) * visitor_out -> argument -> unit;
+  klit : (literal -> unit) * visitor_out -> literal -> unit;
 }
 
 (* note that internally the visitor uses OCaml.v_ref_do_not_visit *)

--- a/semgrep-core/src/fixing/Autofix_metavar_replacement.ml
+++ b/semgrep-core/src/fixing/Autofix_metavar_replacement.ml
@@ -109,6 +109,18 @@ let has_remaining_metavars metavar_tbl ast =
                   idstr;
                 saw_metavar := true);
               k id);
+          klit =
+            (fun (k, _) lit ->
+              (match lit with
+              | String (str, _) ->
+                  if Hashtbl.mem metavar_tbl str then (
+                    logger#info
+                      "Failed to render autofix: did not successfully replace \
+                       metavariable %s in the fix pattern"
+                      str;
+                    saw_metavar := true)
+              | _ -> ());
+              k lit);
         })
   in
   visitor ast;


### PR DESCRIPTION
At some point in the near future, AST-based autofix should correctly replace metavariables in string literals with their contents. However, until it does, and to protect against future regressions, we should look for metavariables in string literals when doing this validation pass.

Test plan:

Rule:

```
rules:
- id: thing
  pattern: |
    foo("$X")
  message: uh oh
  languages: [python]
  severity: WARNING
  fix: bar("$X")
```

Target:

```
foo("asdf")
```

Run `semgrep-core -l py -json -rules str-metavar.yaml str-metavar.py -json -debug`

Before, observe that it provides a `rendered_fix` of `foo("$X")`. After, observe that it does not provide a `rendered_fix` and that it logs the error.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
