### PR TITLE
dogfood: add a rule to detect |_ -> $X, and initial exclude list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,19 +258,25 @@ release:
 ###############################################################################
 .PHONY: check
 
-# add --verbose for debugging
+#coupling: see also .circleci/config.yml and its 'semgrep' job
 SEMGREP_ARGS=--config semgrep.jsonnet --error --exclude tests
+# you can add --verbose for debugging
 
-#coupling: see also .circleci/config.yml and it 'semgrep' jobs
+DOCKER_IMAGE=returntocorp/semgrep:develop
+
+# You need to have semgrep in your PATH! do 'cd cli; pipenv shell' before
+# if needed.
 check:
 	semgrep $(SEMGREP_ARGS)
 
 # If you get semgrep-core parsing errors while running this command, maybe you
-# have an old cached version of the returntocorp/semgrep:develop docker image.
+# have an old cached version of the docker image.
 # You can invalidate the cache with 'docker rmi returntocorp/semgrep:develop`
 check_with_docker:
-	docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop semgrep $(SEMGREP_ARGS)
+	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) semgrep $(SEMGREP_ARGS)
 
+# I use the docker here instead of directly semgrep, because semgrep is not always
+# in my PATH.
 #TODO: this will be less needed once we run semgrep with semgrep.jsonnet in pre-commit
 check_for_emacs:
-	docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop semgrep $(SEMGREP_ARGS) --emacs
+	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) semgrep $(SEMGREP_ARGS) --emacs

--- a/Makefile
+++ b/Makefile
@@ -279,4 +279,4 @@ check_with_docker:
 # in my PATH.
 #TODO: this will be less needed once we run semgrep with semgrep.jsonnet in pre-commit
 check_for_emacs:
-	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) semgrep $(SEMGREP_ARGS) --emacs
+	docker run --rm -v "${PWD}:/src" $(DOCKER_IMAGE) semgrep $(SEMGREP_ARGS) --emacs --quiet

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,19 @@ release:
 ###############################################################################
 .PHONY: check
 
-#coupling: see also .circleci/config.yml and it 'semgrep' jobs
 # add --verbose for debugging
+SEMGREP_ARGS=--config semgrep.jsonnet --error --exclude tests
+
+#coupling: see also .circleci/config.yml and it 'semgrep' jobs
 check:
-	semgrep --config semgrep.jsonnet --error --exclude tests
+	semgrep $(SEMGREP_ARGS)
+
+# If you get semgrep-core parsing errors while running this command, maybe you
+# have an old cached version of the returntocorp/semgrep:develop docker image.
+# You can invalidate the cache with 'docker rmi returntocorp/semgrep:develop`
+check_with_docker:
+	docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop semgrep $(SEMGREP_ARGS)
+
+#TODO: this will be less needed once we run semgrep with semgrep.jsonnet in pre-commit
+check_for_emacs:
+	docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop semgrep $(SEMGREP_ARGS) --emacs

--- a/semgrep-core/src/analyzing/CFG_build.ml
+++ b/semgrep-core/src/analyzing/CFG_build.ml
@@ -301,7 +301,7 @@ and cfg_stmt_list state previ xs =
       label_node state (l :: ls) dummyi;
       state.g |> add_arc_from_opt (lasti_opt, dummyi);
       Some dummyi
-  | _ -> lasti_opt
+  | [] -> lasti_opt
 
 (*****************************************************************************)
 (* Main entry point *)

--- a/semgrep-core/src/cli-bridge/Semgrep_bridge_core.ml
+++ b/semgrep-core/src/cli-bridge/Semgrep_bridge_core.ml
@@ -35,7 +35,7 @@ let semgrep_cli_lib_main (argv : string array)
     | 2 -> raise (Sys_error "read_file callback failed with unknown error.")
     (* The 'contents' contains the error message. *)
     | 3 -> raise (Sys_error (Bytes.to_string contents))
-    | _ ->
+    | __else__ ->
         raise
           (Sys_error
              ("read_file callback failed with code " ^ string_of_int code ^ "."))

