### PR TITLE
enable manually running on bump-pr workflows, in case of release failure

### DIFF
--- a/.github/workflows/open-bump-pr.yml
+++ b/.github/workflows/open-bump-pr.yml
@@ -4,6 +4,33 @@
 name: open-bump-pr
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to bump to"
+        required: true
+        type: string
+      repository:
+        description: "The repo to perform the bump in"
+        required: true
+        default: "returntocorp/semgrep-app"
+        type: "choice"
+        options:
+          - "returntocorp/semgrep-app"
+          - "returntocorp/semgrep-rpc"
+          - "returntocorp/semgrep-action"
+      base_branch:
+        description: "The branch from which to create a new PR and to merge back onto"
+        required: true
+        type: string
+      new_branch_name:
+        description: "If specified, customize the bump branch name"
+        required: false
+        type: string
+      bump_script_path:
+        description: "The path to the bump script in the repo to run."
+        required: true
+        type: string
   workflow_call:
     inputs:
       version:
@@ -31,7 +58,7 @@ on:
 
 jobs:
   bump-version:
-    name: Static Analysis Scan
+    name: Bump Version
     runs-on: ubuntu-22.04
     outputs:
       pr-url: ${{ steps.open-pr.outputs.pr-url }}


### PR DESCRIPTION
Problem:

In the past, if a release failed but was still salvageable, there was no way to re-start a failed release, meaning that PRs would need to be opened manually. 

Solution:

Add `workflow_dispatch` inputs directive, allowing for a "click-to-run" in these rare situations. Use in case of emergency only (e.g., this should not be used except in the rare case that release workflow failed, but the release itself succeeded).

Test plan:

This was tested in [test-gh-actions and was successful.](https://github.com/returntocorp/test-gh-actions/actions/runs/3382007135/jobs/5616470741)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
