### PR TITLE
Fix URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ semgrep -e '$X == $X' --lang=py path/to/src
 $ semgrep --config auto
 ```
 
-To run Semgrep Supply Chain, [contact the Semgrep team](https://semgrpe.dev/contact-us).
+To run Semgrep Supply Chain, [contact the Semgrep team](https://semgrep.dev/contact-us).
 Visit the [full documentation](https://semgrep.dev/docs/getting-started/) to learn more.
 
 ### Rule examples


### PR DESCRIPTION
The contact us URL had a typo.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
