### PR TITLE
only say "blocking" when using semgrep ci subcommand

### DIFF
--- a/changelog.d/gh-6651.changed
+++ b/changelog.d/gh-6651.changed
@@ -1,0 +1,1 @@
+Don't print out summary of blocking rules unless running with semgrep ci subcommand

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -445,6 +445,7 @@ def ci(
         filtered_rules=filtered_rules,
         profiling_data=profiling_data,
         severities=shown_severities,
+        is_ci_invocation=True,
     )
 
     logger.info("CI scan completed successfully.")

--- a/cli/src/semgrep/formatter/base.py
+++ b/cli/src/semgrep/formatter/base.py
@@ -22,6 +22,7 @@ class BaseFormatter(abc.ABC):
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
         shown_severities: Collection[RuleSeverity],
+        is_ci_invocation: bool,
     ) -> str:
         filtered_rules = (r for r in rules if r.severity in shown_severities)
         filtered_matches = (m for m in rule_matches if m.severity in shown_severities)
@@ -31,6 +32,7 @@ class BaseFormatter(abc.ABC):
             semgrep_structured_errors,
             cli_output_extra,
             extra,
+            is_ci_invocation,
         )
 
     @abc.abstractmethod
@@ -41,6 +43,7 @@ class BaseFormatter(abc.ABC):
         semgrep_structured_errors: Sequence[SemgrepError],
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
+        is_ci_invocation: bool,
     ) -> str:
         raise NotImplementedError
 

--- a/cli/src/semgrep/formatter/emacs.py
+++ b/cli/src/semgrep/formatter/emacs.py
@@ -37,6 +37,7 @@ class EmacsFormatter(BaseFormatter):
         semgrep_structured_errors: Sequence[SemgrepError],
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
+        is_ci_invocation: bool,
     ) -> str:
         sorted_matches = sorted(rule_matches, key=lambda r: (r.path, r.rule_id))
         return "\n".join(":".join(self._get_parts(rm)) for rm in sorted_matches)

--- a/cli/src/semgrep/formatter/gitlab_sast.py
+++ b/cli/src/semgrep/formatter/gitlab_sast.py
@@ -86,6 +86,7 @@ class GitlabSastFormatter(BaseFormatter):
         semgrep_structured_errors: Sequence[SemgrepError],
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
+        is_ci_invocation: bool,
     ) -> str:
         """
         Format matches in GitLab SAST report compliant JSON.

--- a/cli/src/semgrep/formatter/json.py
+++ b/cli/src/semgrep/formatter/json.py
@@ -58,6 +58,7 @@ class JsonFormatter(BaseFormatter):
         semgrep_structured_errors: Sequence[SemgrepError],
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
+        is_ci_invocation: bool,
     ) -> str:
         # Note that extra is not used here! Every part of the JSON output should
         # be specified in semgrep_output_v1.atd and be part of CliOutputExtra

--- a/cli/src/semgrep/formatter/junit_xml.py
+++ b/cli/src/semgrep/formatter/junit_xml.py
@@ -37,6 +37,7 @@ class JunitXmlFormatter(BaseFormatter):
         semgrep_structured_errors: Sequence[SemgrepError],
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
+        is_ci_invocation: bool,
     ) -> str:
         test_cases = [
             self._rule_match_to_test_case(rule_match) for rule_match in rule_matches

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -364,6 +364,7 @@ class SarifFormatter(BaseFormatter):
         semgrep_structured_errors: Sequence[SemgrepError],
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
+        is_ci_invocation: bool,
     ) -> str:
         """
         Format matches in SARIF v2.1.0 formatted JSON.

--- a/cli/src/semgrep/formatter/vim.py
+++ b/cli/src/semgrep/formatter/vim.py
@@ -35,5 +35,6 @@ class VimFormatter(BaseFormatter):
         semgrep_structured_errors: Sequence[SemgrepError],
         cli_output_extra: out.CliOutputExtra,
         extra: Mapping[str, Any],
