### PR TITLE
feat!: download m1 binaries for DeepSemgrep

### DIFF
--- a/changelog.d/pa-2153.fixed
+++ b/changelog.d/pa-2153.fixed
@@ -1,0 +1,1 @@
+DeepSemgrep: Added installation path for DeepSemgrep on M1 machines

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -56,9 +56,9 @@ def install_deep_semgrep() -> None:
     if sys.platform.startswith("darwin"):
         # arm64 is possible. Dunno if other arms are, so let's just check a prefix.
         if platform.machine().startswith("arm"):
-            platform_kind = "osx-m1"
+            platform_kind = "osx-arm64"
         else:
-            platform_kind = "osx"
+            platform_kind = "osx-x86_64"
     elif sys.platform.startswith("linux"):
         platform_kind = "manylinux"
     else:

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import shutil
 import stat
 import subprocess
@@ -53,16 +54,20 @@ def install_deep_semgrep() -> None:
         sys.exit(INVALID_API_KEY_EXIT_CODE)
 
     if sys.platform.startswith("darwin"):
-        platform = "osx"
+        # arm64 is possible. Dunno if other arms are, so let's just check a prefix.
+        if platform.machine().startswith("arm"):
+            platform_kind = "osx-m1"
+        else:
+            platform_kind = "osx"
     elif sys.platform.startswith("linux"):
-        platform = "manylinux"
+        platform_kind = "manylinux"
     else:
-        platform = "manylinux"
+        platform_kind = "manylinux"
         logger.info(
             "Running on potentially unsupported platform. Installing linux compatible binary"
         )
 
-    url = f"{state.env.semgrep_url}/api/agent/deployments/deepbinary/{platform}"
+    url = f"{state.env.semgrep_url}/api/agent/deployments/deepbinary/{platform_kind}"
 
     with state.app_session.get(url, timeout=60, stream=True) as r:
         if r.status_code == 401:


### PR DESCRIPTION
## What:
Currently, on M1 machines `install-deep-semgrep` does not work, because it installs `macos` binaries that are not meant for M1 machines.

## Why:
We need this to work so that users can use DeepSemgrep on M1 machines, which is a sizeable population.

## How:
Made `semgrep` able to install the M1 binaries from the S3 bucket. That bucket will be populated by other code.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
