### PR TITLE
semgrep-jsonnet pre-commit config: use a specific semgrep version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,11 +180,13 @@ repos:
       - id: semgrep-jsonnet
         name: semgrep jsonnet
         language: docker_image
-        # See .pre-commit-hooks.yaml for why we need to set those SEMGREP_XXX variables.
-        # Ideally we would not need this because we would use the 'language: python' instead
-        # of 'docker_image' to run semgrep, but for now jsonnet support is not available
-        # via setup.py and only (unofficially) available in docker.
-        entry: -e SEMGREP_LOG_FILE=/tmp/out.log -e SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:develop semgrep
+        # See .pre-commit-hooks.yaml for why we need to set those
+        # SEMGREP_XXX variables.  Ideally we would not need this
+        # because we would use the 'language: python' instead of
+        # 'docker_image' to run semgrep, but for now jsonnet support
+        # is not available via setup.py and only (unofficially)
+        # available in docker.
+        entry: -e SEMGREP_LOG_FILE=/tmp/out.log -e SEMGREP_VERSION_CACHE_PATH=/tmp/cache returntocorp/semgrep:0.116.0 semgrep
         #coupling: 'make check' and the SEMGREP_ARGS variable
         args: [
             "--config",
@@ -192,16 +194,19 @@ repos:
             "--error",
             "--exclude",
             "tests",
-            # note that pre-commit can call multiple times semgrep in one run if there
-            # are many files in a PR (or in CI where it runs on all the files in a repo).
-            # In that case I think pre-commit splits the list of files in multiple batches
-            # and run one semgrep per batch. This is why it's important to use --quiet
-            # otherwise you can have the same banner repeated many times in the output
-            # in case of errors.
+            # note that pre-commit can call multiple times semgrep in
+            # one run if there are many files in a PR (or in CI where
+            # it runs on all the files in a repo).  In that case I
+            # think pre-commit splits the list of files in multiple
+            # batches and run one semgrep per batch. This is why it's
+            # important to use --quiet otherwise you can have the same
+            # banner repeated many times in the output in case of
+            # errors.
             "--quiet",
-            # this is useful in a pre-commit context because pre-commit calls the hooks
-            # with all the files in the PR (or in CI with all the files in the repo)
-            # but we don't want an OCaml rule to be applied on a script.
+            # this is useful in a pre-commit context because
+            # pre-commit calls the hooks with all the files in the PR
+            # (or in CI with all the files in the repo) but we don't
+            # want an OCaml rule to be applied on a script.
             "--skip-unknown-extensions",
           ]
 


### PR DESCRIPTION
Otherwise, it would use the local image tagged `returntocorp/semgrep:develop` which in my case was outdated.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
