### PR TITLE
fix: Bind module name metavariables as text

### DIFF
--- a/changelog.d/gh-6674.fixed
+++ b/changelog.d/gh-6674.fixed
@@ -1,0 +1,1 @@
+When matching module specifiers in imports, prevent metavariables from capturing quotes.

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -295,13 +295,6 @@ let rec m_dotted_name_prefix_ok a b =
  *)
 let m_module_name_prefix a b =
   match (a, b) with
-  (* metavariable case *)
-  | G.FileName ((a_str, _) as a1), B.FileName b1 when MV.is_metavar_name a_str
-    ->
-      (* Bind as a literal string expression so that pretty-printing works.
-       * This also means that this metavar can match both literal strings and
-       * filenames with the same string content. *)
-      envf a1 (MV.E (B.L (B.String b1) |> G.e))
   (* dots: '...' on string or regexp *)
   | G.FileName a, B.FileName b ->
       m_string_ellipsis_or_metavar_or_default


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/6674

Now this just falls through to the next case, where the metavariable is
bound as a `Text` kind, rather than an `E` (expression).

I'm not sure why this would make pretty printing more difficult.
However, given that the old pretty printer is used only in experiments,
and the new one doesn't handle this construct yet, I think we should
prioritize fixing the bug.

Test plan:

Automated tests

Manual test on the example in https://github.com/returntocorp/semgrep/issues/6674 (tests for this kind of bug do not
fit in well with our existing automated test framework). The error
message is "package match is foo" (note the lack of quotes around
"foo").

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
