### PR TITLE
Fix the macOS build scripts to properly statically link libpcre.

### DIFF
--- a/scripts/osx-m1-release.sh
+++ b/scripts/osx-m1-release.sh
@@ -30,8 +30,8 @@ export HOMEBREW_SYSTEM=1
 
 # Remove pcre dynamically linked to force MacOS to use static
 # This needs to be done before make setup since it is used there
-ls -l $(brew --prefix)/opt/pcre/lib || true
-rm -f $(brew --prefix)/opt/pcre/lib/libpcre.1.dylib
+ls -l "$(brew --prefix)"/opt/pcre/lib || true
+rm -f "$(brew --prefix)"/opt/pcre/lib/libpcre.1.dylib
 
 make setup
 

--- a/scripts/osx-m1-release.sh
+++ b/scripts/osx-m1-release.sh
@@ -28,12 +28,12 @@ eval "$(opam env)"
 # Needed so we don't make config w/ sudo
 export HOMEBREW_SYSTEM=1
 
-make setup
-
 # Remove pcre dynamically linked to force MacOS to use static
 # This needs to be done before make setup since it is used there
-ls -l /usr/local/opt/pcre/lib || true
-rm -f /usr/local/opt/pcre/lib/libpcre.1.dylib
+ls -l $(brew --prefix)/opt/pcre/lib || true
+rm -f $(brew --prefix)/opt/pcre/lib/libpcre.1.dylib
+
+make setup
 
 # Remove dynamically linked libraries to force MacOS to use static ones
 # This needs to be done after make setup but before make build-*

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -20,8 +20,8 @@ eval "$(opam env)"
 
 # Remove pcre dynamically linked to force MacOS to use static
 # This needs to be done before make setup since it is used there
-ls -l $(brew --prefix)/opt/pcre/lib || true
-rm -f $(brew --prefix)/opt/pcre/lib/libpcre.1.dylib
+ls -l "$(brew --prefix)"/opt/pcre/lib || true
+rm -f "$(brew --prefix)"/opt/pcre/lib/libpcre.1.dylib
 
 make setup
 

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -18,12 +18,12 @@ git submodule update --init --recursive --depth 1
 
 eval "$(opam env)"
 
-make setup
-
 # Remove pcre dynamically linked to force MacOS to use static
 # This needs to be done before make setup since it is used there
-ls -l /usr/local/opt/pcre/lib || true
-rm -f /usr/local/opt/pcre/lib/libpcre.1.dylib
+ls -l $(brew --prefix)/opt/pcre/lib || true
+rm -f $(brew --prefix)/opt/pcre/lib/libpcre.1.dylib
+
+make setup
 
 # Remove dynamically linked libraries to force MacOS to use static ones
 # This needs to be done after make setup but before make build-*


### PR DESCRIPTION
Run `make setup` after removing the `libpcre` file so that semgrep-core statically links `libpcre` in the macOS build scripts. This should fix  https://github.com/returntocorp/semgrep/issues/6026.

I've also switched to using `brew --prefix` to get the correct directory prefix for `pcre`. This is relevant because depending on your Mac's CPU type, the [directory for things install by Homebrew will be different](https://docs.brew.sh/Installation):

> This script installs Homebrew to its preferred prefix (/usr/local for macOS Intel, /opt/homebrew for Apple Silicon and /home/linuxbrew/.linuxbrew for Linux)...

To confirm after building semgrep-core, otool reports it's no longer linking to `libpcre.1.dylib`:
```
$ otool -L artifacts/semgrep-core
artifacts/semgrep-core:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.23.0)
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
