### PR TITLE
tainting:  Add experimental option `taint_only_propagate_through_assignments`

### DIFF
--- a/interfaces/Config_semgrep.atd
+++ b/interfaces/Config_semgrep.atd
@@ -26,6 +26,7 @@ type t = {
   ~taint_unify_mvars <ocaml default="false"> : bool;
   ~taint_assume_safe_functions <ocaml default="false"> : bool;
   ~taint_assume_safe_indexes <ocaml default="false"> : bool;
+  ~taint_builtin_propagators <ocaml default="true"> : bool;
 
   (* 'ac' stands for associative-commutative matching *)
   ~ac_matching <ocaml default="true"> : bool;

--- a/interfaces/Config_semgrep.atd
+++ b/interfaces/Config_semgrep.atd
@@ -26,7 +26,9 @@ type t = {
   ~taint_unify_mvars <ocaml default="false"> : bool;
   ~taint_assume_safe_functions <ocaml default="false"> : bool;
   ~taint_assume_safe_indexes <ocaml default="false"> : bool;
-  ~taint_builtin_propagators <ocaml default="true"> : bool;
+  (* when you are paranoid about minimizing FPs, and probably useful for
+   * writing secret detection rules *)
+  ~taint_only_propagate_through_assignments <ocaml default="false"> : bool;
 
   (* 'ac' stands for associative-commutative matching *)
   ~ac_matching <ocaml default="true"> : bool;

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -121,12 +121,18 @@ let status_to_taints = function
 let is_exact x = x.overlap > 0.99
 
 let union_map_taints_and_vars env f xs =
-  xs
-  |> List.fold_left
-       (fun (taints1, lval_env) x ->
-         let taints2, lval_env = f { env with lval_env } x in
-         (Taints.union taints1 taints2, lval_env))
-       (Taints.empty, env.lval_env)
+  let taints, lval_env =
+    xs
+    |> List.fold_left
+         (fun (taints1, lval_env) x ->
+           let taints2, lval_env = f { env with lval_env } x in
+           (Taints.union taints1 taints2, lval_env))
+         (Taints.empty, env.lval_env)
+  in
+  let taints =
+    if env.options.taint_builtin_propagators then taints else Taints.empty
+  in
+  (taints, lval_env)
 
 let str_of_name name = spf "%s:%d" (fst name.ident) name.sid
 let orig_is_source config orig = config.is_source (any_of_orig orig)
@@ -538,9 +544,11 @@ and check_tainted_lval_aux env (lval : IL.lval) :
       in
       (* Check taint propagators. *)
       let taints_incoming (* TODO: find a better name *) =
-        sub_new_taints
-        |> Taints.union taints_from_sources
-        |> Taints.union taints_from_offset
+        if env.options.taint_builtin_propagators then
+          sub_new_taints
+          |> Taints.union taints_from_sources
+          |> Taints.union taints_from_offset
+        else taints_from_sources
       in
       let taints_propagated, lval_env =
         handle_taint_propagators { env with lval_env } (`Lval lval)
@@ -581,9 +589,12 @@ and check_tainted_lval_offset env offset =
   | Index e ->
       let taints, lval_env = check_tainted_expr env e in
       let taints =
-        if not env.options.taint_assume_safe_indexes then taints
-        else (* Taint from the index should be ignored. *)
+        if
+          env.options.taint_assume_safe_indexes
+          || not env.options.taint_builtin_propagators
+        then (* Taint from the index should be ignored. *)
           Taints.empty
+        else taints
       in
       (taints, lval_env)
 
@@ -717,7 +728,10 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
           match check_function_signature env e args_taints with
           | Some call_taints -> call_taints
           | None ->
-              if env.options.taint_assume_safe_functions then
+              if
+                env.options.taint_assume_safe_functions
+                || not env.options.taint_builtin_propagators
+              then
                 (* If we asume that function calls are "safe", then taints from
                  * the arguments are not present in the function's output. *)
                 e_taints

--- a/semgrep-core/src/tainting/Dataflow_tainting.ml
+++ b/semgrep-core/src/tainting/Dataflow_tainting.ml
@@ -109,6 +109,18 @@ type env = {
 let hook_function_taint_signature = ref None
 
 (*****************************************************************************)
+(* Options *)
+(*****************************************************************************)
+
+let propagate_through_functions env =
+  (not env.options.taint_assume_safe_functions)
+  && not env.options.taint_only_propagate_through_assignments
+
+let propagate_through_indexes env =
+  (not env.options.taint_assume_safe_indexes)
+  && not env.options.taint_only_propagate_through_assignments
+
+(*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
@@ -130,7 +142,8 @@ let union_map_taints_and_vars env f xs =
          (Taints.empty, env.lval_env)
   in
   let taints =
-    if env.options.taint_builtin_propagators then taints else Taints.empty
+    if env.options.taint_only_propagate_through_assignments then Taints.empty
+    else taints
   in
   (taints, lval_env)
 
@@ -544,11 +557,12 @@ and check_tainted_lval_aux env (lval : IL.lval) :
       in
       (* Check taint propagators. *)
       let taints_incoming (* TODO: find a better name *) =
-        if env.options.taint_builtin_propagators then
+        if env.options.taint_only_propagate_through_assignments then
+          taints_from_sources
+        else
           sub_new_taints
           |> Taints.union taints_from_sources
           |> Taints.union taints_from_offset
-        else taints_from_sources
       in
       let taints_propagated, lval_env =
         handle_taint_propagators { env with lval_env } (`Lval lval)
@@ -589,12 +603,9 @@ and check_tainted_lval_offset env offset =
   | Index e ->
       let taints, lval_env = check_tainted_expr env e in
       let taints =
-        if
-          env.options.taint_assume_safe_indexes
-          || not env.options.taint_builtin_propagators
-        then (* Taint from the index should be ignored. *)
+        if propagate_through_indexes env then taints
+        else (* Taints from the index should be ignored. *)
           Taints.empty
-        else taints
       in
       (taints, lval_env)
 
@@ -728,17 +739,14 @@ let check_tainted_instr env instr : Taints.t * Lval_env.t =
           match check_function_signature env e args_taints with
           | Some call_taints -> call_taints
           | None ->
-              if
-                env.options.taint_assume_safe_functions
-                || not env.options.taint_builtin_propagators
-              then
+              if propagate_through_functions env then
+                (* Assume that the function will propagate
+                   * the taint of its arguments. *)
+                List.fold_left Taints.union e_taints all_taints
+              else
                 (* If we asume that function calls are "safe", then taints from
                  * the arguments are not present in the function's output. *)
                 e_taints
-              else
-                (* Otherwise assume that the function will propagate
-                   * the taint of its arguments. *)
-                List.fold_left Taints.union e_taints all_taints
         in
         (call_taints, lval_env)
     | CallSpecial (_, _, args) ->

--- a/semgrep-core/tests/rules/taint_no_builtin_props.py
+++ b/semgrep-core/tests/rules/taint_no_builtin_props.py
@@ -1,0 +1,14 @@
+
+def bad():
+    x = "password"
+    y = x
+    z = y
+    #ruleid: secrets
+    sink(z)
+
+def ok():
+    x = "password"
+    y = x
+    z = y+"ok"
+    #ok: secrets
+    sink(z)

--- a/semgrep-core/tests/rules/taint_no_builtin_props.py
+++ b/semgrep-core/tests/rules/taint_no_builtin_props.py
@@ -6,9 +6,23 @@ def bad():
     #ruleid: secrets
     sink(z)
 
-def ok():
+def ok1():
     x = "password"
     y = x
     z = y+"ok"
+    #ok: secrets
+    sink(z)
+
+def ok2():
+    x = "password"
+    y = x
+    z = f(y)
+    #ok: secrets
+    sink(z)
+
+def ok3():
+    x = "password"
+    y = x
+    z = a[y]
     #ok: secrets
     sink(z)

--- a/semgrep-core/tests/rules/taint_no_builtin_props.yaml
+++ b/semgrep-core/tests/rules/taint_no_builtin_props.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: secrets
+  severity: WARNING
+  message: Test
+  languages: [python]
+  mode: taint
+  options:
+    taint_builtin_propagators: false
+  pattern-sources:
+  - pattern: '"password"'
+  pattern-sinks:
+  - pattern: sink(...)

--- a/semgrep-core/tests/rules/taint_no_builtin_props.yaml
+++ b/semgrep-core/tests/rules/taint_no_builtin_props.yaml
@@ -5,7 +5,7 @@ rules:
   languages: [python]
   mode: taint
   options:
-    taint_builtin_propagators: false
+    taint_only_propagate_through_assignments: true
   pattern-sources:
   - pattern: '"password"'
   pattern-sinks:


### PR DESCRIPTION
To disable built-in taint propagators, that is: constructors, operators, dot-access, array indexing, and function calls. By disabling this option, the only thing that propagates taint implicit will be assignment statements.

This is meant to be useful for writing secret detection rules.

Closes PA-2193

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
