### PR TITLE
chore(autofix): Debug logging in CLI

### DIFF
--- a/cli/src/semgrep/core_output.py
+++ b/cli/src/semgrep/core_output.py
@@ -158,8 +158,10 @@ def core_matches_to_rule_matches(
         message = interpolate(rule.message, matched_values, propagated_values)
         if match.extra.rendered_fix:
             fix = match.extra.rendered_fix
+            logger.debug(f"Using AST-based autofix rendered in semgrep-core: `{fix}`")
         elif rule.fix:
             fix = interpolate(rule.fix, matched_values, propagated_values)
+            logger.debug(f"Using text-based autofix rendered in cli: `{fix}`")
         else:
             fix = None
         fix_regex = None

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -149,6 +149,7 @@ Running semgrep-core with command:
 <MASKED>
 --- end semgrep-core stderr ---
 skipped 'bar.py' [rule RuleId(value='taint-test')]: SkipReason(value=IrrelevantRule()): No need to perform deeper matching because target does not contain some elements necessary for the rule to match 'taint-test'
+Using AST-based autofix rendered in semgrep-core: `(bar == 2)`
 semgrep ran in <MASKED> on 1 files
 findings summary: 1 error, 0 warning
   Current version has 1 finding.


### PR DESCRIPTION
Now, with the `--debug` flag, the Semgrep CLI will report which autofix rendering strategy was used: AST-based autofix from semgrep-core, or text-based autofix rendered in the CLI. This should help advanced users experimenting with AST-based autofix, and should also help us debug autofix issues when reported by users.

Test plan: Manual test with the `--debug` flag against the example given in #4964. Verify that it is rendered correctly with AST-based autofix and that the debug log reports that fact. Modify `Autofix.ml` to always return `None`, and try again. Observe that the CLI reports that text-based autofix was used, and that the extraneous commas reported in that issue appear in the autofix. Re-run without the `--debug` flag and verify that the message does not appear.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
