### PR TITLE
osemgrep: handle --optimizations all, pass -fast to semgrep-core

### DIFF
--- a/semgrep-core/src/core/Flag_semgrep.ml
+++ b/semgrep-core/src/core/Flag_semgrep.ml
@@ -20,10 +20,6 @@ let pfff_only = ref false
 (* look if identifiers in pattern intersect with file using simple regexps *)
 let filter_irrelevant_patterns = ref false
 
-(* similar to filter_irrelevant_patterns, but use the whole rule to extract
- * the regexp *)
-let filter_irrelevant_rules = ref false
-
 (* check for identifiers before attempting to match a stmt or stmt list
  *
  * We disabled the Bloom filter optimization by default in 0.116.0 due to its

--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -108,6 +108,10 @@ let ncores = ref Runner_config.default.ncores
 (* see Flag_semgrep.ml *)
 let use_parsing_cache = ref Runner_config.default.parsing_cache_dir
 
+(* similar to filter_irrelevant_patterns, but use the whole rule to extract
+ * the regexp *)
+let filter_irrelevant_rules = ref Runner_config.default.filter_irrelevant_rules
+
 (* ------------------------------------------------------------------------- *)
 (* flags used by the semgrep-python wrapper *)
 (* ------------------------------------------------------------------------- *)
@@ -346,6 +350,7 @@ let mk_config () =
     pattern_file = !pattern_file;
     rule_source = !rule_source;
     lang_job = None;
+    filter_irrelevant_rules = !filter_irrelevant_rules;
     (* not part of CLI *)
     equivalences_file = !equivalences_file;
     lang = !lang;
@@ -586,13 +591,13 @@ let options () =
       Arg.Clear Flag.filter_irrelevant_patterns,
       " do not filter patterns" );
     ( "-filter_irrelevant_rules",
-      Arg.Set Flag.filter_irrelevant_rules,
+      Arg.Set filter_irrelevant_rules,
       " filter rules not containing any strings in target file" );
     ( "-no_filter_irrelevant_rules",
-      Arg.Clear Flag.filter_irrelevant_rules,
+      Arg.Clear filter_irrelevant_rules,
       " do not filter rules" );
     ( "-fast",
-      Arg.Set Flag.filter_irrelevant_rules,
+      Arg.Set filter_irrelevant_rules,
       " filter rules not containing any strings in target file" );
     ( "-bloom_filter",
       Arg.Set Flag.use_bloom_filter,

--- a/semgrep-core/src/engine/Match_env.ml
+++ b/semgrep-core/src/engine/Match_env.ml
@@ -41,10 +41,10 @@ type id_to_match_results = (pattern_id, Pattern_match.t) Hashtbl.t
 type xconfig = {
   config : Config_semgrep.t;
   equivs : Equivalence.equivalences;
-  (* Field(s) coming from Runner_config.t used by the engine.
+  (* Fields coming from Runner_config.t used by the engine.
    * We could just include the whole Runner_config.t, but it's
-   * cleaner to explicitely state what the engine depends on.
-   * There's lots of fields in Runner_config.t
+   * cleaner to explicitely state what the engine depends on
+   * (there's lots of fields in Runner_config.t).
    *)
   matching_explanations : bool;
   filter_irrelevant_rules : bool;
@@ -97,6 +97,9 @@ let default_xconfig =
     config = Config_semgrep.default_config;
     equivs = [];
     matching_explanations = false;
-    (* TODO: set to true by default? *)
+    (* TODO: set to true by default?
+     * Anyway it's set to true in Runner_config.default so it will default to
+     * true when running as part of the regular code path (not testing code)
+     *)
     filter_irrelevant_rules = false;
   }

--- a/semgrep-core/src/engine/Match_env.ml
+++ b/semgrep-core/src/engine/Match_env.ml
@@ -41,8 +41,13 @@ type id_to_match_results = (pattern_id, Pattern_match.t) Hashtbl.t
 type xconfig = {
   config : Config_semgrep.t;
   equivs : Equivalence.equivalences;
-  (* field(s) coming from Runner_config.t used by the engine *)
+  (* Field(s) coming from Runner_config.t used by the engine.
+   * We could just include the whole Runner_config.t, but it's
+   * cleaner to explicitely state what the engine depends on.
+   * There's lots of fields in Runner_config.t
+   *)
   matching_explanations : bool;
+  filter_irrelevant_rules : bool;
 }
 
 type env = {
@@ -86,3 +91,12 @@ let fake_rule_id (id, str) =
 let adjust_xconfig_with_rule_options xconf options =
   let config = Common.( ||| ) options xconf.config in
   { xconf with config }
+
+let default_xconfig =
+  {
+    config = Config_semgrep.default_config;
+    equivs = [];
+    matching_explanations = false;
+    (* TODO: set to true by default? *)
+    filter_irrelevant_rules = false;
+  }

--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -421,13 +421,7 @@ let extract_as_separate erule_table xtarget rule_ids matches =
 let extract_nested_lang ~match_hook ~timeout ~timeout_threshold
     (erules : Rule.extract_rule list) xtarget rule_ids =
   let erule_table = mk_rule_table erules in
-  let xconf =
-    {
-      Match_env.config = Config_semgrep.default_config;
-      equivs = [];
-      matching_explanations = false;
-    }
-  in
+  let xconf = Match_env.default_xconfig in
   let res =
     Match_rules.check ~match_hook ~timeout ~timeout_threshold xconf
       (erules :> Rule.rules)

--- a/semgrep-core/src/engine/Match_rules.ml
+++ b/semgrep-core/src/engine/Match_rules.ml
@@ -72,7 +72,8 @@ let skipped_target_of_rule (file_and_more : Xtarget.t) (rule : R.rule) :
 (* Entry point *)
 (*****************************************************************************)
 
-let check ~match_hook ~timeout ~timeout_threshold xconf rules xtarget =
+let check ~match_hook ~timeout ~timeout_threshold (xconf : Match_env.xconfig)
+    rules xtarget =
   let { Xtarget.file; lazy_content; lazy_ast_and_errors; _ } = xtarget in
   logger#trace "checking %s with %d rules" file (List.length rules);
   if !Common.profile = Common.ProfAll then (
@@ -85,7 +86,7 @@ let check ~match_hook ~timeout ~timeout_threshold xconf rules xtarget =
     rules
     |> Common.partition_either (fun r ->
            let relevant_rule =
-             if !Flag_semgrep.filter_irrelevant_rules then (
+             if xconf.filter_irrelevant_rules then (
                match Analyze_rule.regexp_prefilter_of_rule r with
                | None -> true
                | Some (prefilter_formula, func) ->

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -72,13 +72,7 @@ let test_dfg_tainting rules_file file =
   pr2 "Tainting";
   pr2 "========";
   let handle_findings _ _ _ = () in
-  let xconf =
-    {
-      Match_env.config = Config_semgrep.default_config;
-      equivs = [];
-      matching_explanations = false;
-    }
-  in
+  let xconf = Match_env.default_xconfig in
   let config, debug_taint, _exps =
     Match_tainting_mode.taint_config_of_rule xconf file (ast, []) rule
       handle_findings

--- a/semgrep-core/src/engine/Test_engine.ml
+++ b/semgrep-core/src/engine/Test_engine.ml
@@ -175,7 +175,6 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
              in
              E.g_errors := [];
              Flag_semgrep.with_opt_cache := false;
-             let config = Config_semgrep.default_config in
              Report.mode := MTime;
              let rules, extract_rules =
                Common.partition_either
@@ -198,9 +197,7 @@ let make_tests ?(unit_testing = false) ?(get_xlang = None) xs =
                  extracted_ranges
                  ([], Hashtbl.create 5)
              in
-             let xconf =
-               { Match_env.config; equivs = []; matching_explanations = false }
-             in
+             let xconf = Match_env.default_xconfig in
              let res =
                try
                  (* TODO: Maybe we should be using Run_semgrep running the same functions

--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -525,13 +525,7 @@ let tainting_test lang rules_file file =
   let search_rules, taint_rules, extract_rules = Rule.partition_rules rules in
   assert (search_rules = []);
   assert (extract_rules = []);
-  let xconf =
-    {
-      Match_env.config = Config_semgrep.default_config;
-      equivs = [];
-      matching_explanations = false;
-    }
-  in
+  let xconf = Match_env.default_xconfig in
 
   let matches =
     taint_rules
@@ -629,15 +623,7 @@ let full_rule_regression_tests () =
     (let tests, _print_summary =
        Test_engine.make_tests ~unit_testing:true [ path ]
      in
-     tests
-     |> Common.map (fun (name, ftest) ->
-            let test () =
-              Common2.save_excursion_and_enable
-                Flag_semgrep.filter_irrelevant_rules (fun () ->
-                  logger#info "running with -filter_irrelevant_rules";
-                  ftest ())
-            in
-            (name, test)))
+     tests)
 
 (* quite similar to full_rule_regression_tests but prefer to pack_tests
  * with "full semgrep rule Java", so one can just run the Java tests
@@ -723,11 +709,7 @@ let full_rule_semgrep_rules_regression_tests () =
                         if not is_throwing then
                           Alcotest.fail
                             "this used to raise an error (good news?)"
-                    | _ ->
-                        Common2.save_excursion_and_enable
-                          Flag_semgrep.filter_irrelevant_rules (fun () ->
-                            logger#info "running with -filter_irrelevant_rules";
-                            ftest ())
+                    | _ -> ftest ()
                   in
                   (name, test))))
 

--- a/semgrep-core/src/metachecking/Unit_metachecking.ml
+++ b/semgrep-core/src/metachecking/Unit_metachecking.ml
@@ -52,9 +52,7 @@ let metachecker_regression_tests () =
     ( "metachecker regresion testing",
       fun () ->
         let path = Filename.concat tests_path "metachecks" in
-        Common2.save_excursion_and_enable Flag_semgrep.filter_irrelevant_rules
-          (fun () -> Test_metachecking.test_rules ~unit_testing:true [ path ])
-    );
+        Test_metachecking.test_rules ~unit_testing:true [ path ] );
   ]
 
 (*****************************************************************************)

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -132,7 +132,7 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
    max_memory_mb;
    debug;
    output_format;
-   optimizations = _TODO;
+   optimizations;
    (* TOPORT: not handled yet *)
    autofix = _;
    baseline_commit = _;
@@ -161,7 +161,7 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
          *)
         | _else_ -> Runner_config.Json false
       in
-
+      let filter_irrelevant_rules = optimizations in
       {
         Runner_config.default with
         ncores = num_jobs;
@@ -170,6 +170,7 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
         timeout_threshold;
         max_memory_mb;
         debug;
+        filter_irrelevant_rules;
         version = Version.version;
       }
 

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -119,11 +119,6 @@ let split_jobs_by_language all_rules all_targets : Runner_config.lang_job list =
     grouped_rules
 
 let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
-  (* TODO: This is the -fast or -filter_irrelevant_rules flag of semgrep-core.
-      It's currently a global, mutable variable. Move it the config object
-      so we can use it easily.
-     conf.use_optimizations;
-  *)
   match conf with
   | {
    num_jobs;
@@ -136,16 +131,16 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
    (* TOPORT: not handled yet *)
    autofix = _;
    baseline_commit = _;
-   config = _;
    exclude = _;
    include_ = _;
+   config = _;
    lang = _;
+   pattern = _;
+   target_roots = _;
    max_target_bytes = _;
    metrics = _;
-   pattern = _;
-   quiet = _;
    respect_git_ignore = _;
-   target_roots = _;
+   quiet = _;
    verbose = _;
   } ->
       let output_format =
@@ -153,7 +148,7 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
         | Json -> Runner_config.Json false (* no dots *)
         (* TOPORT: I think also in Text mode we should default
          * to Json because we do not want the same text displayed in
-         * osemgrep than in semgrep-core
+         * osemgrep than in semgrep-core.
          *)
         | Text -> Runner_config.Text
         (* defaulting to Json, which really mean just no incremental

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -671,6 +671,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
                Match_env.config = Config_semgrep.default_config;
                equivs = parse_equivalences config.equivalences_file;
                matching_explanations = config.matching_explanations;
+               filter_irrelevant_rules = config.filter_irrelevant_rules;
              }
            in
            let matches =

--- a/semgrep-core/src/runner/Runner_config.ml
+++ b/semgrep-core/src/runner/Runner_config.ml
@@ -66,6 +66,7 @@ type t = {
   max_match_per_file : int;
   ncores : int;
   parsing_cache_dir : Common.dirname; (* "" means no cache *)
+  filter_irrelevant_rules : bool;
   (* Flag used by the semgrep-python wrapper *)
   target_source : target_source option;
   (* Common.ml action for the -dump_xxx *)
@@ -118,6 +119,8 @@ let default =
     max_match_per_file = 10_000;
     ncores = 1;
     parsing_cache_dir = "";
+    filter_irrelevant_rules = true;
+    (* -fast by default *)
     (* "" means no cache *)
     (* Flag used by the semgrep-python wrapper *)
     target_source = None;


### PR DESCRIPTION
test plan:
time ./semgrep-core/_build/default/src/osemgrep/main/Main.exe --config
semgrep-core/tests/osemgrep/osemgrep.yml --json cli/ semgrep-core/src/
now takes 2s instead of 8s

(still 1s more than semgrep on same input, but probably because
we analyze still more files because of not handle .gitignore)


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)