### PR TITLE
osemgrep: reduce the use of Scan_CLI.conf

### DIFF
--- a/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -87,12 +87,12 @@ let contents_of_file (range : Out.position * Out.position) (file : filename) :
 (* TODO: probably want to use Config_resolver.rules_and_origin to
  * get the prefix
  *)
-let config_prefix_of_conf (conf : Scan_CLI.conf) : string =
+let config_prefix_of_rules_source (src : Rule_fetching.rules_source) : string =
   (* TODO: what if it's a registry rule?
    * call Semgrep_dashdash_config.config_kind_of_config_str
    *)
-  match conf.rules_source with
-  | Configs (path :: _TODO) ->
+  match src with
+  | Rule_fetching.Configs (path :: _TODO) ->
       (*  need to prefix with the dotted path of the config file *)
       let dir = Filename.dirname path in
       Str.global_replace (Str.regexp "/") "." dir ^ "."
@@ -430,8 +430,8 @@ let cli_skipped_targets_opt ~(errors : Out.core_error list)
 (* Entry point *)
 (*****************************************************************************)
 
-let cli_output_of_core_results (conf : Scan_CLI.conf) (res : Core_runner.result)
-    : Out.cli_output =
+let cli_output_of_core_results ~logging_level ~rules_source
+    (res : Core_runner.result) : Out.cli_output =
   match res.core with
   | {
    matches;
@@ -444,7 +444,10 @@ let cli_output_of_core_results (conf : Scan_CLI.conf) (res : Core_runner.result)
    time = _;
   } ->
       let env =
-        { hrules = res.hrules; config_prefix = config_prefix_of_conf conf }
+        {
+          hrules = res.hrules;
+          config_prefix = config_prefix_of_rules_source rules_source;
+        }
       in
       (* TODO: not sure how it's sorted. Look at rule_match.py keys? *)
       let matches =
@@ -458,7 +461,7 @@ let cli_output_of_core_results (conf : Scan_CLI.conf) (res : Core_runner.result)
        *)
       let scanned = res.scanned |> Set_.elements in
       let (paths : Out.cli_paths) =
-        match conf.logging_level with
+        match logging_level with
         | Some Logs.Info ->
             let skipped = cli_skipped_targets_opt ~errors ~skipped_targets in
             { scanned; _comment = None; skipped }

--- a/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Cli_json_output.mli
@@ -1,6 +1,10 @@
 (* entry point *)
 val cli_output_of_core_results :
-  Scan_CLI.conf -> Core_runner.result -> Semgrep_output_v1_j.cli_output
+  logging_level:Logs.level option ->
+  (* TODO: should not be needed at some point *)
+  rules_source:Rule_fetching.rules_source ->
+  Core_runner.result ->
+  Semgrep_output_v1_j.cli_output
 
 (* internal function used for the 'lines:' field in the JSON output
  * but also now in Output.ml for the Emacs output.

--- a/semgrep-core/src/osemgrep/cli_scan/Output.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Output.ml
@@ -144,6 +144,7 @@ let dispatch_output_format (output_format : Output_format.t)
 (* Entry point *)
 (*****************************************************************************)
 
+(* TODO: take a more precise conf than Scan_CLI.conf at some point *)
 let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) : unit =
   (* In theory, we should build the JSON CLI output only for the
    * Json conf.output_format, but cli_output contains lots of data-structures
@@ -151,7 +152,8 @@ let output_result (conf : Scan_CLI.conf) (res : Core_runner.result) : unit =
    * it here.
    *)
   let cli_output : Out.cli_output =
-    Cli_json_output.cli_output_of_core_results conf res
+    Cli_json_output.cli_output_of_core_results ~logging_level:conf.logging_level
+      ~rules_source:conf.rules_source res
   in
   if conf.autofix then apply_fixes_and_warn conf cli_output;
   dispatch_output_format conf.output_format cli_output;

--- a/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -93,7 +93,9 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
 
         (* TODO? sanity check errors below too? *)
         let { Out.results; errors = _; _ } =
-          Cli_json_output.cli_output_of_core_results conf res
+          Cli_json_output.cli_output_of_core_results
+            ~logging_level:conf.logging_level ~rules_source:conf.rules_source
+            res
         in
         (* TOPORT?
                 ... run -check_rules in semgrep-core ...

--- a/semgrep-core/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/semgrep-core/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -8,7 +8,7 @@
 
    There are other Semgrep environment variables which are not mentioned
    in this file because their value is accessed by Cmdliner
-   in Scan_CLI.conf (SEMGREP_BASELINE_COMMIT, SEMGREP_SEND_METRICS,
+   in Scan_CLI.ml (SEMGREP_BASELINE_COMMIT, SEMGREP_SEND_METRICS,
    SEMGREP_TIMEOUT, and SEMGREP_RULES).
 *)
 
@@ -25,8 +25,11 @@ let settings_filename = "settings.yml"
 let path_of_string s = s
 let ( / ) a b = Filename.concat a b
 
+(* this causes parse failure in codemap/efuns so commented for now *)
+(*
 let%test_unit "Semgrep_envvars.(/)" =
   [%test_eq: Base.string] ("a/b/" / "c/d" / "foo.c") "a/b/c/d/foo.c"
+*)
 
 let env_opt var = Sys.getenv_opt var
 


### PR DESCRIPTION
test plan:
make


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)