### PR TITLE
fixed: taint labels not being applied to `Dot` offsets

### DIFF
--- a/changelog.d/gh-6355.fixed
+++ b/changelog.d/gh-6355.fixed
@@ -1,1 +1,1 @@
-Taint: Fixed a bug where taint labels were not being correctly applied to findings resulting from dot accesses. For instance, a taint pattern with a `requires` involving `x.y` might ignore the `requires` if the `y` produces a match.
+taint-mode: Fixed a bug in the experimental taint-labels feature that caused labels to be incorrectly applied to dot accesses. For instance, if a pattern-source that requires label A and adds label B matches a dot-access expression like x.a, the field a will get the label B even if it does not carry label A as required.

--- a/changelog.d/gh-6355.fixed
+++ b/changelog.d/gh-6355.fixed
@@ -1,0 +1,1 @@
+Taint: Fixed a bug where taint labels were not being correctly applied to findings resulting from dot accesses. For instance, a taint pattern with a `requires` involving `x.y` might ignore the `requires` if the `y` produces a match.

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -409,9 +409,10 @@ let check_tainted_tok env tok =
   | _ :: _ -> (Taints.empty, env.lval_env)
   | [] ->
       let taints = source_pms |> taints_of_matches in
-      (* Empty because we have no base, but we want to filter the taints we got from
-         the `source_pms`.
-         Otherwise, we might let taints from this token escape a label.
+      (* Empty because we want to filter all the previous taints we got from the
+         `source_pms`, but we have nothing to really union it with.
+         Otherwise, we might let taints from this token escape a label. In particular,
+         this may happen in the `Dot` case.
       *)
       let taints = Taints.empty |> union_taints_filtering_labels ~new_:taints in
       let sinks = sink_pms |> Common.map trace_of_match in

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -409,6 +409,11 @@ let check_tainted_tok env tok =
   | _ :: _ -> (Taints.empty, env.lval_env)
   | [] ->
       let taints = source_pms |> taints_of_matches in
+      (* Empty because we have no base, but we want to filter the taints we got from
+         the `source_pms`.
+         Otherwise, we might let taints from this token escape a label.
+       *)
+      let taints = Taints.empty |> union_taints_filtering_labels ~new_:taints in
       let sinks = sink_pms |> Common.map trace_of_match in
       let findings = findings_of_tainted_sinks env taints sinks in
       report_findings env findings;

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -412,7 +412,7 @@ let check_tainted_tok env tok =
       (* Empty because we have no base, but we want to filter the taints we got from
          the `source_pms`.
          Otherwise, we might let taints from this token escape a label.
-       *)
+      *)
       let taints = Taints.empty |> union_taints_filtering_labels ~new_:taints in
       let sinks = sink_pms |> Common.map trace_of_match in
       let findings = findings_of_tainted_sinks env taints sinks in

--- a/semgrep-core/tests/tainting_rules/go/token_labels.go
+++ b/semgrep-core/tests/tainting_rules/go/token_labels.go
@@ -1,0 +1,8 @@
+// See https://github.com/returntocorp/semgrep/issues/6355 if this breaks.
+// We shouldn't produce a finding because the label should prevent the match. 
+
+func foo() {
+	x := 1 + a.b + 3
+	// ok: go-token-labels 
+	sink(x)
+}

--- a/semgrep-core/tests/tainting_rules/go/token_labels.yaml
+++ b/semgrep-core/tests/tainting_rules/go/token_labels.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: go-token-labels
+    message: A taint label did not prevent the match coming from a tainted token! 
+    severity: ERROR
+    languages:
+      - go
+    mode: taint
+    pattern-sources:
+      - requires: FOO
+        label: BAR
+        pattern: |
+          $A + $B
+    pattern-sinks:
+      - pattern: |
+          sink(...)
+        requires: BAR


### PR DESCRIPTION
## What:
Currently, we are producing findings that should be made impossible due to taint labels. These specifically only occur in the case of them resulting from a `Dot` / `DotAccess`.

## Why:
This is a regular bug that should be fixed. In particular, it was causing erroneous findings on these cases:
https://semgrep.dev/playground/s/JPRQ
https://semgrep.dev/playground/s/RW7N

## How:
We weren't filtering for labels when producing taint from a tainted token, which the `Dot` case was degenerating to. I just added in a filtering step.

Fixes #6355 

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
