### PR TITLE
Fix blocking Semgrep finding in CI

### DIFF
--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -298,9 +298,7 @@ let compare_fixes lang ~file ~fix matches =
         List.fold_left
           (fun file_text ((start, end_), fix) ->
             let before = String.sub file_text 0 start in
-            let after =
-              String.sub file_text end_ (String.length file_text - end_)
-            in
+            let after = Str.string_after file_text end_ in
             before ^ fix ^ after)
           file_text fixes
       in


### PR DESCRIPTION
See https://semgrep.dev/r?q=ocaml.lang.best-practice.string.ocamllint-str-string-after

test plan:
make test

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