--- a/semgrep-core/src/core/Metavariable.ml
+++ b/semgrep-core/src/core/Metavariable.ml
@@ -179,7 +179,7 @@ let is_metavar_name s =
     (* todo: there's also "$GLOBALS" but this may interface with existing rules*)
     ->
       false
-  | _ -> s =~ metavar_regexp_string
+  | __else__ -> s =~ metavar_regexp_string
 
 (* $...XXX multivariadic metavariables. Note that I initially chose
  * $X... but this leads to parsing conflicts in Javascript.

--- a/semgrep-core/src/core/Semgrep_error_code.ml
+++ b/semgrep-core/src/core/Semgrep_error_code.ml
@@ -61,7 +61,17 @@ let mk_error ?(rule_id = None) loc msg err =
     | Out.FatalError
     | Out.TooManyMatches ->
         Printf.sprintf "%s\n\n%s" please_file_issue_text msg
-    | _ -> msg
+    | LexicalError
+    | ParseError
+    | SpecifiedParseError
+    | RuleParseError
+    | InvalidYaml
+    | SemgrepMatchFound
+    | Timeout
+    | OutOfMemory
+    | PatternParseError _
+    | PartialParsing _ ->
+        msg
   in
   { rule_id; loc; typ = err; msg; details = None }
 
@@ -92,7 +102,7 @@ let known_exn_to_error ?(rule_id = None) file (e : Exception.t) : error option =
         match tok with
         | { token = PI.OriginTok { str; _ }; _ } ->
             spf "`%s` was unexpected" str
-        | _ -> "unknown reason"
+        | __else__ -> "unknown reason"
       in
       Some (mk_error_tok tok msg Out.ParseError)
   | Parse_info.Other_error (s, tok) ->

--- a/semgrep-core/src/core/Xlang.ml
+++ b/semgrep-core/src/core/Xlang.ml
@@ -49,7 +49,7 @@ let of_string ?id:(id_opt = None) s =
   | "regex" ->
       LRegex
   | "generic" -> LGeneric
-  | _ -> (
+  | __else__ -> (
       match Lang.lang_of_string_opt s with
       | None -> (
           match id_opt with

--- a/semgrep-core/src/core/Xpattern.ml
+++ b/semgrep-core/src/core/Xpattern.ml
@@ -66,4 +66,4 @@ let mk_xpat pat pstr =
 let is_regexp xpat =
   match xpat.pat with
   | Regexp _ -> true
-  | _ -> false
+  | __else__ -> false

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -2007,7 +2007,7 @@ let interpolated (lquote, xs, rquote) =
   match xs with
   | [ Common.Left3 (str, tstr) ] ->
       L (String (str, Parse_info.combine_infos lquote [ tstr; rquote ])) |> e
-  | _ ->
+  | __else__ ->
       let special = IdSpecial (ConcatString InterpolatedConcat, lquote) |> e in
       Call
         ( special,

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -19,7 +19,7 @@ let vof_bracket of_a (t1, x, t2) =
   let v = of_a x in
   match v1 with
   | OCaml.VUnit -> v
-  | _ -> OCaml.VTuple [ v1; v; v2 ]
+  | __else__ -> OCaml.VTuple [ v1; v; v2 ]
 
 let vof_ident v = vof_wrap OCaml.vof_string v
 let vof_todo_kind v = vof_wrap OCaml.vof_string v

--- a/semgrep-core/src/core/ast/Type_generic.ml
+++ b/semgrep-core/src/core/ast/Type_generic.ml
@@ -60,7 +60,7 @@ let builtin_type_of_ident _langTODO str =
   (* TS *)
   | "number" -> Some TNumber
   | "boolean" -> Some TBool
-  | _ -> None
+  | __else__ -> None
 
 let builtin_type_of_type lang t =
   match t.G.t with
@@ -69,4 +69,4 @@ let builtin_type_of_type lang t =
       builtin_type_of_ident lang str
   (* for Java/Go/... literals *)
   | G.TyN (Id ((str, _t), _idinfo)) -> builtin_type_of_ident lang str
-  | _ -> None
+  | __else__ -> None

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -24,7 +24,10 @@ let string_of_exp e =
   | Literal _ -> "<LIT>"
   | Operator _ -> "<OP>"
   | FixmeExp _ -> "<FIXME-EXP>"
-  | _ -> "<EXP>"
+  | Composite (_, _)
+  | Record _
+  | Cast (_, _) ->
+      "<EXP>"
 
 let short_string_of_node_kind nkind =
   match nkind with

--- a/semgrep-core/src/core/il/IL_helpers.ml
+++ b/semgrep-core/src/core/il/IL_helpers.ml
@@ -64,7 +64,7 @@ and lvals_in_lval lval =
     List.concat_map
       (function
         | Index e -> lvals_of_exp e
-        | _ -> [])
+        | Dot _ -> [])
       lval.rev_offset
   in
   base_lvals @ offset_lvals
@@ -105,7 +105,7 @@ let lval_is_dotted_prefix lval1 lval2 =
   match (lval1, lval2) with
   | { base = Var x; rev_offset = ro1 }, { base = Var y; rev_offset = ro2 } ->
       eq_name x y && offset_prefix (List.rev ro1) (List.rev ro2)
-  | _ -> false
+  | __else__ -> false
 
 let lval_of_instr_opt x =
   match x.i with

--- a/semgrep-core/src/engine/Entropy.ml
+++ b/semgrep-core/src/engine/Entropy.ml
@@ -111,7 +111,7 @@ let get_substring_entropy s =
       let e2 = s.[1] |> Char.code |> Array.get char_entropies in
       (e1 +. e2) /. 2.
   | 1 -> s.[0] |> Char.code |> Array.get char_entropies
-  | _ -> assert false
+  | __else__ -> assert false
 
 let iter_substrings s f =
   for i = 0 to String.length s - 3 do
@@ -165,10 +165,9 @@ let score_entropy x = if x > entropy_threshold then 1 else 0
 let score_density x = if x > density_threshold then 1 else 0
 
 let score s =
-  match s with
-  | "" -> 0
-  | _ ->
-      let ent, density = entropy_data s in
-      score_entropy ent + score_density density
+  if s = "" then 0
+  else
+    let ent, density = entropy_data s in
+    score_entropy ent + score_density density
 
 let has_high_score s = score s = 2

--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -109,7 +109,7 @@ let count_lines_and_trailing =
     (fun (n, c) b ->
       match b with
       | '\n' -> (n + 1, 0)
-      | _ -> (n, c + 1))
+      | __else__ -> (n, c + 1))
     (0, 0)
 
 let offsets_of_mval extract_mvalue =

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -538,9 +538,15 @@ let check_fundef lang taint_config opt_ent fdef =
                       _;
                     } ->
                     add_to_env env id ii
-                | _ -> env)
+                | G.F _ -> env)
               env fields
-        | _ -> env)
+        | G.Param { pname = None; _ }
+        | G.ParamPattern _
+        | G.ParamRest (_, _)
+        | G.ParamHashSplat (_, _)
+        | G.ParamEllipsis _
+        | G.OtherParam (_, _) ->
+            env)
       Lval_env.empty fdef.G.fparams
   in
   let _, xs = AST_to_IL.function_definition lang fdef in

