### PR TITLE
osemgrep: improve JSON output for test_check::test_basic_rule

### DIFF
--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -266,10 +266,14 @@ type rule = mode rule_info [@@deriving show]
 (* aliases *)
 type t = rule [@@deriving show]
 type rules = rule list [@@deriving show]
+type hrules = (rule_id, t) Hashtbl.t
 
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+
+let hrules_of_rules (rules : t list) : hrules =
+  rules |> Common.map (fun r -> (fst r.id, r)) |> Common.hash_of_list
 
 let partition_rules (rules : rules) :
     search_rule list * taint_rule list * extract_rule list =

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -45,20 +45,23 @@ class CoreRunner:
 
 type path = string
 
-(* LATER: ideally we just want Out.cli_output *)
-type result = Out.core_match_results
-(* TODO: original intermediate data structures in python, but
-      we might want to get rid of them entirely and
-      go directly to Out.cli_output
-    {
+(* LATER: ideally we just want directly Out.cli_output? *)
+type result = {
+  (* ocaml: not in original python implem, but just enough to get
+   * Semgrep_scan.cli_output_of_core_results to work
+   *)
+  core : Out.core_match_results;
+  hrules : Rule.hrules;
+      (* TODO: original intermediate data structures in python *)
+      (*
      findings_by_rule : (Rule.t, Rule_match.t list) Map_.t;
      errors : Error.t list;
      all_targets : path Set_.t;
      (*profiling_data: profiling_data; TOPORT: do we need to translate this? *)
      parsing_data : Parsing_data.t;
      explanations : Out.matching_explanation list option;
-   }
-*)
+  *)
+}
 
 (*************************************************************************)
 (* Helpers *)
@@ -249,4 +252,4 @@ let invoke_semgrep_core (conf : Scan_CLI.conf) : result =
   (* TOPORT: figure out the best type for this result. Ideally, this is
      the type corresponding to the JSON output. *)
   ignore skipped_targets;
-  res
+  { core = res; hrules = Rule.hrules_of_rules rules }

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
@@ -7,7 +7,11 @@
 *)
 
 type path = string
-type result = Semgrep_output_v0_t.core_match_results
+
+type result = {
+  core : Semgrep_output_v0_t.core_match_results;
+  hrules : Rule.hrules;
+}
 
 val invoke_semgrep_core : Scan_CLI.conf -> result
 


### PR DESCRIPTION
Here are a few fixes to get the same JSON output than semgrep
on the test_basic_rule__local pytest:
 - sort the json for findings, sort per rule id
 - get the severity from the rule (so need pass around hrules)
 - get metadata from the rule (but needed to fix type of raw_json in atd)

TODO:
 - prefix check_id with path of config file
 - scanned list
 - message metavariable interpolation
 - lines content
 - LATER? fingerprint, but how mask it? need update all the snapshots locally? annoying

test plan:
```
$ PYTEST_USE_OSEMGREP=true pytest -vv
tests/e2e/test_check.py::test_basic_rule__local
E           {
E             "errors": [],
E             "paths": {
E               "_comment": "<add --verbose for a list of skipped paths>",
E         -     "scanned": [
E         +     "scanned": []
E         ?                 +
E         -       "targets/basic/inside.py",
E         -       "targets/basic/metavariable-comparison-bad-content.py",
E         -       "targets/basic/metavariable-comparison-base.py",
E         -       "targets/basic/metavariable-comparison-strip.py",
E         -       "targets/basic/metavariable-comparison.py",
E         -       "targets/basic/metavariable-regex-multi-regex.py",
E         -       "targets/basic/metavariable-regex-multi-rule.py",
E         -       "targets/basic/metavariable-regex.py",
E         -       "targets/basic/nested-patterns.js",
E         -       "targets/basic/nosem.js",
E         -       "targets/basic/nosem.py",
E         -       "targets/basic/regex.py",
E         -       "targets/basic/stupid.js",
E         -       "targets/basic/stupid.py"
E         -     ]
E             },
E             "results": [
E               {
E         -       "check_id": "rules.eqeq-is-bad",
E         ?                    ------
E         +       "check_id": "eqeq-is-bad",
E                 "end": {
E                   "col": 26,
E                   "line": 3,
E                   "offset": 69
E                 },
E                 "extra": {
E         -         "fingerprint": "62b4a09c4569768898c43c09fa0a5b95b7e93257ef3a0911a5c379b6265b4d49fa4aecd5782461632e9aef4779af02d7cad4405b9a5318a0e5ffe9a5bd8daeae_0",
E         +         "fingerprint": "TODO",
E                   "is_ignored": false,
E         -         "lines": "    return a + b == a + b",
E         +         "lines": "TODO",
E         -         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
E         ?                                                   ^^^^^    ^^^^^      ^^^^^    ^^^^^
E         +         "message": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?",
E         ?                                                   ^^    ^^      ^^    ^^
E                   "metadata": {
E                     "shortlink": "https://sg.run/xyz1"
E                   },
E                   "metavars": {
E                     "$X": {
E                       "abstract_content": "a+b",
E                       "end": {
E                         "col": 17,
E                         "line": 3,
E                         "offset": 60
E                       },
E                       "start": {
E                         "col": 12,
E                         "line": 3,
E                         "offset": 55
E                       }
E                     }
E                   },
E                   "severity": "ERROR"
E                 },
E                 "path": "targets/basic/stupid.py",
E                 "start": {
E                   "col": 12,
E                   "line": 3,
E                   "offset": 55
E                 }
E               },
E               {
E         -       "check_id": "rules.javascript-basic-eqeq-bad",
E         ?                    ------
E         +       "check_id": "javascript-basic-eqeq-bad",
E                 "end": {
E                   "col": 19,
E                   "line": 3,
E                   "offset": 67
E                 },
E                 "extra": {
E         -         "fingerprint": "33c7ad418bcb7f83d9dcec68b2a8aa78ace93efbc20a12297ea7e15594ce23f5bca80b0958952b14dad3e874370c9ca7f991d2e1414adc33d243f133b1ff2811_0",
E         +         "fingerprint": "TODO",
E                   "is_ignored": false,
E         -         "lines": "console.log(x == x)",
E         +         "lines": "TODO",
E                   "message": "useless comparison",
E                   "metadata": {},
E                   "metavars": {
E                     "$X": {
E                       "abstract_content": "x",
E                       "end": {
E                         "col": 14,
E                         "line": 3,
E                         "offset": 62
E                       },
E                       "propagated_value": {
E                         "svalue_abstract_content": "window.prompt()",
E                         "svalue_end": {
E                           "col": 24,
E                           "line": 1,
E                           "offset": 23
E                         },
E                         "svalue_start": {
E                           "col": 9,
E                           "line": 1,
E                           "offset": 8
E                         }
E                       },
E                       "start": {
E                         "col": 13,
E                         "line": 3,
E                         "offset": 61
E                       }
E                     }
E                   },
E                   "severity": "ERROR"
E                 },
E                 "path": "targets/basic/stupid.js",
E                 "start": {
E                   "col": 13,
E                   "line": 3,
E                   "offset": 61
E                 }
E               }
E             ],
E             "version": "0.42"
E           }
```


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)