### PR TITLE
fixed(deep): enable aliasing of ResolvedName in IdQualified

### DIFF
--- a/changelog.d/pa-2260.fixed
+++ b/changelog.d/pa-2260.fixed
@@ -1,0 +1,1 @@
+DeepSemgrep: Fixed a bug where imports which reached type names (among other things) would not resolve properly

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -493,7 +493,12 @@ let rec m_name a b =
            name_info =
              {
                B.id_resolved =
-                 { contents = Some (B.ImportedEntity dotted, _sid) };
+                 {
+                   contents =
+                     Some
+                       ( (B.ImportedEntity dotted | B.ResolvedName (dotted, _)),
+                         _sid );
+                 };
                _;
              };
            _;


### PR DESCRIPTION
## What:
We do not currently allow aliasing to match two `IdQualified`s, where one of those `IdQualified`s is a `ResolvedName`. This hasn't come up before because we haven't been naming `IdQualified` correctly in `DeepSemgrep`, near as I can tell.

## Why:
This will enable us to solve stuff like
```
import A.a 

int x = new a.b();
```

and produce a finding with the pattern `new A.a.b()` as opposed to `new a.b()`.

(the `new`s are necessary to shove it into `IdQualified` as opposed to `DotAccess`)

## How:
I just added it to the case, along with `ImportedEntity` (which is the regular Semgrep version of that). In a couple places, `ImportedModule` has been included here, and it wasn't clear to me whether that should be the case here too.

## Test plan:
No test here, `ResolvedName` is a deep thing. Test in the DS PR.

Closes PA-2260

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