--- a/semgrep-core/src/engine/Metavariable_pattern.ml
+++ b/semgrep-core/src/engine/Metavariable_pattern.ml
@@ -31,7 +31,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 let adjust_content_for_language (xlang : Xlang.t) (content : string) : string =
   match xlang with
   | Xlang.L (Lang.Php, _) -> "<?php " ^ content
-  | _ -> content
+  | __else__ -> content
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/engine/ReDoS.ml
+++ b/semgrep-core/src/engine/ReDoS.ml
@@ -44,7 +44,7 @@ let matches_deep test x = find_all test x <> []
 let matches_sequence test_left test_right (x : AST.t) =
   match x with
   | Seq (_, a, b) -> test_left a && test_right b
-  | _ -> false
+  | __else__ -> false
 
 (* A choice that always allows two or more branches to match nonempty input.
    Examples include:
@@ -120,7 +120,7 @@ let matches_nonpossessive_repeat ~min_repeat test (x : AST.t) =
         | Some max_reps -> max_reps >= min_repeat
       in
       satisfies_min_repeats && test x
-  | _ -> false
+  | __else__ -> false
 
 let matches_not_everywhere (x : AST.t) =
   let match_constraints =

--- a/semgrep-core/src/engine/Xpattern_match_comby.ml
+++ b/semgrep-core/src/engine/Xpattern_match_comby.ml
@@ -53,7 +53,7 @@ let comby_matcher (m_all, source) file pat =
                       let t = info_of_token_location loc in
                       let mval = mval_of_string str t in
                       (mvar, mval)
-                  | _ -> raise Impossible)
+                  | __else__ -> raise Impossible)
          in
          let line, column, charpos =
            line_col_charpos_of_comby_range file range

--- a/semgrep-core/src/fixing/Autofix_printer.ml
+++ b/semgrep-core/src/fixing/Autofix_printer.ml
@@ -63,7 +63,7 @@ let get_printer lang external_printer :
     (Ugly_print_AST.printer_t, string) result =
   match lang with
   | Lang.Python -> Ok (new PythonPrinter.printer external_printer)
-  | _ -> Error (spf "No printer available for %s" (Lang.to_string lang))
+  | __else__ -> Error (spf "No printer available for %s" (Lang.to_string lang))
 
 let original_source_of_ast source any =
   let* start, end_ = Visitor_AST.range_of_any_opt any in
