### PR TITLE
OCaml: generate n-tuple if Parse_ocaml_tree_sitter.ml

### DIFF
--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -3022,25 +3022,27 @@ and map_then_clause (env : env) ((v1, v2) : CST.then_clause) =
   let v2 = map_expression_ext env v2 in
   v2
 
-and map_tuple_type_ (env : env) (x : CST.tuple_type_) : type_ =
+and map_tuple_type_ (env : env) (x : CST.tuple_type_) : type_ list =
   match x with
-  | `Simple_type x -> map_simple_type env x
+  | `Simple_type x -> [ map_simple_type env x ]
   | `Tuple_type (v1, v2, v3) ->
       let v1 = map_tuple_type_ext env v1 in
       let _v2 = token env v2 (* "*" *) in
       let v3 = map_simple_type_ext env v3 in
-      TyTuple [ v1; v3 ]
+      v1 @ [ v3 ]
 
-and map_tuple_type_ext (env : env) (x : CST.tuple_type_ext) =
+and map_tuple_type_ext (env : env) (x : CST.tuple_type_ext) : type_ list =
   match x with
   | `Tuple_type_ x -> map_tuple_type_ env x
   | `Exte x ->
       let t = map_extension env x in
-      TyTodo (t, [])
+      [ TyTodo (t, []) ]
 
 and map_type_ (env : env) (x : CST.type_) : type_ =
   match x with
-  | `Tuple_type_ x -> map_tuple_type_ env x
+  | `Tuple_type_ x ->
+      let xs = map_tuple_type_ env x in
+      TyTuple xs
   | `Func_type (v1, v2, v3) ->
       let v1 =
         match v1 with


### PR DESCRIPTION
test plan:
```
$ ~/yy/bin/otarzan tuple.ml
let rec map_bar3 env v =
  (fun env  (v1, v2, v3) ->
    let v1 = map_int env v1 in
    let v2 = map_float env v2 in
    let v3 = map_float env v3 in
    todo env (v1, v2, v3)
  ) env v
$ yy -tree_sitter_only -l ocaml -dump_ast tuple.ml
...
      TypeDef(
        {
         tbody=AliasType(
                 {t_attrs=[];
                  t=TyTuple(
                      [{t_attrs=[];
                        t=TyN(
                            Id(("int", ()),
                              {id_info_id=9; id_hidden=false; id_resolved=Ref(
                               None); id_type=Ref(None); id_svalue=Ref(
                               None); }));
                        };
                       {t_attrs=[];
                        t=TyN(
                            Id(("float", ()),
                              {id_info_id=10; id_hidden=false; id_resolved=Ref(
                               None); id_type=Ref(None); id_svalue=Ref(
                               None); }));
                        };
                       {t_attrs=[];
                        t=TyN(
                            Id(("float", ()),
                              {id_info_id=11; id_hidden=false; id_resolved=Ref(
                               None); id_type=Ref(None); id_svalue=Ref(
                               None); }));
                        }]);
                  });
         })))])
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)