### PR TITLE
osemgrep: add import callback to ojsonnet and handle imported yaml

### DIFF
--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
@@ -29,9 +29,9 @@ module C = Core_jsonnet
 (*****************************************************************************)
 
 (* Hook to customize how ojsonnet should resolve import expressions
- * (`local $NAME = $PATH`). The first parameter below is the base directory
- * of the file currently processed and the second is the $PATH above in
- * the local expression.
+ * (`local $NAME = import $PATH`). The first parameter below is the base
+ * directory of the file currently processed and the second is the $PATH
+ * above in the local expression.
  * The hook should return an AST_jsonnet expression if it can handle
  * the PATH or None, in which case it will default to a regular
  * jsonnet file import as in `local x = "foo.jsonnet".

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
@@ -34,11 +34,11 @@ module C = Core_jsonnet
  * above in the local expression.
  * The hook should return an AST_jsonnet expression if it can handle
  * the PATH or None, in which case it will default to a regular
- * jsonnet file import as in `local x = "foo.jsonnet".
+ * jsonnet file import as in `local x = import "foo.jsonnet".
  *
  * This callback is useful for example in osemgrep to let ojsonnet
- * import yaml files (e.g., local x = 'foo.yaml') or rules from the
- * registry (e.g., local x = 'p/python').
+ * import yaml files (e.g., local x = import 'foo.yaml') or rules from the
+ * registry (e.g., local x = import 'p/python').
  *)
 type import_callback = Common.dirname -> string -> AST_jsonnet.expr option
 

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
@@ -1,7 +1,7 @@
 (* Hook to customize how ojsonnet should resolve import expressions
- * (`local $NAME = $PATH`). The first parameter below is the base directory
- * of the file currently processed and the second is the $PATH above in
- * the local expression.
+ * (`local $NAME = import $PATH`). The first parameter below is the base
+ * directory of the file currently processed and the second is the $PATH
+ * above in the local expression.
  * The hook should return an AST_jsonnet expression if it can handle
  * the PATH or None, in which case it will default to a regular
  * jsonnet file import as in `local x = "foo.jsonnet".

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
@@ -1,7 +1,24 @@
+(* Hook to customize how ojsonnet should resolve import expressions
+ * (`local $NAME = $PATH`). The first parameter below is the base directory
+ * of the file currently processed and the second is the $PATH above in
+ * the local expression.
+ * The hook should return an AST_jsonnet expression if it can handle
+ * the PATH or None, in which case it will default to a regular
+ * jsonnet file import as in `local x = "foo.jsonnet".
+ *
+ * This callback is useful for example in osemgrep to let ojsonnet
+ * import yaml files (e.g., local x = 'foo.yaml') or rules from the
+ * registry (e.g., local x = 'p/python').
+ *)
+type import_callback = Common.dirname -> string -> AST_jsonnet.expr option
+
+val default_callback : import_callback
+
 (* We pass the original file in addition to its AST so desugar can
  * handle correctly imports and import from the dirname of the file.
- * TODO: import_callback so can customize
- * things as the desugar function will "desugar" imports.
  *)
 val desugar_program :
-  Common.filename -> AST_jsonnet.program -> Core_jsonnet.program
+  ?import_callback:import_callback ->
+  Common.filename ->
+  AST_jsonnet.program ->
+  Core_jsonnet.program

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.mli
@@ -4,11 +4,11 @@
  * above in the local expression.
  * The hook should return an AST_jsonnet expression if it can handle
  * the PATH or None, in which case it will default to a regular
- * jsonnet file import as in `local x = "foo.jsonnet".
+ * jsonnet file import as in `local x = import "foo.jsonnet".
  *
  * This callback is useful for example in osemgrep to let ojsonnet
- * import yaml files (e.g., local x = 'foo.yaml') or rules from the
- * registry (e.g., local x = 'p/python').
+ * import yaml files (e.g., local x = import 'foo.yaml') or rules from the
+ * registry (e.g., local x = import 'p/python').
  *)
 type import_callback = Common.dirname -> string -> AST_jsonnet.expr option
 

--- a/semgrep-core/src/ojsonnet/parsing/AST_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/parsing/AST_jsonnet.ml
@@ -267,6 +267,10 @@ type any = E of expr
 (* Helpers *)
 (*****************************************************************************)
 
+let mk_string_ (str, tk) =
+  let fk = Parse_info.unsafe_fake_info "" in
+  (None, DoubleQuote, (fk, [ (str, tk) ], fk))
+
 let string_of_string_ (x : string_) : string wrap =
   let _verbatimTODO, _kindTODO, (l, xs, r) = x in
   let str = xs |> Common.map fst |> String.concat "" in

--- a/semgrep-core/src/osemgrep/cli_scan/AST_generic_to_jsonnet.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/AST_generic_to_jsonnet.ml
@@ -1,0 +1,94 @@
+(* Yoann Padioleau
+ *
+ * Copyright (C) 2022 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+open Common
+module A = AST_jsonnet
+module G = AST_generic
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Convert a generic AST to an AST_jsonnet program. This is used
+ * in Rule_fetching import_callback to convert a yaml program
+ * in a jsonnet program so jsonnet policy can manipulate
+ * legacy YAML rules.
+ *
+ * This is the similar to the reverse of Manifest_jsonnet_to_AST_generic
+ * (used by Parse_rule.ml), but here we produce an AST_jsonnet instead
+ * of a Value_jsonnet.
+ *)
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+let error tk s = raise (Parse_info.Other_error (s, tk))
+
+(*****************************************************************************)
+(* Expr to expr *)
+(*****************************************************************************)
+
+let rec expr_to_expr (e : G.expr) : A.expr =
+  let error () =
+    let tk = Visitor_AST.first_info_of_any (G.E e) in
+    error tk
+      (spf "generic construct without a jsonnet equivalent: %s" (G.show_expr e))
+  in
+  match e.G.e with
+  | G.L literal -> (
+      match literal with
+      | G.Null tk -> A.L (A.Null tk)
+      | G.Bool (b, tk) -> A.L (A.Bool (b, tk))
+      | G.Int (Some i, tk) -> A.L (A.Number (string_of_int i, tk))
+      | G.Float (Some f, tk) -> A.L (A.Number (string_of_float f, tk))
+      | G.String (s, tk) -> A.L (A.Str (A.mk_string_ (s, tk)))
+      | _else_ -> error ())
+  | G.Container (kind, (l, xs, r)) -> (
+      match kind with
+      | G.Array ->
+          let arr_inside = xs |> Common.map (fun e -> expr_to_expr e) in
+          A.A (l, A.Array arr_inside, r)
+      | G.Dict ->
+          let members =
+            xs
+            |> Common.map (fun e ->
+                   match e.G.e with
+                   | G.Container (G.Tuple, (l, [ k; v ], _)) ->
+                       let fld_name =
+                         match k.G.e with
+                         | G.L (G.String (s, tk)) ->
+                             A.FStr (A.mk_string_ (s, tk))
+                         | _else_ -> error ()
+                       in
+                       A.OField
+                         {
+                           fld_name;
+                           fld_attr = None;
+                           fld_hidden = (A.Visible, l);
+                           fld_value = expr_to_expr v;
+                         }
+                   | _else_ -> error ())
+          in
+          A.O (l, Object members, r)
+      | _else_ -> error ())
+  | _else_ -> error ()
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let program (xs : G.program) : A.program =
+  match xs with
+  | [ { G.s = G.ExprStmt (e, _sc); _ } ] -> expr_to_expr e
+  | _else_ -> failwith "not a single toplevel expression"

--- a/semgrep-core/src/osemgrep/cli_scan/AST_generic_to_jsonnet.mli
+++ b/semgrep-core/src/osemgrep/cli_scan/AST_generic_to_jsonnet.mli
@@ -1,0 +1,13 @@
+(* Convert a generic AST (coming for example from Yaml_to_generic)
+ * to an AST_jsonnet program. This is used in Rule_fetching import_callback
+ * to convert a yaml program in a jsonnet program so jsonnet policy
+ * can manipulate legacy YAML rules.
+ *
+ * This is the similar to the reverse of Manifest_jsonnet_to_AST_generic
+ * (used by Parse_rule.ml), but here we produce an AST_jsonnet instead
+ * of a Value_jsonnet.
+ *
+ * may raise Parse_info.Other_Error if the generic AST program contain
+ * constructs that don't have an equivalent in AST_jsonnet.
+ *)
+val program : AST_generic.program -> AST_jsonnet.program

--- a/semgrep-core/src/parsing/Manifest_jsonnet_to_AST_generic.mli
+++ b/semgrep-core/src/parsing/Manifest_jsonnet_to_AST_generic.mli
@@ -1,1 +1,7 @@
+(* Manifest a Jsonnet value to a generic AST program so we can
+ * then parse this jsonnet rule in Parse_rule.ml. This is similar
+ * to what we do to parse a YAML or JSON rule; in both cases
+ * we first parse and create a generic AST before calling
+ * Parse_rule.parse_generic_ast to finally get a Rule.t
+ *)
 val manifest_value : Value_jsonnet.value_ -> AST_generic.program


### PR DESCRIPTION
test plan:
```
$ cat ~/test.jsonnet
local x = import "eqeq.yaml";
{ rules: x.rules }
$ osemgrep --dump-config test.jsonnet
{ Rule_fetching.origin = (Some "test.jsonnet");
  rules =
  [{ Rule.id = ("eq", ());
     mode =
     `Search ((Rule.And ((),
                 { Rule.conjuncts =
                   [(Rule.P
                       { Xpattern.pat =
                         (Xpattern.Sem (
                            (E
                               { e =
                                 (Call (
                                    { e = (IdSpecial ((Op Eq), ()));
                                      e_id = 0; e_range = None },
                                    ((),
                                     [(Arg
                                         { e =
                                           (N
                                              (Id (("$X", ()),
                                                 { id_resolved = ref (None);
                                                   id_type = ref (None);
                                                   id_svalue = ref (None);
                                                   id_hidden = false;
                                                   id_info_id = 1 }
                                                 )));
                                           e_id = 0; e_range = None });
                                       (Arg
                                          { e =
                                            (N
                                               (Id (("$X", ()),
                                                  { id_resolved = ref (None);
                                                    id_type = ref (None);
                                                    id_svalue = ref (None);
                                                    id_hidden = false;
                                                    id_info_id = 2 }
                                                  )));
                                            e_id = 0; e_range = None })
                                       ],
                                     ())
                                    ));
                                 e_id = 0; e_range = None }),
                            Java));
                         pstr = ("$X == $X", ()); pid = 1 })
                     ];
                   conditions = []; focus = [] }
                 )));
     message = "$VAR matched"; severity = Rule.Warning;
     languages = (Xlang.L (Java, [])); options = None; equivalences = None;
     fix = None; fix_regexp = None; paths = None; metadata = None }
    ];
  errors = [] }
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)