### PR TITLE
osemgrep: handle --config <dir>

### DIFF
--- a/semgrep-core/src/osemgrep/cli_scan/Config_resolver.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Config_resolver.mli
@@ -1,3 +1,7 @@
-(* The --config string argument can resolve to one of the config_kind *)
-val rules_from_dashdash_config :
-  string -> Rule.rules * Rule.invalid_rule_error list
+type rules_and_origin = {
+  path : Common.filename option; (* None for remote files *)
+  rules : Rule.rules;
+  errors : Rule.invalid_rule_error list;
+}
+
+val rules_from_dashdash_config : string -> rules_and_origin list

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -100,9 +100,17 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
        * TODO: in theory we can also pass multiple --config and
        * have a default config.
        *)
-      let (rules : Rule.rules), (_errorsTODO : Rule.invalid_rule_error list) =
+      let rules_and_origins =
         Config_resolver.rules_from_dashdash_config conf.config
       in
+      (* TODO: rewrite rule_id using x.Config_resolver.path origin? *)
+      let (rules : Rule.rules) =
+        rules_and_origins |> List.concat_map (fun x -> x.Config_resolver.rules)
+      in
+      let (_errorsTODO : Rule.invalid_rule_error list) =
+        rules_and_origins |> List.concat_map (fun x -> x.Config_resolver.errors)
+      in
+
       let filtered_rules =
         match conf.severity with
         | [] -> rules

--- a/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.ml
+++ b/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.ml
@@ -19,8 +19,10 @@ open Common
 (*****************************************************************************)
 
 type config_kind =
+  (* foo.yaml *)
   | File of Common.filename
-  | Dir of string
+  (* myrules/ (but will not go recursively in subdirs of myrules) *)
+  | Dir of Common.filename
   | R of registry_kind
 
 and registry_kind =
@@ -45,7 +47,7 @@ let config_kind_of_config_str config_str =
   | s when s =~ "^\\(.*\\):\\(.*\\)" ->
       let user, snippet = Common.matched2 s in
       R (SavedSnippet (user, snippet))
-  (* TODO  | file when Sys.is_dir file  -> Dir file *)
+  | dir when Sys.is_directory dir -> Dir dir
   | file when Sys.file_exists file -> File file
   | _else_ -> failwith (spf "not a valid --config string: %s" config_str)
 

--- a/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.mli
+++ b/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.mli
@@ -1,6 +1,8 @@
 type config_kind =
+  (* foo.yaml *)
   | File of Common.filename
-  | Dir of Common.dirname
+  (* myrules/ (but will not go recursively in subdirs of myrules) *)
+  | Dir of Common.filename
   | R of registry_kind
 
 and registry_kind =

--- a/semgrep-core/src/osemgrep/core/Constants.ml
+++ b/semgrep-core/src/osemgrep/core/Constants.ml
@@ -15,10 +15,6 @@ let default_semgrep_config_name = "semgrep"
 let _default_config_file = spf ".%s.yml" default_semgrep_config_name
 let _default_config_folder = spf ".%s" default_semgrep_config_name
 let _default_semgrep_app_config_url = "api/agent/deployments/scans/config"
-let yml_extensions = [ ".yml"; ".yaml" ]
-let _yml_suffixes = Common.map (fun ext -> [ ext ]) yml_extensions
-let _yml_test_suffixes = Common.map (fun ext -> [ ".test"; ext ]) yml_extensions
-let _fixtest_suffix = ".fixed"
 
 let _returntocorp_lever_url =
   "https://api.lever.co/v0/postings/returntocorp?mode=json"

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1365,7 +1365,7 @@ let parse_file ?error_recovery file =
   parse_generic_ast ?error_recovery file ast
 
 (*****************************************************************************)
-(* Entry point *)
+(* Main Entry point *)
 (*****************************************************************************)
 
 let parse file =
@@ -1374,3 +1374,25 @@ let parse file =
   xs
 
 let parse_and_filter_invalid_rules file = parse_file ~error_recovery:true file
+
+(*****************************************************************************)
+(* Valid rule filename checks *)
+(*****************************************************************************)
+(* Those functions could be in a separate file *)
+
+(* TODO? could define
+ * type yaml_kind = YamlRule | YamlTest | YamlFixed | YamlOther
+ *)
+let is_test_yaml_file filepath =
+  (* .test.yaml files are YAML target files rather than config files! *)
+  Filename.check_suffix filepath ".test.yaml"
+  || Filename.check_suffix filepath ".test.fixed.yaml"
+
+let is_valid_rule_filename filename =
+  match File_type.file_type_of_file filename with
+  | FT.Config FT.Yaml -> not (is_test_yaml_file filename)
+  (* old: we were allowing Jsonnet before, but better to skip
+   * them for now to avoid adding a jsonnet dependency in our docker/CI
+   * FT.Config (FT.Json FT.Jsonnet) when not unit_testing -> true
+   *)
+  | _else_ -> false

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -17,3 +17,6 @@ val parse : Common.filename -> Rule.rules
 
 (* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml *)
 val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
+
+(* ex: foo.yaml, foo.yml, but not foo.test.yaml *)
+val is_valid_rule_filename : Common.filename -> bool

--- a/semgrep-core/src/targeting/List_files.mli
+++ b/semgrep-core/src/targeting/List_files.mli
@@ -1,7 +1,7 @@
 (*
    List files recursively in a safe, efficient, and portable manner.
 
-   Replaces the functions in pfff/commons that use external unix commands
+   Replaces the functions in pfff/commons that use external UNIX commands
    such as 'find'.
 *)
 


### PR DESCRIPTION
test plan:
```
$ ~/yy/bin/osemgrep --verbose --json --config tests/e2e/rules/cli_test/basic/ tests/e2e/targets/cli_test/basic/
{"version":"0.120.0","errors":[],"results":[{"check_id":"tests.e2e.rules.cli_test.basic-test","path":"tests/e2e/targets/cli_test/basic/basic.py","start":{"line":2,"col":7,"offset":27},"end":{"line":2,"col":13,"offset":33},"extra":{"metavars":{"$X":{"start":{"line":2,"col":7,"offset":27},"end":{"line":2,"col":8,"offset":28},"abstract_content":"1"}},"fingerprint":"0x42","lines":"print(1 == 1)","message":"Basic test","metadata":{},"severity":"ERROR","is_ignored":false}}],"paths":{"scanned":["tests/e2e/targets/cli_test/basic/basic.py"]}}
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)