### PR TITLE
ruby: Fix translation of foo[bar]

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ruby_tree_sitter.ml
@@ -1530,8 +1530,13 @@ and lhs (env : env) (x : CST.lhs) : AST.expr =
         | None -> []
       in
       let v4 = token2 env v4 in
-      let e = DotAccess (v1, v2, MethodOperator (Op_AREF, v4)) in
-      Call (e, fb v3, None)
+      let e =
+        (* THINK: Why do we need a DotAccess here rather than just `v1' ?
+         *   And why a Call rather than an ArrayAccess ?
+         *)
+        DotAccess (v1, v2, MethodOperator (Op_AREF, v2))
+      in
+      Call (e, (v2, v3, v4), None)
   | `Call x -> call env x
   | `Call_ x -> call_ env x
 

--- a/semgrep-core/tests/rules/taint_ruby_hash_elem_ref.rb
+++ b/semgrep-core/tests/rules/taint_ruby_hash_elem_ref.rb
@@ -1,0 +1,9 @@
+class Test
+
+  def update
+    sort = order_clause_bad(params[:sort_by])
+    #OK: test
+    all_user = User.where("id = '#{params[:user][:id]}'").order(sort)
+  end
+
+end

--- a/semgrep-core/tests/rules/taint_ruby_hash_elem_ref.yaml
+++ b/semgrep-core/tests/rules/taint_ruby_hash_elem_ref.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: test
+  message: Found a `params[...]` value passed to a string literal.
+  languages: [ruby]
+  severity: WARNING
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        params[:sort_by]
+  pattern-sinks:
+    - patterns:
+      - focus-metavariable: $X
+      - pattern-inside: | 
+          "...#{$X}..."


### PR DESCRIPTION
It was translated as `foo.](bar)`, where `foo.]` had the same range as `foo[bar]` itself. This caused problems with taint-mode and field sensitivity. If `foo[bar]` is tainted then `foo.]` is tainted by side-effect, and then `foo[other]` ends up being tainted too.

We now translate it as `foo.[(bar)` instead... we use `[` and `]` tokens instead of the fake `(` and `)` ones so the range of the Call node is the correct one.

Closes PA-2087

Follows PR returntocorp/pfff#570

test plan:
make test # added one test
and
semgrep-core -dump_pfff_ast and semgrep-core -dump_tree_sitter_cst

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
