### PR TITLE
Add SARIF support for security-severity

### DIFF
--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -158,7 +158,7 @@ class SarifFormatter(BaseFormatter):
         for tags in rule.metadata.get("tags", []):
             result.append(tags)
 
-        return result
+        return list(set(result))
 
     @staticmethod
     def _semgrep_error_to_sarif_notification(error: SemgrepError) -> Mapping[str, Any]:

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -158,7 +158,7 @@ class SarifFormatter(BaseFormatter):
         for tags in rule.metadata.get("tags", []):
             result.append(tags)
 
-        return list(set(result))
+        return sorted(set(result))
 
     @staticmethod
     def _semgrep_error_to_sarif_notification(error: SemgrepError) -> Mapping[str, Any]:

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -85,19 +85,30 @@ class SarifFormatter(BaseFormatter):
     def _rule_to_sarif(rule: Rule) -> Mapping[str, Any]:
         severity = SarifFormatter._rule_to_sarif_severity(rule)
         tags = SarifFormatter._rule_to_sarif_tags(rule)
-        rule_json = {
-            "id": rule.id,
-            "name": rule.id,
-            "shortDescription": {"text": rule.message},
-            "fullDescription": {"text": rule.message},
-            "defaultConfiguration": {"level": severity},
-            "properties": {"precision": "very-high", "tags": tags},
-        }
-
         security_severity = rule.metadata.get("security-severity")
         if security_severity is not None:
-            rule_json["properties"]["security-severity"] = security_severity
-        
+            rule_json = {
+                "id": rule.id,
+                "name": rule.id,
+                "shortDescription": {"text": rule.message},
+                "fullDescription": {"text": rule.message},
+                "defaultConfiguration": {"level": severity},
+                "properties": {
+                    "precision": "very-high",
+                    "tags": tags,
+                    "security-severity": security_severity,
+                },
+            }
+        else:
+            rule_json = {
+                "id": rule.id,
+                "name": rule.id,
+                "shortDescription": {"text": rule.message},
+                "fullDescription": {"text": rule.message},
+                "defaultConfiguration": {"level": severity},
+                "properties": {"precision": "very-high", "tags": tags},
+            }
+
         rule_url = rule.metadata.get("source")
         if rule_url is not None:
             rule_json["helpUri"] = rule_url

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -94,6 +94,10 @@ class SarifFormatter(BaseFormatter):
             "properties": {"precision": "very-high", "tags": tags},
         }
 
+        security_severity = rule.metadata.get("security-severity")
+        if security_severity is not None:
+            rule_json["properties"]["security-severity"] = security_severity
+        
         rule_url = rule.metadata.get("source")
         if rule_url is not None:
             rule_json["helpUri"] = rule_url
@@ -131,6 +135,7 @@ class SarifFormatter(BaseFormatter):
         if "cwe" in rule.metadata:
             cwe = rule.metadata["cwe"]
             result.extend(cwe if isinstance(cwe, list) else [cwe])
+            result.append("security")
         if "owasp" in rule.metadata:
             owasp = rule.metadata["owasp"]
             result.extend(


### PR DESCRIPTION
This PR includes changes to the `sarif.py` formatter to include a `security-severity` in the output if the property is contained in a given rule's metadata. When the `security-severity` property is present in a given SARIF upload to GitHub, the severities that GitHub will report are low/medium/high/critical rather than note/warning/error. This aligns with other security tools' approach for prioritization, PR checks, etc.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
  - I don't think there are applicable test, as this is only modifying an output formatter
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
