### PR TITLE
fix(cli): prevent experimental rules from running silently / reporting findings

### DIFF
--- a/changelog.d/pa-2121.fixed
+++ b/changelog.d/pa-2121.fixed
@@ -1,0 +1,2 @@
+CLI: Added a fix preventing findings from experimental rules being displayed.
+Experimental rules also now no longer run silently.


### PR DESCRIPTION
## What:
Currently, experimental rules give no indication that they are being run upon `semgrep ci`, and moreover, they report the findings from those experimental rules.

## Why:
This is not good, because this indicates a lack of transparency with users, who should be aware of when experimental rules are being run, but should not have their findings conflated with actual findings they want to see. So we should prevent that if possible.

## How:
Made all matches from rules marked as `EXPERIMENT` ignored, and added a warning message if there are any experimental matches.

## Test plan:
I have no idea how to test this. Help appreciated, @brendongo ?

## Closes
Closes PA-2121.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
