### PR TITLE
fix(deep): resolve types of function calls made with Id

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1357,18 +1357,25 @@ and type_of_expr lang e : (G.ident * G.type_ option) option =
   (* deep: same *)
   | B.Call
       ( { e = B.DotAccess (_, _, FN (Id (idb, { B.id_type = tb; _ }))); _ },
-        _args )
-  (* deep: in Java, there can be an implicit `this.`
-     so look this up the type here too *)
-  | B.Call ({ e = N (Id (idb, { B.id_type = tb; _ })); _ }, _args)
-    when lang = Lang.Java -> (
+        _args ) -> (
       match !tb with
       (* less: in OCaml functions can be curried, so we need to match
        * _params and _args to calculate the resulting type.
        *)
       | Some { t = TyFun (_params, tret); _ } -> Some (idb, Some tret)
-      | Some _ -> None
-      | None -> None)
+      | Some _
+      | None ->
+          None)
+  (* deep: in Java, there can be an implicit `this.`
+     so calculate the type in the same way as above
+     THINK: should we do this for all languages? Why not? *)
+  | B.Call ({ e = N (Id (idb, { B.id_type = tb; _ })); _ }, _args)
+    when lang = Lang.Java -> (
+      match !tb with
+      | Some { t = TyFun (_params, tret); _ } -> Some (idb, Some tret)
+      | Some _
+      | None ->
+          None)
   | B.ParenExpr (_, e, _) -> type_of_expr lang e
   | _ -> None
 


### PR DESCRIPTION
Supports deep-semgrep

Note: as I mention in the other PR, I restricted this to Java to be conservative but I think we should just always
use the type if we have it

Test plan: see PR in that repo

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
