### PR TITLE
ojsonnet: use latest tree-sitter-jsonnet

### DIFF
--- a/semgrep-core/tests/jsonnet/parsing/tailstrict.jsonnet
+++ b/semgrep-core/tests/jsonnet/parsing/tailstrict.jsonnet
@@ -1,0 +1,7 @@
+{ 
+ lstripChars(str, chars)::
+    if std.length(str) > 0 && std.member(chars, str[0]) then
+      std.lstripChars(str[1:], chars) tailstrict
+    else
+  str
+}


### PR DESCRIPTION
test plan:
```
$ yy -dump_jsonnet_ast tests/jsonnet/parsing/tailstrict.jsonnet
works!
$ yy -dump_jsonnet_ast data/std.jsonnet
works!
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)