### PR TITLE
Deduplicate 'create-tag' step ID in start-release workflow.

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -221,14 +221,14 @@ jobs:
           ref: "${{ needs.release-setup.outputs.release-branch }}"
           token: "${{ steps.token.outputs.token }}"
       - name: Create semgrep release version tag
-        id: create-tag
+        id: create-semgrep-tag
         run: |
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git tag -a -m "Release ${{ needs.release-setup.outputs.version }}" "v${{ needs.release-setup.outputs.version }}"
           git push origin "v${{ needs.release-setup.outputs.version }}"
       - name: Create semgrep-interfaces release version tag
-        id: create-tag
+        id: create-interfaces-tag
         run: |
           cd cli/src/semgrep/semgrep_interfaces
           git tag -a -m "Release ${{ needs.release-setup.outputs.version }}" "v${{ needs.release-setup.outputs.version }}"


### PR DESCRIPTION
This is in response to this failure: https://github.com/returntocorp/semgrep/actions/runs/3333367837

> [Invalid workflow file: .github/workflows/start-release.yml#L231](https://github.com/returntocorp/semgrep/actions/runs/3333367837/workflow)
The workflow is not valid. .github/workflows/start-release.yml (Line: 231, Col: 13): The identifier 'create-tag' may not be used more than once within the same scope.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
