### PR TITLE
fix!: deduplicate overlapping autofixes

### DIFF
--- a/changelog.d/pa-2276.fixed
+++ b/changelog.d/pa-2276.fixed
@@ -1,0 +1,1 @@
+Autofix: If multiple autofixes are targeting an overlapping range, then one of them is picked arbitrarily to occur, to prevent autofixes which may produce incorrect code.

--- a/cli/src/semgrep/autofix.py
+++ b/cli/src/semgrep/autofix.py
@@ -1,11 +1,15 @@
 import re
+from functools import cmp_to_key
 from pathlib import Path
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Set
 from typing import Tuple
 
 from semgrep.error import SemgrepError
+from semgrep.rule import Rule
+from semgrep.rule_match import OrderedRuleMatchList
 from semgrep.rule_match import RuleMatch
 from semgrep.rule_match import RuleMatchMap
 from semgrep.util import unit_str
@@ -130,6 +134,71 @@ def _write_contents(path: Path, contents: str) -> None:
     path.write_text(contents)
 
 
+def matches_compare(x: RuleMatch, y: RuleMatch) -> int:
+    # If paths are not the same, just order based on that.
+    # I just need a total ordering on matches.
+    if x.path < y.path:
+        return -1
+    elif x.path > y.path:
+        return 1
+    else:
+        if x.start.offset < y.start.offset:
+            return -1
+        elif y.start.offset < x.start.offset:
+            return 1
+        else:
+            if x.end.offset < y.end.offset:
+                return -1
+            elif x.end.offset > y.end.offset:
+                return 1
+            else:
+                return 0
+
+
+def matches_overlap(x: RuleMatch, y: RuleMatch) -> bool:
+    if x.path == y.path:
+        if x.start.offset < y.start.offset:
+            return x.end.offset > y.start.offset
+        elif y.start.offset < x.start.offset:
+            return y.end.offset > x.start.offset
+        elif x.start.offset == y.start.offset:
+            return True
+
+    # If they are not from the same file, they cannot overlap.
+    return False
+
+
+def deduplicate_overlapping_matches(
+    rules_and_matches: Iterable[Tuple[Rule, OrderedRuleMatchList]]
+) -> OrderedRuleMatchList:
+
+    final_matches = []
+
+    ordered_matches = sorted(
+        (match for _, matches in rules_and_matches for match in matches),
+        key=cmp_to_key(matches_compare),
+    )
+    acc = None
+
+    for match in ordered_matches:
+        if acc is None:
+            acc = match
+            continue
+
+        if matches_overlap(acc, match):
+            logger.warning("Two autofix matches overlap, arbitrarily picking first one")
+            # Don't do anything, keep `acc` the same, and throw `match` out.`
+
+        else:
+            final_matches.append(acc)
+            acc = match
+
+    if acc is not None:
+        final_matches.append(acc)
+
+    return final_matches
+
+
 def apply_fixes(rule_matches_by_rule: RuleMatchMap, dryrun: bool = False) -> None:
     """
     Modify files in place for all files with findings from rules with an
@@ -137,46 +206,50 @@ def apply_fixes(rule_matches_by_rule: RuleMatchMap, dryrun: bool = False) -> Non
     """
     modified_files: Set[Path] = set()
     modified_files_offsets: Dict[Path, FileOffsets] = {}
