### PR TITLE
ojsonnet: simplify again Core_jsonnet, reuse types from AST_jsonnet

### DIFF
--- a/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
@@ -56,7 +56,7 @@ type ident = string wrap [@@deriving show]
  * no Import (expanded during desugaring).
  *)
 type expr =
-  | L of literal
+  | L of AST_jsonnet.literal
   | O of obj_inside bracket
   (* no complex arr_inside, no ArrayComp *)
   | Array of expr list bracket
@@ -77,27 +77,13 @@ type expr =
   | Error of tok (* 'error' *) * expr
 
 (* ------------------------------------------------------------------------- *)
-(* literals *)
-(* ------------------------------------------------------------------------- *)
-and literal =
-  | Null of tok
-  | Bool of bool wrap
-  | Number of string wrap
-  | Str of string_
-
-and string_ = verbatim option * string_kind * string_content bracket
-and verbatim = tok (* @ *)
-and string_kind = SingleQuote | DoubleQuote | TripleBar (* a.k.a Text block *)
-and string_content = string wrap list
-
-(* ------------------------------------------------------------------------- *)
 (* Calls *)
 (* ------------------------------------------------------------------------- *)
 
 (* no Dollar anymore *)
 and special = Self | Super
 and argument = Arg of expr | NamedArg of ident * tok (* = *) * expr
-and unary_op = UPlus | UMinus | UBang | UTilde
+and unary_op = AST_jsonnet.unary_op
 
 (* no '!=', '==', '%', 'in' *)
 and binary_op =
@@ -161,7 +147,7 @@ and field = {
 and field_name = FExpr of expr bracket
 
 (* =~ visibility *)
-and hidden = Colon | TwoColons | ThreeColons
+and hidden = AST_jsonnet.hidden
 
 (* no more locals1 and locals2, no CompIf *)
 and obj_comprehension = field_name * tok (* : *) * expr * for_comp


### PR DESCRIPTION
test plan:
make


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)