### PR TITLE
fix(js): Faithfully represent import statements in generic AST

### DIFF
--- a/changelog.d/gh-5305.fixed
+++ b/changelog.d/gh-5305.fixed
@@ -1,0 +1,1 @@
+Fix matching issue related to JS imports with multiple imported values

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1749,8 +1749,7 @@ and directive_kind =
   | ImportFrom of
       tok (* 'import'/'from' for Python *)
       * module_name
-      * ident
-      * alias option (* as name alias *)
+      * (ident * alias option (* as name alias *)) list
   | ImportAs of tok * module_name * alias option (* as name *)
   (* Bad practice! hard to resolve name locally.
    * We use ImportAll for C/C++ #include and C++ 'using namespace'.

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -1104,10 +1104,11 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let d_attrs = map_of_list map_attribute d_attrs in
     { d; d_attrs }
   and map_directive_kind = function
-    | ImportFrom (t, v1, v2, v3) ->
+    | ImportFrom (t, v1, v2) ->
         let t = map_tok t in
-        let v1 = map_module_name v1 and v2, v3 = map_alias (v2, v3) in
-        ImportFrom (t, v1, v2, v3)
+        let v1 = map_module_name v1 in
+        let v2 = map_of_list map_alias v2 in
+        ImportFrom (t, v1, v2)
     | ImportAs (t, v1, v2) ->
         let t = map_tok t in
         let v1 = map_module_name v1

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -1318,10 +1318,11 @@ and vof_directive { d; d_attrs } =
   OCaml.VDict bnds
 
 and vof_directive_kind = function
-  | ImportFrom (t, v1, v2, v3) ->
+  | ImportFrom (t, v1, v2) ->
       let t = vof_tok t in
-      let v1 = vof_module_name v1 and v2, v3 = vof_alias (v2, v3) in
-      OCaml.VSum ("ImportFrom", [ t; v1; v2; v3 ])
+      let v1 = vof_module_name v1 in
+      let v2 = OCaml.vof_list vof_alias v2 in
+      OCaml.VSum ("ImportFrom", [ t; v1; v2 ])
   | ImportAs (t, v1, v2) ->
       let t = vof_tok t in
       let v1 = vof_module_name v1
@@ -1347,7 +1348,7 @@ and vof_directive_kind = function
 
 and vof_alias (v1, v2) =
   let v1 = vof_ident v1 and v2 = OCaml.vof_option vof_ident_and_id_info v2 in
-  (v1, v2)
+  OCaml.VTuple [ v1; v2 ]
 
 and vof_item x = vof_stmt x
 and vof_program v = OCaml.vof_list vof_item v

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1272,9 +1272,10 @@ let (mk_visitor :
     let k { d; d_attrs } =
       v_list v_attribute d_attrs;
       match d with
-      | ImportFrom (t, v1, v2, v3) ->
+      | ImportFrom (t, v1, v2) ->
           let t = v_tok t in
-          let v1 = v_module_name v1 and _ = v_alias (v2, v3) in
+          let v1 = v_module_name v1 in
+          let v2 = v_list v_alias v2 in
           ()
       | ImportAs (t, v1, v2) ->
           let t = v_tok t in

--- a/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
@@ -1134,10 +1134,11 @@ and map_directive { d; d_attrs } =
   d
 
 and map_directive_kind = function
-  | ImportFrom (t, v1, v2, v3) ->
+  | ImportFrom (t, v1, v2) ->
       let t = map_tok t in
-      let v1 = map_module_name v1 and v2, v3 = map_alias (v2, v3) in
-      `ImportFrom (t, v1, v2, v3)
+      let v1 = map_module_name v1 in
+      let v2 = map_of_list map_alias v2 in
+      `ImportFrom (t, v1, v2)
   | ImportAs (t, v1, v2) ->
       let t = map_tok t in
       let v1 = map_module_name v1

--- a/semgrep-core/src/matching/Normalize_generic.mli
+++ b/semgrep-core/src/matching/Normalize_generic.mli
@@ -1,4 +1,4 @@
 val normalize_import_opt :
   bool ->
   AST_generic.directive_kind ->
-  (AST_generic.tok * AST_generic.module_name) option
+  (AST_generic.tok * AST_generic.module_name list) option

--- a/semgrep-core/src/optimizing/Analyze_pattern.ml
+++ b/semgrep-core/src/optimizing/Analyze_pattern.ml
@@ -80,7 +80,7 @@ let extract_strings_and_mvars ?lang any =
         V.kdir =
           (fun (k, _) x ->
             match x with
-            | { d = ImportFrom (_, FileName (str, _), _, _); _ }
+            | { d = ImportFrom (_, FileName (str, _), _); _ }
             | { d = ImportAs (_, FileName (str, _), _); _ }
             | { d = ImportAll (_, FileName (str, _), _); _ }
               when str <> "..."

--- a/semgrep-core/src/optimizing/Bloom_annotation.ml
+++ b/semgrep-core/src/optimizing/Bloom_annotation.ml
@@ -92,7 +92,7 @@ let rec statement_strings stmt =
         V.kdir =
           (fun (k, _) x ->
             match x with
-            | { d = ImportFrom (_, FileName (str, _), _, _); _ }
+            | { d = ImportFrom (_, FileName (str, _), _); _ }
             | { d = ImportAs (_, FileName (str, _), _); _ }
             | { d = ImportAll (_, FileName (str, _), _); _ }
               when str <> "..."

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -815,7 +815,7 @@ and stmt_aux env x =
       let v1 = module_name env v1 and v2 = list (alias env) v2 in
       Common.map
         (fun (a, b) ->
-          G.DirectiveStmt (G.ImportFrom (t, v1, a, b) |> G.d) |> G.s)
+          G.DirectiveStmt (G.ImportFrom (t, v1, [ (a, b) ]) |> G.d) |> G.s)
         v2
   | Global (t, v1)
   | NonLocal (t, v1) ->

--- a/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/cpp_to_generic.ml
@@ -1635,7 +1635,7 @@ and map_using_kind env x : G.tok -> (G.directive, G.definition) either =
         | [] -> error tk "Empty name in UsingName"
         | x :: xs ->
             let dots = List.rev xs in
-            Left (G.ImportFrom (tk, G.DottedName dots, x, None) |> G.d))
+            Left (G.ImportFrom (tk, G.DottedName dots, [ (x, None) ]) |> G.d))
   | UsingNamespace (v1, v2) ->
       let v1 = map_tok env v1 and v2 = map_a_ident_name env v2 in
       fun tk ->

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -719,7 +719,7 @@ and import = function
   | ImportAll (t, xs, tok) -> G.ImportAll (t, G.DottedName xs, tok)
   | ImportFrom (t, xs, id) ->
       let id = ident id in
-      G.ImportFrom (t, G.DottedName xs, id, None)
+      G.ImportFrom (t, G.DottedName xs, [ (id, None) ])
 
 and directive = function
   | Import (static, v2) ->

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -702,9 +702,16 @@ and module_directive x =
   | ReExportNamespace (v1, _v2, _opt_alias, _v3, v4) ->
       let v4 = filename v4 in
       G.OtherDirective (("ReExportNamespace", v1), [ G.Str v4 ])
-  | Import (t, (v1, v2), v3) ->
-      let v1 = name v1 and v2 = option alias v2 and v3 = filename v3 in
-      G.ImportFrom (t, G.FileName v3, v1, v2)
+  | Import (t, v1, v2) ->
+      let v1 =
+        Common.map
+          (fun (v1, v2) ->
+            let v1 = name v1 and v2 = option alias v2 in
+            (v1, v2))
+          v1
+      in
+      let v2 = filename v2 in
+      G.ImportFrom (t, G.FileName v2, v1)
   | ModuleAlias (t, v1, v2) ->
       let v1 = alias v1 and v2 = filename v2 in
       G.ImportAs (t, G.FileName v2, Some v1)
@@ -739,9 +746,9 @@ and require_to_import_in_stmt_opt st =
           } )
     when x =$= AST_generic_.special_multivardef_pattern -> (
       try
-        match pattern with
-        | Obj (_, xs, _) ->
-            let ys =
+        let imported_names =
+          match pattern with
+          | Obj (_, xs, _) ->
               xs
               |> Common.map (function
                    | FieldColon
@@ -756,22 +763,22 @@ and require_to_import_in_stmt_opt st =
                          | (s1, _), (s2, _) when s1 =$= s2 -> None
                          | _ -> Some (id2, G.empty_id_info ())
                        in
-                       G.DirectiveStmt
-                         (G.ImportFrom (treq, G.FileName file, id1, alias_opt)
-                         |> G.d)
-                       |> G.s
+                       (id1, alias_opt)
                    | _ -> raise ComplicatedCase)
-            in
-            (* we also keep the require() call in the AST so people using
-             * semgrep patterns like 'require("foo")' still find those
-             * requires in the target. The ImportFrom conversion is mostly
-             * for Naming_AST to recognize those require and do the
-             * right aliasing for them too.
-             * alt: do the conversion in Naming_AST.ml instead?
-             *)
-            let orig = stmt st in
-            Some (ys @ [ orig ])
-        | _ -> raise ComplicatedCase
+          | _ -> raise ComplicatedCase
+        in
+        let import =
+          G.DirectiveStmt
+            (G.ImportFrom (treq, G.FileName file, imported_names) |> G.d)
+          |> G.s
+        in
+        (* we also keep the require() call in the AST so people using
+         * semgrep patterns like 'require("foo")' still find those requires
+         * in the target. The ImportFrom conversion is mostly for Naming_AST
+         * to recognize those require and do the right aliasing for them
+         * too. alt: do the conversion in Naming_AST.ml instead? *)
+        let orig = stmt st in
+        Some [ import; orig ]
       with
       | ComplicatedCase -> None)
   | _ -> None

