### PR TITLE
fix(deep-semgrep): change ast to support parsing multiple vardefs

### DIFF
--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -484,6 +484,7 @@ and stmt st =
   | LocalVar v1 ->
       let ent, v = var_with_init v1 in
       G.DefStmt (ent, G.VarDef v) |> G.s
+  | LocalVarList _ -> failwith "Impossible; should have been removed in stmts"
   | DeclStmt v1 -> decl v1
   | DirectiveStmt v1 -> directive v1
   | Assert (t, v1, v2) ->
@@ -496,7 +497,14 @@ and tok_and_stmt (t, v) =
   let v = stmt v in
   (t, v)
 
-and stmts v = list stmt v
+and stmts v = 
+  let expand_local_var_definition s =
+    match s with
+    | LocalVarList xs -> xs
+    | s -> [s]
+  in
+  let v = v |> Common.map expand_local_var_definition |> List.flatten in
+  list stmt v
 
 and case = function
   | Case (t, v1) ->

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -497,11 +497,11 @@ and tok_and_stmt (t, v) =
   let v = stmt v in
   (t, v)
 
-and stmts v = 
+and stmts v =
   let expand_local_var_definition s =
     match s with
     | LocalVarList xs -> xs
-    | s -> [s]
+    | s -> [ s ]
   in
   let v = v |> Common.map expand_local_var_definition |> List.flatten in
   list stmt v

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -499,6 +499,10 @@ and tok_and_stmt (t, v) =
 
 and stmts v =
   let expand_local_var_definition s =
+    (* This helps us translate `int a = 1, int b = 2;` such that
+       `a` and `b` remain within scope. Without flattening the
+       variable definitions first, they will get wrapped in a
+       Block and treated as a new scope *)
     match s with
     | LocalVarList xs -> xs
     | s -> [ s ]

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -425,17 +425,36 @@ and resources (t1, v, t2) =
   |> G.s
 
 and stmt st =
+  match stmt_aux st with
+  | [] -> G.s (Block (G.fake_bracket []))
+  | [ st ] -> st
+  | xs ->
+      (* This should never happen in a context where we want
+         a single statement. In Java, Blocks correspond with
+         a new scope, so in `stmt_aux` we should explicitly
+         create a Block when we want one. This means that if
+         we reach this case, we do not want a new scope, and
+         should not create a new Block. To avoid giving users
+         errors when we don't need to (e.g. they just want to
+         match) we'll create one anyway, but a good way to
+         debug scoping issues is to put a failwith here. If you
+         run into this, you probably instead want to flatten
+         the statements *)
+      let warning = "this-should-never-happen-and-could-be-a-scoping-problem" in
+      G.s (Block (G.fake warning, xs, G.fake warning))
+
+and stmt_aux st =
   match st with
-  | EmptyStmt t -> G.Block (t, [], t) |> G.s
+  | EmptyStmt t -> [ G.Block (t, [], t) |> G.s ]
   | Block v1 ->
       let v1 = bracket stmts v1 in
-      G.Block v1 |> G.s
+      [ G.Block v1 |> G.s ]
   | Expr (v1, t) ->
       let v1 = expr v1 in
-      G.ExprStmt (v1, t) |> G.s
+      [ G.ExprStmt (v1, t) |> G.s ]
   | If (t, v1, v2, v3) ->
       let v1 = expr v1 and v2 = stmt v2 and v3 = option stmt v3 in
-      G.If (t, G.Cond v1, v2, v3) |> G.s
+      [ G.If (t, G.Cond v1, v2, v3) |> G.s ]
   | Switch (v0, v1, v2) ->
       let v0 = info v0 in
       let v1 = expr v1
@@ -447,68 +466,59 @@ and stmt st =
           v2
         |> Common.map (fun x -> G.CasesAndBody x)
       in
-      G.Switch (v0, Some (G.Cond v1), v2) |> G.s
+      [ G.Switch (v0, Some (G.Cond v1), v2) |> G.s ]
   | While (t, v1, v2) ->
       let v1 = expr v1 and v2 = stmt v2 in
-      G.While (t, G.Cond v1, v2) |> G.s
+      [ G.While (t, G.Cond v1, v2) |> G.s ]
   | Do (t, v1, v2) ->
       let v1 = stmt v1 and v2 = expr v2 in
-      G.DoWhile (t, v1, v2) |> G.s
+      [ G.DoWhile (t, v1, v2) |> G.s ]
   | For (t, v1, v2) ->
       let v1 = for_control t v1 and v2 = stmt v2 in
-      G.For (t, v1, v2) |> G.s
+      [ G.For (t, v1, v2) |> G.s ]
   | Break (t, v1) ->
       let v1 = H.opt_to_label_ident v1 in
-      G.Break (t, v1, G.sc) |> G.s
+      [ G.Break (t, v1, G.sc) |> G.s ]
   | Continue (t, v1) ->
       let v1 = H.opt_to_label_ident v1 in
