### PR TITLE
Add submodule for semgrep-apex

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -97,3 +97,6 @@
 [submodule "semgrep-core/src/tree-sitter-lang/semgrep-jsonnet"]
 	path = semgrep-core/src/tree-sitter-lang/semgrep-jsonnet
 	url = https://github.com/returntocorp/semgrep-jsonnet.git
+[submodule "semgrep-core/src/tree-sitter-lang/semgrep-apex"]
+	path = semgrep-core/src/tree-sitter-lang/semgrep-apex
+	url = https://github.com/returntocorp/semgrep-apex.git


### PR DESCRIPTION
Note that it's only used in conjunction with semgrep-proprietary. It would be best to keep it there but then we'd have to edit the package name `tree-sitter-lang` in the submodule's dune file which is generated upstream by ocaml-tree-sitter.

Pros:
* simplicity

Cons:
* makes semgrep-core larger than necessary (unless dead code is automatically removed by the compiler/linker, which I doubt)

In the future, we might want to add an option to ocaml-tree-sitter so as to generate a suitable dune file, or some equivalent mechanism such as a dune template that can be instantiated after code generation.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