--- a/semgrep-core/src/parsing/pfff/php_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/php_to_generic.ml
@@ -178,7 +178,8 @@ let rec stmt_aux = function
           | name :: path ->
               [
                 G.DirectiveStmt
-                  (G.ImportFrom (t, G.DottedName (List.rev path), name, None)
+                  (G.ImportFrom
+                     (t, G.DottedName (List.rev path), [ (name, None) ])
                   |> G.d)
                 |> G.s;
               ]

--- a/semgrep-core/src/parsing/pfff/scala_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/scala_to_generic.ml
@@ -124,7 +124,9 @@ let v_dotted_name_of_stable_id (v1, v2) =
 let rec v_import_expr tk import_expr =
   match import_expr with
   | Left id ->
-      [ { G.d = G.ImportFrom (tk, DottedName [], id, None); d_attrs = [] } ]
+      [
+        { G.d = G.ImportFrom (tk, DottedName [], [ (id, None) ]); d_attrs = [] };
+      ]
   | Right (v1, v2) ->
       let module_name = G.DottedName (v_dotted_name_of_stable_id v1) in
       let v2 = v_import_spec v2 in
@@ -133,7 +135,7 @@ let rec v_import_expr tk import_expr =
 and v_import_spec = function
   | ImportId v1 ->
       let v1 = v_ident v1 in
-      fun tk path -> [ G.ImportFrom (tk, path, v1, None) |> G.d ]
+      fun tk path -> [ G.ImportFrom (tk, path, [ (v1, None) ]) |> G.d ]
   | ImportWildcard v1 ->
       let v1 = v_tok v1 in
       fun tk path -> [ G.ImportAll (tk, path, v1) |> G.d ]
@@ -147,7 +149,7 @@ and v_import_spec = function
                  | None -> None
                  | Some (_, id) -> Some (id, G.empty_id_info ())
                in
-               G.ImportFrom (tk, path, id, alias) |> G.d)
+               G.ImportFrom (tk, path, [ (id, alias) ]) |> G.d)
 
 let v_import (v1, v2) : G.directive list =
   let v1 = v_tok v1 in

