### PR TITLE
chore: parse java interface stubs to have FBNothing

### DIFF
--- a/changelog.d/pa-2265.fixed
+++ b/changelog.d/pa-2265.fixed
@@ -1,0 +1,1 @@
+DeepSemgrep: Fixed a bug which caused Java functions with interfaces to wipe taint (instead of propagating taint by default)

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -611,16 +611,12 @@ and method_decl ?(cl_kind = None) { m_var; m_formals; m_throws; m_body } =
     |> Common.map (fun t -> G.OtherAttribute (("Throw", G.fake ""), [ G.T t ]))
   in
   let fbody =
-    match cl_kind, v4 with
-    | Some (Interface, _), {s = G.Block (_, [], _); _} -> G.FBNothing
-    | _ -> FBStmt v4 in 
+    match (cl_kind, v4) with
+    | Some (Interface, _), { s = G.Block (_, [], _); _ } -> G.FBNothing
+    | _ -> FBStmt v4
+  in
   ( { ent with G.attrs = ent.G.attrs @ throws },
-    {
-      G.fparams = v2;
-      frettype = rett;
-      fbody; 
-      fkind = (G.Method, G.fake "");
-    } )
+    { G.fparams = v2; frettype = rett; fbody; fkind = (G.Method, G.fake "") } )
 
 and field v = var_with_init v
 
@@ -717,7 +713,7 @@ and decl ?(cl_kind = None) decl : G.stmt =
   | EmptyDecl t -> G.Block (t, [], t) |> G.s
   | AnnotationTypeElementTodo t -> G.OtherStmt (G.OS_Todo, [ G.Tk t ]) |> G.s
 
-and decls ?(cl_kind = None) v : G.stmt list = list (decl ~cl_kind)  v
+and decls ?(cl_kind = None) v : G.stmt list = list (decl ~cl_kind) v
 
 and import = function
   | ImportAll (t, xs, tok) -> G.ImportAll (t, G.DottedName xs, tok)

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -600,7 +600,7 @@ and parameter_binding = function
       G.ParamRest (tk, p)
   | ParamEllipsis t -> G.ParamEllipsis t
 
-and method_decl { m_var; m_formals; m_throws; m_body } =
+and method_decl ?(cl_kind = None) { m_var; m_formals; m_throws; m_body } =
   let ent, rett = var m_var in
   let v2 = parameters m_formals in
   let v3 = list typ m_throws in
@@ -610,11 +610,15 @@ and method_decl { m_var; m_formals; m_throws; m_body } =
     v3
     |> Common.map (fun t -> G.OtherAttribute (("Throw", G.fake ""), [ G.T t ]))
   in
+  let fbody =
+    match cl_kind, v4 with
+    | Some (Interface, _), {s = G.Block (_, [], _); _} -> G.FBNothing
+    | _ -> FBStmt v4 in 
   ( { ent with G.attrs = ent.G.attrs @ throws },
     {
       G.fparams = v2;
       frettype = rett;
-      fbody = G.FBStmt v4;
+      fbody; 
       fkind = (G.Method, G.fake "");
     } )
 
@@ -649,8 +653,8 @@ and enum_constant (v1, v2, v3) =
   let def = { G.ee_args = v2; ee_body = v3 } in
   (ent, G.EnumEntryDef def)
 
-and class_body (l, xs, r) : G.field list G.bracket =
-  let xs = decls xs |> Common.map (fun x -> G.F x) in
+and class_body ?(cl_kind = None) (l, xs, r) : G.field list G.bracket =
+  let xs = decls ~cl_kind xs |> Common.map (fun x -> G.F x) in
   (l, xs, r)
 
 and class_decl
@@ -671,7 +675,7 @@ and class_decl
   let v5 = option class_parent cl_extends in
   let v6 = list ref_type cl_impls in
   let cparams = parameters cl_formals in
