### PR TITLE
fix: Don't size filter lockfiles

### DIFF
--- a/changelog.d/sc-293.fixed
+++ b/changelog.d/sc-293.fixed
@@ -1,0 +1,1 @@
+Lockfiles are no longer subject to size filtering during file targetting, so very large lockfiles can now generate unreachable findings

--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -680,8 +680,10 @@ class TargetManager:
         files = self.filter_excludes(PATHS_ALWAYS_SKIPPED, candidates=files.kept)
         self.ignore_log.always_skipped.update(files.removed)
 
-        files = self.filter_by_size(self.max_target_bytes, candidates=files.kept)
-        self.ignore_log.size_limit.update(files.removed)
+        # Lockfiles are easy to parse, and regularly surpass 1MB for big repos
+        if not isinstance(lang, Ecosystem):
+            files = self.filter_by_size(self.max_target_bytes, candidates=files.kept)
+            self.ignore_log.size_limit.update(files.removed)
 
         if self.file_ignore:
             files = self.file_ignore.filter_paths(candidates=files.kept)


### PR DESCRIPTION
Lockfiles are easy to parse and regularly larger than 1MB in big repos, so we should not be size filtering them. This has bitten several customers. 

test plan: I tested this manually and it worked. Finding a public massive lockfile to include as a test may be annoying.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
