### PR TITLE
test(autofix): Unit tests for autofix printer

### DIFF
--- a/semgrep-core/src/engine/Unit_engine.mli
+++ b/semgrep-core/src/engine/Unit_engine.mli
@@ -4,3 +4,12 @@
    'dune utop' from any location.
 *)
 val tests : unit -> Testutil.test list
+
+(* Can be used from other test code to concisely run Semgrep *)
+val match_pattern :
+  lang:Lang.t ->
+  hook:(Pattern_match.t -> unit) ->
+  file:string ->
+  pattern:string ->
+  fix_pattern:string option ->
+  Pattern_match.t list

--- a/semgrep-core/src/fixing/tests/README.txt
+++ b/semgrep-core/src/fixing/tests/README.txt
@@ -1,0 +1,2 @@
+This is a separate directory to avoid a circular dependency with semgrep_engine,
+since we need to run the engine as part of the unit tests

--- a/semgrep-core/src/fixing/tests/Unit_autofix_printer.ml
+++ b/semgrep-core/src/fixing/tests/Unit_autofix_printer.ml
@@ -1,0 +1,124 @@
+open Common
+
+type autofix_printer_test_case = {
+  target : string;
+  pattern : string;
+  fix_pattern : string;
+  expected : string;
+}
+
+(* Test suite for the python autofix printer.
+ *
+ * This runs Semgrep to get a pattern match, then renders the fix. However, it
+ * feeds in fake strings for the target and fix pattern contents, so that we can
+ * test which parts were lifted from the original source and which parts were
+ * printed from scratch. This functionality is a key part of the autofix
+ * printer, and this allows us to test that it is being done for all of the
+ * nodes we expect.
+ *
+ * Even if our printers become excellent and handle nearly every case, we still
+ * have no plans to include comments, mimic the original formatting, or do any
+ * kind of nicely formatted pretty-printing. And, there is always the
+ * possibility of a bug in the printer. For these reasons, it's important that
+ * we minimize the amount of printing we have to do by lifting the original text
+ * wherever possible. However, it's not obvious in ordinary autofix tests where
+ * the text in the rendered fix came from. So, it would be easy to miss a bug
+ * that led to a particular node getting printed from scratch rather than lifted
+ * from the original text.
+ *
+ * This does not test that we lift the correct ranges from the original target
+ * or fix pattern, just that we lift the correct number of characters. The tests
+ * in `semgrep-core/tests` exercise the system as a whole, and ensure that the
+ * fixes tested there are correct.
+ *
+ * TODO generalize the test runner once we have multiple languages to test
+ *)
+let test_python_autofix_printer () =
+  let check { target; pattern; fix_pattern; expected } =
+    Common2.with_tmp_file ~str:target ~ext:"py" (fun target_file ->
+        let matches =
+          Unit_engine.match_pattern ~lang:Lang.Python
+            ~hook:(fun _ -> ())
+            ~file:target_file ~pattern ~fix_pattern:(Some fix_pattern)
+        in
+        (* To keep it simple, we make sure that each example here has only a
+         * single match. *)
+        let match_ =
+          match matches with
+          | [ m ] -> m
+          | lst ->
+              failwith
+                (spf
+                   "wrong number of matches for `%s`. expected exactly 1, got \
+                    %d"
+                   target (List.length lst))
+        in
+        let fix_pattern_ast =
+          Parse_pattern.parse_pattern Lang.Python fix_pattern
+        in
+        let metavars = match_.env in
+        let fixed_pattern_ast =
+          match
+            Autofix_metavar_replacement.replace_metavars metavars
+              fix_pattern_ast
+          with
+          | Ok x -> x
+          | Error e ->
+              failwith (spf "Failed to replace metevars for `%s`:\n%s" target e)
+        in
+        (* Make a fake string to use when printing instead of the target. Fill
+         * it with 't' so that we can identify it in the final output. *)
+        let fake_target_contents = String.make (String.length target) 't' in
+        (* Same as above, but for the fix pattern *)
+        let fake_fix_pattern = String.make (String.length fix_pattern) 'p' in
+        let fix_text =
+          match
+            Autofix_printer.print_ast ~lang:Lang.Python ~metavars
+              ~target_contents:(lazy fake_target_contents)
+              ~fix_pattern_ast ~fix_pattern:fake_fix_pattern fixed_pattern_ast
+          with
+          | Ok x -> x
+          | Error e ->
+              failwith (spf "Failed to print for test case `%s`:\n%s" target e)
+        in
+        (* Replace the fake target contents with the rendered fix *)
+        let start, end_ =
+          let start, end_ = match_.Pattern_match.range_loc in
+          let _, _, end_charpos = Parse_info.get_token_end_info end_ in
+          (start.Parse_info.charpos, end_charpos)
+        in
+        let full_fixed_text =
+          let before = Str.first_chars fake_target_contents start in
+          let after = Str.string_after fake_target_contents end_ in
+          before ^ fix_text ^ after
+        in
+        Alcotest.(check string) fix_pattern expected full_fixed_text)
+  in
+  List.iter check
+    [
+      (* TODO foobar should be lifted from the pattern *)
+      {
+        target = "foo";
+        pattern = "foo";
+        fix_pattern = "foobar";
+        expected = "foobar";
+      };
+      (* TODO baz should be lifted from the pattern *)
+      {
+        target = "foo + bar";
+        pattern = "bar";
+        fix_pattern = "baz";
+        expected = "ttttttbaz";
+      };
+      (* TODO bar should be lifted from the pattern *)
+      {
+        target = "foo(1, 42, 423)";
+        pattern = "foo(1, $...REST)";
+        fix_pattern = "bar(baz, $...REST)";
+        expected = "bar(ppp, tt, ttt)";
+      };
+    ]
+
+let tests =
+  Testutil.pack_tests "autofix printer"
+    [ ("test python autofix printer", test_python_autofix_printer) ]

--- a/semgrep-core/src/fixing/tests/dune
+++ b/semgrep-core/src/fixing/tests/dune
@@ -1,0 +1,11 @@
+(library
+ (public_name semgrep_fixing_tests)
+ (wrapped false)
+ (libraries
+   commons
+   pfff-lang_GENERIC
+   semgrep_parsing
+   semgrep_engine
+ )
+ (preprocess (pps ppx_deriving.show ppx_profiling))
+)

--- a/semgrep-core/tests/Test.ml
+++ b/semgrep-core/tests/Test.ml
@@ -54,6 +54,7 @@ let tests () = List.flatten [
   Unit_regexp_engine.tests;
   Unit_immutable_buffer.tests;
   Unit_ugly_print_AST.tests;
+  Unit_autofix_printer.tests;
 
   Unit_synthesizer.tests;
   Unit_synthesizer_targets.tests;

--- a/semgrep-core/tests/dune
+++ b/semgrep-core/tests/dune
@@ -26,6 +26,7 @@
 
     semgrep_core
     semgrep_core_ast_tests
+    semgrep_fixing_tests
     semgrep_metachecking
     semgrep_parsing
     semgrep_matching


### PR DESCRIPTION
This tests the autofix printer to make sure that it is lifting the original text from the target and fix_pattern where appropriate. Details are in the main comment in `Unit_autofix_printer.ml`.

This also refactors Unit_engine to pull out the code that runs Semgrep matching over some code and rule, so that it can be used here.

Test plan: Picked an arbitrary semgrep-core test and modify it to change the matching behavior. Ensure that `make test` fails. Change one of the new unit tests so that the output doesn't match. Ensure that `make test` fails.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
