### PR TITLE
chore: enable major version releases for semgrep

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -15,6 +15,7 @@ on:
         required: true
         default: "feature"
         type: "choice"
+        # These options are passed directly into christian-draeger/increment-semantic-version in the `next-vesion` step to decide which of X.Y.Z to increment
         options:
           - "major"
           - "feature"

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -16,6 +16,7 @@ on:
         default: "feature"
         type: "choice"
         options:
+          - "major"
           - "feature"
           - "bug"
 


### PR DESCRIPTION
Problem:

There's currently no automated way to jump from 0.X.Y to 1.0.0.

Solution:

Add an option for bumping the major version git tags. 

Test Plan:

See [a successful run in the test repo](https://github.com/returntocorp/test-gh-actions/actions/runs/3387068374/jobs/5627300153). Changes were then ported to this repo.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
