### PR TITLE
Ensure that Rule.formula is serializable

### DIFF
--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -102,7 +102,8 @@ and metavar_cond =
    * update: this is also useful to keep separate from CondEval for
    * the "regexpizer" optimizer (see Analyze_rule.ml).
    *)
-  | CondRegexp of MV.mvar * Xpattern.regexp * bool (* constant-propagation *)
+  | CondRegexp of
+      MV.mvar * Xpattern.regexp_string * bool (* constant-propagation *)
   | CondAnalysis of MV.mvar * metavar_analysis_kind
   | CondNestedFormula of MV.mvar * Xlang.t option * formula
 
@@ -231,7 +232,7 @@ type 'mode rule_info = {
   (* deprecated? todo: parse them *)
   equivalences : string list option;
   fix : string option;
-  fix_regexp : (Xpattern.regexp * int option * string) option;
+  fix_regexp : (Xpattern.regexp_string * int option * string) option;
   paths : paths option;
   (* ex: [("owasp", "A1: Injection")] but can be anything *)
   metadata : JSON.t option;

--- a/semgrep-core/src/core/Xpattern.ml
+++ b/semgrep-core/src/core/Xpattern.ml
@@ -23,6 +23,7 @@
 
 type compiled_regexp = Regexp_engine.t [@@deriving show, eq]
 type regexp_string = string [@@deriving show, eq]
+(* see the NOTE "Regexp" below for the need to have this type *)
 
 (* used in the engine for rule->mini_rule and match_result gymnastic *)
 type pattern_id = int [@@deriving show, eq]
@@ -31,7 +32,8 @@ type xpattern_kind =
   | Sem of Pattern.t * Lang.t (* language used for parsing the pattern *)
   | Spacegrep of Spacegrep.Pattern_AST.t
   | Regexp of regexp_string
-      (** NOTE: We used to keep the compiled regexp of type `Regexp_engine.t', but
+      (** NOTE "Regexp":
+      * We used to keep the compiled regexp of type `Regexp_engine.t', but
       * that is not a pure OCaml data structure and it cannot be serialized.
       *
       * This had previously caused weird Semgrep crashes like

--- a/semgrep-core/src/engine/Match_search_mode.ml
+++ b/semgrep-core/src/engine/Match_search_mode.ml
@@ -124,7 +124,8 @@ let partition_xpatterns xs =
          match pat with
          | XP.Sem (x, _lang) -> Common.push (x, inside, pid, str) semgrep
          | XP.Spacegrep x -> Common.push (x, pid, str) spacegrep
-         | XP.Regexp x -> Common.push (x, pid, str) regexp
+         | XP.Regexp x ->
+             Common.push (Regexp_engine.pcre_compile x, pid, str) regexp
          | XP.Comby x -> Common.push (x, pid, str) comby);
   (List.rev !semgrep, List.rev !spacegrep, List.rev !regexp, List.rev !comby)
 
@@ -540,7 +541,7 @@ let rec filter_ranges (env : env) (xs : RM.ranges) (cond : R.metavar_cond) :
           * which may not always be a string. The regexp is really done on
           * the text representation of the metavar content.
           *)
-         | R.CondRegexp (mvar, re, const_prop) ->
+         | R.CondRegexp (mvar, re_str, const_prop) ->
              let fk = PI.unsafe_fake_info "" in
              let fki = AST_generic.empty_id_info () in
              let e =
@@ -548,7 +549,6 @@ let rec filter_ranges (env : env) (xs : RM.ranges) (cond : R.metavar_cond) :
                 * but too many possible escaping problems, so easier to build
                 * an expression manually.
                 *)
-               let re_str = Regexp_engine.pcre_pattern re in
                let re_exp = G.L (G.String (re_str, fk)) |> G.e in
                let mvar_exp = G.N (G.Id ((mvar, fk), fki)) |> G.e in
                let call_re_match re_exp str_exp =

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -467,18 +467,7 @@ let pm_of_finding finding =
        * already expect Semgrep (and DeepSemgrep) to report the match on `sink(x)`.
        *)
       let taint_trace =
-        Some
-          ((* FIXME: We replaced `lazy` with `Lazy.from_val` because, after
-              PR #5725 (taint labels), somewhow this prevents Semgrep-core from crashing
-              in some weird cases, see PA-1724. We don't understand why, yet. But it
-              requires -j 2 (so that Parmap is used) and -json (so that the lazy value
-              reaches Parmap unevaluated), and when Parmap tries to marshal this value
-              it crashes with:
-
-                  Invalid_argument "output_value: abstract value (Custom)"
-           *)
-           Lazy.from_val
-             (taint_trace_of_src_to_sink source tokens sink))
+        Some (lazy (taint_trace_of_src_to_sink source tokens sink))
       in
       let sink_pm, _ = T.pm_of_trace sink in
       Some { sink_pm with env = merged_env; taint_trace }

