### PR TITLE
refactor: Extract textedit code

### DIFF
--- a/semgrep-core/src/fixing/Autofix.ml
+++ b/semgrep-core/src/fixing/Autofix.ml
@@ -42,80 +42,6 @@ let validate_fix lang text =
         (spf "Rendered autofix does not parse. Aborting: `%s`:\n%s" text
            (Exception.to_string e))
 
-type textedit = {
-  path : Common.filename;
-  (* 0-based byte index, inclusive *)
-  start : int;
-  (* 0-based byte index, exclusive *)
-  end_ : int;
-  replacement_text : string;
-}
-
-let remove_overlapping_edits edits =
-  let rec f edits discarded_edits = function
-    | e1 :: e2 :: tl ->
-        if e1.end_ > e2.start then
-          let discarded_edits = e2 :: discarded_edits in
-          f edits discarded_edits (e1 :: tl)
-        else
-          let edits = e1 :: edits in
-          f edits discarded_edits (e2 :: tl)
-    | [ edit ] ->
-        let edits = edit :: edits in
-        (List.rev edits, List.rev discarded_edits)
-    | [] -> (List.rev edits, List.rev discarded_edits)
-  in
-  f [] [] edits
-
-type edit_application_result =
-  | Success of string
-  | Overlap of {
-      partial_result : string;
-      (* nonempty *)
-      discarded_edits : textedit list;
-    }
-
-let apply_edits_to_text text edits =
-  let edits = List.sort (fun e1 e2 -> e1.start - e2.start) edits in
-  let edits, discarded_edits = remove_overlapping_edits edits in
-  (* Switch to bottom to top order so that we don't need to track offsets as
-   * we apply multiple patches *)
-  let edits = List.rev edits in
-  let fixed_text =
-    (* Apply the fixes. These string operations are inefficient but should
-     * be fine. The Python CLI version of this code is even more inefficent. *)
-    List.fold_left
-      (fun file_text { start; end_; replacement_text; _ } ->
-        let before = Str.first_chars file_text start in
-        let after = Str.string_after file_text end_ in
-        before ^ replacement_text ^ after)
-      text edits
-  in
-  if discarded_edits = [] then Success fixed_text
-  else Overlap { partial_result = fixed_text; discarded_edits }
-
-let partition_edits_by_file edits =
-  (* TODO Consider using Common.group_by if we update it to return edits in
-   * order and add a comment specifying that changes to it must maintain that
-   * behavior. *)
-  let edits_by_file = Hashtbl.create 8 in
-  List.iter
-    (fun edit ->
-      let prev =
-        match Hashtbl.find_opt edits_by_file edit.path with
-        | Some lst -> lst
-        | None -> []
-      in
-      Hashtbl.replace edits_by_file edit.path (edit :: prev))
-    edits;
-  (* Restore the original order of the edits as they appeared in the input list.
-   * This is important so that we consistently choose to apply the first edit in
-   * the original input when there are edits for an identical span. *)
-  Hashtbl.filter_map_inplace
-    (fun _file edits -> Some (List.rev edits))
-    edits_by_file;
-  edits_by_file
-
 (******************************************************************************)
 (* Entry Points *)
 (******************************************************************************)
