### PR TITLE
[RFC] added(ast_generic): add function kind for function interfaces

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1524,6 +1524,8 @@ and function_kind =
   | Arrow
   (* for Scala *)
   | BlockCases
+  (* For stubs and interfaces, such as in C or Java *)
+  | FunctionInterface
 
 and parameters = parameter list
 


### PR DESCRIPTION
## What:
In languages like Java and C, you can specify the interface of a function.
```c
int foo(int arg);
```
```java
public interface Foo {
  int foo(int arg);
}
```

These are generally translated to `FuncDef`s which have empty bodies. This is an issue, because DeepSemgrep looks at _all_ function definitions when determining function taint signatures.

Inevitably, because of the empty body, all of these functions will end up having clean taint signatures, which means they wipe away taint when called. This should not be the case.

## Why:
This is bad, because by default, we assume that for functions we don't know about, they should propagate taint by default. For these interfaces (which merely specify the type of the function), we still don't really know anything about them, so we should have the same behavior here.

## How:
I propose we add a new function kind corresponding to "functions" which are really just interfaces, such as the preceding two examples. This RFC PR is just to ascertain other people's opinions on this move.

## Alternatives considered:
A few more alternatives were considered. Discussion can be found here: https://linear.app/r2c/issue/PA-2265/java-fn-presence-of-interface-stubs-causes-function-to-have-no-taint

Namely, we could either not modify `AST_generic` and hard-code in checking for an empty body into the taint signature process, or we could do some imperative `Visitor_AST` shenanigans, as I see it. Currently, we have weighed this solution as better.

Pros and cons of this solution are that it is statically cleaner, but also it will require changing a lot of code, and it is possible we will miss a case for an interface in some language.

Open to suggestions.

Related to PA-2265

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
