### PR TITLE
refactoring: introduce Rule.Err that gathers all exns in one type

### DIFF
--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -320,7 +320,6 @@ type error =
   | InvalidYaml of string * Parse_info.t
   | DuplicateYamlKey of string * Parse_info.t
   | UnparsableYamlException of string
-  | ExceededMemoryLimit of string
 
 (* can't use Error because it's used for severity *)
 exception Err of error
@@ -364,9 +363,6 @@ let string_of_error (error : error) : string =
   | UnparsableYamlException s ->
       (* TODO: what's the string s? *)
       spf "unparsable YAML: %s" s
-  | ExceededMemoryLimit s ->
-      (* TODO: what's the string s? *)
-      spf "exceeded memory limit: %s" s
 
 (*
    Exception printers for Printexc.to_string.

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -294,10 +294,8 @@ let partition_rules (rules : rules) :
  *)
 let last_matched_rule : rule_id option ref = ref None
 
-(* Those are recoverable errors; We can just skip the rules containing
- * those errors.
- * less: use a record
- * alt: put in Output_from_core.atd?
+(* Those are recoverable errors; We can just skip the rules containing them.
+ * TODO? put in Output_from_core.atd?
  *)
 type invalid_rule_error = invalid_rule_error_kind * rule_id * Parse_info.t
 
@@ -315,6 +313,21 @@ and invalid_rule_error_kind =
   | MissingPositiveTermInAnd
   | InvalidOther of string
 [@@deriving show]
+
+(* General errors *)
+type error =
+  | InvalidRule of invalid_rule_error
+  | InvalidYaml of string * Parse_info.t
+  | DuplicateYamlKey of string * Parse_info.t
+  | UnparsableYamlException of string
+  | ExceededMemoryLimit of string
+
+(* can't use Error because it's used for severity *)
+exception Err of error
+
+(*****************************************************************************)
+(* String-of *)
+(*****************************************************************************)
 
 let string_of_invalid_rule_error_kind = function
   | InvalidLanguage language -> spf "invalid language %s" language
@@ -334,44 +347,38 @@ let string_of_invalid_rule_error_kind = function
   | DeprecatedFeature s -> spf "deprecated feature: %s" s
   | InvalidOther s -> s
 
-(* General errors
-
-   TODO: define one exception for all this because pattern-matching
-   on exceptions has no exhaustiveness checking.
-*)
-exception InvalidRule of invalid_rule_error
-exception InvalidYaml of string * Parse_info.t
-exception DuplicateYamlKey of string * Parse_info.t
-exception UnparsableYamlException of string
-exception ExceededMemoryLimit of string
-
 let string_of_invalid_rule_error ((kind, rule_id, pos) : invalid_rule_error) =
   spf "invalid rule %s, %s: %s" rule_id
     (Parse_info.string_of_info pos)
     (string_of_invalid_rule_error_kind kind)
+
+let string_of_error (error : error) : string =
+  match error with
+  | InvalidRule x -> string_of_invalid_rule_error x
+  | InvalidYaml (msg, pos) ->
+      spf "invalid YAML, %s: %s" (Parse_info.string_of_info pos) msg
+  | DuplicateYamlKey (key, pos) ->
+      spf "invalid YAML, %s: duplicate key %S"
+        (Parse_info.string_of_info pos)
+        key
+  | UnparsableYamlException s ->
+      (* TODO: what's the string s? *)
+      spf "unparsable YAML: %s" s
+  | ExceededMemoryLimit s ->
+      (* TODO: what's the string s? *)
+      spf "exceeded memory limit: %s" s
 
 (*
    Exception printers for Printexc.to_string.
 *)
 let opt_string_of_exn (exn : exn) =
   match exn with
-  | InvalidRule x -> Some (string_of_invalid_rule_error x)
-  | InvalidYaml (msg, pos) ->
-      Some (spf "invalid YAML, %s: %s" (Parse_info.string_of_info pos) msg)
-  | DuplicateYamlKey (key, pos) ->
-      Some
-        (spf "invalid YAML, %s: duplicate key %S"
-           (Parse_info.string_of_info pos)
-           key)
-  | UnparsableYamlException s ->
-      (* TODO: what's the string s? *)
-      Some (spf "unparsable YAML: %s" s)
-  | ExceededMemoryLimit s ->
-      (* TODO: what's the string s? *)
-      Some (spf "exceeded memory limit: %s" s)
+  | Err x -> Some (string_of_error x)
   | _else_ -> None
 
-(* to be called by the application's main() *)
+(* To be called by the application's main().
+ * TODO? why not evaluate it now like let () = Printexc.register_printer ...?
+ *)
 let register_exception_printer () = Printexc.register_printer opt_string_of_exn
 
 (*****************************************************************************)

--- a/semgrep-core/src/metachecking/Check_rule.ml
+++ b/semgrep-core/src/metachecking/Check_rule.ml
@@ -241,7 +241,7 @@ let run_checks config fparser metachecks xs =
                with
                (* TODO this error is special cased because YAML files that *)
                (* aren't semgrep rules are getting scanned *)
-               | Rule.InvalidYaml _ -> []
+               | R.Err (R.InvalidYaml _) -> []
                | exn ->
                    let e = Exception.catch exn in
                    [ E.exn_to_error file e ])

--- a/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Core_runner.ml
@@ -232,7 +232,7 @@ let invoke_semgrep_core (conf : Scan_CLI.conf) (all_rules : Rule.t list)
    *)
   | err :: _ ->
       (* like in Run_semgrep.sanity_check_rules_and_invalid_rules *)
-      let exn = Rule.InvalidRule err in
+      let exn = Rule.Err (Rule.InvalidRule err) in
       (* like in Run_semgrep.semgrep_with_raw_results_and_exn_handler *)
       let e = Exception.catch exn in
       let err = Semgrep_error_code.exn_to_error "" e in

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -79,13 +79,13 @@ type dict = {
 (* Error Management *)
 (*****************************************************************************)
 
-let yaml_error t s = raise (R.InvalidYaml (s, t))
+let yaml_error t s = raise (R.Err (R.InvalidYaml (s, t)))
 
 let yaml_error_at_expr (e : G.expr) s =
   yaml_error (Visitor_AST.first_info_of_any (G.E e)) s
 
 let yaml_error_at_key (key : key) s = yaml_error (snd key) s
-let error env t s = raise (R.InvalidRule (R.InvalidOther s, env.id, t))
+let error env t s = raise (R.Err (R.InvalidRule (R.InvalidOther s, env.id, t)))
 let error_at_key env (key : key) s = error env (snd key) s
 
 let error_at_expr env (e : G.expr) s =
@@ -189,8 +189,9 @@ let yaml_to_dict_helper error_fun_f error_fun_d (enclosing : string R.wrap)
                   *)
                  if Hashtbl.mem dict key_str then
                    raise
-                     (R.DuplicateYamlKey
-                        (spf "duplicate key '%s' in dictionary" key_str, t));
+                     (R.Err
+                        (R.DuplicateYamlKey
+                           (spf "duplicate key '%s' in dictionary" key_str, t)));
                  Hashtbl.add dict key_str ((key_str, t), value)
              | _ -> error_fun_f field "Not a valid key value pair");
       { h = dict; first_tok = l }
@@ -352,7 +353,7 @@ let parse_focus_mvs env (key : key) (x : G.expr) =
 
 let parse_language ~id ((s, t) as _lang) : Lang.t =
   match Lang.lang_of_string_opt s with
-  | None -> raise (R.InvalidRule (R.InvalidLanguage s, id, t))
+  | None -> raise (R.Err (R.InvalidRule (R.InvalidLanguage s, id, t)))
   | Some l -> l
 
 let parse_languages ~id langs : Xlang.t =
@@ -364,8 +365,11 @@ let parse_languages ~id langs : Xlang.t =
       match languages with
       | [] ->
           raise
-            (R.InvalidRule
-               (R.InvalidOther "we need at least one language", fst id, snd id))
+            (R.Err
+               (R.InvalidRule
+                  ( R.InvalidOther "we need at least one language",
+                    fst id,
+                    snd id )))
       | x :: xs -> L (x, xs))
 
 let parse_severity ~id (s, t) =
@@ -377,11 +381,12 @@ let parse_severity ~id (s, t) =
   | "EXPERIMENT" -> R.Experiment
   | s ->
       raise
-        (R.InvalidRule
-           ( R.InvalidOther
-               (spf "Bad severity: %s (expected ERROR, WARNING or INFO)" s),
-             id,
-             t ))
+        (R.Err
+           (R.InvalidRule
+              ( R.InvalidOther
+                  (spf "Bad severity: %s (expected ERROR, WARNING or INFO)" s),
+                id,
+                t )))
 
 (*****************************************************************************)
 (* Parsers for extra (metavar-xxx:, fix:, etc.) *)
@@ -395,8 +400,7 @@ let parse_python_expression env key s =
     | AST_generic.E e -> e
     | _ -> error_at_key env key "not a Python expression"
   with
-  | Timeout _ as e -> Exception.catch_and_reraise e
-  | UnixExit _n as e -> Exception.catch_and_reraise e
+  | (Timeout _ | UnixExit _) as e -> Exception.catch_and_reraise e
   | exn -> error_at_key env key ("exn: " ^ Common.exn_to_s exn)
 
 let parse_metavar_cond env key s = parse_python_expression env key s
@@ -410,7 +414,9 @@ let parse_regexp env (s, t) =
   with
   | Pcre.Error exn ->
       raise
-        (R.InvalidRule (R.InvalidRegexp (pcre_error_to_string s exn), env.id, t))
+        (R.Err
+           (R.InvalidRule
+              (R.InvalidRegexp (pcre_error_to_string s exn), env.id, t)))
 
 let parse_fix_regex (env : env) (key : key) fields =
   let fix_regex_dict = yaml_to_dict env key fields in
@@ -530,10 +536,12 @@ let parse_xpattern_expr env e =
   (* TODO: capture and adjust pos of parsing error exns instead of using [t] *)
   | exn ->
       raise
-        (R.InvalidRule
-           ( R.InvalidPattern (s, env.languages, Common.exn_to_s exn, env.path),
-             env.id,
-             t ))
+        (R.Err
+           (R.InvalidRule
+              ( R.InvalidPattern
+                  (s, env.languages, Common.exn_to_s exn, env.path),
+                env.id,
+                t )))
 
 (*****************************************************************************)
 (* Parser for old (but current) formula *)
@@ -711,7 +719,7 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
       in
       let pos, _ = R.split_and conjuncts in
       if pos = [] && not env.in_metavariable_pattern then
-        raise (R.InvalidRule (R.MissingPositiveTermInAnd, env.id, t));
+        raise (R.Err (R.InvalidRule (R.MissingPositiveTermInAnd, env.id, t)));
       R.And (t, { conjuncts; focus; conditions })
   | "pattern-regex" ->
       let x = parse_string_wrap env key value in
@@ -732,7 +740,7 @@ and parse_pair_old env ((key, value) : key * G.expr) : R.formula =
   | "metavariable-comparison" ->
       error_at_key env key "Must occur directly under a patterns:"
   | "pattern-where-python" ->
-      raise (R.InvalidRule (R.DeprecatedFeature (fst key), env.id, t))
+      raise (R.Err (R.InvalidRule (R.DeprecatedFeature (fst key), env.id, t)))
   (* fix suggestions *)
   | "metavariable-regexp" ->
       error_at_key env key
@@ -761,7 +769,7 @@ and parse_extra (env : env) (key : key) (value : G.expr) : extra =
   | "metavariable-regex" ->
       let mv_regex_dict =
         try yaml_to_dict env key value with
-        | R.DuplicateYamlKey (msg, t) ->
+        | R.Err (R.DuplicateYamlKey (msg, t)) ->
             error env t (msg ^ ". You should use multiple metavariable-regex")
       in
       let metavar, regexp, const_prop =
@@ -880,11 +888,12 @@ and parse_formula env (value : G.expr) : R.formula =
         (* TODO: capture and adjust pos of parsing error exns instead of using [t] *)
         | exn ->
             raise
-              (R.InvalidRule
-                 ( R.InvalidPattern
-                     (s, env.languages, Common.exn_to_s exn, env.path),
-                   env.id,
-                   t )))
+              (R.Err
+                 (R.InvalidRule
+                    ( R.InvalidPattern
+                        (s, env.languages, Common.exn_to_s exn, env.path),
+                      env.id,
+                      t ))))
   (* If that doesn't work, it should be a key-value pairing.
    *)
   | Right dict -> (
@@ -1017,7 +1026,7 @@ and parse_pair env ((key, value) : key * G.expr) : R.formula =
       let conjuncts = parse_listi env key parse_formula value in
       let pos, _ = R.split_and conjuncts in
       if pos = [] && not env.in_metavariable_pattern then
-        raise (R.InvalidRule (R.MissingPositiveTermInAnd, env.id, t));
+        raise (R.Err (R.InvalidRule (R.MissingPositiveTermInAnd, env.id, t)));
       R.And (t, { conjuncts; focus = []; conditions = [] })
   | "or" -> R.Or (t, parse_listi env key parse_formula value)
   | "regex" ->
@@ -1132,11 +1141,13 @@ let parse_extract_reduction ~id (s, t) =
   | "separate" -> R.Separate
   | s ->
       raise
-        (R.InvalidRule
-           ( R.InvalidOther
-               (spf "Bad extract reduction: %s (expected concat or separate)" s),
-             id,
-             t ))
+        (R.Err
+           (R.InvalidRule
+              ( R.InvalidOther
+                  (spf "Bad extract reduction: %s (expected concat or separate)"
+                     s),
+                id,
+                t )))
 
 (*****************************************************************************)
 (* Main entry point *)
@@ -1318,7 +1329,7 @@ let parse_generic_ast ?(error_recovery = false) (file : Common.filename)
     |> List.mapi (fun i rule ->
            if error_recovery then (
              try Left (parse_one_rule t i rule) with
-             | R.InvalidRule ((kind, ruleid, _) as err) ->
+             | R.Err (R.InvalidRule ((kind, ruleid, _) as err)) ->
                  let s = Rule.string_of_invalid_rule_error_kind kind in
                  logger#warning "skipping rule %s, error = %s" ruleid s;
                  Right err)

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -1,17 +1,17 @@
 (* Parse a rule file.
  *
- * The parser accepts invalid rules, skip them, and return them in
+ * The parser accepts invalid rules, skips them, and returns them in
  * the list of errors.
- * This will not raise Rule.InvalidRule exceptions.
+ * This will not raise Rule.Err (Rule.InvalidRule ...) exceptions.
  *
- * This function may also raise the other exns in Rule (e.g., InvalidYaml).
+ * However, this function may raise the other (Rule.Err ...) exns (e.g., Rule.InvalidYaml).
  *)
 val parse_and_filter_invalid_rules :
   Common.filename -> Rule.rules * Rule.invalid_rule_error list
 
 (* This should be used in testing code. Otherwise you should
  * use parse_and_filter_invalid_rules.
- * This function may raise the exns in Rule (e.g., InvalidRule).
+ * This function may raise (Rule.Err ....)
  *)
 val parse : Common.filename -> Rule.rules
 

--- a/semgrep-core/src/reporting/Semgrep_error_code.ml
+++ b/semgrep-core/src/reporting/Semgrep_error_code.ml
@@ -14,6 +14,7 @@
 open Common
 module PI = Parse_info
 module Out = Output_from_core_j
+module R = Rule
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -107,31 +108,38 @@ let known_exn_to_error ?(rule_id = None) file (e : Exception.t) : error option =
       Some (mk_error_tok tok msg Out.ParseError)
   | Parse_info.Other_error (s, tok) ->
       Some (mk_error_tok ~rule_id tok s Out.SpecifiedParseError)
-  | Rule.InvalidRule
-      (Rule.InvalidPattern (pattern, xlang, message, yaml_path), rule_id, pos)
-    ->
-      Some
-        {
-          rule_id = Some rule_id;
-          typ = Out.PatternParseError yaml_path;
-          loc = PI.unsafe_token_location_of_info pos;
-          msg =
-            spf
-              "Invalid pattern for %s:\n\
-               --- pattern ---\n\
-               %s\n\
-               --- end pattern ---\n\
-               Pattern error: %s\n"
-              (Xlang.to_string xlang) pattern message;
-          details = None;
-        }
-  | Rule.InvalidRule (kind, rule_id, pos) ->
-      let str = Rule.string_of_invalid_rule_error_kind kind in
-      Some (mk_error_tok ~rule_id:(Some rule_id) pos str Out.RuleParseError)
-  | Rule.InvalidYaml (msg, pos) ->
-      Some (mk_error_tok ~rule_id pos msg Out.InvalidYaml)
-  | Rule.DuplicateYamlKey (s, pos) ->
-      Some (mk_error_tok ~rule_id pos s Out.InvalidYaml)
+  | R.Err err -> (
+      match err with
+      | R.InvalidRule
+          (R.InvalidPattern (pattern, xlang, message, yaml_path), rule_id, pos)
+        ->
+          Some
+            {
+              rule_id = Some rule_id;
+              typ = Out.PatternParseError yaml_path;
+              loc = PI.unsafe_token_location_of_info pos;
+              msg =
+                spf
+                  "Invalid pattern for %s:\n\
+                   --- pattern ---\n\
+                   %s\n\
+                   --- end pattern ---\n\
+                   Pattern error: %s\n"
+                  (Xlang.to_string xlang) pattern message;
+              details = None;
+            }
+      | R.InvalidRule (kind, rule_id, pos) ->
+          let str = Rule.string_of_invalid_rule_error_kind kind in
+          Some (mk_error_tok ~rule_id:(Some rule_id) pos str Out.RuleParseError)
+      | R.InvalidYaml (msg, pos) ->
+          Some (mk_error_tok ~rule_id pos msg Out.InvalidYaml)
+      | R.DuplicateYamlKey (s, pos) ->
+          Some (mk_error_tok ~rule_id pos s Out.InvalidYaml)
+      | R.ExceededMemoryLimit msg ->
+          let loc = Parse_info.first_loc_of_file file in
+          Some (mk_error ~rule_id loc msg Out.OutOfMemory)
+      (* TODO?? *)
+      | R.UnparsableYamlException _ -> None)
   | Common.Timeout timeout_info ->
       let s = Printexc.get_backtrace () in
       logger#error "WEIRD Timeout converted to exn, backtrace = %s" s;
@@ -142,9 +150,6 @@ let known_exn_to_error ?(rule_id = None) file (e : Exception.t) : error option =
   | Out_of_memory ->
       let loc = Parse_info.first_loc_of_file file in
       Some (mk_error ~rule_id loc "Heap space exceeded" Out.OutOfMemory)
-  | ExceededMemoryLimit msg ->
-      let loc = Parse_info.first_loc_of_file file in
-      Some (mk_error ~rule_id loc msg Out.OutOfMemory)
   (* general case, can't extract line information from it, default to line 1 *)
   | _exn -> None
 

--- a/semgrep-core/src/reporting/Semgrep_error_code.ml
+++ b/semgrep-core/src/reporting/Semgrep_error_code.ml
@@ -135,9 +135,6 @@ let known_exn_to_error ?(rule_id = None) file (e : Exception.t) : error option =
           Some (mk_error_tok ~rule_id pos msg Out.InvalidYaml)
       | R.DuplicateYamlKey (s, pos) ->
           Some (mk_error_tok ~rule_id pos s Out.InvalidYaml)
-      | R.ExceededMemoryLimit msg ->
-          let loc = Parse_info.first_loc_of_file file in
-          Some (mk_error ~rule_id loc msg Out.OutOfMemory)
       (* TODO?? *)
       | R.UnparsableYamlException _ -> None)
   | Common.Timeout timeout_info ->
@@ -147,6 +144,10 @@ let known_exn_to_error ?(rule_id = None) file (e : Exception.t) : error option =
       let loc = Parse_info.first_loc_of_file file in
       let msg = Common.string_of_timeout_info timeout_info in
       Some (mk_error ~rule_id loc msg Out.Timeout)
+  (* raised in Memory_limit.ml *)
+  | Common.ExceededMemoryLimit msg ->
+      let loc = Parse_info.first_loc_of_file file in
+      Some (mk_error ~rule_id loc msg Out.OutOfMemory)
   | Out_of_memory ->
       let loc = Parse_info.first_loc_of_file file in
       Some (mk_error ~rule_id loc "Heap space exceeded" Out.OutOfMemory)

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -321,9 +321,9 @@ let exn_to_error file (e : Exception.t) =
 let sanity_check_rules_and_invalid_rules _config rules invalid_rules =
   match (rules, invalid_rules) with
   | [], [] -> ()
-  | [], err :: _ -> raise (Rule.InvalidRule err)
+  | [], err :: _ -> raise (R.Err (R.InvalidRule err))
   | _, err :: _ (* TODO fail fast only when in strict mode? *) ->
-      raise (Rule.InvalidRule err)
+      raise (R.Err (R.InvalidRule err))
   | _, [] -> ()
 
 (*****************************************************************************)
@@ -344,11 +344,12 @@ let parse_pattern lang_pattern str =
   | exn ->
       logger#error "parse_pattern: exn = %s" (Common.exn_to_s exn);
       raise
-        (Rule.InvalidRule
-           ( Rule.InvalidPattern
-               (str, Xlang.of_lang lang_pattern, Common.exn_to_s exn, []),
-             "no-id",
-             Parse_info.unsafe_fake_info "no loc" ))
+        (R.Err
+           (R.InvalidRule
+              ( R.InvalidPattern
+                  (str, Xlang.of_lang lang_pattern, Common.exn_to_s exn, []),
+                "no-id",
+                Parse_info.unsafe_fake_info "no loc" )))
   [@@profiling]
 
 (*****************************************************************************)

--- a/semgrep-core/src/system/Memory_limit.ml
+++ b/semgrep-core/src/system/Memory_limit.ml
@@ -5,6 +5,8 @@
 open Common
 
 let logger = Logging.get_logger [ __MODULE__ ]
+
+(* Why those values? *)
 let default_stack_warning_kb = 100
 let default_heap_warning_mb = 400
 
@@ -59,7 +61,7 @@ let run_with_memory_limit ?get_context
       logger#info
         "%sexceeded heap+stack memory limit: %d bytes (stack=%d, heap=%d)"
         (context ()) mem_bytes stack_bytes heap_bytes;
-      raise (ExceededMemoryLimit "Exceeded memory limit"))
+      raise (Common.ExceededMemoryLimit "Exceeded memory limit"))
     else if !heap_warning > 0 && heap_bytes > !heap_warning then (
       logger#warning
         "%slarge heap size: %d MiB (memory limit is %d MiB). If a crash \


### PR DESCRIPTION
test plan:
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)