### PR TITLE
osemgrep: return error exit code when error in a rule

### DIFF
--- a/semgrep-core/src/osemgrep/TOPORT/core_output.py
+++ b/semgrep-core/src/osemgrep/TOPORT/core_output.py
@@ -1,31 +1,5 @@
-from semgrep.error import Level
-from semgrep.types import JsonObject
 
-def core_error_to_semgrep_error(err: core.CoreError) -> SemgrepCoreError:
-    if isinstance(err.error_type.value, core.PatternParseError):
-        yaml_path = err.error_type.value.value[::-1]
-        error_span = _core_location_to_error_span(err.location)
-        config_start = out.PositionBis(line=0, col=1)
-        config_end = out.PositionBis(
-            line=err.location.end.line - err.location.start.line,
-            col=err.location.end.col - err.location.start.col + 1,
-        )
-        spans = [
-            dataclasses.replace(
-                error_span,
-                config_start=config_start,
-                config_end=config_end,
-                config_path=yaml_path,
-            )
-        ]
-    ...
-    return SemgrepCoreError(code, level, spans, err)
-
-
-def core_matches_to_rule_matches(
-    rules: List[Rule], res: core.CoreMatchResults
-) -> Dict[Rule, List[RuleMatch]]:
-
+def xxx():
     def convert_to_rule_match(match: core.CoreMatch) -> RuleMatch:
         # this validation for fix_regex code was in autofix.py before
         # TODO: this validation should be done in rule.py when parsing the rule

--- a/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -168,11 +168,27 @@ let error_message ~rule_id ~(location : Out.location)
   spf "%s %s:\n %s" (error_type_string error_type) error_context core_message
 
 (* #spans are used only for PatternParseError *)
-let error_spans ~(error_type : Out.core_error_kind) =
+let error_spans ~(error_type : Out.core_error_kind) ~(location : Out.location) =
   match error_type with
-  | PatternParseError _ ->
-      pr2 "TODO: Span of PatternParseError";
-      None
+  | PatternParseError _yaml_pathTODO ->
+      (* TOPORT
+         yaml_path = err.error_type.value.value[::-1]
+         config_start = out.PositionBis(line=0, col=1)
+         config_end = out.PositionBis(
+             line=err.location.end.line - err.location.start.line,
+             col=err.location.end.col - err.location.start.col + 1,
+         )
+         spans = [
+             dataclasses.replace(
+                 ...
+                 config_start=config_start,
+                 config_end=config_end,
+                 config_path=yaml_path,
+             )
+         ]
+      *)
+      let span = core_location_to_error_span location in
+      Some [ span ]
   | PartialParsing locs -> Some (locs |> Common.map core_location_to_error_span)
   | _else_ -> None
 
@@ -223,7 +239,7 @@ let cli_error_of_core_error (x : Out.core_error) : Out.cli_error =
       let message =
         Some (error_message ~rule_id ~error_type ~location ~core_message)
       in
-      let spans = error_spans ~error_type in
+      let spans = error_spans ~error_type ~location in
       {
         (* LATER? seems to be either 2 (fatal) or 3 (invalid_code), so maybe
          * better to change the ATD spec and use a variant for cli_error.code

--- a/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -170,7 +170,9 @@ let error_message ~rule_id ~(location : Out.location)
 (* #spans are used only for PatternParseError *)
 let error_spans ~(error_type : Out.core_error_kind) =
   match error_type with
-  | PatternParseError _ -> failwith "TODO: Span of PatternParseError"
+  | PatternParseError _ ->
+      pr2 "TODO: Span of PatternParseError";
+      None
   | PartialParsing locs -> Some (locs |> Common.map core_location_to_error_span)
   | _else_ -> None
 

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.mli
@@ -14,7 +14,12 @@ type result = {
   scanned : path Set_.t;
 }
 
-val invoke_semgrep_core : Scan_CLI.conf -> Rule.rules -> path list -> result
+val invoke_semgrep_core :
+  Scan_CLI.conf ->
+  Rule.rules ->
+  Rule.invalid_rule_error list ->
+  path list ->
+  result
 
 (* Helper used in Semgrep_scan.ml *)
 val runner_config_of_conf : Scan_CLI.conf -> Runner_config.t

--- a/semgrep-core/src/reporting/JSON_report.mli
+++ b/semgrep-core/src/reporting/JSON_report.mli
@@ -19,5 +19,8 @@ val match_results_of_matches_and_errors :
  *)
 val metavar_string_of_any : AST_generic.any -> string
 
+(* now used also in osemgrep *)
+val error_to_error : Semgrep_error_code.error -> Output_from_core_t.core_error
+
 (* internal *)
 val match_to_error : Pattern_match.t -> unit


### PR DESCRIPTION
test plan:
```
$ ~/yy/bin/osemgrep --config rules/invalid-rules/invalid-pattern.yaml --json targets/basic/stupid.py
TODO: Span of PatternParseError
{"version":"0.120.0","errors":[{"code":2,"level":"error","type":"Pattern parse error","rule_id":"print","message":"Pattern parse error in rule print:\n Invalid pattern for Python:\n--- pattern ---\nprint..);\n--- end pattern ---\nPattern error: Parsing.Parse_error\n"}],"results":[],"paths":{"scanned":[],"_comment":"<add --verbose for a list of skipped paths>"}}
(cli) [pad@thinkstation e2e (osemgrep_rule_error)]$ echo $?
2
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)