### PR TITLE
fix: Handle nested transitive dependencies in package-lock.json

### DIFF
--- a/changelog.d/sc-247.fixed
+++ b/changelog.d/sc-247.fixed
@@ -1,0 +1,1 @@
+Fixed bug where nested dependencies in package-lock.json files were not detected

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -194,7 +194,8 @@ def parse_package_lock(
                 transitivity=transitivity,
                 line_number=int(line_number) + 1 if line_number else None,
             )
-            if nested_deps := dep_blob.get("dependencies"):
+            nested_deps = dep_blob.get("dependencies")
+            if nested_deps:
                 yield from parse_deps(nested_deps, True)
 
     yield from parse_deps(deps, False)

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -154,6 +154,9 @@ def parse_package_lock(
         manifest_deps = None
 
     def parse_deps(deps: Dict[str, Any], nested: bool) -> Iterator[FoundDependency]:
+        # Dependency dicts in a package-lock.json can be nested:
+        # {"foo" : {stuff, "dependencies": {"bar": stuff, "dependencies": {"baz": stuff}}}}
+        # So we need to handle them recursively
         for dep, dep_blob in deps.items():
             version = dep_blob.get("version")
             if not version:

--- a/cli/tests/e2e/rules/dependency_aware/nested_package_lock.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/nested_package_lock.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: nested_package_lock
+    r2c-internal-project-depends-on:
+        namespace: npm
+        package: "@types/jquery"
+        version: "== 3.3.1"
+    message: oh no
+    languages: [js]
+    severity: WARNING

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarenested_package_lock.yaml-dependency_awarenested_package_lock/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarenested_package_lock.yaml-dependency_awarenested_package_lock/results.txt
@@ -1,0 +1,77 @@
+=== command
+SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERSION_CACHE_PATH="<MASKED>" SEMGREP_ENABLE_VERSION_CHECK="0" SEMGREP_SEND_METRICS="off" semgrep --strict --config rules/dependency_aware/nested_package_lock.yaml --json targets/dependency_aware/nested_package_lock
+=== end of command
+
+=== exit code
+0
+=== end of exit code
+
+=== stdout - plain
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": []
+  },
+  "results": [
+    {
+      "check_id": "rules.dependency_aware.nested_package_lock",
+      "end": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      },
+      "extra": {
+        "fingerprint": "6171c4ae4a0a6eace4536e4a32a3e7e35f9eb8519fcce025e313bb1a0781af751f7478e822f66ca3f8621561de156b91be382a13820eba0a86f3e6a399d2f028_0",
+        "is_ignored": false,
+        "lines": "",
+        "message": "oh no",
+        "metadata": {},
+        "metavars": {},
+        "sca_info": {
+          "dependency_match": {
+            "dependency_pattern": {
+              "ecosystem": "npm",
+              "package": "@types/jquery",
+              "semver_range": "== 3.3.1"
+            },
+            "found_dependency": {
+              "allowed_hashes": {
+                "sha512": [
+                  "6b8243708849847627a160a41b7c53d826715d9780f7625e444112a2b8340cc43766c8ee285e3c87b5cae25e469761916bf22d191a4a313d29c8af3cc9182a5d"
+                ]
+              },
+              "ecosystem": "npm",
+              "line_number": 41,
+              "package": "@types/jquery",
+              "resolved_url": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
+              "transitivity": "transitive",
+              "version": "3.3.1"
+            },
+            "lockfile": "targets/dependency_aware/nested_package_lock/package-lock.json"
+          },
+          "reachability_rule": false,
+          "reachable": false,
+          "sca_finding_schema": 20220913
+        },
+        "severity": "WARNING"
+      },
+      "path": "targets/dependency_aware/nested_package_lock/package-lock.json",
+      "start": {
+        "col": 0,
+        "line": 0,
+        "offset": 0
+      }
+    }
+  ],
+  "version": "0.42"
+}
+=== end of stdout - plain
+
+=== stderr - plain
+Nothing to scan.
+
+
+Ran 1 rule on 0 files: 1 finding.
+
+=== end of stderr - plain

