### PR TITLE
fix(js): parse specials consistently

### DIFF
--- a/changelog.d/pa-2030.fixed
+++ b/changelog.d/pa-2030.fixed
@@ -1,0 +1,1 @@
+JS/TS: Fixed a parsing bug where special identifiers were parsed differently in patterns

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -1175,7 +1175,7 @@ and primary_expression (env : env) (x : CST.primary_expression) : expr =
           | `Member_exp x -> member_expression env x
           | `Paren_exp x -> parenthesized_expression env x
           | `Choice_unde x -> identifier_ env x
-          | `Choice_decl x -> reserved_identifier env x |> idexp
+          | `Choice_decl x -> reserved_identifier env x |> idexp_or_special
           | `This tok -> this env tok (* "this" *)
           | `Super tok -> super env tok (* "super" *)
           | `Num tok ->


### PR DESCRIPTION
## What:
Special identifiers are parsed inconsistently between the pattern and target in JS.

## Why:
Ty brought up this example in the security research channel: https://semgrep.dev/s/BK7R

Here, `module` is parsed differently in the pattern and AST. We see this via:
```
brandonspark@MacBook-Pro ~/playground> sc -dump_pattern test.js -lang js
E(
  Assign(
    DotAccess(OtherExpr(("Module", ()), []), (),
      FN(
        Id(("exports", ()),
          {id_info_id=1; id_hidden=false; id_resolved=Ref(None);
           id_type=Ref(None); id_svalue=Ref(None); }))), (),
    N(
      Id(("$DATA", ()),
        {id_info_id=2; id_hidden=false; id_resolved=Ref(None);
         id_type=Ref(None); id_svalue=Ref(None); }))))
brandonspark@MacBook-Pro ~/playground> sc -dump_ast test.js -lang js
Pr(
  [ExprStmt(
     Assign(
       DotAccess(
         N(
           Id(("module", ()),
             {id_info_id=1; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })), (),
         FN(
           Id(("exports", ()),
             {id_info_id=2; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }))), (),
       N(
         Id(("$DATA", ()),
           {id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }))), ())])
```

## How:
I changed an `idexp` to an `idexp_or_special` in the corresponding place. We use the Treesitter and pfff parsers for both pattern and target, but in different orders. This means that both parsers need to be kept closely in sync, or they will produce differing trees for both.

I'm unfamiliar with Javascript. I see a whole bunch of `idexp`s in `Parse_typescript_tree_sitter.ml`, but I don't know which ones are safe to change to `idexp_or_special`. I will call on a Javascript expert -- @nmote ?

Also, why is it that we even use both parsers in different orders? I don't remember the reason, but would it be feasible to change one of them to be pfff-before-tree-sitter or tree-sitter-before-pfff? That would make bugs like this impossible.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
