### PR TITLE
tainting: Track taint coming from params' default values

### DIFF
--- a/changelog.d/gh-6298.added
+++ b/changelog.d/gh-6298.added
@@ -1,4 +1,4 @@
 Taint mode will now track taint coming from the default values of function
-parameters. For example, given `def test3(url = "http://example.com"):`,
-if `"http://example.com"` is a taint source, then `url` will be marked as
-tainted during the analysis of `test3`.
+parameters. For example, given `def test(url = "http://example.com"):`,
+if `"http://example.com"` is a taint source (due to not using TLS), then
+`url` will be marked as tainted during the analysis of `test`.

--- a/changelog.d/gh-6298.added
+++ b/changelog.d/gh-6298.added
@@ -1,0 +1,4 @@
+Taint mode will now track taint coming from the default values of function
+parameters. For example, given `def test3(url = "http://example.com"):`,
+if `"http://example.com"` is a taint source, then `url` will be marked as
+tainted during the analysis of `test3`.

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -496,7 +496,6 @@ let check_fundef lang options taint_config opt_ent fdef =
     Some (D.str_of_name name)
   in
   let add_to_env env id ii pdefault =
-    pr2 (spf "add_to_env %s pdefault?=%b" (fst id) (Option.is_some pdefault));
     let var = AST_to_IL.var_of_id_info id ii in
     let source_pms =
       taint_config.D.is_source (G.Tk (snd id))

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -495,14 +495,22 @@ let check_fundef lang options taint_config opt_ent fdef =
     let* name = AST_to_IL.name_of_entity ent in
     Some (D.str_of_name name)
   in
-  let add_to_env env id ii =
+  let add_to_env env id ii pdefault =
+    pr2 (spf "add_to_env %s pdefault?=%b" (fst id) (Option.is_some pdefault));
     let var = AST_to_IL.var_of_id_info id ii in
-    let taint =
+    let source_pms =
       taint_config.D.is_source (G.Tk (snd id))
+      @
+      match pdefault with
+      | Some e -> taint_config.D.is_source (G.E e)
+      | None -> []
+    in
+    let taints =
+      source_pms
       |> Common.map (fun (x : _ D.tmatch) -> (x.pm, x.spec))
       |> T.taints_of_pms
     in
-    Lval_env.add_var var taint env
+    Lval_env.add_var var taints env
   in
   let in_env =
     (* For each argument, check if it's a source and, if so, add it to the input
@@ -510,7 +518,8 @@ let check_fundef lang options taint_config opt_ent fdef =
     List.fold_left
       (fun env par ->
         match par with
-        | G.Param { pname = Some id; pinfo; _ } -> add_to_env env id pinfo
+        | G.Param { pname = Some id; pinfo; pdefault; _ } ->
+            add_to_env env id pinfo pdefault
         (* JS: {arg} : type *)
         | G.ParamPattern
             (G.OtherPat
@@ -537,7 +546,7 @@ let check_fundef lang options taint_config opt_ent fdef =
                           );
                       _;
                     } ->
-                    add_to_env env id ii
+                    add_to_env env id ii None
                 | G.F _ -> env)
               env fields
         | G.Param { pname = None; _ }
@@ -551,7 +560,10 @@ let check_fundef lang options taint_config opt_ent fdef =
   in
   let _, xs = AST_to_IL.function_definition lang fdef in
   let flow = CFG_build.cfg_of_stmts xs in
-  Dataflow_tainting.fixpoint ~in_env ?name options taint_config flow |> ignore
+  let mapping =
+    Dataflow_tainting.fixpoint ~in_env ?name options taint_config flow
+  in
+  (flow, mapping)
 
 let check_rule (rule : R.taint_rule) match_hook (xconf : Match_env.xconfig)
     (xtarget : Xtarget.t) =
@@ -579,7 +591,10 @@ let check_rule (rule : R.taint_rule) match_hook (xconf : Match_env.xconfig)
   in
 
   (* Check each function definition. *)
-  Visit_function_defs.visit (check_fundef lang xconf.config taint_config) ast;
+  Visit_function_defs.visit
+    (fun opt_ent fdef ->
+      check_fundef lang xconf.config taint_config opt_ent fdef |> ignore)
+    ast;
 
   (* Check the top-level statements.
    * In scripting languages it is not unusual to write code outside

--- a/semgrep-core/src/engine/Match_tainting_mode.mli
+++ b/semgrep-core/src/engine/Match_tainting_mode.mli
@@ -20,6 +20,14 @@ val taint_config_of_rule :
   unit) ->
   Dataflow_tainting.config * debug_taint * Matching_explanation.t list
 
+val check_fundef :
+  Lang.t ->
+  Config_semgrep_t.t ->
+  Dataflow_tainting.config ->
+  AST_generic.entity option ->
+  AST_generic.function_definition ->
+  IL.cfg * Dataflow_tainting.mapping
+
 val check_rule :
   Rule.taint_rule ->
   (string -> Pattern_match.t -> unit) ->