--- a/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_rust_tree_sitter.ml
@@ -2746,7 +2746,7 @@ and map_use_clause (env : env) (x : CST.use_clause) use : G.directive list =
   | `Choice_self x ->
       let dots, ident = map_path_ident env x in
       let modname = G.DottedName dots in
-      [ G.ImportFrom (use, modname, ident, None) |> G.d ]
+      [ G.ImportFrom (use, modname, [ (ident, None) ]) |> G.d ]
   | `Use_as_clause (v1, v2, v3) ->
       let dots, ident_ = map_path_ident env v1 in
       let modname = G.DottedName dots in
@@ -2754,7 +2754,8 @@ and map_use_clause (env : env) (x : CST.use_clause) use : G.directive list =
       let alias = ident env v3 in
       (* pattern (r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]* *)
       [
-        G.ImportFrom (use, modname, ident_, Some (alias, G.empty_id_info ()))
+        G.ImportFrom
+          (use, modname, [ (ident_, Some (alias, G.empty_id_info ())) ])
         |> G.d;
       ]
   | `Use_list x -> map_use_list env x use None
@@ -2788,9 +2789,9 @@ and prepend_scope (dir : G.directive) (scope : G.dotted_ident option) :
   match scope with
   | Some scope -> (
       match dir.d with
-      | ImportFrom (tok, modname, id, alias) ->
+      | ImportFrom (tok, modname, imported_names) ->
           let modname = prepend_module_name scope modname in
-          { dir with d = G.ImportFrom (tok, modname, id, alias) }
+          { dir with d = G.ImportFrom (tok, modname, imported_names) }
       | ImportAs (tok, modname, alias) ->
           let modname = prepend_module_name scope modname in
           { dir with d = G.ImportAs (tok, modname, alias) }

--- a/semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_solidity_tree_sitter.ml
@@ -644,7 +644,7 @@ let map_import_clause (env : env) (x : CST.import_clause) =
         | Left _tstar, Some alias ->
             [ ImportAs (timport, modname, Some alias) |> G.d ]
         | Right id, alias_opt ->
-            [ ImportFrom (timport, modname, id, alias_opt) |> G.d ])
+            [ ImportFrom (timport, modname, [ (id, alias_opt) ]) |> G.d ])
   | `Mult_import (v1, v2, v3) ->
       let _lb = (* "{" *) token env v1 in
       let xs =
