### PR TITLE
fix(const prop): allow cast and parens in sym prop

### DIFF
--- a/changelog.d/pa-2054.fixed
+++ b/changelog.d/pa-2054.fixed
@@ -1,0 +1,1 @@
+Constant propagation: Type casts and parenthesized expressions (in Go) can now be symbolically propagated.

--- a/semgrep-core/src/analyzing/Dataflow_svalue.ml
+++ b/semgrep-core/src/analyzing/Dataflow_svalue.ml
@@ -386,7 +386,10 @@ let rec is_symbolic_expr expr =
   | G.L _ -> true
   | G.N _ -> true
   | G.IdSpecial _ -> true
-  | G.DotAccess (e, _, FN _) -> is_symbolic_expr e
+  | G.ParenExpr (_, e, _)
+  | G.Cast (_, _, e)
+  | G.DotAccess (e, _, FN _) ->
+      is_symbolic_expr e
   | G.ArrayAccess (e1, (_, e2, _)) -> is_symbolic_expr e1 && is_symbolic_expr e2
   | G.Call (e, (_, args, _)) ->
       is_symbolic_expr e && List.for_all is_symbolic_arg args

--- a/semgrep-core/tests/rules/cast_symbol_prop.go
+++ b/semgrep-core/tests/rules/cast_symbol_prop.go
@@ -1,0 +1,8 @@
+
+func foo() {
+	// Note that the Go parser parses this to a Cast of a ParenExpr
+	x := f([]int("foo"))
+
+	// ruleid: cast-symbol-prop
+	sink(x)
+}

--- a/semgrep-core/tests/rules/cast_symbol_prop.yaml
+++ b/semgrep-core/tests/rules/cast_symbol_prop.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: cast-symbol-prop 
+  languages:
+  - go 
+  pattern: |
+    sink(f(...)) 
+  message: Successfully propagated a Cast/ParenExpr 
+  options:
+    symbolic_propagation: true
+  severity: ERROR


### PR DESCRIPTION
## What:
Constant propagation currently limits things which can be symbolically propagated. As of right now, it won't do either `Cast`s or `ParenExpr`s, the latter being only a thing in Go.

## Why:
We should propagate these symbolically, because there's no real reason not to.

## How:
Made them register as symbolic expressions. Semgrep takes care of the rest.

## Test plan:
`make test`

Closes PA-2054

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
