### PR TITLE
tainting: Track taint as precisely as possible

### DIFF
--- a/changelog.d/pa-2086.changed
+++ b/changelog.d/pa-2086.changed
@@ -1,0 +1,4 @@
+taint-mode: Semgrep can now track taint through l-values of the form `this.x`.
+It will also be more precise when tracking taint on l-values involving an
+array access, previously if `x.a[i]` was tainted, then `x` itself was tainted;
+now only `x.a` will be considered tainted.

--- a/semgrep-core/src/core/il/IL_helpers.ml
+++ b/semgrep-core/src/core/il/IL_helpers.ml
@@ -83,17 +83,12 @@ let rlvals_of_instr x =
 
 let lval_of_var var = { IL.base = Var var; rev_offset = [] }
 
-let lval_is_var_and_dots { base; rev_offset } =
-  match base with
-  | Var _ ->
-      rev_offset
-      |> List.for_all (fun offset ->
-             match offset.o with
-             | Dot _ -> true
-             | Index _ -> false)
-  | VarSpecial _
-  | Mem _ ->
-      false
+let is_dots_offset offset =
+  offset
+  |> List.for_all (fun o ->
+         match o.o with
+         | Dot _ -> true
+         | Index _ -> false)
 
 let lval_is_dotted_prefix lval1 lval2 =
   let eq_name x y = compare_name x y = 0 in

--- a/semgrep-core/src/core/il/IL_helpers.mli
+++ b/semgrep-core/src/core/il/IL_helpers.mli
@@ -4,13 +4,13 @@ val exp_of_arg : IL.exp IL.argument -> IL.exp
 
 val lval_of_var : IL.name -> IL.lval
 
