### PR TITLE
dogfood: add a 'make check' that runs semgrep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,12 @@
 # Prelude
 ##########################################################################################
 # The main goals of this pipeline are to:
-# - dogfood Semgrep by running `semgrep --config semgrep.yml` on each semgrep PRs.
-#   This also checks that Semgrep can run in alternate CI platforms like Circle CI
+# - dogfood Semgrep by running it on each semgrep PRs.
+# - check that Semgrep can run in alternate CI platforms like Circle CI
 #   (and not just in Github actions).
 # - have a cron that update our parsing statistics as well as some benchmarks,
 #   which are then accessible at https://dashboard.semgrep.dev/metrics
+#   and also at https://metabase.corp.r2c.dev/collection/59-semgrep
 
 version: 2.1
 
@@ -23,9 +24,10 @@ jobs:
     working_directory: /src
     steps:
       - checkout
-      # we now need the submodules because semgrep.jsonnet include semgrep-core/pfff/semgrep.yml
+      # we now need the submodules because semgrep.jsonnet includes semgrep-core/pfff/semgrep.yml
       - run: git submodule update --init --recursive --recommend-shallow semgrep-core/src/pfff
-      # Dogfooding to the edge by using jsonnet and the new syntax!
+      # Dogfooding on the bleeding edge by using jsonnet and the new syntax!
+      # coupling: see also 'make check'
       - run: semgrep --config semgrep.jsonnet --error --verbose --exclude tests
 
   # For the benchmarks below, we had two alternatives:

--- a/Makefile
+++ b/Makefile
@@ -252,3 +252,13 @@ gitclean:
 .PHONY: release
 release:
 	./scripts/release/bump
+
+###############################################################################
+# Dogfood!
+###############################################################################
+.PHONY: check
+
+#coupling: see also .circleci/config.yml and it 'semgrep' jobs
+# add --verbose for debugging
+check:
+	semgrep --config semgrep.jsonnet --error --exclude tests


### PR DESCRIPTION
test plan:
cd cli; pipenv shell
cd ..
make check


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)