### PR TITLE
osemgrep: centralize error management in CLI.ml

### DIFF
--- a/semgrep-core/src/osemgrep/TOPORT/util.py
+++ b/semgrep-core/src/osemgrep/TOPORT/util.py
@@ -8,10 +8,6 @@ def is_rules(rules: str) -> bool:
 def path_has_permissions(path: Path, permissions: int) -> bool:
     return path.exists() and path.stat().st_mode & permissions == permissions
 
-def abort(message: str) -> None:
-    click.secho(message, fg="red", err=True)
-    sys.exit(2)
-
 def with_color(
     color: Colors,
     text: str,

--- a/semgrep-core/src/osemgrep/cli/CLI.mli
+++ b/semgrep-core/src/osemgrep/cli/CLI.mli
@@ -5,5 +5,7 @@
    If called as a standalone program, the 'exit' function should be called
    with this exit status. If testing, the exit status can be checked
    against expectations.
+
+   Exceptions are caught and turned into an appropriate exit code.
 *)
 val main : string array -> Exit_code.t

--- a/semgrep-core/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -43,11 +43,4 @@ let parse_argv (argv : string array) : (conf, Exit_code.t) result =
   (* mostly a copy of Scan_CLI.parse_argv with different doc and man *)
   let info : Cmd.info = Cmd.info "semgrep ci" ~doc ~man in
   let cmd : conf Cmd.t = Cmd.v info Scan_CLI.cmdline_term in
-  match Cmd.eval_value ~argv cmd with
-  | Error _n -> Error Exit_code.fatal
-  | Ok ok -> (
-      match ok with
-      | `Ok config -> Ok config
-      | `Version
-      | `Help ->
-          Error Exit_code.ok)
+  CLI_common.eval_value ~argv cmd

--- a/semgrep-core/src/osemgrep/cli_ci/Ci_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_ci/Ci_subcommand.ml
@@ -36,5 +36,5 @@ let run (_conf : Ci_CLI.conf) : Exit_code.t =
 let main (argv : string array) : Exit_code.t =
   let res = Ci_CLI.parse_argv argv in
   match res with
-  | Ok conf -> CLI_common.safe_run run conf
+  | Ok conf -> run conf
   | Error exit_code -> exit_code

--- a/semgrep-core/src/osemgrep/cli_ci/Ci_subcommand.mli
+++ b/semgrep-core/src/osemgrep/cli_ci/Ci_subcommand.mli
@@ -4,7 +4,6 @@
    Usage: main [| "semgrep-ci"; ... |]
 
    This function returns an exit code to be passed to the 'exit' function.
-   Exceptions are caught and turned into an appropriate exit code.
 *)
 val main : string array -> Exit_code.t
 

--- a/semgrep-core/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_login/Login_subcommand.ml
@@ -72,5 +72,5 @@ let run (_conf : login_cli_conf) : Exit_code.t =
 let main (argv : string array) : Exit_code.t =
   let res = parse_argv argv in
   match res with
-  | Ok conf -> CLI_common.safe_run run conf
+  | Ok conf -> run conf
   | Error exit_code -> exit_code

--- a/semgrep-core/src/osemgrep/cli_login/Login_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_login/Login_subcommand.ml
@@ -42,14 +42,7 @@ let man : Manpage.block list =
 let parse_argv (argv : string array) : (conf, Exit_code.t) result =
   let info : Cmd.info = Cmd.info "semgrep login" ~doc ~man in
   let cmd : conf Cmd.t = Cmd.v info cmdline_term in
-  match Cmd.eval_value ~argv cmd with
-  | Error _n -> Error Exit_code.fatal
-  | Ok ok -> (
-      match ok with
-      | `Ok config -> Ok config
-      | `Version
-      | `Help ->
-          Error Exit_code.ok)
+  CLI_common.eval_value ~argv cmd
 
 (*****************************************************************************)
 (* Main logic *)

--- a/semgrep-core/src/osemgrep/cli_login/Login_subcommand.mli
+++ b/semgrep-core/src/osemgrep/cli_login/Login_subcommand.mli
@@ -1,15 +1,14 @@
-(* no parameters for now *)
-type login_cli_conf = unit
-
 (*
    Parse a semgrep-login command, execute it and exit.
 
    Usage: main [| "semgrep-login"; ... |]
 
    This function returns an exit code to be passed to the 'exit' function.
-   Exceptions are caught and turned into an appropriate exit code.
 *)
 val main : string array -> Exit_code.t
