### PR TITLE
ojsonnet: skeleton for -dump_jsonnet_core

### DIFF
--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -427,6 +427,9 @@ let all_actions () =
     ( "-dump_jsonnet_ast",
       " <file>",
       Common.mk_action_1_arg Test_ojsonnet.dump_jsonnet_ast );
+    ( "-dump_jsonnet_core",
+      " <file>",
+      Common.mk_action_1_arg Test_ojsonnet.dump_jsonnet_core );
     ( "-dump_tree_sitter_cst",
       " <file> dump the CST obtained from a tree-sitter parser",
       Common.mk_action_1_arg (fun file ->

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
@@ -18,6 +18,15 @@ module C = Core_jsonnet
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
+(* AST_jsonnet to Core_jsonnet
+ *
+ * See https://jsonnet.org/ref/spec.html#desugaring
+ *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+type env = { within_an_object : bool }
 
 (*****************************************************************************)
 (* Helpers *)
@@ -54,9 +63,9 @@ let desugar_bracket ofa env (v1, v2, v3) =
   let v3 = desugar_tok env v3 in
   todo env (v1, v2, v3)
 
-let desugar_ident env v = (desugar_wrap desugar_string) env v
+let desugar_ident env v : C.ident = (desugar_wrap desugar_string) env v
 
-let rec desugar_expr env v = desugar_expr_kind env v
+let rec desugar_expr env v : C.expr = desugar_expr_kind env v
 
 and desugar_expr_kind env v =
   match v with
@@ -352,19 +361,19 @@ and desugar_import env v =
       let v2 = desugar_string_ env v2 in
       todo env (v1, v2)
 
-let desugar_program env v = desugar_expr env v
-
-let desugar_any env v =
+(*
+let desugar_any env v :  =
   match v with
   | E v ->
       let v = desugar_expr env v in
       todo env v
+*)
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
-(* TODO: see https://jsonnet.org/ref/spec.html#desugaring *)
-let desugar (_e : expr) : C.expr =
-  ignore (desugar_program, desugar_any);
-  failwith "TODO"
+let desugar_program (x : program) : C.program =
+  let env = { within_an_object = false } in
+  let core = desugar_expr env x in
+  core

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
@@ -1,4 +1,4 @@
 (* TODO: probably need pass pwd, current file, import_callback so can customize
  * things as the desugar function will "desugar" imports.
  *)
-val desugar : AST_jsonnet.expr -> Core_jsonnet.expr
+val desugar_program : AST_jsonnet.program -> Core_jsonnet.program

--- a/semgrep-core/src/ojsonnet/tests/Test_ojsonnet.ml
+++ b/semgrep-core/src/ojsonnet/tests/Test_ojsonnet.ml
@@ -5,3 +5,8 @@ let dump_jsonnet_ast file =
   (* let res = Parse_jsonnet_tree_sitter.parse file in *)
   let ast = Parse_jsonnet.parse_program file in
   pr2 (AST_jsonnet.show_program ast)
+
+let dump_jsonnet_core file =
+  let ast = Parse_jsonnet.parse_program file in
+  let core = Desugar_jsonnet.desugar_program ast in
+  pr2 (Core_jsonnet.show_program core)

--- a/semgrep-core/src/ojsonnet/tests/Test_ojsonnet.mli
+++ b/semgrep-core/src/ojsonnet/tests/Test_ojsonnet.mli
@@ -1,1 +1,2 @@
 val dump_jsonnet_ast : Common.filename -> unit
+val dump_jsonnet_core : Common.filename -> unit


### PR DESCRIPTION
test plan:
```
$ yy -dump_jsonnet_core string.jsonnet
...
Failure Todo
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)