### PR TITLE
fix: call workflow instead of checking out scripts

### DIFF
--- a/.github/workflows/call-bump-pr-workflow.yml
+++ b/.github/workflows/call-bump-pr-workflow.yml
@@ -4,6 +4,16 @@
 name: call-bump-pr-workflow
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: The version of semgrep to bump to
+      repository:
+        required: true
+        type: string
+        description: Which repo to call the `bump_version.yaml` workflow in
   workflow_call:
     inputs:
       version:
@@ -42,4 +52,4 @@ jobs:
           REPOSITORY: "${{ inputs.repository }}"
         run: |
           # Initiate run of workflow (non-blocking)
-          gh workflow run bump_version.yaml --repo "${REPOSITORY}" --raw-field version="${NEW_SEMGREP_VERSION}"
+          gh workflow run bump_version.yml --repo "${REPOSITORY}" --raw-field version="${NEW_SEMGREP_VERSION}"

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -330,24 +330,20 @@ jobs:
   bump-semgrep-app:
     needs: [validate-release-trigger, release-setup]
     name: Bump Semgrep App Semgrep Version
-    uses: ./.github/workflows/open-bump-pr.yml
+    uses: ./.github/workflows/call-bump-pr-workflow.yml
     secrets: inherit
     with:
       version: ${{needs.release-setup.outputs.version}}
       repository: "returntocorp/semgrep-app"
-      base_branch: "develop"
-      bump_script_path: "scripts/bump-version"
 
   bump-semgrep-action:
     needs: [validate-release-trigger, release-setup]
     name: Bump Semgrep Action Semgrep Version
-    uses: ./.github/workflows/open-bump-pr.yml
+    uses: ./.github/workflows/call-bump-pr-workflow.yml
     secrets: inherit
     with:
       version: ${{needs.release-setup.outputs.version}}
       repository: "returntocorp/semgrep-action"
-      base_branch: "develop"
-      bump_script_path: "scripts/bump-version"
 
   bump-semgrep-rpc:
     needs: [validate-release-trigger, release-setup]


### PR DESCRIPTION
This PR changes how we open PRs in other workflows. Note that the original `open-bump-pr.yml` is still used in one more place, and must stay around for that reason. 

Test plan:

[this has been tested in the test-gh-actions repo](https://github.com/returntocorp/test-gh-actions/actions/runs/3421847562), and workflow calls succeeded. The downstream workflows failed for other reasons (e.g., 0.999.0 as used for testing isn't found as a valid semgrep version).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