@@ -98,7 +98,17 @@ let add_metavars (tbl : ast_node_table) metavars =
       | MV.Args args ->
           List.iter (fun arg -> ASTTable.replace tbl (Ar arg) Target) args
       (* TODO iterate through other metavariable values that are lists *)
-      | _ -> ())
+      | Id ((_, _), _)
+      | N _
+      | E _
+      | S _
+      | T _
+      | P _
+      | Ss _
+      | Params _
+      | Xmls _
+      | Text (_, _) ->
+          ())
     metavars
 
 (* Add each AST node from the fix pattern AST to the lookup table so that it can

--- a/semgrep-core/src/matching/Apply_equivalences.ml
+++ b/semgrep-core/src/matching/Apply_equivalences.ml
@@ -65,7 +65,7 @@ let subst_e (env : Env.t) e =
                 | None ->
                     failwith
                       (spf "could not find metavariable %s in environment" str))
-            | _ -> k x);
+            | __else__ -> k x);
       }
   in
   visitor.M.vexpr e
@@ -85,7 +85,8 @@ let apply equivs lang any =
              Common.push (l, r) stmt_rules;
              Common.push (r, l) stmt_rules
          | S l, Eq.Imply, S r -> Common.push (l, r) stmt_rules
-         | _ -> failwith "only expr and stmt equivalence patterns are supported");
+         | __else__ ->
+             failwith "only expr and stmt equivalence patterns are supported");
   (* the order matters, keep the original order reverting Common.push *)
   let expr_rules = List.rev !expr_rules in
   let _stmt_rulesTODO = List.rev !stmt_rules in

--- a/semgrep-core/src/matching/Match_patterns.ml
+++ b/semgrep-core/src/matching/Match_patterns.ml
@@ -268,7 +268,30 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
            | Fld pattern -> Common.push (pattern, rule, cache) fld_rules
            | Flds pattern -> Common.push (pattern, rule, cache) flds_rules
            | Partial pattern -> Common.push (pattern, rule, cache) partial_rules
-           | _ ->
+           | Args _
+           | Params _
+           | Xmls _
+           | I _
+           | Str _
+           | Def _
+           | Dir _
+           | Tk _
+           | TodoK _
+           | Ar _
+           | Pa _
+           | Tp _
+           | Ta _
+           | Modn _
+           | Ce _
+           | Cs _
+           | ForOrIfComp _
+           | ModDk _
+           | En _
+           | Dk _
+           | Di _
+           | Lbli _
+           | Anys _
+           | Pr _ ->
                failwith
                  "only expr/stmt(s)/type/pattern/annotation/field(s)/partial \
                   patterns are supported");

--- a/semgrep-core/src/optimizing/Analyze_rule.ml
+++ b/semgrep-core/src/optimizing/Analyze_rule.ml
@@ -330,7 +330,7 @@ let and_step1bis_filter_general (And xs) =
              xs
              |> List.exists (function
                   | StringsAndMvars ([], _) -> true
-                  | _ -> false)
+                  | __else__ -> false)
            then Left (Or xs)
            else Right (Or xs))
   in
@@ -353,7 +353,7 @@ let and_step1bis_filter_general (And xs) =
                                          | Regexp _ -> false
                                          | MvarRegexp (mvar2, _, _) ->
                                              mvar2 = mvar)))
-                  | _ -> false)
+                  | __else__ -> false)
            in
            if null xs' then None else Some (Or xs'))
   in

--- a/semgrep-core/src/optimizing/Bloom_annotation.ml
+++ b/semgrep-core/src/optimizing/Bloom_annotation.ml
@@ -103,7 +103,7 @@ let rec statement_strings stmt =
                  * Generic_vs_generic.m_module_name_prefix. *)
                 Common.split {|/\|\\|} str |> List.iter (fun s -> push s res);
                 k x
-            | _ -> k x);
+            | __else__ -> k x);
         V.kexpr =
           (fun (k, _) x ->
             match x.e with
@@ -112,7 +112,7 @@ let rec statement_strings stmt =
              *)
             | L (String (str, _tok)) -> push str res
             | IdSpecial (_, tok) -> push (Parse_info.str_of_info tok) res
-            | _ -> k x);
+            | __else__ -> k x);
         V.ksvalue =
           (fun (_k, _) x ->
             match x with

--- a/semgrep-core/src/optimizing/Caching.ml
+++ b/semgrep-core/src/optimizing/Caching.ml
@@ -138,7 +138,7 @@ let diff_backrefs bound_metavars ~new_backref_counts ~old_backref_counts =
         in
         match added_backref_count with
         | 0 -> Set_.add k acc
-        | _ -> acc)
+        | __else__ -> acc)
       bound_metavars Set_.empty
   in
   Set_.diff bound_metavars not_backrefs_in_rest_of_pattern
