### PR TITLE
feat(autofix): Avoid printing entire argument lists

### DIFF
--- a/semgrep-core/src/core/ast/Ugly_print_AST.ml
+++ b/semgrep-core/src/core/ast/Ugly_print_AST.ml
@@ -67,6 +67,9 @@ class type printer_t =
     method print_argument : G.argument -> (Immutable_buffer.t, string) result
     method print_arguments : G.arguments -> (Immutable_buffer.t, string) result
 
+    method print_unbracketed_arguments :
+      G.argument list -> (Immutable_buffer.t, string) result
+
     method print_call :
       G.expr -> G.arguments -> (Immutable_buffer.t, string) result
 
@@ -165,6 +168,7 @@ class base_printer : printer_t =
     method print_expr_kind _ = print_fail ()
     method print_argument _ = print_fail ()
     method print_arguments _ = print_fail ()
+    method print_unbracketed_arguments _ = print_fail ()
 
     method print_call e args =
       match e.G.e with
@@ -198,9 +202,13 @@ class python_printer : printer_t =
     inherit base_printer
 
     method! print_arguments (_b1, args, _b2) =
-      let/ args = map_all self#print_argument args in
+      let/ args = self#print_unbracketed_arguments args in
       (* TODO Consider using original tokens for parens when available? *)
-      Ok (combine [ b "("; combine ~sep:", " args; b ")" ])
+      Ok (combine [ b "("; args; b ")" ])
+
+    method! print_unbracketed_arguments args =
+      let/ args = map_all self#print_argument args in
+      Ok (combine ~sep:", " args)
 
     method! print_argument =
       function

--- a/semgrep-core/src/fixing/Hybrid_print.ml
+++ b/semgrep-core/src/fixing/Hybrid_print.ml
@@ -70,6 +70,10 @@ end = struct
         with_fallback (primary (G.E e))
           (lazy (fallback#print_expr_without_parens e))
 
+      method! print_unbracketed_arguments args =
+        with_fallback (primary (G.Args args))
+          (lazy (fallback#print_unbracketed_arguments args))
+
       (* TODO Fill in more cases as needed. *)
     end
 end

--- a/semgrep-core/src/fixing/tests/Unit_autofix_printer.ml
+++ b/semgrep-core/src/fixing/tests/Unit_autofix_printer.ml
@@ -120,6 +120,12 @@ let test_python_autofix_printer () =
         fix_pattern = "($X + $Y) * 2";
         expected = "((t p t) p p)";
       };
+      {
+        target = "foo(1, 2, 3)";
+        pattern = "foo($...ARGS)";
+        fix_pattern = "bar($...ARGS)";
+        expected = "ppp(ttttttt)";
+      };
     ]
 
 let tests =


### PR DESCRIPTION
As demonstrated by the test, now when an entire argument list is copied via a metavar, we lift the original text for the whole list rather than lifting the text for each individual argument and gluing them together with commas.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