+
+(* no parameters for now *)
+type login_cli_conf = unit
 
 (* internal *)
 val run : login_cli_conf -> Exit_code.t

--- a/semgrep-core/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -37,14 +37,7 @@ let man : Manpage.block list =
 let parse_argv (argv : string array) : (conf, Exit_code.t) result =
   let info : Cmd.info = Cmd.info "semgrep logout" ~doc ~man in
   let cmd : conf Cmd.t = Cmd.v info cmdline_term in
-  match Cmd.eval_value ~argv cmd with
-  | Error _n -> Error Exit_code.fatal
-  | Ok ok -> (
-      match ok with
-      | `Ok config -> Ok config
-      | `Version
-      | `Help ->
-          Error Exit_code.ok)
+  CLI_common.eval_value ~argv cmd
 
 (*****************************************************************************)
 (* Main logic *)

--- a/semgrep-core/src/osemgrep/cli_login/Logout_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_login/Logout_subcommand.ml
@@ -67,5 +67,5 @@ let run (_conf : logout_cli_conf) : Exit_code.t =
 let main (argv : string array) : Exit_code.t =
   let res = parse_argv argv in
   match res with
-  | Ok conf -> CLI_common.safe_run run conf
+  | Ok conf -> run conf
   | Error exit_code -> exit_code

--- a/semgrep-core/src/osemgrep/cli_login/Logout_subcommand.mli
+++ b/semgrep-core/src/osemgrep/cli_login/Logout_subcommand.mli
@@ -1,15 +1,14 @@
-(* no parameters for now *)
-type logout_cli_conf = unit
-
 (*
    Parse a semgrep-logout command, execute it and exit.
 
    Usage: main [| "semgrep-logut"; ... |]
 
    This function returns an exit code to be passed to the 'exit' function.
-   Exceptions are caught and turned into an appropriate exit code.
 *)
 val main : string array -> Exit_code.t
+
+(* no parameters for now *)
+type logout_cli_conf = unit
 
 (* internal *)
 val run : logout_cli_conf -> Exit_code.t

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -510,6 +510,12 @@ let cmdline_term : conf Term.t =
       | false, false, true -> None (* TOPORT: list the possibilities *)
       | _else_ -> failwith "mutually exclusive options"
     in
+    (* sanity checks *)
+    if List.mem "auto" config && metrics = Metrics.State.Off then
+      Error.abort
+        "Cannot create auto config when metrics are off. Please allow metrics \
+         or run with a specific config.";
+
     {
       autofix;
       baseline_commit;
@@ -584,7 +590,7 @@ let man : Manpage.block list =
 let parse_argv (argv : string array) : (conf, Exit_code.t) result =
   let info : Cmd.info = Cmd.info "semgrep scan" ~doc ~man in
   let cmd : conf Cmd.t = Cmd.v info cmdline_term in
-  match Cmd.eval_value ~argv cmd with
+  match Cmd.eval_value ~catch:false ~argv cmd with
   | Error _n -> Error Exit_code.fatal
   | Ok ok -> (
       match ok with

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -154,13 +154,6 @@ environment variable, defaults to 'auto'.
  *  rules' languages. These options alter which files Semgrep scans."
  *)
 
-let o_exclude_rule_ids : string list Term.t =
-  let info =
-    Arg.info [ "exclude-rule" ]
-      ~doc:{|Skip any rule with the given id. Can add multiple times.|}
-  in
-  Arg.value (Arg.opt_all Arg.string [] info)
-
 let o_exclude : string list Term.t =
   let info =
     Arg.info [ "exclude" ]
@@ -439,6 +432,13 @@ Each should be one of INFO, WARNING, or ERROR.
   in
   Arg.value (Arg.opt_all Severity.converter [] info)
 
+let o_exclude_rule_ids : string list Term.t =
+  let info =
+    Arg.info [ "exclude-rule" ]
+      ~doc:{|Skip any rule with the given id. Can add multiple times.|}
+  in
+  Arg.value (Arg.opt_all Arg.string [] info)
+
 let o_show_supported_languages : bool Term.t =
   let info =
     Arg.info
@@ -590,11 +590,4 @@ let man : Manpage.block list =
 let parse_argv (argv : string array) : (conf, Exit_code.t) result =
   let info : Cmd.info = Cmd.info "semgrep scan" ~doc ~man in
   let cmd : conf Cmd.t = Cmd.v info cmdline_term in
-  match Cmd.eval_value ~catch:false ~argv cmd with
-  | Error _n -> Error Exit_code.fatal
-  | Ok ok -> (
-      match ok with
-      | `Ok config -> Ok config
-      | `Version
-      | `Help ->
-          Error Exit_code.ok)
+  CLI_common.eval_value ~argv cmd

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -85,7 +85,7 @@ let exit_code_of_errors ~strict (errors : Semgrep_output_v1_t.core_error list) :
    exit code. *)
 let run (conf : Scan_CLI.conf) : Exit_code.t =
   setup_logging conf;
