### PR TITLE
fix(scala): parse generator guards with newlines test

### DIFF
--- a/changelog.d/pa-1902.fixed
+++ b/changelog.d/pa-1902.fixed
@@ -1,0 +1,1 @@
+Scala: Fixed a bug where generators would not parse if newlines were present, in certain cases

--- a/semgrep-core/tests/parsing/scala/generator_guards.scala
+++ b/semgrep-core/tests/parsing/scala/generator_guards.scala
@@ -1,0 +1,28 @@
+for { x <- 5 if true} yield 2
+for { x <- 5 } yield 2
+
+for ( x <- 5 ) yield 2
+for ( x <- 5 if true ) yield 2
+
+for ( x <- 5 if true if false ) yield 2
+for ( x <- 5
+    if true if false ) yield 2
+for ( x <- 5
+    if true
+    if false ) yield 2
+for ( x <- 5
+    if true
+    if false
+    ) yield 2
+
+for ( x <- 5 ; if true
+    if false ) yield 2
+for { x <- 5 ; if true} yield 2
+for ( x <- 5 ; if true ) yield 2
+for { x <- 5
+      x <- 6
+    if true if false } yield 2
+for { x <- 5
+      x <- 6
+    if true
+    if false } yield 2


### PR DESCRIPTION
## What:
This is a revival of my old branch. It died and now I have no idea where it is.

Scala generator guards are pretty finnicky when it comes to newlines. I added changes that make it parse correctly.

## Why:
Requested by a customer to fix this, some two weeks ago.

## How:
I made it so that we do some more whitespace-agnostic look-aheads.

Actually the `pfff` change is already in, but this adds a test.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
