### PR TITLE
fix(autofix): Abort on failure to replace metavar anywhere in string literal

### DIFF
--- a/changelog.d/autofix-string-metavar.fixed
+++ b/changelog.d/autofix-string-metavar.fixed
@@ -1,0 +1,1 @@
+Fixed an autofix regression that caused Semgrep to fail to replace metavariables in string literals, e.g. `foo("xyz $X")`.


### PR DESCRIPTION
This is an extension of #6242. What I didn't realize when I wrote that was that textual autofix allows a metavariable to appear anywhere within a string literal. This makes sense, since the implementation can't distinguish between the inside of a string literal and anything else.

Now, after performing metavariable replacement, we search string literals for any instance of metavariables, and we abort if we find one. Previously, we only aborted if the string literal's contents was, exactly, the string literal in question.

Test plan: The test plan of #6242, then repeated with the fix changed to `bar("x$Xy")`

Also repeat the test with the pattern `foo("$X", "$Y")`, the target `foo("asdf", "bar")`, and the fix `bar("$Y", "$X")` to test that the regular expression is joined properly.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
