### PR TITLE
Make it possible to turn off skipping minimized files

### DIFF
--- a/semgrep-core/src/configuring/Flag_semgrep.ml
+++ b/semgrep-core/src/configuring/Flag_semgrep.ml
@@ -54,6 +54,9 @@ let max_cache = ref false
 (* Maximum size of a single target file, in bytes (exceptions apply). *)
 let max_target_bytes = ref 5_000_000
 
+(* Whether or not to skip files believed to be minified. *)
+let skip_minified_files = ref true
+
 (* Disabling this lets us measure the effectiveness of our GC tuning. *)
 let gc_tuning = ref true
 

--- a/semgrep-core/src/targeting/Skip_target.ml
+++ b/semgrep-core/src/targeting/Skip_target.ml
@@ -23,6 +23,13 @@ module Resp = Output_from_core_t
      than 500 bytes at the same time.
    - only some really short source files (2-3 lines) were found to have
      between 5% and 8% whitespace.
+
+  However, this threshold works less well for java files because it is not
+  unusual to have large import blocks at the top, resulting in a very low
+  whitespace fraction. This should not affect very many Java files, so for
+  now it is ok that we leave it. The consequence of reducing the frequency
+  is that Semgrep would likely take longer as it scans more costly minified
+  files. TODO we might want to do some benchmarking and change this default
 *)
 let min_whitespace_frequency = 0.07
 
@@ -72,6 +79,8 @@ let whitespace_stat_of_block ?block_size path =
   whitespace_stat_of_string s
 
 let is_minified path =
+  if not !Flag_semgrep.skip_minified_files then Ok path
+  else
   let stat = whitespace_stat_of_block ~block_size:4096 path in
   (*
      A small file could contain a long URL with no whitespace without being

--- a/semgrep-core/src/targeting/Skip_target.ml
+++ b/semgrep-core/src/targeting/Skip_target.ml
@@ -81,37 +81,38 @@ let whitespace_stat_of_block ?block_size path =
 let is_minified path =
   if not !Flag_semgrep.skip_minified_files then Ok path
   else
-  let stat = whitespace_stat_of_block ~block_size:4096 path in
-  (*
+    let stat = whitespace_stat_of_block ~block_size:4096 path in
+    (*
      A small file could contain a long URL with no whitespace without being
      minified. That's why we require a minimum file size.
   *)
-  if stat.sample_size > 1000 then
-    if stat.ws_freq < min_whitespace_frequency then
-      Error
-        {
-          Resp.path;
-          reason = Minified;
-          details =
-            spf "file contains too little whitespace: %.3f%% (min = %.1f%%)"
-              (100. *. stat.ws_freq)
-              (100. *. min_whitespace_frequency);
-          rule_id = None;
-        }
-    else if stat.line_freq < min_line_frequency then
-      Error
-        {
-          Resp.path;
-          reason = Minified;
-          details =
-            spf
-              "file contains too few lines for its size: %.4f%% (min = %.2f%%)"
-              (100. *. stat.line_freq)
-              (100. *. min_line_frequency);
-          rule_id = None;
-        }
+    if stat.sample_size > 1000 then
+      if stat.ws_freq < min_whitespace_frequency then
+        Error
+          {
+            Resp.path;
+            reason = Minified;
+            details =
+              spf "file contains too little whitespace: %.3f%% (min = %.1f%%)"
+                (100. *. stat.ws_freq)
+                (100. *. min_whitespace_frequency);
+            rule_id = None;
+          }
+      else if stat.line_freq < min_line_frequency then
+        Error
+          {
+            Resp.path;
+            reason = Minified;
+            details =
+              spf
+                "file contains too few lines for its size: %.4f%% (min = \
+                 %.2f%%)"
+                (100. *. stat.line_freq)
+                (100. *. min_line_frequency);
+            rule_id = None;
+          }
+      else Ok path
     else Ok path
-  else Ok path
 
 let exclude_minified_files paths = Common.partition_result is_minified paths
 


### PR DESCRIPTION
See https://github.com/returntocorp/semgrep-proprietary/pull/328

This helps DeepSemgrep. I could instead have added an option to tune the amount of whitespace, but for now I wanted to err on the side of skipping fewer files, since performance is not a priority for DeepSemgrep. We can revisit this later.

Test plan: see the DeepSemgrep PR; nothing should change for Semgrep users

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
