### PR TITLE
fix(sca): experimental rules filtered out incorrectly

### DIFF
--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -270,7 +270,6 @@ class ScanHandler:
         new_ignored, new_matches = partition(
             all_matches,
             lambda match: bool(match.is_ignored)
-            or match.severity == RuleSeverity.EXPERIMENT,
         )
         findings = [
             match.to_app_finding_format(commit_date).to_json() for match in new_matches

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -268,8 +268,7 @@ class ScanHandler:
             for match in matches_of_rule
         ]
         new_ignored, new_matches = partition(
-            all_matches,
-            lambda match: bool(match.is_ignored)
+            all_matches, lambda match: bool(match.is_ignored)
         )
         findings = [
             match.to_app_finding_format(commit_date).to_json() for match in new_matches


### PR DESCRIPTION
Experiment severity rules were already not being shown on cli output. This change reverts a change in https://github.com/returntocorp/semgrep/pull/6459 that treated experimental findings as ignored findings. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
