### PR TITLE
Make supply chain findings non-blocking in all cases

### DIFF
--- a/changelog.d/sca-nonblocking.changed
+++ b/changelog.d/sca-nonblocking.changed
@@ -1,0 +1,2 @@
+Reachable Supply Chain findings will no longer block pull requests when using `semgrep ci`.
+Note that unreachable findings have been non-blocking already.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -423,13 +423,8 @@ def ci(
                 cai_matches_by_rule
                 if "r2c-internal-cai" in rule.id
                 else blocking_matches_by_rule
-                # if an SCA finding is unreachable, it always goes in non-blocking
-                if rule.is_blocking
-                and (
-                    match.extra["sca_info"].reachable
-                    if "sca_info" in match.extra
-                    else True
-                )
+                # note that SCA findings are always non-blocking
+                if rule.is_blocking and "sca_info" not in match.extra
                 else nonblocking_matches_by_rule
             )
             applicable_result_set[rule].append(match)


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date https://github.com/returntocorp/semgrep-docs/pull/800
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