-    for _, rule_matches in rule_matches_by_rule.items():
-        for rule_match in rule_matches:
-            fix = rule_match.fix
-            fix_regex = rule_match.fix_regex
-            filepath = rule_match.path
-            # initialize or retrieve/update offsets for the file
-            file_offsets = modified_files_offsets.get(
-                filepath, FileOffsets(0, 0, rule_match.start.line)
-            )
-            if file_offsets.active_line != rule_match.start.line:
-                file_offsets.active_line = rule_match.start.line
-                file_offsets.col_offset = 0
-            if fix:
-                try:
-                    fixobj, new_file_offset = _basic_fix(rule_match, file_offsets, fix)
-                except Exception as e:
-                    raise SemgrepError(f"unable to modify file {filepath}: {e}")
-            elif fix_regex:
-                regex = fix_regex.regex
-                replacement = fix_regex.replacement
-                count = fix_regex.count or 0
-                try:
-                    fixobj, new_file_offset = _regex_replace(
-                        rule_match, file_offsets, regex, replacement, count
-                    )
-                except Exception as e:
-                    raise SemgrepError(
-                        f"unable to use regex to modify file {filepath} with fix '{fix}': {e}"
-                    )
-            else:
-                continue
-            # endif
-            if not dryrun:
-                _write_contents(rule_match.path, fixobj.fixed_contents)
-                modified_files.add(filepath)
-                modified_files_offsets[filepath] = new_file_offset
-            else:
-                rule_match.extra[
-                    "fixed_lines"
-                ] = fixobj.fixed_lines  # Monkey patch in fixed lines
+
+    nonoverlapping_matches = deduplicate_overlapping_matches(
+        rule_matches_by_rule.items()
+    )
+
+    for rule_match in nonoverlapping_matches:
+        fix = rule_match.fix
+        fix_regex = rule_match.fix_regex
+        filepath = rule_match.path
+        # initialize or retrieve/update offsets for the file
+        file_offsets = modified_files_offsets.get(
+            filepath, FileOffsets(0, 0, rule_match.start.line)
+        )
+        if file_offsets.active_line != rule_match.start.line:
+            file_offsets.active_line = rule_match.start.line
+            file_offsets.col_offset = 0
+        if fix:
+            try:
+                fixobj, new_file_offset = _basic_fix(rule_match, file_offsets, fix)
+            except Exception as e:
+                raise SemgrepError(f"unable to modify file {filepath}: {e}")
+        elif fix_regex:
+            regex = fix_regex.regex
+            replacement = fix_regex.replacement
+            count = fix_regex.count or 0
+            try:
+                fixobj, new_file_offset = _regex_replace(
+                    rule_match, file_offsets, regex, replacement, count
+                )
+            except Exception as e:
+                raise SemgrepError(
+                    f"unable to use regex to modify file {filepath} with fix '{fix}': {e}"
+                )
+        else:
+            continue
+        # endif
+        if not dryrun:
+            _write_contents(rule_match.path, fixobj.fixed_contents)
+            modified_files.add(filepath)
+            modified_files_offsets[filepath] = new_file_offset
+        else:
+            rule_match.extra[
+                "fixed_lines"
+            ] = fixobj.fixed_lines  # Monkey patch in fixed lines
 
     if not dryrun:
         if len(modified_files):

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixexact-collision.yaml-autofixcollision.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixexact-collision.yaml-autofixcollision.py-dryrun/results.json
@@ -44,9 +44,6 @@
       "extra": {
         "fingerprint": "0x42",
         "fix": "twice",
-        "fixed_lines": [
-          "a = twice"
-        ],
         "is_ignored": false,
         "lines": "a = 1",
         "message": "Semgrep found a match",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixexact-collision.yaml-autofixcollision.py-not-dryrun/autofix/collision.py-fixed
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixexact-collision.yaml-autofixcollision.py-not-dryrun/autofix/collision.py-fixed
@@ -1,5 +1,5 @@
 
-a = onctwice
+a = once
 b = 2
 c = 3
 d = 4

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixoverlapping-collision.yaml-autofixcollision.py-dryrun/results.json
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixoverlapping-collision.yaml-autofixcollision.py-dryrun/results.json
@@ -71,9 +71,6 @@
       "extra": {
         "fingerprint": "0x42",
         "fix": "twice",
-        "fixed_lines": [
-          "twice"
-        ],
         "is_ignored": false,
         "lines": "b = 2\nc = 3\nd = 4",
         "message": "Semgrep found a match",

--- a/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixoverlapping-collision.yaml-autofixcollision.py-not-dryrun/autofix/collision.py-fixed
+++ b/cli/tests/e2e/snapshots/test_autofix/test_autofix/rulesautofixoverlapping-collision.yaml-autofixcollision.py-not-dryrun/autofix/collision.py-fixed
@@ -1,1 +1,3 @@
-twice
+
+once
+d = 4


### PR DESCRIPTION
## What:
#6626 introduced test cases where autofixes overlap, which is a possibility, especially with taint findings which are not deduplicated purely based on sinks. We should avoid multiple autofixes going and mangling the same space, which more likely than not will create invalid code.

## Why:
If Semgrep creates invalid code, users will not trust our autofixes.

## How:
I just ordered all matches and arbitrarily picked one, whenever two overlap.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
