### PR TITLE
fix(autofix): Handle focus-metavariable matches in AST-based autofix

### DIFF
--- a/changelog.d/focus-metavariable-autofix.fixed
+++ b/changelog.d/focus-metavariable-autofix.fixed
@@ -1,0 +1,1 @@
+Fix an issue preventing AST-based autofix from running in the presence of `focus-metavariable`.

--- a/semgrep-core/src/core/Xlang.ml
+++ b/semgrep-core/src/core/Xlang.ml
@@ -23,6 +23,13 @@ let to_lang (x : t) : Lang.t =
   | LRegex -> failwith (Lang.unsupported_language_message "regex")
   | LGeneric -> failwith (Lang.unsupported_language_message "generic")
 
+let to_langs (x : t) : Lang.t list =
+  match x with
+  | L (lang, langs) -> lang :: langs
+  | LRegex
+  | LGeneric ->
+      []
+
 let lang_of_opt_xlang (x : t option) : Lang.t =
   match x with
   | None -> failwith (Lang.unsupported_language_message "unset")

--- a/semgrep-core/src/core/Xlang.mli
+++ b/semgrep-core/src/core/Xlang.mli
@@ -21,6 +21,9 @@ val of_lang : Lang.t -> t
 (* raises an exception with error message *)
 val to_lang : t -> Lang.t
 
+(* Does not raise, but returns empty list for all but the L variant *)
+val to_langs : t -> Lang.t list
+
 (* raises an exception with error message *)
 val lang_of_opt_xlang : t option -> Lang.t
 

--- a/semgrep-core/src/engine/Range_with_metavars.ml
+++ b/semgrep-core/src/engine/Range_with_metavars.ml
@@ -37,11 +37,14 @@ let (range_to_pattern_match_adjusted : Rule.t -> t -> Pattern_match.t) =
  fun r range ->
   let m = range.origin in
   let rule_id = m.rule_id in
+  let languages = Xlang.to_langs r.Rule.languages in
   (* adjust the rule id *)
   let rule_id =
     {
       rule_id with
       Pattern_match.id = fst r.Rule.id;
+      fix = r.Rule.fix;
+      languages;
       message =
         r.Rule.message (* keep pattern_str which can be useful to debug *);
     }


### PR DESCRIPTION
At the point where we try to render an autofix, the rule that we have when there is a focus-metavariable is the one that has been created by `Match_env.fake_rule_id` called from
`Match_search_mode.apply_focus_on_ranges`. This fake rule ID is later adjusted in `Range_with_metavars.range_to_pattern_match_adjusted`.

I've updated that later adjustment to copy over the fix and the languages, which are both needed for autofix.

Previously, the fix and languages weren't copied over either in the place where the rule ID was created, or when adjusted later. I'm not sure of the history or the broader architecture here, so I'm not sure why we create a rule ID with dummy data and then update it later, rather than just using the correct info to begin with. But, I think that my changes fit in with the existing design. It might be time to update some names, but I don't think I have the context to suggest improvements.

Test plan:

`./autofix-printing-stats/run` --> 96.4% (27/28) for Python, up from 67.9% (19/28)

Manually run the CLI against the python/distributed/security.yaml rule in semgrep-rules, and verify that it performs the fix correctly.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
