### PR TITLE
ojsonnet: use latest tree-sitter-jsonnet with 3args support

### DIFF
--- a/semgrep-core/src/parsing/Unit_parsing.ml
+++ b/semgrep-core/src/parsing/Unit_parsing.ml
@@ -90,7 +90,10 @@ let lang_parsing_tests () =
       pack_parsing_tests_for_lang Lang.R "r" ".r";
       pack_parsing_tests_for_lang Lang.Solidity "solidity" ".sol";
       pack_parsing_tests_for_lang Lang.Ocaml "ocaml" ".ml";
-      pack_parsing_tests_for_lang Lang.Julia "julia" ".jl";
+      pack_parsing_tests_for_lang Lang.Julia "julia" ".jl"
+      (* TODO: once jsonnet_to_generic.ml is finished
+         pack_parsing_tests_for_lang Lang.Jsonnet "jsonnet" ".jsonnet";
+      *);
     ]
 
 (* It's important that our parsers generate classic parsing errors

--- a/semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_jsonnet_tree_sitter.ml
@@ -156,35 +156,32 @@ let map_string_ (env : env) (x : CST.string_) : string_ =
 
 let rec map_args (env : env) (x : CST.args) : argument list =
   match x with
-  | `Expr_opt_COMMA_expr_opt_COMMA_named_arg_opt_COMMA (v1, v2, v3, v4) ->
+  | `Expr_rep_COMMA_expr_rep_COMMA_named_arg_opt_COMMA (v1, v2, v3, v4) ->
       let v1 = map_document env v1 in
       let v2 =
-        match v2 with
-        | Some (v1, v2) ->
-            let _v1 = (* "," *) token env v1 in
-            let v2 = map_document env v2 in
-            [ Arg v2 ]
-        | None -> []
+        v2
+        |> Common.map (fun (v1, v2) ->
+               let _v1 = (* "," *) token env v1 in
+               let v2 = map_document env v2 in
+               Arg v2)
       in
       let v3 =
-        match v3 with
-        | Some (v1, v2) ->
-            let _v1 = (* "," *) token env v1 in
-            let v2 = map_named_argument env v2 in
-            [ v2 ]
-        | None -> []
+        v3
+        |> Common.map (fun (v1, v2) ->
+               let _v1 = (* "," *) token env v1 in
+               let v2 = map_named_argument env v2 in
+               v2)
       in
       let _v4 = trailing_comma env v4 in
       Arg v1 :: (v2 @ v3)
-  | `Named_arg_opt_COMMA_named_arg_opt_COMMA (v1, v2, v3) ->
+  | `Named_arg_rep_COMMA_named_arg_opt_COMMA (v1, v2, v3) ->
       let v1 = map_named_argument env v1 in
       let v2 =
-        match v2 with
-        | Some (v1, v2) ->
-            let _v1 = (* "," *) token env v1 in
-            let v2 = map_named_argument env v2 in
-            [ v2 ]
-        | None -> []
+        v2
+        |> Common.map (fun (v1, v2) ->
+               let _v1 = (* "," *) token env v1 in
+               let v2 = map_named_argument env v2 in
+               v2)
       in
       let _v3 = trailing_comma env v3 in
       v1 :: v2

--- a/semgrep-core/tests/jsonnet/parsing/call_3args.jsonnet
+++ b/semgrep-core/tests/jsonnet/parsing/call_3args.jsonnet
@@ -1,0 +1,5 @@
+
+local x = foo(1,2);
+# this does not work right now
+local y = foo(1,2,3);
+foo(1,2)


### PR DESCRIPTION
test plan:
```
$ yy -dump_jsonnet_ast call_3args.jsonnet
(Local ((),
   [(B (("x", ()), (),
       (Call ((Id ("foo", ())),
          ((), [(Arg (L (Number ("1", ())))); (Arg (L (Number ("2", ()))))],
           ())
          ))
       ))
     ],
   (),
   (Local ((),
      [(B (("y", ()), (),
          (Call ((Id ("foo", ())),
             ((),
              [(Arg (L (Number ("1", ())))); (Arg (L (Number ("2", ()))));
                (Arg (L (Number ("3", ()))))],
              ())
             ))
          ))
        ],
      (),
      (Call ((Id ("foo", ())),
         ((), [(Arg (L (Number ("1", ())))); (Arg (L (Number ("2", ()))))],
          ())
         ))
      ))
   ))
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)