### PR TITLE
fix(terraform): fix nondeterministic output by standardizing filepath

### DIFF
--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -220,7 +220,7 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
   let file =
     if
       x.file <> min_loc.file
-      || (x.file <> max_loc.file && min_loc.file != "FAKE TOKEN LOCATION")
+      || (x.file <> max_loc.file && min_loc.file <> "FAKE TOKEN LOCATION")
     then min_loc.file
     else x.file
   in

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -217,9 +217,16 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
     let* edit = render_fix x in
     Some edit.Textedit.replacement_text
   in
+  let file =
+    if
+      x.file <> min_loc.file
+      || (x.file <> max_loc.file && min_loc.file != "FAKE TOKEN LOCATION")
+    then min_loc.file
+    else x.file
+  in
   {
     Out.rule_id = x.rule_id.id;
-    location = { path = x.file; start = startp; end_ = endp };
+    location = { path = file; start = startp; end_ = endp };
     extra =
       {
         message = Some x.rule_id.message;

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -217,10 +217,16 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
     let* edit = render_fix x in
     Some edit.Textedit.replacement_text
   in
+  (* We need to do this, because in Terraform, we may end up with a `file` which
+     does not correspond to the actual location of the tokens. This `file` is
+     erroneous, and should be replaced by the location of the code of the match,
+     if possible. Not if it's fake, though.
+     In other languages, this should hopefully not happen.
+  *)
   let file =
     if
-      x.file <> min_loc.file
-      || (x.file <> max_loc.file && min_loc.file <> "FAKE TOKEN LOCATION")
+      (x.file <> min_loc.file || x.file <> max_loc.file)
+      && min_loc.file <> "FAKE TOKEN LOCATION"
     then min_loc.file
     else x.file
   in


### PR DESCRIPTION
Remember that part where I said I was doing the last bandaid fix for Terraform? Yeah that was a lie.

## What:
This fixes a nondeterminism bug in DeepSemgrep for Terraform: https://github.com/returntocorp/semgrep-proprietary/issues/319
Basically, when we inject the fake function definition, we put it in an arbitrary file. This can cause some matches to think that they originate within that file, because they arise from analyzing the body of the fake function definition. This borks things, and causes the JSON output to have unreliable results, claiming that the matches are in random files, depending on where the fake function definition is put.

## Why:
This is a bug, and causes bad things to happen in terms of DeepSemgrep's output. The previews in particular are all messed up.

## How:
This bug originates from the fact that `Pattern_match`es have both the locations of their starts and ends (which are tokens with associated files), but also a dedicated `file` field. These two things do not necessarily need to be the same. For instance, if the tokens were fake, then the starts and ends may have fake filenames. Or, in the case of Terraform, if we are located in a random file, but the code we are analyzing is from different files, these may not corroborate.

This should not happen in the general case, so what I've done is just added a part where, before going to the JSON output, we take the location as said by the tokens in the _code_ (if it is not a fake location), if the match file is not the same as the token files. This shouldn't happen for any other case than Terraform. I would have cased on the language if I could, but it's not available at that part of the code.

## Test plan:
`make test` breaks nothing. DeepSemgrep seems to have no nondeterminism after this.

I consider this non-user facing, so no changelog.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
