### PR TITLE
feat(scip): install scip files with deepsemgrep

### DIFF
--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -7,6 +7,7 @@ import click
 
 from semgrep.commands.ci import ci
 from semgrep.commands.install import install_deep_semgrep
+from semgrep.commands.install import install_scip
 from semgrep.commands.login import login
 from semgrep.commands.login import logout
 from semgrep.commands.lsp import lsp
@@ -92,5 +93,6 @@ cli.add_command(logout)
 cli.add_command(publish)
 cli.add_command(scan)
 cli.add_command(install_deep_semgrep)
+cli.add_command(install_scip)
 cli.add_command(shouldafound)
 cli.add_command(lsp)

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -48,9 +48,6 @@ def install_deep_semgrep() -> None:
         logger.info(
             f"Overwriting DeepSemgrep binary already installed in {deep_semgrep_path}"
         )
-    scip_path = Path(core_path).parent / "scip_files.zip"
-    if scip_path.exists():
-        logger.info(f"Overwriting SCIP files already installed in {scip_path}")
 
     if state.app_session.token is None:
         logger.info("run `semgrep login` before using `semgrep install`")
@@ -67,9 +64,6 @@ def install_deep_semgrep() -> None:
         )
 
     url = f"{state.env.semgrep_url}/api/agent/deployments/deepbinary/{platform}"
-    # The SCIP URL is used to get the binaries which are necessary for SCIP-enhanced
-    # analysis in DeepSemgrep.
-    scip_url = f"{state.env.semgrep_url}/api/agent/deployments/scipfiles/{platform}"
 
     with state.app_session.get(url, timeout=60, stream=True) as r:
         if r.status_code == 401:
@@ -91,16 +85,6 @@ def install_deep_semgrep() -> None:
             with tqdm.wrapattr(r.raw, "read", total=file_size) as r_raw:
                 shutil.copyfileobj(r_raw, f)
 
-    with state.app_session.get(scip_url, timeout=60, stream=True) as r:
-        file_size = int(r.headers.get("Content-Length", 0))
-
-        with open(scip_path, "wb") as f:
-            with tqdm.wrapattr(r.raw, "read", total=file_size) as r_raw:
-                shutil.copyfileobj(r_raw, f)
-
-        with ZipFile(scip_path, "r") as zfile:
-            zfile.extractall(path=scip_path.parent)
-
     # THINK: Do we need to give exec permissions to everybody? Can this be a security risk?
     #        The binary should not have setuid or setgid rights, so letting others
     #        execute it should not be a problem.
@@ -118,3 +102,63 @@ def install_deep_semgrep() -> None:
         stderr=subprocess.DEVNULL,
     ).rstrip()
     logger.info(f"DeepSemgrep Version Info: ({version})")
+
+
+@click.command(hidden=True)
+@handle_command_errors
+def install_scip() -> None:
+    """
+    Install the DeepSemgrep binary (Experimental)
+
+    The binary is installed in the same directory that semgrep-core
+    is installed in. Does not reinstall if existing binary already exists.
+
+    Must be logged in and have access to DeepSemgrep beta
+    Visit https://semgrep.dev/deep-semgrep-beta for more information
+    """
+    state = get_state()
+    state.terminal.configure(verbose=False, debug=False, quiet=False, force_color=False)
+
+    core_path = SemgrepCore.path()
+    if core_path is None:
+        logger.info(
+            "Could not find `semgrep-core` executable so not sure where to install SCIP files"
+        )
+        logger.info("There is something wrong with your semgrep installtation")
+        sys.exit(FATAL_EXIT_CODE)
+
+    install_dir = Path(core_path).parent
+    scip_path = install_dir / "scip_files.zip"
+    if scip_path.exists():
+        logger.info(f"Overwriting SCIP files already installed in {install_dir}")
+
+    if sys.platform.startswith("darwin"):
+        platform = "osx"
+    elif sys.platform.startswith("linux"):
+        platform = "manylinux"
+    else:
+        platform = "manylinux"
+        logger.info(
+            "Running on potentially unsupported platform. Installing linux compatible binary"
+        )
+
+    # The SCIP URL is used to get the binaries which are necessary for SCIP-enhanced
+    # analysis in DeepSemgrep.
+    scip_url = f"{state.env.semgrep_url}/api/agent/deployments/scipfiles/{platform}"
+
+    # We won't do authentication checking here, since the SCIP stuff is just open-source, and
+    # we aren't installing any DeepSemgrep real proprietary stuff.
+    with state.app_session.get(scip_url, timeout=60, stream=True) as r:
+        file_size = int(r.headers.get("Content-Length", 0))
+
+        with open(scip_path, "wb") as f:
+            with tqdm.wrapattr(r.raw, "read", total=file_size) as r_raw:
+                shutil.copyfileobj(r_raw, f)
+
+        with ZipFile(scip_path, "r") as zfile:
+            zfile.extractall(path=scip_path.parent)
+
+    # THINK: Do I need to give exec perms to the things I just installed, like above with
+    # DeepSemgrep?
+
+    logger.info(f"Installed SCIP files to {install_dir}")


### PR DESCRIPTION
## What:
This is a part of a multi-step change towards increasing type and naming resolution in DeepSemgrep, by using SCIP information. This is detailed in [this scope doc](https://www.notion.so/r2cdev/LSIF-Integration-408de64b7726488cb3c1c328f548fad1).

## Why:
This will make it so that we can distribute the necessary SCIP files in a relatively easy way, and produce better findings within DeepSemgrep.

## How:
This PR adds a change where, during installation of DeepSemgrep, we also access another endpoint within the App, which will distribute the URL of the S3 bucket which we can download the SCIP artifacts from. These will then be used by DeepSemgrep.

## Test plan:
Can't test this until the App change is added (adding the endpoint).

## Closes:
Closes PA-2108

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