@@ -146,7 +146,7 @@ let diff_backrefs bound_metavars ~new_backref_counts ~old_backref_counts =
 let is_ellipsis_stmt (x : stmt) =
   match x.s with
   | ExprStmt ({ e = Ellipsis _; _ }, _) -> true
-  | _ -> false
+  | __else__ -> false
 
 (*
    Decorate a pattern and target ASTs to make the suitable for memoization

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -223,4 +223,4 @@ let dump_tree_sitter_pattern_cst lang file =
   | Lang.Kotlin ->
       Tree_sitter_kotlin.Parse.file file
       |> dump_and_print_errors Tree_sitter_kotlin.CST.dump_tree
-  | _ -> ()
+  | __else__ -> ()

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -41,7 +41,40 @@ let range_of_any_opt startp_of_match_range any =
   | Args []
   | Xmls [] ->
       Some empty_range
-  | _ ->
+  (* TODO? Flds [] ? Pr []? *)
+  | Ss _
+  | Params _
+  | Args _
+  | Xmls _
+  | E _
+  | S _
+  | T _
+  | P _
+  | At _
+  | Fld _
+  | Flds _
+  | Partial _
+  | I _
+  | Str _
+  | Def _
+  | Dir _
+  | Pr _
+  | Tk _
+  | TodoK _
+  | Ar _
+  | Pa _
+  | Tp _
+  | Ta _
+  | Modn _
+  | Ce _
+  | Cs _
+  | ForOrIfComp _
+  | ModDk _
+  | En _
+  | Dk _
+  | Di _
+  | Lbli _
+  | Anys _ ->
       let* min_loc, max_loc = V.range_of_any_opt any in
       let startp, endp = OutH.position_range min_loc max_loc in
       Some (startp, endp)
@@ -86,7 +119,7 @@ let get_propagated_value default_start mvalue =
       | Some (Cst _) -> None
       | Some NotCst -> None
       | None -> None)
-  | _ -> None
+  | __else__ -> None
 
 let metavars startp_of_match_range (s, mval) =
   let any = MV.mvalue_to_any mval in

--- a/semgrep-core/src/reporting/Statistics_report.ml
+++ b/semgrep-core/src/reporting/Statistics_report.ml
@@ -99,7 +99,7 @@ let parse_run (rule, xs) =
                (* best guess *)
                last_time := !last_time +. !timeout;
                Some (f, !last_time)
-           | _ -> None)
+           | __else__ -> None)
     |> map_with_previous
          (fun (_, prevtime) (f, time) -> (f, time -. prevtime))
          ("<nofile>", 0.)

--- a/semgrep-core/src/runner/Parse_with_caching.ml
+++ b/semgrep-core/src/runner/Parse_with_caching.ml
@@ -62,7 +62,7 @@ let get_value_and_run_checks ?(filecheck = None) version_cur file_cache =
       failwith
         (spf "Not the same file! Md5sum collision! Clean the cache file %s"
            file_cache)
