### PR TITLE
osemgrep: more improvement to JSON output for basic_test

### DIFF
--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -265,7 +265,9 @@ let check_files mk_config fparser input =
   | Text -> List.iter (fun err -> pr2 (E.string_of_error err)) errors
   | Json _ ->
       let res = { RP.empty_final_result with errors } in
-      let json = JSON_report.match_results_of_matches_and_errors [] res in
+      let nfiles = 0 in
+      (* for the stats, but we don't care? *)
+      let json = JSON_report.match_results_of_matches_and_errors nfiles res in
       pr (SJ.string_of_core_match_results json)
 
 let stat_files fparser xs =

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -265,8 +265,8 @@ let check_files mk_config fparser input =
   | Text -> List.iter (fun err -> pr2 (E.string_of_error err)) errors
   | Json _ ->
       let res = { RP.empty_final_result with errors } in
+      (* for the stats.okfiles, but we don't care? *)
       let nfiles = 0 in
-      (* for the stats, but we don't care? *)
       let json = JSON_report.match_results_of_matches_and_errors nfiles res in
       pr (SJ.string_of_core_match_results json)
 

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
@@ -11,6 +11,7 @@ type path = string
 type result = {
   core : Semgrep_output_v0_t.core_match_results;
   hrules : Rule.hrules;
+  scanned : path Set_.t;
 }
 
 val invoke_semgrep_core : Scan_CLI.conf -> result

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
@@ -19,9 +19,9 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* environment to pass to the cli_output generator *)
 type env = {
   hrules : Rule.hrules;
-  (* string to prefix all rule_id with,
-   * e.g., semgrep-core.tests.osemgrep... if the osemgrep argument
-   * was --config semgrep-core/tests/osemgrep.yml
+  (* string to prefix all rule_id with
+   * (e.g., "semgrep-core.tests." if the --config argument
+    * was semgrep-core/tests/osemgrep.yml)
    *)
   config_prefix : string;
 }

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_scan.ml
@@ -12,9 +12,30 @@ let logger = Logging.get_logger [ __MODULE__ ]
    Translated from scan.py
    TODO and semgrep_main.py?
 *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+(* environment to pass to the cli_output generator *)
+type env = {
+  hrules : Rule.hrules;
+  (* string to prefix all rule_id with,
+   * e.g., semgrep-core.tests.osemgrep... if the osemgrep argument
+   * was --config semgrep-core/tests/osemgrep.yml
+   *)
+  config_prefix : string;
+}
+
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+
+let config_prefix_of_conf (conf : Scan_CLI.conf) : string =
+  (* TODO: what if it's a registry rule? *)
+  let path = conf.config in
+  (*  need to prefix with the dotted path of the config file *)
+  let dir = Filename.dirname path in
+  dir ^ "."
 
 (*****************************************************************************)
 (* Core output to Cli output *)
@@ -35,8 +56,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 let cli_error_of_core_error (_x : Out.core_error) : Out.cli_error =
   failwith "TODO: cli_error_of_core_error"
 
-let cli_match_of_core_match (hrules : Rule.hrules) (x : Out.core_match) :
-    Out.cli_match =
+let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
   match x with
   | {
    rule_id;
@@ -46,7 +66,7 @@ let cli_match_of_core_match (hrules : Rule.hrules) (x : Out.core_match) :
                           dataflow_trace = _; rendered_fix = _ };
   } ->
       let rule =
-        try Hashtbl.find hrules rule_id with
+        try Hashtbl.find env.hrules rule_id with
         | Not_found -> raise Impossible
       in
       let path = location.path in
@@ -58,11 +78,8 @@ let cli_match_of_core_match (hrules : Rule.hrules) (x : Out.core_match) :
         | Some s -> s
         | None -> ""
       in
-      (* TODO: need to prefix with the dotted path of the config file,
-       * e.g., semgrep-core.tests.osemgrep... if the argument
-       * was --config semgrep-core/tests/osemgrep.yml
-       *)
-      let check_id = rule_id in
+      (*  need to prefix with the dotted path of the config file *)
+      let check_id = env.config_prefix ^ rule_id in
       let metavars = Some metavars in
       (* LATER: this should be a variant in semgrep_output_v0.atd
        * and merged with Constants.rule_severity
@@ -80,6 +97,13 @@ let cli_match_of_core_match (hrules : Rule.hrules) (x : Out.core_match) :
         | None -> `Assoc []
         | Some json -> JSON.to_yojson json
       in
+      (* TODO: should use a faster implementation, using a cache
+       * to avoid rereading the same file again and again
+       *)
+      let lines =
+        Matching_report.lines_of_file (start.line, end_.line) path
+        |> String.concat "\n"
+      in
       {
         check_id;
         path;
@@ -88,8 +112,8 @@ let cli_match_of_core_match (hrules : Rule.hrules) (x : Out.core_match) :
         extra =
           {
             metavars;
+            lines;
             (* TODO *)
-            lines = "TODO";
             message;
             (* fields derived from the rule *)
             severity;
@@ -107,7 +131,8 @@ let cli_match_of_core_match (hrules : Rule.hrules) (x : Out.core_match) :
           };
       }
 
-let cli_output_of_core_results (res : Core_runner.result) : Out.cli_output =
+let cli_output_of_core_results (conf : Scan_CLI.conf) (res : Core_runner.result)
+    : Out.cli_output =
   match res.core with
   | {
    matches;
@@ -120,19 +145,24 @@ let cli_output_of_core_results (res : Core_runner.result) : Out.cli_output =
    stats = _;
    time = _;
   } ->
+      let env =
+        { hrules = res.hrules; config_prefix = config_prefix_of_conf conf }
+      in
       (* TODO: not sure how it's sorted *)
       let matches =
         matches
         |> List.sort (fun (a : Out.core_match) (b : Out.core_match) ->
                compare a.rule_id b.rule_id)
       in
+      (* TODO: not sure how it's sorted *)
+      let scanned = res.scanned |> Set_.elements in
       {
         version = Some Version.version;
-        results = matches |> Common.map (cli_match_of_core_match res.hrules);
+        results = matches |> Common.map (cli_match_of_core_match env);
         (* TODO *)
         paths =
           {
-            scanned = [];
+            scanned;
             _comment = Some "<add --verbose for a list of skipped paths>";
             skipped = None;
           };
@@ -169,7 +199,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
 
   (* !!!TODO!!! use the result!! see semgrep_main.py *)
   let (res : Core_runner.result) = Core_runner.invoke_semgrep_core conf in
-  let (cli_output : Out.cli_output) = cli_output_of_core_results res in
+  let (cli_output : Out.cli_output) = cli_output_of_core_results conf res in
 
   (* TODO: if conf.output_format = Json *)
   let s = Out.string_of_cli_output cli_output in

--- a/semgrep-core/src/osemgrep/cli_scan/dune
+++ b/semgrep-core/src/osemgrep/cli_scan/dune
@@ -7,6 +7,7 @@
     cmdliner
     commons  ; from pfff
     semgrep_core_cli  ; semgrep-core's CLI
+    semgrep_reporting
     osemgrep_utils
     osemgrep_core
   )

--- a/semgrep-core/src/reporting/JSON_report.mli
+++ b/semgrep-core/src/reporting/JSON_report.mli
@@ -6,7 +6,7 @@ val match_to_match :
   (Output_from_core_t.core_match, Semgrep_error_code.error) Common.either
 
 val match_results_of_matches_and_errors :
-  Common.filename list ->
+  int (* number of files processed, for the stats.okfiles *) ->
   Report.final_result ->
   Output_from_core_t.core_match_results
 

--- a/semgrep-core/src/reporting/Matching_report.ml
+++ b/semgrep-core/src/reporting/Matching_report.ml
@@ -55,6 +55,15 @@ let rec join_with_space_if_needed xs =
         x ^ " " ^ join_with_space_if_needed (y :: xs)
       else x ^ join_with_space_if_needed (y :: xs)
 
+(* TODO? slow, and maybe we should cache it to avoid rereading
+ * each time the same file for each match.
+ * Note that the returned lines do not contain \n.
+ *)
+let lines_of_file (start_line, end_line) file : string list =
+  let arr = Common2.cat_array file in
+  let lines = Common2.enum start_line end_line in
+  lines |> Common.map (fun i -> arr.(i))
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -66,20 +75,16 @@ let print_match ?(format = Normal) ?(str = "") ?(spaces = 0) ii =
     in
     let file, line = (PI.file_of_info mini, PI.line_of_info mini) in
     let prefix = spf "%s:%d" file line in
-    let arr = Common2.cat_array file in
-    let lines = Common2.enum (PI.line_of_info mini) end_line in
-
+    let lines_str = lines_of_file (PI.line_of_info mini, end_line) file in
     match format with
     | Normal ->
         let prefix = if str = "" then prefix else prefix ^ " " ^ str in
         let spaces_string = String.init spaces (fun _ -> ' ') in
         pr (spaces_string ^ prefix);
         (* todo? some context too ? *)
-        lines
-        |> Common.map (fun i -> arr.(i))
-        |> List.iter (fun s -> pr (spaces_string ^ " " ^ s))
+        lines_str |> List.iter (fun s -> pr (spaces_string ^ " " ^ s))
     (* bugfix: do not add extra space after ':', otherwise M-x wgrep will not work *)
-    | Emacs -> pr (prefix ^ ":" ^ arr.(List.hd lines))
+    | Emacs -> pr (prefix ^ ":" ^ List.hd lines_str)
     | OneLine ->
         pr
           (prefix ^ ": "

--- a/semgrep-core/src/reporting/Matching_report.mli
+++ b/semgrep-core/src/reporting/Matching_report.mli
@@ -18,3 +18,12 @@ val print_match :
   unit
 
 val join_with_space_if_needed : string list -> string
+
+(* [lines_of_file (start_line, end_line) file] returns
+ * the list of lines from start_line to end_line included.
+ *
+ * Note that the returned lines do not contain \n.
+ *
+ * This function is slow, you should not use it!
+ *)
+val lines_of_file : int * int -> Common.filename -> string list

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -799,7 +799,9 @@ let semgrep_with_rules_and_formatted_output config =
    *)
   match config.output_format with
   | Json _ -> (
-      let res = JSON_report.match_results_of_matches_and_errors files res in
+      let res =
+        JSON_report.match_results_of_matches_and_errors (List.length files) res
+      in
       (*
         Not pretty-printing the json output (Yojson.Safe.prettify)
         because it kills performance, adding an extra 50% time on our
@@ -897,7 +899,9 @@ let semgrep_with_one_pattern config =
       let res, files =
         semgrep_with_rules config (([ rule ], []), rules_parse_time)
       in
-      let json = JSON_report.match_results_of_matches_and_errors files res in
+      let json =
+        JSON_report.match_results_of_matches_and_errors (List.length files) res
+      in
       let s = Out.string_of_core_match_results json in
       pr s
   | Text ->


### PR DESCRIPTION
fixed:
 - check_id: prefix with path of config file
 - lines: content
 - scanned: list of scanned targets

TODO:
 - message: metavariable interpolation
 - LATER? fingerprint, but how mask it? need update all the snapshots locally? annoying

test plan:
```
$ PYTEST_USE_OSEMGREP=true pytest -vv tests/e2e/test_check.py::test_basic_rule__local
E           {
E             "errors": [],
E             "paths": {
E               "_comment": "<add --verbose for a list of skipped paths>",
E               "scanned": [
E                 "targets/basic/inside.py",
E                 "targets/basic/metavariable-comparison-bad-content.py",
E                 "targets/basic/metavariable-comparison-base.py",
E                 "targets/basic/metavariable-comparison-strip.py",
E                 "targets/basic/metavariable-comparison.py",
E                 "targets/basic/metavariable-regex-multi-regex.py",
E                 "targets/basic/metavariable-regex-multi-rule.py",
E                 "targets/basic/metavariable-regex.py",
E                 "targets/basic/nested-patterns.js",
E                 "targets/basic/nosem.js",
E                 "targets/basic/nosem.py",
E                 "targets/basic/regex.py",
E                 "targets/basic/stupid.js",
E                 "targets/basic/stupid.py"
E               ]
E             },
E             "results": [
E               {
E                 "check_id": "rules.eqeq-is-bad",
E                 "end": {
E                   "col": 26,
E                   "line": 3,
E                   "offset": 69
E                 },
E                 "extra": {
E         -         "fingerprint": "62b4a09c4569768898c43c09fa0a5b95b7e93257ef3a0911a5c379b6265b4d49fa4aecd5782461632e9aef4779af02d7cad4405b9a5318a0e5ffe9a5bd8daeae_0",
E         +         "fingerprint": "TODO",
E                   "is_ignored": false,
E                   "lines": "    return a + b == a + b",
E         -         "message": "useless comparison operation `a + b == a + b` or `a + b != a + b`; possible bug?",
E         ?                                                   ^^^^^    ^^^^^      ^^^^^    ^^^^^
E         +         "message": "useless comparison operation `$X == $X` or `$X != $X`; possible bug?",
E         ?                                                   ^^    ^^      ^^    ^^
E                   "metadata": {
E                     "shortlink": "https://sg.run/xyz1"
E                   },
E                   "metavars": {
E                     "$X": {
E                       "abstract_content": "a+b",
E                       "end": {
E                         "col": 17,
E                         "line": 3,
E                         "offset": 60
E                       },
E                       "start": {
E                         "col": 12,
E                         "line": 3,
E                         "offset": 55
E                       }
E                     }
E                   },
E                   "severity": "ERROR"
E                 },
E                 "path": "targets/basic/stupid.py",
E                 "start": {
E                   "col": 12,
E                   "line": 3,
E                   "offset": 55
E                 }
E               },
E               {
E                 "check_id": "rules.javascript-basic-eqeq-bad",
E                 "end": {
E                   "col": 19,
E                   "line": 3,
E                   "offset": 67
E                 },
E                 "extra": {
E         -         "fingerprint": "33c7ad418bcb7f83d9dcec68b2a8aa78ace93efbc20a12297ea7e15594ce23f5bca80b0958952b14dad3e874370c9ca7f991d2e1414adc33d243f133b1ff2811_0",
E         +         "fingerprint": "TODO",
E                   "is_ignored": false,
E                   "lines": "console.log(x == x)",
E                   "message": "useless comparison",
E                   "metadata": {},
E                   "metavars": {
E                     "$X": {
E                       "abstract_content": "x",
E                       "end": {
E                         "col": 14,
E                         "line": 3,
E                         "offset": 62
E                       },
E                       "propagated_value": {
E                         "svalue_abstract_content": "window.prompt()",
E                         "svalue_end": {
E                           "col": 24,
E                           "line": 1,
E                           "offset": 23
E                         },
E                         "svalue_start": {
E                           "col": 9,
E                           "line": 1,
E                           "offset": 8
E                         }
E                       },
E                       "start": {
E                         "col": 13,
E                         "line": 3,
E                         "offset": 61
E                       }
E                     }
E                   },
E                   "severity": "ERROR"
E                 },
E                 "path": "targets/basic/stupid.js",
E                 "start": {
E                   "col": 13,
E                   "line": 3,
E                   "offset": 61
E                 }
E               }
E             ],
E             "version": "0.42"
E           }

```

Also
time osemgrep --config e2e/rules/eqeq.yaml --json e2e/targets/basic/ --quiet | jq
0.119s
vs
time semgrep --config e2e/rules/eqeq.yaml --json e2e/targets/basic/ --quiet --metrics=off --disable-version-check | jq
0.646s

progress!!


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)