### PR TITLE
ci: Fix autofix-printing-stats job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,15 +71,29 @@ jobs:
   # Run parsing stats and publish them to the semgrep dashboard.
   autofix-printing-stats:
     docker:
-      - image: returntocorp/semgrep-dev:develop
+      # The returntocorp/semgrep-dev:develop image doesn't have OCaml, so
+      # instead we use an OCaml image and install the production version of
+      # Semgrep.
+      #
+      # TODO build a docker image with both OCaml and semgrep-core available.
+      # Perhaps we can adapt our current Dockerfiles to publish an appropriate
+      # image here?
+      - image: ocaml/opam:ubuntu
     steps:
       - checkout
       - run:
           name: autofix printing stats
           no_output_timeout: 60m
           command: |
-            cd autofix-printing-stats
-            ./run --upload
+            sudo apt-get update
+            sudo apt-get install -y python3-pip jq
+            pip3 install semgrep
+            # Put semgrep-core on the path. This is a little bit shady but
+            # apparently the `pip show` output is meant to be machine-parseable
+            # so this output should be stable:
+            # https://github.com/pypa/pip/issues/5261
+            PATH=$PATH:"$(pip3 show semgrep | grep '^Location' | sed -e 's/Location: //')/semgrep/bin"
+            opam exec -- ./autofix-printing-stats/run --upload
 
 ##########################################################################################
 # The workflows
@@ -156,3 +170,13 @@ workflows:
             branches:
               only:
                 - parsing-stats
+
+  # This is for testing or for forcing a stats job. Requires pushing
+  # to a branch named 'autofix-printing-stats'.
+  autofix-printing-stats-on-commit:
+    jobs:
+      - autofix-printing-stats:
+          filters:
+            branches:
+              only:
+                - autofix-printing-stats


### PR DESCRIPTION
The `returntocorp/semgrep-dev:develop` image doesn't have OCaml, so instead we use an OCaml image and install the production version of Semgrep.

I also added a trigger for this job on branch push, which allowed for testing.

I had to do a bit of a hack (documented inline) to get access to the `semgrep-core` binary, but I think it should be alright.

Test plan: https://app.circleci.com/pipelines/github/returntocorp/semgrep/14680/workflows/75c67aa7-6871-40f4-9d1e-6991a24d8c64/jobs/18758

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