-  | _ -> ());
+  | __else__ -> ());
   res
 
 (* The function below is mostly a copy-paste of Common.cache_computation.

--- a/semgrep-core/src/tainting/Taint_lval_env.ml
+++ b/semgrep-core/src/tainting/Taint_lval_env.ml
@@ -69,7 +69,7 @@ let add lval taints ({ tainted; propagated; cleaned } as lval_env) =
         else
           taints
           |> Taints.map (fun t -> { t with tokens = var_tok :: t.tokens })
-    | _ -> taints
+    | __else__ -> taints
   in
   if Taints.is_empty taints then lval_env
   else

--- a/semgrep-core/src/targeting/Skip_target.ml
+++ b/semgrep-core/src/targeting/Skip_target.ml
@@ -57,7 +57,7 @@ let whitespace_stat_of_string s =
     | '\n' ->
         incr whitespace;
         incr lines
-    | _ -> incr other
+    | __else__ -> incr other
   done;
   let total = !whitespace + !other in
   let sample_size = String.length s in

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -33,20 +33,20 @@ local semgrep_rules = [
     severity: "WARNING",
     message: |||
         Using a catch all pattern is dangerous in the long term. If someone adds a new
-	constructor, the compiler will not help us and telling us to maybe update this code.
+        constructor, the compiler will not help us and telling us to maybe update this code.
         Try to replace with the list of the remaining cases not handled instead (you can
-	rely on ocamlc to give you the disjunctive pattern covering all the cases and copy
-	paste it in the code). You can also add a nosemgrep comment if you think
-	you know what you're doing.
+        rely on ocamlc to give you the disjunctive pattern covering all the cases and copy
+        paste it in the code). You can also add a nosemgrep comment if you think
+        you know what you're doing.
     |||,
     paths: {
       #TODO: we should make a tool or a flag to help construct those exclude lists
       # or include something like 'bento archive' in semgrep
       # or automatically add the (* nosemgrep *) annotation everywhere.
       exclude: [
-	#TODO: those files contain less than 100 findings in total, so
-	# they should not be too hard to fix
-	# 1 finding per file
+        #TODO: those files contain less than 100 findings in total, so
+        # they should not be too hard to fix
+        # 1 finding per file
         "semgrep-core/src/analyzing/CFG_build.ml",
         "semgrep-core/src/cli-bridge/Semgrep_bridge_core.ml",
         "semgrep-core/src/core/Metavariable.ml",
@@ -64,7 +64,7 @@ local semgrep_rules = [
         "semgrep-core/src/runner/Parse_with_caching.ml",
         "semgrep-core/src/targeting/Skip_target.ml",
         "semgrep-core/src/tainting/Taint_lval_env.ml",
-	# 2 findings per file
+        # 2 findings per file
         "semgrep-core/src/core/Semgrep_error_code.ml",
         "semgrep-core/src/core/ast/Type_generic.ml",
         "semgrep-core/src/core/il/IL_helpers.ml",
@@ -77,7 +77,7 @@ local semgrep_rules = [
         "semgrep-core/src/optimizing/Bloom_annotation.ml",
         "semgrep-core/src/optimizing/Caching.ml",
         "semgrep-core/src/reporting/JSON_report.ml",
-	# more findings per file
+        # more findings per file
         "semgrep-core/src/analyzing/Dataflow_svalue.ml",
         "semgrep-core/src/core/ast/AST_generic_helpers.ml",
         "semgrep-core/src/engine/Match_search_mode.ml",
@@ -91,20 +91,20 @@ local semgrep_rules = [
         "semgrep-core/src/tainting/Dataflow_tainting.ml",
         "semgrep-core/src/targeting/Guess_lang.ml",
         "semgrep-core/src/utils/Regexp_engine.ml",
-	#TODO: we should fix those too. They account for 464 findings in total
-	"Generic_vs_generic.ml",
-	"Visitor_AST.ml",
-	"Naming_AST.ml",
-	"Pretty_print_AST.ml",
-	"Constant_propagation.ml",
-	"Eval_generic.ml",
-	"AST_to_IL.ml",
-	"Parse_rule.ml",
-	"parsing/tree_sitter/*",
-	"parsing/pfff/*",
-	"parsing/other/*",
-	"parsing/ast/*",
-	"metachecking/*",
+        #TODO: we should fix those too. They account for 464 findings in total
+        "Generic_vs_generic.ml",
+        "Visitor_AST.ml",
+        "Naming_AST.ml",
+        "Pretty_print_AST.ml",
+        "Constant_propagation.ml",
+        "Eval_generic.ml",
+        "AST_to_IL.ml",
+        "Parse_rule.ml",
+        "parsing/tree_sitter/*",
+        "parsing/pfff/*",
+        "parsing/other/*",
+        "parsing/ast/*",
+        "metachecking/*",
         ] + test_code_globs + less_important_code_globs,
     }
   }
@@ -130,9 +130,9 @@ local all = yml.rules + semgrep_rules + pfff.rules + ocaml.rules;
 
   { rules:
       [  if std.objectHas(override_messages, r.id)
-	 then r + {message: override_messages[r.id]}
+         then r + {message: override_messages[r.id]}
          else r
-	for r in all
-	if !std.member(todo_skipped_for_now, r.id)
+        for r in all
+        if !std.member(todo_skipped_for_now, r.id)
       ]
   }

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -36,7 +36,8 @@ local semgrep_rules = [
 	constructor, the compiler will not help us and telling us to maybe update this code.
         Try to replace with the list of the remaining cases not handled instead (you can
 	rely on ocamlc to give you the disjunctive pattern covering all the cases and copy
-	paste it in the code). You can also add a nosemgrep comment if you know what you're doing.
+	paste it in the code). You can also add a nosemgrep comment if you think
+	you know what you're doing.
     |||,
     paths: {
       #TODO: we should make a tool or a flag to help construct those exclude lists

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -1,6 +1,12 @@
+# legacy rules written in YAML
 local yml = import "semgrep.yml";
 local pfff = import "semgrep-core/src/pfff/semgrep.yml";
+# registry rules!
 local ocaml = import "p/ocaml";
+
+# this is useful to factorize exclude
+local test_code_globs = ["Unit_*.ml", "Test_*.ml"];
+local less_important_code_globs = ["spacegrep/*", "experiments/*", "scripts/*"];
 
 local semgrep_rules = [
   #TODO: this rule could be moved in pfff/semgrep.yml at some point
@@ -17,6 +23,89 @@ local semgrep_rules = [
         It is easy to forget to close `open_in` with `close_in`.
         Use `Common.with_open_infile()` instead.
     |||,
+  },
+  #TODO: this is an experimental rule. It has lots of findings, so maybe it is too
+  # noisy, but it's nice to dogfood how to handle noisy rules.
+  # 564 findings before the exclude
+  { id: "semgrep-no-catch-all-match-underscore",
+    match: "| _ -> $X",
+    languages: ["ocaml"],
+    severity: "WARNING",
+    message: |||
+        Using a catch all pattern is dangerous in the long term. If someone adds a new
+	constructor, the compiler will not help us and telling us to maybe update this code.
+        Try to replace with the list of the remaining cases not handled instead (you can
+	rely on ocamlc to give you the disjunctive pattern covering all the cases and copy
+	paste it in the code). You can also add a nosemgrep comment if you know what you're doing.
+    |||,
+    paths: {
+      #TODO: we should make a tool or a flag to help construct those exclude lists
+      # or include something like 'bento archive' in semgrep
+      # or automatically add the (* nosemgrep *) annotation everywhere.
+      exclude: [
+	#TODO: those files contain less than 100 findings in total, so
+	# they should not be too hard to fix
+	# 1 finding per file
+        "semgrep-core/src/analyzing/CFG_build.ml",
+        "semgrep-core/src/cli-bridge/Semgrep_bridge_core.ml",
+        "semgrep-core/src/core/Metavariable.ml",
+        "semgrep-core/src/core/Xlang.ml",
+        "semgrep-core/src/core/Xpattern.ml",
+        "semgrep-core/src/core/ast/AST_generic.ml",
+        "semgrep-core/src/core/ast/Meta_AST.ml",
+        "semgrep-core/src/engine/Match_extract_mode.ml",
+        "semgrep-core/src/engine/Metavariable_pattern.ml",
+        "semgrep-core/src/core/il/Display_IL.ml",
+        "semgrep-core/src/engine/Xpattern_match_comby.ml",
+        "semgrep-core/src/matching/Match_patterns.ml",
+        "semgrep-core/src/parsing/Parse_pattern.ml",
+        "semgrep-core/src/reporting/Statistics_report.ml",
+        "semgrep-core/src/runner/Parse_with_caching.ml",
+        "semgrep-core/src/targeting/Skip_target.ml",
+        "semgrep-core/src/tainting/Taint_lval_env.ml",
+	# 2 findings per file
+        "semgrep-core/src/core/Semgrep_error_code.ml",
+        "semgrep-core/src/core/ast/Type_generic.ml",
+        "semgrep-core/src/core/il/IL_helpers.ml",
+        "semgrep-core/src/engine/Entropy.ml",
+        "semgrep-core/src/engine/Match_tainting_mode.ml",
+        "semgrep-core/src/engine/ReDoS.ml",
+        "semgrep-core/src/fixing/Autofix_printer.ml",
+        "semgrep-core/src/matching/Apply_equivalences.ml",
+        "semgrep-core/src/optimizing/Analyze_rule.ml",
+        "semgrep-core/src/optimizing/Bloom_annotation.ml",
+        "semgrep-core/src/optimizing/Caching.ml",
+        "semgrep-core/src/reporting/JSON_report.ml",
+	# more findings per file
+        "semgrep-core/src/analyzing/Dataflow_svalue.ml",
+        "semgrep-core/src/core/ast/AST_generic_helpers.ml",
+        "semgrep-core/src/engine/Match_search_mode.ml",
+        "semgrep-core/src/fixing/Autofix_metavar_replacement.ml",
+        "semgrep-core/src/matching/Matching_generic.ml",
+        "semgrep-core/src/matching/SubAST_generic.ml",
+        "semgrep-core/src/optimizing/Analyze_pattern.ml",
+        "semgrep-core/src/parsing/Parse_equivalences.ml",
+        "semgrep-core/src/parsing/Parse_target.ml",
+        "semgrep-core/src/runner/Run_semgrep.ml",
+        "semgrep-core/src/tainting/Dataflow_tainting.ml",
+        "semgrep-core/src/targeting/Guess_lang.ml",
+        "semgrep-core/src/utils/Regexp_engine.ml",
+	#TODO: we should fix those too. They account for 464 findings in total
+	"Generic_vs_generic.ml",
+	"Visitor_AST.ml",
+	"Naming_AST.ml",
+	"Pretty_print_AST.ml",
+	"Constant_propagation.ml",
+	"Eval_generic.ml",
+	"AST_to_IL.ml",
+	"Parse_rule.ml",
+	"parsing/tree_sitter/*",
+	"parsing/pfff/*",
+	"parsing/other/*",
+	"parsing/ast/*",
+	"metachecking/*",
+        ] + test_code_globs + less_important_code_globs,
+    }
   }
 ];
 

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -47,21 +47,7 @@ local semgrep_rules = [
       exclude: [
         #TODO: those files contain less than 100 findings in total, so
         # they should not be too hard to fix
-        # 1 finding per file
-        # 2 findings per file
-        "semgrep-core/src/core/Semgrep_error_code.ml",
-        "semgrep-core/src/core/ast/Type_generic.ml",
-        "semgrep-core/src/core/il/IL_helpers.ml",
-        "semgrep-core/src/engine/Entropy.ml",
-        "semgrep-core/src/engine/Match_tainting_mode.ml",
-        "semgrep-core/src/engine/ReDoS.ml",
-        "semgrep-core/src/fixing/Autofix_printer.ml",
-        "semgrep-core/src/matching/Apply_equivalences.ml",
-        "semgrep-core/src/optimizing/Analyze_rule.ml",
-        "semgrep-core/src/optimizing/Bloom_annotation.ml",
-        "semgrep-core/src/optimizing/Caching.ml",
-        "semgrep-core/src/reporting/JSON_report.ml",
-        # more findings per file
+        # a few findings per file
         "semgrep-core/src/analyzing/Dataflow_svalue.ml",
         "semgrep-core/src/core/ast/AST_generic_helpers.ml",
         "semgrep-core/src/engine/Match_search_mode.ml",

--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -32,12 +32,13 @@ local semgrep_rules = [
     languages: ["ocaml"],
     severity: "WARNING",
     message: |||
-        Using a catch all pattern is dangerous in the long term. If someone adds a new
+        Using a catch all pattern is dangerous in the long term for patterns over algebraic
+        data types (for matching over ints and strings it's fine). If someone adds a new
         constructor, the compiler will not help us and telling us to maybe update this code.
         Try to replace with the list of the remaining cases not handled instead (you can
         rely on ocamlc to give you the disjunctive pattern covering all the cases and copy
-        paste it in the code). You can also add a nosemgrep comment if you think
-        you know what you're doing.
+        paste it in the code). If you think adding a new constructor should have no
+        impact on this code, then replace the pattern with '| __else__ ->' instead.
     |||,
     paths: {
       #TODO: we should make a tool or a flag to help construct those exclude lists
@@ -47,23 +48,6 @@ local semgrep_rules = [
         #TODO: those files contain less than 100 findings in total, so
         # they should not be too hard to fix
         # 1 finding per file
-        "semgrep-core/src/analyzing/CFG_build.ml",
-        "semgrep-core/src/cli-bridge/Semgrep_bridge_core.ml",
-        "semgrep-core/src/core/Metavariable.ml",
-        "semgrep-core/src/core/Xlang.ml",
-        "semgrep-core/src/core/Xpattern.ml",
-        "semgrep-core/src/core/ast/AST_generic.ml",
-        "semgrep-core/src/core/ast/Meta_AST.ml",
-        "semgrep-core/src/engine/Match_extract_mode.ml",
-        "semgrep-core/src/engine/Metavariable_pattern.ml",
-        "semgrep-core/src/core/il/Display_IL.ml",
-        "semgrep-core/src/engine/Xpattern_match_comby.ml",
-        "semgrep-core/src/matching/Match_patterns.ml",
-        "semgrep-core/src/parsing/Parse_pattern.ml",
-        "semgrep-core/src/reporting/Statistics_report.ml",
-        "semgrep-core/src/runner/Parse_with_caching.ml",
-        "semgrep-core/src/targeting/Skip_target.ml",
-        "semgrep-core/src/tainting/Taint_lval_env.ml",
         # 2 findings per file
         "semgrep-core/src/core/Semgrep_error_code.ml",
         "semgrep-core/src/core/ast/Type_generic.ml",


### PR DESCRIPTION
This is an experiment. Maybe this rule is too annoying. Let's try
to use it and let's see how many (* nosemgrep *) we end up writing.

test plan:
make check


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)