### PR TITLE
refactor: Add `Require` node to generic AST

### DIFF
--- a/semgrep-core/src/analyzing/AST_to_IL.ml
+++ b/semgrep-core/src/analyzing/AST_to_IL.ml
@@ -786,6 +786,7 @@ and call_special _env (x, tok) =
     | G.Sizeof -> Sizeof
     | G.ConcatString _kindopt -> Concat
     | G.Spread -> Spread
+    | G.Require -> Require
     | G.EncodedString _
     | G.Defined
     | G.HashSplat

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -748,6 +748,11 @@ and special =
   | Op of operator
   (* less: should be lift up and transformed in Assign at stmt level *)
   | IncrDecr of (incr_decr * prefix_postfix)
+  (* JS: `require('foo')`. Calls to require are different than imports as
+   * represented by e.g. `ImportFrom`. They are expressions rather than top
+   * level statements, and can therefore appear inline in any expression, so
+   * it's not generally possible to desugar to imports. *)
+  | Require
 
 (* mostly binary operators.
  * less: could be divided in really Arith vs Logical (bool) operators,

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -461,6 +461,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | Spread
     | HashSplat
     | NextArrayIndex
+    | Require
     | InterpolatedElement ->
         x
     | Op v1 ->

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -439,6 +439,7 @@ and vof_special = function
       let v = vof_inc_dec v in
       OCaml.VSum ("IncrDecr", [ v ])
   | NextArrayIndex -> OCaml.VSum ("NextArrayIndex", [])
+  | Require -> OCaml.VSum ("Require", [])
 
 and vof_interpolated_kind = function
   | FString v1 ->

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -518,6 +518,7 @@ let (mk_visitor :
     | Spread -> ()
     | HashSplat -> ()
     | NextArrayIndex -> ()
+    | Require -> ()
     | EncodedString v1 ->
         let v1 = v_string v1 in
         ()

--- a/semgrep-core/src/core/il/IL.ml
+++ b/semgrep-core/src/core/il/IL.ml
@@ -288,6 +288,8 @@ and call_special =
   (* when transpiling certain features (e.g., patterns, foreach) *)
   | ForeachNext
   | ForeachHasNext
+  (* JS: require('foo') *)
+  | Require
 
 (* primitives called under the hood *)
 

--- a/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
@@ -402,6 +402,7 @@ and map_special x =
   | Spread -> `Spread
   | HashSplat -> `HashSplat
   | NextArrayIndex -> `NextArrayIndex
+  | Require -> `Require
   | Op v1 ->
       let v1 = map_arithmetic_operator v1 in
       `Op v1

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -168,7 +168,9 @@ let should_match_call = function
    * IdSpecial for super calls *)
   | G.Super
   | G.Self
-  | G.Parent ->
+  | G.Parent
+  (* JS `require("fs")` *)
+  | G.Require ->
       true
   (* TODO Eval should probably be allowed to match *)
   | G.Eval
@@ -1213,6 +1215,7 @@ and m_special a b =
   | G.IncrDecr (a1, a2), B.IncrDecr (b1, b2) ->
       m_eq a1 b1 >>= fun () -> m_eq a2 b2
   | G.NextArrayIndex, B.NextArrayIndex -> return ()
+  | G.Require, B.Require -> return ()
   | G.This, _
   | G.Super, _
   | G.Self, _
@@ -1230,6 +1233,7 @@ and m_special a b =
   | G.Defined, _
   | G.ForOf, _
   | G.NextArrayIndex, _
+  | G.Require, _
   | InterpolatedElement, _ ->
       fail ()
 

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -74,7 +74,7 @@ let special (x, tok) =
   | Undefined -> SR_Literal (G.Undefined tok)
   | This -> SR_Special (G.This, tok)
   | Super -> SR_Special (G.Super, tok)
-  | Require -> other_expr "Require"
+  | Require -> SR_Special (G.Require, tok)
   | Exports -> other_expr "Exports"
   | Module -> other_expr "Module"
   | Define -> other_expr "Define"


### PR DESCRIPTION
Currently, in JS, `require('foo')` is represented using `OtherExpr` for the `require` part of that expression. This is fine currently since we don't do any analysis of `require` calls after the AST generic translation. Instead, we desugar them to `ImportFrom` in some cases, and Semgrep's existing naming logic for imported symbols takes it from there.

However, that desugaring is causing some issues. See #6532 for details.

Instead of desugaring, we need to represent `Require` in the AST properly, and analyze it directly. We could simply treat it like a normal function call to a function named `require`, but it's a separate node in the JS AST and doing analysis by matching on specific literal values is more error-prone.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
