### PR TITLE
feat(js): allow angular JS dependencies to be named

### DIFF
--- a/changelog.d/pa-2233.fixed
+++ b/changelog.d/pa-2233.fixed
@@ -1,1 +1,1 @@
-JS/TS: Allow information about the arguments to constructors of classes (such as types) to spread to instances of the the argument.
+JS/TS: Allow dependencies to @Injectable classes in Angular JS to be visible outside the scope of the constructor.

--- a/changelog.d/pa-2233.fixed
+++ b/changelog.d/pa-2233.fixed
@@ -1,1 +1,1 @@
-JS/TS: Allow dependencies to @Injectable classes in Angular JS to be visible outside the scope of the constructor.
+JS/TS: Allow dependencies to @Injectable and @Component classes in Angular JS to be visible outside the scope of the constructor.

--- a/changelog.d/pa-2233.fixed
+++ b/changelog.d/pa-2233.fixed
@@ -1,0 +1,1 @@
+JS/TS: Allow information about the arguments to constructors of classes (such as types) to spread to instances of the the argument.

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -505,7 +505,7 @@ let resolve lang prog =
                     if lang = Lang.Js || lang = Lang.Ts then
                       let _, fields, _ = c.cbody in
                       js_add_angular_constructor_args env attrs
-                        (List.map (fun (F x) -> x) fields)
+                        (Common.map (fun (F x) -> x) fields)
                     else []
                   in
                   (* TODO? Maybe we need a `with_new_class_scope`. For now, abusing `with_new_function_scope`. *)

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -403,7 +403,15 @@ let params_of_parameters env xs =
            Some (H.str_of_ident id, resolved)
        | _ -> None)
 
-let js_get_constructor_args env attrs defs =
+(* In Angular JS, we have some "Injectable" classes, which are marked with an
+   @Injectable decorator.
+   https://angular.io/guide/dependency-injection-in-action
+   These classes may reference parameters to the constructor of the class, outside
+   of the actual code of the constructor itself.
+   So we must add them to the scope, should we find the decorator and a constructor's
+   parameters.
+*)
+let js_add_angular_constructor_args env attrs defs =
   let ( let* ) = Option.bind in
   match
     let* () =
@@ -494,7 +502,7 @@ let resolve lang prog =
                   let special_class_params =
                     if lang = Lang.Js || lang = Lang.Ts then
                       let _, fields, _ = c.cbody in
-                      js_get_constructor_args env attrs
+                      js_add_angular_constructor_args env attrs
                         (List.map (fun (F x) -> x) fields)
                     else []
                   in

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -410,6 +410,7 @@ let params_of_parameters env xs =
    of the actual code of the constructor itself.
    So we must add them to the scope, should we find the decorator and a constructor's
    parameters.
+   This also works for `@Component`.
 *)
 let js_add_angular_constructor_args env attrs defs =
   let ( let* ) = Option.bind in
@@ -417,7 +418,8 @@ let js_add_angular_constructor_args env attrs defs =
     let* () =
       List.find_map
         (function
-          | NamedAttr (_, Id (("Injectable", _), _), _) -> Some ()
+          | NamedAttr (_, Id ((("Injectable" | "Component"), _), _), _) ->
+              Some ()
           | _ -> None)
         attrs
     in

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -413,10 +413,10 @@ let params_of_parameters env xs =
    This also works for `@Component`.
 *)
 let js_get_angular_constructor_args env attrs defs =
-  let is_injectable = List.exists 
+  let is_injectable = List.exists
     (function
           | NamedAttr (_, Id ((("Injectable" | "Component"), _), _), _) ->
-              true 
+              true
           | _ -> false)
         attrs
   in

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -413,25 +413,25 @@ let params_of_parameters env xs =
    This also works for `@Component`.
 *)
 let js_get_angular_constructor_args env attrs defs =
