### PR TITLE
tainting: Assume sources and sanitizers are pure

### DIFF
--- a/changelog.d/pa-1629.fixed
+++ b/changelog.d/pa-1629.fixed
@@ -1,0 +1,21 @@
+taint-mode: In 0.94.0 we made that when a `pattern-source` (or `pattern-sanitizer`)
+matched a variable exactly, this was understood as that variable being tainted
+(sanitized, resp.) by side-effect. For example, given `tainted(x)` we would taint `x`
+by side-effect, and subsequent occurrences of `x` were also considered tainted.
+This allowed to write rules like `c.lang.security.use-after-free.use-after-free`
+in a very succint way, and it also addressed some limitations of the workarounds that
+were being used to simulate this until then.
+
+This worked well initially, or so we thought, until in 0.113.0 we added
+field-sensitivity to taint-mode, and in subsequent versions we made sources and
+sanitizers apply by side-effect to more kinds of l-values than just simple variables.
+It was then that we started to see regressions that were fairly unintuitive for users.
+For example, if `$_GET['foo']` was a taint source, this would make `$_GET` itself to
+be tainted by side-effect, and a subsequent expression like `$_GET['bar']` was also
+considered tainted.
+
+We now correct the situation by adding the `by-side-effect` option to sources and
+sanitizers, and requiring this option to be explicitly enabled
+(that is, `by-side-effect: true`) in order to apply the source or the sanitizer by
+side-effect. Otherwise, the default is that sources and sanitizers matching l-values
+apply only to the precise occurrences that they match.

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -125,6 +125,7 @@ type taint_spec = {
 
 and taint_source = {
   source_formula : formula;
+  source_by_side_effect : bool;
   label : string;
       (* The label to attach to the data.
        * Alt: We could have an optional label instead, allow taint that is not
@@ -153,6 +154,7 @@ and taint_source = {
  *)
 and taint_sanitizer = {
   sanitizer_formula : formula;
+  sanitizer_by_side_effect : bool;
   not_conflicting : bool;
       (* If [not_conflicting] is enabled, the sanitizer cannot conflict with
        * a sink or a source (i.e., match the exact same range) otherwise

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1078,6 +1078,10 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
     if is_old then parse_formula_old_from_dict else parse_formula_from_dict
   in
   let source_dict = yaml_to_dict env key value in
+  let source_by_side_effect =
+    take_opt source_dict env parse_bool "by-side-effect"
+    |> Option.value ~default:false
+  in
   let label =
     take_opt source_dict env parse_string "label"
     |> Option.value ~default:R.default_source_label
@@ -1088,7 +1092,7 @@ let parse_taint_source ~(is_old : bool) env (key : key) (value : G.expr) :
     |> Option.value ~default:(R.default_source_requires tok)
   in
   let source_formula = f env source_dict in
-  { source_formula; label; source_requires }
+  { source_formula; source_by_side_effect; label; source_requires }
 
 let parse_taint_propagator ~(is_old : bool) env (key : key) (value : G.expr) :
     Rule.taint_propagator =
@@ -1106,13 +1110,17 @@ let parse_taint_sanitizer ~(is_old : bool) env (key : key) (value : G.expr) =
     if is_old then parse_formula_old_from_dict else parse_formula_from_dict
   in
   let sanitizer_dict = yaml_to_dict env key value in
+  let sanitizer_by_side_effect =
+    take_opt sanitizer_dict env parse_bool "by-side-effect"
+    |> Option.value ~default:false
+  in
   let not_conflicting =
     take_opt sanitizer_dict env parse_bool
       (if is_old then "not_conflicting" else "not-conflicting")
     |> Option.value ~default:false
   in
   let sanitizer_formula = f env sanitizer_dict in
-  { R.not_conflicting; sanitizer_formula }
+  { sanitizer_formula; sanitizer_by_side_effect; R.not_conflicting }
 
 let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
     Rule.taint_sink =

--- a/semgrep-core/tests/rules/field_sensitive7.yaml
+++ b/semgrep-core/tests/rules/field_sensitive7.yaml
@@ -6,7 +6,8 @@ rules:
     severity: WARNING
     mode: taint
     pattern-sources:
-      - patterns:
+      - by-side-effect: true
+        patterns:
         - pattern: $X.b
         - focus-metavariable: $X
     pattern-sinks:

--- a/semgrep-core/tests/rules/taint_if_cond_sink.yaml
+++ b/semgrep-core/tests/rules/taint_if_cond_sink.yaml
@@ -2,7 +2,8 @@ rules:
   - id: use-after-free-taint
     mode: taint
     pattern-sources:
-      - patterns:
+      - by-side-effect: true
+        patterns:
           - pattern: free($VAR);
           - focus-metavariable: $VAR
     pattern-sinks:

--- a/semgrep-core/tests/rules/taint_labels5.yaml
+++ b/semgrep-core/tests/rules/taint_labels5.yaml
@@ -5,12 +5,14 @@ rules:
     languages: [py]
     mode: taint
     pattern-sources:
-      - label: closed
+      - by-side-effect: true
+        label: closed
         patterns:
           - pattern: |
               $FILE.close()
           - focus-metavariable: $FILE
-      - label: reopened
+      - by-side-effect: true
+        label: reopened
         requires: closed
         patterns:
           - pattern: |

--- a/semgrep-core/tests/rules/taint_labels6.yaml
+++ b/semgrep-core/tests/rules/taint_labels6.yaml
@@ -5,16 +5,19 @@ rules:
     languages: [py]
     mode: taint
     pattern-sources:
-      - label: closed
+      - by-side-effect: true
+        label: closed
         patterns:
           - pattern: $FILE.close()
           - focus-metavariable: $FILE
-      - label: closed_twice
+      - by-side-effect: true
+        label: closed_twice
         requires: closed
         patterns:
           - pattern: $FILE.close()
           - focus-metavariable: $FILE
-      - label: reopened
+      - by-side-effect: true
+        label: reopened
         requires: closed
         patterns:
           - pattern: |

--- a/semgrep-core/tests/rules/taint_sanitizer_var.yaml
+++ b/semgrep-core/tests/rules/taint_sanitizer_var.yaml
@@ -8,7 +8,8 @@ rules:
     pattern-sources:
       - pattern: source
     pattern-sanitizers:
-      - patterns:
+      - by-side-effect: true
+        patterns:
         - pattern-inside: sanitize($X)
         - focus-metavariable: $X
     pattern-sinks:

--- a/semgrep-core/tests/rules/taint_source_var.yaml
+++ b/semgrep-core/tests/rules/taint_source_var.yaml
@@ -6,7 +6,8 @@ rules:
     severity: WARNING
     mode: taint
     pattern-sources:
-      - patterns:
+      - by-side-effect: true
+        patterns:
         # if $X is a variable, it will become tainted by side effect
         - pattern: taint($X)
         - focus-metavariable: $X

--- a/semgrep-core/tests/rules/taint_source_var1.yaml
+++ b/semgrep-core/tests/rules/taint_source_var1.yaml
@@ -6,7 +6,8 @@ rules:
     severity: WARNING
     mode: taint
     pattern-sources:
-      - patterns:
+      - by-side-effect: true
+        patterns:
         # if $X is a variable, it will become tainted by side effect
         - pattern: taint($X)
         - focus-metavariable: $X

--- a/semgrep-core/tests/rules/taint_wo_side_effects.php
+++ b/semgrep-core/tests/rules/taint_wo_side_effects.php
@@ -1,0 +1,8 @@
+<?php
+
+$a = $_GET;
+// ruleid:test
+call_me($a['bb']);
+
+// ok:test
+call_me($_GET['page']);

--- a/semgrep-core/tests/rules/taint_wo_side_effects.yaml
+++ b/semgrep-core/tests/rules/taint_wo_side_effects.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: test
+    severity: ERROR
+    message: Test
+    languages:
+      - php
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: $_GET
+          - pattern-not-inside: $_GET['page']
+    pattern-sinks:
+      - pattern: call_me(...)

--- a/semgrep-core/tests/rules/taint_wo_side_effects1.php
+++ b/semgrep-core/tests/rules/taint_wo_side_effects1.php
@@ -1,0 +1,17 @@
+<?php
+
+$var = source();
+// ruleid:regression_0116
+sink($var);
+
+if ( $var  == 'aaa' || $var  == 'bb' ) {
+    $aa = 'bb';
+}
+
+// ruleid:regression_0116
+sink('aaa' . $var);
+
+if ($var == 'a') {
+    // ok:regression_0116
+    sink($var);
+}

--- a/semgrep-core/tests/rules/taint_wo_side_effects1.yaml
+++ b/semgrep-core/tests/rules/taint_wo_side_effects1.yaml
@@ -1,0 +1,37 @@
+rules:
+  - id: regression_0116
+    message: Semgrep found a match
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sanitizers:
+      - patterns:
+          - pattern: $SOURCE
+          - pattern-either:
+              - pattern: |
+                  if (<... in_array($SOURCE, ...) ...>) {
+                    ...
+                    $SOURCE = '...';
+                  }
+              - pattern-inside: |
+                  if (<... '...' === $SOURCE ...>) {
+                    ...
+                  }
+              - pattern-inside: |
+                  if (<... '...' == $SOURCE ...>) {
+                    ...
+                  }
+              - pattern-inside: |
+                  if (<... $SOURCE === '...' ...>) {
+                    ...
+                  }
+              - pattern-inside: |
+                  if (<... $SOURCE == '...' ...>) {
+                    ...
+                  }
+

--- a/semgrep-core/tests/rules/taint_wo_side_effects2.php
+++ b/semgrep-core/tests/rules/taint_wo_side_effects2.php
@@ -1,0 +1,7 @@
+<?php
+
+// ruleid:regression_0121
+echo $_SERVER['REQUEST_URI'];
+
+// ok:regression_0121
+echo $_SERVER['SERVER_NAME']

--- a/semgrep-core/tests/rules/taint_wo_side_effects2.yaml
+++ b/semgrep-core/tests/rules/taint_wo_side_effects2.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: regression_0121
+    message: Semgrep found a match
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: $_SERVER['REQUEST_URI']
+    pattern-sinks:
+      - pattern: echo ...;


### PR DESCRIPTION
Pure in the sense of having no side-effects.

In 0.94.0 we made it so when a pattern-source matched a variable exactly
this was understood as that variable being tainted by side-effect, e.g.
given `tainted(x)` we would taint `x` by side-effect. Same was done for
sanitizers.

This worked well initially, or so we thought, until in 0.113.0 we added
field-sensitivity, and in subsequent versions we applied sources and
sanitizers by side-effect on more general l-values. It was then that we
started to see regressions that were fairly unintuitive for users (see
added tests).

We now correct the situation by adding the `by-side-effect` option to
sources and sanitizers, and requiring this option to be explicitly enabled
in order to apply the source or the sanitizer by side-effect.

Requires https://github.com/returntocorp/semgrep-rules/pull/2577

Fixes: https://github.com/returntocorp/semgrep/commit/653db7dfa787b2e6057ee65dbf1ddb7c16b5bea0 ("tainting: Allow variables to be taint sources by side-effect (https://github.com/returntocorp/semgrep/pull/5240)")
Fixes: https://github.com/returntocorp/semgrep/commit/4ced4711358a6f19da87b59d9e7b3e69070bcdd1 ("tainting: Allow variables to be sanitized by side-effect (https://github.com/returntocorp/semgrep/pull/5266)")

Closes [PA-1629](https://linear.app/r2c/issue/PA-1629)
Closes [PA-2229](https://linear.app/r2c/issue/PA-2229)

Reviewed-by: Emma Jin

test plan:
make test # added three tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
