### PR TITLE
osemgrep: Port autofix application for `fix`

### DIFF
--- a/semgrep-core/src/fixing/Autofix.mli
+++ b/semgrep-core/src/fixing/Autofix.mli
@@ -16,6 +16,22 @@ val render_fix :
   target_contents:string Lazy.t ->
   string option
 
+type textedit = {
+  path : string;
+  (* 0-based byte index, inclusive *)
+  start : int;
+  (* 0-based byte index, exclusive *)
+  end_ : int;
+  replacement_text : string;
+}
+
+(* Apply a list of edits, modifying the files in place. If dryrun, do everything
+ * but write to the files.
+ *
+ * Returns the list of modified files and the list of edits that were not
+ * applied because they overlapped with others. *)
+val apply_edits : dryrun:bool -> textedit list -> string list * textedit list
+
 (* Apply the fix for the list of matches to the given file, returning the
  * resulting file contents. Currently used only for tests, but with some changes
  * could be used in production as well. *)

--- a/semgrep-core/src/osemgrep/TOPORT/autofix.py
+++ b/semgrep-core/src/osemgrep/TOPORT/autofix.py
@@ -64,36 +64,6 @@ def _get_match_context(
     return start_line, start_col, end_line, end_col
 
 
-def _basic_fix(
-    rule_match: RuleMatch, file_offsets: FileOffsets, fix: str
-) -> Tuple[Fix, FileOffsets]:
-
-    p = rule_match.path
-    lines = _get_lines(p)
-
-    # get the start and end points
-    start_line, start_col, end_line, end_col = _get_match_context(
-        rule_match, file_offsets
-    )
-
-    # break into before, to modify, after
-    before_lines = lines[:start_line]
-    before_on_start_line = lines[start_line][:start_col]
-    after_on_end_line = lines[end_line][end_col:]  # next char after end of match
-    modified_lines = (before_on_start_line + fix + after_on_end_line).splitlines()
-    after_lines = lines[end_line + 1 :]  # next line after end of match
-    contents_after_fix = before_lines + modified_lines + after_lines
-
-    # update offsets
-    file_offsets.line_offset = (
-        len(contents_after_fix) - len(lines) + file_offsets.line_offset
-    )
-    if start_line == end_line:
-        file_offsets.col_offset = len(fix) - (end_col - start_col)
-
-    return Fix(SPLIT_CHAR.join(contents_after_fix), modified_lines), file_offsets
-
-
 def _regex_replace(
     rule_match: RuleMatch,
     file_offsets: FileOffsets,

--- a/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
+++ b/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
@@ -272,16 +272,6 @@ def scan_options(func: Callable) -> Callable:
 @optgroup.group("Configuration options", cls=MutuallyExclusiveOptionGroup)
 
 @click.option(
-    "--dryrun/--no-dryrun",
-    is_flag=True,
-    default=False,
-    help="""
-        If --dryrun, does not write autofixes to a file. This will print the changes
-        to the console. This lets you see the changes before you commit to them. Only
-        works with the --autofix flag. Otherwise does nothing.
-    """,
-)
-@click.option(
     "--severity",
     multiple=True,
     type=click.Choice(["INFO", "WARNING", "ERROR"]),

--- a/semgrep-core/src/osemgrep/TOPORT/util.py
+++ b/semgrep-core/src/osemgrep/TOPORT/util.py
@@ -156,15 +156,6 @@ def flatten(some_list: List[List[T]]) -> List[T]:
 PathFilterCallable = Callable[..., FrozenSet[Path]]
 
 
-def unit_str(count: int, unit: str, pad: bool = False) -> str:
-    if count != 1:
-        unit += "s"
-    elif pad:
-        unit += " "
-
-    return f"{count} {unit}"
-
-
 def git_check_output(command: Sequence[str], cwd: Optional[str] = None) -> str:
     """
     Helper function to run a GIT command that prints out helpful debugging information

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -154,6 +154,7 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
    (* TOPORT: not handled yet *)
    logging_level = _;
    autofix = _;
+   dryrun = _;
    baseline_commit = _;
    exclude = _;
    include_ = _;

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -7,6 +7,7 @@
 *)
 type conf = {
   autofix : bool;
+  dryrun : bool;
   baseline_commit : string option;
   config : string;
   exclude : string list;

--- a/semgrep-core/src/utils/String_utils.ml
+++ b/semgrep-core/src/utils/String_utils.ml
@@ -1,0 +1,5 @@
+open Common
+
+let unit_str ?(pad = false) count str =
+  let str = if count <> 1 then str ^ "s" else if pad then str ^ " " else str in
+  spf "%d %s" count str


### PR DESCRIPTION
This isn't an exact port of the relevant code in `autofix.py`. I already had some autofix application code in `Autofix.ml` for testing purposes. In #6391 I refactored it to make it usable in this context.

Several differences:
- Instead of tracking details about applied fixes so that we can correctly apply multiple fixes to the same file, we just apply them from bottom to top so that they can't interfere with each other.
- We discard overlapping fixes and apply the ones that we can apply without conflicts. I think the Python CLI just applies them anyway, possibly incorrectly. However, the Python CLI also dedups matches that are the same except for metavariable bindings, which eliminates a major source of overlapping fixes. This logic is not ported yet.
- Here, we apply fixes using the byte offset into the file, instead of reading the file, splitting into lines, and then updating using the line and column like the CLI does. This is a lot simpler.
- When the `--dryrun` flag is passed, the Python CLI reports a list of fixed lines in its JSON output. This hasn't been ported yet, and in fact using the byte offset (see above) will make this a little bit more complicated.

Test plan:

Manual testing with the example given in #4964:

`osemgrep scan -c autofix.yaml autofix.py --autofix`

Note that this is an example where there are multiple matches reported for the same range, due to different possible metavariable bindings. For overlapping ranges, osemgrep applies the first one in the list that semgrep-core returns, just like the Python CLI. So, in this example it applies the same fix as the CLI.

Also, ran the e2e tests:

`PYTEST_USE_OSEMGREP=true pipenv run python -m pytest tests/e2e`

Before: 77 passed

After: 83 passed

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
