### PR TITLE
tainting: Fix taint tracking for l-values with array accesses

### DIFF
--- a/changelog.d/pa-2225.fixed
+++ b/changelog.d/pa-2225.fixed
@@ -1,0 +1,5 @@
+taint-mode: Improved taint tracking for array-like accesses. Previously, if
+`x.a.b[i].c` got tainted, Semgrep would track `x.a.b` as tainted, and thus
+`x.a.b[i].d` would be incorrectly considered as tainted too. Now Semgrep will
+do the right thing and track `x.a.b[*].c` as tainted, and `x.a.b[i].d` will
+not be considered tainted.

--- a/semgrep-core/src/core/il/IL_helpers.ml
+++ b/semgrep-core/src/core/il/IL_helpers.ml
@@ -90,23 +90,6 @@ let is_dots_offset offset =
          | Dot _ -> true
          | Index _ -> false)
 
-let lval_is_dotted_prefix lval1 lval2 =
-  let eq_name x y = compare_name x y = 0 in
-  let rec offset_prefix os1 os2 =
-    match (os1, os2) with
-    | [], _ -> true
-    | _ :: _, [] -> false
-    | { o = Index _; _ } :: _, _
-    | _, { o = Index _; _ } :: _ ->
-        false
-    | { o = Dot a; _ } :: os1, { o = Dot b; _ } :: os2 ->
-        eq_name a b && offset_prefix os1 os2
-  in
-  match (lval1, lval2) with
-  | { base = Var x; rev_offset = ro1 }, { base = Var y; rev_offset = ro2 } ->
-      eq_name x y && offset_prefix (List.rev ro1) (List.rev ro2)
-  | __else__ -> false
-
 let lval_of_instr_opt x =
   match x.i with
   | Assign (lval, _)

--- a/semgrep-core/src/core/il/IL_helpers.mli
+++ b/semgrep-core/src/core/il/IL_helpers.mli
@@ -7,11 +7,6 @@ val lval_of_var : IL.name -> IL.lval
 val is_dots_offset : IL.offset list -> bool
 (** Test whether an offset is of the form .a_1. ... .a_N.  *)
 
-val lval_is_dotted_prefix : IL.lval -> IL.lval -> bool
-(** [lval_is_dotted_prefix lval1 lval2] tests whether [lval1] is of the
-    form x.a_1. ... .a_N, and whether [lval2] is an extension of [lval1],
-    that is, x.a_1. ... .a_N.o_1 ... . o_M. *)
-
 val lval_of_instr_opt : IL.instr -> IL.lval option
 (** If the given instruction stores its result in [lval] then it is
     [Some lval], otherwise it is [None]. *)
@@ -22,6 +17,8 @@ val lvar_of_instr_opt : IL.instr -> IL.name option
 
 val rlvals_of_node : IL.node_kind -> IL.lval list
 (** The lvalues that occur in the RHS of a node. *)
+
+val compare_name : IL.name -> IL.name -> int
 
 (** Useful to instantiate data strutures like Map and Set. *)
 module LvalOrdered : sig

--- a/semgrep-core/src/tainting/Taint_lval_env.ml
+++ b/semgrep-core/src/tainting/Taint_lval_env.ml
@@ -69,36 +69,50 @@ let union le1 le2 =
  * not represent the exact same object as the original l-value, but an
  * overapproximation. For example, the normalized l-value of `x[i]` will be `x`,
  * so the taints of any element of an array are tracked via the array itself. *)
-let rec normalize_lval lval =
+let normalize_lval lval =
+  let open Common in
   let { IL.base; rev_offset } = lval in
-  match lval.IL.rev_offset with
-  | [] -> (
-      (* Base case, no offset; we can only track variables. *)
-      match base with
-      | Var _ -> Some lval
-      | VarSpecial _
-      | Mem _ ->
-          None)
-  | _ :: rev_offset' -> (
-      (* Must find the longest prefix of the form x.a_1. ... . a_N. *)
-      let is_dots = LV.is_dots_offset rev_offset in
-      match base with
-      | Var _ when is_dots -> Some lval
-      | VarSpecial _ when is_dots -> (
-          (* this.x.a_1. ... . a_N becomes x.a_1. ... . a_N *)
-          match List.rev lval.rev_offset with
-          | { o = IL.Dot var; _ } :: offset' ->
-              Some { IL.base = Var var; rev_offset = List.rev offset' }
-          | []
-          | { o = IL.Index _; _ } :: _ ->
-              logger#error "normalize_lval: Impossible happened";
-              None)
-      | Var _
-      | VarSpecial _ ->
-          (* Offset-chain is not of the form .a_1. ... . a_N, so drop the last
-           * offset until the condition is met or we reach the base case. *)
-          normalize_lval { base; rev_offset = rev_offset' }
-      | Mem _ -> None)
+  let* base, rev_offset =
+    match base with
+    | Var _ -> Some (base, rev_offset)
+    | VarSpecial _ -> (
+        (* this.x.a_1. ... . a_N becomes x.a_1. ... . a_N *)
+        match List.rev lval.rev_offset with
+        | { o = IL.Dot var; _ } :: offset' -> Some (Var var, List.rev offset')
+        | [] -> None
+        | { o = IL.Index _; _ } :: _ ->
+            logger#error "normalize_lval: Impossible happened";
+            None)
+    | Mem _ -> None
+  in
+  let rev_offset =
+    rev_offset
+    |> List.filter (fun o ->
+           match o.IL.o with
+           | IL.Dot _ -> true
+           | IL.Index _ -> false)
+  in
+  Some { IL.base; rev_offset }
+
+let lval_is_prefix lval1 lval2 =
+  let open IL in
+  let eq_name x y = LV.compare_name x y = 0 in
+  let rec offset_prefix os1 os2 =
+    match (os1, os2) with
+    | [], _ -> true
+    | _ :: _, []
+    | { o = Index _; _ } :: _, { o = Dot _; _ } :: _
+    | { o = Dot _; _ } :: _, { o = Index _; _ } :: _ ->
+        false
+    | { o = Index _; _ } :: os1, { o = Index _; _ } :: os2 ->
+        offset_prefix os1 os2
+    | { o = Dot a; _ } :: os1, { o = Dot b; _ } :: os2 ->
+        eq_name a b && offset_prefix os1 os2
+  in
+  match (lval1, lval2) with
+  | { base = Var x; rev_offset = ro1 }, { base = Var y; rev_offset = ro2 } ->
+      eq_name x y && offset_prefix (List.rev ro1) (List.rev ro2)
+  | __else__ -> false
 
 let add ({ tainted; propagated; cleaned } as lval_env) lval taints =
   match normalize_lval lval with
