### PR TITLE
fix: brew release PR creation is now functional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,10 +500,16 @@ jobs:
           python-version: "3.9.x"
       - name: Brew update
         run: brew update
+      # pipgrip tries to install python@3.11, and that has linking issues unless --overwrite is passed.
+      # we may be able to remove the python setup above.
+      - name: Brew install python@3.11
+        run: brew install --overwrite python@3.11
+      - name: Install pipgrip
+        run: brew install --overwrite pipgrip
       - name: Open Brew PR on homebrew/homebrew-core
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
         run: |
           brew bump-formula-pr --force --no-audit --no-browse \
             --message="Bump semgrep to version ${{ needs.create_release.outputs.VERSION }}" \
-            --fork-org=returntocorp --tag="v${{ needs.create_release.outputs.VERSION }}" semgrep
+            --fork-org=returntocorp --tag="${{ needs.create_release.outputs.VERSION }}" semgrep


### PR DESCRIPTION
This PR fixes a failing brew step. `brew bump-formula-pr --dry-run` is not a direct proxy for `brew bump-formula-pr`, which means that the passing test jobs we saw in the past didn't fully capture what needed to occur. 

Additionally, the [tagging logic here was incorrect.](https://github.com/returntocorp/semgrep/actions/runs/3422553305/jobs/5700458793)

Test plan: 

[This test workflow was run](https://github.com/returntocorp/test-gh-actions/actions/runs/3423823404) and resulted in [this PR being created on homebrew.](https://github.com/Homebrew/homebrew-core/pull/115241). It was then ported to this repository.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
