### PR TITLE
fixed(cli): default `semgrep --deep` jobs to 1

### DIFF
--- a/changelog.d/pa-2231.fixed
+++ b/changelog.d/pa-2231.fixed
@@ -1,0 +1,1 @@
+CLI: Made the number of jobs when using `semgrep --deep` default to 1.

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -315,10 +315,9 @@ _scan_options: List[Callable] = [
         "-j",
         "--jobs",
         type=int,
-        default=__get_cpu_count(),
         help="""
             Number of subprocesses to use to run checks in parallel. Defaults to the
-            number of cores on the system.
+            number of cores on the system (1 if using --deep).
         """,
     ),
     optgroup.option(
@@ -625,7 +624,7 @@ def scan(
     gitlab_sast: bool,
     gitlab_secrets: bool,
     include: Optional[Tuple[str, ...]],
-    jobs: int,
+    jobs: Optional[int],
     json: bool,
     junit_xml: bool,
     lang: Optional[str],
@@ -711,6 +710,10 @@ def scan(
         abort(
             "Cannot create auto config when metrics are off. Please allow metrics or run with a specific config."
         )
+
+    print("before jobs", jobs)
+    jobs = jobs if jobs else 1 if deep else __get_cpu_count()
+    print("after jobs", jobs)
 
     output_time = time_flag
 

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 import tempfile
 from itertools import chain
@@ -55,13 +54,6 @@ logger = getLogger(__name__)
 
 
 ScanReturn = Optional[Tuple[RuleMatchMap, List[SemgrepError], List[Rule], Set[Path]]]
-
-
-def __get_cpu_count() -> int:
-    try:
-        return multiprocessing.cpu_count()
-    except NotImplementedError:
-        return 1  # CPU count is not implemented on Windows
 
 
 def __validate_lang(option: str, lang: Optional[str]) -> str:
@@ -711,8 +703,6 @@ def scan(
             "Cannot create auto config when metrics are off. Please allow metrics or run with a specific config."
         )
 
-    jobs = jobs if jobs else 1 if deep else __get_cpu_count()
-
     output_time = time_flag
 
     # Note this must be after the call to `terminal.configure` so that verbosity is respected
@@ -800,6 +790,7 @@ def scan(
                     try:
                         metacheck_errors = CoreRunner(
                             jobs=jobs,
+                            deep=deep,
                             timeout=timeout,
                             max_memory=max_memory,
                             timeout_threshold=timeout_threshold,

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -711,9 +711,7 @@ def scan(
             "Cannot create auto config when metrics are off. Please allow metrics or run with a specific config."
         )
 
-    print("before jobs", jobs)
     jobs = jobs if jobs else 1 if deep else __get_cpu_count()
-    print("after jobs", jobs)
 
     output_time = time_flag
 

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -70,7 +70,7 @@ INPUT_BUFFER_LIMIT: int = 1024 * 1024 * 1024
 LARGE_READ_SIZE: int = 1024 * 1024 * 512
 
 
-def __get_cpu_count() -> int:
+def get_cpu_count() -> int:
     try:
         return multiprocessing.cpu_count()
     except NotImplementedError:
@@ -524,7 +524,7 @@ class CoreRunner:
         optimizations: str,
         core_opts_str: Optional[str],
     ):
-        self._jobs = jobs if jobs else 1 if deep else __get_cpu_count()
+        self._jobs = jobs if jobs else 1 if deep else get_cpu_count()
         self._timeout = timeout
         self._max_memory = max_memory
         self._timeout_threshold = timeout_threshold

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import contextlib
 import json
+import multiprocessing
 import resource
 import shlex
 import subprocess
@@ -67,6 +68,13 @@ INPUT_BUFFER_LIMIT: int = 1024 * 1024 * 1024
 #
 # test/e2e/test_performance.py is one test that exercises this risk.
 LARGE_READ_SIZE: int = 1024 * 1024 * 512
+
+
+def __get_cpu_count() -> int:
+    try:
+        return multiprocessing.cpu_count()
+    except NotImplementedError:
+        return 1  # CPU count is not implemented on Windows
 
 
 def setrlimits_preexec_fn() -> None:
@@ -508,14 +516,15 @@ class CoreRunner:
 
     def __init__(
         self,
-        jobs: int,
+        jobs: Optional[int],
+        deep: bool,
         timeout: int,
         max_memory: int,
         timeout_threshold: int,
         optimizations: str,
         core_opts_str: Optional[str],
     ):
-        self._jobs = jobs
+        self._jobs = jobs if jobs else 1 if deep else __get_cpu_count()
         self._timeout = timeout
         self._max_memory = max_memory
         self._timeout_threshold = timeout_threshold

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -284,7 +284,7 @@ def main(
     lang: Optional[str],
     configs: Sequence[str],
     no_rewrite_rule_ids: bool = False,
-    jobs: Optional[int],
+    jobs: Optional[int] = None,
     include: Optional[Sequence[str]] = None,
     exclude: Optional[Sequence[str]] = None,
     exclude_rule: Optional[Sequence[str]] = None,

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -284,7 +284,7 @@ def main(
     lang: Optional[str],
     configs: Sequence[str],
     no_rewrite_rule_ids: bool = False,
-    jobs: int = 1,
+    jobs: Optional[int],
     include: Optional[Sequence[str]] = None,
     exclude: Optional[Sequence[str]] = None,
     exclude_rule: Optional[Sequence[str]] = None,
@@ -403,6 +403,7 @@ def main(
     core_start_time = time.time()
     core_runner = CoreRunner(
         jobs=jobs,
+        deep=deep,
         timeout=timeout,
         max_memory=max_memory,
         timeout_threshold=timeout_threshold,


### PR DESCRIPTION
## What:
`semgrep` defaults the number of jobs to the number of cores on the machine, when not specified. This can cause OOM when using DeepSemgrep, due to the number of jobs taking a lot of memory.

## Why:
We should default it to 1 instead when using `semgrep --deep`, at least for now, while memory usage is unstable.

## How:
I changed it so jobs no longer default, and we set the number of jobs to `1` if `--deep` is specified, and the cpu counts otherwise.

## Test plan:
I tested this manually by printing out the values. The output is as follows:
![image](https://user-images.githubusercontent.com/49291449/204407703-d9994b42-6107-4cd1-884a-33f15e83b5c8.png)

Where `before jobs` denotes what `jobs` was prior to assignment, and `after jobs` for what it was assigned to after.

Closes PA-2231.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
