### PR TITLE
fix(semdep): Stop marking yarn.lock findings as transitive

### DIFF
--- a/changelog.d/sc-425.fixed
+++ b/changelog.d/sc-425.fixed
@@ -1,0 +1,3 @@
+Supply Chain findings from a yarn.lock lockfile were marked as 'transitive'
+when we couldn't find the matching package.json file.
+These findings will now be marked as having 'unknown' transitivity.

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -136,7 +136,7 @@ def parse_yarn1(
         version, line_number = get_version(lines)
         resolved = get_resolved(lines)
         integrity = get_integrity(lines)
-        if manifest_deps is None:
+        if not manifest_deps:
             transitivity = Transitivity(Unknown())
         else:
             if package_name in manifest_deps:
@@ -201,7 +201,7 @@ def parse_yarn2(
             raise SemgrepError("yarn.lock dependency {package} missing version?")
         version, line_number = fields["version"].split(" ")
 
-        if manifest_deps is None:
+        if not manifest_deps:
             transitivity = Transitivity(Unknown())
         else:
             if package in manifest_deps:

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
@@ -55,7 +55,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "line_number": 18,
               "package": "ansi-html",
               "resolved_url": "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz",
-              "transitivity": "transitive",
+              "transitivity": "unknown",
               "version": "0.0.7"
             },
             "lockfile": "targets/dependency_aware/ansi/yarn.lock"


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
