### PR TITLE
fix(autofix): Verify fixes by applying and parsing entire file

### DIFF
--- a/semgrep-core/src/parsing/Parse_target.mli
+++ b/semgrep-core/src/parsing/Parse_target.mli
@@ -14,8 +14,6 @@ type parsing_result = {
  * (e.g. Parse_info.Pasing_error).
  *)
 val parse_and_resolve_name : Lang.t -> Common.filename -> parsing_result
-
-(* used only for testing purpose *)
 val just_parse_with_lang : Lang.t -> Common.filename -> parsing_result
 val parse_program : Common.filename -> AST_generic.program
 

--- a/semgrep-core/src/utils/Textedit.ml
+++ b/semgrep-core/src/utils/Textedit.ml
@@ -48,6 +48,11 @@ let remove_overlapping_edits edits =
   in
   f [] [] edits
 
+let apply_edit_to_text text { start; end_; replacement_text; _ } =
+  let before = Str.first_chars text start in
+  let after = Str.string_after text end_ in
+  before ^ replacement_text ^ after
+
 let apply_edits_to_text text edits =
   let edits = List.sort (fun e1 e2 -> e1.start - e2.start) edits in
   let edits, discarded_edits = remove_overlapping_edits edits in
@@ -58,10 +63,7 @@ let apply_edits_to_text text edits =
     (* Apply the fixes. These string operations are inefficient but should
      * be fine. The Python CLI version of this code is even more inefficent. *)
     List.fold_left
-      (fun file_text { start; end_; replacement_text; _ } ->
-        let before = Str.first_chars file_text start in
-        let after = Str.string_after file_text end_ in
-        before ^ replacement_text ^ after)
+      (fun file_text edit -> apply_edit_to_text file_text edit)
       text edits
   in
   if discarded_edits = [] then Success fixed_text

--- a/semgrep-core/src/utils/Textedit.mli
+++ b/semgrep-core/src/utils/Textedit.mli
@@ -24,3 +24,7 @@ val apply_edits : dryrun:bool -> t list -> string list * t list
 
 (* Applies the edits to the given text and returns the result. Pure function. *)
 val apply_edits_to_text : string -> t list -> edit_application_result
+
+(* Applies the edit to the given text and returns the resulting string. Pure
+ * function. *)
+val apply_edit_to_text : string -> t -> string


### PR DESCRIPTION
The previous validation step parsed the rendered fix itself as a pattern. This had two main drawbacks:
- It does not verify that the fix, as rendered, is valid in the context where it will be applied.
- It allowed Semgrep extensions such as ellipsis and metavariables, and would not fail if those crept in to the fix (though depending on the parser, it still might not)

Currently, if this validation step fails, we still fall back on the CLI's text-based autofix. However, the textual autofix may also synthesize incorrect code. At some point we will likely want to move this step after textual autofix is rendered, and perhaps after all autofixes for a particular file have been applied. However, that's currently done in Python, so there's no feasible way to call back into semgrep-core for this check. It will be trivial with osemgrep.

Test plan:

Existing automated tests, plus the manual tests below. Our automated test framework doesn't like files with syntax errors, so this would be difficult to add an automated test for. Plus, it's fairly simple code and not likely to change very often.

`semgrep-core -l py -rules broken.yaml broken.py -json_nodots -debug`

broken.yaml:

```
rules:
- id: test
  pattern: foo($X)
  message: test
  languages: [python]
  severity: WARNING
  fix: bar($X)
```

broken.py:

```
<<<

f(1);

foo(1);
```

Verify that `semgrep-core` provides a `rendered_fix` of `bar(1)`.

Then, using that same example, modify `Autofix.ml` to append a `)` to every autofix, before the validation phase. Observe these log items, and observe that no `rendered_fix` appears in the output:

```
[0.022  Info       Main.Autofix         ] Failed to render fix `bar($X)`:
[0.022  Info       Main.Autofix         ] Rendered autofix does not parse. Aborting: `bar(1))`:
[0.022  Info       Main.Autofix         ] More partial parse failures after autofix application
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
