### PR TITLE
ci: Autofix printing stats job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,19 @@ jobs:
       - store_artifacts:
           path: parsing-stats/results.txt
 
+  # Run parsing stats and publish them to the semgrep dashboard.
+  autofix-printing-stats:
+    docker:
+      - image: returntocorp/semgrep-dev:develop
+    steps:
+      - checkout
+      - run:
+          name: autofix printing stats
+          no_output_timeout: 60m
+          command: |
+            cd autofix-printing-stats
+            ./run --upload
+
 ##########################################################################################
 # The workflows
 ##########################################################################################
@@ -116,6 +129,23 @@ workflows:
               only:
                 - develop
                 - main
+
+  scheduled-autofix-printing-stats:
+    triggers:
+      - schedule:
+          # Run at 00:00 every day, UTC.
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - autofix-printing-stats:
+          # Run only on these branches
+          filters:
+            branches:
+              only:
+                - develop
 
   # This is for testing or for forcing a stats job. Requires pushing
   # to a branch named 'parsing-stats'.


### PR DESCRIPTION
I mostly copy-pasted what we have for printing stats. This should run the autofix printing stats script from #6300 daily in CircleCI.

Test plan:

`circleci config validate`

For the rest, just hope?

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
