### PR TITLE
C#: fix bad interaction between -fast and the code for LINQ queries

### DIFF
--- a/changelog.d/gh-6666.fixed
+++ b/changelog.d/gh-6666.fixed
@@ -1,0 +1,2 @@
+C#: bugfix on bad interaction between -fast and the internal code generated
+for LINQ queries

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -911,7 +911,7 @@ let semgrep_with_one_pattern config =
       in
       (* sanity check *)
       if config.filter_irrelevant_rules then
-        failwith "-fast does not work with -f/-e, or you need also -json";
+        logger#warning "-fast does not work with -f/-e, or you need also -json";
       files
       |> List.iter (fun file ->
              logger#info "processing: %s" file;

--- a/semgrep-core/src/runner/Run_semgrep.ml
+++ b/semgrep-core/src/runner/Run_semgrep.ml
@@ -909,6 +909,9 @@ let semgrep_with_one_pattern config =
       let files =
         target_info.target_mappings |> Common.map (fun t -> t.In.path)
       in
+      (* sanity check *)
+      if config.filter_irrelevant_rules then
+        failwith "-fast does not work with -f/-e, or you need also -json";
       files
       |> List.iter (fun file ->
              logger#info "processing: %s" file;

--- a/semgrep-core/tests/patterns/csharp/misc_linq.cs
+++ b/semgrep-core/tests/patterns/csharp/misc_linq.cs
@@ -1,0 +1,4 @@
+// this used to not match because of bad interaction with -fast
+// and the code generated for LINK queries
+//ERROR: match
+from m in somelist select m.foo;

--- a/semgrep-core/tests/patterns/csharp/misc_linq.sgrep
+++ b/semgrep-core/tests/patterns/csharp/misc_linq.sgrep
@@ -1,0 +1,1 @@
+from m in somelist select m.foo;


### PR DESCRIPTION
This closes #6666

test plan:
test file included


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)