### PR TITLE
osemgrep: progress on test_check.py::test_basic_rule__local

### DIFF
--- a/cli/tests/semgrep_runner.py
+++ b/cli/tests/semgrep_runner.py
@@ -139,5 +139,8 @@ class SemgrepRunner:
         else:
             # TODO: do we need to support 'input' i.e. passing a string
             # to the program's stdin?
-            extra_env = dict(self._env, **env)
+            if env:
+                extra_env = dict(self._env, **env)
+            else:
+                extra_env = dict(self._env)
             return invoke_osemgrep(args, env=extra_env)

--- a/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
+++ b/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
@@ -356,11 +356,6 @@ def scan_options(func: Callable) -> Callable:
     is_flag=True,
     help="Exit 1 if there are findings. Useful for CI and scripts.",
 )
-@click.option(
-    "--strict/--no-strict",
-    is_flag=True,
-    default=False,
-    help="Return a nonzero exit code when WARN level errors are encountered. Fails early if invalid configuration files are present. Defaults to --no-strict.",
 )
 # These flags are deprecated or experimental - users should not
 # rely on their existence, or their output being stable
@@ -398,7 +393,6 @@ def scan(
     scan_unknown_extensions: bool,
     severity: Optional[Tuple[str, ...]],
     show_supported_languages: bool,
-    strict: bool,
     test: bool,
     test_ignore_todo: bool,
     time_flag: bool,

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -146,6 +146,7 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
    max_target_bytes = _;
    metrics = _;
    respect_git_ignore = _;
+   strict = _;
    quiet = _;
    verbose = _;
   } ->

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -42,6 +42,7 @@ type conf = {
   pattern : string option;
   quiet : bool;
   respect_git_ignore : bool;
+  strict : bool;
   target_roots : string list;
   timeout : float;
   timeout_threshold : int;
@@ -71,6 +72,7 @@ let default : conf =
     pattern = None;
     quiet = false;
     respect_git_ignore = true;
+    strict = false;
     target_roots = [ "." ];
     timeout = float_of_int Constants.default_timeout;
     timeout_threshold = 3;
@@ -361,6 +363,14 @@ Must be used with -e/--pattern.
 (* ------------------------------------------------------------------ *)
 (* TOPORT "Test and debug options" *)
 (* ------------------------------------------------------------------ *)
+let o_strict : bool Term.t =
+  H.negatable_flag [ "strict" ] ~neg_options:[ "no-strict" ]
+    ~default:default.strict
+    ~doc:
+      {|Return a nonzero exit code when WARN level errors are encountered.
+Fails early if invalid configuration files are present.
+Defaults to --no-strict.
+|}
 
 (* ------------------------------------------------------------------ *)
 (* positional arguments *)
@@ -381,8 +391,8 @@ let o_target_roots =
 let cmdline_term : conf Term.t =
   let combine autofix baseline_commit config debug emacs exclude include_ json
       lang max_memory_mb max_target_bytes metrics num_jobs optimizations pattern
-      quiet respect_git_ignore target_roots timeout timeout_threshold verbose
-      vim =
+      quiet respect_git_ignore strict target_roots timeout timeout_threshold
+      verbose vim =
     let output_format =
       match (json, emacs, vim) with
       | false, false, false -> default.output_format
@@ -410,6 +420,7 @@ let cmdline_term : conf Term.t =
       pattern;
       quiet;
       respect_git_ignore;
+      strict;
       target_roots;
       timeout;
       timeout_threshold;
@@ -421,7 +432,7 @@ let cmdline_term : conf Term.t =
     const combine $ o_autofix $ o_baseline_commit $ o_config $ o_debug $ o_emacs
     $ o_exclude $ o_include $ o_json $ o_lang $ o_max_memory_mb
     $ o_max_target_bytes $ o_metrics $ o_num_jobs $ o_optimizations $ o_pattern
-    $ o_quiet $ o_respect_git_ignore $ o_target_roots $ o_timeout
+    $ o_quiet $ o_respect_git_ignore $ o_strict $ o_target_roots $ o_timeout
     $ o_timeout_threshold $ o_verbose $ o_vim)
 
 let doc = "run semgrep rules on files"

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -22,6 +22,7 @@ type conf = {
   pattern : string option;
   quiet : bool;
   respect_git_ignore : bool;
+  strict : bool;
   target_roots : string list;
   timeout : float;
   timeout_threshold : int;

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
@@ -39,37 +39,44 @@ let cli_match_of_core_match (x : Out.core_match) : Out.cli_match =
    (* TODO *)
    location;
    extra =
-     {
-       message = _;
-       metavars = _;
-       (* LATER *)
-       dataflow_trace = _;
-       rendered_fix = _;
-     };
+     { message; metavars; (* LATER *)
+                          dataflow_trace = _; rendered_fix = _ };
   } ->
       let path = location.path in
       let start = location.start in
       let end_ = location.end_ in
