### PR TITLE
osemgrep: move conf for validate in its own file

### DIFF
--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -722,7 +722,7 @@ let cmdline_term : conf Term.t =
             Error.abort
               "Nothing to validate, use the --config or --pattern flag to \
                specify a rule"
-        | Configs _ :: _
+        | Configs (_ :: _)
         | Pattern _ ->
             Some
               {

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -34,12 +34,12 @@ type conf = {
   metrics : Metrics.State.t;
   version_check : bool;
   (* Ugly: should be in separate subcommands *)
-  dump_ast : Dump_subcommand.conf option;
+  version : bool;
   show_supported_languages : bool;
+  dump_ast : Dump_subcommand.conf option;
+  validate : Validate_subcommand.conf option;
   test : bool;
   test_ignore_todo : bool;
-  validate : bool;
-  version : bool;
 }
 [@@deriving show]
 

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -122,29 +122,10 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
    * semgrep scan flags
    *)
   | _ when conf.test -> Test_subcommand.run conf
-  | _ when conf.validate ->
-      let conf =
-        match conf with
-        | { rules_source = Configs []; _ } ->
-            (* TOPORT? was a Logs.err but seems better as an abort *)
-            Error.abort
-              "Nothing to validate, use the --config or --pattern flag to \
-               specify a rule"
-        | { rules_source; logging_level; core_runner_conf; _ } ->
-            {
-              Validate_subcommand.rules_source;
-              logging_level;
-              core_runner_conf;
-            }
-      in
-      Validate_subcommand.run conf
+  | _ when conf.validate <> None ->
+      Validate_subcommand.run (Common2.some conf.validate)
   | _ when conf.dump_ast <> None ->
-      let conf =
-        match conf.dump_ast with
-        | None -> assert false
-        | Some conf -> conf
-      in
-      Dump_subcommand.run conf
+      Dump_subcommand.run (Common2.some conf.dump_ast)
   | _else_ ->
       (* --------------------------------------------------------- *)
       (* Let's go *)

--- a/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.ml
@@ -47,6 +47,7 @@ type conf = {
   core_runner_conf : Core_runner.conf;
   logging_level : Logs.level option;
 }
+[@@deriving show]
 
 (* The "meta" rules are stored in the semgrep-rules public repository here:
  * https://github.com/returntocorp/semgrep-rules/tree/develop/yaml/semgrep

--- a/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Validate_subcommand.mli
@@ -8,5 +8,6 @@ type conf = {
   core_runner_conf : Core_runner.conf;
   logging_level : Logs.level option;
 }
+[@@deriving show]
 
 val run : conf -> Exit_code.t


### PR DESCRIPTION
test plan:
make


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)