--- a/cli/tests/e2e/targets/dependency_aware/nested_package_lock/package-lock.json
+++ b/cli/tests/e2e/targets/dependency_aware/nested_package_lock/package-lock.json
@@ -1,0 +1,70 @@
+{
+    "requires": true,
+    "lockfileVersion": 2,
+    "packages": {
+        "": {
+          "name": "model-viewer-packages",
+          "license": "Apache-2.0",
+          "devDependencies": {
+            "@typescript-eslint/eslint-plugin": "^4.28.3",
+            "@typescript-eslint/parser": "^4.28.3",
+            "clang-format": "^1.5.0",
+            "eslint": "^7.30.0",
+            "eslint-config-google": "^0.14.0",
+            "eslint-plugin-mocha": "^9.0.0",
+            "eslint-plugin-wc": "^1.3.0",
+            "http-server": "^0.12.3",
+            "husky": "^7.0.1",
+            "lerna": "^4.0.0",
+            "typescript": "4.3.5"
+          },
+          "engines": {
+            "node": ">=12.0.0"
+          }
+        },
+        "node_modules/@babel/code-frame": {
+          "version": "7.12.11"
+        }
+    },
+    "dependencies": {
+        "@types/backbone": {
+            "version": "1.3.43",
+            "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.3.43.tgz",
+            "integrity": "sha512-TAoXvN4neAw2rEOQN8mg0Y0oLYgmPoCWtcMW4Rk19vJahcYueK0Yrf/2TZKWM81K/E1QpHKKyhITaU9LwXAATA==",
+            "dev": true,
+            "requires": {
+                "@types/jquery": "*",
+                "@types/underscore": "*"
+            },
+            "dependencies": {
+                "@types/jquery": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
+                    "integrity": "sha512-a4JDcIhJhHYnoWCkG3xT2CZxXZeA92JeREESorg0DMQ3ZsjuKF48h7XK4l5Gl2GRa/ItGRpKMT0pyK88yRgqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/sizzle": "*"
+                    }
+                }
+            }
+        },
+        "@types/jquery": {
+            "version": "3.3.22",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.22.tgz",
+            "integrity": "sha512-a4JDcIhJhHYnoWCkG3xT2CZxXZeA92JeREESorg0DMQ3ZsjuKF48h7XK4l5Gl2GRa/ItGRpKMT0pyK88yRgqXQ==",
+            "dev": true,
+            "requires": {
+                "@types/sizzle": "*"
+            }
+        },
+        "dagre": {
+            "version": "github:clientIO/dagre#99d86433de741e3e1508c0e59ac2917863156896",
+            "from": "github:clientIO/dagre#v1.2-joint",
+            "requires": {
+                "graphlib": "^2.1.1",
+                "lodash": "^4.15.0",
+                "npm-install-security-check": "^1.0.2"
+            }
+        }
+    }
+}

--- a/cli/tests/e2e/test_dependency_aware_rules.py
+++ b/cli/tests/e2e/test_dependency_aware_rules.py
@@ -40,6 +40,10 @@ from ..conftest import TESTS_PATH
             "rules/dependency_aware/monorepo.yaml",
             "dependency_aware/monorepo/",
         ),
+        (
+            "rules/dependency_aware/nested_package_lock.yaml",
+            "dependency_aware/nested_package_lock/",
+        ),
     ],
 )
 def test_dependency_aware_rules(run_semgrep_on_copied_files, snapshot, rule, target):


### PR DESCRIPTION
Previously we would not detect `find-up` when scanning this entry in a `package-lock.json` file:
```
"yargs": {
  "version": "15.4.1",
  "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
  "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
  "dependencies": {
    "find-up": {
      "version": "4.1.0",
      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
      "requires": {
        "locate-path": "^5.0.0",
        "path-exists": "^4.0.0"
      }
    }
```
This happens when a package is a dependency of multiple other packages at different versions.
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
