### PR TITLE
osemgrep: `fix` JSON output

### DIFF
--- a/semgrep-core/src/osemgrep/cli_scan/Output.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Output.ml
@@ -167,6 +167,13 @@ let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
         | Some s -> interpolate_metavars s metavars path
         | None -> ""
       in
+      let fix =
+        (* TOPORT: debug logging which indicates the source of the fix *)
+        match (x.extra.rendered_fix, rule.fix) with
+        | Some fix, _ -> Some fix
+        | None, Some fix -> Some (interpolate_metavars fix metavars path)
+        | None, None -> None
+      in
       (*  need to prefix with the dotted path of the config file *)
       let check_id = env.config_prefix ^ rule_id in
       let metavars = Some metavars in
@@ -194,7 +201,7 @@ let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
             severity;
             metadata;
             (* TODO: other fields derived from the rule *)
-            fix = None;
+            fix;
             fix_regex = None;
             (* TODO: extra fields *)
             is_ignored = Some false;


### PR DESCRIPTION
Still need to implement modifying files in place and fix_regex.

Test plan:

Manual with the test case in #4964. `osemgrep scan --json -c autofix.yaml autofix.py` has the correct `fix` field. Modifying `Autofix.ml` to always return `None`, I can see that osemgrep reports the incorrect fix from text-based autofix.

`PYTEST_USE_OSEMGREP=true pipenv run python -m pytest -vv tests/e2e`

Before: 73 passed
After: 74 passed

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
