### PR TITLE
tainting: Fix regression in DeepSemgrep after PR #6640

### DIFF
--- a/changelog.d/pa-2304.fixed
+++ b/changelog.d/pa-2304.fixed
@@ -1,0 +1,3 @@
+DeepSemgrep: Fix regression in taint-mode introduced by Semgrep v1.1 that caused
+some findings to be missed. Also, DeepSemgrep will assume, for now, that a method
+call on a tainted object is always tainted.


### PR DESCRIPTION
Better check unconditionally whether the function is a sink and, if so, check whether its arguments are tainted. When the function acts like a taint propagator, that will produce some duplicate findings, but they should be filtered out during deduplication anyways.

In addition, the taint of the function expression itself should always be propagated, also in DeepSemgrep. The function/method itself could be a taint source. Plus, for now it helps us identify `x.foo()` as tainted when `x` is tainted, although in the future we want to do this properly.

Fixes: 1eb330d6887 ("tainting: Make identification of sinks more precise (#6640)")

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
