### PR TITLE
osemgrep: add a --dump-config

### DIFF
--- a/semgrep-core/src/core/Xlang.ml
+++ b/semgrep-core/src/core/Xlang.ml
@@ -62,7 +62,7 @@ let of_string ?id:(id_opt = None) s =
       LRegex
   | "generic" -> LGeneric
   | __else__ -> (
-      match Lang.lang_of_string_opt s with
+      match Lang.of_string_opt s with
       | None -> (
           match id_opt with
           | None -> failwith (unsupported_xlang_message s)

--- a/semgrep-core/src/core/ast/Lang.ml.j2
+++ b/semgrep-core/src/core/ast/Lang.ml.j2
@@ -65,7 +65,7 @@ let assoc =
 
 let lang_map = Common.hash_of_list assoc
 
-let lang_of_string_opt x = Hashtbl.find_opt lang_map (String.lowercase_ascii x)
+let of_string_opt x = Hashtbl.find_opt lang_map (String.lowercase_ascii x)
 
 let keys = Common2.hkeys lang_map
 
@@ -133,3 +133,8 @@ let unsupported_language_message lang =
   else
     Common.spf "unsupported language: %s; supported language tags are: %s" lang
       supported_langs
+
+let of_string string =
+  match of_string_opt string with
+  | None -> failwith (unsupported_language_message string)
+  | Some l -> l

--- a/semgrep-core/src/core/ast/Lang.mli.j2
+++ b/semgrep-core/src/core/ast/Lang.mli.j2
@@ -3,13 +3,6 @@ type t =
 {% endfor %}
 [@@deriving show, eq]
 
-(* accept any variants *)
-val is_js : t -> bool
-
-val lang_map : (string, t) Hashtbl.t
-
-val lang_of_string_opt : string -> t option
-
 (* unsupported_language_message [lang] takes the language as a string and
  * returns an error message.
  *
@@ -19,14 +12,10 @@ val lang_of_string_opt : string -> t option
  *)
 val unsupported_language_message : string -> string
 
-(* Association from a valid name for a language to its unique internal ID. *)
-val assoc : (string * t) list
+val of_string_opt : string -> t option
 
-(* list of languages *)
-val keys : string list
-
-(* See also Find_target.files_of_dirs_or_files *)
-val langs_of_filename : Common.filename -> t list
+(* may raise Failure unsupported_language_message *)
+val of_string: string -> t
 
 (*
    Produce a human-readable representation of the language e.g. "C#"
@@ -71,3 +60,17 @@ val excluded_exts_of_lang : t -> string list
    Return a list of programs that can run a script written in this language.
 *)
 val shebangs_of_lang : t -> string list
+
+(* See also Find_target.files_of_dirs_or_files *)
+val langs_of_filename : Common.filename -> t list
+
+(* accept any variants *)
+val is_js : t -> bool
+
+val lang_map : (string, t) Hashtbl.t
+
+(* Association from a valid name for a language to its unique internal ID. *)
+val assoc : (string * t) list
+
+(* list of languages *)
+val keys : string list

--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -297,7 +297,7 @@ let dump_ext_of_lang () =
   let lang_to_exts =
     Lang.keys
     |> Common.map (fun lang_str ->
-           match Lang.lang_of_string_opt lang_str with
+           match Lang.of_string_opt lang_str with
            | Some lang ->
                lang_str ^ "->" ^ String.concat ", " (Lang.ext_of_lang lang)
            | None -> "")

--- a/semgrep-core/src/osemgrep/cli_scan/Dump_subcommand.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Dump_subcommand.mli
@@ -3,9 +3,12 @@
  * a subcommand.
  *)
 
-type conf = { language : string; target : target_kind; json : bool }
+type conf = { target : target_kind; json : bool }
 
-and target_kind = Pattern of string | File of Common.filename
+and target_kind =
+  | Pattern of string * Lang.t
+  | File of Common.filename * Lang.t
+  | Config of Semgrep_dashdash_config.config_str
 [@@deriving show]
 
 val run : conf -> Exit_code.t

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -36,7 +36,7 @@ type conf = {
   (* Ugly: should be in separate subcommands *)
   version : bool;
   show_supported_languages : bool;
-  dump_ast : Dump_subcommand.conf option;
+  dump : Dump_subcommand.conf option;
   validate : Validate_subcommand.conf option;
   test : Test_subcommand.conf option;
 }

--- a/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -124,8 +124,7 @@ let run (conf : Scan_CLI.conf) : Exit_code.t =
   | _ when conf.test <> None -> Test_subcommand.run (Common2.some conf.test)
   | _ when conf.validate <> None ->
       Validate_subcommand.run (Common2.some conf.validate)
-  | _ when conf.dump_ast <> None ->
-      Dump_subcommand.run (Common2.some conf.dump_ast)
+  | _ when conf.dump <> None -> Dump_subcommand.run (Common2.some conf.dump)
   | _else_ ->
       (* --------------------------------------------------------- *)
       (* Let's go *)

--- a/semgrep-core/src/parsing/Parse_equivalences.ml
+++ b/semgrep-core/src/parsing/Parse_equivalences.ml
@@ -45,7 +45,7 @@ let parse file =
                            langs
                            |> Common.map (function
                                 | `String s -> (
-                                    match Lang.lang_of_string_opt s with
+                                    match Lang.of_string_opt s with
                                     | None ->
                                         error (spf "unsupported language: %s" s)
                                     | Some l -> l)

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -355,7 +355,7 @@ let parse_focus_mvs env (key : key) (x : G.expr) =
 (*****************************************************************************)
 
 let parse_language ~id ((s, t) as _lang) : Lang.t =
-  match Lang.lang_of_string_opt s with
+  match Lang.of_string_opt s with
   | None -> raise (R.Err (R.InvalidRule (R.InvalidLanguage s, id, t)))
   | Some l -> l
 

--- a/semgrep-core/src/parsing/Parse_rule.mli
+++ b/semgrep-core/src/parsing/Parse_rule.mli
@@ -1,26 +1,15 @@
-(* Parse a rule file, either in JSON or YAML (or even JSONNET) format
+(* Parse a rule file, either in YAML or JSON (or even JSONNET) format
  * depending on the filename extension.
  *
  * The parser accepts invalid rules, skips them, and returns them in
  * the list of errors.
  * This will not raise Rule.Err (Rule.InvalidRule ...) exceptions.
  *
- * However, this function may raise the other (Rule.Err ...) exns (e.g., Rule.InvalidYaml).
+ * However, this function may raise the other (Rule.Err ...) exns
+ * (e.g., Rule.InvalidYaml).
  *)
 val parse_and_filter_invalid_rules :
   Common.filename -> Rule.rules * Rule.invalid_rule_error list
-
-(* This should be used mostly in testing code. Otherwise you should
- * use parse_and_filter_invalid_rules.
- * This function may raise (Rule.Err ....) or Assert_failure (when
- * there are invalid rules).
- *)
-val parse : Common.filename -> Rule.rules
-
-(* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml
- * and now also in osemgrep Config_resolver.ml.
- *)
-val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
 
 (* ex: foo.yaml, foo.yml, but not foo.test.yaml.
  *
@@ -33,3 +22,25 @@ val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
  * and also in Test_engine.ml.
  *)
 val is_valid_rule_filename : Common.filename -> bool
+
+(* this can be used for parsing -e/-f extended patterns in Run_semgrep.ml
+ * and now also in osemgrep Config_resolver.ml.
+ *)
+val parse_xpattern : Xlang.t -> string Rule.wrap -> Xpattern.t
+
+(* This should be used mostly in testing code. Otherwise you should
+ * use parse_and_filter_invalid_rules.
+ * This function may raise (Rule.Err ....) or Assert_failure (when
+ * there are invalid rules).
+ *)
+val parse : Common.filename -> Rule.rules
+
+(* Internals, used by osemgrep to setup a ojsonnet import hook.
+ * The filename parameter is just used in case of missing 'rules:'
+ * to report the error on the first line of the file.
+ *)
+val parse_generic_ast :
+  ?error_recovery:bool ->
+  Common.filename ->
+  AST_generic.program ->
+  Rule.rules * Rule.invalid_rule_error list


### PR DESCRIPTION
This also prepare for a better ojsonnet integration

test plan:
```
$ xx --dump-config myrule.jsonnet
...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)