### PR TITLE
osemgrep: basic json output!

### DIFF
--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
@@ -1,22 +1,15 @@
 (*
    This calls the semgrep-core command like the Python implementation used
-   to, but without creating a subprocess unless necessary.
+   to, but without creating a subprocess.
 
-   This module should go away, eventually, with some parts being integrated
-   into what's currently semgrep-core.
+   LATER: This module should go away, eventually, with some parts being
+   integrated into what's currently semgrep-core.
 *)
 
 type path = string
+type result = Semgrep_output_v0_t.core_match_results
 
-type result = {
-  findings_by_rule : (Rule.t, Rule_match.t list) Map_.t;
-  errors : Error.t list;
-  all_targets : path Set_.t;
-  parsing_data : Parsing_data.t;
-  explanations : Semgrep_output_v0_t.matching_explanation list option;
-}
-
-val invoke_semgrep : Scan_CLI.conf -> result
+val invoke_semgrep_core : Scan_CLI.conf -> result
 
 (* Helper used in Semgrep_scan.ml *)
 val runner_config_of_conf : Scan_CLI.conf -> Runner_config.t

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -789,10 +789,7 @@ let semgrep_with_prepared_rules_and_targets config (x : lang_job) =
       rule_source = Some (Rules x.rules);
     }
   in
-  let opt_exn, results, _ok_targets =
-    semgrep_with_raw_results_and_exn_handler config
-  in
-  (opt_exn, results)
+  semgrep_with_raw_results_and_exn_handler config
 
 let semgrep_with_rules_and_formatted_output config =
   let exn, res, files = semgrep_with_raw_results_and_exn_handler config in

--- a/semgrep-core/src/runner/Run_semgrep.mli
+++ b/semgrep-core/src/runner/Run_semgrep.mli
@@ -126,11 +126,15 @@ val semgrep_with_raw_results_and_exn_handler :
 
 (* Same as semgrep_with_raw_results_and_exn_handler but takes rules
    and targets already filtered for a specific language.
-   All other options are read from the runner_config object. *)
+   All other options are read from the runner_config object.
+   TODO: we should not need this function because
+   semgrep_with_raw_results_and_exn_handler can take a list of targets
+   in different language (via config.targets set via --targets)
+*)
 val semgrep_with_prepared_rules_and_targets :
   Runner_config.t ->
   Runner_config.lang_job ->
-  Exception.t option * Report.final_result
+  Exception.t option * Report.final_result * Common.filename list
 
 (* utilities functions used in tests or semgrep-core variants *)
 

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -36,6 +36,7 @@ rules:
         - core_cli/*.ml
         - cli/*.ml
         - scripts/*
+        - cli_*/*.ml
         - Test.ml
         - Matching_report.ml
         - Matching_explanation.ml


### PR DESCRIPTION
test plan:
```
$ time ./semgrep-core/_build/default/src/osemgrep/main/Main.exe --config
semgrep-core/tests/osemgrep/osemgrep.yml --json cli/ semgrep-core/src/
| jq
...
[1.623  Info       Main.Run_semgrep     ] found 4 matches, 0 errors
{
  "version": "0.116.0",
  "errors": [],
  "results": [
    {
      "check_id": "py1",
      "path": "cli/src/semgrep/config_resolver.py",
      "start": {
        "line": 288,
        "col": 5,
        "offset": 10389
      },
      "end": {
        "line": 290,
        "col": 32,
        "offset": 10493
      },
      "extra": {
        "fingerprint": "TODO",
        "lines": "TODO",
        "message": "",
        "metadata": null,
        "severity": "TODO"
      }
    },
    {
      "check_id": "py1",
      "path": "cli/src/semgrep/error.py",
      "start": {
        "line": 329,
        "col": 5,
        "offset": 11362
      },
      "end": {
        "line": 330,
        "col": 30,
        "offset": 11417
      },
      "extra": {
        "fingerprint": "TODO",
        "lines": "TODO",
        "message": "",
        "metadata": null,
        "severity": "TODO"
      }
    },
    {
      "check_id": "py1",
      "path": "semgrep-core/src/osemgrep/TOPORT/config_resolver.py",
      "start": {
        "line": 288,
        "col": 5,
        "offset": 10389
      },
      "end": {
        "line": 290,
        "col": 32,
        "offset": 10493
      },
      "extra": {
        "fingerprint": "TODO",
        "lines": "TODO",
        "message": "",
        "metadata": null,
        "severity": "TODO"
      }
    },
    {
      "check_id": "py1",
      "path": "semgrep-core/src/osemgrep/TOPORT/error.py",
      "start": {
        "line": 311,
        "col": 5,
        "offset": 10877
      },
      "end": {
        "line": 312,
        "col": 30,
        "offset": 10932
      },
      "extra": {
        "fingerprint": "TODO",
        "lines": "TODO",
        "message": "",
        "metadata": null,
        "severity": "TODO"
      }
    },
    {
      "check_id": "ocaml1",
      "path": "semgrep-core/src/runner/Run_semgrep.ml",
      "start": {
        "line": 634,
        "col": 5,
        "offset": 26496
      },
      "end": {
        "line": 634,
        "col": 62,
        "offset": 26553
      },
      "extra": {
        "fingerprint": "TODO",
        "lines": "TODO",
        "message": "",
        "metadata": null,
        "severity": "TODO"
      }
    }
  ],
  "paths": {
    "scanned": [],
    "_comment": "<add --verbose for a list of skipped paths>"
  }
}

real	0m2.108s
user	0m2.077s
sys	0m0.791s
```

