### PR TITLE
chore: Append _exn to Xlang functions

### DIFF
--- a/semgrep-core/src/core/Xlang.ml
+++ b/semgrep-core/src/core/Xlang.ml
@@ -17,7 +17,7 @@ exception InternalInvalidLanguage of string (* rule id *) * string (* msg *)
 
 let of_lang (x : Lang.t) = L (x, [])
 
-let to_lang (x : t) : Lang.t =
+let to_lang_exn (x : t) : Lang.t =
   match x with
   | L (lang, _) -> lang
   | LRegex -> failwith (Lang.unsupported_language_message "regex")
@@ -30,10 +30,10 @@ let to_langs (x : t) : Lang.t list =
   | LGeneric ->
       []
 
-let lang_of_opt_xlang (x : t option) : Lang.t =
+let lang_of_opt_xlang_exn (x : t option) : Lang.t =
   match x with
   | None -> failwith (Lang.unsupported_language_message "unset")
-  | Some xlang -> to_lang xlang
+  | Some xlang -> to_lang_exn xlang
 
 let flatten x =
   match x with

--- a/semgrep-core/src/core/Xlang.mli
+++ b/semgrep-core/src/core/Xlang.mli
@@ -19,13 +19,13 @@ exception InternalInvalidLanguage of string (* rule id *) * string (* msg *)
 val of_lang : Lang.t -> t
 
 (* raises an exception with error message *)
-val to_lang : t -> Lang.t
+val to_lang_exn : t -> Lang.t
 
 (* Does not raise, but returns empty list for all but the L variant *)
 val to_langs : t -> Lang.t list
 
 (* raises an exception with error message *)
-val lang_of_opt_xlang : t option -> Lang.t
+val lang_of_opt_xlang_exn : t option -> Lang.t
 
 (*
    Convert an object that represent a pattern's multiple languages into

--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -196,7 +196,7 @@ let dump_pattern (file : Common.filename) =
   let file = Run_semgrep.replace_named_pipe_by_regular_file file in
   let s = Common.read_file file in
   (* mostly copy-paste of parse_pattern in runner, but with better error report *)
-  let lang = Xlang.lang_of_opt_xlang !lang in
+  let lang = Xlang.lang_of_opt_xlang_exn !lang in
   E.try_with_print_exn_and_reraise file (fun () ->
       let any = Parse_pattern.parse_pattern lang ~print_errors:true s in
       let v = Meta_AST.vof_any any in
@@ -391,7 +391,7 @@ let all_actions () =
     ( "-generate_ast_binary",
       " <file> save in file.ast.binary the marshalled generic AST of file",
       Common.mk_action_1_arg (fun file ->
-          generate_ast_binary (Xlang.lang_of_opt_xlang !lang) file) );
+          generate_ast_binary (Xlang.lang_of_opt_xlang_exn !lang) file) );
     ( "-prefilter_of_rules",
       " <file> dump the prefilter regexps of rules in JSON ",
       Common.mk_action_1_arg prefilter_of_rules );
@@ -399,7 +399,7 @@ let all_actions () =
       " <files or dirs> generate parsing statistics (use -json for JSON output)",
       Common.mk_action_n_arg (fun xs ->
           Test_parsing.parsing_stats
-            (Xlang.lang_of_opt_xlang !lang)
+            (Xlang.lang_of_opt_xlang_exn !lang)
             ~json:(!output_format <> Text) ~verbose:true xs) );
     (* the dumpers *)
     ( "-dump_extensions",
@@ -410,13 +410,13 @@ let all_actions () =
       " <file>",
       fun file ->
         Common.mk_action_1_arg
-          (dump_ast ~naming:false (Xlang.lang_of_opt_xlang !lang))
+          (dump_ast ~naming:false (Xlang.lang_of_opt_xlang_exn !lang))
           file );
     ( "-dump_named_ast",
       " <file>",
       fun file ->
         Common.mk_action_1_arg
-          (dump_ast ~naming:true (Xlang.lang_of_opt_xlang !lang))
+          (dump_ast ~naming:true (Xlang.lang_of_opt_xlang_exn !lang))
           file );
     ("-dump_il_all", " <file>", Common.mk_action_1_arg dump_il_all);
     ("-dump_il", " <file>", Common.mk_action_1_arg dump_il);
@@ -431,20 +431,22 @@ let all_actions () =
       " <file> dump the CST obtained from a tree-sitter parser",
       Common.mk_action_1_arg (fun file ->
           let file = Run_semgrep.replace_named_pipe_by_regular_file file in
-          Test_parsing.dump_tree_sitter_cst (Xlang.lang_of_opt_xlang !lang) file)
-    );
+          Test_parsing.dump_tree_sitter_cst
+            (Xlang.lang_of_opt_xlang_exn !lang)
+            file) );
     ( "-dump_tree_sitter_pattern_cst",
       " <file>",
       Common.mk_action_1_arg (fun file ->
           let file = Run_semgrep.replace_named_pipe_by_regular_file file in
           Parse_pattern.dump_tree_sitter_pattern_cst
-            (Xlang.lang_of_opt_xlang !lang)
+            (Xlang.lang_of_opt_xlang_exn !lang)
             file) );
     ( "-dump_pfff_ast",
       " <file> dump the generic AST obtained from a pfff parser",
       Common.mk_action_1_arg (fun file ->
           let file = Run_semgrep.replace_named_pipe_by_regular_file file in
-          Test_parsing.dump_pfff_ast (Xlang.lang_of_opt_xlang !lang) file) );
+          Test_parsing.dump_pfff_ast (Xlang.lang_of_opt_xlang_exn !lang) file)
+    );
     ( "-diff_pfff_tree_sitter",
       " <file>",
       Common.mk_action_n_arg Test_parsing.diff_pfff_tree_sitter );
@@ -470,13 +472,15 @@ let all_actions () =
     ( "-parsing_regressions",
       " <files or dirs> look for parsing regressions",
       Common.mk_action_n_arg (fun xs ->
-          Test_parsing.parsing_regressions (Xlang.lang_of_opt_xlang !lang) xs)
-    );
+          Test_parsing.parsing_regressions
+            (Xlang.lang_of_opt_xlang_exn !lang)
+            xs) );
     ( "-test_parse_tree_sitter",
       " <files or dirs> test tree-sitter parser on target files",
       Common.mk_action_n_arg (fun xs ->
-          Test_parsing.test_parse_tree_sitter (Xlang.lang_of_opt_xlang !lang) xs)
-    );
+          Test_parsing.test_parse_tree_sitter
+            (Xlang.lang_of_opt_xlang_exn !lang)
+            xs) );
     ( "-check_rules",
       " <metachecks file> <files or dirs>",
       Common.mk_action_n_arg (Check_rule.check_files mk_config Parse_rule.parse)

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -889,7 +889,7 @@ let semgrep_with_one_pattern config =
   assert (config.rule_source = None);
 
   (* TODO: support generic and regex patterns as well? See code in Deep. *)
-  let lang = Xlang.lang_of_opt_xlang config.lang in
+  let lang = Xlang.lang_of_opt_xlang_exn config.lang in
   let pattern, pattern_string = pattern_of_config lang config in
 
   match config.output_format with


### PR DESCRIPTION
As suggested in review for #6381.

Test plan: make

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
