### PR TITLE
osemgrep: disable --config auto and r2c to avoid slowdown in tests

### DIFF
--- a/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.ml
+++ b/semgrep-core/src/osemgrep/configuring/Semgrep_dashdash_config.ml
@@ -91,9 +91,16 @@ let url_of_registry_kind rkind =
     | Pack s -> spf "%s/p/%s" prefix s
     | Snippet s -> spf "%s/s/%s" prefix s
     | SavedSnippet (user, snippet) -> spf "%s/%s:%s" prefix user snippet
+    (* LATER: the code below is temporarily comment because handling those
+     * shortcuts leads to a 50s slowdown in make osemgrep-e2e; too many tests
+     * are relying on those configs which take a long time to download.
+     * Those tests should be optimized and use local configs instead.
+     *
     | Auto -> spf "%s/p/default" prefix
     | R2c -> spf "%s/p/r2c" prefix
     | Policy -> spf "TODO: handle --config policy"
     | SupplyChain -> spf "TODO: handle --config supply-chain"
+     *)
+    | _else_ -> failwith (spf "TORESTORE: %s" (show_registry_kind rkind))
   in
   Uri.of_string url


### PR DESCRIPTION
As said in the comment, too many tests are using the --config auto
which leads to a 50s slowdown in make osemgrep-e2e, so for
now faster to disable it.

test plan:
time make osemgrep-e2e
=> 40s or less


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)