for comparison:
```
(cli) [pad@thinkstation semgrep (osemgrep_json_output)]$ time semgrep --config semgrep-core/tests/osemgrep/osemgrep.yml --json cli/ semgrep-core/src/ --quiet | jq
{
  "errors": [],
  "paths": {
    "_comment": "<add --verbose for a list of skipped paths>",
    "scanned": [
      "cli/scripts/compare.py",
      "cli/setup.py",
      "cli/src/semdep/__init__.py",
      "cli/src/semdep/find_lockfiles.py",
      "cli/src/semdep/package_restrictions.py",
      "cli/src/semdep/parse_lockfile.py",
      "cli/src/semgrep/__init__.py",
      "cli/src/semgrep/__main__.py",
      "cli/src/semgrep/app/__init__.py",
      "cli/src/semgrep/app/auth.py",
      "cli/src/semgrep/app/registry.py",
      "cli/src/semgrep/app/scans.py",
      "cli/src/semgrep/app/session.py",
      "cli/src/semgrep/app/version.py",
      "cli/src/semgrep/autofix.py",
      "cli/src/semgrep/bin/__init__.py",
      "cli/src/semgrep/bytesize.py",
      "cli/src/semgrep/cli.py",
      "cli/src/semgrep/commands/__init__.py",
      "cli/src/semgrep/commands/ci.py",
      "cli/src/semgrep/commands/install.py",
      "cli/src/semgrep/commands/login.py",
      "cli/src/semgrep/commands/lsp.py",
      "cli/src/semgrep/commands/publish.py",
      "cli/src/semgrep/commands/scan.py",
      "cli/src/semgrep/commands/shouldafound.py",
      "cli/src/semgrep/commands/wrapper.py",
      "cli/src/semgrep/config_resolver.py",
      "cli/src/semgrep/constants.py",
      "cli/src/semgrep/core_output.py",
      "cli/src/semgrep/core_runner.py",
      "cli/src/semgrep/default_group.py",
      "cli/src/semgrep/dependency_aware_rule.py",
      "cli/src/semgrep/dump_ast.py",
      "cli/src/semgrep/env.py",
      "cli/src/semgrep/error.py",
      "cli/src/semgrep/error_handler.py",
      "cli/src/semgrep/exclude_rules.py",
      "cli/src/semgrep/external/__init__.py",
      "cli/src/semgrep/external/git_url_parser.py",
      "cli/src/semgrep/external/junit_xml.py",
      "cli/src/semgrep/external/pymmh3.py",
      "cli/src/semgrep/fork_subprocess.py",
      "cli/src/semgrep/formatter/__init__.py",
      "cli/src/semgrep/formatter/base.py",
      "cli/src/semgrep/formatter/emacs.py",
      "cli/src/semgrep/formatter/gitlab_sast.py",
      "cli/src/semgrep/formatter/gitlab_secrets.py",
      "cli/src/semgrep/formatter/json.py",
      "cli/src/semgrep/formatter/junit_xml.py",
      "cli/src/semgrep/formatter/sarif.py",
      "cli/src/semgrep/formatter/text.py",
      "cli/src/semgrep/formatter/vim.py",
      "cli/src/semgrep/git.py",
      "cli/src/semgrep/ignores.py",
      "cli/src/semgrep/join_rule.py",
      "cli/src/semgrep/lsp/__init__.py",
      "cli/src/semgrep/lsp/config.py",
      "cli/src/semgrep/lsp/convert.py",
      "cli/src/semgrep/lsp/metrics.py",
      "cli/src/semgrep/lsp/run_semgrep.py",
      "cli/src/semgrep/lsp/server.py",
      "cli/src/semgrep/lsp/types.py",
      "cli/src/semgrep/meta.py",
      "cli/src/semgrep/metrics.py",
      "cli/src/semgrep/nosemgrep.py",
      "cli/src/semgrep/notifications.py",
      "cli/src/semgrep/output.py",
      "cli/src/semgrep/output_from_core.py",
      "cli/src/semgrep/parsing_data.py",
      "cli/src/semgrep/profile_manager.py",
      "cli/src/semgrep/profiling.py",
      "cli/src/semgrep/project.py",
      "cli/src/semgrep/rule.py",
      "cli/src/semgrep/rule_lang.py",
      "cli/src/semgrep/rule_match.py",
      "cli/src/semgrep/semgrep_core.py",
      "cli/src/semgrep/semgrep_main.py",
      "cli/src/semgrep/semgrep_types.py",
      "cli/src/semgrep/settings.py",
      "cli/src/semgrep/state.py",
      "cli/src/semgrep/target_manager.py",
      "cli/src/semgrep/terminal.py",
      "cli/src/semgrep/test.py",
      "cli/src/semgrep/types.py",
      "cli/src/semgrep/util.py",
      "cli/src/semgrep/verbose_logging.py",
      "cli/stubs/astpretty.pyi",
      "cli/stubs/boltons/__init__.pyi",
      "cli/stubs/boltons/cacheutils.pyi",
      "cli/stubs/boltons/debugutils.pyi",
      "cli/stubs/boltons/deprutils.pyi",
      "cli/stubs/boltons/dictutils.pyi",
      "cli/stubs/boltons/easterutils.pyi",
      "cli/stubs/boltons/ecoutils.pyi",
      "cli/stubs/boltons/excutils.pyi",
      "cli/stubs/boltons/fileutils.pyi",
      "cli/stubs/boltons/formatutils.pyi",
      "cli/stubs/boltons/funcutils.pyi",
      "cli/stubs/boltons/gcutils.pyi",
      "cli/stubs/boltons/ioutils.pyi",
      "cli/stubs/boltons/iterutils.pyi",
      "cli/stubs/boltons/jsonutils.pyi",
      "cli/stubs/boltons/listutils.pyi",
      "cli/stubs/boltons/mathutils.pyi",
      "cli/stubs/boltons/mboxutils.pyi",
      "cli/stubs/boltons/namedutils.pyi",
      "cli/stubs/boltons/queueutils.pyi",
      "cli/stubs/boltons/setutils.pyi",
      "cli/stubs/boltons/socketutils.pyi",
      "cli/stubs/boltons/statsutils.pyi",
      "cli/stubs/boltons/strutils.pyi",
      "cli/stubs/boltons/tableutils.pyi",
      "cli/stubs/boltons/tbutils.pyi",
      "cli/stubs/boltons/timeutils.pyi",
      "cli/stubs/boltons/typeutils.pyi",
      "cli/stubs/boltons/urlutils.pyi",
      "cli/stubs/click_option_group/__init__.py",
      "cli/stubs/click_option_group/optgroup.pyi",
      "cli/stubs/glom/__init__.pyi",
      "cli/stubs/glom/core.pyi",
      "cli/stubs/packaging/__init__.py",
      "cli/stubs/packaging/version.pyi",
      "cli/stubs/ruamel/__init__.py",
      "cli/stubs/ruamel/yaml.pyi",
      "cli/stubs/semgrep_bridge_python.pyi",
      "cli/tests/__init__.py",
      "cli/tests/conftest.py",
      "cli/tests/consistency/__init__.py",
      "cli/tests/consistency/test_lang_consistency.py",
      "cli/tests/e2e/__init__.py",
      "cli/tests/e2e/rules/cli_test/error/long.py",
      "cli/tests/e2e/test_api.py",
      "cli/tests/e2e/test_autofix.py",
      "cli/tests/e2e/test_baseline.py",
      "cli/tests/e2e/test_check.py",
      "cli/tests/e2e/test_ci.py",
      "cli/tests/e2e/test_cli_test.py",
      "cli/tests/e2e/test_config_resolver.py",
      "cli/tests/e2e/test_dependency_aware_rules.py",
      "cli/tests/e2e/test_dump_ast.py",
      "cli/tests/e2e/test_exclude_include.py",
      "cli/tests/e2e/test_fixtest.py",
      "cli/tests/e2e/test_help.py",
      "cli/tests/e2e/test_ignores.py",
      "cli/tests/e2e/test_join_rules.py",
      "cli/tests/e2e/test_log_file.py",
      "cli/tests/e2e/test_login.py",
      "cli/tests/e2e/test_lsp.py",
      "cli/tests/e2e/test_match_based_id.py",
      "cli/tests/e2e/test_max_target_bytes.py",
      "cli/tests/e2e/test_messsage_interpolation.py",
      "cli/tests/e2e/test_metavariable_matching.py",
      "cli/tests/e2e/test_metavariable_regex_const_prop.py",
      "cli/tests/e2e/test_metrics.py",
      "cli/tests/e2e/test_missing_file.py",
      "cli/tests/e2e/test_multi_config_fail.py",
      "cli/tests/e2e/test_nosemgrep.py",
      "cli/tests/e2e/test_output.py",
      "cli/tests/e2e/test_parse_rate_metrics.py",
      "cli/tests/e2e/test_paths.py",
      "cli/tests/e2e/test_performance.py",
      "cli/tests/e2e/test_publish.py",
      "cli/tests/e2e/test_rule_parser.py",
      "cli/tests/e2e/test_rule_validation.py",
      "cli/tests/e2e/test_semgrep_core_parse_error.py",
      "cli/tests/e2e/test_severity.py",
      "cli/tests/e2e/test_shouldafound.py",
      "cli/tests/e2e/test_spacegrep.py",
      "cli/tests/e2e/test_version.py",
      "cli/tests/metavariable_comparison.py",
      "cli/tests/qa/__init__.py",
      "cli/tests/qa/public_repos.py",
      "cli/tests/qa/test_public_repos.py",
      "cli/tests/qa/test_semgrep_rules_repo.py",
      "cli/tests/semgrep_runner.py",
      "cli/tests/unit/targeting/test_exclude.py",
      "cli/tests/unit/targeting/test_include.py",
      "cli/tests/unit/targeting/test_size_limit.py",
      "cli/tests/unit/targeting/test_target_manager.py",
      "cli/tests/unit/test_baseline.py",
      "cli/tests/unit/test_bytesize.py",
      "cli/tests/unit/test_error_handler.py",
      "cli/tests/unit/test_filter_exclude_rule.py",
      "cli/tests/unit/test_fork_subprocess.py",
      "cli/tests/unit/test_formatters.py",
      "cli/tests/unit/test_join_rule.py",
      "cli/tests/unit/test_metric_manager.py",
      "cli/tests/unit/test_project_config.py",
      "cli/tests/unit/test_rule.py",
      "cli/tests/unit/test_rule_match.py",
      "cli/tests/unit/test_semgrep_test.py",
      "cli/tests/unit/test_shouldafound.py",
      "cli/tests/unit/test_version.py",
      "cli/tests/unit/test_yaml_parsing.py",
      "semgrep-core/src/analyzing/AST_to_IL.ml",
      "semgrep-core/src/analyzing/AST_to_IL.mli",
      "semgrep-core/src/analyzing/CFG_build.ml",
      "semgrep-core/src/analyzing/CFG_build.mli",
      "semgrep-core/src/analyzing/Constant_propagation.ml",
      "semgrep-core/src/analyzing/Constant_propagation.mli",
      "semgrep-core/src/analyzing/Dataflow_core.ml",
      "semgrep-core/src/analyzing/Dataflow_core.mli",
      "semgrep-core/src/analyzing/Dataflow_svalue.ml",
      "semgrep-core/src/analyzing/Dataflow_svalue.mli",
      "semgrep-core/src/analyzing/Dataflow_var_env.ml",
      "semgrep-core/src/analyzing/Dataflow_var_env.mli",
      "semgrep-core/src/analyzing/Test_analyze_generic.ml",
      "semgrep-core/src/analyzing/Test_analyze_generic.mli",
      "semgrep-core/src/analyzing/Unit_dataflow.ml",
      "semgrep-core/src/analyzing/Unit_dataflow.mli",
      "semgrep-core/src/analyzing/Visit_function_defs.ml",
      "semgrep-core/src/cli-bridge/Semgrep_bridge_core.ml",
      "semgrep-core/src/core/Config_semgrep.ml",
      "semgrep-core/src/core/Equivalence.ml",
      "semgrep-core/src/core/Flag_semgrep.ml",
      "semgrep-core/src/core/Hooks.ml",
      "semgrep-core/src/core/Hooks.mli",
      "semgrep-core/src/core/Matching_explanation.ml",
      "semgrep-core/src/core/Metavariable.ml",
      "semgrep-core/src/core/Mini_rule.ml",
      "semgrep-core/src/core/Output_from_core_j.ml",
      "semgrep-core/src/core/Output_from_core_t.ml",
      "semgrep-core/src/core/Output_from_core_util.ml",
      "semgrep-core/src/core/Output_from_core_util.mli",
      "semgrep-core/src/core/Pattern.ml",
      "semgrep-core/src/core/Pattern_match.ml",
      "semgrep-core/src/core/Range.ml",
      "semgrep-core/src/core/Range.mli",
      "semgrep-core/src/core/Report.ml",
      "semgrep-core/src/core/Report.mli",
      "semgrep-core/src/core/Rule.ml",
      "semgrep-core/src/core/Rule_match.ml",
      "semgrep-core/src/core/Semgrep_error_code.ml",
      "semgrep-core/src/core/Semgrep_error_code.mli",
      "semgrep-core/src/core/Target.ml",
      "semgrep-core/src/core/Xlang.ml",
      "semgrep-core/src/core/Xlang.mli",
      "semgrep-core/src/core/Xpattern.ml",
      "semgrep-core/src/core/Xtarget.ml",
      "semgrep-core/src/core/ast/AST_generic.ml",
      "semgrep-core/src/core/ast/AST_generic_helpers.ml",
      "semgrep-core/src/core/ast/AST_generic_helpers.mli",
      "semgrep-core/src/core/ast/AST_utils.ml",
      "semgrep-core/src/core/ast/Map_AST.ml",
      "semgrep-core/src/core/ast/Map_AST.mli",
      "semgrep-core/src/core/ast/Meta_AST.ml",
      "semgrep-core/src/core/ast/Meta_AST.mli",
      "semgrep-core/src/core/ast/Pretty_print_AST.ml",
      "semgrep-core/src/core/ast/Pretty_print_AST.mli",
      "semgrep-core/src/core/ast/Type_generic.ml",
      "semgrep-core/src/core/ast/Ugly_print_AST.ml",
      "semgrep-core/src/core/ast/Visitor_AST.ml",
      "semgrep-core/src/core/ast/Visitor_AST.mli",
      "semgrep-core/src/core/ast/gen_lang.py",
      "semgrep-core/src/core/ast/tests/Unit_ugly_print_AST.ml",
      "semgrep-core/src/core/il/CFG.ml",
      "semgrep-core/src/core/il/Display_IL.ml",
      "semgrep-core/src/core/il/Display_IL.mli",
      "semgrep-core/src/core/il/IL.ml",
      "semgrep-core/src/core/il/IL_helpers.ml",
      "semgrep-core/src/core/il/IL_helpers.mli",
      "semgrep-core/src/core_cli/Core_CLI.ml",
      "semgrep-core/src/core_cli/version.ml",
      "semgrep-core/src/engine/Entropy.ml",
      "semgrep-core/src/engine/Entropy.mli",
      "semgrep-core/src/engine/Entropy_data.ml",
      "semgrep-core/src/engine/Eval_generic.ml",
      "semgrep-core/src/engine/Eval_generic.mli",
      "semgrep-core/src/engine/Match_env.ml",
      "semgrep-core/src/engine/Match_extract_mode.ml",
      "semgrep-core/src/engine/Match_extract_mode.mli",
      "semgrep-core/src/engine/Match_rules.ml",
      "semgrep-core/src/engine/Match_rules.mli",
      "semgrep-core/src/engine/Match_search_mode.ml",
      "semgrep-core/src/engine/Match_search_mode.mli",
      "semgrep-core/src/engine/Match_tainting_mode.ml",
      "semgrep-core/src/engine/Match_tainting_mode.mli",
      "semgrep-core/src/engine/Metavariable_analysis.ml",
      "semgrep-core/src/engine/Metavariable_analysis.mli",
      "semgrep-core/src/engine/Metavariable_pattern.ml",
      "semgrep-core/src/engine/Metavariable_pattern.mli",
      "semgrep-core/src/engine/Range_with_metavars.ml",
      "semgrep-core/src/engine/Range_with_metavars.mli",
      "semgrep-core/src/engine/ReDoS.ml",
      "semgrep-core/src/engine/ReDoS.mli",
      "semgrep-core/src/engine/String_literal.ml",
      "semgrep-core/src/engine/String_literal.mli",
      "semgrep-core/src/engine/Test_comby.ml",
      "semgrep-core/src/engine/Test_comby.mli",
      "semgrep-core/src/engine/Test_dataflow_tainting.ml",
      "semgrep-core/src/engine/Test_dataflow_tainting.mli",
      "semgrep-core/src/engine/Test_engine.ml",
      "semgrep-core/src/engine/Test_engine.mli",
      "semgrep-core/src/engine/Unit_ReDoS.ml",
      "semgrep-core/src/engine/Unit_engine.ml",
      "semgrep-core/src/engine/Unit_engine.mli",
      "semgrep-core/src/engine/Unit_entropy.ml",
      "semgrep-core/src/engine/Xpattern_match_comby.ml",
      "semgrep-core/src/engine/Xpattern_match_comby.mli",
      "semgrep-core/src/engine/Xpattern_match_regexp.ml",
      "semgrep-core/src/engine/Xpattern_match_regexp.mli",
      "semgrep-core/src/engine/Xpattern_match_spacegrep.ml",
      "semgrep-core/src/engine/Xpattern_match_spacegrep.mli",
      "semgrep-core/src/engine/Xpattern_matcher.ml",
      "semgrep-core/src/experiments/api/AST_generic_to_v0.ml",
      "semgrep-core/src/experiments/api/AST_generic_to_v0.mli",
      "semgrep-core/src/experiments/datalog/Datalog_experiment.ml",
      "semgrep-core/src/experiments/datalog/Datalog_experiment.mli",
      "semgrep-core/src/experiments/datalog/Datalog_fact.ml",
      "semgrep-core/src/experiments/datalog/Datalog_io.ml",
      "semgrep-core/src/experiments/datalog/Datalog_io.mli",
      "semgrep-core/src/experiments/lsp/LSP_client.ml",
      "semgrep-core/src/experiments/misc/Experiments.ml",
      "semgrep-core/src/experiments/synthesizing/Pattern_from_Code.ml",
      "semgrep-core/src/experiments/synthesizing/Pattern_from_Code.mli",
      "semgrep-core/src/experiments/synthesizing/Pattern_from_Targets.ml",
      "semgrep-core/src/experiments/synthesizing/Pattern_from_Targets.mli",
      "semgrep-core/src/experiments/synthesizing/Pattern_from_diff.ml",
      "semgrep-core/src/experiments/synthesizing/Pattern_from_diff.mli",
      "semgrep-core/src/experiments/synthesizing/Pretty_print_pattern.ml",
      "semgrep-core/src/experiments/synthesizing/Pretty_print_pattern.mli",
      "semgrep-core/src/experiments/synthesizing/Range_to_AST.ml",
      "semgrep-core/src/experiments/synthesizing/Range_to_AST.mli",
      "semgrep-core/src/experiments/synthesizing/Synthesizer.ml",
      "semgrep-core/src/experiments/synthesizing/Synthesizer.mli",
      "semgrep-core/src/experiments/synthesizing/Test_synthesizing.ml",
      "semgrep-core/src/experiments/synthesizing/Test_synthesizing.mli",
      "semgrep-core/src/experiments/synthesizing/Unit_synthesizer.ml",
      "semgrep-core/src/experiments/synthesizing/Unit_synthesizer_targets.ml",
      "semgrep-core/src/fixing/Autofix.ml",
      "semgrep-core/src/fixing/Autofix.mli",
      "semgrep-core/src/fixing/Autofix_metavar_replacement.ml",
      "semgrep-core/src/fixing/Autofix_metavar_replacement.mli",
      "semgrep-core/src/fixing/Autofix_printer.ml",
      "semgrep-core/src/fixing/Autofix_printer.mli",
      "semgrep-core/src/fixing/Hybrid_print.ml",
      "semgrep-core/src/fixing/tests/Unit_autofix_printer.ml",
      "semgrep-core/src/main/Main.ml",
      "semgrep-core/src/matching/Apply_equivalences.ml",
      "semgrep-core/src/matching/Apply_equivalences.mli",
      "semgrep-core/src/matching/Generic_vs_generic.ml",
      "semgrep-core/src/matching/Generic_vs_generic.mli",
      "semgrep-core/src/matching/Match_patterns.ml",
      "semgrep-core/src/matching/Match_patterns.mli",
      "semgrep-core/src/matching/Matching_generic.ml",
      "semgrep-core/src/matching/Matching_generic.mli",
      "semgrep-core/src/matching/Normalize_generic.ml",
      "semgrep-core/src/matching/Normalize_generic.mli",
      "semgrep-core/src/matching/SubAST_generic.ml",
      "semgrep-core/src/matching/SubAST_generic.mli",
      "semgrep-core/src/matching/Trace_matching.ml",
      "semgrep-core/src/matching/Trace_matching.mli",
      "semgrep-core/src/matching/Unit_matcher.ml",
      "semgrep-core/src/matching/Unit_matcher.mli",
      "semgrep-core/src/metachecking/Check_rule.ml",
      "semgrep-core/src/metachecking/Check_rule.mli",
      "semgrep-core/src/metachecking/Test_metachecking.ml",
      "semgrep-core/src/metachecking/Test_metachecking.mli",
      "semgrep-core/src/metachecking/Translate_rule.ml",
      "semgrep-core/src/metachecking/Translate_rule.mli",
      "semgrep-core/src/metachecking/Unit_metachecking.ml",
      "semgrep-core/src/metachecking/Unit_metachecking.mli",
      "semgrep-core/src/naming/Naming_AST.ml",
      "semgrep-core/src/naming/Naming_AST.mli",
      "semgrep-core/src/naming/Test_naming_generic.ml",
      "semgrep-core/src/naming/Test_naming_generic.mli",
      "semgrep-core/src/naming/Unit_naming_generic.ml",
      "semgrep-core/src/naming/Unit_naming_generic.mli",
      "semgrep-core/src/naming/Unit_typing_generic.ml",
      "semgrep-core/src/optimizing/Analyze_pattern.ml",
      "semgrep-core/src/optimizing/Analyze_pattern.mli",
      "semgrep-core/src/optimizing/Analyze_rule.ml",
      "semgrep-core/src/optimizing/Analyze_rule.mli",
      "semgrep-core/src/optimizing/Bloom_annotation.ml",
      "semgrep-core/src/optimizing/Bloom_annotation.mli",
      "semgrep-core/src/optimizing/Caching.ml",
      "semgrep-core/src/optimizing/Caching.mli",
      "semgrep-core/src/optimizing/Metavariable_capture.ml",
      "semgrep-core/src/optimizing/Mini_rules_filter.ml",
      "semgrep-core/src/optimizing/Mini_rules_filter.mli",
      "semgrep-core/src/optimizing/Stmts_match_span.ml",
      "semgrep-core/src/osemgrep/TOPORT/app/auth.py",
      "semgrep-core/src/osemgrep/TOPORT/app/registry.py",
      "semgrep-core/src/osemgrep/TOPORT/app/scans.py",
      "semgrep-core/src/osemgrep/TOPORT/app/session.py",
      "semgrep-core/src/osemgrep/TOPORT/app/version.py",
      "semgrep-core/src/osemgrep/TOPORT/autofix.py",
      "semgrep-core/src/osemgrep/TOPORT/bytesize.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/ci.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/install.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/login.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/lsp.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/publish.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/scan.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/shouldafound.py",
      "semgrep-core/src/osemgrep/TOPORT/commands/wrapper.py",
      "semgrep-core/src/osemgrep/TOPORT/config_resolver.py",
      "semgrep-core/src/osemgrep/TOPORT/core_output.py",
      "semgrep-core/src/osemgrep/TOPORT/core_runner.py",
      "semgrep-core/src/osemgrep/TOPORT/dependency_aware_rule.py",
      "semgrep-core/src/osemgrep/TOPORT/dump_ast.py",
      "semgrep-core/src/osemgrep/TOPORT/env.py",
      "semgrep-core/src/osemgrep/TOPORT/error.py",
      "semgrep-core/src/osemgrep/TOPORT/error_handler.py",
      "semgrep-core/src/osemgrep/TOPORT/exclude_rules.py",
      "semgrep-core/src/osemgrep/TOPORT/external/git_url_parser.py",
      "semgrep-core/src/osemgrep/TOPORT/external/junit_xml.py",
      "semgrep-core/src/osemgrep/TOPORT/external/pymmh3.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/base.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/emacs.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/gitlab_sast.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/gitlab_secrets.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/json.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/junit_xml.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/sarif.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/text.py",
      "semgrep-core/src/osemgrep/TOPORT/formatter/vim.py",
      "semgrep-core/src/osemgrep/TOPORT/git.py",
      "semgrep-core/src/osemgrep/TOPORT/ignores.py",
      "semgrep-core/src/osemgrep/TOPORT/join_rule.py",
      "semgrep-core/src/osemgrep/TOPORT/lsp/config.py",
      "semgrep-core/src/osemgrep/TOPORT/lsp/convert.py",
      "semgrep-core/src/osemgrep/TOPORT/lsp/metrics.py",
      "semgrep-core/src/osemgrep/TOPORT/lsp/run_semgrep.py",
      "semgrep-core/src/osemgrep/TOPORT/lsp/server.py",
      "semgrep-core/src/osemgrep/TOPORT/lsp/types.py",
      "semgrep-core/src/osemgrep/TOPORT/meta.py",
      "semgrep-core/src/osemgrep/TOPORT/metrics.py",
      "semgrep-core/src/osemgrep/TOPORT/nosemgrep.py",
      "semgrep-core/src/osemgrep/TOPORT/notifications.py",
      "semgrep-core/src/osemgrep/TOPORT/output.py",
      "semgrep-core/src/osemgrep/TOPORT/parsing_data.py",
      "semgrep-core/src/osemgrep/TOPORT/profile_manager.py",
      "semgrep-core/src/osemgrep/TOPORT/profiling.py",
      "semgrep-core/src/osemgrep/TOPORT/project.py",
      "semgrep-core/src/osemgrep/TOPORT/rule.py",
      "semgrep-core/src/osemgrep/TOPORT/rule_lang.py",
      "semgrep-core/src/osemgrep/TOPORT/rule_match.py",
      "semgrep-core/src/osemgrep/TOPORT/semgrep_main.py",
      "semgrep-core/src/osemgrep/TOPORT/semgrep_types.py",
      "semgrep-core/src/osemgrep/TOPORT/settings.py",
      "semgrep-core/src/osemgrep/TOPORT/state.py",
      "semgrep-core/src/osemgrep/TOPORT/target_manager.py",
      "semgrep-core/src/osemgrep/TOPORT/terminal.py",
      "semgrep-core/src/osemgrep/TOPORT/test.py",
      "semgrep-core/src/osemgrep/TOPORT/types.py",
      "semgrep-core/src/osemgrep/TOPORT/util.py",
      "semgrep-core/src/osemgrep/TOPORT/verbose_logging.py",
      "semgrep-core/src/osemgrep/cli/CLI.ml",
      "semgrep-core/src/osemgrep/cli/CLI.mli",
      "semgrep-core/src/osemgrep/cli_scan/Core_runner.ml",
      "semgrep-core/src/osemgrep/cli_scan/Core_runner.mli",
      "semgrep-core/src/osemgrep/cli_scan/Metrics.ml",
      "semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml",
      "semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli",
      "semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml",
      "semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.mli",
      "semgrep-core/src/osemgrep/core/CLI_common.ml",
      "semgrep-core/src/osemgrep/core/Constants.ml",
      "semgrep-core/src/osemgrep/core/Error.ml",
      "semgrep-core/src/osemgrep/core/Error.mli",
      "semgrep-core/src/osemgrep/core/Exit_code.ml",
      "semgrep-core/src/osemgrep/core/Exit_code.mli",
      "semgrep-core/src/osemgrep/core/Finding.ml",
      "semgrep-core/src/osemgrep/core/Parsing_data.ml",
      "semgrep-core/src/osemgrep/core/Rule_lang.ml",
      "semgrep-core/src/osemgrep/main/Main.ml",
      "semgrep-core/src/osemgrep/targeting/Target_manager.ml",
      "semgrep-core/src/osemgrep/utils/Cmdliner_helpers.ml",
      "semgrep-core/src/parsing/Check_pattern.ml",
      "semgrep-core/src/parsing/Check_pattern.mli",
      "semgrep-core/src/parsing/Parse_equivalences.ml",
      "semgrep-core/src/parsing/Parse_equivalences.mli",
      "semgrep-core/src/parsing/Parse_pattern.ml",
      "semgrep-core/src/parsing/Parse_pattern.mli",
      "semgrep-core/src/parsing/Parse_rule.ml",
      "semgrep-core/src/parsing/Parse_rule.mli",
      "semgrep-core/src/parsing/Parse_target.ml",
      "semgrep-core/src/parsing/Parse_target.mli",
      "semgrep-core/src/parsing/Test_parsing.ml",
      "semgrep-core/src/parsing/Test_parsing.mli",
      "semgrep-core/src/parsing/Unit_parsing.ml",
      "semgrep-core/src/parsing/Unit_parsing.mli",
      "semgrep-core/src/parsing/ast/AST_bash.ml",
      "semgrep-core/src/parsing/ast/AST_dockerfile.ml",
      "semgrep-core/src/parsing/ast/Bash_to_generic.ml",
      "semgrep-core/src/parsing/ast/Bash_to_generic.mli",
      "semgrep-core/src/parsing/ast/Dockerfile_to_generic.ml",
      "semgrep-core/src/parsing/ast/Dockerfile_to_generic.mli",
      "semgrep-core/src/parsing/ast/Loc.ml",
      "semgrep-core/src/parsing/ast/Loc.mli",
      "semgrep-core/src/parsing/other/yaml_to_generic.ml",
      "semgrep-core/src/parsing/other/yaml_to_generic.mli",
      "semgrep-core/src/parsing/pfff/Python_to_generic.ml",
      "semgrep-core/src/parsing/pfff/Python_to_generic.mli",
      "semgrep-core/src/parsing/pfff/c_to_generic.ml",
      "semgrep-core/src/parsing/pfff/c_to_generic.mli",
      "semgrep-core/src/parsing/pfff/cpp_to_generic.ml",
      "semgrep-core/src/parsing/pfff/cpp_to_generic.mli",
      "semgrep-core/src/parsing/pfff/go_to_generic.ml",
      "semgrep-core/src/parsing/pfff/go_to_generic.mli",
      "semgrep-core/src/parsing/pfff/java_to_generic.ml",
      "semgrep-core/src/parsing/pfff/java_to_generic.mli",
      "semgrep-core/src/parsing/pfff/js_to_generic.ml",
      "semgrep-core/src/parsing/pfff/js_to_generic.mli",
      "semgrep-core/src/parsing/pfff/json_to_generic.ml",
      "semgrep-core/src/parsing/pfff/json_to_generic.mli",
      "semgrep-core/src/parsing/pfff/ml_to_generic.ml",
      "semgrep-core/src/parsing/pfff/ml_to_generic.mli",
      "semgrep-core/src/parsing/pfff/php_to_generic.ml",
      "semgrep-core/src/parsing/pfff/php_to_generic.mli",
      "semgrep-core/src/parsing/pfff/ruby_to_generic.ml",
      "semgrep-core/src/parsing/pfff/ruby_to_generic.mli",
      "semgrep-core/src/parsing/pfff/scala_to_generic.ml",
      "semgrep-core/src/parsing/pfff/scala_to_generic.mli",
      "semgrep-core/src/parsing/tree_sitter/CST_tree_sitter_typescript.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_bash_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_c_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_cpp_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_dart_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_dart_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_dockerfile_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_dockerfile_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_elixir_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_hcl_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_html_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_julia_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_julia_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_kotlin_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_lua_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_php_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_python_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_r_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_swift_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_tree_sitter_helpers.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.mli",
      "semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.ml",
      "semgrep-core/src/parsing/tree_sitter/Parse_vue_tree_sitter.mli",
      "semgrep-core/src/reporting/JSON_report.ml",
      "semgrep-core/src/reporting/JSON_report.mli",
      "semgrep-core/src/reporting/Matching_report.ml",
      "semgrep-core/src/reporting/Matching_report.mli",
      "semgrep-core/src/reporting/Statistics_report.ml",
      "semgrep-core/src/reporting/Unit_reporting.ml",
      "semgrep-core/src/reporting/Unit_reporting.mli",
      "semgrep-core/src/runner/Parse_with_caching.ml",
      "semgrep-core/src/runner/Parse_with_caching.mli",
      "semgrep-core/src/runner/Run_semgrep.ml",
      "semgrep-core/src/runner/Run_semgrep.mli",
      "semgrep-core/src/runner/Runner_config.ml",
      "semgrep-core/src/runner/Runner_exit.ml",
      "semgrep-core/src/runner/Runner_exit.mli",
      "semgrep-core/src/runner/Setup_logging.ml",
      "semgrep-core/src/runner/Setup_logging.mli",
      "semgrep-core/src/spacegrep/src/bin/Space_main.ml",
      "semgrep-core/src/spacegrep/src/bin/Spacecat_main.ml",
      "semgrep-core/src/spacegrep/src/bin/Spacegrep_main.ml",
      "semgrep-core/src/spacegrep/src/lib/Comment.ml",
      "semgrep-core/src/spacegrep/src/lib/Comment.mli",
      "semgrep-core/src/spacegrep/src/lib/Doc_AST.ml",
      "semgrep-core/src/spacegrep/src/lib/File_type.ml",
      "semgrep-core/src/spacegrep/src/lib/Find_files.ml",
      "semgrep-core/src/spacegrep/src/lib/Find_files.mli",
      "semgrep-core/src/spacegrep/src/lib/Loc.ml",
      "semgrep-core/src/spacegrep/src/lib/Match.ml",
      "semgrep-core/src/spacegrep/src/lib/Match.mli",
      "semgrep-core/src/spacegrep/src/lib/Parse_doc.ml",
      "semgrep-core/src/spacegrep/src/lib/Parse_doc.mli",
      "semgrep-core/src/spacegrep/src/lib/Parse_pattern.ml",
      "semgrep-core/src/spacegrep/src/lib/Parse_pattern.mli",
      "semgrep-core/src/spacegrep/src/lib/Pattern_AST.ml",
      "semgrep-core/src/spacegrep/src/lib/Pre_match.ml",
      "semgrep-core/src/spacegrep/src/lib/Pre_match.mli",
      "semgrep-core/src/spacegrep/src/lib/Print.ml",
      "semgrep-core/src/spacegrep/src/lib/Print_match.ml",
      "semgrep-core/src/spacegrep/src/lib/Src_file.ml",
      "semgrep-core/src/spacegrep/src/lib/Src_file.mli",
      "semgrep-core/src/spacegrep/src/lib/Timeout.ml",
      "semgrep-core/src/spacegrep/src/test/Comment.ml",
      "semgrep-core/src/spacegrep/src/test/File_type.ml",
      "semgrep-core/src/spacegrep/src/test/Matcher.ml",
      "semgrep-core/src/spacegrep/src/test/Parser.ml",
      "semgrep-core/src/spacegrep/src/test/Src_file.ml",
      "semgrep-core/src/spacegrep/src/test/test.ml",
      "semgrep-core/src/system/Memory_limit.ml",
      "semgrep-core/src/system/Memory_limit.mli",
      "semgrep-core/src/system/Unit_memory_limit.ml",
      "semgrep-core/src/system/Unit_memory_limit.mli",
      "semgrep-core/src/tainting/Dataflow_tainting.ml",
      "semgrep-core/src/tainting/Dataflow_tainting.mli",
      "semgrep-core/src/tainting/Taint.ml",
      "semgrep-core/src/tainting/Taint.mli",
      "semgrep-core/src/tainting/Taint_lval_env.ml",
      "semgrep-core/src/tainting/Taint_lval_env.mli",
      "semgrep-core/src/targeting/Find_target.ml",
      "semgrep-core/src/targeting/Find_target.mli",
      "semgrep-core/src/targeting/Guess_lang.ml",
      "semgrep-core/src/targeting/Guess_lang.mli",
      "semgrep-core/src/targeting/List_files.ml",
      "semgrep-core/src/targeting/List_files.mli",
      "semgrep-core/src/targeting/Skip_target.ml",
      "semgrep-core/src/targeting/Skip_target.mli",
      "semgrep-core/src/targeting/Unit_guess_lang.ml",
      "semgrep-core/src/targeting/Unit_guess_lang.mli",
      "semgrep-core/src/targeting/Unit_list_files.ml",
      "semgrep-core/src/targeting/Unit_list_files.mli",
      "semgrep-core/src/utils/Fnptr.ml",
      "semgrep-core/src/utils/Immutable_buffer.ml",
      "semgrep-core/src/utils/Immutable_buffer.mli",
      "semgrep-core/src/utils/Regexp_engine.ml",
      "semgrep-core/src/utils/Regexp_engine.mli",
      "semgrep-core/src/utils/SPcre.ml",
      "semgrep-core/src/utils/SPcre.mli",
      "semgrep-core/src/utils/Unit_SPcre.ml",
      "semgrep-core/src/utils/Unit_SPcre.mli",
      "semgrep-core/src/utils/Unit_immutable_buffer.ml",
      "semgrep-core/src/utils/Unit_regexp_engine.ml",
      "semgrep-core/src/utils/Unit_regexp_engine.mli"
    ]
  },
  "results": [
    {
      "check_id": "semgrep-core.tests.osemgrep.py1",
      "end": {
        "col": 32,
        "line": 290,
        "offset": 10493
      },
      "extra": {
        "fingerprint": "cac6e35463a9985b5bddf4a8101623c1b74dc165794bf522844c0dd0c0ebd6863231608a729a2973d363b096d8350d223136f6a0d2887f9d35f1b5b116aeb232_0",
        "is_ignored": false,
        "lines": "    def __str__(self) -> str:\n        # TODO return the resolved config_path\n        return self._config_str",
        "message": "_config_str matched",
        "metadata": {},
        "metavars": {
          "$ARG": {
            "abstract_content": "self",
            "end": {
              "col": 21,
              "line": 288,
              "offset": 10405
            },
            "start": {
              "col": 17,
              "line": 288,
              "offset": 10401
            }
          },
          "$X": {
            "abstract_content": "_config_str",
            "end": {
              "col": 32,
              "line": 290,
              "offset": 10493
            },
            "start": {
              "col": 21,
              "line": 290,
              "offset": 10482
            }
          }
        },
        "severity": "WARNING"
      },
      "path": "cli/src/semgrep/config_resolver.py",
      "start": {
        "col": 5,
        "line": 288,
        "offset": 10389
      }
    },
    {
      "check_id": "semgrep-core.tests.osemgrep.py1",
      "end": {
        "col": 30,
        "line": 330,
        "offset": 11417
      },
      "extra": {
        "fingerprint": "1f06dba6fcf733b0e12aec0a270d1b2869117f4b6ba11036057dee0e5f8790ef891fa32d0ca292356dc541e231630f238989cfacf65261d869c9501da21e0a54_0",
        "is_ignored": false,
        "lines": "    def __str__(self) -> str:\n        return self.short_msg",
        "message": "short_msg matched",
        "metadata": {},
        "metavars": {
          "$ARG": {
            "abstract_content": "self",
            "end": {
              "col": 21,
              "line": 329,
              "offset": 11378
            },
            "start": {
              "col": 17,
              "line": 329,
              "offset": 11374
            }
          },
          "$X": {
            "abstract_content": "short_msg",
            "end": {
              "col": 30,
              "line": 330,
              "offset": 11417
            },
            "start": {
              "col": 21,
              "line": 330,
              "offset": 11408
            }
          }
        },
        "severity": "WARNING"
      },
      "path": "cli/src/semgrep/error.py",
      "start": {
        "col": 5,
        "line": 329,
        "offset": 11362
      }
    },
    {
      "check_id": "semgrep-core.tests.osemgrep.py1",
      "end": {
        "col": 32,
        "line": 290,
        "offset": 10493
      },
      "extra": {
        "fingerprint": "05918d722a34cec14aa8da871897fb9638eef7b3d3d4f7bb97d9af671752b52e33c20471c30436243282fd5ee8632aff7fa3664178fc77e7392c00df8135cf22_0",
        "is_ignored": false,
        "lines": "    def __str__(self) -> str:\n        # TODO return the resolved config_path\n        return self._config_str",
        "message": "_config_str matched",
        "metadata": {},
        "metavars": {
          "$ARG": {
            "abstract_content": "self",
            "end": {
              "col": 21,
              "line": 288,
              "offset": 10405
            },
            "start": {
              "col": 17,
              "line": 288,
              "offset": 10401
            }
          },
          "$X": {
            "abstract_content": "_config_str",
            "end": {
              "col": 32,
              "line": 290,
              "offset": 10493
            },
            "start": {
              "col": 21,
              "line": 290,
              "offset": 10482
            }
          }
        },
        "severity": "WARNING"
      },
      "path": "semgrep-core/src/osemgrep/TOPORT/config_resolver.py",
      "start": {
        "col": 5,
        "line": 288,
        "offset": 10389
      }
    },
    {
      "check_id": "semgrep-core.tests.osemgrep.py1",
      "end": {
        "col": 30,
        "line": 312,
        "offset": 10932
      },
      "extra": {
        "fingerprint": "039a10e002d74944574d67afe3dd8ddb46b170031525133f92bb27c6d19237e972f64ad4daaf2b4e38a607a3ff991b04b305d751d8d3d95290accbd08dad7fc4_0",
        "is_ignored": false,
        "lines": "    def __str__(self) -> str:\n        return self.short_msg",
        "message": "short_msg matched",
        "metadata": {},
        "metavars": {
          "$ARG": {
            "abstract_content": "self",
            "end": {
              "col": 21,
              "line": 311,
              "offset": 10893
            },
            "start": {
              "col": 17,
              "line": 311,
              "offset": 10889
            }
          },
          "$X": {
            "abstract_content": "short_msg",
            "end": {
              "col": 30,
              "line": 312,
              "offset": 10932
            },
            "start": {
              "col": 21,
              "line": 312,
              "offset": 10923
            }
          }
        },
        "severity": "WARNING"
      },
      "path": "semgrep-core/src/osemgrep/TOPORT/error.py",
      "start": {
        "col": 5,
        "line": 311,
        "offset": 10877
      }
    },
    {
      "check_id": "semgrep-core.tests.osemgrep.ocaml1",
      "end": {
        "col": 62,
        "line": 634,
        "offset": 26553
      },
      "extra": {
        "fingerprint": "3e566012118c3c539258cd6e16ac43cbf4e70f8e4d74549d2eb77557174a137ee3033229bc2f7858127441e9be78e0326959d3d46b195393b4a071220b87330e_0",
        "is_ignored": false,
        "lines": "    extracted_targets_of_config config rule_ids extract_rules",
        "message": "config matched",
        "metadata": {},
        "metavars": {
          "$ARG1": {
            "abstract_content": "config",
            "end": {
              "col": 39,
              "line": 634,
              "offset": 26530
            },
            "start": {
              "col": 33,
              "line": 634,
              "offset": 26524
            }
          },
          "$ARG2": {
            "abstract_content": "rule_ids",
            "end": {
              "col": 48,
              "line": 634,
              "offset": 26539
            },
            "start": {
              "col": 40,
              "line": 634,
              "offset": 26531
            }
          },
          "$ARG3": {
            "abstract_content": "extract_rules",
            "end": {
              "col": 62,
              "line": 634,
              "offset": 26553
            },
            "start": {
              "col": 49,
              "line": 634,
              "offset": 26540
            }
          }
        },
        "severity": "WARNING"
      },
      "path": "semgrep-core/src/runner/Run_semgrep.ml",
      "start": {
        "col": 5,
        "line": 634,
        "offset": 26496
      }
    }
  ],
  "version": "0.116.0"
}

real	0m0.901s
user	0m1.440s
sys	0m0.271s
```


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)