@@ -157,22 +171,21 @@ let clean ({ tainted; propagated; cleaned } as lval_env) lval =
       lval_env
   | Some lval ->
       let prefix_is_tainted =
-        tainted |> LvalMap.exists (fun lv _ -> LV.lval_is_dotted_prefix lv lval)
+        tainted |> LvalMap.exists (fun lv _ -> lval_is_prefix lv lval)
       in
       let needs_clean_mark = prefix_is_tainted && lval.rev_offset <> [] in
       {
         tainted =
           (* If `x.a` is clean then `x.a` and any extension of it (`x.a.b`, `x.a.b.c`,
            * and so on) are clean too, and we remove them all from tainted. *)
-          tainted
-          |> LvalMap.filter (fun lv _ -> not (LV.lval_is_dotted_prefix lval lv));
+          tainted |> LvalMap.filter (fun lv _ -> not (lval_is_prefix lval lv));
         propagated;
         cleaned =
           (* Similarly, if `x.a` will have a "clean" mark, then we can remove any
            * such mark on any extension of `x.a`. It would be redundant to record
            * `x.a.b` as clean when we already have that `x.a` is clean. *)
           (cleaned
-          |> LvalSet.filter (fun lv -> not (LV.lval_is_dotted_prefix lval lv))
+          |> LvalSet.filter (fun lv -> not (lval_is_prefix lval lv))
           |> if needs_clean_mark then LvalSet.add lval else fun x -> x);
       }
 

--- a/semgrep-core/tests/rules/field_sensitive2.js
+++ b/semgrep-core/tests/rules/field_sensitive2.js
@@ -10,6 +10,8 @@ function f() {
     sink(x.b)
     //ruleid: test
     sink(x.b.c)
+    //ruleid: test
+    sink(x.c[j])
 
     //ok: test
     sink(x.a)
@@ -17,11 +19,7 @@ function f() {
     sink(x.a.b)
 
     //ok: test
-    sink(x.c[i].d)
+    sink(x.c[j].d)
     //ok: test
-    sink(x.c[i])
-    //ok: test
-    sink(x.c[j])
-    //ok: test
-    sink(x.c)
+    sink(x.c[j].d.e)
 }

--- a/semgrep-core/tests/rules/field_sensitive3.js
+++ b/semgrep-core/tests/rules/field_sensitive3.js
@@ -7,8 +7,6 @@ function f() {
     sink(x.a.b.c)
     //ruleid: test
     sink(x.a.b.c.d)
-    //ok: test
-    sink(x.d.e)
     //ruleid: test
     sink(x.d.e[k].f.g[l].h)
     //ruleid: test

--- a/semgrep-core/tests/rules/field_sensitive3.js
+++ b/semgrep-core/tests/rules/field_sensitive3.js
@@ -7,10 +7,12 @@ function f() {
     sink(x.a.b.c)
     //ruleid: test
     sink(x.a.b.c.d)
-    //ruleid: test
+    //ok: test
     sink(x.d.e)
     //ruleid: test
-    sink(x.d.e[i].f)
+    sink(x.d.e[k].f.g[l].h)
+    //ruleid: test
+    sink(x.d.e[k].f.g[l].h.i)
 
     // These are OK because we have not enabled propagation of taint up through
     // fields, to avoid FPs
@@ -22,6 +24,10 @@ function f() {
     sink(x.a.c)
     //ok: test
     sink(x.a)
+    //ok: test
+    sink(x.d.e[i].f.g[j])
+    //ok: test
+    sink(x.d.e)
     //ok: test
     sink(x.d)
     //ok: test


### PR DESCRIPTION
Taint going into `x.a[i].c` should not make `x.a[i]` tainted!

Closes PA-2225

test plan:
make test # updated two tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