@@ -667,7 +667,7 @@ let map_import_clause (env : env) (x : CST.import_clause) =
       fun timport modname ->
         xs
         |> Common.map (fun (id, aliasopt) ->
-               ImportFrom (timport, modname, id, aliasopt) |> G.d)
+               ImportFrom (timport, modname, [ (id, aliasopt) ]) |> G.d)
 
 let map_mapping_key (env : env) (x : CST.mapping_key) : type_ =
   match x with

--- a/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_typescript_tree_sitter.ml
@@ -459,9 +459,7 @@ let named_imports (env : env) ((v1, v2, v3, v4) : CST.named_imports) =
   in
   let _close = token env v4 (* "}" *) in
   fun (import_tok : tok) (from_path : a_filename) ->
-    imports
-    |> Common.map (fun (name, opt_as_name) ->
-           Import (import_tok, (name, opt_as_name), from_path))
+    [ Import (import_tok, imports, from_path) ]
 
 let import_clause (env : env) (x : CST.import_clause) =
   match x with
@@ -486,7 +484,9 @@ let import_clause (env : env) (x : CST.import_clause) =
         | None -> fun _t _path -> []
       in
       fun t path ->
-        let default = Import (t, ((default_entity, snd v1), Some v1), path) in
+        let default =
+          Import (t, [ ((default_entity, snd v1), Some v1) ], path)
+        in
         default :: v2 t path
 
 let rec decorator_member_expression (env : env)
@@ -2328,7 +2328,9 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
                 v1
                 |> List.concat_map (fun (n1, n2opt) ->
                        let tmpname = ("!tmp_" ^ fst n1, snd n1) in
-                       let import = Import (tok2, (n1, Some tmpname), path) in
+                       let import =
+                         Import (tok2, [ (n1, Some tmpname) ], path)
+                       in
                        let e = idexp tmpname in
                        match n2opt with
                        | None ->

--- a/semgrep-core/tests/patterns/js/equivalence_import_variations4.js
+++ b/semgrep-core/tests/patterns/js/equivalence_import_variations4.js
@@ -1,0 +1,10 @@
+import {x} from 'module-name';
+import {y} from 'module-name';
+// MATCH:
+import {x, y} from 'module-name';
+// MATCH:
+import {y, x} from 'module-name';
+// MATCH:
+import {x, z, y} from 'module-name';
+// MATCH:
+import {a, x, b, y, c} from 'module-name';

--- a/semgrep-core/tests/patterns/js/equivalence_import_variations4.sgrep
+++ b/semgrep-core/tests/patterns/js/equivalence_import_variations4.sgrep
@@ -1,0 +1,1 @@
+import {x, y} from "module-name";

--- a/semgrep-core/tests/patterns/ts/dots_import_complex.ts
+++ b/semgrep-core/tests/patterns/ts/dots_import_complex.ts
@@ -1,4 +1,4 @@
-// TODO:
+// MATCH:
 import Foo, { y, x } from "bar";
 // MATCH:
 import Foo, { x, y } from "bar";


### PR DESCRIPTION
Previously, a statement such as `import {x, y} from 'z'` would have been desugared into two separate `ImportFrom` statements. This caused issues with matching, such as #5305, and it also led to the issue described in #6532.

This PR changes the `ImportFrom` node to have a list of imported values instead of a single imported value. That allows us to represent the example above as a single `ImportFrom` node without desugaring. It also allows `import {} from 'z';` to be represented (though it's unclear to me why anybody would ever write that). This change addresses the issues mentioned above.

Fixes #5305

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
