### PR TITLE
tainting: Fix field-sensitivity regression

### DIFF
--- a/changelog.d/pa-1928.fixed
+++ b/changelog.d/pa-1928.fixed
@@ -1,0 +1,6 @@
+taint-mode: Fixed regression in 0.113.0, after field sensitivity support was added,
+that broke existing behavior when a prefix in a chain of dot-accesses such as
+`x.a.b` was specified as a source/sanitizer/sink. For example, if `x` had been
+previously tainted, then we encountered `sink(x.a.b)` where `x.a` matched a
+sanitizer, there was a finding reported because `x.a.b` was incorrectly considered
+tainted.

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -110,13 +110,14 @@ let result_of_function_call_is_constant lang f args =
         e =
           ( Fetch
               {
-                rev_offset = Dot { ident; id_info = { id_resolved; _ }; _ } :: _;
+                rev_offset =
+                  { o = Dot { ident; id_info = { id_resolved; _ }; _ }; _ } :: _;
                 _;
               }
           | Fetch
               {
                 base = Var { ident; id_info = { id_resolved; _ }; _ };
-                rev_offset = [] | Index _ :: _;
+                rev_offset = [] | { o = Index _; _ } :: _;
               } );
         _;
       },
@@ -544,7 +545,12 @@ let transfer :
             update_env_with inp' var cexp
         | Call
             ( None,
-              { e = Fetch { base = Var var; rev_offset = Dot _ :: _; _ }; _ },
+              {
+                e =
+                  Fetch
+                    { base = Var var; rev_offset = { o = Dot _; _ } :: _; _ };
+                _;
+              },
               _ ) ->
             (* Method call `var.f(args)` that returns void, we conservatively
              * assume that it may be updating `var`; e.g. in Ruby strings are

--- a/semgrep-core/src/core/il/Display_IL.ml
+++ b/semgrep-core/src/core/il/Display_IL.ml
@@ -10,7 +10,7 @@ let string_of_base base =
   | Mem _ -> "<Mem>"
 
 let string_of_offset offset =
-  match offset with
+  match offset.o with
   | Dot a -> str_of_name a
   | Index _ -> "[...]"
 
@@ -32,6 +32,16 @@ let string_of_exp e =
   | Cast (_, _) ->
       "<EXP>"
 
+let string_of_argument arg =
+  match arg with
+  | Unnamed { e = Fetch lval; _ } -> string_of_lval lval
+  | Unnamed _
+  | Named _ ->
+      "_"
+
+let string_of_arguments args =
+  Common.map string_of_argument args |> String.concat ","
+
 let short_string_of_node_kind nkind =
   match nkind with
   | Enter -> "<enter>"
@@ -52,21 +62,22 @@ let short_string_of_node_kind nkind =
       match x.i with
       | Assign (lval, exp) -> string_of_lval lval ^ " = " ^ string_of_exp exp
       | AssignAnon _ -> " ... = <lambda|class>"
-      | Call (lval_opt, exp, _) ->
+      | Call (lval_opt, exp, args) ->
           let lval_str =
             match lval_opt with
             | None -> ""
             | Some lval -> string_of_lval lval ^ " = "
           in
-          lval_str ^ string_of_exp exp ^ "(...)"
-      | CallSpecial (lval_opt, (call_special, _tok), _args) ->
+          lval_str ^ string_of_exp exp ^ "(" ^ string_of_arguments args ^ ")"
+      | CallSpecial (lval_opt, (call_special, _tok), args) ->
           let lval_str =
             match lval_opt with
             | None -> ""
             | Some lval -> Common.spf " %s =" (string_of_lval lval)
           in
-          Common.spf "<special>%s %s(...)" lval_str
+          Common.spf "<special>%s = %s(%s)" lval_str
             (IL.show_call_special call_special)
+            (string_of_arguments args)
       | FixmeInstr _ -> "<fix-me instr>")
   | NTodo _ -> "<to-do stmt>"
 

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -171,7 +171,20 @@ and base =
   (* THINK: Mem of exp -> Deref of name *)
   | Mem of exp
 
