### PR TITLE
osemgrep: simplify Scan_CLI.ml and Semgrep_scan.ml

### DIFF
--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -101,7 +101,7 @@ Make sure your files are stored in a version control system. Note that
 this mode is experimental and not guaranteed to function properly.
 |}
 
-let o_baseline_commit =
+let o_baseline_commit : string option Term.t =
   let info =
     Arg.info [ "baseline_commit" ]
       ~doc:
@@ -395,7 +395,7 @@ let cmdline_term : conf Term.t =
 let doc = "run semgrep rules on files"
 
 (* TODO: document the exit codes as defined in Error.mli *)
-let man =
+let man : Manpage.block list =
   [
     `S Manpage.s_description;
     `P
@@ -422,8 +422,9 @@ let man =
 (*****************************************************************************)
 
 let parse_argv (argv : string array) : (conf, Exit_code.t) result =
-  let info = Cmd.info "semgrep scan" ~doc ~man in
-  match Cmd.eval_value ~argv (Cmd.v info cmdline_term) with
+  let info : Cmd.info = Cmd.info "semgrep scan" ~doc ~man in
+  let cmd : conf Cmd.t = Cmd.v info cmdline_term in
+  match Cmd.eval_value ~argv cmd with
   | Error _n -> Error Exit_code.fatal
   | Ok ok -> (
       match ok with

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -47,12 +47,12 @@ type conf = {
   verbose : bool;
 }
 
-let get_cpu_count () =
+let get_cpu_count () : int =
   (* Parmap subtracts 1 from the number of detected cores.
      This comes with no guarantees. *)
   max 1 (Parmap.get_default_ncores () + 1)
 
-let default =
+let default : conf =
   {
     autofix = false;
     baseline_commit = None;
@@ -92,7 +92,7 @@ let _validate_lang option lang_str =
 (* No group *)
 (* ------------------------------------------------------------------ *)
 
-let o_autofix =
+let o_autofix : bool Term.t =
   H.negatable_flag [ "a"; "autofix" ] ~neg_options:[ "no-autofix" ]
     ~default:default.autofix
     ~doc:
@@ -288,7 +288,7 @@ let o_debug =
   Arg.value (Arg.flag info)
 
 (* ------------------------------------------------------------------ *)
-(* TOPORT "Output formats" *)
+(* TOPORT "Output formats" (mutually exclusive) *)
 (* ------------------------------------------------------------------ *)
 
 (* ------------------------------------------------------------------ *)
@@ -359,32 +359,31 @@ let o_target_roots =
 (*** Subcommand 'scan' ***)
 (*****************************************************************************)
 
-let cmdline_term run =
+let cmdline_term : conf Term.t =
   let combine autofix baseline_commit config debug exclude include_ lang
       max_memory_mb max_target_bytes metrics num_jobs optimizations pattern
       quiet respect_git_ignore target_roots timeout timeout_threshold verbose =
-    run
-      {
-        autofix;
-        baseline_commit;
-        config;
-        debug;
-        exclude;
-        include_;
-        lang;
-        max_memory_mb;
-        max_target_bytes;
-        metrics;
-        num_jobs;
-        optimizations;
-        pattern;
-        quiet;
-        respect_git_ignore;
-        target_roots;
-        timeout;
-        timeout_threshold;
-        verbose;
-      }
+    {
+      autofix;
+      baseline_commit;
+      config;
+      debug;
+      exclude;
+      include_;
+      lang;
+      max_memory_mb;
+      max_target_bytes;
+      metrics;
+      num_jobs;
+      optimizations;
+      pattern;
+      quiet;
+      respect_git_ignore;
+      target_roots;
+      timeout;
+      timeout_threshold;
+      verbose;
+    }
   in
   Term.(
     const combine $ o_autofix $ o_baseline_commit $ o_config $ o_debug
@@ -422,7 +421,13 @@ let man =
 (* Entry point *)
 (*****************************************************************************)
 
-let parse_and_run (argv : string array) (run : conf -> Exit_code.t) =
-  let run conf = CLI_common.safe_run run conf |> Exit_code.to_int in
+let parse_argv (argv : string array) : (conf, Exit_code.t) result =
   let info = Cmd.info "semgrep scan" ~doc ~man in
-  run |> cmdline_term |> Cmd.v info |> Cmd.eval' ~argv |> Exit_code.of_int
+  match Cmd.eval_value ~argv (Cmd.v info cmdline_term) with
+  | Error _n -> Error Exit_code.fatal
+  | Ok ok -> (
+      match ok with
+      | `Ok config -> Ok config
+      | `Version
+      | `Help ->
+          Error Exit_code.ok)

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -385,6 +385,7 @@ let cmdline_term : conf Term.t =
       verbose;
     }
   in
+  (* Term defines 'const' but also the '$' operator *)
   Term.(
     const combine $ o_autofix $ o_baseline_commit $ o_config $ o_debug
     $ o_exclude $ o_include $ o_lang $ o_max_memory_mb $ o_max_target_bytes

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -29,4 +29,13 @@ type conf = {
 
 (* Command-line defaults. *)
 val default : conf
+
+(*
+   Usage: parse_argv [| "semgrep-scan"; <args> |]
+
+   This function returns an exit code to be passed to the 'exit' function
+   if there was an error parsing argv (Exit_code.fatal) or when
+   using semgrep scan --help (Exit_code.ok), and the conf otherwise if everything
+   went fine.
+*)
 val parse_argv : string array -> (conf, Exit_code.t) result

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -29,11 +29,4 @@ type conf = {
 
 (* Command-line defaults. *)
 val default : conf
-
-(*
-   Usage: parse_and_run [| "semgrep-scan"; <args> |] run
-
-   This function returns an exit code to be passed to the 'exit' function.
-   Exceptions are caught and turned into an appropriate exit code.
-*)
-val parse_and_run : string array -> (conf -> Exit_code.t) -> Exit_code.t
+val parse_argv : string array -> (conf, Exit_code.t) result

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
@@ -4,8 +4,15 @@
 
 (* All the business logic after command-line parsing. Return the desired
    exit code. *)
-let run (conf : Scan_CLI.conf) =
+let run (conf : Scan_CLI.conf) : Exit_code.t =
   let _res = Core_runner.invoke_semgrep conf in
   Exit_code.ok
 
-let main argv = Scan_CLI.parse_and_run argv run
+let main (argv : string array) : Exit_code.t =
+  let res = Scan_CLI.parse_argv argv in
+  (* LATER: this error handling could be factorized probably
+   * between the different subcommands at some point
+   *)
+  match res with
+  | Ok conf -> CLI_common.safe_run run conf
+  | Error exit_code -> exit_code

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.mli
@@ -2,5 +2,8 @@
    Parse a semgrep-scan command, execute it and exit.
 
    Usage: main [| "semgrep-scan"; ... |]
+
+   This function returns an exit code to be passed to the 'exit' function.
+   Exceptions are caught and turned into an appropriate exit code.
 *)
 val main : string array -> Exit_code.t

--- a/semgrep-core/src/osemgrep/core/Constants.ml
+++ b/semgrep-core/src/osemgrep/core/Constants.ml
@@ -119,6 +119,8 @@ let break_line = String.make break_line_width break_line_char
 let max_chars_flag_name = "--max-chars-per-line"
 let default_max_chars_per_line = 160
 let ellipsis_string = " ... "
+
+(* LATER: move to Scan_CLI.default directly *)
 let default_max_target_size = 1_000_000 (* 1 MB *)
 
 (* python: original code:


### PR DESCRIPTION
Avoid run callbacks, just return the config in Scan_CLI.ml
and then run everything in Semgrep_scan.ml

All those run conf wrappers callbacks were confusing me. I think
it's simpler like that.

test plan:
make test


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)