### PR TITLE
Use stdcompat so we can compile semgrep with OCaml 4.12.0

### DIFF
--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -105,7 +105,7 @@ type extract_range = {
 }
 
 let count_lines_and_trailing =
-  String.fold_left
+  Stdcompat.String.fold_left
     (fun (n, c) b ->
       match b with
       | '\n' -> (n + 1, 0)
@@ -214,7 +214,9 @@ let map_res map_loc tmpfile file
           file;
           range_loc = Common2.pair map_loc m.range_loc;
           taint_trace =
-            Option.map (Lazy.map_val (map_taint_trace map_loc)) m.taint_trace;
+            Option.map
+              (Stdcompat.Lazy.map_val (map_taint_trace map_loc))
+              m.taint_trace;
         })
       mr.matches
   in

--- a/semgrep-core/src/parsing/Test_parsing.ml
+++ b/semgrep-core/src/parsing/Test_parsing.ml
@@ -50,7 +50,8 @@ let process_exn () =
         match tokens with
         | "Called" :: "from" :: funcname :: _in :: _file :: _filename :: "line"
           :: linenum :: _ ->
-            if String.ends_with ~suffix:"todo" funcname then process rest
+            if Stdcompat.String.ends_with ~suffix:"todo" funcname then
+              process rest
             else funcname ^ ":" ^ linenum
         | _ -> process rest)
   in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -1573,7 +1573,7 @@ and map_field_declaration_type (env : env) (x : CST.field_declaration) : G.type_
       ty
   | `Ellips v1 ->
       let t = token env v1 in
-      TyEllipsis t |> G.t
+      G.TyEllipsis t |> G.t
 
 (* for enum definition (OrConstructor) *)
 and map_field_declaration_list_types (env : env)
@@ -1617,7 +1617,7 @@ and map_field_declaration_union (env : env) (x : CST.field_declaration) :
   | `Ellips v1 ->
       let t = token env v1 in
       (* TODO *)
-      let ty = TyEllipsis t |> G.t in
+      let ty = G.TyEllipsis t |> G.t in
       G.OrUnion (("...", t), ty)
 
 (* for union definition *)
@@ -2919,7 +2919,7 @@ and map_declaration_statement (env : env) x : G.stmt list =
   | `Choice_const_item x -> map_declaration_statement_bis env x
   | `Ellips v1 ->
       let t = token env v1 in
-      [ Ellipsis t |> G.e |> G.exprstmt ]
+      [ G.Ellipsis t |> G.e |> G.exprstmt ]
 
 (* was called map_item_kind by ruin *)
 and map_declaration_statement_bis (env : env) (*_outer_attrs _visibility*) x :


### PR DESCRIPTION
test plan:
opam switch 4.12.0
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)