### PR TITLE
feat(deep-semgrep)!: Pass max-memory to deep-semgrep

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -855,8 +855,8 @@ class CoreRunner:
                     # str(self._timeout),
                     # "--timeout_threshold",
                     # str(self._timeout_threshold),
-                    # "--max_memory",
-                    # str(self._max_memory),
+                    "--max_memory",
+                    str(self._max_memory),
                 ]
 
             stderr: Optional[int] = subprocess.PIPE
@@ -872,7 +872,9 @@ class CoreRunner:
                 # to copy+paste it to a shell.  (The real command is
                 # still visible in the log message above.)
                 printed_cmd = cmd.copy()
-                printed_cmd[0] = SemgrepCore.executable_path()
+                printed_cmd[0] = (
+                    deep_path if deep_path and deep else SemgrepCore.executable_path()
+                )
                 print(" ".join(printed_cmd))
                 sys.exit(0)
 


### PR DESCRIPTION
Allow users to call deep-semgrep with a `--max-memory` field. This will break `semgrep --deep` for users who haven't upgraded.

Also fix the path used in `dump_command_for_core`

Test plan for the latter `semgrep --config <config> --deep . -d` Test plan for the rest is in the deep-semgrep PR

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