-  (* could adjust conf.num_jobs (-j) *)
+  (* return a new conf because can adjust conf.num_jobs (-j) *)
   let conf = setup_profiling conf in
 
   match () with
@@ -166,5 +166,5 @@ let main (argv : string array) : Exit_code.t =
    * between the different subcommands at some point
    *)
   match res with
-  | Ok conf -> CLI_common.safe_run run conf
+  | Ok conf -> run conf
   | Error exit_code -> exit_code

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.mli
@@ -4,7 +4,6 @@
    Usage: main [| "semgrep-scan"; ... |]
 
    This function returns an exit code to be passed to the 'exit' function.
-   Exceptions are caught and turned into an appropriate exit code.
 *)
 val main : string array -> Exit_code.t
 

--- a/semgrep-core/src/osemgrep/core/CLI_common.ml
+++ b/semgrep-core/src/osemgrep/core/CLI_common.ml
@@ -12,24 +12,3 @@ let help_page_bottom =
       "If you encounter an issue, please report it at\n\
       \      https://github.com/returntocorp/semgrep/issues";
   ]
-
-(* Wrapper that catches exceptions and turns them into an exit code. *)
-let safe_run run conf : Exit_code.t =
-  try
-    Printexc.record_backtrace true;
-    run conf
-  with
-  | Error.Semgrep_error (s, opt_exit_code) -> (
-      (* TODO? use Logs.error? *)
-      Printf.eprintf "Error: %s\n" s;
-      match opt_exit_code with
-      | None -> Exit_code.fatal
-      | Some code -> code)
-  | Common.UnixExit i -> Exit_code.of_int i
-  | Failure msg ->
-      Printf.eprintf "Error: %s\n%!" msg;
-      Exit_code.fatal
-  | e ->
-      let trace = Printexc.get_backtrace () in
-      Printf.eprintf "Error: exception %s\n%s%!" (Printexc.to_string e) trace;
-      Exit_code.fatal

--- a/semgrep-core/src/osemgrep/core/CLI_common.ml
+++ b/semgrep-core/src/osemgrep/core/CLI_common.ml
@@ -12,3 +12,20 @@ let help_page_bottom =
       "If you encounter an issue, please report it at\n\
       \      https://github.com/returntocorp/semgrep/issues";
   ]
+
+(* Small wrapper around Cmdliner.Cmd.eval_value.
+ * Note that I didn't put this helper function in Cmdliner_helpers.ml because
+ * it's using Exit_code.ml which is semgrep-specific.
+ *)
+let eval_value ~argv cmd =
+  (* the ~catch:false is to let non-cmdliner exn (e.g., Error.Semgrep_error)
+   * to bubble up; those exns will then be caught in CLI.safe_run.
+   *)
+  match Cmd.eval_value ~catch:false ~argv cmd with
+  | Error (`Term | `Parse | `Exn) -> Error Exit_code.fatal
+  | Ok ok -> (
+      match ok with
+      | `Ok config -> Ok config
+      | `Version
+      | `Help ->
+          Error Exit_code.ok)

--- a/semgrep-core/src/osemgrep/core/CLI_common.mli
+++ b/semgrep-core/src/osemgrep/core/CLI_common.mli
@@ -1,4 +1,1 @@
 val help_page_bottom : Cmdliner.Manpage.block list