+      let message =
+        match message with
+        (* TODO: message where the metavars have been interpolated *)
+        | Some s -> s
+        | None -> ""
+      in
+      (* TODO: need to prefix with the dotted path of the config file,
+       * e.g., semgrep-core.tests.osemgrep... if the argument
+       * was --config semgrep-core/tests/osemgrep.yml
+       *)
+      let check_id = rule_id in
+      let metavars = Some metavars in
       {
-        check_id = rule_id;
+        check_id;
         path;
         start;
         end_;
         extra =
           {
+            metavars;
             (* TODO *)
-            metavars = None;
-            fingerprint = "TODO";
             lines = "TODO";
+            message;
             (* TODO: fields derived from the rule *)
-            message = "";
-            metadata = `Null;
+            metadata = `Assoc [];
             severity = "TODO";
             fix = None;
             fix_regex = None;
             (* TODO: extra fields *)
-            is_ignored = None;
+            is_ignored = Some false;
             (* LATER *)
+            fingerprint = "TODO";
             sca_info = None;
             fixed_lines = None;
             dataflow_trace = None;


### PR DESCRIPTION
At least we get a JSON and a diff on what remains to be fixed instead
of a TypeError like we had before

test plan:
```
$ PYTEST_USE_OSEMGREP=true pytest -vv
tests/e2e/test_check.py::test_basic_rule__local
E           {
E             "errors": [],
E             "paths": {
E               "_comment": "<add --verbose for a list of skipped paths>",
E         -     "scanned": [
E         +     "scanned": []
E         ?                 +
E         -       "targets/basic/inside.py",
E         -       "targets/basic/metavariable-comparison-bad-content.py",
E         -       "targets/basic/metavariable-comparison-base.py",
E         -       "targets/basic/metavariable-comparison-strip.py",
E         -       "targets/basic/metavariable-comparison.py",
E         -       "targets/basic/metavariable-regex-multi-regex.py",
E         -       "targets/basic/metavariable-regex-multi-rule.py",
E         -       "targets/basic/metavariable-regex.py",
E         -       "targets/basic/nested-patterns.js",
E         -       "targets/basic/nosem.js",
E         -       "targets/basic/nosem.py",
E         -       "targets/basic/regex.py",
E         -       "targets/basic/stupid.js",
E         -       "targets/basic/stupid.py"
E         -     ]
E             },
E             "results": [
E               {
E         -       "check_id": "rules.eqeq-is-bad",
E         -       "end": {
E         -         "col": 26,
E         -         "line": 3,
E         -         "offset": 69
E         -       },
E         -       "extra": {
E         -         "fingerprint": "62b4a09c4569768898c43c09fa0a5b95b7e93257ef3a0911a5c379b6265b4d49fa4aecd5782461632e9aef4779af02d7cad4405b9a5318a0e5ffe9a5bd8daeae_0",
E         -         "is_ignored": false,
E         -         "lines": "    return a + b == a + b",
E         -         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
E         -         "metadata": {
E         -           "shortlink": "https://sg.run/xyz1"
E         -         },
E         -         "metavars": {
E         -           "$X": {
E         -             "abstract_content": "a+b",
E         -             "end": {
E         -               "col": 17,
E         -               "line": 3,
E         -               "offset": 60
E         -             },
E         -             "start": {
E         -               "col": 12,
E         -               "line": 3,
E         -               "offset": 55
E         -             }
E         -           }
E         -         },
E         -         "severity": "ERROR"
E         -       },
E         -       "path": "targets/basic/stupid.py",
E         -       "start": {
E         -         "col": 12,
E         -         "line": 3,
E         -         "offset": 55
E         -       }
E         -     },
E         -     {
E         -       "check_id": "rules.javascript-basic-eqeq-bad",
E         ?                    ------
E         +       "check_id": "javascript-basic-eqeq-bad",
E                 "end": {
E                   "col": 19,
E                   "line": 3,
E                   "offset": 67
E                 },
E                 "extra": {
E         -         "fingerprint": "33c7ad418bcb7f83d9dcec68b2a8aa78ace93efbc20a12297ea7e15594ce23f5bca80b0958952b14dad3e874370c9ca7f991d2e1414adc33d243f133b1ff2811_0",
E         +         "fingerprint": "TODO",
E                   "is_ignored": false,
E         -         "lines": "console.log(x == x)",
E         +         "lines": "TODO",
E                   "message": "useless comparison",
E                   "metadata": {},
E                   "metavars": {
E                     "$X": {
E                       "abstract_content": "x",
E                       "end": {
E                         "col": 14,
E                         "line": 3,
E                         "offset": 62
E                       },
E                       "propagated_value": {
E                         "svalue_abstract_content": "window.prompt()",
E                         "svalue_end": {
E                           "col": 24,
E                           "line": 1,
E                           "offset": 23
E                         },
E                         "svalue_start": {
E                           "col": 9,
E                           "line": 1,
E                           "offset": 8
E                         }
E                       },
E                       "start": {
E                         "col": 13,
E                         "line": 3,
E                         "offset": 61
E                       }
E                     }
E                   },
E         -         "severity": "ERROR"
E         ?                      ^^^ ^
E         +         "severity": "TODO"
E         ?                      ^ ^^
E                 },
E                 "path": "targets/basic/stupid.js",
E                 "start": {
E                   "col": 13,
E                   "line": 3,
E                   "offset": 61
E                 }
E         +     },
E         +     {
E         +       "check_id": "eqeq-is-bad",
E         +       "end": {
E         +         "col": 26,
E         +         "line": 3,
E         +         "offset": 69
E         +       },
E         +       "extra": {
E         +         "fingerprint": "TODO",
E         +         "is_ignored": false,
E         +         "lines": "TODO",
E         +         "message": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?",
E         +         "metadata": {},
E         +         "metavars": {
E         +           "$X": {
E         +             "abstract_content": "a+b",
E         +             "end": {
E         +               "col": 17,
E         +               "line": 3,
E         +               "offset": 60
E         +             },
E         +             "start": {
E         +               "col": 12,
E         +               "line": 3,
E         +               "offset": 55
E         +             }
E         +           }
E         +         },
E         +         "severity": "TODO"
E         +       },
E         +       "path": "targets/basic/stupid.py",
E         +       "start": {
E         +         "col": 12,
E         +         "line": 3,
E         +         "offset": 55
E         +       }
E               }
E             ],
E             "version": "0.42"
E           }

/home/pad/github/semgrep/cli/tests/e2e/test_check.py:41: AssertionError
```


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)