### PR TITLE
Parse_rule: convert Parse_info exn in Rule.Err exn

### DIFF
--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -1,4 +1,5 @@
-(* Parse a rule file.
+(* Parse a rule file, either in JSON or YAML (or even JSONNET) format
+ * depending on the filename extension.
  *
  * The parser accepts invalid rules, skips them, and returns them in
  * the list of errors.
@@ -11,7 +12,8 @@ val parse_and_filter_invalid_rules :
 
 (* This should be used mostly in testing code. Otherwise you should
  * use parse_and_filter_invalid_rules.
- * This function may raise (Rule.Err ....)
+ * This function may raise (Rule.Err ....) or Assert_failure (when
+ * there are invalid rules).
  *)
 val parse : Common.filename -> Rule.rules
 
@@ -20,5 +22,14 @@ val parse : Common.filename -> Rule.rules
  *)
 val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
 
-(* ex: foo.yaml, foo.yml, but not foo.test.yaml *)
+(* ex: foo.yaml, foo.yml, but not foo.test.yaml.
+ *
+ * Note that even if parse() above accepts JSON (and Jsonnet) files,
+ * foo.json (and foo.jsonnet) are currently not considered
+ * valid_rule_filename.
+ *
+ * This function is currently used for osemgrep, to get all
+ * the valid rule files when using --config <DIR>,
+ * and also in Test_engine.ml.
+ *)
 val is_valid_rule_filename : Common.filename -> bool

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -9,13 +9,15 @@
 val parse_and_filter_invalid_rules :
   Common.filename -> Rule.rules * Rule.invalid_rule_error list
 
-(* This should be used in testing code. Otherwise you should
+(* This should be used mostly in testing code. Otherwise you should
  * use parse_and_filter_invalid_rules.
  * This function may raise (Rule.Err ....)
  *)
 val parse : Common.filename -> Rule.rules
 
-(* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml *)
+(* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml
+ * and now also in osemgrep Config_resolver.ml.
+ *)
 val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
 
 (* ex: foo.yaml, foo.yml, but not foo.test.yaml *)

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -550,14 +550,6 @@ let parse_yaml_file file str =
   let xs = parse env in
   Common.map G.exprstmt xs
 
-(* This needs to be separate since we call parse_rule to parse yaml rules
-   for other languages, but when we parse yaml-language rules/targets we
-   preprocess unicode characters differently *)
-
-let parse_rule file =
-  let str = Common.read_file file in
-  parse_yaml_file file str
-
 (* The entry points for yaml-language parsing *)
 
 let any str =

--- a/semgrep-core/src/parsing/other/yaml_to_generic.mli
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.mli
@@ -1,3 +1,10 @@
-val parse_rule : Common.filename -> AST_generic.program
+(* Parsing a YAML file.
+ * This may raise Parse_info.Other_error.
+ *)
 val program : Common.filename -> AST_generic.program
+
+(* parsing a semgrep YAML pattern *)
 val any : string -> AST_generic.any
+
+(* internals used in Parse_rule.ml *)
+val parse_yaml_file : Common.filename -> string -> AST_generic.program


### PR DESCRIPTION
test plan:
with a test.yaml containing a yaml error, we now get:
```
osemgrep --validate --config ~/test.yaml
+ /home/pad/yy/_build/default/src/osemgrep/main/Main.exe --validate --config /home/pad/test.yaml
Main.exe: [ERROR] Error: exception invalid YAML, /home/pad/test.yaml:20:0: (approximate error location; error nearby after) error calling parser: could not find expected ':' character 0 position 0 returned: 0
Raised at Parse_rule.parse_yaml_rule_file in file "src/parsing/Parse_rule.ml", line 1352, characters 8-44
Called from Parse_rule.parse_file in file "src/parsing/Parse_rule.ml", line 1391, characters 27-52
Called from Config_resolver.load_rules_from_file in file "src/osemgrep/cli_scan/Config_resolver.ml", line 59, characters 24-70
Called from Config_resolver.rules_from_dashdash_config in file "src/osemgrep/cli_scan/Config_resolver.ml", line 88, characters 19-44
Called from Stdlib__List.concat_map.aux in file "list.ml", line 268, characters 16-19
Called from Validate_subcommand.run in file "src/osemgrep/cli_scan/Validate_subcommand.ml", line 16, characters 25-61
Called from CLI.safe_run in file "src/osemgrep/cli/CLI.ml", line 163, characters 8-12

```

instead of an Other_error exn.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)