### PR TITLE
osemgrep: support for --config p/ocaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ install-deps: install-deps-for-semgrep-core
 # - pcre-dev: for ocaml-pcre now used in semgrep-core
 # - python3: used also during building semgrep-core for processing lang.json
 # - python3-dev: for the semgrep Python bridge to build Python C extensions
-ALPINE_APK_DEPS=pcre-dev python3 python3-dev
+# - gmp-dev: for osemgrep and its use of cohttp
+ALPINE_APK_DEPS=pcre-dev python3 python3-dev gmp-dev
 
 #TODO why this one?
 PIPENV='pipenv==2022.6.7'

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -40,7 +40,7 @@ depends: [
   "pcre"
   "parmap"
   "ppxlib"
-  "quests" # this brings lots of dependencies. This is for osemgrep.
+  "cohttp-lwt-unix" # this brings lots of dependencies. This is for osemgrep.
   "lsp" {= "1.7.0"}
   "comby-kernel" {= "1.4.1"}
 ]

--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "semgrep"
-version: "0.73.0"
+version: "0.117.0"
 synopsis: "Like grep but for code: fast and syntax-aware semantic code pattern for many languages"
 description: """
 Semgrep is like grep but for searching patterns at the AST level.
@@ -19,8 +19,8 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 # A big dependency is pfff, but it's now a submodule so it's not listed here
 #TODO: restore  "bisect_ppx" {>= "2.5.0"} once can use ppxlib 0.22.0
 
-# For semgrep CI to be fast, we try to pre-install these packages as part of
-# of the base docker image. When you add a new package or change a version
+#coupling: for semgrep CI to be fast, we try to pre-install these packages as
+# part of of the base docker image. When you add a new package or change a version
 # here, please also update the list of packages there:
 #
 #   https://github.com/returntocorp/ocaml-layer/blob/master/common-config.sh
@@ -40,6 +40,7 @@ depends: [
   "pcre"
   "parmap"
   "ppxlib"
+  "quests" # this brings lots of dependencies. This is for osemgrep.
   "lsp" {= "1.7.0"}
   "comby-kernel" {= "1.4.1"}
 ]

--- a/semgrep-core/src/osemgrep/TOPORT/config_resolver.py
+++ b/semgrep-core/src/osemgrep/TOPORT/config_resolver.py
@@ -1,21 +1,3 @@
-import json
-import os
-import time
-from collections import OrderedDict
-from enum import auto
-from enum import Enum
-from pathlib import Path
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Mapping
-from typing import NamedTuple
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from urllib.parse import urlencode
-from urllib.parse import urlparse
-
 import requests
 import ruamel.yaml
 from ruamel.yaml import YAMLError
@@ -51,8 +33,6 @@ from semgrep.util import terminal_wrap
 from semgrep.util import with_color
 from semgrep.verbose_logging import getLogger
 
-logger = getLogger(__name__)
-
 AUTO_CONFIG_KEY = "auto"
 AUTO_CONFIG_LOCATION = "c/auto"
 
@@ -70,16 +50,10 @@ DEFAULT_CONFIG = {
     ],
 }
 
-
 class ConfigFile(NamedTuple):
     config_id: Optional[str]  # None for remote files
     contents: str
     config_path: str
-
-
-class ConfigType(Enum):
-    REGISTRY = auto()
-    LOCAL = auto()
 
 
 class ConfigLoader:
@@ -652,19 +626,6 @@ def load_default_config() -> Dict[str, YamlTree]:
         config_infos = read_config_folder(default_folder, relative=True)
     return parse_config_files(config_infos)
 
-
-def is_registry_id(config_str: str) -> bool:
-    """
-    Starts with r/, p/, s/ for registry, pack, and snippet respectively
-    """
-    return config_str[:2] in {"r/", "p/", "s/"}
-
-
-def is_saved_snippet(config_str: str) -> bool:
-    """
-    config_str is saved snippet which has format username:snippetname
-    """
-    return len(config_str.split(":")) == 2
 
 
 def registry_id_to_url(registry_id: str) -> str:

--- a/semgrep-core/src/osemgrep/cli_scan/Output.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Output.ml
@@ -8,6 +8,9 @@ module Out = Semgrep_output_v0_j
    'semgrep scan' output.
 
    Partially translated from output.py
+
+   For now only the JSON output is supported.
+   TODO? move most of the content of this file to Output_JSON.ml?
 *)
 
 (*****************************************************************************)
@@ -94,7 +97,7 @@ let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
         | None -> `Assoc []
         | Some json -> JSON.to_yojson json
       in
-      (* TODO: should use a faster implementation, using a cache
+      (* TODO: we should use a faster implementation, using a cache
        * to avoid rereading the same file again and again
        *)
       let lines =
@@ -133,7 +136,6 @@ let cli_output_of_core_results (conf : Scan_CLI.conf) (res : Core_runner.result)
   match res.core with
   | {
    matches;
-   (* TODO *)
    errors;
    (* LATER *)
    skipped_targets = _;
@@ -156,11 +158,11 @@ let cli_output_of_core_results (conf : Scan_CLI.conf) (res : Core_runner.result)
       {
         version = Some Version.version;
         results = matches |> Common.map (cli_match_of_core_match env);
-        (* TODO *)
         paths =
           {
             scanned;
             _comment = Some "<add --verbose for a list of skipped paths>";
+            (* TOPORT *)
             skipped = None;
           };
         errors = errors |> Common.map cli_error_of_core_error;

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -48,9 +48,17 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
   (* --------------------------------------------------------- *)
   (* Let's go *)
   (* --------------------------------------------------------- *)
+  (* TODO: in theory we should have an intermediate module that
+   * handle the -e/--lang, or --config, but for now we care
+   * only about --config.
+   * TODO: in theory we can also pass multiple --config and
+   * have a default config.
+   *)
   let rules, _errorsTODO =
     Semgrep_dashdash_config.rules_from_dashdash_config conf.config
   in
+  (* TODO: there are more ways to specify targets? see target_manager.py
+   *)
   let targets, _skipped_targetsTODO =
     Find_target.select_global_targets ~includes:conf.include_
       ~excludes:conf.exclude ~max_target_bytes:conf.max_target_bytes

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_dashdash_config.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_dashdash_config.ml
@@ -56,7 +56,8 @@ let config_kind_of_config_str config_str =
   | _else_ -> failwith (spf "not a valid --config string: %s" config_str)
 
 let url_of_registry_kind rkind =
-  let prefix = "https://semgrep.dev" in
+  (* TODO: go through curl interface for now (c/) *)
+  let prefix = "https://semgrep.dev/c" in
   match rkind with
   | Registry s -> spf "%s/r/%s" prefix s
   | Pack s -> spf "%s/r/%s" prefix s
@@ -81,7 +82,9 @@ let rules_from_dashdash_config config_str =
       logger#debug "trying to download from %s" url;
       let resp_promise = Quests.get url in
       let resp = Lwt_main.run resp_promise in
-      pr (Quests.Response.show resp);
-      failwith "TODO"
+      let content = resp.content in
+      (* to debug: pr (Quests.Response.show resp); *)
+      Common2.with_tmp_file ~str:content ~ext:"yaml" (fun file ->
+          load_rules_from_file file)
   | _else_ ->
       failwith (spf "TODO: config not handled yet: %s" (show_config_kind kind))

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_dashdash_config.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_dashdash_config.ml
@@ -1,3 +1,7 @@
+open Common
+
+let logger = Logging.get_logger [ __MODULE__ ]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -10,20 +14,74 @@
    a possible .semgrep).
 
    Partially translated from config_resolver.py
+
+   TODO:
+    - handle the registry-aware jsonnet format (LONG)
+    - lots of stuff ...
 *)
 
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
 
+type config_kind =
+  | File of Common.filename
+  | Dir of string
+  | R of registry_kind
+
+and registry_kind =
+  (* r/... *)
+  | Registry of string
+  (* p/... *)
+  | Pack of string
+  (* s/... *)
+  | Snippet of string
+  (* pad:basic *)
+  | SavedSnippet of string (* username *) * string (* snippetname *)
+[@@deriving show]
+
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
+let config_kind_of_config_str config_str =
+  match config_str with
+  | s when s =~ "^r/\\(.*\\)" -> R (Registry (Common.matched1 s))
+  | s when s =~ "^p/\\(.*\\)" -> R (Pack (Common.matched1 s))
+  | s when s =~ "^s/\\(.*\\)" -> R (Snippet (Common.matched1 s))
+  | s when s =~ "^\\(.*\\):\\(.*\\)" ->
+      let user, snippet = Common.matched2 s in
+      R (SavedSnippet (user, snippet))
+  (* TODO  | file when Sys.is_dir file  -> Dir file *)
+  | file when Sys.file_exists file -> File file
+  | _else_ -> failwith (spf "not a valid --config string: %s" config_str)
+
+let url_of_registry_kind rkind =
+  let prefix = "https://semgrep.dev" in
+  match rkind with
+  | Registry s -> spf "%s/r/%s" prefix s
+  | Pack s -> spf "%s/r/%s" prefix s
+  | Snippet s -> spf "%s/s/%s" prefix s
+  | SavedSnippet (user, snippet) -> spf "%s/%s:%s" prefix user snippet
+
+let load_rules_from_file file =
+  logger#debug "loading local config from %s" file;
+  Parse_rule.parse_and_filter_invalid_rules file
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
-let rules_from_dashdash_config config =
+let rules_from_dashdash_config config_str =
   (* TOPORT: resolve rule file URLs; for now we assume it's a file. *)
-  Parse_rule.parse_and_filter_invalid_rules config
+  let kind = config_kind_of_config_str config_str in
+  match kind with
+  | File file -> load_rules_from_file file
+  | R rkind ->
+      let url = url_of_registry_kind rkind in
+      logger#debug "trying to download from %s" url;
+      let resp_promise = Quests.get url in
+      let resp = Lwt_main.run resp_promise in
+      pr (Quests.Response.show resp);
+      failwith "TODO"
+  | _else_ ->
+      failwith (spf "TODO: config not handled yet: %s" (show_config_kind kind))

--- a/semgrep-core/src/osemgrep/cli_scan/Semgrep_dashdash_config.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Semgrep_dashdash_config.mli
@@ -1,9 +1,19 @@
-(* The --config argument can be:
- *  - a filename
- *  - TODO a registry entry,
- *  - TODO a URL,
- *  - TODO a folder name
- *  - TODO loads from defaults if None
- *)
+type config_kind =
+  | File of Common.filename
+  | Dir of Common.dirname
+  | R of registry_kind
+
+and registry_kind =
+  (* r/... *)
+  | Registry of string
+  (* p/... *)
+  | Pack of string
+  (* s/... *)
+  | Snippet of string
+  (* pad:basic *)
+  | SavedSnippet of string (* username *) * string (* snippetname *)
+[@@deriving show]
+
+(* The --config string argument can resolve to one of the config_kind above *)
 val rules_from_dashdash_config :
   string -> Rule.rules * Rule.invalid_rule_error list

--- a/semgrep-core/src/osemgrep/cli_scan/dune
+++ b/semgrep-core/src/osemgrep/cli_scan/dune
@@ -6,7 +6,7 @@
   (libraries
     cmdliner
     lwt
-    quests
+    cohttp cohttp-lwt-unix
 
     commons  ; from pfff
     semgrep_core_cli  ; semgrep-core's CLI

--- a/semgrep-core/src/osemgrep/cli_scan/dune
+++ b/semgrep-core/src/osemgrep/cli_scan/dune
@@ -5,10 +5,21 @@
   (wrapped false)
   (libraries
     cmdliner
+    lwt
+    quests
+
     commons  ; from pfff
     semgrep_core_cli  ; semgrep-core's CLI
     semgrep_reporting
     osemgrep_utils
     osemgrep_core
   )
+ (preprocess
+   (pps
+     ppx_profiling
+     ppx_deriving.show
+     ppx_deriving.eq
+     ppx_hash
+   )
+ )
 )


### PR DESCRIPTION
test plan:
$ time ./semgrep-core/bin/osemgrep --config p/ocaml --json cli/ semgrep-core/src/
but does not work yet!


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)