### PR TITLE
osemgrep: interpolate value($X) in message using propagated value

### DIFF
--- a/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpropagated-constant.yaml-message_interpolationpropagated_constant.py/results.json
+++ b/cli/tests/e2e/snapshots/test_messsage_interpolation/test_message_interpolation/rulesmessage_interpolationpropagated-constant.yaml-message_interpolationpropagated_constant.py/results.json
@@ -75,7 +75,7 @@
       "end": {
         "col": 21,
         "line": 7,
-        "offset": 93
+        "offset": 92
       },
       "extra": {
         "fingerprint": "0x42",
@@ -102,12 +102,12 @@
             "end": {
               "col": 16,
               "line": 7,
-              "offset": 88
+              "offset": 87
             },
             "start": {
               "col": 15,
               "line": 7,
-              "offset": 87
+              "offset": 86
             }
           }
         },
@@ -117,7 +117,7 @@
       "start": {
         "col": 15,
         "line": 7,
-        "offset": 87
+        "offset": 86
       }
     }
   ],

--- a/cli/tests/e2e/targets/message_interpolation/propagated_constant.py
+++ b/cli/tests/e2e/targets/message_interpolation/propagated_constant.py
@@ -1,7 +1,7 @@
 class A():
     def B():
        x = 0
-       return x == 0 
+       return x == 0
 
     def C():
        return 0 == 0

--- a/semgrep-core/src/osemgrep/TOPORT/util.py
+++ b/semgrep-core/src/osemgrep/TOPORT/util.py
@@ -208,20 +208,6 @@ def git_check_output(command: Sequence[str], cwd: Optional[str] = None) -> str:
         )
 
 
-def read_range(fd: TextIOWrapper, start_offset: int, end_offset: int) -> str:
-    """
-    Takes a file descriptor and returns the text between the offsets. Start
-    inclusive, end exclusive.
-
-    It is recommended to open the fd with `open(path, errors="replace"). See
-    https://stackoverflow.com/a/56441652.
-    """
-    # Offsets are start inclusive and end exclusive
-    length = end_offset - start_offset
-    fd.seek(start_offset)
-    return fd.read(length)
-
-
 def get_lines(
     path: Path,
     start_line: int,

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -5,7 +5,7 @@ module RP = Report
 (* Prelude *)
 (*************************************************************************)
 (*
-   Translated from core_runner.py
+   Translated from core_runner.py and core_output.py
 *)
 
 (* python: Don't translate this:
@@ -208,6 +208,8 @@ let invoke_semgrep_core (conf : Scan_CLI.conf) (all_rules : Rule.t list)
   (* TOADAPT
      (* this used to be in Core_CLI.ml but we get a config object
       * later in osemgrep
+      * TODO: Just pass directly a Runner_config.t to invoke_semgrep_core
+      * so can build and adjust the config in the caller
       *)
      let config =
        if config.profile then (
@@ -221,9 +223,8 @@ let invoke_semgrep_core (conf : Scan_CLI.conf) (all_rules : Rule.t list)
    * Run_semgrep.semgrep_with_raw_results_and_exn_handler can accept
    * a list of targets with different languages! We just
    * need to pass the right target object (and not a lang_job)
-   * Martin said the issue was that Run_semgrep.targets_of_config requires
-   * the xlang object to contain a single language.
-   *
+   * TODO: Martin said the issue was that Run_semgrep.targets_of_config
+   * requires the xlang object to contain a single language.
    *)
   let lang_jobs = split_jobs_by_language all_rules all_targets in
   let results_by_language =
@@ -246,6 +247,19 @@ let invoke_semgrep_core (conf : Scan_CLI.conf) (all_rules : Rule.t list)
   let match_results =
     JSON_report.match_results_of_matches_and_errors (Set_.cardinal scanned) res
   in
+
+  (* TOPORT? or move in semgrep-core so get info ASAP
+     if match_results.skipped_targets:
+         for skip in match_results.skipped_targets:
+             if skip.rule_id:
+                 rule_info = f"rule {skip.rule_id}"
+             else:
+                 rule_info = "all rules"
+             logger.verbose(
+                 f"skipped '{skip.path}' [{rule_info}]: {skip.reason}: {skip.details}"
+             )
+  *)
+
   (* TOADAPT:
       match exn with
       | Some e -> Runner_exit.exit_semgrep (Unknown_exception e)


### PR DESCRIPTION
test plan:
```
$ PYTEST_USE_OSEMGREP=true pytest -vv tests/e2e/test_messsage_interpolation.py
8 passed
```
All passed now!

For a total of 59 passed (and 343 failed) 14% pass!


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)