### PR TITLE
feat(java): propagate singly assigned private vars

### DIFF
--- a/changelog.d/pa-2230.fixed
+++ b/changelog.d/pa-2230.fixed
@@ -1,0 +1,1 @@
+Java: `private`, singly-assigned class variables now permit constant propagation

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -92,6 +92,11 @@ type var_stats = (var, lr_stats) Hashtbl.t
 let ( let* ) o f = Option.bind o f
 let ( let/ ) o f = Option.iter f o
 
+let is_private attr =
+  match attr with
+  | KeywordAttr (Private, _) -> true
+  | _ -> false
+
 (*****************************************************************************)
 (* Environment Helpers *)
 (*****************************************************************************)
@@ -571,6 +576,8 @@ let propagate_basic lang prog =
                    H.has_keyword_attr Const attrs
                    || H.has_keyword_attr Final attrs
                    || (!(stats.lvalue) = 1 && is_js env)
+                   || !(stats.lvalue) = 1 && env.lang = Some Lang.Java
+                      && List.exists is_private attrs
                   then
                    match e.e with
                    | L literal -> add_constant_env id (sid, Lit literal) env

--- a/semgrep-core/tests/rules/java_private_prop.java
+++ b/semgrep-core/tests/rules/java_private_prop.java
@@ -1,0 +1,20 @@
+public class Class {
+  private int x = 5;
+  public int y = 5;  
+  private int z = 5;
+
+
+  public void foo() {
+    // ruleid: java-private-prop
+    return x;
+  }
+
+  public void bar() {
+    return y; 
+  }
+
+  public void qux() {
+    z = 3;
+    return z; 
+  }
+}

--- a/semgrep-core/tests/rules/java_private_prop.yaml
+++ b/semgrep-core/tests/rules/java_private_prop.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: java_private_prop
+    message: Should be able to propagate a singly-assigned private field in Java 
+    languages:
+      - java 
+    severity: WARNING
+    pattern: |
+      return 5;


### PR DESCRIPTION
## What:
We do not allow constant propagation on singly assigned variables in Java. This is only safe if those variables are `private`, so they are not accessed outside of the class itself.

## Why:
We should do this, it will help write Java rules.

## How:
Added it as a condition in constant propagation.

## Test plan:
`make test`

Closes PA-2230

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
