### PR TITLE
fix: ensure that version of badlibs won't conflict with our versioning

### DIFF
--- a/cli/tests/e2e/rules/dependency_aware/go-sca.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/go-sca.yaml
@@ -5,10 +5,10 @@ rules:
       depends-on-either:
         - namespace: gomod
           package: github.com/cheekybits/genny
-          version: "== 1.0.0"
+          version: "== 99.99.99"
         - namespace: gomod
           package: github.com/cheekybits/genny
-          version: "<= 0.9.0"
+          version: "<= 98.98.98"
     message: oh no
     languages: [go]
     severity: WARNING

--- a/cli/tests/e2e/rules/dependency_aware/no-pattern.yaml
+++ b/cli/tests/e2e/rules/dependency_aware/no-pattern.yaml
@@ -3,7 +3,7 @@ rules:
     r2c-internal-project-depends-on:
         namespace: npm
         package: bad-yarn-lib
-        version: "<= 1.0.0"
+        version: "<= 99.99.99"
     message: that's a bad lib
     languages: [javascript]
     severity: WARNING

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -314,11 +314,11 @@ Would have sent findings and ignores blob: {
                     "dependency_pattern": {
                         "ecosystem": "pypi",
                         "package": "badlib",
-                        "semver_range": "== 1.0.0"
+                        "semver_range": "== 99.99.99"
                     },
                     "found_dependency": {
                         "package": "badlib",
-                        "version": "1.0.0",
+                        "version": "99.99.99",
                         "ecosystem": "pypi",
                         "allowed_hashes": {},
                         "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -240,11 +240,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -237,11 +237,11 @@
           "dependency_pattern": {
             "ecosystem": "pypi",
             "package": "badlib",
-            "semver_range": "== 1.0.0"
+            "semver_range": "== 99.99.99"
           },
           "found_dependency": {
             "package": "badlib",
-            "version": "1.0.0",
+            "version": "99.99.99",
             "ecosystem": "pypi",
             "allowed_hashes": {},
             "transitivity": "unknown",

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -379,7 +379,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             "dependency_pattern": {
               "ecosystem": "pypi",
               "package": "badlib",
-              "semver_range": "== 1.0.0"
+              "semver_range": "== 99.99.99"
             },
             "found_dependency": {
               "allowed_hashes": {},
@@ -387,7 +387,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "line_number": 2,
               "package": "badlib",
               "transitivity": "unknown",
-              "version": "1.0.0"
+              "version": "99.99.99"
             },
             "lockfile": "poetry.lock"
           },

--- a/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -376,7 +376,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
             "dependency_pattern": {
               "ecosystem": "pypi",
               "package": "badlib",
-              "semver_range": "== 1.0.0"
+              "semver_range": "== 99.99.99"
             },
             "found_dependency": {
               "allowed_hashes": {},
@@ -384,7 +384,7 @@ SEMGREP_APP_TOKEN="fake_key" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS
               "line_number": 2,
               "package": "badlib",
               "transitivity": "unknown",
-              "version": "1.0.0"
+              "version": "99.99.99"
             },
             "lockfile": "poetry.lock"
           },

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego/results.txt
@@ -35,7 +35,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "dependency_pattern": {
               "ecosystem": "gomod",
               "package": "github.com/cheekybits/genny",
-              "semver_range": "<= 98.98.98"
+              "semver_range": "== 99.99.99"
             },
             "found_dependency": {
               "allowed_hashes": {
@@ -47,7 +47,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
               "package": "github.com/cheekybits/genny",
               "resolved_url": "github.com/cheekybits/genny",
               "transitivity": "unknown",
-              "version": "1.0.0"
+              "version": "99.99.99"
             },
             "lockfile": "targets/dependency_aware/go/go.sum"
           },

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awarego-sca.yaml-dependency_awarego/results.txt
@@ -35,7 +35,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "dependency_pattern": {
               "ecosystem": "gomod",
               "package": "github.com/cheekybits/genny",
-              "semver_range": "== 1.0.0"
+              "semver_range": "<= 98.98.98"
             },
             "found_dependency": {
               "allowed_hashes": {

--- a/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareno-pattern.yaml-dependency_awareyarn/results.txt
+++ b/cli/tests/e2e/snapshots/test_dependency_aware_rules/test_dependency_aware_rules/rulesdependency_awareno-pattern.yaml-dependency_awareyarn/results.txt
@@ -33,7 +33,7 @@ SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_VERS
             "dependency_pattern": {
               "ecosystem": "npm",
               "package": "bad-yarn-lib",
-              "semver_range": "<= 1.0.0"
+              "semver_range": "<= 99.99.99"
             },
             "found_dependency": {
               "allowed_hashes": {

--- a/cli/tests/e2e/targets/dependency_aware/go/go.sum
+++ b/cli/tests/e2e/targets/dependency_aware/go/go.sum
@@ -12,7 +12,7 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
+github.com/cheekybits/genny v99.99.99 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -82,7 +82,7 @@ def git_tmp_path_with_commit(monkeypatch, tmp_path, mocker):
         dedent(
             """[[package]]
     name = "badlib"
-    version = "1.0.0"
+    version = "99.99.99"
     description = "it's bad"
     category = "dev"
     optional = false
@@ -203,7 +203,7 @@ def automocks(mocker):
           r2c-internal-project-depends-on:
             namespace: pypi
             package: badlib
-            version: == 1.0.0
+            version: == 99.9.99
           metadata:
             dev.semgrep.actions: [block]
         - id: supply-chain2
@@ -213,7 +213,7 @@ def automocks(mocker):
           r2c-internal-project-depends-on:
             namespace: npm
             package: badlib
-            version: == 1.0.0
+            version: == 99.99.99
         """
     ).lstrip()
 

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -203,7 +203,7 @@ def automocks(mocker):
           r2c-internal-project-depends-on:
             namespace: pypi
             package: badlib
-            version: == 99.9.99
+            version: == 99.99.99
           metadata:
             dev.semgrep.actions: [block]
         - id: supply-chain2


### PR DESCRIPTION
Our Snapshot tests mask the current version of semgrep under test in the outputs. Now that we're releasing 1.0.0, we have a conflict between the actual version of semgrep and our dummy versions in some tests.

[This PR](https://github.com/returntocorp/semgrep/pull/6648) applies the 1.0.0 version bump and confirms that this fix will unblock release. 

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
