### PR TITLE
fix(python): Faithfully represent import statements in the generic AST

### DIFF
--- a/changelog.d/python-imports.fixed
+++ b/changelog.d/python-imports.fixed
@@ -1,0 +1,1 @@
+Fix matching issue related to Python imports with multiple imported values

--- a/semgrep-core/src/parsing/pfff/Python_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/Python_to_generic.ml
@@ -813,10 +813,7 @@ and stmt_aux env x =
       [ G.DirectiveStmt (G.ImportAll (t, mname, v2) |> G.d) |> G.s ]
   | ImportFrom (t, v1, v2) ->
       let v1 = module_name env v1 and v2 = list (alias env) v2 in
-      Common.map
-        (fun (a, b) ->
-          G.DirectiveStmt (G.ImportFrom (t, v1, [ (a, b) ]) |> G.d) |> G.s)
-        v2
+      [ G.DirectiveStmt (G.ImportFrom (t, v1, v2) |> G.d) |> G.s ]
   | Global (t, v1)
   | NonLocal (t, v1) ->
       let v1 = list (name env) v1 in

--- a/semgrep-core/tests/patterns/python/multi_import.py
+++ b/semgrep-core/tests/patterns/python/multi_import.py
@@ -1,0 +1,11 @@
+# MATCH:
+from z import x, y
+
+# MATCH:
+from z import x, a, y
+
+from z import x
+from z import y
+
+# MATCH:
+from z import a, x, b, y, c

--- a/semgrep-core/tests/patterns/python/multi_import.sgrep
+++ b/semgrep-core/tests/patterns/python/multi_import.sgrep
@@ -1,0 +1,1 @@
+from z import x, y


### PR DESCRIPTION
This is a followup to #6582. It uses the improved fidelity in the generic AST to improve matching behavior in Python, just as that PR did so for JS.

Test plan: Automated tests

Compare the matching behavior in the tests to the current behavior: https://semgrep.dev/s/ZYqL

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
