### PR TITLE
feat(cli, DS): add error message and suggestion to update

### DIFF
--- a/changelog.d/pa-2283.fixed
+++ b/changelog.d/pa-2283.fixed
@@ -1,0 +1,1 @@
+DeepSemgrep: Added a message which suggests that users update their version of DeepSemgrep, if the DeepSemgrep binary crashes

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -889,11 +889,12 @@ class CoreRunner:
                 try:
                     returncode = runner.execute()
                 except:
-                    logger.error("DeepSemgrep crashed during execution (unknown reason).\nTry updating to the latest version? (`semgrep --install-deep-semgrep`)")
+                    logger.error(
+                        "DeepSemgrep crashed during execution (unknown reason).\nTry updating to the latest version? (`semgrep --install-deep-semgrep`)"
+                    )
                     sys.exit(0)
             else:
                 returncode = runner.execute()
-
 
             # Process output
             output_json = self._extract_core_output(

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -878,7 +878,22 @@ class CoreRunner:
 
             runner = StreamingSemgrepCore(cmd, plan.num_targets)
             runner.vfs_map = vfs_map
-            returncode = runner.execute()
+
+            if deep:
+                # Sometimes we may run into synchronicity issues with the latest DeepSemgrep binary.
+                # These issues may possibly cause a failure if a user, for instance, updates their
+                # version of Semgrep, but does not update to the latest version of DeepSemgrep.
+
+                # A short bandaid solution for now is to suggest that a user updates to the latest
+                # version, if the DeepSemgrep binary crashes for any reason.
+                try:
+                    returncode = runner.execute()
+                except:
+                    logger.error("DeepSemgrep crashed during execution (unknown reason).\nTry updating to the latest version? (`semgrep --install-deep-semgrep`)")
+                    sys.exit(0)
+            else:
+                returncode = runner.execute()
+
 
             # Process output
             output_json = self._extract_core_output(

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -955,7 +955,7 @@ class CoreRunner:
         version, if the DeepSemgrep binary crashes for any reason.
         """
         try:
-            self._run_rules_direct_to_semgrep_core_helper(
+            return self._run_rules_direct_to_semgrep_core_helper(
                 rules, target_manager, dump_command_for_core, deep
             )
         except Exception as e:


### PR DESCRIPTION
## What:
Sometimes we release changes to Semgrep which break on older versions of DeepSemgrep. Since it's on users to update their versions of DeepSemgrep, we don't want them getting mad over it crashing because of this versioning issue. A bandaid solution is to make Semgrep suggest to update, whenever DeepSemgrep crashes.

## Why:
We don't want customers to get confused and frustrated with our product when DeepSemgrep cryptically crashes, which could conceivably happen to anyone who forgets to update DeepSemgrep (and who does that?)

## How:
Added a `try` which wraps the DeepSemgrep call, so that we can suggest that users update.

<img width="1286" alt="image" src="https://user-images.githubusercontent.com/49291449/205412175-420554cc-c26a-4a83-9e7d-6520ba101403.png">

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
