### PR TITLE
chore: Show all errors by default in make test

### DIFF
--- a/semgrep-core/Makefile
+++ b/semgrep-core/Makefile
@@ -40,7 +40,7 @@ test: all
 	# in some contexts.
 	# The following command ensures that we can call 'test.exe --help'
 	# without having to chdir into the test data folder.
-	./_build/default/tests/test.exe --help 2>&1 >/dev/null
+	./_build/default/tests/test.exe --show-errors --help 2>&1 >/dev/null
 	$(MAKE) -C src/spacegrep test
 	dune runtest -f --no-buffer
 


### PR DESCRIPTION
Test plan: change two annotations in the tests and run `make test`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
