### PR TITLE
Add script to check compatibility with semgrep-proprietary

### DIFF
--- a/scripts/build-semgrep-proprietary
+++ b/scripts/build-semgrep-proprietary
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+#
+# CI job that checks whether semgrep-proprietary can compile using the
+# current semgrep commit as a submodule.
+#
+set -eu
+
+semgrep_pro_url="git@github.com:returntocorp/semgrep-proprietary.git"
+semgrep_root=$(git rev-parse --show-toplevel)
+semgrep_commit=$(git rev-parse --short=7 HEAD)
+
+echo <<EOF
+We're attempting to build semgrep-proprietary using the current version
+of semgrep. We're assuming we're in a folder within the semgrep repo.
+
+Here's what we found about semgrep:
+
+semgrep repo root: $semgrep_root
+semgrep commit: $semgrep_commit
+semgrep-proprietary remote URL: $semgrep_pro_url
+semgrep git status:
+$(cd "$semgrep_root" && git status)
+EOF
+
+# Use a folder where it's safe to delete any existing semgrep-proprietary.
+workdir=$semgrep_root/../tmp-semgrep-pro
+mkdir -p "$workdir"
+(
+  cd "$workdir"
+  rm -rf semgrep-proprietary
+  git clone "$semgrep_pro_url" --depth 1
+  (
+    cd semgrep-proprietary
+    echo "semgrep-proprietary work folder: $(pwd)"
+
+    # Fetch all submodules (although we don't need the semgrep submodule)
+    git submodule update --init --recursive --depth 1
+
+    # Replace the semgrep submodule
+    rm -rf semgrep
+    ln -s "$semgrep_root" semgrep
+
+    # Build semgrep-proprietary
+    make
+  )
+)

--- a/scripts/build-semgrep-proprietary
+++ b/scripts/build-semgrep-proprietary
@@ -5,7 +5,7 @@
 #
 set -eu
 
-semgrep_pro_url="git@github.com:returntocorp/semgrep-proprietary.git"
+semgrep_pro_url="https://github.com/returntocorp/semgrep-proprietary.git"
 semgrep_root=$(git rev-parse --show-toplevel)
 semgrep_commit=$(git rev-parse --short=7 HEAD)
 

--- a/scripts/build-semgrep-proprietary
+++ b/scripts/build-semgrep-proprietary
@@ -5,11 +5,18 @@
 #
 set -eu
 
-semgrep_pro_url="https://github.com/returntocorp/semgrep-proprietary.git"
+# Try to not print the GitHub access token since it's a secret.
+access=""
+if [[ -n "$GITHUB_TOKEN" ]]; then
+  echo "Using GITHUB_TOKEN from environment."
+  access="$GITHUB_TOKEN:@"
+fi
+
+semgrep_pro_url="https://${access}github.com/returntocorp/semgrep-proprietary.git"
 semgrep_root=$(git rev-parse --show-toplevel)
 semgrep_commit=$(git rev-parse --short=7 HEAD)
 
-echo <<EOF
+cat <<EOF
 We're attempting to build semgrep-proprietary using the current version
 of semgrep. We're assuming we're in a folder within the semgrep repo.
 
@@ -17,7 +24,7 @@ Here's what we found about semgrep:
 
 semgrep repo root: $semgrep_root
 semgrep commit: $semgrep_commit
-semgrep-proprietary remote URL: $semgrep_pro_url
+semgrep-proprietary remote URL: <hidden>
 semgrep git status:
 $(cd "$semgrep_root" && git status)
 EOF
@@ -32,6 +39,8 @@ mkdir -p "$workdir"
   (
     cd semgrep-proprietary
     echo "semgrep-proprietary work folder: $(pwd)"
+    echo "Git remote:"
+    git remote -v
 
     # Fetch all submodules (although we don't need the semgrep submodule)
     git submodule update --init --recursive --depth 1

--- a/scripts/build-semgrep-proprietary
+++ b/scripts/build-semgrep-proprietary
@@ -7,7 +7,7 @@ set -eu
 
 # Try to not print the GitHub access token since it's a secret.
 access=""
-if [[ -n "$GITHUB_TOKEN" ]]; then
+if [[ -n "${GITHUB_TOKEN+x}" ]]; then
   echo "Using GITHUB_TOKEN from environment."
   access="$GITHUB_TOKEN:@"
 fi

--- a/scripts/build-semgrep-proprietary
+++ b/scripts/build-semgrep-proprietary
@@ -51,5 +51,8 @@ mkdir -p "$workdir"
 
     # Build semgrep-proprietary
     make
+
+    # Run the tests
+    make test
   )
 )


### PR DESCRIPTION
This is https://github.com/returntocorp/semgrep/pull/6603 without the CI parts, because they don't work yet but I want to use the script already on my own machine.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
