### PR TITLE
ojsonnet: use lazy array elt and fields

### DIFF
--- a/semgrep-core/tests/jsonnet/interpreting/obj_access.jsonnet
+++ b/semgrep-core/tests/jsonnet/interpreting/obj_access.jsonnet
@@ -1,0 +1,5 @@
+local obj = { foo: 1, bar: 2};
+
+{ foo: obj.foo,
+  bar: obj.bar,
+}


### PR DESCRIPTION
The old code could not work without using those new
lazy_value type because calling eval at manifestation time
is too late and does not have the right environment to evaluate
the value.

test plan:
```
$ /home/pad/yy/_build/default/src/main/Main.exe -dump_jsonnet_json obj_access.jsonnet
{"foo":1,"bar":2}
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)