### PR TITLE
fix(autofix): Handle unexpected exceptions

### DIFF
--- a/changelog.d/autofix-exception.fixed
+++ b/changelog.d/autofix-exception.fixed
@@ -1,0 +1,1 @@
+Handle unexpected exceptions when performing AST-based autofix.


### PR DESCRIPTION
Unexpected exceptions while rendering an autofix shouldn't bring down the whole semgrep-core process. This was inspired by the particular case given below. I'll address the root cause of that issue in a separate PR, but it made me want to limit the damage that problems with the autofix code can do.

Test plan:

```
rules:
- id: test
  message: test
  languages: [js]
  severity: ERROR
  pattern: foo()
  fix: |
    foo({x: true})
```

```
foo();
```

`semgrep-core -l js -json_nodots -debug -rules crash.yaml crash.js`

Before, this crashed. Now, it returns normally with the debug info below, although without including a rendered autofix in the output.

```
[0.018  Info       Main.Autofix         ] Failed to render fix `foo({x: true})
[0.018  Info       Main.Autofix         ] `:
[0.018  Info       Main.Autofix         ] Unexpected error while rendering autofix:
[0.018  Info       Main.Autofix         ] (Failure "Call AST_utils.with_xxx_equal to avoid this error.")
[0.018  Info       Main.Autofix         ] Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
[0.018  Info       Main.Autofix         ] Called from AST_generic.equal_stmt.(fun) in file "src/core/ast/AST_generic.ml", line 915, characters 2-91
...
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
