### PR TITLE
Add the _v1 suffix to rule_schema.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,13 +114,13 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: rule-schema-yaml
-          path: rule_schema.yaml
+          path: rule_schema_v1.yaml
       - name: Upload Schema Files
         id: upload-semgrep-schema-files
         env:
           GITHUB_TOKEN: "${{ steps.token.outputs.token }}"
         run: |
-          gh release --repo returntocorp/semgrep-interfaces upload ${{ steps.get_version.outputs.VERSION }} rule_schema.yaml
+          gh release --repo returntocorp/semgrep-interfaces upload ${{ steps.get_version.outputs.VERSION }} rule_schema_v1.yaml
       - name: Publish Release Semgrep Interfaces
         id: publish_release_semgrep_interfaces
         env:
@@ -140,7 +140,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: rule-schema-yaml
-          path: rule_schema.yaml
+          path: rule_schema_v1.yaml
 
   release-docker:
     name: Build and push Semgrep Docker image

--- a/cli/MANIFEST.in
+++ b/cli/MANIFEST.in
@@ -1,4 +1,4 @@
-include src/semgrep/semgrep_interfaces/rule_schema.yaml
+include src/semgrep/semgrep_interfaces/rule_schema_v1.yaml
 include src/semgrep/lang/lang.json
 include LICENSE
 include src/semgrep/templates/.semgrepignore

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -42,7 +42,7 @@ class OutputFormat(Enum):
         return self in [OutputFormat.JSON, OutputFormat.SARIF]
 
 
-# Ensure consistency with 'severity' in 'rule_schema.yaml'
+# Ensure consistency with 'severity' in 'rule_schema_v1.yaml'
 class RuleSeverity(Enum):
     INFO = "INFO"
     WARNING = "WARNING"

--- a/cli/src/semgrep/rule_lang.py
+++ b/cli/src/semgrep/rule_lang.py
@@ -50,7 +50,7 @@ class RuleSchema:
         if not cls._schema:
             yaml = YAML()
             schema_path = (
-                Path(__file__).parent / "semgrep_interfaces" / "rule_schema.yaml"
+                Path(__file__).parent / "semgrep_interfaces" / "rule_schema_v1.yaml"
             )
             with schema_path.open() as fd:
                 cls._schema = yaml.load(fd)

--- a/interfaces/Input_to_core.atd
+++ b/interfaces/Input_to_core.atd
@@ -3,7 +3,7 @@
    python wrapper, 'semgrep'.
 
    There are other very important form of inputs which are not specified here:
-    - The rule syntax and schema (see rule_schema.yaml; only the
+    - The rule syntax and schema (see rule_schema_v1.yaml; only the
       semgrep matching engine options are specified in Config_semgrep.atd)
     - The syntax for all the target files (see the grammar for the different
       tree-sitter and pfff parsers)

--- a/interfaces/notes.txt
+++ b/interfaces/notes.txt
@@ -6,6 +6,6 @@ by the different semgrep components:
 We're using atdgen to specify the types of most of those interfaces.
 See https://github.com/ahrefs/atd for more information on atdgen.
 
-We're also using jsonschema for rule_schema.yaml (JSON schemas
+We're also using jsonschema for rule_schema_v1.yaml (JSON schemas
 can also be specified using a YAML syntax, and they can also
 be used to check the schema of YAML files).

--- a/semgrep-core/src/osemgrep/core/Constants.ml
+++ b/semgrep-core/src/osemgrep/core/Constants.ml
@@ -53,7 +53,7 @@ let _output_format_is_json = function
   | Vim ->
       false
 
-(* coupling: ensure consistency with 'serverity' in 'rule_schema.yaml'
+(* coupling: ensure consistency with 'serverity' in 'rule_schema_v1.yaml'
  * LATER: redundant with Rule.severity in semgrep-core.
  *)
 type rule_severity = Info | Warning | Error | Inventory | Experiment

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -30,7 +30,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (*****************************************************************************)
 (* Parsing a Semgrep rule, including complex pattern formulas.
  *
- * See also the JSON schema in rule_schema.yaml.
+ * See also the JSON schema in rule_schema_v1.yaml.
  *
  * history: we used to parse a semgrep rule by simply using the basic API of
  * the OCaml 'yaml' library. This API allows converting a yaml file into


### PR DESCRIPTION
This is in preparation to the release of semgrep 1.0.0
and to be consistent with the other formal spec of semgrep
(ast_generic_v1.atd, semgrep_output_v1.atd)

test plan:
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)