--- a/semgrep-core/src/metachecking/Translate_rule.ml
+++ b/semgrep-core/src/metachecking/Translate_rule.ml
@@ -43,12 +43,8 @@ let rec expr_to_string expr =
 and translate_metavar_cond cond : [> `O of (string * Yaml.value) list ] =
   match cond with
   | CondEval e -> `O [ ("comparison", `String (expr_to_string e)) ]
-  | CondRegexp (mv, re, _) ->
-      `O
-        [
-          ("metavariable", `String mv);
-          ("regex", `String (Regexp_engine.pcre_pattern re));
-        ]
+  | CondRegexp (mv, re_str, _) ->
+      `O [ ("metavariable", `String mv); ("regex", `String re_str) ]
   | CondAnalysis (mv, analysis) ->
       `O
         [

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -402,7 +402,12 @@ let parse_python_expression env key s =
 let parse_metavar_cond env key s = parse_python_expression env key s
 
 let parse_regexp env (s, t) =
-  try Regexp_engine.pcre_compile s with
+  (* We try to compile the regexp just to make sure it's valid, but we store
+   * the raw string, see notes attached to 'Xpattern.xpattern_kind'. *)
+  try
+    ignore (Regexp_engine.pcre_compile s);
+    s
+  with
   | Pcre.Error exn ->
       raise
         (R.InvalidRule (R.InvalidRegexp (pcre_error_to_string s exn), env.id, t))
@@ -541,7 +546,7 @@ let parse_xpattern_expr env e =
  *)
 (* extra conditions, usually on metavariable content *)
 type extra =
-  | MetavarRegexp of MV.mvar * Xpattern.regexp * bool
+  | MetavarRegexp of MV.mvar * Xpattern.regexp_string * bool
   | MetavarPattern of MV.mvar * Xlang.t option * Rule.formula
   | MetavarComparison of metavariable_comparison
   | MetavarAnalysis of MV.mvar * Rule.metavar_analysis_kind

--- a/semgrep-core/src/utils/Regexp_engine.ml
+++ b/semgrep-core/src/utils/Regexp_engine.ml
@@ -71,6 +71,7 @@ let matching_exact_word s =
                just at the beginning and end of input.
 *)
 let pcre_compile pat = (pat, SPcre.regexp ~flags:[ `MULTILINE ] pat)
+  [@@profiling]
 
 let anchored_match ?on_error =
   (* ~iflags are precompiled flags for better performance compared to ~flags *)


### PR DESCRIPTION
The `Regexp_engine.t` type is a wrapper for a C type coming from the C PCRE library, and it is represented by a "Custom" block. Values of this type are not serializable, and will cause an exception if we try calling `Marshal.to_string` (or variant) on them. This can cause problems when serializing any data structure that depends on `Xpattern.t` and `Rule.formula`.

Previously, we got weird crashes after PR #5725 (taint labels). This was due to redefining type `Taint.source` as `Rule.taint_source call_trace`, where `Rule.taint_source` contains a `Rule.formula`. Whenever a taint finding is produced, we compute the taint trace this way:

    lazy (taint_trace_of_src_to_sink source tokens sink)

This `lazy ...` expression creates a thunk that capturies a `source` which contains a `Rule.formula`. Even though the formula is not used to compute the taint trace, it still needs to be serialized in order to serialize the thunk.

So, when using -j 2 (or higher) and -json (in text mode we print findings right away and hence the thunk gets evaluated), this thunk remains unevaluated and reaches the result of `Match_rules.check`. Then Parmap tries to serialize it to communicate the result back to the master process... and if the formula contains any compiled regex, it crashes.

This also affects us if we try to serialize a `Dataflow_tainting.config` for caching purposes. While we could remove the formulas from these types, it is less error prone to just make sure that formulas can be serialized.

Follows: 2e6b3079d51 ("Quick-fix for regression in 0.107.0 after taint labels PR (#5867)")

Regarding perf, this should not cause any noticeable regression, unless we build some synthetic case with lots of rules making an absurd use of regexes. I ran `semgrep -c p/default` on three repos from stress-test-monorepo (elasticsearch, vscode, and mediawiki) and with this change all runs were actually a little bit faster (maybe just coincidence).

test plan:
make test
(In PR #5867 we modified Test_engine.ml to check that the result of Match_rules.check can be serialized, see 'Test_engine.make_tests'.)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