-
-(* Wrapper that catches exceptions and turns them into an exit code. *)
-val safe_run : ('a -> Exit_code.t) -> 'a -> Exit_code.t

--- a/semgrep-core/src/osemgrep/core/CLI_common.mli
+++ b/semgrep-core/src/osemgrep/core/CLI_common.mli
@@ -1,1 +1,5 @@
 val help_page_bottom : Cmdliner.Manpage.block list
+
+(* small wrapper around Cmdliner.Cmd.eval_value *)
+val eval_value :
+  argv:string array -> 'a Cmdliner.Cmd.t -> ('a, Exit_code.t) result

--- a/semgrep-core/src/osemgrep/core/Error.ml
+++ b/semgrep-core/src/osemgrep/core/Error.ml
@@ -9,9 +9,8 @@
    LATER: we should merge with Semgrep_core_error.ml, as well
    as the errors defined in semgrep_output_v1.atd (especially core_error).
 
-   coupling: See CLI_common.safe_run function which should
-   catch all the exns in this module and return an appropriate
-   exit code.
+   coupling: See the CLI.safe_run function which should catch all the exns
+   defined in this module and return an appropriate exit code.
 *)
 
 (*****************************************************************************)
@@ -19,7 +18,7 @@
 (*****************************************************************************)
 
 (* If no exit code is given, will default to Exit_code.fatal.
-   See CLI_common.safe_run()
+   See CLI.safe_run()
 *)
 exception Semgrep_error of string * Exit_code.t option
 
@@ -81,3 +80,11 @@ exception Semgrep_error of string * Exit_code.t option
    *)
    let () = register_exception_printer ()
 *)
+
+(*****************************************************************************)
+(* Misc *)
+(*****************************************************************************)
+
+let abort msg =
+  (* TOPORT: click.seecho(message, fg="red", err=True) *)
+  raise (Semgrep_error (msg, None))

--- a/semgrep-core/src/osemgrep/core/Error.mli
+++ b/semgrep-core/src/osemgrep/core/Error.mli
@@ -1,1 +1,4 @@
 exception Semgrep_error of string * Exit_code.t option
+
+(* shortcut *)
+val abort : string -> 'a

--- a/semgrep-core/src/osemgrep/core/Exit_code.ml
+++ b/semgrep-core/src/osemgrep/core/Exit_code.ml
@@ -1,7 +1,7 @@
 (*
    Exit codes for the semgrep executable.
-   Translated from error.py
 
+   Partially translated from error.py
 *)
 
 type t = int

--- a/semgrep-core/src/osemgrep/core/Exit_code.mli
+++ b/semgrep-core/src/osemgrep/core/Exit_code.mli
@@ -26,4 +26,6 @@ val missing_config : t
 val invalid_language : t
 val invalid_api_key : t
 val scan_fail : t
+
+(* to remove at some point *)
 val not_implemented_in_osemgrep : t

--- a/semgrep-core/src/osemgrep/core/Severity.ml
+++ b/semgrep-core/src/osemgrep/core/Severity.ml
@@ -7,7 +7,7 @@
  *  - rule_schema_v1.yaml
  *  - Rule.severity in semgrep-core
  *  - core_severity in semgrep_output_v1.atd
- *  - level in Error.ml
+ *  - DONE level in Error.ml
  * We should remove some of those.
  *
  * python: was in constants.py, but not really constants, more like types!

--- a/semgrep-core/src/osemgrep/core/Severity.mli
+++ b/semgrep-core/src/osemgrep/core/Severity.mli
@@ -5,8 +5,8 @@ type extended_severity = [ rule_severity | `Inventory | `Experiment ]
 (* for CLI Json output of semgrep errors *)
 val string_of_basic_severity : basic_severity -> string
 
-(* LATER: to get rid at some point *)
+(* LATER: get rid off at some point *)
 val rule_severity_of_rule_severity_opt : Rule.severity -> rule_severity option
 
-(* for CLI --severity *)
+(* for CLI --severity xxx parsing *)
 val converter : rule_severity Cmdliner.Arg.conv


### PR DESCRIPTION
All subcommands should behave the same regarding exn and exit_code
so just simpler to centralize it in CLI.ml instead of
explicitely calling CLI_Common.safe_run in every subcommands

test plan:
```
$ ~/yy/bin/osemgrep --config auto --metrics off .
Error: Cannot create auto config when metrics are off. Please allow metrics or run with a specific config.
```


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)