@@ -179,26 +105,6 @@ let render_fix lang metavars ~fix_pattern ~target_contents =
       |> List.iter (fun line -> logger#info "%s" line);
       None
 
-let apply_edits ~dryrun edits =
-  let edits_by_file = partition_edits_by_file edits in
-  let all_discarded_edits = ref [] in
-  Hashtbl.iter
-    (fun file file_edits ->
-      let file_text = Common.read_file file in
-      let new_text =
-        match apply_edits_to_text file_text file_edits with
-        | Success x -> x
-        | Overlap { partial_result; discarded_edits } ->
-            Common.push discarded_edits all_discarded_edits;
-            partial_result
-      in
-      (* TOPORT: when dryrun, report fixed lines *)
-      if not dryrun then Common.write_file ~file new_text)
-    edits_by_file;
-  let modified_files = Hashtbl.to_seq_keys edits_by_file |> List.of_seq in
-  let discarded_edits = List.concat !all_discarded_edits in
-  (modified_files, discarded_edits)
-
 (* Apply the fix for the list of matches to the given file, returning the
  * resulting file contents. Currently used only for tests, but with some changes
  * could be used in production as well. *)
@@ -219,12 +125,12 @@ let apply_fixes_to_file lang matches ~file =
             ~target_contents:(lazy file_text)
         with
         | Some replacement_text ->
-            { path = file; start; end_; replacement_text }
+            { Textedit.path = file; start; end_; replacement_text }
         (* TODO option rather than exception if used in production *)
         | None -> failwith (spf "could not render fix for %s" file))
       matches
   in
-  match apply_edits_to_text file_text edits with
+  match Textedit.apply_edits_to_text file_text edits with
   | Success x -> x
   | Overlap { discarded_edits; _ } ->
       failwith

--- a/semgrep-core/src/fixing/Autofix.mli
+++ b/semgrep-core/src/fixing/Autofix.mli
@@ -16,22 +16,6 @@ val render_fix :
   target_contents:string Lazy.t ->
   string option
 
-type textedit = {
-  path : string;
-  (* 0-based byte index, inclusive *)
-  start : int;
-  (* 0-based byte index, exclusive *)
-  end_ : int;
-  replacement_text : string;
-}
-
-(* Apply a list of edits, modifying the files in place. If dryrun, do everything
- * but write to the files.
- *
- * Returns the list of modified files and the list of edits that were not
- * applied because they overlapped with others. *)
-val apply_edits : dryrun:bool -> textedit list -> string list * textedit list
-
 (* Apply the fix for the list of matches to the given file, returning the
  * resulting file contents. Currently used only for tests, but with some changes
  * could be used in production as well. *)

--- a/semgrep-core/src/osemgrep/cli_scan/Output.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Output.ml
@@ -15,17 +15,17 @@ module Out = Semgrep_output_v0_j
 
 let apply_fixes (conf : Scan_CLI.conf) (cli_output : Out.cli_output) =
   (* TODO fix_regex *)
-  let edits : Autofix.textedit list =
+  let edits : Textedit.t list =
     List.filter_map
       (fun (result : Out.cli_match) ->
         let path = result.Out.path in
         let* fix = result.Out.extra.fix in
         let start = result.Out.start.offset in
         let end_ = result.Out.end_.offset in
-        Some Autofix.{ path; start; end_; replacement_text = fix })
+        Some Textedit.{ path; start; end_; replacement_text = fix })
       cli_output.results
   in
