### PR TITLE
Add AST_generic.Name, and Parse_pattern.normalize_any

### DIFF
--- a/changelog.d/gh-6594.fixed
+++ b/changelog.d/gh-6594.fixed
@@ -1,0 +1,1 @@
+Rust: parse correctly scoped identifier in constructor

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1838,6 +1838,7 @@ and any =
   | Params of parameter list
   | Xmls of xml_body list
   | Partial of partial
+  | Name of name
   (* misc *)
   | I of ident
   | Str of string wrap

--- a/semgrep-core/src/core/ast/Map_AST.ml
+++ b/semgrep-core/src/core/ast/Map_AST.ml
@@ -1176,6 +1176,9 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let v1 = map_case_and_body v1 in
         PartialSwitchCase v1
   and map_any = function
+    | Name v1 ->
+        let v1 = map_name v1 in
+        Name v1
     | Xmls v1 ->
         let v1 = map_of_list map_xml_body v1 in
         Xmls v1

--- a/semgrep-core/src/core/ast/Meta_AST.ml
+++ b/semgrep-core/src/core/ast/Meta_AST.ml
@@ -1383,6 +1383,9 @@ and vof_partial = function
       OCaml.VSum ("PartialSwitchCase", [ v1 ])
 
 and vof_any = function
+  | Name v1 ->
+      let v1 = vof_name v1 in
+      OCaml.VSum ("Name", [ v1 ])
   | Xmls v1 ->
       let v1 = OCaml.vof_list vof_xml_body v1 in
       OCaml.VSum ("Xmls", [ v1 ])

--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1310,6 +1310,7 @@ let (mk_visitor :
     v_id_info v2
   and v_program v = v_stmts v
   and v_any = function
+    | Name v1 -> v_name v1
     | Xmls v1 -> v_list v_xml_body v1
     | ForOrIfComp v1 -> v_for_or_if_comp v1
     | Tp v1 -> v_type_parameter v1

--- a/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
+++ b/semgrep-core/src/experiments/api/AST_generic_to_v1.ml
@@ -1287,6 +1287,7 @@ and map_program v = map_of_list map_item v
 
 and map_any x : B.any =
   match x with
+  | Name _
   | Xmls _
   | ForOrIfComp _
   | Ta _ ->

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -3307,6 +3307,7 @@ and m_any a b =
   | G.E a1, B.E b1 -> m_expr a1 b1
   | G.S a1, B.S b1 -> m_stmt a1 b1
   | G.Partial a1, B.Partial b1 -> m_partial a1 b1
+  | G.Name a1, B.Name b1 -> m_name a1 b1
   | G.Args a1, B.Args b1 -> m_list m_argument a1 b1
   | G.Params a1, B.Params b1 -> m_list m_parameter a1 b1
   | G.Xmls a1, B.Xmls b1 -> m_list m_xml_body a1 b1
@@ -3362,6 +3363,7 @@ and m_any a b =
   | G.ModDk _, _
   | G.TodoK _, _
   | G.Partial _, _
+  | G.Name _, _
   | G.Args _, _
   | G.Params _, _
   | G.Xmls _, _

--- a/semgrep-core/src/matching/Generic_vs_generic.mli
+++ b/semgrep-core/src/matching/Generic_vs_generic.mli
@@ -13,6 +13,7 @@ val m_attribute : AST_generic.attribute Matching_generic.matcher
 val m_partial : AST_generic.partial Matching_generic.matcher
 val m_field : AST_generic.field Matching_generic.matcher
 val m_fields : AST_generic.field list Matching_generic.matcher
+val m_name : AST_generic.name Matching_generic.matcher
 
 (* used only for unit testing *)
 val m_any : AST_generic.any Matching_generic.matcher

--- a/semgrep-core/src/matching/Match_patterns.ml
+++ b/semgrep-core/src/matching/Match_patterns.ml
@@ -126,6 +126,11 @@ let match_flds_flds rule a b env =
       set_last_matched_rule rule (fun () -> GG.m_fields a b env))
   [@@profiling]
 
