### PR TITLE
fix!: constant/sym prop outside functions

### DIFF
--- a/changelog.d/pa-1656.fixed
+++ b/changelog.d/pa-1656.fixed
@@ -1,0 +1,2 @@
+Constant propagation: Fixed a bug where constant propagation would only run within functions. Now,
+it runs on the top-level of the program as well.

--- a/semgrep-core/src/analyzing/Constant_propagation.ml
+++ b/semgrep-core/src/analyzing/Constant_propagation.ml
@@ -694,4 +694,14 @@ let propagate_dataflow lang ast =
       |> Visit_function_defs.visit (fun _ent fdef ->
              let inputs, xs = AST_to_IL.function_definition lang fdef in
              let flow = CFG_build.cfg_of_stmts xs in
-             propagate_dataflow_one_function lang inputs flow)
+             propagate_dataflow_one_function lang inputs flow);
+
+      (* We consider the top-level function the interior of a degenerate function,
+         and simply run constant propagation on that.
+
+         Since we don't traverse into each function body recursively, we shouldn't
+         duplicate any work.
+      *)
+      let xs = AST_to_IL.stmt lang (G.stmt1 ast) in
+      let flow = CFG_build.cfg_of_stmts xs in
+      propagate_dataflow_one_function lang [] flow

--- a/semgrep-core/tests/rules/top_level_sym_prop.py
+++ b/semgrep-core/tests/rules/top_level_sym_prop.py
@@ -1,0 +1,5 @@
+
+x = g(150) 
+
+# ruleid: top-level-sym-prop 
+f(x)

--- a/semgrep-core/tests/rules/top_level_sym_prop.yaml
+++ b/semgrep-core/tests/rules/top_level_sym_prop.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: top-level-sym-prop 
+    options:
+      symbolic_propagation: true
+    message: We should be able to symbolically propagate at the top level of a program! 
+    languages:
+      - python 
+    severity: INFO
+    pattern: |
+      f(g(150))


### PR DESCRIPTION
## What:
Almost five months ago, when I first started at this company, one of the first tasks I was given was PA-223, which was a bug concerning the fact that constant propagation only ran inside functions. Reasonably quickly, I came up with a solution to just run dataflow on the entire program, modelled as a big function definition. I noticed in several places in Semgrep's logic, we had a distinction between function definitions and not, and I then started working on https://github.com/returntocorp/semgrep/pull/5787, which was meant to unify these notions.

Unfortunately, at this point, I did not know anything about taint signatures or DeepSemgrep, and I was so used to ML that the idea that mutable variables might actually cause it to _not_ be a good idea to bring top-scope information into function bodies did _not_ occur to me. Suffice to say, this was a bad idea, and it never got merged.

I then quickly moved onto Swift parsing and DeepSemgrep for Terraform that I quickly forgot about PA-223.

Until now. It's been four months, but I'm sick of having this ticket "in progress" on my Linear dashboard.

## Why:
It's annoying because constant prop works inside functions, and then you expect it to on the top level, but it doesn't. I swear this trips me up every other month because I try to come up with an example, and then I remember "oh right, const prop doesn't work outside functions"

## How:
This is just the exact same solution as what I originally had. I regard the entire program as a degenerate function body, and run constant propagation on that. This shouldn't repeat work, because constant propagation does not traverse into function bodies recursively.

## Test plan:
`make test`

Closes PA-223

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
