### PR TITLE
osemgrep: convert the semgrep-core error in CLI JSON output

### DIFF
--- a/cli/tests/e2e/test_semgrep_core_parse_error.py
+++ b/cli/tests/e2e/test_semgrep_core_parse_error.py
@@ -18,7 +18,7 @@ def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, sett
         options=["--verbose", "--no-time"],
         output_format=OutputFormat.JSON,
         force_color=True,
-        assert_exit_code=0,
+        assert_exit_code=3,
     )
     snapshot.assert_match(stdout, "out.json")
     snapshot.assert_match(stderr, "error.txt")

--- a/cli/tests/e2e/test_semgrep_core_parse_error.py
+++ b/cli/tests/e2e/test_semgrep_core_parse_error.py
@@ -18,7 +18,7 @@ def test_rule_parser__failure__error_messages(run_semgrep_in_tmp, snapshot, sett
         options=["--verbose", "--no-time"],
         output_format=OutputFormat.JSON,
         force_color=True,
-        assert_exit_code=3,
+        assert_exit_code=0,
     )
     snapshot.assert_match(stdout, "out.json")
     snapshot.assert_match(stderr, "error.txt")

--- a/semgrep-core/src/osemgrep/TOPORT/output.py
+++ b/semgrep-core/src/osemgrep/TOPORT/output.py
@@ -1,9 +1,6 @@
-from collections import defaultdict
 from functools import reduce
 from boltons.iterutils import partition
-
 from semgrep.error import Level
-from semgrep.state import get_state
 from semgrep.target_manager import FileTargetingLog
 from semgrep.util import is_url
 from semgrep.util import terminal_wrap

--- a/semgrep-core/src/osemgrep/TOPORT/output.py
+++ b/semgrep-core/src/osemgrep/TOPORT/output.py
@@ -362,12 +362,7 @@ class OutputHandler:
     def _build_output(
         self,
     ) -> str:
-        # CliOutputExtra members
-        cli_paths = out.CliPaths(
-            scanned=[str(path) for path in sorted(self.all_targets)],
-            _comment=None,
-            skipped=None,
-        )
+        cli_paths = out.CliPaths(...)
         cli_timing: Optional[out.CliTiming] = None
         explanations: Optional[List[out.MatchingExplanation]] = self.explanations
         # Extra, extra! This just in! 🗞️
@@ -398,6 +393,7 @@ class OutputHandler:
             cli_paths = dataclasses.replace(
                 cli_paths, _comment="<add --verbose for a list of skipped paths>"
             )
