### PR TITLE
feat(ojsonnet): desugar array comprehensions and eval specials

### DIFF
--- a/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
@@ -82,7 +82,7 @@ type expr =
 (* ------------------------------------------------------------------------- *)
 
 (* no Dollar anymore *)
-and special = Self | Super | StdLength | StdMakeArray
+and special = Self | Super
 
 (* the NamedArg are supposed to be the last arguments *)
 and argument = Arg of expr | NamedArg of ident * tok (* = *) * expr

--- a/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Core_jsonnet.ml
@@ -82,7 +82,7 @@ type expr =
 (* ------------------------------------------------------------------------- *)
 
 (* no Dollar anymore *)
-and special = Self | Super
+and special = Self | Super | StdLength | StdMakeArray
 
 (* the NamedArg are supposed to be the last arguments *)
 and argument = Arg of expr | NamedArg of ident * tok (* = *) * expr

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
@@ -289,7 +289,7 @@ and desugar_comprehension_helper env expr comps =
       let inner_exp =
         match rest with
         | [] -> mk_array [ expr ]
-        | _ -> desugar_comprehension_helper env expr rest
+        | __else__ -> desugar_comprehension_helper env expr rest
       in
       If (tok, cond, inner_exp, empty_else)
   | CompFor (_, x, _, for_expr) :: rest ->
@@ -307,7 +307,7 @@ and desugar_comprehension_helper env expr comps =
         let inner_exp =
           match rest with
           | [] -> mk_array [ expr ]
-          | _ -> desugar_comprehension_helper env expr rest
+          | __else__ -> desugar_comprehension_helper env expr rest
         in
         let i = freshvar () in
         Lambda
@@ -327,7 +327,7 @@ and desugar_comprehension_helper env expr comps =
           [ B (arr, fk, for_expr) ],
           fk,
           std_join (mk_array [], std_mk_array (std_length (Id arr), f)) )
-  | _ -> failwith "lol"
+  | [] -> failwith "impossible: Empty array comprehension"
 
 and desugar_comprehension env expr comps =
   desugar_expr env (desugar_comprehension_helper env expr comps)

--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
@@ -66,7 +66,9 @@ let error tk s =
   raise (Error (s, tk))
 
 let fk = Parse_info.unsafe_fake_info ""
+let fb x = (fk, x, fk)
 let mk_str_literal (str, tk) = Str (None, DoubleQuote, (fk, [ (str, tk) ], fk))
+let mk_array exprs = A (fk, Array exprs, fk)
 
 let mk_DotAccess_std id : expr =
   let std_id = ("std", fk) in
@@ -76,6 +78,12 @@ and expr_or_null v : expr =
   match v with
   | None -> L (Null fk)
   | Some e -> e
+
+let freshvar =
+  let store = ref 0 in
+  fun () ->
+    incr store;
+    ("reallylongfreshvariablename" ^ string_of_int !store, fk)
 
 let todo _env _v = failwith "TODO"
 
@@ -215,6 +223,8 @@ and desugar_special _env v =
   match v with
   | Self -> C.Self
   | Super -> C.Super
+  | StdLength -> C.StdLength
+  | StdMakeArray -> C.StdMakeArray
   | Dollar -> assert false
 
 and desugar_argument env v =
@@ -262,42 +272,65 @@ and desugar_arr_inside env (l, v, r) : C.expr =
   | Array v ->
       let xs = (desugar_list desugar_expr) env v in
       C.Array (l, xs, r)
-  | ArrayComp v ->
-      let v = (desugar_comprehension desugar_expr) env v in
+  | ArrayComp (expr, for_comp, rest_comp) ->
+      let v = desugar_comprehension env expr (CompFor for_comp :: rest_comp) in
       todo env v
 
-and desugar_comprehension ofa env v =
-  (fun env (v1, v2, v3) ->
-    let v1 = ofa env v1 in
-    let v2 = todo env v2 in
-    let v3 = (desugar_list desugar_for_or_if_comp) env v3 in
-    todo env (v1, v2, v3))
-    env v
+(* Strictly speaking, the semantics say you're supposed to desugar as an expression in tandem with
+   desugaring the comprehension.
+   However, these return two different types in our desugaring process. So we can't do that.
 
-and desugar_for_or_if_comp env v =
-  match v with
-  | CompFor v ->
-      let v = desugar_for_comp env v in
-      todo env v
-  | CompIf v ->
-      let v = desugar_if_comp env v in
-      todo env v
+   I hope that applying a single outer-level desugar_expr is equivalent to interleaving it.
+*)
+and desugar_comprehension_helper env expr comps =
+  match comps with
+  | CompIf (tok, cond) :: rest ->
+      let empty_else = Some (fk, mk_array []) in
+      let inner_exp =
+        match rest with
+        | [] -> mk_array [ expr ]
+        | _ -> desugar_comprehension_helper env expr rest
+      in
+      If (tok, cond, inner_exp, empty_else)
+  | CompFor (_, x, _, for_expr) :: rest ->
+      let std_join (l, r) =
+        Call (DotAccess (Id ("std", fk), fk, ("join", fk)), fb [ Arg l; Arg r ])
+      in
+      let std_mk_array (length, f) =
+        Call (IdSpecial (StdMakeArray, fk), fb [ Arg length; Arg f ])
+      in
+      let std_length array =
+        Call (IdSpecial (StdLength, fk), fb [ Arg array ])
+      in
+      let arr = freshvar () in
+      let f =
+        let inner_exp =
+          match rest with
+          | [] -> mk_array [ expr ]
+          | _ -> desugar_comprehension_helper env expr rest
+        in
+        let i = freshvar () in
+        Lambda
+          {
+            f_tok = fk;
+            f_params = fb [ P (i, None) ];
+            f_body =
+              Local
+                ( fk,
+                  [ B (x, fk, ArrayAccess (Id arr, Id i |> fb)) ],
+                  fk,
+                  inner_exp );
+          }
+      in
+      Local
+        ( fk,
+          [ B (arr, fk, for_expr) ],
+          fk,
+          std_join (mk_array [], std_mk_array (std_length (Id arr), f)) )
+  | _ -> failwith "lol"
 