+        is_ci_invocation: bool,
     ) -> str:
         return "\n".join(":".join(self._get_parts(rm)) for rm in rule_matches)

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -173,6 +173,7 @@ class OutputHandler:
         self.semgrep_structured_errors: List[SemgrepError] = []
         self.error_set: Set[SemgrepError] = set()
         self.has_output = False
+        self.is_ci_invocation = False
         self.filtered_rules: List[Rule] = []
         self.profiling_data: ProfilingData = (
             ProfilingData()
@@ -291,6 +292,7 @@ class OutputHandler:
         explanations: Optional[List[out.MatchingExplanation]] = None,
         severities: Optional[Collection[RuleSeverity]] = None,
         print_summary: bool = False,
+        is_ci_invocation: bool = False,
     ) -> None:
         state = get_state()
         self.has_output = True
@@ -317,6 +319,8 @@ class OutputHandler:
             self.explanations = explanations
         if severities:
             self.severities = severities
+
+        self.is_ci_invocation = is_ci_invocation
 
         final_error = None
         any_findings_not_ignored = any(not rm.is_ignored for rm in self.rule_matches)
@@ -469,4 +473,5 @@ class OutputHandler:
             ),
             extra,
             self.severities,
+            is_ci_invocation=self.is_ci_invocation,
         )

--- a/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stdout.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
          15┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stdout.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           7┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stdout.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   baz.py 
           1┆ baz = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stdout.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stdout.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   foo.py 
           3┆ foo = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stdout.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stdout.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ bar = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/full.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   file_or_dir.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_symlink_changed/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_symlink_changed/full.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   dir_one/foo.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   file_or_dir.py/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/full.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   file_or_dir.py/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/diff.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   definitely_a_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_symlink/full.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   definitely_a_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_intersection/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_intersection/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_one_commit_with_baseline/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_one_commit_with_baseline/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/full.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   dir_new/bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
         203┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
         201┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   Foo.py 
         203┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   Foo.py 
         201┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/baseline_output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/baseline_output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_some_intersection/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink/output.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink/output.txt
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   bar.py 
           1┆ y = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   symlink_or_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/full.out
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/full.out
@@ -1,5 +1,5 @@
 
-Blocking Findings:
+Findings:
 
   symlink_or_file.py 
           1┆ x = 23478921

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Blocking Findings:
+Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -23,10 +23,6 @@ Blocking Findings:
         Details: https://sg.run/xyz1
 
           3┆ return a + b == a + b
-
-Blocking Rules Fired:
-   rules.eqeq-is-bad   
-   rules.javascript-basic-eqeq-bad
 
 === end of stdout - plain
 
@@ -52,7 +48,7 @@ Ran 4 rules on 14 files: 2 findings.
 
 === stdout - color
 
