### PR TITLE
ojsonnet: finish AST_jsonnet and Parse_jsonnet_tree_sitter.ml

### DIFF
--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -100,7 +100,7 @@ local all = yml.rules + semgrep_rules + pfff.rules + ocaml.rules;
 
   { rules:
       [  if std.objectHas(override_messages, r.id)
-         then r + {message: override_messages[r.id]}
+         then (r + {message: override_messages[r.id]})
          else r
         for r in all
         if !std.member(todo_skipped_for_now, r.id)


### PR DESCRIPTION
There's a few TodoExpr remaining, but at least no more todo().

This closes PA-2111 and PA-2114

test plan:
```
$ semgrep-core -dump_jsonnet_ast ~/github/semgrep/semgrep.jsonnet
...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)