### PR TITLE
fix(SSC): Fix a host of yarn2 parse errors

### DIFF
--- a/changelog.d/sc-406.fixed
+++ b/changelog.d/sc-406.fixed
@@ -1,0 +1,3 @@
+Yarn 2 parse failure on versions like @storybook/react-docgen-typescript-plugin@canary. This is only present as some kind special version range specifier and never appears as a concrete version. It would only be used to check if the dependency was in the manifest file, so we just parse the version as "canary"
+Yarn 2 parse failure on versions like @types/ol-ext@npm:@siedlerchr/types-ol-ext@3.0.6
+Yarn 2 parse failure on versions like resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>. These are now just ignored, as they appear to always come with a non-patch version as well.

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -179,10 +179,10 @@ def parse_yarn2(
         constraints = []
         for c in constraint_strs:
             if c[0] == "@":
-                name, constraint = c[1:].split("@")
+                name, constraint = c[1:].split("@", 1)
                 name = "@" + name
             else:
-                name, constraint = c.split("@")
+                name, constraint = c.split("@", 1)
 
             if ":" in constraint:
                 constraint = constraint.split(":")[1]  # npm:^1.0.0 --> ^1.0.0

--- a/cli/src/semdep/parse_lockfile.py
+++ b/cli/src/semdep/parse_lockfile.py
@@ -183,8 +183,11 @@ def parse_yarn2(
                 name = "@" + name
             else:
                 name, constraint = c.split("@")
-            constraint = constraint.split(":")[1]  # npm:^1.0.0 --> ^1.0.0
+
+            if ":" in constraint:
+                constraint = constraint.split(":")[1]  # npm:^1.0.0 --> ^1.0.0
             constraints.append((name, constraint))
+
         return constraints[0][0], constraints
 
     def parse_dep(dep: str) -> FoundDependency:
@@ -195,6 +198,7 @@ def parse_yarn2(
             l.split(":")
             for l in lines[1:]
             if not (l.startswith("dependencies") or l.startswith("resolution"))
+            if l
         ]
         fields = {f: v.strip(" ") for f, v in field_lines}
         if "version" not in fields:
@@ -227,6 +231,8 @@ def parse_yarn2(
 
     deps = lockfile_text.split("\n\n")[2:]
     for dep in deps:
+        if "@patch:" in dep:
+            continue
         yield parse_dep(dep)
 
 

--- a/cli/tests/e2e/targets/dependency_aware/yarn2/yarn.lock
+++ b/cli/tests/e2e/targets/dependency_aware/yarn2/yarn.lock
@@ -87,3 +87,34 @@ __metadata:
   checksum: bc183f2109648849c8fde0b3c5cf08adf2f7ad6dc617b546fd20f34c8ef574ee5ee293c8d1bd0ed0221212e8f5907cdc2c42097870f1dcc769a654107d82c95b
   languageName: node
   linkType: hard
+
+"resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
+  version: 1.22.1
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
+  languageName: node
+  linkType: hard
+
+"@storybook/react-docgen-typescript-plugin@canary, @storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0":
+  version: 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0
+  resolution: "@storybook/react-docgen-typescript-plugin@npm:1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0"
+  dependencies:
+    debug: ^4.1.1
+    endent: ^2.0.1
+    find-cache-dir: ^3.3.1
+    flat-cache: ^3.0.4
+    micromatch: ^4.0.2
+    react-docgen-typescript: ^2.1.1
+    tslib: ^2.0.0
+  peerDependencies:
+    typescript: ">= 3.x"
+    webpack: ">= 4"
+  checksum: 91a3015d384e93d9ffb4def904cad51218eb1a9eaf504c758083f2988a97d8bf8748bc280aa629864eb26fd9f7fc05bd087df95383d719e0c914c722016804b9
+  languageName: node
+  linkType: hard

--- a/cli/tests/e2e/targets/dependency_aware/yarn2/yarn.lock
+++ b/cli/tests/e2e/targets/dependency_aware/yarn2/yarn.lock
@@ -118,3 +118,12 @@ __metadata:
   checksum: 91a3015d384e93d9ffb4def904cad51218eb1a9eaf504c758083f2988a97d8bf8748bc280aa629864eb26fd9f7fc05bd087df95383d719e0c914c722016804b9
   languageName: node
   linkType: hard
+
+"@types/ol-ext@npm:@siedlerchr/types-ol-ext@3.0.6":
+  version: 3.0.6
+  resolution: "@siedlerchr/types-ol-ext@npm:3.0.6"
+  dependencies:
+    jspdf: ^2.5.1
+  checksum: d43e5c8730b04d1469407e24dfa017e38289a6f930e9d514be5811f3426b49c879e53e847f63ef5451de4194ee99eea70a7d1884fc4ab6476f00ad03c78d9f33
+  languageName: node
+  linkType: hard


### PR DESCRIPTION
This PR fixes the following issues:
* Parse failure on versions like `@storybook/react-docgen-typescript-plugin@canary`. This is only present as some kind special version range specifier and never appears as a concrete version. It would only be used to check if the dependency was in the manifest file, so we just parse the version as "canary"
* Parse failure on versions like `@types/ol-ext@npm:@siedlerchr/types-ol-ext@3.0.6`
* Parse failure on versions like `resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>`. These are now just ignored, as they appear to always come with a non-patch version as well.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
