### PR TITLE
fix: remove gradle as a separate supply chain ecosystem

### DIFF
--- a/changelog.d/sc-256.fixed
+++ b/changelog.d/sc-256.fixed
@@ -1,0 +1,1 @@
+Removed Gradle as a separate supply chain ecosystem. Maven rules now work on Gradle projects

--- a/cli/src/semdep/find_lockfiles.py
+++ b/cli/src/semdep/find_lockfiles.py
@@ -10,7 +10,6 @@ from semgrep.semgrep_interfaces.semgrep_output_v0 import Ecosystem
 from semgrep.semgrep_interfaces.semgrep_output_v0 import FoundDependency
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Gem
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Gomod
-from semgrep.semgrep_interfaces.semgrep_output_v0 import Gradle
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Maven
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Npm
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Pypi
@@ -21,8 +20,7 @@ ECOSYSTEM_TO_LOCKFILES = {
     Ecosystem(Gem()): ["Gemfile.lock"],
     Ecosystem(Gomod()): ["go.sum"],
     Ecosystem(Cargo()): ["Cargo.lock"],
-    Ecosystem(Maven()): ["pom.xml"],
-    Ecosystem(Gradle()): ["gradle.lockfile"],
+    Ecosystem(Maven()): ["pom.xml", "gradle.lockfile"],
 }
 
 LOCKFILE_TO_MANIFEST = {

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -32,7 +32,6 @@ from semgrep.semgrep_interfaces.semgrep_output_v0 import Gomod
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Gem
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Cargo
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Maven
-from semgrep.semgrep_interfaces.semgrep_output_v0 import Gradle
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Transitivity
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Direct
 from semgrep.semgrep_interfaces.semgrep_output_v0 import Transitive
@@ -434,7 +433,7 @@ def parse_gradle(
         return FoundDependency(
             package=name,
             version=version,
-            ecosystem=Ecosystem(Gradle()),
+            ecosystem=Ecosystem(Maven()),
             resolved_url=None,
             allowed_hashes={},
             transitivity=Transitivity(Unknown()),

--- a/cli/tests/e2e/rules/dependency_aware/java-gradle-sca.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/java-gradle-sca.yaml
@@ -2,7 +2,7 @@ rules:
   - id: java-gradle-sca
     pattern: bad()
     r2c-internal-project-depends-on:
-        namespace: gradle
+        namespace: maven
         package: swagger-ui-dist
         version: <= 3.35.2
     message: oh no

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle/results.txt
@@ -33,13 +33,13 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
         "sca_info": {
           "dependency_match": {
             "dependency_pattern": {
-              "ecosystem": "gradle",
+              "ecosystem": "maven",
               "package": "swagger-ui-dist",
               "semver_range": "<= 3.35.2"
             },
             "found_dependency": {
               "allowed_hashes": {},
-              "ecosystem": "gradle",
+              "ecosystem": "maven",
               "package": "swagger-ui-dist",
               "transitivity": "unknown",
               "version": "3.35.2"


### PR DESCRIPTION
Gradle gets packages from the same place as maven, so maven rules should work on gradle lockfiles.

test plan: updated gradle tests to use the maven ecosystem key
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