-Blocking Findings:
+Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -67,10 +63,6 @@ Blocking Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
-
-Blocking Rules Fired:
-   [1m[24mrules.eqeq-is-bad[0m   
-   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output/results_second.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Blocking Findings:
+Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -23,10 +23,6 @@ Blocking Findings:
         Details: https://sg.run/xyz1
 
           3┆ return a + b == a + b
-
-Blocking Rules Fired:
-   rules.eqeq-is-bad   
-   rules.javascript-basic-eqeq-bad
 
 === end of stdout - plain
 
@@ -46,7 +42,7 @@ Ran 4 rules on 14 files: 2 findings.
 
 === stdout - color
 
-Blocking Findings:
+Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -61,10 +57,6 @@ Blocking Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
-
-Blocking Rules Fired:
-   [1m[24mrules.eqeq-is-bad[0m   
-   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
+++ b/cli/tests/e2e/snapshots/test_check/test_terminal_output_quiet/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_FORCE_COLOR="true" SEMGREP_USER_AGENT_A
 
 === stdout - plain
 
-Blocking Findings:
+Findings:
 
   targets/basic/stupid.js 
      rules.javascript-basic-eqeq-bad
@@ -24,10 +24,6 @@ Blocking Findings:
 
           3┆ return a + b == a + b
 
-Blocking Rules Fired:
-   rules.eqeq-is-bad   
-   rules.javascript-basic-eqeq-bad
-
 === end of stdout - plain
 
 === stderr - plain
@@ -36,7 +32,7 @@ Blocking Rules Fired:
 
 === stdout - color
 
-Blocking Findings:
+Findings:
 
 [36m[22m[24m  targets/basic/stupid.js [0m
      [1m[24mrules.javascript-basic-eqeq-bad[0m
@@ -51,10 +47,6 @@ Blocking Findings:
         Details: https://sg.run/xyz1
 
           3┆ return [1m[24ma + b == a + b[0m
-
-Blocking Rules Fired:
-   [1m[24mrules.eqeq-is-bad[0m   
-   [1m[24mrules.javascript-basic-eqeq-bad[0m
 
 === end of stdout - color
 

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_time/results.txt
@@ -1,14 +1,11 @@
 
-Blocking Findings:
+Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[x.xxx == 1[0m)
-
-Blocking Rules Fired:
-   [1m[24mrules.cli_test.basic.basic-test[0m
 
 ============================[ summary ]============================
 Total time: x.xxxs Config time: x.xxxs Core time: x.xxxs

--- a/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
+++ b/cli/tests/e2e/snapshots/test_cli_test/test_cli_test_verbose/results.txt
@@ -1,11 +1,8 @@
 
-Blocking Findings:
+Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[x.xxx == 1[0m)
-
-Blocking Rules Fired:
-   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting/results.txt
@@ -1,11 +1,8 @@
 
-Blocking Findings:
+Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[24m1 == 1[0m)
-
-Blocking Rules Fired:
-   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__force_color_and_no_color/results.txt
@@ -1,11 +1,8 @@
 
-Blocking Findings:
+Findings:
 
 [36m[22m[24m  targets/cli_test/basic/basic.py [0m
      [1m[24mrules.cli_test.basic.basic-test[0m
         Basic test
 
           2┆ print([1m[24m1 == 1[0m)
-
-Blocking Rules Fired:
-   [1m[24mrules.cli_test.basic.basic-test[0m

--- a/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_output_highlighting__no_color/results.txt
@@ -1,11 +1,8 @@
 
-Blocking Findings:
+Findings:
 
   targets/cli_test/basic/basic.py 
      rules.cli_test.basic.basic-test
         Basic test
 
           2┆ print(1 == 1)
-
-Blocking Rules Fired:
-   rules.cli_test.basic.basic-test

--- a/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_sca_output/results.txt
@@ -17,7 +17,7 @@ Unreachable Supply Chain Findings:
         oh no
 
 
-First-Party Blocking Findings:
+First-Party Findings:
 
   targets/dependency_aware/monorepo/build.js 
      rules.dependency_aware.js-other
@@ -31,6 +31,3 @@ First-Party Blocking Findings:
         this is always bad
 
           1┆ bad()
-
-First-Party Blocking Rules Fired:
-   rules.dependency_aware.js-other

--- a/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/results.txt
+++ b/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/None-X__X/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERS
 
 === stdout - plain
 
-Blocking Findings:
+Findings:
 
   stupid.py 
           3┆ return a + b == a + b

--- a/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/results.txt
+++ b/cli/tests/e2e/snapshots/test_shouldafound/test_shouldafound_findings_output/foobar-X__X/results.txt
@@ -8,7 +8,7 @@ SEMGREP_SETTINGS_FILE="<MASKED>" SEMGREP_USER_AGENT_APPEND="pytest" SEMGREP_VERS
 
 === stdout - plain
 
-Blocking Findings:
+Findings:
 
   stupid.py 
           3┆ return a + b == a + b


### PR DESCRIPTION
don't print out summary of blocking findings unless running with semgrep ci subcommand

closes https://linear.app/r2c/issue/PA-2207/only-show-blocking-rules-fired-in-cli-output-when-using-semgrep-ci

revises https://github.com/returntocorp/semgrep/pull/6118 a bit

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
