### PR TITLE
refactor(autofix): Refactor fix application logic

### DIFF
--- a/semgrep-core/src/engine/Unit_engine.ml
+++ b/semgrep-core/src/engine/Unit_engine.ml
@@ -251,7 +251,7 @@ let compare_fixes lang ~file matches =
     in
     Common.read_file expected_fixed_file
   in
-  let fixed_text = Autofix.apply_fixes lang matches ~file in
+  let fixed_text = Autofix.apply_fixes_to_file lang matches ~file in
   Alcotest.(check string) "applied autofixes" expected_fixed_text fixed_text
 
 let match_pattern ~lang ~hook ~file ~pattern ~fix_pattern =

--- a/semgrep-core/src/fixing/Autofix.mli
+++ b/semgrep-core/src/fixing/Autofix.mli
@@ -19,4 +19,5 @@ val render_fix :
 (* Apply the fix for the list of matches to the given file, returning the
  * resulting file contents. Currently used only for tests, but with some changes
  * could be used in production as well. *)
-val apply_fixes : Lang.t -> Pattern_match.t list -> file:string -> string
+val apply_fixes_to_file :
+  Lang.t -> Pattern_match.t list -> file:string -> string


### PR DESCRIPTION
This updates the fix application code, which is currently used only in tests, to have pieces which are usable in production. This will be used in the OCaml port of the CLI code in `autofix.py`.

In particular:
- I introduced the `textedit` type, which describes a single change to a file.
- Using `textedit` as an intermediate type, I separated the code that determines what changes to make based on a set of pattern matches from the code that actually applies the changes.
- I updated the code to abort on overlapping fixes to instead discard overlapping fixes, and report to callers which ones were discarded.

Note that instead of tracking changes to files like we do in `autofix.py`, we simply apply fixes starting from the end of the file.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
