### PR TITLE
feat!: extended pattern-{not, inside, not-inside} to allow arbitrary patterns

### DIFF
--- a/semgrep-core/tests/rules/rule_extensions.yaml
+++ b/semgrep-core/tests/rules/rule_extensions.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: rule-extensions 
+  patterns:
+  - pattern-not: 
+      pattern: "A"
+  - pattern-inside:
+      pattern: "B"
+  - pattern-not-inside:
+      pattern: "C"
+  message: This rule is just meant to illustrate that we can parse "extensions" to old-grammar rules. 
+  severity: WARNING
+  languages: [python]


### PR DESCRIPTION
## What:
![image](https://user-images.githubusercontent.com/49291449/200414444-de12f984-5394-48b4-bb22-55fa3b7c9ea2.png)

## Why:
This will make SR's lives noticeably better at almost zero cost. To be honest, I should have written this a long time ago.

## How:
Just changed the parsing engine. The back-end is all already done, due to the invisible new syntax changes.

## Test plan:
`make test`

Closes PA-1723

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
