### PR TITLE
tainting: Make identification of sinks more precise

### DIFF
--- a/changelog.d/pa-2142.fixed
+++ b/changelog.d/pa-2142.fixed
@@ -1,0 +1,3 @@
+taint-mode: Fixed matching of `pattern-sinks` to be more precise, so that e.g.
+it will no longer report `sink(ok1 if tainted else ok2)` as a tainted sink, as
+the expression passed to the `sink` is actually not tainted.

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -170,6 +170,7 @@ and taint_sanitizer = {
 }
 
 and taint_sink = {
+  sink_id : string;  (** See 'Parse_rule.parse_taint_sink'. *)
   sink_formula : formula;
   sink_requires : AST_generic.expr;
       (* A Boolean expression over taint labels. See also 'taint_source'.

--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -64,7 +64,7 @@ let logger = Logging.get_logger [ __MODULE__ ]
  * limited to expressions or single statements.
  *
  * However, using sub-range checks leads to duplicates. For example, the PHP
- * expression `sink("$source" . 'here')` will be transalted to IL as two
+ * expression `sink("$source" . 'here')` will be translated to IL as two
  * instructions `tmp = "$source" . 'here'` and `sink(tmp)`. If `sink(...)`
  * is a `pattern-sinks`, then both instructions' ranges are inside
  * the `pattrn-sinks` ranges. If `$source` is a `pattern-sources`, then both
@@ -284,9 +284,9 @@ let any_is_in_sources_matches rule any matches =
   |> List.filter_map (fun (rwm, ts) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
-             (let pm = RM.range_to_pattern_match_adjusted rule rwm in
+             (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
               let overlap = overlap_with ~match_range:rwm.RM.r r in
-              { D.spec = ts; pm; overlap })
+              { D.spec = ts; spec_pm; range = r; overlap })
          else None)
 
 (* Check whether `any` matches either the `from` or the `to` of any of the
@@ -300,12 +300,12 @@ let any_is_in_propagators_matches rule any matches :
       matches
       |> List.concat_map (fun prop ->
              let var = prop.id in
-             let pm = RM.range_to_pattern_match_adjusted rule prop.rwm in
+             let spec_pm = RM.range_to_pattern_match_adjusted rule prop.rwm in
              let is_from = is_exact_match ~match_range:prop.from r in
              let is_to = is_exact_match ~match_range:prop.to_ r in
              let mk_match kind =
                let spec : D.a_propagator = { kind; prop = prop.spec; var } in
-               { D.spec; pm; overlap = 1.0 }
+               { D.spec; spec_pm; range = r; overlap = 1.0 }
              in
              (if is_from then [ mk_match `From ] else [])
              @ (if is_to then [ mk_match `To ] else [])
@@ -318,9 +318,9 @@ let any_is_in_sanitizers_matches rule any matches =
   |> List.filter_map (fun (rwm, spec) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
-             (let pm = RM.range_to_pattern_match_adjusted rule rwm in
+             (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
               let overlap = overlap_with ~match_range:rwm.RM.r r in
-              { D.spec; pm; overlap })
+              { D.spec; spec_pm; range = r; overlap })
          else None)
 
 let any_is_in_sinks_matches rule any matches =
@@ -330,9 +330,9 @@ let any_is_in_sinks_matches rule any matches =
   |> List.filter_map (fun (rwm, spec) ->
          if Range.( $<=$ ) r rwm.RM.r then
            Some
-             (let pm = RM.range_to_pattern_match_adjusted rule rwm in
+             (let spec_pm = RM.range_to_pattern_match_adjusted rule rwm in
               let overlap = overlap_with ~match_range:rwm.RM.r r in
-              { D.spec; pm; overlap })
+              { D.spec; spec_pm; range = r; overlap })
          else None)
 
 let lazy_force x = Lazy.force x [@@profiling]
@@ -501,7 +501,7 @@ let check_fundef lang options taint_config opt_ent fdef =
     in
     let taints =
       source_pms
-      |> Common.map (fun (x : _ D.tmatch) -> (x.pm, x.spec))
+      |> Common.map (fun (x : _ D.tmatch) -> (x.spec_pm, x.spec))
       |> T.taints_of_pms
     in
     Lval_env.add env (IL_helpers.lval_of_var var) taints

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1116,6 +1116,7 @@ let parse_taint_sanitizer ~(is_old : bool) env (key : key) (value : G.expr) =
 
 let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
     Rule.taint_sink =
+  let sink_id = String.concat ":" env.path in
   let f =
     if is_old then parse_formula_old_from_dict else parse_formula_from_dict
   in
@@ -1126,7 +1127,7 @@ let parse_taint_sink ~(is_old : bool) env (key : key) (value : G.expr) :
     |> Option.value ~default:(R.default_sink_requires tok)
   in
   let sink_formula = f env sink_dict in
-  { sink_formula; sink_requires }
+  { sink_id; sink_formula; sink_requires }
 
 (*****************************************************************************)
 (* Parsers for extract mode *)
@@ -1171,7 +1172,7 @@ let parse_mode env mode_opt (rule_dict : dict) : R.mode =
   | Some ("taint", _) ->
       let parse_specs parse_spec env key x =
         ( snd key,
-          parse_list env key
+          parse_listi env key
             (fun env -> parse_spec env (fst key ^ "list item", snd key))
             x )
       in

--- a/semgrep-core/src/tainting/Dataflow_tainting.mli
+++ b/semgrep-core/src/tainting/Dataflow_tainting.mli
@@ -7,7 +7,18 @@ type overlap = float
  * 1.0 means that the AST node matches the annotation perfectly. For
  * practical purposes we can interpret >0.99 as being the same as 1.0. *)
 
-type 'spec tmatch = { spec : 'spec; pm : Pattern_match.t; overlap : overlap }
+type 'spec tmatch = {
+  spec : 'spec;
+      (** The specification on which the match is based, e.g. a taint source.
+      * This spec should have a pattern formula. *)
+  spec_pm : Pattern_match.t;
+      (** A pattern match obtained directly from the spec's pattern formula. *)
+  range : Range.t;
+      (** The range of this particular match, which will be a subrange of 'spec_pm',
+      * see note on 'Taint-tracking via ranges' in 'Match_tainting_mode.ml'. *)
+  overlap : overlap;
+      (** The overlap of this match ('range') with the spec match ('spec_pm'). *)
+}
 
 type a_propagator = {
   kind : [ `From | `To ];

--- a/semgrep-core/tests/rules/taint_assume_safe_funcs.php
+++ b/semgrep-core/tests/rules/taint_assume_safe_funcs.php
@@ -5,10 +5,7 @@ function not_tainted($data) {
     return '2';
 }
 
-//Problem here is that `tainted('a')` is in itself considered a sink because
-//currently taint-mode considers anything that falls within a sink-range to be
-//a sink... and the sink range here is whatever it matches `sink(...)`!
-//todook:tainted
+//ok:tainted
 sink(not_tainted(tainted('a')));
 
 $ok = not_tainted(tainted('a'));

--- a/semgrep-core/tests/rules/taint_best_fit_sink.py
+++ b/semgrep-core/tests/rules/taint_best_fit_sink.py
@@ -1,0 +1,11 @@
+#ruleid: test
+sink(tainted())
+
+#ok:test
+sink(ok1 if tainted() else ok2)
+
+#ok:test
+sink(not_a_propagator(tainted()))
+
+#ok:test
+sink(some_array[tainted()])

--- a/semgrep-core/tests/rules/taint_best_fit_sink.yaml
+++ b/semgrep-core/tests/rules/taint_best_fit_sink.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Match
+    mode: taint
+    options:
+      taint_assume_safe_functions: true
+      taint_assume_safe_indexes: true
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: tainted(...)
+    severity: WARNING
+

--- a/semgrep-core/tests/rules/taint_lambda1.java
+++ b/semgrep-core/tests/rules/taint_lambda1.java
@@ -207,9 +207,9 @@ public class ErrorBasedSQLInjectionVulnerability {
         try {
             ResponseEntity<String> response =
                     applicationJdbcTemplate.query(
-                            // ruleid: jdbc
                             (conn) ->
                                     conn.prepareStatement(
+                                            // ruleid: jdbc
                                             "select * from cars where id='" + id + "'"),
                             (ps) -> {},
                             (rs) -> {


### PR DESCRIPTION
This way we will not incorrectly report `sink(ok1 if tainted else ok2)` as a tainted sink. Taint-mode will no longer consider that `tainted` itself is being passed into a sink, but the whole if-expression.

Closes PA-2142

test plan:
make test # tests added

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
