### PR TITLE
fix!: resolvedname aliasing

### DIFF
--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -496,7 +496,7 @@ let rec m_name a b =
                  {
                    contents =
                      Some
-                       ( (B.ImportedEntity dotted | B.ResolvedName (dotted, _)),
+                       ( (B.ImportedEntity dotted | B.ResolvedName (dotted, _)) as resolved,
                          _sid );
                  };
                _;

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -503,8 +503,11 @@ let rec m_name a b =
              };
            _;
          } as nameinfo) ) ->
+      try_parents dotted
+      >||> try_alternate_names resolved
       (* try without resolving anything *)
-      m_name a (B.IdQualified { nameinfo with name_info = B.empty_id_info () })
+      >||> m_name a
+             (B.IdQualified { nameinfo with name_info = B.empty_id_info () })
       >||>
       (* try this time by replacing the qualifier by the resolved one *)
       let new_qualifier =

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -496,7 +496,8 @@ let rec m_name a b =
                  {
                    contents =
                      Some
-                       ( (B.ImportedEntity dotted | B.ResolvedName (dotted, _)) as resolved,
+                       ( ((B.ImportedEntity dotted | B.ResolvedName (dotted, _))
+                         as resolved),
                          _sid );
                  };
                _;


### PR DESCRIPTION
## What:
In #6667, I added ability to use `ResolvedName` in matching aliased `IdQualified`s. This, however, prevents some tests from reaching the "boilerplate" case below it, which actually does some stuff we want to do.

## Why:
We should fix this because it causes some Ruby tests to fail.

## How:
I added the logic from the case it no longer reached into the modified case.

## Test plan:
`make test` with these changes from DeepSemgrep.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
