### PR TITLE
fix(pre-commit): set log file path for pre-commit docker hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,8 +20,8 @@
   description: This hook runs semgrep:develop
   # See https://pre-commit.com/#docker_image for more information
   language: docker_image
-  # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit 
-  # runs docker images with -u set to non-root uid which doesnt have permissions 
+  # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit
+  # runs docker images with -u set to non-root uid which doesnt have permissions
   # to default path /.semgrep
   entry: -e SEMGREP_LOG_FILE=/tmp/out.log SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:develop semgrep
 
@@ -30,7 +30,7 @@
   name: semgrep
   description: This hook runs semgrep (a.k.a. semgrep:latest)
   language: docker_image
-  # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit 
-  # runs docker images with -u set to non-root uid which doesnt have permissions 
+  # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit
+  # runs docker images with -u set to non-root uid which doesnt have permissions
   # to default path /.semgrep
   entry: -e SEMGREP_LOG_FILE=/tmp/out.log SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:latest semgrep

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,11 +20,11 @@
   description: This hook runs semgrep:develop
   # See https://pre-commit.com/#docker_image for more information
   language: docker_image
-  entry: returntocorp/semgrep:develop
+  entry: -e SEMGREP_LOG_FILE=/tmp/out.log returntocorp/semgrep:develop semgrep
 
 # using latest instead
 - id: semgrep-docker
   name: semgrep
   description: This hook runs semgrep (a.k.a. semgrep:latest)
   language: docker_image
-  entry: returntocorp/semgrep:latest
+  entry: -e SEMGREP_LOG_FILE=/tmp/out.log returntocorp/semgrep:latest semgrep

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,11 +20,17 @@
   description: This hook runs semgrep:develop
   # See https://pre-commit.com/#docker_image for more information
   language: docker_image
-  entry: -e SEMGREP_LOG_FILE=/tmp/out.log returntocorp/semgrep:develop semgrep
+  # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit 
+  # runs docker images with -u set to non-root uid which doesnt have permissions 
+  # to default path /.semgrep
+  entry: -e SEMGREP_LOG_FILE=/tmp/out.log SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:develop semgrep
 
 # using latest instead
 - id: semgrep-docker
   name: semgrep
   description: This hook runs semgrep (a.k.a. semgrep:latest)
   language: docker_image
-  entry: -e SEMGREP_LOG_FILE=/tmp/out.log returntocorp/semgrep:latest semgrep
+  # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit 
+  # runs docker images with -u set to non-root uid which doesnt have permissions 
+  # to default path /.semgrep
+  entry: -e SEMGREP_LOG_FILE=/tmp/out.log SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:latest semgrep

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,7 +23,7 @@
   # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit
   # runs docker images with -u set to non-root uid which doesnt have permissions
   # to default path /.semgrep
-  entry: -e SEMGREP_LOG_FILE=/tmp/out.log SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:develop semgrep
+  entry: -e SEMGREP_LOG_FILE=/tmp/out.log -e SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:develop semgrep
 
 # using latest instead
 - id: semgrep-docker
@@ -33,4 +33,4 @@
   # Need to set SEMGREP_LOG_FILE and SEMGREP_VERSION_CACHE_PATH since pre-commit
   # runs docker images with -u set to non-root uid which doesnt have permissions
   # to default path /.semgrep
-  entry: -e SEMGREP_LOG_FILE=/tmp/out.log SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:latest semgrep
+  entry: -e SEMGREP_LOG_FILE=/tmp/out.log -e SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:latest semgrep


### PR DESCRIPTION
pre-commit runs docker hooks with current running uid which might be different than the uid 0 that we need to run as root to have permissions to directories like /.semgrep where we put logs by default.

This PR sets the log file location envvar so any uid will have permission to write to log file.

Fixes https://github.com/returntocorp/semgrep/issues/6243

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