-and offset = { o : offset_kind; oorig : orig }
+and offset = {
+  o : offset_kind;
+  oorig : orig;
+      (** `oorig' should be a DotAccess expression and gives us the corresponding
+      * Generic expression for a sub-lvalue. Now that we represent `x.a.b.c` as
+      * { base = "x"; rev_offsets = ["c"; "b"; "a"]}, it makes it very easy to
+      * check whether a sub-lvalue is a source/santizer/sink by just checking
+      * the range of the `oorig'.
+      *
+      * alt: We could compute the range of the sub-lvalue from the ranges of all
+      *      the offsets in the sub-lvalue, but this is probably less efficent
+      *      unless we cache the range here. So it seems better to have `oorig'.
+      *)
+}
 
 and offset_kind =
   (* What about computed field names?

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -171,7 +171,9 @@ and base =
   (* THINK: Mem of exp -> Deref of name *)
   | Mem of exp
 
-and offset =
+and offset = { o : offset_kind; oorig : orig }
+
+and offset_kind =
   (* What about computed field names?
    * - handle them in Special?
    * - convert in Index with a string exp?

--- a/semgrep-core/src/core/il/IL_helpers.ml
+++ b/semgrep-core/src/core/il/IL_helpers.ml
@@ -62,7 +62,8 @@ and lvals_in_lval lval =
   in
   let offset_lvals =
     List.concat_map
-      (function
+      (fun offset ->
+        match offset.o with
         | Index e -> lvals_of_exp e
         | Dot _ -> [])
       lval.rev_offset
@@ -80,13 +81,16 @@ let rlvals_of_instr x =
 (* Public *)
 (*****************************************************************************)
 
+let lval_of_var var = { IL.base = Var var; rev_offset = [] }
+
 let lval_is_var_and_dots { base; rev_offset } =
   match base with
   | Var _ ->
       rev_offset
-      |> List.for_all (function
-           | Dot _ -> true
-           | Index _ -> false)
+      |> List.for_all (fun offset ->
+             match offset.o with
+             | Dot _ -> true
+             | Index _ -> false)
   | VarSpecial _
   | Mem _ ->
       false
@@ -97,10 +101,11 @@ let lval_is_dotted_prefix lval1 lval2 =
     match (os1, os2) with
     | [], _ -> true
     | _ :: _, [] -> false
-    | Index _ :: _, _
-    | _, Index _ :: _ ->
+    | { o = Index _; _ } :: _, _
+    | _, { o = Index _; _ } :: _ ->
         false
-    | Dot a :: os1, Dot b :: os2 -> eq_name a b && offset_prefix os1 os2
+    | { o = Dot a; _ } :: os1, { o = Dot b; _ } :: os2 ->
+        eq_name a b && offset_prefix os1 os2
   in
   match (lval1, lval2) with
   | { base = Var x; rev_offset = ro1 }, { base = Var y; rev_offset = ro2 } ->
@@ -158,7 +163,7 @@ module LvalOrdered = struct
         else
           List.compare
             (fun offset1 offset2 ->
-              match (offset1, offset2) with
+              match (offset1.o, offset2.o) with
               | Dot a, Dot b -> compare_name a b
               | Index _, _
               | _, Index _ ->

--- a/semgrep-core/src/core/il/IL_helpers.mli
+++ b/semgrep-core/src/core/il/IL_helpers.mli
@@ -2,6 +2,8 @@ val exp_of_arg : IL.exp IL.argument -> IL.exp
 
 (** Lvalue/Rvalue helpers working on the IL *)
 
+val lval_of_var : IL.name -> IL.lval
+
 val lval_is_var_and_dots : IL.lval -> bool
 (** Test whether an lvalue is of the form x.a_1. ... .a_n *)
 

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -509,7 +509,7 @@ let check_fundef lang options taint_config opt_ent fdef =
       |> Common.map (fun (x : _ D.tmatch) -> (x.pm, x.spec))
       |> T.taints_of_pms
     in
-    Lval_env.add_var var taints env
+    Lval_env.add (IL_helpers.lval_of_var var) taints env
   in
   let in_env =
     (* For each argument, check if it's a source and, if so, add it to the input

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -83,6 +83,7 @@ type mapping = Lval_env.t D.mapping
 (* HACK: Tracks tainted functions intrafile. *)
 type fun_env = (var, Taints.t) Hashtbl.t
 
+(* THINK: Separate read-only enviroment into a new a "cfg" type? *)
 type env = {
   options : Config_semgrep.t; (* rule options *)
   config : config;
@@ -100,6 +101,14 @@ let hook_function_taint_signature = ref None
 (* Helpers *)
 (*****************************************************************************)
 
+let status_to_taints = function
+  | `None
+  | `Clean ->
+      Taints.empty
+  | `Tainted taints -> taints
+
+let is_exact x = x.overlap > 0.99
+
 let union_map_taints_and_vars env f xs =
   xs
   |> List.fold_left
@@ -112,6 +121,19 @@ let str_of_name name = spf "%s:%d" (fst name.ident) name.sid
 let orig_is_source config orig = config.is_source (any_of_orig orig)
 let orig_is_sanitized config orig = config.is_sanitizer (any_of_orig orig)
 let orig_is_sink config orig = config.is_sink (any_of_orig orig)
+
+let any_of_lval lval =
+  match lval with
+  | { rev_offset = { oorig; _ } :: _; _ } -> any_of_orig oorig
+  | { base = Var var; rev_offset = [] } ->
+      let _, tok = var.ident in
+      G.Tk tok
+  | { base = VarSpecial (_, tok); rev_offset = [] } -> G.Tk tok
+  | { base = Mem e; rev_offset = [] } -> any_of_orig e.eorig
+
+let lval_is_source config lval = config.is_source (any_of_lval lval)
+let lval_is_sanitized config lval = config.is_sanitizer (any_of_lval lval)
+let lval_is_sink config lval = config.is_sink (any_of_lval lval)
 let trace_of_match x = T.trace_of_pm (x.pm, x.spec)
 
 let taints_of_matches xs =
@@ -160,7 +182,7 @@ let merge_source_sink_mvars env source_mvars sink_mvars =
     (* The union of both sets, but taking the sink mvars in case of collision. *)
     sink_biased_union_mvars source_mvars sink_mvars
 
-let labels_in_taint taints : LabelSet.t =
+let labels_of_taints taints : LabelSet.t =
   taints |> Taints.to_seq
   |> Seq.filter_map (fun (t : T.taint) ->
          match t.orig with
@@ -183,7 +205,7 @@ let rec eval_label_requires ~labels e =
       match (op, eval_label_args ~labels args) with
       | G.And, xs -> List.fold_left ( && ) true xs
       | G.Or, xs -> List.fold_left ( || ) false xs
-      | _ ->
+      | __else__ ->
           logger#error "Unexpected Boolean operator";
           false)
   | G.ParenExpr (_, e, _) -> eval_label_requires ~labels e
@@ -202,7 +224,7 @@ and eval_label_args ~labels args =
 
 (* Produces a finding for every taint source that is unifiable with the sink. *)
 let findings_of_tainted_sink env taints (sink : T.sink) : T.finding list =
-  let labels = labels_in_taint taints in
+  let labels = labels_of_taints taints in
   let sink_pm, ts = T.pm_of_trace sink in
   let req = eval_label_requires ~labels ts.sink_requires in
   (* TODO: With taint labels it's less clear what is "the source",
@@ -240,8 +262,7 @@ let findings_of_tainted_return taints return_tok : T.finding list =
          | T.Arg i -> T.ArgToReturn (i, tokens, return_tok)
          | T.Src src -> T.SrcToReturn (src, tokens, return_tok))
 
-let union_taints_filtering_labels ~new_ curr =
-  let labels = labels_in_taint curr in
+let filter_taints_by_labels labels taints =
   Taints.fold
     (fun new_taint taints ->
       match new_taint.orig with
@@ -250,7 +271,12 @@ let union_taints_filtering_labels ~new_ curr =
           let _, ts = T.pm_of_trace src in
           let req = eval_label_requires ~labels ts.source_requires in
           if req then Taints.add new_taint taints else taints)
-    new_ curr
+    taints Taints.empty
+
+let union_taints_filtering_labels ~new_ curr =
+  let labels = labels_of_taints curr in
+  let new_filtered = filter_taints_by_labels labels new_ in
+  Taints.union new_filtered curr
 
 let find_args_taints args_taints fdef =
   let pos_args_taints, named_args_taints =
@@ -285,7 +311,7 @@ let find_args_taints args_taints fdef =
                 acc
                 (* Otherwise, it has not been consumed, so keep it in the remaining parameters.*)
             | None -> param :: acc (* Same as above. *))
-        | _ -> param :: acc)
+        | __else__ -> param :: acc)
       fdef.G.fparams []
   in
   let _ =
