### PR TITLE
fix(deep-semgrep): allow WithUsingResource declare multiple resources

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -1252,7 +1252,7 @@ and stmt_aux env st =
       in
       [ mk_s (Try (try_stmt, List.rev catches_stmt_rev, finally_stmt)) ]
   | G.WithUsingResource (_, stmt1, stmt2) ->
-      let stmt1 = stmt env stmt1 in
+      let stmt1 = List.concat_map (stmt env) stmt1 in
       let stmt2 = stmt env stmt2 in
       stmt1 @ stmt2
   | G.DisjStmt _ -> sgrep_construct (G.S st)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -991,7 +991,7 @@ and stmt_kind =
   | Try of tok * stmt * catch list * finally option
   | WithUsingResource of
       tok (* 'with' in Python, 'using' in C# *)
-      * stmt (* resource acquisition *)
+      * stmt list (* resource acquisition *)
       * stmt (* newscope: block *)
   (* old: was 'expr * expr option' for Python/Java, but better to generalize.
    * alt: could move in expr and have Assert be an IdSpecial

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -685,7 +685,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
             Try (t, v1, v2, v3)
         | WithUsingResource (t, v1, v2) ->
             let t = map_tok t in
-            let v1 = map_stmt v1 in
+            let v1 = map_of_list map_stmt v1 in
             let v2 = map_stmt v2 in
             WithUsingResource (t, v1, v2)
         | Assert (t, args, sc) ->

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -751,7 +751,7 @@ and vof_stmt st =
       OCaml.VSum ("Try", [ t; v1; v2; v3 ])
   | WithUsingResource (t, v1, v2) ->
       let t = vof_tok t in
-      let v1 = vof_stmt v1 in
+      let v1 = OCaml.vof_list vof_stmt v1 in
       let v2 = vof_stmt v2 in
       OCaml.VSum ("WithUsingResource", [ t; v1; v2 ])
   | Assert (t, args, sc) ->

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -794,7 +794,7 @@ let (mk_visitor :
           ()
       | WithUsingResource (t, v1, v2) ->
           let t = v_tok t in
-          let v1 = v_stmt v1 and v2 = v_stmt v2 in
+          let v1 = v_list v_stmt v1 and v2 = v_stmt v2 in
           ()
       | Assert (t, args, sc) ->
           let t = v_tok t in

--- a/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
@@ -719,7 +719,7 @@ and map_stmt x : B.stmt =
         `Try (t, v1, v2, v3)
     | WithUsingResource (t, v1, v2) ->
         let t = map_tok t in
-        let v1 = map_stmt v1 in
+        let v1 = map_stmt (G.stmt1 v1) in
         let v2 = map_stmt v2 in
         `WithUsingResource (t, v1, v2)
     | Assert (t, args, sc) ->

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -2254,7 +2254,7 @@ and m_stmt a b =
       m_list m_any a2 b2 >>= fun () -> m_stmt a3 b3
   | G.WithUsingResource (a1, a2, a3), B.WithUsingResource (b1, b2, b3) ->
       m_tok a1 b1 >>= fun () ->
-      m_stmt a2 b2 >>= fun () -> m_stmt a3 b3
+      m_list m_stmt a2 b2 >>= fun () -> m_stmt a3 b3
   | G.ExprStmt _, _
   | G.DefStmt _, _
   | G.DirectiveStmt _, _

--- a/semgrep-core/src/matching/SubAST_generic.ml
+++ b/semgrep-core/src/matching/SubAST_generic.ml
@@ -297,7 +297,7 @@ let substmts_of_stmt st =
       [ st ]
   (* 2 *)
   | If (_, _, st1, st2) -> st1 :: Option.to_list st2
-  | WithUsingResource (_, st1, st2) -> [ st1; st2 ]
+  | WithUsingResource (_, st1, st2) -> st1 @ [ st2 ]
   (* n *)
   | Block (_, xs, _) -> xs
   | Switch (_, _, xs) ->

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -417,12 +417,7 @@ and resource t (v : resource) : G.stmt =
       G.DefStmt (ent, G.VarDef v) |> G.s
   | Right e -> G.ExprStmt (expr e, t) |> G.s
 
-and resources (t1, v, t2) =
-  G.Block
-    ( t1,
-      (* TODO save the semicolon instead of using t2*) list (resource t2) v,
-      t2 )
-  |> G.s
+and resources (_t1, v, t2) = list (resource t2) v
 
 and stmt st =
   match stmt_aux st with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_csharp_tree_sitter.ml
@@ -1870,7 +1870,7 @@ and statement (env : env) (x : CST.statement) =
       in
       let _v5 = token env v5 (* ")" *) in
       let v6 = statement env v6 in
-      WithUsingResource (v2, v4, v6) |> G.s
+      WithUsingResource (v2, [ v4 ], v6) |> G.s
   | `While_stmt (v1, v2, v3, v4, v5) ->
       let v1 = token env v1 (* "while" *) in
       let _v2 = token env v2 (* "(" *) in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_hack_tree_sitter.ml
@@ -2353,7 +2353,7 @@ and statement (env : env) (x : CST.statement) =
         | `Exp_stmt x ->
             G.WithUsingResource
               ( using_stmt,
-                expression_statement env x |> G.s,
+                [ expression_statement env x |> G.s ],
                 G.Block (G.fake_bracket []) |> G.s )
         | `LPAR_exp_rep_COMMA_exp_RPAR_choice_comp_stmt (v1, v2, v3, v4, v5) ->
             let v1 = (* "(" *) token env v1 in
@@ -2366,8 +2366,8 @@ and statement (env : env) (x : CST.statement) =
                   v2)
                 v3
             in
-            let v4 = (* ")" *) token env v4 in
-            let exprs = G.Block (v1, v2 :: v3, v4) |> G.s in
+            let _v4 = (* ")" *) token env v4 in
+            let exprs = v2 :: v3 in
             let v5 = inline_compound_statement env v5 in
             G.WithUsingResource (using_stmt, exprs, v5)
       in


### PR DESCRIPTION
Java try with resource allows multiple resources, e.g.:

```
	    try (FileReader fr = new FileReader(path);
	         BufferedReader br = new BufferedReader(fr)) {
	        return br.readLine();
	    }
```

Currently, this is parsed into a Block, creating a new scope. This PR allows it to be parsed into a list.

Test plan: see semgrep-proprietary PR

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
