### PR TITLE
chore: pass `--json_time` to DeepSemgrep binary

### DIFF
--- a/changelog.d/pa-2280.fixed
+++ b/changelog.d/pa-2280.fixed
@@ -1,0 +1,1 @@
+DeepSemgrep: Time data now outputs properly when running `semgrep --deep --time`

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -850,6 +850,7 @@ class CoreRunner:
                     target_file.name,
                     "--root",
                     root,
+                    "--json_time",
                     # "--timeout",
                     # str(self._timeout),
                     # "--timeout_threshold",


### PR DESCRIPTION
## What:
After merging https://github.com/returntocorp/semgrep-proprietary/pull/377, we will want to actually pass in the added `--json_time` command to the DeepSemgrep binary. This PR does that.

## Why:
We want to make sure that when you use `semgrep --deep --time`, this time data is output. Right now, CLI won't ever get that data from the DeepSemgrep binary.

## How:
Added a flag.

Closes PA-2280

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
