### PR TITLE
Fix(js): Remove desugaring for JS requires

### DIFF
--- a/changelog.d/require-match.fixed
+++ b/changelog.d/require-match.fixed
@@ -1,0 +1,1 @@
+Improved matching behavior on JS `require` calls

--- a/semgrep-core/src/matching/Matching_generic.ml
+++ b/semgrep-core/src/matching/Matching_generic.ml
@@ -96,6 +96,7 @@ and tout = tin list
  * same language for the host language and pattern language
  *)
 type 'a matcher = 'a -> 'a -> tin -> tout
+type ('a, 'b) general_matcher = 'a -> 'b -> tin -> tout
 type 'a comb_result = tin -> ('a * tout) list
 type 'a comb_matcher = 'a -> 'a list -> 'a list comb_result
 

--- a/semgrep-core/src/matching/Matching_generic.mli
+++ b/semgrep-core/src/matching/Matching_generic.mli
@@ -23,6 +23,7 @@ and tout = tin list
  * same language for the host language and pattern language
  *)
 type 'a matcher = 'a -> 'a -> tin -> tout
+type ('a, 'b) general_matcher = 'a -> 'b -> tin -> tout
 
 type 'a comb_result = tin -> ('a * tout) list
 (** See [comb_matcher] *)
@@ -119,7 +120,10 @@ val m_list_with_dots_and_metavar_ellipsis :
     ('a -> (AST_generic.ident * ('a list -> Metavariable.mvalue)) option) ->
   'a list matcher
 
-val m_list_in_any_order : less_is_ok:bool -> 'a matcher -> 'a list matcher
+val m_list_in_any_order :
+  less_is_ok:bool ->
+  ('a, 'b) general_matcher ->
+  ('a list, 'b list) general_matcher
 
 val m_comb_unit : 'a -> 'a comb_result
 (** Unit operation for the comb_result monad. *)

--- a/semgrep-core/src/parsing/pfff/js_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/js_to_generic.ml
@@ -38,9 +38,6 @@ let string = id
 let error = AST_generic.error
 let fb = G.fake_bracket
 
-(* for the require -> import translation *)
-exception ComplicatedCase
-
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -726,73 +723,11 @@ and module_directive x =
       let v1 = name v1 in
       G.OtherDirective (("Export", t), [ G.I v1 ])
 
-and require_to_import_in_stmt_opt st =
-  match st with
-  (* ex: const { f1, f2 } = require("file"); *)
-  | DefStmt
-      ( { name = x, _; attrs = [] },
-        VarDef
-          {
-            v_kind = _;
-            v_type = _;
-            v_init =
-              Some
-                (Assign
-                  ( pattern,
-                    _,
-                    Apply
-                      (IdSpecial (Require, treq), (_, [ L (String file) ], _))
-                  ));
-          } )
-    when x =$= AST_generic_.special_multivardef_pattern -> (
-      try
-        let imported_names =
-          match pattern with
-          | Obj (_, xs, _) ->
-              xs
-              |> Common.map (function
-                   | FieldColon
-                       {
-                         fld_name = PN id1;
-                         fld_body = Some (Id id2);
-                         fld_attrs = [];
-                         fld_type = None;
-                       } ->
-                       let alias_opt =
-                         match (id1, id2) with
-                         | (s1, _), (s2, _) when s1 =$= s2 -> None
-                         | _ -> Some (id2, G.empty_id_info ())
-                       in
-                       (id1, alias_opt)
-                   | _ -> raise ComplicatedCase)
-          | _ -> raise ComplicatedCase
-        in
-        let import =
-          G.DirectiveStmt
-            (G.ImportFrom (treq, G.FileName file, imported_names) |> G.d)
-          |> G.s
-        in
-        (* we also keep the require() call in the AST so people using
-         * semgrep patterns like 'require("foo")' still find those requires
-         * in the target. The ImportFrom conversion is mostly for Naming_AST
-         * to recognize those require and do the right aliasing for them
-         * too. alt: do the conversion in Naming_AST.ml instead? *)
-        let orig = stmt st in
-        Some [ import; orig ]
-      with
-      | ComplicatedCase -> None)
-  | _ -> None
-
 and list_stmt xs =
   (* converting require() in import, so they can benefit from the
    * other goodies coming with import in semgrep (e.g., equivalence aliasing)
    *)
