### PR TITLE
osemgrep: porting more flags to Scan_CLI.ml

### DIFF
--- a/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
+++ b/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
@@ -115,47 +115,8 @@ METRICS_STATE_TYPE = MetricsStateType()
 CONTEXT_SETTINGS = {"max_content_width": 90}
 
 _scan_options: List[Callable] = [
-    click.option(
-        "--disable-metrics",
-        "metrics_legacy",
-        is_flag=True,
-        type=METRICS_STATE_TYPE,
-        flag_value="off",
-        hidden=True,
-    ),
-    click.option(
-        "--enable-metrics",
-        "metrics_legacy",
-        is_flag=True,
-        type=METRICS_STATE_TYPE,
-        flag_value="on",
-        hidden=True,
-    ),
- optgroup.group(
-        "Path options",
-        help="""
-            By default, Semgrep scans all git-tracked files with extensions matching rules' languages.
-            These options alter which files Semgrep scans.
-        """,
-    ),
-    optgroup.option(
-        "--exclude-rule",
-        multiple=True,
-        default=[],
-        help="""
-            Skip any rule with the given id. Can add multiple times.
-        """,
-        shell_complete=__get_file_options,
-    ),
-    optgroup.option(
-        "--scan-unknown-extensions/--skip-unknown-extensions",
-        is_flag=True,
-        default=True,
-        help="""
-            If true, explicit files will be scanned using the language specified in
-            --lang. If --skip-unknown-extensions, these files will not be scanned
-        """,
-    ),
+
+
  optgroup.group("Performance and memory options"),
     optgroup.option(
         "--enable-version-check/--disable-version-check",
@@ -210,15 +171,6 @@ _scan_options: List[Callable] = [
         "--output",
         help="Save search results to a file or post to URL. Default is to print to stdout.",
         shell_complete=__get_file_options,
-    ),
-    optgroup.option(
-        "--rewrite-rule-ids/--no-rewrite-rule-ids",
-        is_flag=True,
-        default=True,
-        help="""
-            Rewrite rule ids when they appear in nested sub-directories (Rule 'foo' in
-            test/rules.yaml will be renamed 'test.foo').
-        """,
     ),
 
 
@@ -329,25 +281,20 @@ def scan_options(func: Callable) -> Callable:
 def scan(
     *,
     deep: bool,
-    dryrun: bool,
     dump_ast: bool,
     enable_nosem: bool,
     enable_version_check: bool,
     error_on_findings: bool,
-    exclude_rule: Optional[Tuple[str, ...]],
     force_color: bool,
     gitlab_sast: bool,
     gitlab_secrets: bool,
     junit_xml: bool,
     max_chars_per_line: int,
     max_lines_per_finding: int,
-    metrics_legacy: Optional[MetricsState],
     dataflow_traces: bool,
     output: Optional[str],
     replacement: Optional[str],
-    rewrite_rule_ids: bool,
     sarif: bool,
-    scan_unknown_extensions: bool,
     severity: Optional[Tuple[str, ...]],
     show_supported_languages: bool,
     test: bool,
@@ -496,7 +443,6 @@ def scan(
                     _,
                 ) = semgrep.semgrep_main.main(
                     configs=(config or []),
-                    no_rewrite_rule_ids=(not rewrite_rule_ids),
                     exclude_rule=exclude_rule,
                     disable_nosem=(not enable_nosem),
                     no_git_ignore=(not use_git_ignore),

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -156,6 +156,7 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
    autofix = _;
    dryrun = _;
    baseline_commit = _;
+   exclude_rule_ids = _;
    exclude = _;
    include_ = _;
    config = _;
@@ -165,6 +166,8 @@ let runner_config_of_conf (conf : Scan_CLI.conf) : Runner_config.t =
    max_target_bytes = _;
    metrics = _;
    respect_git_ignore = _;
+   rewrite_rule_ids = _;
+   scan_unknown_extensions = _;
    strict = _;
    time_flag = _;
   } ->

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -1,4 +1,4 @@
-open Printf
+open Common
 
 (* Provide 'Term', 'Arg', and 'Manpage' modules. *)
 open Cmdliner
@@ -26,10 +26,11 @@ module H = Cmdliner_helpers
 *)
 type conf = {
   autofix : bool;
-  dryrun : bool;
   baseline_commit : string option;
   (* TOPORT: can have multiple calls to --config, so string list here *)
   config : string;
+  dryrun : bool;
+  exclude_rule_ids : string list;
   exclude : string list;
   include_ : string list;
   lang : string option;
@@ -42,6 +43,8 @@ type conf = {
   output_format : Constants.output_format;
   pattern : string option;
   respect_git_ignore : bool;
+  rewrite_rule_ids : bool;
+  scan_unknown_extensions : bool;
   strict : bool;
   target_roots : string list;
   time_flag : bool;
@@ -57,9 +60,10 @@ let get_cpu_count () : int =
 let default : conf =
   {
     autofix = false;
-    dryrun = false;
     baseline_commit = None;
     config = "auto";
+    dryrun = false;
+    exclude_rule_ids = [];
     exclude = [];
     include_ = [];
     lang = None;
@@ -72,6 +76,8 @@ let default : conf =
     pattern = None;
     logging_level = Some Logs.Warning;
     respect_git_ignore = true;
+    rewrite_rule_ids = true;
+    scan_unknown_extensions = false;
     strict = false;
     target_roots = [ "." ];
     time_flag = false;
@@ -85,7 +91,7 @@ let default : conf =
 
 let _validate_lang option lang_str =
   match lang_str with
-  | None -> failwith (sprintf "%s and -l/--lang must both be specified" option)
+  | None -> failwith (spf "%s and -l/--lang must both be specified" option)
   | Some lang -> lang
 
 (*************************************************************************)
@@ -128,7 +134,10 @@ given baseline hash doesn't exist.
   in
   Arg.value (Arg.opt Arg.(some string) None info)
 
-let o_metrics =
+(* TOPORT? there's also a --disable-metrics and --enable-metrics
+ * but they are marked as legacy flags, so maybe not worth porting
+ *)
+let o_metrics : Metrics.State.t Term.t =
   let info =
     Arg.info [ "metrics" ]
       ~env:(Cmd.Env.info "SEMGREP_SEND_METRICS")
@@ -146,8 +155,19 @@ environment variable, defaults to 'auto'.
 (* ------------------------------------------------------------------ *)
 (* TOPORT "Path options" *)
 (* ------------------------------------------------------------------ *)
+(* TOPORT:
+ * "By default, Semgrep scans all git-tracked files with extensions matching
+ *  rules' languages. These options alter which files Semgrep scans."
+ *)
 
-let o_exclude =
+let o_exclude_rule_ids : string list Term.t =
+  let info =
+    Arg.info [ "exclude-rule" ]
+      ~doc:{|Skip any rule with the given id. Can add multiple times.|}
+  in
+  Arg.value (Arg.opt_all Arg.string [] info)
+
+let o_exclude : string list Term.t =
   let info =
     Arg.info [ "exclude" ]
       ~doc:
@@ -159,7 +179,7 @@ Can add multiple times. If present, any --include directives are ignored.
   in
   Arg.value (Arg.opt_all Arg.string [] info)
 
-let o_include =
+let o_include : string list Term.t =
   let info =
     Arg.info [ "include" ]
       ~doc:
@@ -179,7 +199,7 @@ https://docs.python.org/3/library/glob.html
   in
   Arg.value (Arg.opt_all Arg.string [] info)
 
-let o_max_target_bytes =
+let o_max_target_bytes : int Term.t =
   let info =
     Arg.info
       [ "max-target-bytes" ]
@@ -193,7 +213,7 @@ negative value disables this filter. Defaults to 1000000 bytes.
   (* TOPORT: support '1.5MB' and such, see bytesize.py *)
   Arg.value (Arg.opt Arg.int default.max_target_bytes info)
 
-let o_respect_git_ignore =
+let o_respect_git_ignore : bool Term.t =
   H.negatable_flag [ "use-git-ignore" ] ~neg_options:[ "no-git-ignore" ]
     ~default:default.respect_git_ignore
     ~doc:
@@ -206,11 +226,21 @@ filtering. Setting this flag does nothing if the scanning root is not
 in a git repository.
 |}
 
+let o_scan_unknown_extensions : bool Term.t =
+  H.negatable_flag
+    [ "scan-unknown-extensions" ]
+    ~neg_options:[ "skip-unknown-extensions" ]
+    ~default:default.scan_unknown_extensions
+    ~doc:
+      {|If true, explicit files will be scanned using the language specified
+in --lang. If --skip-unknown-extensions, these files will not be scanned.
+|}
+
 (* ------------------------------------------------------------------ *)
 (* TOPORT: "Performance and memory options" *)
 (* ------------------------------------------------------------------ *)
 
-let o_num_jobs =
+let o_num_jobs : int Term.t =
   let info =
     Arg.info [ "j"; "jobs" ]
       ~doc:
@@ -220,7 +250,7 @@ parallel. Defaults to the number of cores detected on the system.
   in
   Arg.value (Arg.opt Arg.int default.num_jobs info)
 
-let o_max_memory_mb =
+let o_max_memory_mb : int Term.t =
   let info =
     Arg.info [ "max-memory-mb" ]
       ~doc:
@@ -230,11 +260,11 @@ in MB. If set to 0 will not have memory limit. Defaults to 0.
   in
   Arg.value (Arg.opt Arg.int default.max_memory_mb info)
 
-let o_optimizations =
+let o_optimizations : bool Term.t =
   let parse = function
     | "all" -> Ok true
     | "none" -> Ok false
-    | other -> Error (sprintf "unsupported value %S" other)
+    | other -> Error (spf "unsupported value %S" other)
   in
   let print fmt = function
     | true -> Format.pp_print_string fmt "all"
@@ -250,7 +280,7 @@ Use 'none' to turn all optimizations off.
   in
   Arg.value (Arg.opt converter default.optimizations info)
 
-let o_timeout =
+let o_timeout : float Term.t =
   let info =
     Arg.info
       [ "timeout" ] (* TOPORT: use default value in doc. switch to int? *)
@@ -262,7 +292,7 @@ seconds. If set to 0 will not have time limit. Defaults to 30 s.
   (*TOPORT: envvar="SEMGREP_TIMEOUT" *)
   Arg.value (Arg.opt Arg.float default.timeout info)
 
-let o_timeout_threshold =
+let o_timeout_threshold : int Term.t =
   let info =
     Arg.info [ "timeout-threshold" ]
       ~doc:
@@ -278,6 +308,14 @@ the file is skipped. If set to 0 will not have limit. Defaults to 3.
 
 (* TODO? use Fmt_cli.style_renderer ? *)
 
+let o_rewrite_rule_ids : bool Term.t =
+  H.negatable_flag [ "rewrite-rule-ids" ] ~neg_options:[ "no-rewrite-rule-ids" ]
+    ~default:default.rewrite_rule_ids
+    ~doc:
+      {|Rewrite rule ids when they appear in nested sub-directories
+(Rule 'foo' in test/rules.yaml will be renamed 'test.foo').
+|}
+
 let o_time : bool Term.t =
   H.negatable_flag [ "time" ] ~neg_options:[ "no-time" ]
     ~default:default.time_flag
@@ -292,11 +330,11 @@ let o_time : bool Term.t =
 (* alt: we could use Logs_cli.level(), but by defining our own flags
  * we can give better ~doc:. We lose the --verbosity=Level though.
  *)
-let o_quiet =
+let o_quiet : bool Term.t =
   let info = Arg.info [ "q"; "quiet" ] ~doc:{|Only output findings.|} in
   Arg.value (Arg.flag info)
 
-let o_verbose =
+let o_verbose : bool Term.t =
   let info =
     Arg.info [ "v"; "verbose" ]
       ~doc:
@@ -306,7 +344,7 @@ failed to parse, etc.
   in
   Arg.value (Arg.flag info)
 
-let o_debug =
+let o_debug : bool Term.t =
   let info =
     Arg.info [ "debug" ]
       ~doc:{|All of --verbose, but with additional debugging information.|}
@@ -316,19 +354,19 @@ let o_debug =
 (* ------------------------------------------------------------------ *)
 (* TOPORT "Output formats" (mutually exclusive) *)
 (* ------------------------------------------------------------------ *)
-let o_json =
+let o_json : bool Term.t =
   let info =
     Arg.info [ "json" ] ~doc:{|Output results in Semgrep's JSON format.|}
   in
   Arg.value (Arg.flag info)
 
-let o_emacs =
+let o_emacs : bool Term.t =
   let info =
     Arg.info [ "emacs" ] ~doc:{|Output results in Emacs single-line format.|}
   in
   Arg.value (Arg.flag info)
 
-let o_vim =
+let o_vim : bool Term.t =
   let info =
     Arg.info [ "vim" ] ~doc:{|Output results in vim single-line format.|}
   in
@@ -338,7 +376,7 @@ let o_vim =
 (* TOPORT "Configuration options" *)
 (* ------------------------------------------------------------------ *)
 (* TOPORT: multiple = true *)
-let o_config =
+let o_config : string Term.t =
   let info =
     Arg.info [ "c"; "f"; "config" ]
       ~env:(Cmd.Env.info "SEMGREP_RULES")
@@ -359,7 +397,7 @@ configuration file format.
   in
   Arg.value (Arg.opt Arg.string default.config info)
 
-let o_pattern =
+let o_pattern : string option Term.t =
   let info =
     Arg.info [ "e"; "pattern" ]
       ~doc:
@@ -368,7 +406,7 @@ let o_pattern =
   in
   Arg.value (Arg.opt Arg.(some string) None info)
 
-let o_lang =
+let o_lang : string option Term.t =
   let info =
     Arg.info [ "l"; "lang" ]
       ~doc:
@@ -398,7 +436,7 @@ Defaults to --no-strict.
 (* positional arguments *)
 (* ------------------------------------------------------------------ *)
 
-let o_target_roots =
+let o_target_roots : string list Term.t =
   let info =
     Arg.info [] ~docv:"TARGETS"
       ~doc:{|Files or folders to be scanned by semgrep.
@@ -411,9 +449,10 @@ let o_target_roots =
 (*****************************************************************************)
 
 let cmdline_term : conf Term.t =
-  let combine autofix dryrun baseline_commit config debug emacs exclude include_
-      json lang max_memory_mb max_target_bytes metrics num_jobs optimizations
-      pattern quiet respect_git_ignore strict target_roots time_flag timeout
+  let combine autofix baseline_commit config debug dryrun emacs exclude_rule_ids
+      exclude include_ json lang max_memory_mb max_target_bytes metrics num_jobs
+      optimizations pattern quiet respect_git_ignore rewrite_rule_ids
+      scan_unknown_extensions strict target_roots time_flag timeout
       timeout_threshold verbose vim =
     let output_format =
       match (json, emacs, vim) with
@@ -435,9 +474,10 @@ let cmdline_term : conf Term.t =
     in
     {
       autofix;
-      dryrun;
       baseline_commit;
       config;
+      dryrun;
+      exclude_rule_ids;
       exclude;
       include_;
       lang;
@@ -450,6 +490,8 @@ let cmdline_term : conf Term.t =
       output_format;
       pattern;
       respect_git_ignore;
+      rewrite_rule_ids;
+      scan_unknown_extensions;
       strict;
       target_roots;
       time_flag;
@@ -459,12 +501,12 @@ let cmdline_term : conf Term.t =
   in
   (* Term defines 'const' but also the '$' operator *)
   Term.(
-    const combine $ o_autofix $ o_dryrun $ o_baseline_commit $ o_config
-    $ o_debug $ o_emacs $ o_exclude $ o_include $ o_json $ o_lang
-    $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs
-    $ o_optimizations $ o_pattern $ o_quiet $ o_respect_git_ignore $ o_strict
-    $ o_target_roots $ o_time $ o_timeout $ o_timeout_threshold $ o_verbose
-    $ o_vim)
+    const combine $ o_autofix $ o_baseline_commit $ o_config $ o_debug
+    $ o_dryrun $ o_emacs $ o_exclude_rule_ids $ o_exclude $ o_include $ o_json
+    $ o_lang $ o_max_memory_mb $ o_max_target_bytes $ o_metrics $ o_num_jobs
+    $ o_optimizations $ o_pattern $ o_quiet $ o_respect_git_ignore
+    $ o_rewrite_rule_ids $ o_scan_unknown_extensions $ o_strict $ o_target_roots
+    $ o_time $ o_timeout $ o_timeout_threshold $ o_verbose $ o_vim)
 
 let doc = "run semgrep rules on files"
 

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -7,9 +7,10 @@
 *)
 type conf = {
   autofix : bool;
-  dryrun : bool;
   baseline_commit : string option;
   config : string;
+  dryrun : bool;
+  exclude_rule_ids : string list;
   exclude : string list;
   include_ : string list;
   lang : string option;
@@ -22,6 +23,8 @@ type conf = {
   output_format : Constants.output_format;
   pattern : string option;
   respect_git_ignore : bool;
+  rewrite_rule_ids : bool;
+  scan_unknown_extensions : bool;
   strict : bool;
   target_roots : string list;
   time_flag : bool;
@@ -42,5 +45,5 @@ val default : conf
 *)
 val parse_argv : string array -> (conf, Exit_code.t) result
 
-(* used by Ci_CLI.ml *)
+(* exported because used by Ci_CLI.ml too *)
 val cmdline_term : conf Cmdliner.Term.t


### PR DESCRIPTION
test plan:
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)