### PR TITLE
feat(rule syntax): enable upgraded `pattern-not`, `pattern-inside`, and `pattern-not-inside`

### DIFF
--- a/changelog.d/pa-1723.fixed
+++ b/changelog.d/pa-1723.fixed
@@ -1,0 +1,1 @@
+Rule syntax: Allow `pattern-not`, `pattern-inside`, and `pattern-not-inside` to take in arbitrary patterns (such as `patterns`, `pattern-either`, and friends)

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error-in-color.txt
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error-in-color.txt
@@ -10,6 +10,7 @@
 [94m[22m[24m11 | [0m              - pattern: self.$X == self.$X
 [94m[22m[24m12 | [0m      - pattern-not: 1 == 1
 
-[31m[22m[24m[{'pattern': '$X == $X'}, {'pattern': '$X != $X'}, {'patterns': [{'pattern-inside': 'def __init__(...):\n    ...\n'}, {'pattern': 'self.$X == self.$X'}]}] is not of type 'string'[0m
+[31m[22m[24m[{'pattern': '$X == $X'}, {'pattern': '$X != $X'}, {'patterns': [{'pattern-inside': 'def __init__(...):\n    ...\n'}, {'pattern': 'self.$X == self.$X'}]}] is not of type 'object'
+[{'pattern': '$X == $X'}, {'pattern': '$X != $X'}, {'patterns': [{'pattern-inside': 'def __init__(...):\n    ...\n'}, {'pattern': 'self.$X == self.$X'}]}] is not of type 'string'[0m
 
 [31m[41m[22m[24m[[0m[38;5;231m[41m[1m[24mERROR[0m[31m[41m[22m[24m][0m Ran with --strict and got 1 error while loading configs

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad1/error.json
@@ -3,7 +3,7 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "[{'pattern': '$X == $X'}, {'pattern': '$X != $X'}, {'patterns': [{'pattern-inside': 'def __init__(...):\\n    ...\\n'}, {'pattern': 'self.$X == self.$X'}]}] is not of type 'string'",
+      "long_msg": "[{'pattern': '$X == $X'}, {'pattern': '$X != $X'}, {'patterns': [{'pattern-inside': 'def __init__(...):\\n    ...\\n'}, {'pattern': 'self.$X == self.$X'}]}] is not of type 'object'\n[{'pattern': '$X == $X'}, {'pattern': '$X != $X'}, {'patterns': [{'pattern-inside': 'def __init__(...):\\n    ...\\n'}, {'pattern': 'self.$X == self.$X'}]}] is not of type 'string'",
       "short_msg": "Invalid rule schema",
       "spans": [
         {


### PR DESCRIPTION
## What:
I already merged the one which changes `semgrep-core`, but this updates the `semgrep-interfaces` submodule so that we can actually use the new syntax with `semgrep`.

## Why:
Make SR's lives easier.

## How:
Upgraded the submodule.

## Test plan:
I tested it locally, the new schema works.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
