### PR TITLE
fix(ci): release issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   create_release:
     name: Create the Github Release
     runs-on: ubuntu-latest
-    needs: [upload-wheels, release-ubuntu-16-04, release-schema]
+    needs: [upload-wheels, release-ubuntu-16-04]
     outputs:
       VERSION: ${{ steps.get_version.outputs.VERSION }}
     if: ${{ !contains(github.ref, '-test-release') }}
@@ -123,27 +123,13 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ steps.token.outputs.token }}"
         run: |
-          gh release --repo returntocorp/semgrep-interfaces upload ${{ needs.create_release.outputs.VERSION }} cli/src/semgrep/semgrep_interfaces/rule_schema.yaml
+          gh release --repo returntocorp/semgrep-interfaces upload ${{ needs.create_release.outputs.VERSION }} cli/src/semgrep/semgrep_interfaces/rule_schema_v1.yaml
       - name: Publish Release Semgrep Interfaces
         id: publish_release_semgrep_interfaces
         env:
           GITHUB_TOKEN: "${{ steps.token.outputs.token }}"
         run: |
           gh release --repo returntocorp/semgrep-interfaces edit ${{ needs.create_release.outputs.VERSION }} --draft=false
-
-  release-schema:
-    name: Create and tag latest Semgrep rule schema
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Upload artifacts rule schema
-        uses: actions/upload-artifact@v3
-        with:
-          name: rule-schema-yaml
-          path: rule_schema_v1.yaml
 
   release-docker:
     name: Build and push Semgrep Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     name: Create the Github Release
     runs-on: ubuntu-latest
     needs: [upload-wheels, release-ubuntu-16-04, release-schema]
+    outputs:
+      VERSION: ${{ steps.get_version.outputs.VERSION }}
     if: ${{ !contains(github.ref, '-test-release') }}
     steps:
       - name: Get the version
@@ -89,7 +91,7 @@ jobs:
           gh release --repo returntocorp/semgrep edit ${{ steps.get_version.outputs.VERSION }} --draft=false
 
   create-release-interfaces:
-    name: Create the Github Release
+    name: Create the Github Release on Semgrep Interfaces
     runs-on: ubuntu-latest
     needs: [create_release]
     if: ${{ !contains(github.ref, '-test-release') }}
@@ -111,22 +113,23 @@ jobs:
           jq -r .token)"
           echo "::add-mask::$TOKEN"
           echo "::set-output name=token::$TOKEN"
-      - uses: actions/download-artifact@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
-          name: rule-schema-yaml
-          path: rule_schema_v1.yaml
+          submodules: true
+          token: ${{ steps.token.outputs.token }}
       - name: Upload Schema Files
         id: upload-semgrep-schema-files
         env:
           GITHUB_TOKEN: "${{ steps.token.outputs.token }}"
         run: |
-          gh release --repo returntocorp/semgrep-interfaces upload ${{ steps.get_version.outputs.VERSION }} rule_schema_v1.yaml
+          gh release --repo returntocorp/semgrep-interfaces upload ${{ needs.create_release.outputs.VERSION }} cli/src/semgrep/semgrep_interfaces/rule_schema.yaml
       - name: Publish Release Semgrep Interfaces
         id: publish_release_semgrep_interfaces
         env:
           GITHUB_TOKEN: "${{ steps.token.outputs.token }}"
         run: |
-          gh release --repo returntocorp/semgrep-interfaces edit ${{ steps.get_version.outputs.VERSION }} --draft=false
+          gh release --repo returntocorp/semgrep-interfaces edit ${{ needs.create_release.outputs.VERSION }} --draft=false
 
   release-schema:
     name: Create and tag latest Semgrep rule schema


### PR DESCRIPTION
This change fixes and issue experienced [in releasing semgrep 0.120.0](https://github.com/returntocorp/semgrep/actions/runs/3379203790) and some follow-on issues that would've popped up if that step had succeeded. 

Test plan: 

The changes in this PR were tested in go/test-gh-actions and then ported to this repo.
- [source](https://github.com/returntocorp/test-gh-actions/blob/develop/.github/workflows/release.yml)
- [successful run](https://github.com/returntocorp/test-gh-actions/actions/runs/3381581391)
- [uploaded schema file (draft release)](https://github.com/returntocorp/semgrep-interfaces/releases)

In addition, I'll be running another release soon to ensure we're good to go.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
