### PR TITLE
Typed-metavariables: try to infer the type of ternary expressions

### DIFF
--- a/changelog.d/pa-2328.fixed
+++ b/changelog.d/pa-2328.fixed
@@ -1,0 +1,2 @@
+typed-metavariables: handle ternary expressions so we can type correctly
+expressions like `foo(cond ? new A() : this.a)`

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -1311,7 +1311,10 @@ and m_container_ordered_elements a b =
       | _ -> false)
     ~less_is_ok:false (* empty list can not match non-empty list *) a b
 
-(* Poor's man typechecker on literals (for now).
+(* Poor's man typechecker. Note that some of the typing work is also
+ * done in Naming_AST.get_resolved_type() (or in deepSemgrep in
+ * Naming_SAST.map_expr()) and leveraged below via the id_type field.
+ *
  * old: was partly in typing/Typechecking_generic.ml before.
  *
  * todo:
@@ -1332,7 +1335,7 @@ and m_compatible_type lang typed_mvar t e =
       | T.TString, B.String _ ->
           envf typed_mvar (MV.E e)
       | _ -> fail ())
-  | _ -> (
+  | _else_ -> (
       match (t.G.t, e.G.e) with
       (* for C specific literals *)
       | ( G.TyPointer (_, { t = TyN (G.Id (("char", _), _)); _ }),
@@ -1354,15 +1357,22 @@ and m_compatible_type lang typed_mvar t e =
           envf typed_mvar (MV.Id (idb, Some id_infob))
       | _ta, _eb -> (
           match type_of_expr lang e with
-          | Some (idb, tb) ->
-              m_type_option_with_hook idb (Some t) tb >>= fun () ->
+          | tbopt, Some idb ->
+              m_type_option_with_hook idb (Some t) tbopt >>= fun () ->
               envf typed_mvar (MV.E e)
-          | _ -> fail ()))
+          | Some tb, None ->
+              let* () = m_type_ t tb in
+              envf typed_mvar (MV.E e)
+          | None, None -> fail ()))
 
-(* returns a type option and an ident that can be used to query LSP *)
-and type_of_expr lang e : (G.ident * G.type_ option) option =
+(* returns possibly the inferred type of the expression,
+ * as well as an ident option that can then be used to query LSP to get the
+ * type of the ident.
+ *)
+and type_of_expr lang e : G.type_ option * G.ident option =
   match e.B.e with
-  | B.New (tk, t, _) -> Some (("new", tk), Some t)
+  (* TODO? or generate a fake "new" id for LSP to query on tk? *)
+  | B.New (_tk, t, _) -> (Some t, None)
   (* this is covered by the basic type propagation done in Naming_AST.ml *)
   | B.N
       (B.IdQualified
@@ -1370,9 +1380,9 @@ and type_of_expr lang e : (G.ident * G.type_ option) option =
   | B.DotAccess
       ({ e = IdSpecial (This, _); _ }, _, FN (Id (idb, { B.id_type = tb; _ })))
     ->
-      Some (idb, !tb)
+      (!tb, Some idb)
   (* deep: those are usually resolved only in deep mode *)
-  | B.DotAccess (_, _, FN (Id (idb, { B.id_type = tb; _ }))) -> Some (idb, !tb)
+  | B.DotAccess (_, _, FN (Id (idb, { B.id_type = tb; _ }))) -> (!tb, Some idb)
   (* deep: same *)
   | B.Call
       ( { e = B.DotAccess (_, _, FN (Id (idb, { B.id_type = tb; _ }))); _ },
@@ -1381,22 +1391,46 @@ and type_of_expr lang e : (G.ident * G.type_ option) option =
       (* less: in OCaml functions can be curried, so we need to match
        * _params and _args to calculate the resulting type.
        *)
-      | Some { t = TyFun (_params, tret); _ } -> Some (idb, Some tret)
+      | Some { t = TyFun (_params, tret); _ } -> (Some tret, Some idb)
       | Some _
       | None ->
-          None)
+          (None, Some idb))
   (* deep: in Java, there can be an implicit `this.`
      so calculate the type in the same way as above
      THINK: should we do this for all languages? Why not? *)
   | B.Call ({ e = N (Id (idb, { B.id_type = tb; _ })); _ }, _args)
     when lang = Lang.Java -> (
       match !tb with
-      | Some { t = TyFun (_params, tret); _ } -> Some (idb, Some tret)
+      | Some { t = TyFun (_params, tret); _ } -> (Some tret, Some idb)
       | Some _
       | None ->
-          None)
+          (None, Some idb))
   | B.ParenExpr (_, e, _) -> type_of_expr lang e
-  | _ -> None
+  | B.Conditional (_, e1, e2) ->
+      let ( let* ) = Option.bind in
+      let t1opt, id1opt = type_of_expr lang e1 in
+      let t2opt, id2opt = type_of_expr lang e2 in
+      (* LATER: we could also not enforce to have a type for both branches,
+       * but let's go simple for now and enforce both branches have
+       * a type and that the types are equal.
+       *)
+      let topt =
+        let* t1 = t1opt in
+        let* t2 = t2opt in
+        (* LATER: in theory we should look if the types are compatible,
+         * and take the lowest upper bound of the two types *)
+        if AST_utils.with_structural_equal G.equal_type_ t1 t2 then Some t1
+        else None
+      in
+      let idopt =
+        (* TODO? is there an Option.xxx or Common.xxx function for that? *)
+        match (id1opt, id2opt) with
+        | Some id1, _ -> Some id1
+        | _, Some id2 -> Some id2
+        | None, None -> None
+      in
+      (topt, idopt)
+  | _else_ -> (None, None)
 
 (*---------------------------------------------------------------------------*)
 (* XML *)

--- a/semgrep-core/tests/patterns/java/typed_metavar_ternary.java
+++ b/semgrep-core/tests/patterns/java/typed_metavar_ternary.java
@@ -1,0 +1,21 @@
+class Test {
+    Properties fld;
+    
+    void main() {
+	Properties x1;
+
+	// The classic matches
+	
+	//ERROR: match
+	foo(x1);
+	//ERROR: match
+    	foo(this.fld);
+	//ERROR: match
+	foo(new Properties());
+
+	// and the new ternary one!
+
+	//ERROR: match
+	foo(this.properties == null ? new Properties() : this.fld);
+}
+}

--- a/semgrep-core/tests/patterns/java/typed_metavar_ternary.sgrep
+++ b/semgrep-core/tests/patterns/java/typed_metavar_ternary.sgrep
@@ -1,0 +1,1 @@
+foo((Properties $PROPS))


### PR DESCRIPTION
test plan:
test file included


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)