### PR TITLE
osemgrep: support multiple --config

### DIFF
--- a/semgrep-core/src/osemgrep/TOPORT/core_output.py
+++ b/semgrep-core/src/osemgrep/TOPORT/core_output.py
@@ -48,18 +48,4 @@ def core_matches_to_rule_matches(
             fix_regex = out.FixRegex(regex=regex, replacement=replacement, count=count)
 
         return RuleMatch(...)
-
-    findings: Dict[Rule, RuleMatchSet] = {rule: RuleMatchSet(rule) for rule in rules}
-    seen_cli_unique_keys: Set[Tuple] = set()
-    for match in res.matches:
-        rule = rule_table[match.rule_id.value]
-        rule_match = convert_to_rule_match(match)
-        if rule_match.cli_unique_key in seen_cli_unique_keys:
-            continue
-        seen_cli_unique_keys.add(rule_match.cli_unique_key)
-        findings[rule].add(rule_match)
-
-    # Sort results so as to guarantee the same results across different
-    # runs. Results may arrive in a different order due to parallelism
-    # (-j option).
-    return {rule: sorted(matches) for rule, matches in findings.items()}
+    ...

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -27,8 +27,7 @@ module H = Cmdliner_helpers
 type conf = {
   autofix : bool;
   baseline_commit : string option;
-  (* TOPORT: can have multiple calls to --config, so string list here *)
-  config : string;
+  config : string list;
   dryrun : bool;
   exclude : string list;
   exclude_rule_ids : string list;
@@ -61,7 +60,7 @@ let default : conf =
   {
     autofix = false;
     baseline_commit = None;
-    config = "auto";
+    config = [ "auto" ];
     dryrun = false;
     exclude = [];
     exclude_rule_ids = [];
@@ -380,8 +379,7 @@ let o_vim : bool Term.t =
 (* ------------------------------------------------------------------ *)
 (* TOPORT "Configuration options" *)
 (* ------------------------------------------------------------------ *)
-(* TOPORT: multiple = true *)
-let o_config : string Term.t =
+let o_config : string list Term.t =
   let info =
     Arg.info [ "c"; "f"; "config" ]
       ~env:(Cmd.Env.info "SEMGREP_RULES")
@@ -400,7 +398,7 @@ See https://semgrep.dev/docs/writing-rules/rule-syntax for information on
 configuration file format.
 |}
   in
-  Arg.value (Arg.opt Arg.string default.config info)
+  Arg.value (Arg.opt_all Arg.string default.config info)
 
 let o_pattern : string option Term.t =
   let info =

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -8,7 +8,7 @@
 type conf = {
   autofix : bool;
   baseline_commit : string option;
-  config : string;
+  config : string list;
   dryrun : bool;
   exclude : string list;
   exclude_rule_ids : string list;

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -101,7 +101,8 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
        * have a default config.
        *)
       let rules_and_origins =
-        Config_resolver.rules_from_dashdash_config conf.config
+        conf.config
+        |> List.concat_map Config_resolver.rules_from_dashdash_config
       in
       (* TODO: rewrite rule_id using x.Config_resolver.path origin? *)
       let (rules : Rule.rules) =

--- a/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.ml
+++ b/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.ml
@@ -19,9 +19,9 @@ open Common
 (*****************************************************************************)
 
 type config_kind =
-  (* foo.yaml *)
+  (* ex: 'foo.yaml' *)
   | File of Common.filename
-  (* myrules/ (but will not go recursively in subdirs of myrules) *)
+  (* ex: 'myrules/' (will go also recursively in subdirs of myrules) *)
   | Dir of Common.filename
   | R of registry_kind
 
@@ -32,7 +32,7 @@ and registry_kind =
   | Pack of string
   (* s/... *)
   | Snippet of string
-  (* pad:basic *)
+  (* ex: 'pad:basic' *)
   | SavedSnippet of string (* username *) * string (* snippetname *)
 [@@deriving show]
 

--- a/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.mli
+++ b/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.mli
@@ -1,7 +1,7 @@
 type config_kind =
-  (* foo.yaml *)
+  (* ex: 'foo.yaml' *)
   | File of Common.filename
-  (* myrules/ (but will not go recursively in subdirs of myrules) *)
+  (* ex: 'myrules/' (will go also recursively in subdirs of myrules) *)
   | Dir of Common.filename
   | R of registry_kind
 
@@ -12,7 +12,7 @@ and registry_kind =
   | Pack of string
   (* s/... *)
   | Snippet of string
-  (* pad:basic *)
+  (* ex: 'pad:basic' *)
   | SavedSnippet of string (* username *) * string (* snippetname *)
 [@@deriving show]
 


### PR DESCRIPTION
test plan:
PYTEST_USE_OSEMGREP=true pytest
tests/e2e/test_check.py::test_multiple_configs_file -vv
now passes


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)