### PR TITLE
test(autofix): Unit tests for ugly printer

### DIFF
--- a/semgrep-core/src/core/ast/tests/README.txt
+++ b/semgrep-core/src/core/ast/tests/README.txt
@@ -1,0 +1,2 @@
+This needs to be a separate directory so that the tests for `core/ast` can use
+dependencies that we do not want to add to `core/ast`.

--- a/semgrep-core/src/core/ast/tests/Unit_ugly_print_AST.ml
+++ b/semgrep-core/src/core/ast/tests/Unit_ugly_print_AST.ml
@@ -1,0 +1,18 @@
+open Common
+
+let test_python_printer () =
+  let printer = new Ugly_print_AST.python_printer in
+  let check (source, expected) =
+    (* Parse as a pattern to allow us to test printing snippets of code *)
+    let ast = Parse_pattern.parse_pattern Lang.Python source in
+    match printer#print_any ast with
+    | Error e -> failwith (spf "Couldn't print `%s`:\n%s" source e)
+    | Ok actual ->
+        let actual = Immutable_buffer.to_string actual in
+        Alcotest.(check string) source expected actual
+  in
+  List.iter check [ ("foo", "foo"); ("foo()", "foo()") ]
+
+let tests =
+  Testutil.pack_tests "ugly printer"
+    [ ("test python printer", test_python_printer) ]

--- a/semgrep-core/src/core/ast/tests/dune
+++ b/semgrep-core/src/core/ast/tests/dune
@@ -1,0 +1,10 @@
+(library
+ (public_name semgrep_core_ast_tests)
+ (wrapped false)
+ (libraries
+   commons
+   pfff-lang_GENERIC
+   semgrep_parsing
+ )
+ (preprocess (pps ppx_deriving.show ppx_profiling))
+)

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -53,6 +53,7 @@ let tests () = List.flatten [
   Unit_SPcre.tests;
   Unit_regexp_engine.tests;
   Unit_immutable_buffer.tests;
+  Unit_ugly_print_AST.tests;
 
   Unit_synthesizer.tests;
   Unit_synthesizer_targets.tests;

--- a/semgrep-core/tests/dune
+++ b/semgrep-core/tests/dune
@@ -25,6 +25,7 @@
     pfff-lang_FUZZY
 
     semgrep_core
+    semgrep_core_ast_tests
     semgrep_metachecking
     semgrep_parsing
     semgrep_matching


### PR DESCRIPTION
This sets up unit testing for the ugly printer, and includes a couple of tests. Currently, the printer can't print very much, but this should help us test appropriately as we extend it.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
