### PR TITLE
RFC: WIP on removing desugaring for JS requires

### DIFF
--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -38,9 +38,6 @@ let string = id
 let error = AST_generic.error
 let fb = G.fake_bracket
 
-(* for the require -> import translation *)
-exception ComplicatedCase
-
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -719,73 +716,11 @@ and module_directive x =
       let v1 = name v1 in
       G.OtherDirective (("Export", t), [ G.I v1 ])
 
-and require_to_import_in_stmt_opt st =
-  match st with
-  (* ex: const { f1, f2 } = require("file"); *)
-  | DefStmt
-      ( { name = x, _; attrs = [] },
-        VarDef
-          {
-            v_kind = _;
-            v_type = _;
-            v_init =
-              Some
-                (Assign
-                  ( pattern,
-                    _,
-                    Apply
-                      (IdSpecial (Require, treq), (_, [ L (String file) ], _))
-                  ));
-          } )
-    when x =$= AST_generic_.special_multivardef_pattern -> (
-      try
-        match pattern with
-        | Obj (_, xs, _) ->
-            let ys =
-              xs
-              |> Common.map (function
-                   | FieldColon
-                       {
-                         fld_name = PN id1;
-                         fld_body = Some (Id id2);
-                         fld_attrs = [];
-                         fld_type = None;
-                       } ->
-                       let alias_opt =
-                         match (id1, id2) with
-                         | (s1, _), (s2, _) when s1 =$= s2 -> None
-                         | _ -> Some (id2, G.empty_id_info ())
-                       in
-                       G.DirectiveStmt
-                         (G.ImportFrom (treq, G.FileName file, id1, alias_opt)
-                         |> G.d)
-                       |> G.s
-                   | _ -> raise ComplicatedCase)
-            in
-            (* we also keep the require() call in the AST so people using
-             * semgrep patterns like 'require("foo")' still find those
-             * requires in the target. The ImportFrom conversion is mostly
-             * for Naming_AST to recognize those require and do the
-             * right aliasing for them too.
-             * alt: do the conversion in Naming_AST.ml instead?
-             *)
-            let orig = stmt st in
-            Some (ys @ [ orig ])
-        | _ -> raise ComplicatedCase
-      with
-      | ComplicatedCase -> None)
-  | _ -> None
-
 and list_stmt xs =
   (* converting require() in import, so they can benefit from the
    * other goodies coming with import in semgrep (e.g., equivalence aliasing)
    *)
-  xs
-  |> Common.map (fun st ->
-         match require_to_import_in_stmt_opt st with
-         | Some xs -> xs
-         | None -> [ stmt st ])
-  |> List.flatten
+  xs |> Common.map (fun st -> [ stmt st ]) |> List.flatten
 
 and program v = list_stmt v
 
@@ -824,12 +759,9 @@ and any = function
   | Expr v1 ->
       let v1 = expr v1 in
       G.E v1
-  | Stmt v1 -> (
-      match require_to_import_in_stmt_opt v1 with
-      | Some xs -> G.Ss xs
-      | None ->
-          let v1 = stmt v1 in
-          G.S v1)
+  | Stmt v1 ->
+      let v1 = stmt v1 in
+      G.S v1
   | Stmts v1 ->
       let v1 = list_stmt v1 in
       G.Ss v1

--- a/semgrep-core/tests/patterns/js/aliasing_require.js
+++ b/semgrep-core/tests/patterns/js/aliasing_require.js
@@ -7,7 +7,7 @@ const { execSync: es } = require('child_process');
 es("ls");
 
 const cp = require('child_process');
-// TODO:
+// MATCH:
 cp.execSync("ls");
 
 // TODO:


### PR DESCRIPTION
I'd like to address the TODOs in the aliasing_require.js test, and also have some consistent logic in Semgrep upon which I can build while adding CommonJS import/export support to DeepSemgrep.

Currently, we desugar `require` calls to `ImportFrom` nodes in one specific case. This only occurs when the `require` is on the RHS of a variable assignment, and the LHS is a destructuring, e.g. `const { f1, f2 } = require("file");`. However, instead of replacing the `require`, the `ImportFrom` appears alongside it. I believe that this was done because there isn't a way to consistently transform require calls into `ImportFrom`. `require` calls are simply expressions, and can appear anywhere. There is also the potential for complicated destructuring where Semgrep bails out from desugaring at all. Thus, to be able to consistently match a pattern such as `require('file')` we need to keep the original node around.

There is no equivalent desugaring to `ImportAs` for `const f = require("file");`, thus the TODO item in the test.

My first attempt was to simply add an equivalent desugaring to `ImportAs`. Unfortunately, this led to an issue when matching the pattern `const $X = require('file');` against the target `const x = require('file')`. Both the target and pattern get desugared. Then, in the target, the name `x` is defined twice, once in the traditional `DefStmt` and once in the additional `ImportAs`. Differences in how these names get resolved mean that the `$X` metavariable is not considered to be bound to different things in the two different places, and so the match fails.

Rather than attempting to figure out how to change that behavior without disrupting other behavior that we rely on, I decided to try to remove the desugaring altogether and instead perform name resolution on `Require`s in `Naming_AST`, as suggested in a comment in the removed code.

That worked fairly well, except that there is also a test case (equivalence_import_require.js) where we want to match `import {$X1, $X2} from "module-name";` with `const { export1, export2 } = require("module-name");`

At first glance, this looks like it just requires a simple adjustment to the matching code to handle this case, now that we don't desugar requires to `ImportFrom` (which is how this matched before). I implemented this matching change here in `Generic_vs_generic.ml`. But, I was stymied by another desugaring. `import {x, y} from 'z'` is desugared into two `ImportFrom` nodes, one for `x` and one for `y`. There appears to be no straightforward way to change matching behavior so that in this one specific case, a single statement in the target can be matched by one or more statements in the pattern. We could change `m_stmts_deep_uncached` to make this work, but this, again, felt like a point where I should take a step back and consider whether the desugaring makese sense.

To solve this, I would like to remove the desugaring of `import {x, y} from 'z';` into multiple `ImportFrom` nodes. To keep current behavior, we would have to make sure that `import {x} from 'z';` also matches the target `import {x, y} from 'z';`. This would be straightforward to implement. We would have to make some changes to the generic AST to represent the underlying JS code with greater fidelity, and that is always a bit of an undertaking since it impacts most of Semgrep. However, I don't know what effects this might have, or whether it might make some analyses more complex. Still, it seems like the right way forward. All of these problems are basically caused by losing fidelity when we desugar. It seems clear to me that the solution is to maintain fidelity and avoid desugaring.

Feedback is welcome.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
