### PR TITLE
chore: Add missing changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - taint-mode: It is now possible for `this` or `this.x` to be a source of taint. (pa-1929)
 - taint-mode: Fixed a bug that made Semgrep miss taint findings when the sink was
   located inside an `if` condition or a `throw` (aka `raise`) expression/statement. (pa-1933)
+- Start to use the AST to render autofixes in some specific cases. As this is extended, autofix will become more correct and more powerful. (ast-autofix)
+- Fixed a parser error in some package-lock.json files (sca-parse-error)
 
 ## [0.115.0](https://github.com/returntocorp/semgrep/releases/tag/v0.115.0) - 2022-09-27
 

--- a/changelog.d/ast-autofix.fix
+++ b/changelog.d/ast-autofix.fix
@@ -1,1 +1,0 @@
-Start to use the AST to render autofixes in some specific cases. As this is extended, autofix will become more correct and more powerful.

--- a/changelog.d/sca-parse-error.fix
+++ b/changelog.d/sca-parse-error.fix
@@ -1,1 +1,0 @@
-Fixed a parser error in some package-lock.json files


### PR DESCRIPTION
Both of these incorrectly had a `.fix` extension instead of `.fixed`, so they were not automatically included. Both belong in the v0.116 release notes. They were originally introduced in
b6b536ee2a83e3956dd61dce0fdd32266bbec6b8 and
0c27680384ae4943bb3007a6feacace11db7423c

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
