### PR TITLE
feat(lsif): pfff update, exposed generic functions

### DIFF
--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -358,7 +358,6 @@ let mk_config () =
     match_format = !match_format;
     mvars = !mvars;
     lsp = !lsp;
-    lsif = false;
     timeout = !timeout;
     timeout_threshold = !timeout_threshold;
     max_memory_mb = !max_memory_mb;

--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -358,6 +358,7 @@ let mk_config () =
     match_format = !match_format;
     mvars = !mvars;
     lsp = !lsp;
+    lsif = false;
     timeout = !timeout;
     timeout_threshold = !timeout_threshold;
     max_memory_mb = !max_memory_mb;

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -946,3 +946,7 @@ let any x =
   | DictElem v1 ->
       let v1 = dictorset_elt env v1 in
       G.E v1
+
+let type_for_lsif ty =
+  let env : env = empty_env ~assign_to_vardef:false InPattern in
+  type_ env ty

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -950,3 +950,7 @@ let any x =
 let type_for_lsif ty =
   let env : env = empty_env ~assign_to_vardef:false InPattern in
   type_ env ty
+
+let parameters_for_lsif params =
+  let env : env = empty_env ~assign_to_vardef:false InPattern in
+  parameters env params

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.mli
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.mli
@@ -3,6 +3,7 @@ val program :
 
 val any : AST_python.any -> AST_generic.any
 val type_for_lsif : AST_python.type_ -> AST_generic.type_
+val parameters_for_lsif : AST_python.parameters -> AST_generic.parameters
 
 (* exception Error of string * Parse_info.info *)
 (* may raise Error *)

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.mli
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.mli
@@ -2,6 +2,7 @@ val program :
   ?assign_to_vardef:bool -> AST_python.program -> AST_generic.program
 
 val any : AST_python.any -> AST_generic.any
+val type_for_lsif : AST_python.type_ -> AST_generic.type_
 
 (* exception Error of string * Parse_info.info *)
 (* may raise Error *)

--- a/semgrep-core/src/runner/Runner_config.ml
+++ b/semgrep-core/src/runner/Runner_config.ml
@@ -57,6 +57,7 @@ type t = {
   match_format : Matching_report.match_format;
   mvars : Metavariable.mvar list;
   lsp : bool;
+  lsif : bool;
   (* Limits *)
   (* maximum time to spend running a rule on a single file *)
   timeout : float;
@@ -110,6 +111,7 @@ let default =
     match_format = Matching_report.Normal;
     mvars = [];
     lsp = false;
+    lsif = false;
     (* Limits *)
     (* maximum time to spend running a rule on a single file *)
     timeout = 0.;

--- a/semgrep-core/src/runner/Runner_config.ml
+++ b/semgrep-core/src/runner/Runner_config.ml
@@ -57,7 +57,6 @@ type t = {
   match_format : Matching_report.match_format;
   mvars : Metavariable.mvar list;
   lsp : bool;
-  lsif : bool;
   (* Limits *)
   (* maximum time to spend running a rule on a single file *)
   timeout : float;
@@ -111,7 +110,6 @@ let default =
     match_format = Matching_report.Normal;
     mvars = [];
     lsp = false;
-    lsif = false;
     (* Limits *)
     (* maximum time to spend running a rule on a single file *)
     timeout = 0.;


### PR DESCRIPTION
## What:
This change adds some `pfff` changes that are needed for the LSIF experiment, and exposed some functions which are helpful for the LSIF experiment

## Why:
This change is a part of the LSIF experiment, as described by the scope doc here: https://www.notion.so/r2cdev/Semgrep-LSIF-Querying-e9261a3fbee94084a129014d599045bd

We are trying to use the LSIF format to get type information for free, instead of needing to implement a Typescript typechecker ourselves. To that end, DeepSemgrep needs an LSIF command-line flag to enable the experiment.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