-val lval_is_var_and_dots : IL.lval -> bool
-(** Test whether an lvalue is of the form x.a_1. ... .a_n *)
+val is_dots_offset : IL.offset list -> bool
+(** Test whether an offset is of the form .a_1. ... .a_N.  *)
 
 val lval_is_dotted_prefix : IL.lval -> IL.lval -> bool
 (** [lval_is_dotted_prefix lval1 lval2] tests whether [lval1] is of the
-    form x.a_1. ... .a_n, and whether [lval2] is an extension of [lval1],
-    that is, x.a_1. ... .a_n.o_1 ... . o_M. *)
+    form x.a_1. ... .a_N, and whether [lval2] is an extension of [lval1],
+    that is, x.a_1. ... .a_N.o_1 ... . o_M. *)
 
 val lval_of_instr_opt : IL.instr -> IL.lval option
 (** If the given instruction stores its result in [lval] then it is

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -509,7 +509,7 @@ let check_fundef lang options taint_config opt_ent fdef =
       |> Common.map (fun (x : _ D.tmatch) -> (x.pm, x.spec))
       |> T.taints_of_pms
     in
-    Lval_env.add (IL_helpers.lval_of_var var) taints env
+    Lval_env.add env (IL_helpers.lval_of_var var) taints
   in
   let in_env =
     (* For each argument, check if it's a source and, if so, add it to the input

--- a/semgrep-core/src/tainting/Taint_lval_env.ml
+++ b/semgrep-core/src/tainting/Taint_lval_env.ml
@@ -25,8 +25,11 @@ module VarMap = Var_env.VarMap
 module LvalMap = Map.Make (LV.LvalOrdered)
 module LvalSet = Set.Make (LV.LvalOrdered)
 
+let logger = Logging.get_logger [ __MODULE__ ]
+
 type t = {
-  tainted : T.taints LvalMap.t;  (** Lvalues that are tainted. *)
+  tainted : T.taints LvalMap.t;
+      (** Lvalues that are tainted, it is only meant to track l-values of the form x.a_1. ... . a_N. *)
   propagated : T.taints VarMap.t;
       (** Taint that is propagated via taint propagators (internally represented by
     unique propagator variables). *)
@@ -62,66 +65,116 @@ let union le1 le2 =
     cleaned = LvalSet.union cleaned1 cleaned2;
   }
 
-let add lval taints ({ tainted; propagated; cleaned } as lval_env) =
-  let taints =
-    (* If the lvalue is a simple variable, we record it as part of
-       the taint trace. *)
-    match lval with
-    | { IL.base = Var var; rev_offset = [] } ->
-        let var_tok = snd var.ident in
-        if Parse_info.is_fake var_tok then taints
-        else
-          taints
-          |> Taints.map (fun t -> { t with tokens = var_tok :: t.tokens })
-    | __else__ -> taints
-  in
-  if Taints.is_empty taints then lval_env
-  else
-    {
-      tainted =
-        LvalMap.update lval
-          (function
-            | None -> Some taints
-            (* THINK: couldn't we just replace the existing taints? *)
-            | Some taints' -> Some (Taints.union taints taints'))
-          tainted;
-      propagated;
-      cleaned = LvalSet.remove lval cleaned;
-    }
+(* Reduces an l-value into the form x.a_1. ... . a_N, the resulting l-value may
+ * not represent the exact same object as the original l-value, but an
+ * overapproxiamation. For example, the normalized l-value of `x[i]` will be `x`,
+ * so the taints of any element of an array are tracked via the array itself. *)
+let rec normalize_lval lval =
+  let { IL.base; rev_offset } = lval in
+  match lval.IL.rev_offset with
+  | [] -> (
+      (* Base case, no offset; we can only track variables. *)
+      match base with
+      | Var _ -> Some lval
+      | VarSpecial _
+      | Mem _ ->
+          None)
+  | _ :: rev_offset' -> (
+      (* Must find the largest prefix of the form x.a_1. ... . a_N. *)
+      let is_dots = LV.is_dots_offset rev_offset in
+      match base with
+      | Var _ when is_dots -> Some lval
+      | VarSpecial _ when is_dots -> (
+          (* this.x.a_1. ... . a_N becomes x.a_1. ... . a_N *)
+          match List.rev lval.rev_offset with
+          | { o = IL.Dot var; _ } :: offset' ->
+              Some { IL.base = Var var; rev_offset = List.rev offset' }
+          | []
+          | { o = IL.Index _; _ } :: _ ->
+              logger#error "Impossible happened";
+              None)
+      | Var _
+      | VarSpecial _ ->
+          (* Offset-chain is not of the form .a_1. ... . a_N, so drop the last
+           * offset until the condition is met or we reach the base case. *)
+          normalize_lval { base; rev_offset = rev_offset' }
+      | Mem _ -> None)
+
+let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
+  match normalize_lval lval with
+  | None ->
+      (* Cannot track taint for this l-value; e.g. because the base is not a simple
+         variable. We just return the same environment untouched. *)
+      lval_env
+  | Some lval ->
+      let taints =
+        (* If the lvalue is a simple variable, we record it as part of
+           the taint trace. *)
+        match lval with
+        | { IL.base = Var var; rev_offset = [] } ->
+            let var_tok = snd var.ident in
+            if Parse_info.is_fake var_tok then taints
+            else
+              taints
+              |> Taints.map (fun t -> { t with tokens = var_tok :: t.tokens })
+        | __else__ -> taints
+      in
+      if Taints.is_empty taints then lval_env
+      else
+        {
+          tainted =
+            LvalMap.update lval
+              (function
+                | None -> Some taints
+                (* THINK: couldn't we just replace the existing taints? *)
+                | Some taints' -> Some (Taints.union taints taints'))
+              tainted;
+          propagated;
+          cleaned = LvalSet.remove lval cleaned;
+        }
 
 let propagate_to prop_var taints env =
   if Taints.is_empty taints then env
   else { env with propagated = VarMap.add prop_var taints env.propagated }
 
 let dumb_find { tainted; cleaned; _ } lval =
-  if LvalSet.mem lval cleaned then `Clean
-  else
-    match LvalMap.find_opt lval tainted with
-    | None -> `None
-    | Some taints -> `Tainted taints
+  match normalize_lval lval with
+  | None -> `None
+  | Some lval -> (
+      if LvalSet.mem lval cleaned then `Clean
+      else
+        match LvalMap.find_opt lval tainted with
+        | None -> `None
+        | Some taints -> `Tainted taints)
 
 let propagate_from prop_var env = VarMap.find_opt prop_var env.propagated
 
-let clean lval { tainted; propagated; cleaned } =
-  let prefix_is_tainted =
-    tainted |> LvalMap.exists (fun lv _ -> LV.lval_is_dotted_prefix lv lval)
-  in
-  let needs_clean_mark = prefix_is_tainted && lval.rev_offset <> [] in
-  {
-    tainted =
-      (* If `x.a` is clean then `x.a` and any extension of it (`x.a.b`, `x.a.b.c`,
-       * and so on) are clean too, and we remove them all from tainted. *)
-      tainted
-      |> LvalMap.filter (fun lv _ -> not (LV.lval_is_dotted_prefix lval lv));
-    propagated;
-    cleaned =
-      (* Similarly, if `x.a` will have a "clean" mark, then we can remove any
-       * such mark on any extension of `x.a`. It would be redundant to record
-       * `x.a.b` as clean when we already have that `x.a` is clean. *)
-      (cleaned
-      |> LvalSet.filter (fun lv -> not (LV.lval_is_dotted_prefix lval lv))
-      |> if needs_clean_mark then LvalSet.add lval else fun x -> x);
-  }
+let clean ({ tainted; propagated; cleaned } as lval_env) lval =
+  match normalize_lval lval with
+  | None ->
+      (* Cannot track taint for this l-value; e.g. because the base is not a simple
+         variable. We just return the same environment untouched. *)
+      lval_env
+  | Some lval ->
+      let prefix_is_tainted =
+        tainted |> LvalMap.exists (fun lv _ -> LV.lval_is_dotted_prefix lv lval)
+      in
+      let needs_clean_mark = prefix_is_tainted && lval.rev_offset <> [] in
+      {
+        tainted =
+          (* If `x.a` is clean then `x.a` and any extension of it (`x.a.b`, `x.a.b.c`,
+           * and so on) are clean too, and we remove them all from tainted. *)
+          tainted
+          |> LvalMap.filter (fun lv _ -> not (LV.lval_is_dotted_prefix lval lv));
+        propagated;
+        cleaned =
+          (* Similarly, if `x.a` will have a "clean" mark, then we can remove any
+           * such mark on any extension of `x.a`. It would be redundant to record
+           * `x.a.b` as clean when we already have that `x.a` is clean. *)
+          (cleaned
+          |> LvalSet.filter (fun lv -> not (LV.lval_is_dotted_prefix lval lv))
+          |> if needs_clean_mark then LvalSet.add lval else fun x -> x);
+      }
 
 let equal le1 le2 =
   LvalMap.equal Taints.equal le1.tainted le2.tainted

--- a/semgrep-core/src/tainting/Taint_lval_env.ml
+++ b/semgrep-core/src/tainting/Taint_lval_env.ml
@@ -67,7 +67,7 @@ let union le1 le2 =
 
 (* Reduces an l-value into the form x.a_1. ... . a_N, the resulting l-value may
  * not represent the exact same object as the original l-value, but an
- * overapproxiamation. For example, the normalized l-value of `x[i]` will be `x`,
+ * overapproximation. For example, the normalized l-value of `x[i]` will be `x`,
  * so the taints of any element of an array are tracked via the array itself. *)
 let rec normalize_lval lval =
   let { IL.base; rev_offset } = lval in
@@ -80,7 +80,7 @@ let rec normalize_lval lval =
       | Mem _ ->
           None)
   | _ :: rev_offset' -> (
-      (* Must find the largest prefix of the form x.a_1. ... . a_N. *)
+      (* Must find the longest prefix of the form x.a_1. ... . a_N. *)
       let is_dots = LV.is_dots_offset rev_offset in
       match base with
       | Var _ when is_dots -> Some lval
@@ -91,7 +91,7 @@ let rec normalize_lval lval =
               Some { IL.base = Var var; rev_offset = List.rev offset' }
           | []
           | { o = IL.Index _; _ } :: _ ->
-              logger#error "Impossible happened";
+              logger#error "normalize_lval: Impossible happened";
               None)
       | Var _
       | VarSpecial _ ->

--- a/semgrep-core/src/tainting/Taint_lval_env.mli
+++ b/semgrep-core/src/tainting/Taint_lval_env.mli
@@ -10,7 +10,7 @@
  * We rely on Naming_AST to resolve the variables correctly.
  *
  * L-values of the form x.a_1. ... . a_N [i] o_1...o_M are normalized as
- * x.a_1. ... . a_N. That is, we obtain the largest prefix of dot-offsets
+ * x.a_1. ... . a_N. That is, we obtain the longest prefix of dot-offsets
  * possible. See docs of `add` and `clean` below for more details.
  *
  * We track taints per variable, but not per object in memory. There is

--- a/semgrep-core/src/tainting/Taint_lval_env.mli
+++ b/semgrep-core/src/tainting/Taint_lval_env.mli
@@ -1,12 +1,20 @@
 (** Lval-to-taints environments used by taint-mode.
  *
- * Only lvalues of the form x.a_1. ... . a_N (i.e. a variable followed by field
- * accesses) are tracked. The main purpose of tracking fields is to remove FPs.
+ * This environment is field-sensitive, but only for l-values of the form
+ * x.a_1. ... . a_N (i.e. a variable followed by field accesses). The main
+ * purpose of tracking fields is to remove FPs.
  *
- * These environments help making taint analysis sensitive to individual fields
- * in records/objects in a limited way. Essentially, they add per variable field
- * sensitivity, but not per object in memory field sensitivity. There is no alias
- * analysis involved!
+ * L-values of the form this.x.a_1. ... . a_N are normalized as
+ * x.a_1. ... . a_N. The `this` base is not important as different variables
+ * `x` should have different 'sid's. Same applies to `self`, `super`, etc.
+ * We rely on Naming_AST to resolve the variables correctly.
+ *
+ * L-values of the form x.a_1. ... . a_N [i] o_1...o_M are normalized as
+ * x.a_1. ... . a_N. That is, we obtain the largest prefix of dot-offsets
+ * possible. See docs of `add` and `clean` below for more details.
+ *
+ * We track taints per variable, but not per object in memory. There is
+ * no alias analysis involved!
  *)
 
 type t
@@ -15,31 +23,39 @@ type env = t
 val empty : env
 val empty_inout : env Dataflow_core.inout
 
-val add : IL.lval -> Taint.taints -> env -> env
-(** Add taint to an lvalue.
+val add : env -> IL.lval -> Taint.taints -> env
+(** Add taints to an l-value.
 
-    Note that if we add taint to x.a_1. ... .a_N, the prefixes
-    x.a_1. ... .a_i (i < N) will not be considered tainted (unless they become
-    tainted separately).
+    Adding taints to x.a_1. ... .a_N will NOT taint the prefixes
+    x.a_1. ... .a_i (i < N) (unless they become tainted separately).
+
+    Adding taints to x.a_1. ... . a_N [i] o_1...o_M is effectively
+    the same as adding taint to x.a_1. ... . a_N, since this environment
+    is not index-sensitive.
  *)
 
 (* THINK: Perhaps keep propagators outside of this environment? *)
 val propagate_to : Dataflow_var_env.var -> Taint.taints -> env -> env
 
 val dumb_find : env -> IL.lval -> [> `Clean | `None | `Tainted of Taint.taints ]
-(** Look up an lvalue on the environemnt and return whether it's tainted, clean,
+(** Look up an l-value on the environemnt and return whether it's tainted, clean,
     or we hold no info about it. It does not check sub-lvalues, e.g. if we record
     that 'x.a' is tainted but had no explicit info about 'x.a.b', checking for
-    'x.a.b' would return `None. The way we determine whether an lvalue is actually
-    tainted is a "bit" more complex, see Dataflow_tainting.check_tainted_lval. *)
+    'x.a.b' would return `None. The way we determine whether an l-value is tainted
+    is a "bit" more complex, see Dataflow_tainting.check_tainted_lval. *)
 
 val propagate_from : Dataflow_var_env.var -> env -> Taint.taints option
 
-val clean : IL.lval -> env -> env
+val clean : env -> IL.lval -> env
 (** Remove taint from an lvalue.
 
-    Given x.a_1. ... .a_N, it will clean that lvalue as well as all its
-    extensions x.a_1. ... .a_N. ... .a_M.  *)
+    Cleaning x.a_1. ... .a_N will clean that l-value as well as all its
+    extensions x.a_1. ... .a_N. ... .a_M.
+
+    Crucially, cleaning x.a_1. ... . a_N [i] o_1...o_M  is the same as cleaning
+    x.a_1. ... . a_N. So, cleaning an element of an array such as x[1] would
+    clean the entire array! This seems drastic but it should help reducing FPs.
+ *)
 
 val union : env -> env -> env
 (** Compute the environment for the join of two branches.

--- a/semgrep-core/tests/rules/field_sensitive1.js
+++ b/semgrep-core/tests/rules/field_sensitive1.js
@@ -3,6 +3,7 @@ function f() {
     x.a = source // only x.a or its extension are tainted after this
     x.b = safe
     x.c = source // only x.c or its extension are tainted after this
+    x.d[i] = source // only x.d is tainted
 
     // x.a is tainted
     //ruleid: test
@@ -15,6 +16,13 @@ function f() {
     sink(x.c)
     //ruleid: test
     sink(x.c.d)
+
+    //ruleid: test
+    sink(x.d[i])
+    //ruleid: test
+    sink(x.d[j])
+    //ruleid: test
+    sink(x.d)
 
     // x itself and other fields of x are not tainted
     //ok: test

--- a/semgrep-core/tests/rules/field_sensitive2.js
+++ b/semgrep-core/tests/rules/field_sensitive2.js
@@ -1,20 +1,27 @@
-// Mark taint on all of `x`, remember that only `x.a` is clean
+// Mark taint on all of `x`, mark some fields as clean
 function f() {
     x = source
     x.a = safe
+    x.c[i].d = safe
     
     //ruleid: test
     sink(x)
-
     //ruleid: test
     sink(x.b)
-
     //ruleid: test
     sink(x.b.c)
 
     //ok: test
     sink(x.a)
-
     //ok: test
     sink(x.a.b)
+
+    //ok: test
+    sink(x.c[i].d)
+    //ok: test
+    sink(x.c[i])
+    //ok: test
+    sink(x.c[j])
+    //ok: test
+    sink(x.c)
 }

--- a/semgrep-core/tests/rules/field_sensitive3.js
+++ b/semgrep-core/tests/rules/field_sensitive3.js
@@ -1,11 +1,16 @@
 // Quite similar to field_sensitive1 ...
 function f() {
     x.a.b.c = source
+    x.d.e[i].f.g[j].h = source
 
     //ruleid: test
     sink(x.a.b.c)
     //ruleid: test
     sink(x.a.b.c.d)
+    //ruleid: test
+    sink(x.d.e)
+    //ruleid: test
+    sink(x.d.e[i].f)
 
     // These are OK because we have not enabled propagation of taint up through
     // fields, to avoid FPs
@@ -17,6 +22,8 @@ function f() {
     sink(x.a.c)
     //ok: test
     sink(x.a)
+    //ok: test
+    sink(x.d)
     //ok: test
     sink(x)
 }

--- a/semgrep-core/tests/rules/taint_array.py
+++ b/semgrep-core/tests/rules/taint_array.py
@@ -1,0 +1,9 @@
+x[i] = tainted
+# something got tainted, let's assume array is tainted
+#ruleid: test
+sink(x[j])
+
+# something got clean, let's assume array is clean
+x[j] = safe
+#ok: test
+sink(x[k])

--- a/semgrep-core/tests/rules/taint_array.yaml
+++ b/semgrep-core/tests/rules/taint_array.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+      - pattern: tainted
+    pattern-sinks:
+      - pattern: sink(...)
+    message: Semgrep found a match
+    languages:
+      - python
+    severity: WARNING
+

--- a/semgrep-core/tests/rules/taint_this1.java
+++ b/semgrep-core/tests/rules/taint_this1.java
@@ -1,0 +1,21 @@
+class Test {
+    String x;
+
+    public void foo() {
+        x = tainted;
+        //ruleid: test
+        sink(x);
+    }
+
+    public void bar() {
+        this.x = tainted;
+        //ruleid: test
+        sink(this.x);
+    }
+
+    public void baz() {
+        this.x = tainted;
+        //ruleid: test
+        sink(x);
+    }
+}

--- a/semgrep-core/tests/rules/taint_this1.yaml
+++ b/semgrep-core/tests/rules/taint_this1.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: test
+    mode: taint
+    pattern-sources:
+      - pattern: tainted
+    pattern-sinks:
+      - pattern: sink(...)
+    message: Semgrep found a match
+    languages:
+      - java
+    severity: WARNING
+


### PR DESCRIPTION
And move all this logic to Taint_lval_env.

Even after adding field-sensitivity, if we had an l-value such as `x.y[i]`, we would track it as `x` rather than as `x.y`. Now we try to be as precise as possible, and we find the longest dotted-offset prefix to track.

We also added support for `thix. ...` l-values, by simply dropping the `this`.

Follows: 9de8d50fc18 ("tainting: Fix field-sensitivity regression (#6279)")
Follows: 756408aafeb ("Field Sensitive Tainting (#5697)")

Closes PA-2086

test plan:
make test # added two tests and updated three more

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