-      G.Continue (t, v1, G.sc) |> G.s
+      [ G.Continue (t, v1, G.sc) |> G.s ]
   | Return (t, v1) ->
       let v1 = option expr v1 in
-      G.Return (t, v1, G.sc) |> G.s
+      [ G.Return (t, v1, G.sc) |> G.s ]
   | Label (v1, v2) ->
       let v1 = ident v1 and v2 = stmt v2 in
-      G.Label (v1, v2) |> G.s
+      [ G.Label (v1, v2) |> G.s ]
   | Sync (v1, v2) ->
       let v1 = expr v1 and v2 = stmt v2 in
-      G.OtherStmtWithStmt (G.OSWS_Sync, [ G.E v1 ], v2) |> G.s
+      [ G.OtherStmtWithStmt (G.OSWS_Sync, [ G.E v1 ], v2) |> G.s ]
   | Try (t, v0, v1, v2, v3) -> (
       let v1 = stmt v1 and v2 = catches v2 and v3 = option tok_and_stmt v3 in
       let try_stmt = G.Try (t, v1, v2, v3) |> G.s in
       match v0 with
-      | None -> try_stmt
-      | Some r -> G.WithUsingResource (t, resources r, try_stmt) |> G.s)
+      | None -> [ try_stmt ]
+      | Some r -> [ G.WithUsingResource (t, resources r, try_stmt) |> G.s ])
   | Throw (t, v1) ->
       let v1 = expr v1 in
-      G.Throw (t, v1, G.sc) |> G.s
-  | LocalVar v1 ->
-      let ent, v = var_with_init v1 in
-      G.DefStmt (ent, G.VarDef v) |> G.s
-  | LocalVarList _ -> failwith "Impossible; should have been removed in stmts"
-  | DeclStmt v1 -> decl v1
-  | DirectiveStmt v1 -> directive v1
+      [ G.Throw (t, v1, G.sc) |> G.s ]
+  | LocalVarList vs ->
+      Common.map
+        (fun v1 ->
+          let ent, v = var_with_init v1 in
+          G.DefStmt (ent, G.VarDef v) |> G.s)
+        vs
+  | DeclStmt v1 -> [ decl v1 ]
+  | DirectiveStmt v1 -> [ directive v1 ]
   | Assert (t, v1, v2) ->
       let v1 = expr v1 and v2 = option expr v2 in
       let es = v1 :: Option.to_list v2 in
       let args = es |> Common.map G.arg in
-      G.Assert (t, fb args, G.sc) |> G.s
+      [ G.Assert (t, fb args, G.sc) |> G.s ]
 
 and tok_and_stmt (t, v) =
   let v = stmt v in
   (t, v)
 
-and stmts v =
-  let expand_local_var_definition s =
-    (* This helps us translate `int a = 1, int b = 2;` such that
-       `a` and `b` remain within scope. Without flattening the
-       variable definitions first, they will get wrapped in a
-       Block and treated as a new scope *)
-    match s with
-    | LocalVarList xs -> xs
-    | s -> [ s ]
-  in
-  let v = v |> Common.map expand_local_var_definition |> List.flatten in
-  list stmt v
+and stmts v = list stmt_aux v |> List.flatten
 
 and case = function
   | Case (t, v1) ->

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -875,8 +875,9 @@ and statement_aux env x : Ast_java.stmt list =
           let v3 = block env v3 in
           [ Sync (v2, v3) ]
       | `Local_var_decl x ->
+          (* Emma TODO this will get translated into a Block. You don't want that *)
           let xs = local_variable_declaration env x in
-          xs |> Common.map (fun x -> LocalVar x)
+          [ LocalVarList (xs |> Common.map (fun x -> LocalVar x)) ]
       | `Throw_stmt (v1, v2, v3) ->
           let v1 = token env v1 (* "throw" *) in
           let v2 = expression env v2 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -875,7 +875,6 @@ and statement_aux env x : Ast_java.stmt list =
           let v3 = block env v3 in
           [ Sync (v2, v3) ]
       | `Local_var_decl x ->
-          (* Emma TODO this will get translated into a Block. You don't want that *)
           let xs = local_variable_declaration env x in
           [ LocalVarList (xs |> Common.map (fun x -> LocalVar x)) ]
       | `Throw_stmt (v1, v2, v3) ->

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -876,7 +876,7 @@ and statement_aux env x : Ast_java.stmt list =
           [ Sync (v2, v3) ]
       | `Local_var_decl x ->
           let xs = local_variable_declaration env x in
-          [ LocalVarList (xs |> Common.map (fun x -> LocalVar x)) ]
+          [ LocalVarList xs ]
       | `Throw_stmt (v1, v2, v3) ->
           let v1 = token env v1 (* "throw" *) in
           let v2 = expression env v2 in


### PR DESCRIPTION
Parse `int a = 1, b = 2` into two DefStmts.

Test plan: see PR on semgrep-proprietary

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