+
         if self.settings.output_format == OutputFormat.TEXT:
             extra["color_output"] = (
                 self.settings.output_destination is None and sys.stdout.isatty(),

--- a/semgrep-core/src/osemgrep/TOPORT/output.py
+++ b/semgrep-core/src/osemgrep/TOPORT/output.py
@@ -203,13 +203,8 @@ class OutputHandler:
                 logger.error(error.format_for_terminal())
 
     def _final_raise(self, ex: Optional[Exception]) -> None:
-        if ex is None:
-            return
         if isinstance(ex, SemgrepError):
-            if ex.level == Level.ERROR:
-                raise ex
-            elif self.settings.strict:
-                raise ex
+            ...
         else:
             raise ex
 

--- a/semgrep-core/src/osemgrep/TOPORT/types.py
+++ b/semgrep-core/src/osemgrep/TOPORT/types.py
@@ -1,22 +1,6 @@
-from collections import defaultdict
-from pathlib import Path
-from typing import Any
-from typing import FrozenSet
-from typing import Mapping
-from typing import TYPE_CHECKING
-
-from attrs import field
-from attrs import frozen
-
-if TYPE_CHECKING:
-    from semgrep.rule_match import RuleMatchMap
-
-JsonObject = Mapping[str, Any]
 
 Targets = FrozenSet[Path]
 
-
-@frozen
 class FilteredFiles:
     """
     The return value of functions that filters target files.
@@ -25,8 +9,6 @@ class FilteredFiles:
     kept: Targets
     removed: Targets = field(factory=frozenset)
 
-
-@frozen
 class FilteredMatches:
     """
     The return value of functions that filter matches files.

--- a/semgrep-core/src/osemgrep/cli/CLI.ml
+++ b/semgrep-core/src/osemgrep/cli/CLI.ml
@@ -6,7 +6,7 @@
 
    This module determines the subcommand invoked on the command line
    and has another module handle it as if it were an independent command.
-   We don't use Cmdliner to dispatch subcommands because it's a too
+   We don't use Cmdliner to dispatch subcommands because it's too
    complicated and we never show a help page for the whole command anyway
    since we fall back to the 'scan' subcommand if none is given.
 
@@ -116,7 +116,9 @@ let dispatch_subcommand argv =
         let subcmd_argv0 = argv0 ^ "-" ^ subcmd in
         subcmd_argv0 :: subcmd_args |> Array.of_list
       in
-      (* coupling: with known_subcommands above *)
+      (* coupling: with known_subcommands if you add an entry below.
+       * coupling: with the main_help_msg if you add an entry below.
+       *)
       match subcmd with
       | "ci" -> Ci_subcommand.main subcmd_argv
       | "login" -> Login_subcommand.main subcmd_argv
@@ -157,6 +159,8 @@ let main argv =
   (* TODO? the logging setup is now done in Semgrep_scan.ml, because that's
    * when we have a config object, but ideally we would like
    * to analyze argv and do it sooner for all subcommands here.
+   * update: now that we use the Logs library, maybe we could do it
+   * here as we don't need a config object anymore.
    *)
 
   (* TOADAPT
@@ -179,7 +183,7 @@ let main argv =
       state = get_state()
       state.terminal.init_for_cli()
       abort_if_linux_arm64()
-      commands: Dict[str, click.Command] = ctx.command.commands  # type: ignore
+      commands: Dict[str, click.Command] = ctx.command.commands
       subcommand: str = (
           ctx.invoked_subcommand if ctx.invoked_subcommand in commands else "unset"
       )

--- a/semgrep-core/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -13,6 +13,7 @@ open Cmdliner
 (* Types and constants *)
 (*****************************************************************************)
 
+(* 'semgrep ci' shares most of its flags with 'semgrep scan' *)
 type conf = Scan_CLI.conf
 
 (*************************************************************************)

--- a/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.mli
@@ -15,3 +15,6 @@ val contents_of_file :
   Semgrep_output_v1_j.position * Semgrep_output_v1_j.position ->
   Common.filename ->
   string
+
+(* internals used in Scan_subcommant.ml *)
+val exit_code_of_error_type : Semgrep_output_v1_j.core_error_kind -> Exit_code.t

--- a/semgrep-core/src/osemgrep/cli_scan/Output.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Output.mli
@@ -1,8 +1,11 @@
 (* Output the core results on stdout depending on flags in
  * the configuration:
  *  - Json
+ -  - Vim
+ *  - Emacs
  *  - TODO Text
  *  - TODO Sarif
  *  - TODO ...
+ *
  *)
 val output_result : Scan_CLI.conf -> Core_runner.result -> unit

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -9,26 +9,14 @@
 *)
 
 (*****************************************************************************)
-(* Types *)
+(* Logging/Profiling/Debugging *)
 (*****************************************************************************)
 
-(*****************************************************************************)
-(* Helpers *)
-(*****************************************************************************)
-
-(*****************************************************************************)
-(* Main logic *)
-(*****************************************************************************)
-
-(* All the business logic after command-line parsing. Return the desired
-   exit code. *)
-let run (conf : Scan_CLI.conf) : Exit_code.t =
+let setup_logging (conf : Scan_CLI.conf) =
   (* This used to be in Core_CLI.ml, and so should be in CLI.ml but
-   * we get a conf object later in osesmgrep.
+   * we get a conf object later in osemgrep.
    *)
-  (* --------------------------------------------------------- *)
-  (* Setting up debugging/profiling *)
-  (* --------------------------------------------------------- *)
+
   (* For osemgrep we use the Logs library instead of the Logger
    * library in pfff. We had a few issues with Logger (which is a small
    * wrapper around the easy_logging library), and we don't really want
@@ -49,12 +37,47 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
    * logging information at runtime, hence this call.
    *)
   Setup_logging.setup config;
+  ()
 
+(* TODO *)
+let setup_profiling _conf =
   (* TOADAPT
      if config.debug then Report.mode := MDebug
      else if config.report_time then Report.mode := MTime
      else Report.mode := MNo_info;
   *)
+  ()
+
+(*****************************************************************************)
+(* Error management *)
+(*****************************************************************************)
+
+(* python: this used to be done in a _final_raise method from output.py
+ * but better separation of concern to do it here.
+ *)
+let exit_code_of_errors (conf : Scan_CLI.conf)
+    (errors : Semgrep_output_v1_t.core_error list) : Exit_code.t =
+  match List.rev errors with
+  | [] -> Exit_code.ok
+  | x :: _ -> (
+      (* alt: raise a Semgrep_error that would be catched by CLI_Common
+       * wrapper instead of returning an exit code directly? *)
+      match () with
+      | _ when x.severity = Semgrep_output_v1_t.Error ->
+          Cli_json_output.exit_code_of_error_type x.error_type
+      | _ when conf.strict ->
+          Cli_json_output.exit_code_of_error_type x.error_type
+      | _else_ -> Exit_code.ok)
+
+(*****************************************************************************)
+(* Main logic *)
+(*****************************************************************************)
+
+(* All the business logic after command-line parsing. Return the desired
+   exit code. *)
+let run (conf : Scan_CLI.conf) : Exit_code.t =
+  setup_logging conf;
+  setup_profiling conf;
 
   (* --------------------------------------------------------- *)
   (* Let's go *)
@@ -65,12 +88,11 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
    * TODO: in theory we can also pass multiple --config and
    * have a default config.
    *)
-  let rules, _errorsTODO =
+  let (rules : Rule.rules), (_errorsTODO : Rule.invalid_rule_error list) =
     Config_resolver.rules_from_dashdash_config conf.config
   in
-  (* TODO: there are more ways to specify targets? see target_manager.py
-   *)
-  let targets, _skipped_targetsTODO =
+  (* TODO: there are more ways to specify targets? see target_manager.py *)
+  let (targets : Common.filename list), _skipped_targetsTODO =
     Find_target.select_global_targets ~includes:conf.include_
       ~excludes:conf.exclude ~max_target_bytes:conf.max_target_bytes
       ~respect_git_ignore:conf.respect_git_ignore conf.target_roots
@@ -78,8 +100,10 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
   let (res : Core_runner.result) =
     Core_runner.invoke_semgrep_core conf rules targets
   in
+  (* outputting the result! in JSON or Text or whatever depending on conf *)
   Output.output_result conf res;
-  Exit_code.ok
+  (* final result for the shell *)
+  exit_code_of_errors conf res.core.errors
 
 (*****************************************************************************)
 (* Entry point *)

--- a/semgrep-core/src/osemgrep/core/Error.ml
+++ b/semgrep-core/src/osemgrep/core/Error.ml
@@ -4,9 +4,17 @@
 
 module C = Output_from_core_t
 
+(* LATER: do we need this intermediate data-structure? Can't we
+ * reuse simply Rule.severity? Or even Output_from_core_t.core_severity.
+ *)
 type level =
   | Warn (* = 3; Always an error *)
   | Error (* = 4; Only an error if "strict" is set *)
+
+(* for CLI JSON output *)
+let string_of_level = function
+  | Warn -> "warn"
+  | Error -> "error"
 
 (*
    originally: class ErrorWithSpan(SemgrepError)

--- a/semgrep-core/src/osemgrep/core/Error.mli
+++ b/semgrep-core/src/osemgrep/core/Error.mli
@@ -13,6 +13,9 @@ type level =
   | Warn (* always an error *)
   | Error (* only an error if "strict" is set *)
 
+(* for the CLI JSON output *)
+val string_of_level : level -> string
+
 exception Semgrep_error of t
 
 (*

--- a/semgrep-core/src/osemgrep/core/Exit_code.ml
+++ b/semgrep-core/src/osemgrep/core/Exit_code.ml
@@ -17,8 +17,7 @@ let of_int x = x
 let ok = 0
 let findings = 1
 let fatal = 2
-
-(* let invalid_code = 3 *)
+let invalid_code = 3
 let invalid_pattern = 4
 let unparseable_yaml = 5
 

--- a/semgrep-core/src/osemgrep/core/Exit_code.mli
+++ b/semgrep-core/src/osemgrep/core/Exit_code.mli
@@ -1,5 +1,8 @@
 (*
-   Exit codes of the semgrep executable (not just 'semgrep scan')
+   Exit codes of the semgrep executable (not just 'semgrep scan').
+
+   Some of those exit codes are also (ab)used to represent some error code
+   for errors reported in the semgrep CLI JSON output.
 *)
 
 (* This ensures that exit codes are declared and documented here. *)
@@ -16,6 +19,7 @@ val of_int : int -> t
 val ok : t
 val findings : t
 val fatal : t
+val invalid_code : t
 val invalid_pattern : t
 val unparseable_yaml : t
 val missing_config : t


### PR DESCRIPTION
test plan:
```
PYTEST_USE_OSEMGREP=true pytest tests/e2e/test_semgrep_core_parse_error.py::test_rule_parser__failure__error_messages[settings0] -vv
```
shows almost no more difference in the JSON output


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)