### PR TITLE
change default of --scan-unknown-extensions to false!

### DIFF
--- a/changelog.d/pa-1932.changed
+++ b/changelog.d/pa-1932.changed
@@ -1,4 +1,4 @@
 The `--scan-unknown-extensions` option is now set to false by default.
 This means that from now on `--skip-unknown-extensions` is the default.
 This is an important change that prevents many errors when using
-semgrep in a pre-commit context or in CI.
+Semgrep in a pre-commit context or in CI.

--- a/changelog.d/pa-1932.changed
+++ b/changelog.d/pa-1932.changed
@@ -1,0 +1,4 @@
+The --scan-unknown-extensions option will be now set by default to false
+(which means --skip-unknown-extensions is now the default).
+This is an important change but this will avoid many errors when using
+semgrep in a pre-commit context or in CI.

--- a/changelog.d/pa-1932.changed
+++ b/changelog.d/pa-1932.changed
@@ -1,4 +1,4 @@
 The `--scan-unknown-extensions` option is now set to false by default.
 This means that from now on `--skip-unknown-extensions` is the default.
-This is an important change but this will avoid many errors when using
+This is an important change that prevents many errors when using
 semgrep in a pre-commit context or in CI.

--- a/changelog.d/pa-1932.changed
+++ b/changelog.d/pa-1932.changed
@@ -1,4 +1,4 @@
 The `--scan-unknown-extensions` option is now set to false by default.
-(which means --skip-unknown-extensions is now the default).
+This means that from now on `--skip-unknown-extensions` is the default.
 This is an important change but this will avoid many errors when using
 semgrep in a pre-commit context or in CI.

--- a/changelog.d/pa-1932.changed
+++ b/changelog.d/pa-1932.changed
@@ -1,4 +1,4 @@
-The --scan-unknown-extensions option will be now set by default to false
+The `--scan-unknown-extensions` option is now set to false by default.
 (which means --skip-unknown-extensions is now the default).
 This is an important change but this will avoid many errors when using
 semgrep in a pre-commit context or in CI.

--- a/cli/tests/e2e/test_check.py
+++ b/cli/tests/e2e/test_check.py
@@ -66,11 +66,13 @@ def test_deduplication(run_semgrep_in_tmp, snapshot):
 def test_noextension_filtering(run_semgrep_in_tmp, snapshot):
     """
     Check that semgrep does not filter out files without extensions when
-    said file is explicitly passed
+    said file is explicitly passed AND when we use --scan-unknown-extensions.
     """
     snapshot.assert_match(
         run_semgrep_in_tmp(
-            "rules/eqeq-python.yaml", target_name="basic/stupid_no_extension"
+            "rules/eqeq-python.yaml",
+            target_name="basic/stupid_no_extension",
+            options=["--scan-unknown-extensions"],
         ).stdout,
         "results.json",
     )
@@ -80,13 +82,13 @@ def test_noextension_filtering(run_semgrep_in_tmp, snapshot):
 def test_noextension_filtering_optimizations(run_semgrep_in_tmp, snapshot):
     """
     Check that semgrep does not filter out files without extensions when
-    said file is explicitly passed
+    said file is explicitly passed AND when we use --scan-unknown-extensions.
     """
     snapshot.assert_match(
         run_semgrep_in_tmp(
             "rules/eqeq-python.yaml",
             target_name="basic/stupid_no_extension",
-            options=["--optimizations", "all"],
+            options=["--scan-unknown-extensions", "--optimizations", "all"],
         ).stdout,
         "results.json",
     )


### PR DESCRIPTION
This is an important UX change.
This might close PA-1932, PA-1949, #6247, #6167

This has bitten us many times. In a pre-commit context,
pre-commit will pass an explicit list of files to semgrep
(the files modified in the PR), and this was causing semgrep
to try for example some Scala rules on some foo.h header files, which does not
make any sense.

This also happened in a semgrep ci context.

test plan:
```
(cli) [pad@thinkstation ~]$ cat targeting.yaml
rules:
- id: test
  patterns:
    - pattern: $FOO
  message: $FOO matched
  languages: [scala]
  severity: WARNING
(cli) [pad@thinkstation ~]$ cat /tmp/foo/foo.h
bla
bla
$XXX
foo ...

(cli) [pad@thinkstation ~]$ semgrep --config targeting.yaml /tmp/foo/foo.h
Nothing to scan.

Ran 1 rule on 0 files: 0 findings.
If Semgrep missed a finding, please send us feedback to let us know!
  $ semgrep shouldafound --help
```

This used to crash because of a parse error on $XXX, but it does not
make any sense to parse foo.h with a Scala parser ...


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)