-  let fields = class_body cl_body in
+  let fields = class_body ~cl_kind:(Some cl_kind) cl_body in
   let ent = G.basic_entity v1 ~attrs:(more_attrs @ v4) ~tparams:v3 in
   let cdef =
     {
@@ -692,13 +696,13 @@ and class_kind_and_more (x, t) =
   | AtInterface -> ((G.Interface, t), [ G.attr AnnotationClass t ])
   | Record -> ((G.Class, t), [ G.attr RecordClass t ])
 
-and decl decl : G.stmt =
+and decl ?(cl_kind = None) decl : G.stmt =
   match decl with
   | Class v1 ->
       let ent, def = class_decl v1 in
       G.DefStmt (ent, G.ClassDef def) |> G.s
   | Method v1 ->
-      let ent, def = method_decl v1 in
+      let ent, def = method_decl ~cl_kind v1 in
       G.DefStmt (ent, G.FuncDef def) |> G.s
   | Field v1 ->
       let ent, def = field v1 in
@@ -713,7 +717,7 @@ and decl decl : G.stmt =
   | EmptyDecl t -> G.Block (t, [], t) |> G.s
   | AnnotationTypeElementTodo t -> G.OtherStmt (G.OS_Todo, [ G.Tk t ]) |> G.s
 
-and decls v : G.stmt list = list decl v
+and decls ?(cl_kind = None) v : G.stmt list = list (decl ~cl_kind)  v
 
 and import = function
   | ImportAll (t, xs, tok) -> G.ImportAll (t, G.DottedName xs, tok)


### PR DESCRIPTION
## What:
Currently, we parse the following Java file this way:
```
public interface Foo {
  int main();
}
```
to
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("Foo", ()),
                {id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[KeywordAttr((Public, ()))]; tparams=[]; },
      ClassDef(
        {ckind=(Interface, ()); cextends=[]; cimplements=[]; cmixins=[
         ]; cparams=[];
         cbody=[F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("main", ()),
                               {id_info_id=2; id_hidden=false; id_resolved=Ref(
                                None); id_type=Ref(None); id_svalue=Ref(
                                None); }));
                      attrs=[]; tparams=[]; },
                     FuncDef(
                       {fkind=(Method, ()); fparams=[];
                        frettype=Some({t_attrs=[];
                                       t=TyN(
                                           Id(("int", ()),
                                             {id_info_id=1; id_hidden=false; id_resolved=Ref(
                                              None); id_type=Ref(None); id_svalue=Ref(
                                              None); }));
                                       });
                        fbody=FBStmt(Block([])); }))))];
         })))])
```

Notably, this is pretty similar to:
```
public class Foo {
  int main() { 
  }
}
```
which parses to
```
Pr(
  [DefStmt(
     ({
       name=EN(
              Id(("Foo", ()),
                {id_info_id=3; id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); }));
       attrs=[KeywordAttr((Public, ()))]; tparams=[]; },
      ClassDef(
        {ckind=(Class, ()); cextends=[]; cimplements=[]; cmixins=[]; cparams=[
         ];
         cbody=[F(
                  DefStmt(
                    ({
                      name=EN(
                             Id(("main", ()),
                               {id_info_id=2; id_hidden=false; id_resolved=Ref(
                                None); id_type=Ref(None); id_svalue=Ref(
                                None); }));
                      attrs=[]; tparams=[]; },
                     FuncDef(
                       {fkind=(Method, ()); fparams=[];
                        frettype=Some({t_attrs=[];
                                       t=TyN(
                                           Id(("int", ()),
                                             {id_info_id=1; id_hidden=false; id_resolved=Ref(
                                              None); id_type=Ref(None); id_svalue=Ref(
                                              None); }));
                                       });
                        fbody=FBStmt(Block([])); }))))];
         })))])
```

This means that, at the time of generating function signatures, we cannot discern the two. There is a very important difference, however, as the latter is a clean function (containing no code), and the former is the interface of a function which we do not know the code of (which could propagate taint).

The default behavior of Semgrep is to assume that unknown functions propagate taint, but this coincidence of parsing means that we will assume all interface functions do not propagate taint. This causes FNs, such as PA-2265.

## Why:
We should fix this so that we solve FNs like the above.

## How:
I changed the parsing in Java to use FBNothing.

## Test plan:
Examine the output from the CLI

Closes PA-2265

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
