### PR TITLE
osemgrep: manifest jsonnet to AST generic

### DIFF
--- a/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
@@ -54,6 +54,7 @@ type ident = string wrap [@@deriving show]
  * no Array slices, no complex Array or Object comprehension,
  * no DotAccess (use generalized ArrayAccess), no Assert, no ParenExpr,
  * no Import (expanded during desugaring).
+ * TODO? add Import that resolves lazily during Eval?
  *)
 type expr =
   | L of AST_jsonnet.literal

--- a/semgrep-core/src/parsing/Manifest_jsonnet_to_AST_generic.ml
+++ b/semgrep-core/src/parsing/Manifest_jsonnet_to_AST_generic.ml
@@ -14,6 +14,7 @@
  *)
 module V = Value_jsonnet
 module G = AST_generic
+module A = AST_jsonnet
 
 (*****************************************************************************)
 (* Prelude *)
@@ -23,7 +24,51 @@ module G = AST_generic
  *)
 
 (*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let error tk s = raise (Parse_info.Other_error (s, tk))
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
-let manifest_value (_v : V.value_) : G.program = failwith "TODO: manifest_value"
+let rec value_to_expr (v : V.value_) : G.expr =
+  match v with
+  | V.Primitive x ->
+      let literal =
+        match x with
+        | V.Null tk -> G.Null tk
+        | V.Bool (b, tk) -> G.Bool (b, tk)
+        | V.Double (f, tk) -> G.Float (Some f, tk)
+        | V.Str (s, tk) -> G.String (s, tk)
+      in
+      G.L literal |> G.e
+  | V.Function { f_tok = tk; _ } -> error tk "Function value"
+  | V.Array (l, arr, r) ->
+      let xs =
+        arr |> Array.to_list
+        |> Common.map (fun lzv ->
+               let v = Lazy.force lzv.V.v in
+               value_to_expr v)
+      in
+      G.Container (G.Array, (l, xs, r)) |> G.e
+  | V.Object (l, (_assertsTODO, fields), r) ->
+      (* TODO: evaluate asserts *)
+      let xs =
+        fields
+        |> Common.map_filter (fun { V.fld_name; fld_hidden; fld_value } ->
+               match fst fld_hidden with
+               | A.Hidden -> None
+               | A.Visible
+               | A.ForcedVisible ->
+                   let v = Lazy.force fld_value.v in
+                   let e = value_to_expr v in
+                   let k = G.L (G.String fld_name) |> G.e in
+                   Some (G.keyval k (snd fld_name) e))
+      in
+      G.Container (G.Dict, (l, xs, r)) |> G.e
+
+let manifest_value (v : V.value_) : G.program =
+  let e = value_to_expr v in
+  [ G.exprstmt e ]


### PR DESCRIPTION
This allows to use jsonnet rules in osemgrep!

test plan:
add an error to myrule.jsonnet such as removing the message: field:

```
$ yy -dump_rule myrule.jsonnet
Uncaught exception:

  invalid rule my-rule, myrule.jsonnet:3:0: Missing required field message
```

Note that the error is now reported on the original myrule.jsonnet!
not some temporary json generated by an external jsonnet command.


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)