### PR TITLE
feat: Fail early on bad version ranges in supply chain rules

### DIFF
--- a/changelog.d/ssc-fail-early.added
+++ b/changelog.d/ssc-fail-early.added
@@ -1,0 +1,1 @@
+Fail immediately if semgrep tries to run a supply chain rule with an invalid version range specifier

--- a/cli/src/semgrep/dependency_aware_rule.py
+++ b/cli/src/semgrep/dependency_aware_rule.py
@@ -5,6 +5,9 @@ from typing import List
 from typing import Set
 from typing import Tuple
 
+from packaging.specifiers import InvalidSpecifier
+from packaging.specifiers import SpecifierSet
+
 import semgrep.output_from_core as core
 from semdep.find_lockfiles import find_single_lockfile
 from semdep.package_restrictions import dependencies_range_match_any
@@ -40,6 +43,11 @@ def parse_depends_on_yaml(entries: List[Dict[str, str]]) -> Iterator[DependencyP
         semver_range = entry.get("version")
         if semver_range is None:
             raise SemgrepError(f"project-depends-on is missing `version`")
+        try:
+            SpecifierSet(semver_range)
+        except InvalidSpecifier:
+            raise SemgrepError(f"invalid semver range {semver_range}")
+
         yield DependencyPattern(
             ecosystem=ecosystem, package=package, semver_range=semver_range
         )


### PR DESCRIPTION
Currently we won't fail on a rule with a bad version range unless we find a lockfile with the correct ecosystem and package name for the rule. This PR updates things so we will fail as soon as we try to read the rule.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
