### PR TITLE
Update 'make dev' + documentation

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -61,15 +61,26 @@ install:
 # Developer targets
 ###############################################################################
 
-# Build semgrep-core and place it where semgrep expects it.
+# Build executables and place them where semgrep expects them.
+# These are normally copied by '/cli/setup.py' but it doesn't happen if we
+# run only 'dune build'.
+#
 # This is for development purposes only as I'm not sure if a symlink is ok
-# for packaging things up on the python side.
+# for packaging things up on the Python side.
+#
+# Usage:
+#  $ make dev
+#  $ PIPENV_PIPFILE=~/semgrep/cli/Pipfile pipenv run semgrep ...
+#
 .PHONY: dev
 dev:
 	$(MAKE) all
 	rm -f ../cli/src/semgrep/bin/semgrep-core
 	ln -s ../../../../semgrep-core/bin/semgrep-core \
 	  ../cli/src/semgrep/bin/semgrep-core
+	rm -f ../cli/src/semgrep/bin/osemgrep
+	ln -s ../../../../semgrep-core/bin/osemgrep \
+	  ../cli/src/semgrep/bin/osemgrep
 	rm -f ../cli/src/semgrep/bin/semgrep_bridge_core.so
 	ln -s ../../../../semgrep-core/bin/semgrep_bridge_core.so \
 	  ../cli/src/semgrep/bin/semgrep_bridge_core.so


### PR DESCRIPTION
This allows `semgrep` to find the latest build of `osemgrep`.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