-  Autofix.apply_edits ~dryrun:conf.dryrun edits
+  Textedit.apply_edits ~dryrun:conf.dryrun edits
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/utils/Textedit.ml
+++ b/semgrep-core/src/utils/Textedit.ml
@@ -1,0 +1,110 @@
+(* Nat Mote
+ *
+ * Copyright (C) 2019-2022 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+
+(* This module represents and applies edits to text *)
+
+type t = {
+  path : Common.filename;
+  (* 0-based byte index, inclusive *)
+  start : int;
+  (* 0-based byte index, exclusive *)
+  end_ : int;
+  replacement_text : string;
+}
+
+type edit_application_result =
+  | Success of string
+  | Overlap of {
+      partial_result : string;
+      (* nonempty *)
+      discarded_edits : t list;
+    }
+
+let remove_overlapping_edits edits =
+  let rec f edits discarded_edits = function
+    | e1 :: e2 :: tl ->
+        if e1.end_ > e2.start then
+          let discarded_edits = e2 :: discarded_edits in
+          f edits discarded_edits (e1 :: tl)
+        else
+          let edits = e1 :: edits in
+          f edits discarded_edits (e2 :: tl)
+    | [ edit ] ->
+        let edits = edit :: edits in
+        (List.rev edits, List.rev discarded_edits)
+    | [] -> (List.rev edits, List.rev discarded_edits)
+  in
+  f [] [] edits
+
+let apply_edits_to_text text edits =
+  let edits = List.sort (fun e1 e2 -> e1.start - e2.start) edits in
+  let edits, discarded_edits = remove_overlapping_edits edits in
+  (* Switch to bottom to top order so that we don't need to track offsets as
+   * we apply multiple patches *)
+  let edits = List.rev edits in
+  let fixed_text =
+    (* Apply the fixes. These string operations are inefficient but should
+     * be fine. The Python CLI version of this code is even more inefficent. *)
+    List.fold_left
+      (fun file_text { start; end_; replacement_text; _ } ->
+        let before = Str.first_chars file_text start in
+        let after = Str.string_after file_text end_ in
+        before ^ replacement_text ^ after)
+      text edits
+  in
+  if discarded_edits = [] then Success fixed_text
+  else Overlap { partial_result = fixed_text; discarded_edits }
+
+let partition_edits_by_file edits =
+  (* TODO Consider using Common.group_by if we update it to return edits in
+   * order and add a comment specifying that changes to it must maintain that
+   * behavior. *)
+  let edits_by_file = Hashtbl.create 8 in
+  List.iter
+    (fun edit ->
+      let prev =
+        match Hashtbl.find_opt edits_by_file edit.path with
+        | Some lst -> lst
+        | None -> []
+      in
+      Hashtbl.replace edits_by_file edit.path (edit :: prev))
+    edits;
+  (* Restore the original order of the edits as they appeared in the input list.
+   * This is important so that we consistently choose to apply the first edit in
+   * the original input when there are edits for an identical span. *)
+  Hashtbl.filter_map_inplace
+    (fun _file edits -> Some (List.rev edits))
+    edits_by_file;
+  edits_by_file
+
+let apply_edits ~dryrun edits =
+  let edits_by_file = partition_edits_by_file edits in
+  let all_discarded_edits = ref [] in
+  Hashtbl.iter
+    (fun file file_edits ->
+      let file_text = Common.read_file file in
+      let new_text =
+        match apply_edits_to_text file_text file_edits with
+        | Success x -> x
+        | Overlap { partial_result; discarded_edits } ->
+            Common.push discarded_edits all_discarded_edits;
+            partial_result
+      in
+      (* TOPORT: when dryrun, report fixed lines *)
+      if not dryrun then Common.write_file ~file new_text)
+    edits_by_file;
+  let modified_files = Hashtbl.to_seq_keys edits_by_file |> List.of_seq in
+  let discarded_edits = List.concat !all_discarded_edits in
+  (modified_files, discarded_edits)

--- a/semgrep-core/src/utils/Textedit.mli
+++ b/semgrep-core/src/utils/Textedit.mli
@@ -1,0 +1,26 @@
+type t = {
+  path : Common.filename;
+  (* 0-based byte index, inclusive *)
+  start : int;
+  (* 0-based byte index, exclusive *)
+  end_ : int;
+  replacement_text : string;
+}
+
+type edit_application_result =
+  | Success of string
+  | Overlap of {
+      partial_result : string;
+      (* nonempty *)
+      discarded_edits : t list;
+    }
+
+(* Apply a list of edits, modifying the files in place. If dryrun, do everything
+ * but write to the files.
+ *
+ * Returns the list of modified files and the list of edits that were not
+ * applied because they overlapped with others. *)
+val apply_edits : dryrun:bool -> t list -> string list * t list
+
+(* Applies the edits to the given text and returns the result. Pure function. *)
+val apply_edits_to_text : string -> t list -> edit_application_result


### PR DESCRIPTION
None of this is specific to autofix. It could be useful to have it available for other purposes.

Test plan: make

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