-  xs
-  |> Common.map (fun st ->
-         match require_to_import_in_stmt_opt st with
-         | Some xs -> xs
-         | None -> [ stmt st ])
-  |> List.flatten
+  xs |> Common.map (fun st -> [ stmt st ]) |> List.flatten
 
 and program v = list_stmt v
 
@@ -831,12 +766,9 @@ and any = function
   | Expr v1 ->
       let v1 = expr v1 in
       G.E v1
-  | Stmt v1 -> (
-      match require_to_import_in_stmt_opt v1 with
-      | Some xs -> G.Ss xs
-      | None ->
-          let v1 = stmt v1 in
-          G.S v1)
+  | Stmt v1 ->
+      let v1 = stmt v1 in
+      G.S v1
   | Stmts v1 ->
       let v1 = list_stmt v1 in
       G.Ss v1

--- a/semgrep-core/tests/patterns/js/aliasing_require.js
+++ b/semgrep-core/tests/patterns/js/aliasing_require.js
@@ -7,7 +7,7 @@ const { execSync: es } = require('child_process');
 es("ls");
 
 const cp = require('child_process');
-// TODO:
+// MATCH:
 cp.execSync("ls");
 
 // TODO:

--- a/semgrep-core/tests/patterns/js/equivalence_import_variations.js
+++ b/semgrep-core/tests/patterns/js/equivalence_import_variations.js
@@ -30,3 +30,8 @@ import '/modules/my-module.js';
 // TODO
 var promise = import("module-name");
 let module = await import('/modules/my-module.js');
+
+//ERROR: yes
+const {x} = require('module-name');
+//ERROR: yes
+const y = require('module-name');


### PR DESCRIPTION
## Background

My end goal here is to add CommonJS import/export support to DeepSemgrep. To do this, I need some consistency in how requires are represented.

Currently, we desugar `require` calls to `ImportFrom` nodes in one specific case. This only occurs when the `require` is on the RHS of a variable assignment, and the LHS is a destructuring, e.g. `const { f1, f2 } = require("file");`. However, instead of replacing the `require`, the `ImportFrom` appears alongside it. I believe that this was done because there isn't a way to consistently transform require calls into `ImportFrom`. `require` calls are simply expressions, and can appear anywhere. There is also the potential for complicated destructuring where Semgrep bails out from desugaring at all. Thus, to be able to consistently match a pattern such as `require('file')` we need to keep the original node around.

There is no equivalent desugaring to `ImportAs` for `const f = require("file");`, thus the TODO item in the `aliasing_require` test that is addressed by this change.

Because there is no way to map all `require` calls to the existing import nodes that we have, we need to remove this partial desugaring if we want to build a maintainable analysis.

## Implementation

This removes the code that does the desugaring in `js_to_generic.ml`. With that desugaring gone, we need to make sure that both naming and matching behave as desired, so I've added code to handle `require` calls to both `Naming_AST.ml` and `Generic_vs_generic.ml`.

Some things for reviewers to focus on:
- I added `m_directive_vs_def`. This performs matching on two different kinds of AST nodes. I couldn't find a precedent for this. Is this the right thing to do? Thoughts on naming? For matching partial nodes we generate synthetic nodes in the visitor. Maybe we should use that approach here? I think this is clearer, though.
- Related to the above, I added the `general_matcher` type which takes two type parameters so that `m_list_in_any_order` can operate on a matcher that matches a different type on the left and the right.

## Test plan

Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
