### PR TITLE
osemgrep: Use Common.filename in lines_of_file

### DIFF
--- a/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.mli
@@ -3,5 +3,5 @@ val cli_output_of_core_results :
 
 val lines_of_file :
   Semgrep_output_v0_j.position * Semgrep_output_v0_j.position ->
-  string ->
+  Common.filename ->
   string list


### PR DESCRIPTION
Requested in #6392

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
