### PR TITLE
Java: support Java 10 'var' keyword for typed metavariables

### DIFF
--- a/changelog.d/gh-6672.fixed
+++ b/changelog.d/gh-6672.fixed
@@ -1,0 +1,2 @@
+Java: support the Java 10 'var' keyword by not using 'var' as a valid type when
+using typed metavariables.

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1245,8 +1245,8 @@ and type_kind =
   | TyArray of (* const_expr *) expr option bracket * type_
   | TyTuple of type_ list bracket
   | TyVar of ident (* type variable in polymorphic types (not a typedef) *)
-  (* anonymous type, '_' in OCaml, 'dynamic' in Kotlin, 'auto' in C++.
-   * TODO: type bounds Scala? *)
+  (* dynamic/unknown type: '_' in OCaml, 'dynamic' in Kotlin, 'auto' in C++,
+   * 'var' in Java. TODO: type bounds Scala? *)
   | TyAny of tok
   | TyPointer of tok * type_
   | TyRef of tok * type_ (* C++/Rust *)

--- a/semgrep-core/src/naming/Naming_AST.ml
+++ b/semgrep-core/src/naming/Naming_AST.ml
@@ -319,27 +319,26 @@ let make_type type_string tok =
  *)
 let get_resolved_type lang (vinit, vtype) =
   match vtype with
-  | Some _ -> vtype
-  | None -> (
-      (* Should never be reached by languages where the type is in the declaration *)
-      (* e.g. Java, C *)
-      let string_str =
-        match lang with
-        | Lang.Go -> "str"
-        | Lang.Js
-        | Lang.Ts ->
-            "string"
-        | _ -> "string"
-      in
+  | None
+  | Some { t = TyAny _; _ } -> (
       (* Currently these vary between languages *)
-      (* Alternative is to define a TyInt, TyBool, etc in the generic AST *)
-      (* so this is more portable across languages *)
+      (* Alternative is to define a TyInt, TyBool, etc. in the generic AST *)
+      (* so this would be more portable across languages *)
       match vinit with
       | Some { e = L (Bool (_, tok)); _ } -> make_type "bool" tok
       | Some { e = L (Int (_, tok)); _ } -> make_type "int" tok
       | Some { e = L (Float (_, tok)); _ } -> make_type "float" tok
       | Some { e = L (Char (_, tok)); _ } -> make_type "char" tok
-      | Some { e = L (String (_, tok)); _ } -> make_type string_str tok
+      | Some { e = L (String (_, tok)); _ } ->
+          let string_str =
+            match lang with
+            | Lang.Go -> "str"
+            | Lang.Js
+            | Lang.Ts ->
+                "string"
+            | _ -> "string"
+          in
+          make_type string_str tok
       | Some { e = L (Regexp ((_, (_, tok), _), _)); _ } ->
           make_type "regexp" tok
       | Some { e = RegexpTemplate ((l, _fragments, _r), _); _ } ->
@@ -352,6 +351,7 @@ let get_resolved_type lang (vinit, vtype) =
       | Some { e = N (Id (_, { id_type; _ })); _ } -> !id_type
       | Some { e = New (_, tp, (_, _, _)); _ } -> Some tp
       | _ -> None)
+  | Some _ -> vtype
 
 (*****************************************************************************)
 (* Other Helpers *)

--- a/semgrep-core/src/parsing/pfff/java_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/java_to_generic.ml
@@ -83,6 +83,9 @@ let rec typ = function
   | TArray (t1, v1, t2) ->
       let v1 = typ v1 in
       G.TyArray ((t1, None, t2), v1) |> G.t
+  | TVar t ->
+      let t = info t in
+      G.TyAny t |> G.t
 
 and type_arguments v = bracket (list type_argument) v
 

--- a/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_java_tree_sitter.ml
@@ -441,9 +441,12 @@ and basic_type_extra env = function
   | `Inte_type x -> integral_type env x
   | `Floa_point_type x -> floating_point_type env x
   | `Bool_type tok -> TBasic (str env tok) (* "boolean" *)
-  | `Id tok ->
+  | `Id tok -> (
       let x = str env tok (* pattern [a-zA-Z_]\w* *) in
-      TClass [ (x, None) ]
+      match x with
+      (* since Java 10 *)
+      | "var", tk -> TVar tk
+      | x -> TClass [ (x, None) ])
   | `Scoped_type_id x ->
       let x = scoped_type_identifier env x in
       TClass x

--- a/semgrep-core/tests/patterns/java/typed_metavar_var.java
+++ b/semgrep-core/tests/patterns/java/typed_metavar_var.java
@@ -1,0 +1,7 @@
+class Foo {
+    void test1() {
+	var sb = new StringBuilder("abc");
+	//ERROR: match
+	sb.append('c');
+    }
+}

--- a/semgrep-core/tests/patterns/java/typed_metavar_var.sgrep
+++ b/semgrep-core/tests/patterns/java/typed_metavar_var.sgrep
@@ -1,0 +1,1 @@
+(StringBuilder $SB).append(...)


### PR DESCRIPTION
This closes #6672

When processing var x = new Foo(), we should use "Foo"
as a the type of x, not "var".

test plan:
test file included


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)