@@ -312,7 +338,7 @@ let find_args_taints args_taints fdef =
       with
       | Some taints, _ -> Some taints
       | _, Some taints -> Some taints
-      | _ -> None
+      | __else__ -> None
     in
     if Option.is_none taint_opt then
       logger#error
@@ -323,15 +349,15 @@ let find_args_taints args_taints fdef =
 (* Tainted *)
 (*****************************************************************************)
 
-let sanitize_var lval_env sanitizer_pms var =
-  let var_is_now_safe =
-    (* If the variable is an exact match (overlap > 0.99) for a sanitizer
-       * annotation, then we infer that the variable itself has been updated
-       * (presumably by side-effect) and is no longer tainted. We will update
-       * the environment (i.e., `var_env') accordingly. *)
-    List.exists (fun x -> x.overlap > 0.99) sanitizer_pms
+let sanitize_lval lval_env sanitizer_pms lval =
+  let lval_is_now_safe =
+    (* If the l-value is an exact match (overlap > 0.99) for a sanitizer
+     * annotation, then we infer that the l-value itself has been updated
+     * (presumably by side-effect) and is no longer tainted. We will update
+     * the environment (i.e., `lval_env') accordingly. *)
+    List.exists is_exact sanitizer_pms
   in
-  if var_is_now_safe then Lval_env.clean_var var lval_env else lval_env
+  if lval_is_now_safe then Lval_env.clean lval lval_env else lval_env
 
 (* Check if an expression is sanitized, if so, return a new variable environment. *)
 let exp_is_sanitized env exp =
@@ -339,10 +365,13 @@ let exp_is_sanitized env exp =
   | [] -> None
   | sanitizer_pms -> (
       match exp.e with
-      | Fetch { base = Var var; rev_offset = [] } ->
-          Some (sanitize_var env.lval_env sanitizer_pms var)
-      | _ -> Some env.lval_env)
+      | Fetch lval when LV.lval_is_var_and_dots lval ->
+          Some (sanitize_lval env.lval_env sanitizer_pms lval)
+      | __else__ -> Some env.lval_env)
 
+(* Checks if `x' is a propagator `from' and if so propagates `taints' through it.
+   Checks if `x` is a propagator `'to' and if so fetches any taints that had been
+   previously propagated. Returns *only* the newly propagated taint. *)
 let handle_taint_propagators env x taints =
   (* We propagate taints via an auxiliary variable (the propagator id). This is
    * simple but it has limitations, we can only propagate "forward" and, within
@@ -352,25 +381,25 @@ let handle_taint_propagators env x taints =
    * `y` or `z`, or from `z` to `y`. *)
   let lval_env = env.lval_env in
   let propagators =
-    match x with
-    | `Var var ->
-        let _, tok = var.ident in
-        if Parse_info.is_origintok tok then env.config.is_propagator (G.Tk tok)
-        else []
-    | `Exp exp -> env.config.is_propagator (any_of_orig exp.eorig)
-    | `Ins ins -> env.config.is_propagator (any_of_orig ins.iorig)
+    let any =
+      match x with
+      | `Lval lval -> any_of_lval lval
+      | `Exp exp -> any_of_orig exp.eorig
+      | `Ins ins -> any_of_orig ins.iorig
+    in
+    env.config.is_propagator any
   in
   let propagate_froms, propagate_tos =
     List.partition (fun p -> p.spec.kind = `From) propagators
   in
-  let var_env =
+  let lval_env =
     (* `x` is the source (the "from") of propagation, we add its taints to
      * the environment. *)
     List.fold_left
       (fun lval_env prop -> Lval_env.propagate_to prop.spec.var taints lval_env)
       lval_env propagate_froms
   in
-  let taints_incoming =
+  let taints_propagated =
     (* `x` is the destination (the "to") of propagation. we collect all the
      * incoming taints by looking for the propagator ids in the environment. *)
     List.fold_left
@@ -383,134 +412,171 @@ let handle_taint_propagators env x taints =
         Taints.union taints_in_acc taints_strid)
       Taints.empty propagate_tos
   in
-  let taints = Taints.union taints taints_incoming in
-  let var_env =
+  let lval_env =
     match x with