-and desugar_for_comp env v =
-  (fun env (v1, v2, v3, v4) ->
-    let v1 = todo env v1 in
-    let v2 = todo env v2 in
-    let v3 = todo env v3 in
-    let v4 = desugar_expr env v4 in
-    todo env (v1, v2, v3, v4))
-    env v
-
-and desugar_if_comp env v =
-  (fun env (v1, v2) ->
-    let v1 = desugar_tok env v1 in
-    let v2 = desugar_expr env v2 in
-    todo env (v1, v2))
-    env v
+and desugar_comprehension env expr comps =
+  desugar_expr env (desugar_comprehension_helper env expr comps)
 
 (* The desugaring of method was already done at parsing time,
  * so no need to handle id with parameters here. See AST_jsonnet.bind comment.

--- a/semgrep-core/src/ojsonnet/interpreting/Eval_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Eval_jsonnet.ml
@@ -53,6 +53,7 @@ let error tk s =
   (* TODO? if Parse_info.is_fake tk ... *)
   raise (Error (s, tk))
 
+let fk = Parse_info.unsafe_fake_info ""
 let sv e = V.show_value_ e
 let todo _env _v = failwith "TODO"
 
@@ -124,6 +125,40 @@ and eval_expr_aux (env : env) (v : expr) : V.value_ =
   | Id (s, tk) -> lookup env tk (LId s)
   | IdSpecial (Self, tk) -> lookup env tk LSelf
   | IdSpecial (Super, tk) -> lookup env tk LSuper
+  (* Should not have to evaluate these on their own. *)
+  | IdSpecial (StdLength, _)
+  | IdSpecial (StdMakeArray, _) ->
+      assert false
+  | Call (IdSpecial (StdLength, _), (_l, args, _r)) ->
+      Primitive (Double (float_of_int (List.length args), fk))
+  | Call (IdSpecial (StdMakeArray, tk), (_l, args, _r)) -> (
+      let mk_lazy_val i fdef =
+        let e =
+          Call
+            (Lambda fdef, (fk, [ Arg (L (Number (string_of_int i, fk))) ], fk))
+        in
+        { V.v = lazy (eval_expr env e); e }
+      in
+      match args with
+      | [ Arg e; Arg e' ] -> (
+          match (eval_expr env e, e') with
+          | Primitive (Double (n, tk)), Lambda fdef ->
+              if Float.is_integer n then
+                Array
+                  ( fk,
+                    Array.init (Float.to_int n) (fun i -> mk_lazy_val i fdef),
+                    fk )
+              else error tk (spf "Got non-integer %f in std.makeArray" n)
+          | v, e' ->
+              error tk
+                (spf "Improper arguments to std.makeArray: %s, %s" (sv v)
+                   ([%show: expr] e')))
+      | _ ->
+          error tk
+            (spf
+               "Improper number of arguments to std.makeArray: expected 2, got \
+                %d"
+               (List.length args)))
   | Local (_tlocal, binds, _tsemi, e) ->
       let locals =
         binds

--- a/semgrep-core/src/ojsonnet/parsing/AST_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/parsing/AST_jsonnet.ml
@@ -135,7 +135,13 @@ and string_content = string wrap list
  * "core" language where super is at the expression level, so this is
  * probably simpler to have it here instead of in 3 special constructs.
  *)
-and special = Self | Super | Dollar (* ??? *)
+and special =
+  | Self
+  | Super
+  | Dollar
+  (* ??? *)
+  | StdMakeArray
+  | StdLength
 
 (* the NamedArg are supposed to be the last arguments *)
 and argument = Arg of expr | NamedArg of ident * tok (* = *) * expr

--- a/semgrep-core/src/ojsonnet/parsing/AST_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/parsing/AST_jsonnet.ml
@@ -135,13 +135,7 @@ and string_content = string wrap list
  * "core" language where super is at the expression level, so this is
  * probably simpler to have it here instead of in 3 special constructs.
  *)
-and special =
-  | Self
-  | Super
-  | Dollar
-  (* ??? *)
-  | StdMakeArray
-  | StdLength
+and special = Self | Super | Dollar
 
 (* the NamedArg are supposed to be the last arguments *)
 and argument = Arg of expr | NamedArg of ident * tok (* = *) * expr


### PR DESCRIPTION
## What:
Adds in desugaring of array comprehensions. Also adds in evaluation of some specials I added.

## Why:
Need it to make `ojsonnet`'s semantics work

## How:
I added two specials, `StdMakeArray` and `StdLength`, which are base functions whose semantics are given in the operational semantics. These are then cased on in `Eval_jsonnet`, which I also implemented the big-step dynamics of.

For the generation of fresh variable names, I just picked an unlikely variable name and appended increasing numbers to it. I realize this is disgusting, but in practice it will never come up. C'mon. Should have used de Bruijn indices if you didn't want me to do that.

Closes PA-2245

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