+let match_name_name rule a b env =
+  Common.profile_code ("rule:" ^ rule.MR.id) (fun () ->
+      set_last_matched_rule rule (fun () -> GG.m_name a b env))
+  [@@profiling]
+
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
@@ -240,6 +245,7 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
     let fld_rules = ref [] in
     let flds_rules = ref [] in
     let partial_rules = ref [] in
+    let name_rules = ref [] in
     rules
     |> List.iter (fun rule ->
            (* less: normalize the pattern? *)
@@ -268,6 +274,7 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
            | Fld pattern -> Common.push (pattern, rule, cache) fld_rules
            | Flds pattern -> Common.push (pattern, rule, cache) flds_rules
            | Partial pattern -> Common.push (pattern, rule, cache) partial_rules
+           | Name pattern -> Common.push (pattern, rule, cache) name_rules
            | Args _
            | Params _
            | Xmls _
@@ -494,6 +501,12 @@ let check2 ~hook mvar_context range_filter (config, equivs) rules
             match_rules_and_recurse lang config (file, hook, matches)
               !partial_rules match_partial_partial k
               (fun x -> Partial x)
+              x);
+        V.kname =
+          (fun (k, _) x ->
+            match_rules_and_recurse lang config (file, hook, matches)
+              !name_rules match_name_name k
+              (fun x -> Name x)
               x);
       }
     in

--- a/semgrep-core/src/parsing/Parse_pattern.ml
+++ b/semgrep-core/src/parsing/Parse_pattern.ml
@@ -13,6 +13,7 @@
  * LICENSE for more details.
  *)
 open Common
+module G = AST_generic
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -88,6 +89,22 @@ let run_either ~print_errors parsers program =
   match f parsers with
   | Ok res -> res
   | Error e -> Exception.reraise e
+
+(* We used to do this normalization in each
+ * Parse_xxx_tree_sitter.parse_pattern or xxx_to_generic.any but it's
+ * better to factorize it here.
+ *)
+let rec normalize_any (lang : Lang.t) (any : G.any) : G.any =
+  match any with
+  | G.Pr xs -> normalize_any lang (G.Ss xs)
+  | G.Ss [ x ] -> normalize_any lang (G.S x)
+  | G.S { G.s = G.ExprStmt (e, sc); _ }
+    when Parse_info.is_fake sc || Parse_info.str_of_info sc = "" ->
+      normalize_any lang (G.E e)
+  (* TODO: generalizing to other languages generate many regressions *)
+  | G.E { e = G.N name; _ } when lang = Lang.Rust ->
+      normalize_any lang (G.Name name)
+  | _else_ -> any
 
 (*****************************************************************************)
 (* Entry point *)
@@ -212,6 +229,7 @@ let parse_pattern lang ?(print_errors = false) str =
         (* Lang.Xxx failwith "No Xxx generic parser yet" *)
     | Lang.Dart -> failwith "Dart patterns not supported yet"
   in
+  let any = normalize_any lang any in
 
   Caching.prepare_pattern any;
   Check_pattern.check lang any;

--- a/semgrep-core/src/reporting/JSON_report.ml
+++ b/semgrep-core/src/reporting/JSON_report.ml
@@ -77,6 +77,7 @@ let range_of_any_opt startp_of_match_range any =
   | Fld _
   | Flds _
   | Partial _
+  | Name _
   | I _
   | Str _
   | Def _

--- a/semgrep-core/tests/patterns/rust/misc_name_pattern.rs
+++ b/semgrep-core/tests/patterns/rust/misc_name_pattern.rs
@@ -1,0 +1,4 @@
+//use rustls::{RootCertStore, Certificate, ServerCertVerified, TLSError, ServerCertVerifier};
+
+//ERROR: match
+let mut c2 = rustls::client::DangerousClientConfig {cfg: &mut cfg};

--- a/semgrep-core/tests/patterns/rust/misc_name_pattern.sgrep
+++ b/semgrep-core/tests/patterns/rust/misc_name_pattern.sgrep
@@ -1,0 +1,1 @@
+rustls::client::DangerousClientConfig


### PR DESCRIPTION
This also fix the parsing of Rust scoped identifiers.
Regarding Parse_pattern.normalize_any, I'll make a separate
PR to simplify the code in many Parse_xxx_tree_sitter.ml
and xxx_to_generic.ml

This closes #6594

test plan:
test file included


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)