-    | `Var var ->
-        (* If `x` is a variable, then taint is propagated by side-effect. This
-         * allows us to e.g. propagate taint from `x` to `y` in `f(x,y)`. *)
-        Lval_env.add_var var taints_incoming var_env
+    (* If `x` is a variable, then taint is propagated by side-effect. This
+     * allows us to e.g. propagate taint from `x` to `y` in `f(x,y)`. *)
+    | `Lval lval when LV.lval_is_var_and_dots lval ->
+        Lval_env.add lval taints_propagated lval_env
+    | `Lval _
     | `Exp _
     | `Ins _ ->
-        var_env
+        lval_env
   in
-  (taints, var_env)
+  (taints_propagated, lval_env)
 
-(* coupling: check_tainted_var *)
-let check_tainted_tok env tok =
-  let source_pms, sanitizer_pms, sink_pms =
-    if Parse_info.is_origintok tok then
-      ( env.config.is_source (G.Tk tok),
-        env.config.is_sanitizer (G.Tk tok),
-        env.config.is_sink (G.Tk tok) )
-    else ([], [], [])
+let find_lval_taint_sources env ~labels lval =
+  let source_pms = lval_is_source env.config lval in
+  let mut_source_pms, reg_source_pms =
+    (* If the variable is an exact match (overlap > 0.99) for a source
+       * annotation, then we infer that the variable itself is now tainted
+       * (presumably by side-effect) and we will update the `var_env`
+       * accordingly. Otherwise the variable belongs to a piece of code that
+       * is a source of taint, but it is not tainted on its own. *)
+    List.partition is_exact source_pms
   in
-  match sanitizer_pms with
-  | _ :: _ -> (Taints.empty, env.lval_env)
-  | [] ->
-      let taints = source_pms |> taints_of_matches in
-      (* Empty because we want to filter all the previous taints we got from the
-         `source_pms`, but we have nothing to really union it with.
-         Otherwise, we might let taints from this token escape a label. In particular,
-         this may happen in the `Dot` case.
-      *)
-      let taints = Taints.empty |> union_taints_filtering_labels ~new_:taints in
-      let sinks = sink_pms |> Common.map trace_of_match in
-      let findings = findings_of_tainted_sinks env taints sinks in
-      report_findings env findings;
-      (taints, env.lval_env)
+  let taints_sources_reg =
+    reg_source_pms |> taints_of_matches |> filter_taints_by_labels labels
+  and taints_sources_mut =
+    mut_source_pms |> taints_of_matches |> filter_taints_by_labels labels
+  in
+  let lval_env = Lval_env.add lval taints_sources_mut env.lval_env in
+  (Taints.union taints_sources_reg taints_sources_mut, lval_env)
 
-(* Test whether a variable occurrence is tainted, and if it is also a sink,
- * report the finding too (by side effect).
- *
- * THINK: Could we generalize this for lvalues? So we won't need special
- *     Lval_env.add_var and Lval_env.find_var, but just work with lvalues
- *     everywhere?
- *)
-let check_tainted_var env (var : IL.name) : Taints.t * Lval_env.t =
-  let source_pms, sanitizer_pms, sink_pms =
-    let _, tok = var.ident in
-    if Parse_info.is_origintok tok then
-      ( env.config.is_source (G.Tk tok),
-        env.config.is_sanitizer (G.Tk tok),
-        env.config.is_sink (G.Tk tok) )
-    else ([], [], [])
-  in
-  match sanitizer_pms with
+let rec check_tainted_lval env (lval : IL.lval) : Taints.t * Lval_env.t =
+  let new_taints, lval_in_env, lval_env = check_tainted_lval_aux env lval in
+  let taints_from_env = status_to_taints lval_in_env in
+  let taints = Taints.union new_taints taints_from_env in
+  let sinks = lval_is_sink env.config lval |> Common.map trace_of_match in
+  let findings = findings_of_tainted_sinks { env with lval_env } taints sinks in
+  report_findings { env with lval_env } findings;
+  (taints, lval_env)
+
+and check_tainted_lval_aux env (lval : IL.lval) :
+    Taints.t * [ `Clean | `None | `Tainted of Taints.t ] * Lval_env.t =
+  (* Recursively checks an l-value bottom-up.
+   *
+   *  This check needs to combine matches from pattern-{sources,sanitizers,sinks}
+   *  with the info we have stored in `env.lval_env`. This can be subtle, see
+   *  comments below.
+   *)
+  match lval_is_sanitized env.config lval with
   (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
-  | _ :: _ ->
-      let lval_env' = sanitize_var env.lval_env sanitizer_pms var in
-      (Taints.empty, lval_env')
+  | _ :: _ as sanitizer_pms ->
+      (* NOTE [lval/clean]:
+       *  If lval is sanitized, then we will "bubble up" the `Clean status, so any
+       *  taint recorded in lval_env for any extension of lval will be discarded.
+       *
+       *  So, if we are checking `x.a.b.c` and `x.a` is clean (could be due to
+       *  sanitization) then any extension of `x.a` is considered clean as well,
+       *  and we do look for taint info in the environment.
+       *
+       *  *IF* sanitization is side-effectful then any taint info will be removed
+       *  from lval_env by sanitize_lval, but that is not guaranteed.
+       *)
+      let lval_env = sanitize_lval env.lval_env sanitizer_pms lval in
+      (Taints.empty, `Clean, lval_env)
   | [] ->
-      let mut_source_pms, reg_source_pms =
-        (* If the variable is an exact match (overlap > 0.99) for a source
-         * annotation, then we infer that the variable itself is now tainted
-         * (presumably by side-effect) and we will update the `var_env`
-         * accordingly. Otherwise the variable belongs to a piece of code that
-         * is a source of taint, but it is not tainted on its own. *)
-        List.partition (fun src -> src.overlap > 0.99) source_pms
+      (* Recursive call, check sub-lvalues first.
+       *
+       * It needs to be done bottom-up because any sub-lvalue can be a source and a
+       * sink by itself, even if an extension of lval is not. For example, given
+       * `x.a.b`, this lvalue may be considered sanitized, but at the same time `x.a`
+       * could be tainted and considered a sink in some context. We cannot just check
+       * `x.a.b` and forget about the sub-lvalues.
+       *)
+      let sub_new_taints, sub_in_env, lval_env =
+        match lval with
+        | { base; rev_offset = [] } ->
+            (* Base case, no offset. *)
+            let taints, lval_env = check_tainted_lval_base env base in
+            (taints, `None, lval_env)
+        | { base = _; rev_offset = _ :: rev_offset' } ->
+            (* Recursive case, given `x.a.b` we must first check `x.a`. *)
+            check_tainted_lval_aux env { lval with rev_offset = rev_offset' }
       in
-      let taints_sources_reg = reg_source_pms |> taints_of_matches
-      and taints_sources_mut = mut_source_pms |> taints_of_matches
-      and taints_var_env =
-        Lval_env.find_var var env.lval_env |> Option.value ~default:Taints.empty
+      (* Check the status of lval in the environemnt. *)
+      let lval_in_env =
+        match sub_in_env with
+        | `Clean ->
+            (* See NOTE [lval/clean] *)
+            `Clean
+        | (`None | `Tainted _) as st -> (
+            match Lval_env.find_lval lval_env lval with
+            | (`Clean | `Tainted _) as st' -> st'
+            | `None -> st)
       in
-      let lval_env' = Lval_env.add_var var taints_sources_mut env.lval_env in
-      let taints_sources = Taints.union taints_sources_reg taints_sources_mut in
-      let taints : Taints.t =
-        taints_var_env |> union_taints_filtering_labels ~new_:taints_sources
+      let taints_from_env = status_to_taints lval_in_env in
+      (* Find taint sources matching lval. *)
+      let current_taints = Taints.union sub_new_taints taints_from_env in
+      let labels = labels_of_taints current_taints in
+      let taints_from_sources, lval_env =
+        find_lval_taint_sources { env with lval_env } ~labels lval
       in
-      let taints, lval_env' =
-        handle_taint_propagators
-          { env with lval_env = lval_env' }
-          (`Var var) taints
+      (* Check sub-expressions in the offset. *)
+      let taints_from_offset, lval_env =
+        match lval.rev_offset with
+        | [] -> (Taints.empty, lval_env)
+        | offset :: _ -> check_tainted_lval_offset { env with lval_env } offset
       in
-      let sinks = sink_pms |> Common.map trace_of_match in
-      let findings = findings_of_tainted_sinks env taints sinks in
-      report_findings env findings;
-      (taints, lval_env')
+      (* Check taint propagators. *)
+      let taints_incoming (* TODO: find a better name *) =
+        sub_new_taints
+        |> Taints.union taints_from_sources
+        |> Taints.union taints_from_offset
+      in
+      let taints_propagated, lval_env =
+        handle_taint_propagators { env with lval_env } (`Lval lval)
+          (taints_incoming |> Taints.union taints_from_env)
+      in
+      let new_taints = taints_incoming |> Taints.union taints_propagated in
+      let sinks =
+        lval_is_sink env.config lval
+        (* For sub-lvals we require sinks to be exact matches. Why? Let's say
+           * we have `sink(x.a)` and `x' is tainted but `x.a` is clean...
+           * with the normal subset semantics for sinks we would consider `x'
+           * itself to be a sink, and we would report a finding!
+        *)
+        |> List.filter is_exact
+        |> Common.map trace_of_match
+      in
+      let all_taints = Taints.union taints_from_env new_taints in
+      let findings =
+        findings_of_tainted_sinks { env with lval_env } all_taints sinks
+      in
+      report_findings { env with lval_env } findings;
+      (new_taints, lval_in_env, lval_env)
+
+and check_tainted_lval_base env base =
+  match base with
+  | Var _
+  | VarSpecial _ ->
+      (Taints.empty, env.lval_env)
+  | Mem e ->
+      let taints, lval_env = check_tainted_expr env e in
+      (taints, lval_env)
+
+and check_tainted_lval_offset env offset =
+  match offset.o with
+  | Dot _n ->
+      (* THINK: Allow fields to be taint sources, sanitizers, or sinks ??? *)
+      (Taints.empty, env.lval_env)
+  | Index e ->
+      let taints, lval_env = check_tainted_expr env e in
+      let taints =
+        if not env.options.taint_assume_safe_indexes then taints
+        else (* Taint from the index should be ignored. *)
+          Taints.empty
+      in
+      (taints, lval_env)
 
 (* Test whether an expression is tainted, and if it is also a sink,
  * report the finding too (by side effect). *)
-let rec check_tainted_expr env exp : Taints.t * Lval_env.t =
+and check_tainted_expr env exp : Taints.t * Lval_env.t =
   let check env = check_tainted_expr env in
-  let check_base env = function
-    | Var var -> check_tainted_var env var
-    | VarSpecial (_, tok) -> check_tainted_tok env tok
-    | Mem e -> check env e
-  in
-  let check_offset env = function
-    | Index e ->
-        let taints, lval_env = check env e in
-        let taints =
-          if not env.options.taint_assume_safe_indexes then taints
-          else (* Taint from the index should be ignored. *)
-            Taints.empty
-        in
-        (taints, lval_env)
-    | Dot fld -> check_tainted_tok env (snd fld.ident)
-  in
   let check_subexpr exp =
     match exp.e with
-    | Fetch ({ base; rev_offset; _ } as lval) -> (
-        let lval_info =
-          match Lval_env.find lval env.lval_env with
-          | `Clean -> `Clean
-          | `None -> `Tainted Taints.empty
-          | `Tainted taints -> `Tainted taints
-        in
-        match lval_info with
-        | `Clean -> (Taints.empty, env.lval_env)
-        | `Tainted taints ->
-            (* If not explicitly marked clean, then we look for taint in the
-               base and offsets separately... THINK: Should we? *)
-            let base_taints, lval_env = check_base env base in
-            let offset_taints, lval_env =
-              union_map_taints_and_vars { env with lval_env } check_offset
-                rev_offset
-            in
-            ( Taints.union taints (Taints.union base_taints offset_taints),
-              lval_env ))
+    | Fetch lval -> check_tainted_lval env lval
     | FixmeExp (_, _, Some e) -> check env e
     | Literal _
     | FixmeExp (_, _, None) ->
@@ -530,9 +596,9 @@ let rec check_tainted_expr env exp : Taints.t * Lval_env.t =
     | Cast (_, e) -> check env e
   in
   match exp_is_sanitized env exp with
-  | Some var_env ->
+  | Some lval_env ->
       (* TODO: We should check that taint and sanitizer(s) are unifiable. *)
-      (Taints.empty, var_env)
+      (Taints.empty, lval_env)
   | None ->
       let sinks =
         orig_is_sink env.config exp.eorig |> Common.map trace_of_match
@@ -544,12 +610,16 @@ let rec check_tainted_expr env exp : Taints.t * Lval_env.t =
       let taints =
         taints_exp |> union_taints_filtering_labels ~new_:taints_sources
       in
-      let taints, var_env =
+      let taints_propagated, var_env =
         handle_taint_propagators { env with lval_env } (`Exp exp) taints
       in
+      let taints = Taints.union taints taints_propagated in
       let findings = findings_of_tainted_sinks env taints sinks in
       report_findings env findings;
       (taints, var_env)
+
+let check_tainted_var env (var : IL.name) : Taints.t * Lval_env.t =
+  check_tainted_lval env (LV.lval_of_var var)
 
 let check_function_signature env fun_exp args_taints =
   match (!hook_function_taint_signature, fun_exp) with
@@ -570,9 +640,13 @@ let check_function_signature env fun_exp args_taints =
                    (* Case `$F()` *)
                    | { base = Var { ident; _ }; rev_offset = []; _ }
                    (* Case `$X. ... .$F()` *)
-                   | { base = _; rev_offset = Dot { ident; _ } :: _; _ } ->
+                   | {
+                       base = _;
+                       rev_offset = { o = Dot { ident; _ }; _ } :: _;
+                       _;
+                     } ->
                        Some ident
-                   | _ -> None
+                   | __else__ -> None
                  in
                  Some
                    (arg_taints
@@ -658,11 +732,12 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
       let taints =
         taints_instr |> union_taints_filtering_labels ~new_:taint_sources
       in
-      let taints, lval_env' =
+      let taints_propagated, lval_env' =
         handle_taint_propagators
           { env with lval_env = lval_env' }
           (`Ins instr) taints
       in
+      let taints = Taints.union taints taints_propagated in
       let findings = findings_of_tainted_sinks env taints sinks in
       report_findings env findings;
       (taints, lval_env')
@@ -713,37 +788,38 @@ let (transfer :
   let out' : Lval_env.t =
     let env = { options; config; fun_name = opt_name; lval_env = in' } in
     match node.F.n with
-    | NInstr x -> (
+    | NInstr x ->
         let taints, lval_env' = check_tainted_instr env x in
         let opt_lval = LV.lval_of_instr_opt x in
         let lval_env' =
           match opt_lval with
-          | Some { base = Var name; rev_offset = _ } ->
+          | Some lval ->
               (* We call `check_tainted_var` here because the assigned `var`
                * itself could be annotated as a source of taint. *)
-              check_tainted_var { env with lval_env = lval_env' } name |> snd
-          | Some _
-          | None ->
+              check_tainted_lval { env with lval_env = lval_env' } lval |> snd
+          | None -> lval_env'
+        in
+        let lval_env' =
+          match (Taints.is_empty taints, opt_lval) with
+          | true, Some lval when LV.lval_is_var_and_dots lval ->
+              (* Instruction returns safe data, remove taint from lval. *)
+              Lval_env.clean lval lval_env'
+          | true, Some { base = Var x; _ } ->
+              (* This also handles cases like `x[i] = safe`, cleaning `x`. *)
+              Lval_env.clean (LV.lval_of_var x) lval_env'
+          | false, Some lval when LV.lval_is_var_and_dots lval ->
+              (* Instruction returns tainted data, add taint to lval *)
+              Lval_env.add lval taints lval_env'
+          | false, Some { base = Var x; _ } ->
+              (* This handles cases like `x[i] = tainted`, tainting `x`. *)
+              Lval_env.add (LV.lval_of_var x) taints lval_env'
+          | _, Some _
+          | _, None ->
+              (* Either we cannot obtain a simple dotted lvalue to track, or the
+               * instruction returns 'void'. *)
               lval_env'
         in
-        match (Taints.is_empty taints, opt_lval) with
-        (* Instruction returns safe data, remove taint from lval. *)
-        | true, Some lval when LV.lval_is_var_and_dots lval ->
-            Lval_env.clean lval lval_env'
-        | true, Some { base = Var x; _ } ->
-            (* This handles cases like `x[i] = safe`, cleaning `x`. *)
-            Lval_env.clean_var x lval_env'
-        (* Instruction returns tainted data, add taint to lval *)
-        | false, Some lval when LV.lval_is_var_and_dots lval ->
-            Lval_env.add lval taints lval_env'
-        | false, Some { base = Var x; _ } ->
-            (* This handles cases like `x[i] = tainted`, tainting `x`. *)
-            Lval_env.add_var x taints lval_env'
-        | _, Some _
-        | _, None ->
-            (* Either we cannot obtain a simple dotted lvalue to track, or the
-             * instruction returns 'void'. *)
-            lval_env')
+        lval_env'
     | NCond (_tok, e)
     | NThrow (_tok, e) ->
         let _, lval_env' = check_tainted_expr env e in

--- a/semgrep-core/src/tainting/Taint.ml
+++ b/semgrep-core/src/tainting/Taint.ml
@@ -115,5 +115,7 @@ let _show_taint_label taint =
       ts.label
 
 let show_taints taints =
-  taints |> Taint_set.elements |> Common.map show_taint |> String.concat ", "
+  taints |> Taint_set.elements
+  |> Common.map _show_taint_label
+  |> String.concat ", "
   |> fun str -> "{ " ^ str ^ " }"

--- a/semgrep-core/src/tainting/Taint_lval_env.mli
+++ b/semgrep-core/src/tainting/Taint_lval_env.mli
@@ -23,27 +23,9 @@ val add : IL.lval -> Taint.taints -> env -> env
     tainted separately).
  *)
 
-val add_var : IL.name -> Taint.taints -> env -> env
-
 (* THINK: Perhaps keep propagators outside of this environment? *)
 val propagate_to : Dataflow_var_env.var -> Taint.taints -> env -> env
-
-val find : IL.lval -> env -> [ `None | `Clean | `Tainted of Taint.taints ]
-(** Find whether an lvalue is tainted or not.
-
-    [`None] means no taint.
-    [`Clean] means no taint for this particular lvalue x.a_1. ... .a_N, but
-    some of its prefixes x.a_1. ... .a_i (i < N) is tainted.
-
-    Given x.a_1. ... . a_N, it recursively checks all the prefixes of the
-    lvalue (from longest to shortest) until it finds one that is either
-    explicitly tainted (returns [`Tainted]) or explicitly clean (returns
-    [`Clean]). If none is found then it returns [`None].
-
-    If x.a.b is tainted with label B and x.a is tainted with label A,
-    the taint of x.a.b is still just B. *)
-
-val find_var : IL.name -> env -> Taint.taints option
+val find_lval : env -> IL.lval -> [> `Clean | `None | `Tainted of Taint.taints ]
 val propagate_from : Dataflow_var_env.var -> env -> Taint.taints option
 
 val clean : IL.lval -> env -> env
@@ -51,8 +33,6 @@ val clean : IL.lval -> env -> env
 
     Given x.a_1. ... .a_N, it will clean that lvalue as well as all its
     extensions x.a_1. ... .a_N. ... .a_M.  *)
-
-val clean_var : IL.name -> env -> env
 
 val union : env -> env -> env
 (** Compute the environment for the join of two branches.

--- a/semgrep-core/src/tainting/Taint_lval_env.mli
+++ b/semgrep-core/src/tainting/Taint_lval_env.mli
@@ -25,7 +25,14 @@ val add : IL.lval -> Taint.taints -> env -> env
 
 (* THINK: Perhaps keep propagators outside of this environment? *)
 val propagate_to : Dataflow_var_env.var -> Taint.taints -> env -> env
-val find_lval : env -> IL.lval -> [> `Clean | `None | `Tainted of Taint.taints ]
+
+val dumb_find : env -> IL.lval -> [> `Clean | `None | `Tainted of Taint.taints ]
+(** Look up an lvalue on the environemnt and return whether it's tainted, clean,
+    or we hold no info about it. It does not check sub-lvalues, e.g. if we record
+    that 'x.a' is tainted but had no explicit info about 'x.a.b', checking for
+    'x.a.b' would return `None. The way we determine whether an lvalue is actually
+    tainted is a "bit" more complex, see Dataflow_tainting.check_tainted_lval. *)
+
 val propagate_from : Dataflow_var_env.var -> env -> Taint.taints option
 
 val clean : IL.lval -> env -> env
@@ -39,9 +46,9 @@ val union : env -> env -> env
 
      If an lvalue x.a_1. ... .a_N was clean in one branch, we still consider it
      clean in the union unless it is explicitly tainted in the other branch.
-     Note that f e.g. x.a_1. ... .a_i (with i <> N) were tainted in the other
-     branch, then  x.a_1. ... . a_N may no longer be clean, but we assume the
-     best case scenario. *)
+     Note that if e.g. x.a_1. ... .a_i (with i < N) were tainted in the other
+     branch, then x.a_1. ... . a_N may no longer be clean, but we assume the
+     best case scenario to reduce FPs. *)
 
 val equal : env -> env -> bool
 val to_string : (Taint.taints -> string) -> env -> string

--- a/semgrep-core/tests/rules/field_sensitive1.js
+++ b/semgrep-core/tests/rules/field_sensitive1.js
@@ -1,11 +1,26 @@
-// Separately mark taint/no taint on each field of `a`
+// Separately mark taint/no taint on each field of `x`
 function f() {
-    a.b = source
-    a.c = safe
+    x.a = source // only x.a or its extension are tainted after this
+    x.b = safe
+    x.c = source // only x.c or its extension are tainted after this
 
+    // x.a is tainted
     //ruleid: test
-    sink(a.b)
+    sink(x.a)
+    //ruleid: test
+    sink(x.a.b)
 
+    // x.c is tainted
+    //ruleid: test
+    sink(x.c)
+    //ruleid: test
+    sink(x.c.d)
+
+    // x itself and other fields of x are not tainted
     //ok: test
-    sink(a.c)
+    sink(x)
+    //ok: test
+    sink(x.b)
+    //ok: test
+    sink(x.b.c)
 }

--- a/semgrep-core/tests/rules/field_sensitive2.js
+++ b/semgrep-core/tests/rules/field_sensitive2.js
@@ -1,14 +1,20 @@
-// Mark taint on all of `a`, remember that only `a.b` is clean
+// Mark taint on all of `x`, remember that only `x.a` is clean
 function f() {
-    a = source
-    a.b = safe
+    x = source
+    x.a = safe
     
     //ruleid: test
-    sink(a)
+    sink(x)
 
     //ruleid: test
-    sink(a.c)
+    sink(x.b)
+
+    //ruleid: test
+    sink(x.b.c)
 
     //ok: test
-    sink(a.b)
+    sink(x.a)
+
+    //ok: test
+    sink(x.a.b)
 }

--- a/semgrep-core/tests/rules/field_sensitive3.js
+++ b/semgrep-core/tests/rules/field_sensitive3.js
@@ -1,12 +1,22 @@
+// Quite similar to field_sensitive1 ...
 function f() {
-    a.b.c = source
+    x.a.b.c = source
 
     //ruleid: test
-    sink(a.b.c)
+    sink(x.a.b.c)
+    //ruleid: test
+    sink(x.a.b.c.d)
 
-    // These are ok because we have not enabled propagation of taint up through fields, to avoid FPs
+    // These are OK because we have not enabled propagation of taint up through
+    // fields, to avoid FPs
     //ok: test
-    sink(a.b)
+    sink(x.a.b.d)
     //ok: test
-    sink(a)
+    sink(x.a.b)
+    //ok: test
+    sink(x.a.c)
+    //ok: test
+    sink(x.a)
+    //ok: test
+    sink(x)
 }

--- a/semgrep-core/tests/rules/field_sensitive4.js
+++ b/semgrep-core/tests/rules/field_sensitive4.js
@@ -1,17 +1,22 @@
-// If `a.b` is marked clean, then any l-value that starts with `a.b` should
+// If `x.a` is marked clean, then any l-value that starts with `x.a` should
 // become clean too!
 function f() {
-    a.b.c = source
-    a.b.d = source
+    x.a.b = source
+    x.a.c = source
+
     //ruleid: test
-    sink(a.b.c.x)
-    a.b = safe
+    sink(x.a.b)
+    //ruleid: test
+    sink(x.a.c)
+    //ruleid: test
+    sink(x.a.b.x)
+
+    // After this, all the above ones become clean!
+    x.a = safe
     //ok: test
-    sink(a.b)
+    sink(x.a.b)
     //ok: test
-    sink(a.b.c)
+    sink(x.a.c)
     //ok: test
-    sink(a.b.c.d)
-    //ok: test
-    sink(a.b.c.x)
+    sink(x.a.b.x)
 }

--- a/semgrep-core/tests/rules/field_sensitive5.php
+++ b/semgrep-core/tests/rules/field_sensitive5.php
@@ -1,0 +1,12 @@
+<?php
+
+$id = isset(source()) ? source() : '';
+
+$obj = new Obj($id);
+
+// ok:regression_0113
+sink($obj->attr);
+
+$other_obj = new Unsafe();
+// ruleid:regression_0113
+sink($other_obj->method(source()));

--- a/semgrep-core/tests/rules/field_sensitive5.php
+++ b/semgrep-core/tests/rules/field_sensitive5.php
@@ -4,9 +4,10 @@ $id = isset(source()) ? source() : '';
 
 $obj = new Obj($id);
 
-// ok:regression_0113
+// We have a sanitizer cleaning $obj right here
+// ok:regression_0.113.0
 sink($obj->attr);
 
 $other_obj = new Unsafe();
-// ruleid:regression_0113
+// ruleid:regression_0.113.0
 sink($other_obj->method(source()));

--- a/semgrep-core/tests/rules/field_sensitive5.yaml
+++ b/semgrep-core/tests/rules/field_sensitive5.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: regression_0113
+    message: Semgrep found a match
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sanitizers:
+      - patterns:
+          - pattern: $TAINTED
+          - pattern-either:
+              - pattern: $TAINTED->$ATTR
+              - pattern: $TAINTED->$METHOD(...)

--- a/semgrep-core/tests/rules/field_sensitive6.py
+++ b/semgrep-core/tests/rules/field_sensitive6.py
@@ -1,0 +1,10 @@
+x = source()
+x.a = safe
+# `x` is tainted by `x.a` is marked clean
+
+# The actual sink is `x` which is tainted, even if `x.a` is not!
+#ruleid: test
+exotic(x.a)
+
+#ok: test
+sink(x.a)

--- a/semgrep-core/tests/rules/field_sensitive6.yaml
+++ b/semgrep-core/tests/rules/field_sensitive6.yaml
@@ -1,15 +1,14 @@
 rules:
-  - id: regression_0.113.0
+  - id: test
     message: Semgrep found a match
     languages:
-      - php
+      - python
     severity: WARNING
     mode: taint
     pattern-sources:
       - pattern: source()
     pattern-sinks:
       - pattern: sink(...)
-    pattern-sanitizers:
       - patterns:
-          - pattern: $TAINTED->$ATTR
-          - focus-metavariable: $TAINTED
+        - pattern: exotic($X.$A)
+        - focus-metavariable: $X

--- a/semgrep-core/tests/rules/field_sensitive7.py
+++ b/semgrep-core/tests/rules/field_sensitive7.py
@@ -1,0 +1,9 @@
+x = safe
+
+# `x.a` matches a taint source!
+#ruleid: test
+sink(x.a.b)
+
+# `x.a` has been tainted by side-effect...
+#ruleid: test
+sink(x.a)

--- a/semgrep-core/tests/rules/field_sensitive7.yaml
+++ b/semgrep-core/tests/rules/field_sensitive7.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test
+    message: Semgrep found a match
+    languages:
+      - python
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+        - pattern: $X.b
+        - focus-metavariable: $X
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
Before 0.113.0, each dot-access was an l-value expression on its own,
and we checked l-values bottom-up like any other expression. But in
0.113.0 we began representing a chain of dot-accesses as a single
l-value, and sub-lvalues were no longer checked as expressions of their
own, leading to regressions.

Closes PA-1928
Followed by PR returntocorp/semgrep-rules#2504

test plan:
make test # added one test

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
