### PR TITLE
semgrep ci installs DeepSemgrep automatically when needed

### DIFF
--- a/changelog.d/pa-2226.fixed
+++ b/changelog.d/pa-2226.fixed
@@ -1,0 +1,5 @@
+DeepSemgrep: When the "DeepSemgrep" setting is enabled in Semgrep App, `semgrep ci`
+will try to run the analysis using the DeepSemgrep engine. But if this engine was
+not installed, `semgrep ci` failed. Now `semgrep ci` will automatically try to
+install DeepSemgrep if it is not already present. Note that, if DeepSemgrep is
+already installed, `semgrep ci` does not attempt to upgrade it to a newer version.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -16,6 +16,8 @@ import click
 import semgrep.semgrep_main
 from semgrep.app import auth
 from semgrep.app.scans import ScanHandler
+from semgrep.commands.install import determine_deep_semgrep_path
+from semgrep.commands.install import run_install_deep_semgrep
 from semgrep.commands.scan import CONTEXT_SETTINGS
 from semgrep.commands.scan import scan_options
 from semgrep.commands.wrapper import handle_command_errors
@@ -323,6 +325,9 @@ def ci(
             # Run DeepSemgrep when available but only for full scans
             is_full_scan = metadata.merge_base_ref is None
             deep = scan_handler.deepsemgrep if scan_handler and is_full_scan else False
+            deep_semgrep_path = determine_deep_semgrep_path()
+            if deep and not deep_semgrep_path.exists():
+                run_install_deep_semgrep()
 
             # Append ignores configured on semgrep.dev
             requested_excludes = scan_handler.ignore_patterns if scan_handler else []

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -20,21 +20,7 @@ from semgrep.verbose_logging import getLogger
 logger = getLogger(__name__)
 
 
-@click.command(hidden=True)
-@handle_command_errors
-def install_deep_semgrep() -> None:
-    """
-    Install the DeepSemgrep binary (Experimental)
-
-    The binary is installed in the same directory that semgrep-core
-    is installed in. Does not reinstall if existing binary already exists.
-
-    Must be logged in and have access to DeepSemgrep beta
-    Visit https://semgrep.dev/deep-semgrep-beta for more information
-    """
-    state = get_state()
-    state.terminal.configure(verbose=False, debug=False, quiet=False, force_color=False)
-
+def determine_deep_semgrep_path() -> Path:
     core_path = SemgrepCore.path()
     if core_path is None:
         logger.info(
@@ -44,6 +30,14 @@ def install_deep_semgrep() -> None:
         sys.exit(FATAL_EXIT_CODE)
 
     deep_semgrep_path = Path(core_path).parent / "deep-semgrep"
+    return deep_semgrep_path
+
+
+def run_install_deep_semgrep() -> None:
+    state = get_state()
+    state.terminal.configure(verbose=False, debug=False, quiet=False, force_color=False)
+
+    deep_semgrep_path = determine_deep_semgrep_path()
     if deep_semgrep_path.exists():
         logger.info(
             f"Overwriting DeepSemgrep binary already installed in {deep_semgrep_path}"
@@ -106,3 +100,18 @@ def install_deep_semgrep() -> None:
         stderr=subprocess.DEVNULL,
     ).rstrip()
     logger.info(f"DeepSemgrep Version Info: ({version})")
+
+
+@click.command(hidden=True)
+@handle_command_errors
+def install_deep_semgrep() -> None:
+    """
+    Install the DeepSemgrep binary (Experimental)
+
+    The binary is installed in the same directory that semgrep-core
+    is installed in.
+
+    Must be logged in and have access to DeepSemgrep beta
+    Visit https://semgrep.dev/deep-semgrep-beta for more information
+    """
+    run_install_deep_semgrep()


### PR DESCRIPTION
Fixes: 44b45065750 ("semgrep ci runs DeepSemgrep when it is enabled in App (#6624)")

Reviewed-by: Brendon Go

test plan:
Remove deep-semgrep, enable DeepSemgrep in App/Settings, and run `semgrep ci` on a Java repo

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
