### PR TITLE
osemgrep: started to port --validate

### DIFF
--- a/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
+++ b/semgrep-core/src/osemgrep/TOPORT/commands/scan.py
@@ -149,40 +149,6 @@ def scan(
 
         if dump_ast:
             dump_parsed_ast(json, __validate_lang("--dump-ast", lang), pattern, targets)
-        elif validate:
-            if not (pattern or lang or config):
-                logger.error(
-                    f"Nothing to validate, use the --config or --pattern flag to specify a rule"
-                )
-            else:
-                resolved_configs, config_errors = semgrep.config_resolver.get_config(
-                    pattern, lang, config or [], project_url=get_project_url()
-                )
-
-                # Run metachecks specifically on the config files
-                if config:
-                    try:
-                        metacheck_errors = CoreRunner(
-                            jobs=jobs,
-                            timeout=timeout,
-                            max_memory=max_memory,
-                            timeout_threshold=timeout_threshold,
-                            optimizations=optimizations,
-                        ).validate_configs(config)
-                    except SemgrepError as e:
-                        metacheck_errors = [e]
-
-                config_errors = list(chain(config_errors, metacheck_errors))
-
-                valid_str = "invalid" if config_errors else "valid"
-                rule_count = len(resolved_configs.get_rules(True))
-                logger.info(
-                    f"Configuration is {valid_str} - found {len(config_errors)} configuration error(s), and {rule_count} rule(s)."
-                )
-                if config_errors:
-                    output_handler.handle_semgrep_errors(config_errors)
-                    output_handler.output({}, all_targets=set(), filtered_rules=[])
-                    raise SemgrepError("Please fix the above errors and try again.")
         else:
             try:
                 (

--- a/semgrep-core/src/osemgrep/cli_scan/Config_resolver.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Config_resolver.ml
@@ -32,6 +32,18 @@ and origin = Common.filename option (* None for remote files *)
 (* Helpers *)
 (*****************************************************************************)
 
+let partition_rules_and_errors (xs : rules_and_origin list) :
+    Rule.rules * Rule.invalid_rule_error list =
+  let (rules : Rule.rules) = xs |> List.concat_map (fun x -> x.rules) in
+  let (errors : Rule.invalid_rule_error list) =
+    xs |> List.concat_map (fun x -> x.errors)
+  in
+  (rules, errors)
+
+(*****************************************************************************)
+(* Loading rules *)
+(*****************************************************************************)
+
 let load_rules_from_file file : rules_and_origin =
   Logs.debug (fun m -> m "loading local config from %s" file);
   if Sys.file_exists file then (

--- a/semgrep-core/src/osemgrep/cli_scan/Config_resolver.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Config_resolver.mli
@@ -7,6 +7,9 @@ type rules_and_origin = {
 and origin = Common.filename option (* None for remote files *)
 [@@deriving show]
 
+val partition_rules_and_errors :
+  rules_and_origin list -> Rule.rules * Rule.invalid_rule_error list
+
 (* [rules_from_conf] returns rules from --config or -e
  * TODO: does it rewrite the rule_id?
  *)

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -71,6 +71,7 @@ and rules_source =
   (* --config. In theory we could even parse the string to get
    * some Semgrep_dashdash_config.config_kind list *)
   | Configs of string list
+    (* TODO? | ProjectUrl of Uri.t? or just use Configs for it? *)
 [@@deriving show]
 
 let default : conf =
@@ -596,8 +597,13 @@ let cmdline_term : conf Term.t =
     in
     let rules_source =
       match (config, (pattern, lang, replacement)) with
+      | [], (None, _, _) when validate ->
+          (* TOPORT? was a Logs.err but seems better as an abort *)
+          Error.abort
+            "Nothing to validate, use the --config or --pattern flag to \
+             specify a rule"
       (* TOPORT: handle get_project_url() if empty Configs? *)
-      | [], (None, None, None) ->
+      | [], (None, _, _) ->
           (* alt: default.rules_source *)
           (* TOPORT: raise with Exit_code.missing_config *)
           Error.abort

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -144,11 +144,8 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
           rules_and_origins
           |> List.iter (fun x ->
                  m "rules = %s" (Config_resolver.show_rules_and_origin x)));
-      let (rules : Rule.rules) =
-        rules_and_origins |> List.concat_map (fun x -> x.Config_resolver.rules)
-      in
-      let (errors : Rule.invalid_rule_error list) =
-        rules_and_origins |> List.concat_map (fun x -> x.Config_resolver.errors)
+      let rules, errors =
+        Config_resolver.partition_rules_and_errors rules_and_origins
       in
       let filtered_rules = filter_rules conf rules in
 

--- a/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -12,4 +12,39 @@
 
 (* LATER: at some point we may want a Validate_CLI.conf instead of
  * abusing Scan_CLI.conf *)
-let run (_conf : Scan_CLI.conf) : Exit_code.t = failwith "TODO"
+let run (conf : Scan_CLI.conf) : Exit_code.t =
+  let rules_and_origin = Config_resolver.rules_from_conf conf in
+  let rules, errors =
+    Config_resolver.partition_rules_and_errors rules_and_origin
+  in
+  let metacheck_errors =
+    match conf.rules_source with
+    | Scan_CLI.Configs _xs ->
+        (* TODO: run metachecks on the config files
+            try:
+               metacheck_errors = CoreRunner(
+                     jobs=jobs,
+                        timeout=timeout,
+                        max_memory=max_memory,
+                        timeout_threshold=timeout_threshold,
+                        optimizations=optimizations,
+                    ).validate_configs(config)
+              except SemgrepError as e:
+                    metacheck_errors = [e]
+            ...
+            if config_errors:
+              output_handler.handle_semgrep_errors(config_errors)
+              output_handler.output({}, all_targets=set(), filtered_rules=[])
+        *)
+        []
+    | Scan_CLI.Pattern _ -> []
+  in
+  let all_errors = errors @ metacheck_errors in
+  (* was logger.info, but works without --verbose, so Logs.app better *)
+  Logs.app (fun m ->
+      m "Configuration is %s - found %d configuration error(s), and %d rule(s)."
+        (if all_errors = [] then "valid" else "invalid")
+        (List.length all_errors) (List.length rules));
+  if all_errors <> [] (* was a raise SemgrepError originally *) then
+    Error.abort "Please fix the above errors and try again.";
+  Exit_code.ok


### PR DESCRIPTION
test plan:
in semgrep-rules
```
export SEMGREP=osemgrep
make validate
...
======== validate rule files in ./generic ========
Configuration is valid - found 0 configuration error(s), and 84 rule(s).
real 0.06
user 0.05
sys 0.01
...
```
it crashes at some point because it tries to parse some .test.yaml
but it's a start


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)