### PR TITLE
fix: Invalidation for file cache in Range.ml

### DIFF
--- a/changelog.d/cache-invalidation.fixed
+++ b/changelog.d/cache-invalidation.fixed
@@ -1,0 +1,1 @@
+Fixed rare crash that could occur due to stale file caches when temp file names overlap

--- a/semgrep-core/src/core/Range.ml
+++ b/semgrep-core/src/core/Range.ml
@@ -122,6 +122,9 @@ let range_of_tokens xs =
 
 let hmemo = Hashtbl.create 101
 
+let () =
+  Common2.register_tmp_file_cleanup_hook (fun file -> Hashtbl.remove hmemo file)
+
 let content_at_range file r =
   let str = Common.memoized hmemo file (fun () -> Common.read_file file) in
   String.sub str r.start (r.end_ - r.start + 1)


### PR DESCRIPTION
This addresses a DeepSemgrep crash when run on the `NodeBB` repo (see test plan), but it's probably possible to trigger this crash in other ways including without DeepSemgrep.

Basically, the issue is that collisions in tmp file names can lead to outdated information available in the cache. If we try to read, a substring starting at, say character 10, but the temp file that is cached is only 5 characters long, we get a crash.

Test plan: See https://github.com/returntocorp/pfff/pull/575

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
