### PR TITLE
fix: simplify and fix brew command used to open brew PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -489,8 +489,7 @@ jobs:
 
   homebrew-core-pr:
     name: Update on Homebrew-Core
-    needs: [sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
-
+    needs: [create_release, sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-12
     if: ${{ !contains(github.ref,'-test-release') }}
     steps:
@@ -501,18 +500,10 @@ jobs:
           python-version: "3.9.x"
       - name: Brew update
         run: brew update
-      - name: Install brew pipgrip
-        run: brew install pipgrip
-      - name: Install pip pipgrip
-        run: pip install pipgrip
-      - name: Point homebrew pipgrip to pip pipgrip
-        # Homebrew brew calls brew pipgrip internally but brew pipgrip is pinned to python3.10
-        # this tricks it into using our 3.9 pipgrip
-        run: rm /usr/local/opt/pipgrip/bin/pipgrip && ln "/Users/runner/hostedtoolcache/Python/${{ steps.python-setup.outputs.python-version }}/x64/bin/pipgrip" /usr/local/opt/pipgrip/bin/pipgrip
-      - uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          # see https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/semgrep.rb
-          formula: semgrep
-          org: returntocorp
-          force: true
+      - name: Open Brew PR on semgrep
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
+        run: |
+          brew bump-formula-pr --force --no-audit --no-browse \
+            --message="Bump semgrep to version ${{ needs.create_release.outputs.VERSION }}" \
+            --fork-org=returntocorp --tag="v${{ needs.create_release.outputs.VERSION }}" semgrep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,7 +500,7 @@ jobs:
           python-version: "3.9.x"
       - name: Brew update
         run: brew update
-      - name: Open Brew PR on semgrep
+      - name: Open Brew PR on homebrew/homebrew-core
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
         run: |


### PR DESCRIPTION
This PR addresses [a failure to release.](https://github.com/returntocorp/semgrep/actions/runs/3413515162)

Test Plan:

This has been tested in go/test-gh-actions and [the run succeeded in draft form](https://github.com/returntocorp/test-gh-actions/actions/runs/3420549300). Run failed when I tried to test real PR opening, since we already had a PR open. 

I'll also be running another release to ensure this goes smoothly.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