--- a/semgrep-core/src/engine/Match_tainting_mode.mli
+++ b/semgrep-core/src/engine/Match_tainting_mode.mli
@@ -22,11 +22,17 @@ val taint_config_of_rule :
 
 val check_fundef :
   Lang.t ->
-  Config_semgrep_t.t ->
+  Config_semgrep_t.t (** rule options *) ->
   Dataflow_tainting.config ->
-  AST_generic.entity option ->
+  AST_generic.entity option (** entity being analyzed *) ->
   AST_generic.function_definition ->
   IL.cfg * Dataflow_tainting.mapping
+(** Check a function definition using a [Dataflow_tainting.config] (which can
+  * be obtained with [taint_config_of_rule]). Findings are passed on-the-fly
+  * to the [handle_findings] callback in the dataflow config.
+  *
+  * This is a low-level function exposed for debugging purposes (-dfg_tainting).
+  *)
 
 val check_rule :
   Rule.taint_rule ->

--- a/semgrep-core/src/engine/Test_dataflow_tainting.ml
+++ b/semgrep-core/src/engine/Test_dataflow_tainting.ml
@@ -1,6 +1,4 @@
 open Common
-open AST_generic
-module H = AST_generic_helpers
 module G = AST_generic
 module V = Visitor_AST
 module RM = Range_with_metavars
@@ -25,12 +23,11 @@ let pr2_ranges file rwms =
          Common.pr2 (code_text ^ " @l." ^ line_str))
 
 let test_tainting lang file options config def =
-  let xs = AST_to_IL.stmt lang (H.funcbody_to_stmt def.fbody) in
-  let flow = CFG_build.cfg_of_stmts xs in
-
   Common.pr2 "\nDataflow";
   Common.pr2 "--------";
-  let mapping = Dataflow_tainting.fixpoint options config flow in
+  let flow, mapping =
+    Match_tainting_mode.check_fundef lang options config None def
+  in
   let taint_to_str taint =
     let show_taint t =
       match t.Taint.orig with

--- a/semgrep-core/tests/rules/taint_param_default.py
+++ b/semgrep-core/tests/rules/taint_param_default.py
@@ -1,0 +1,52 @@
+# https://github.com/returntocorp/semgrep/issues/6298
+# The minimal test would be test3 or test4, but we include the original
+# example for extra coverage.
+import requests
+
+def test1():
+    session = requests.Session()
+    # ruleid: request-session-with-http
+    session.get("http://example.com")
+
+def test1_ok():
+    session = requests.Session()
+    # ok: request-session-with-http
+    session.get("https://example.com")
+
+def test2():
+    session = requests.Session()
+    url = "http://example.com"
+    # ruleid: request-session-with-http
+    session.post(url)
+
+def test2_ok():
+    session = requests.Session()
+    url = "https://example.com"
+    # ok: request-session-with-http
+    session.post(url)
+
+def test3(url = "http://example.com"):
+    session = requests.Session()
+    # ruleid: request-session-with-http
+    session.delete(url)
+
+def test3_ok(url = "https://example.com"):
+    session = requests.Session()
+    # ok: request-session-with-http
+    session.delete(url)
+
+def test4(url = "http://example.com"):
+    session = requests.Session()
+    # ruleid: request-session-with-http
+    session.request("HEAD", url, timeout=30)
+
+def test4_ok(url = "https://example.com"):
+    session = requests.Session()
+    # ok: request-session-with-http
+    session.request("HEAD", url, timeout=30)
+
+def test_localhost_ok(url = "http://localhost/blah"):
+    session = requests.Session()
+    # ok: request-session-with-http
+    session.request("HEAD", url, timeout=30)
+

--- a/semgrep-core/tests/rules/taint_param_default.yaml
+++ b/semgrep-core/tests/rules/taint_param_default.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: request-session-with-http
+    options:
+      symbolic_propagation: true
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $URL
+          - metavariable-pattern:
+              metavariable: $URL
+              patterns:
+                - pattern-regex: http://
+                - pattern-not-regex: .*://localhost
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: requests.Session(...).$W($SINK, ...)
+              - pattern: requests.Session(...).request($METHOD, $SINK, ...)
+          - focus-metavariable: $SINK
+    fix-regex:
+      regex: "[Hh][Tt][Tt][Pp]://"
+      replacement: https://
+      count: 1
+    message: Detected a request using 'http://'. This request will be unencrypted.
+      Use 'https://' instead.
+    languages:
+      - python
+    severity: WARNING
+


### PR DESCRIPTION
Plus a small refactoring, to make -dfg_tainting use the same code as for running taint rules, otherwise results can differ sometimes.

Closes #6298
Fixes PA-1991

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