-  let is_injectable = List.exists
-    (function
-          | NamedAttr (_, Id ((("Injectable" | "Component"), _), _), _) ->
-              true
-          | _ -> false)
-        attrs
-  in
-    defs
-  |> List.filter_map
+  let is_injectable =
+    List.exists
       (function
-        | {
-            s =
-              DefStmt
-                ( { name = EN (Id (("constructor", _), _)); _ },
-                  FuncDef { fparams; _ } );
-            _;
-          } when is_injectable ->
-            Some (params_of_parameters env fparams)
-        | _ -> None)
+        | NamedAttr (_, Id ((("Injectable" | "Component"), _), _), _) -> true
+        | _ -> false)
+      attrs
+  in
+  defs
+  |> List.filter_map (function
+       | {
+           s =
+             DefStmt
+               ( { name = EN (Id (("constructor", _), _)); _ },
+                 FuncDef { fparams; _ } );
+           _;
+         }
+         when is_injectable ->
+           Some (params_of_parameters env fparams)
+       | _ -> None)
   |> List.concat
 
 let declare_var env lang id id_info ~explicit vinit vtype =

--- a/semgrep-core/tests/rules/js_constructor_naming.js
+++ b/semgrep-core/tests/rules/js_constructor_naming.js
@@ -12,6 +12,21 @@ class ClassName {
         return this.http
     }
   }
+
+@Component
+class ClassName {
+    foo () {
+        // ruleid: js-constructor-naming
+        return this.http.thing
+    }
+
+    constructor (http: Ty) { }
+  
+    bar () {
+        // ruleid: js-constructor-naming
+        return this.http
+    }
+  }
   
 
 // not injectable

--- a/semgrep-core/tests/rules/js_constructor_naming.js
+++ b/semgrep-core/tests/rules/js_constructor_naming.js
@@ -1,3 +1,4 @@
+@Injectable
 class ClassName {
     foo () {
         // ruleid: js-constructor-naming
@@ -12,3 +13,16 @@ class ClassName {
     }
   }
   
+
+// not injectable
+class ClassName {
+    foo () {
+        return this.http.thing
+    }
+
+    constructor (http: Ty) { }
+
+    bar () {
+        return this.http
+    }
+}

--- a/semgrep-core/tests/rules/js_constructor_naming.js
+++ b/semgrep-core/tests/rules/js_constructor_naming.js
@@ -1,0 +1,14 @@
+class ClassName {
+    foo () {
+        // ruleid: js-constructor-naming
+        return this.http.thing
+    }
+
+    constructor (http: Ty) { }
+  
+    bar () {
+        // ruleid: js-constructor-naming
+        return this.http
+    }
+  }
+  

--- a/semgrep-core/tests/rules/js_constructor_naming.yaml
+++ b/semgrep-core/tests/rules/js_constructor_naming.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: js-constructor-naming 
+    message: Naming should work within the body of a JS class using the constructor's args! 
+    languages:
+      - javascript
+      - typescript
+    severity: WARNING
+    patterns:
+      - pattern: |
+          ($THING: Ty)


### PR DESCRIPTION
## What:
In JS, classes may have constructors, which take parameters. In Angular JS, there is a concept of "dependency injection", which allows these dependencies to be specified in the parameters to a class's constructors, when marked with an `@Injectable` or `@Component` decorator. These dependencies may then be referenced outside of the scope of the constructor, but within the class generally. We should change naming so these things work that way, which is different than regular JS.

## Why:
This way, we can produce findings in line with the actual behavior. In particular, Lewis needs it to write some rules.

## How:
I moved the `class_definition` stuff out of `kclass_definition` in `Naming_AST`, because I needed the decorators along with the class definition.

I added extra logic which searches all the top-level definitions in a class, when that class is marked with a decorator `@Injectable` or `@Component`. Then, all parameters to that constructor are added to the parameters that are in scope within the class itself, making the parameters to the constructor visible outside the constructor itself.

## Test plan:
`make test`

Closes PA-2223.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
