### PR TITLE
Go: fix NoTokenLocation for function type with no parameters

### DIFF
--- a/changelog.d/gh-6715.fixed
+++ b/changelog.d/gh-6715.fixed
@@ -1,0 +1,2 @@
+Go: fix NoTokenLocation for metavariables matching function type without
+an argument (e.g. `func()`)

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -1233,7 +1233,7 @@ and type_kind =
    * parameters so we need at least 'type_ * attributes', at which point
    * it's simpler to just reuse parameter.
    *)
-  | TyFun of parameter list * type_ (* return type *)
+  | TyFun of parameter list (* TODO bracket *) * type_ (* return type *)
   (* a special case of TApply, also a special case of TPointer *)
   | TyArray of (* const_expr *) expr option bracket * type_
   | TyTuple of type_ list bracket
@@ -1520,6 +1520,7 @@ and function_kind =
   (* for Scala *)
   | BlockCases
 
+(* TODO bracket *)
 and parameters = parameter list
 
 (* newvar: *)

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -323,7 +323,7 @@ and interface_body (env : env) (x : CST.interface_body) : interface_field =
         | Some x -> anon_choice_param_list_29faba4 env x
         | None -> []
       in
-      Method (id, { fparams; fresults })
+      Method (id, { ftok = snd id; fparams; fresults })
   | `Inte_type_name x ->
       let name = interface_type_name env x in
       EmbeddedInterface name
@@ -518,7 +518,9 @@ and struct_type (env : env) ((v1, v2) : CST.struct_type) =
 and anon_choice_param_list_29faba4 (env : env)
     (x : CST.anon_choice_param_list_29faba4) : parameter_binding list =
   match x with
-  | `Param_list x -> parameter_list env x
+  | `Param_list x ->
+      let _l, xs, _r = parameter_list env x in
+      xs
   | `Simple_type x ->
       let x = simple_type env x in
       [ ParamClassic { pname = None; ptype = x; pdots = None } ]
@@ -559,14 +561,14 @@ and simple_type (env : env) (x : CST.simple_type) : type_ =
   | `Map_type x -> map_type env x
   | `Chan_type x -> channel_type env x
   | `Func_type (v1, v2, v3) ->
-      let _v1 = token env v1 (* "func" *) in
+      let ftok = token env v1 (* "func" *) in
       let v2 = parameter_list env v2 in
       let v3 =
         match v3 with
         | Some x -> anon_choice_param_list_29faba4 env x
         | None -> []
       in
-      TFunc { fparams = v2; fresults = v3 }
+      TFunc { ftok; fparams = v2; fresults = v3 }
 
 and generic_type (env : env) ((v1, v2) : CST.generic_type) : type_ =
   let name = interface_type_name env v1 in
@@ -720,7 +722,7 @@ and expression (env : env) (x : CST.expression) : expr =
       let v2 = map_literal_value env v2 in
       CompositeLit (v1, v2)
   | `Func_lit (v1, v2, v3, v4) ->
-      let _v1 = token env v1 (* "func" *) in
+      let ftok = token env v1 (* "func" *) in
       let v2 = parameter_list env v2 in
       let v3 =
         match v3 with
@@ -728,7 +730,7 @@ and expression (env : env) (x : CST.expression) : expr =
         | None -> []
       in
       let v4 = block env v4 in
-      FuncLit ({ fparams = v2; fresults = v3 }, v4)
+      FuncLit ({ ftok; fparams = v2; fresults = v3 }, v4)
   | `Choice_raw_str_lit x -> BasicLit (String (string_literal env x))
   | `Int_lit tok -> BasicLit (Int (int_literal env tok)) (* int_literal *)
   | `Float_lit tok ->
@@ -1109,9 +1111,9 @@ and channel_type (env : env) (x : CST.channel_type) =
       TChan (v2, TSend, v3)
 
 and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
-    parameter_binding list =
-  let _v1 = token env v1 (* "(" *) in
-  let v2 =
+    parameter_binding list bracket =
+  let lp = token env v1 (* "(" *) in
+  let xs =
     match v2 with
     | Some (v1, v2) ->
         let v1 =
@@ -1133,8 +1135,8 @@ and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
         v1
     | None -> []
   in
-  let _v3 = token env v3 (* ")" *) in
-  v2
+  let rp = token env v3 (* ")" *) in
+  (lp, xs, rp)
 
 and literal_element (env : env) (x : CST.literal_element) : init =
   match x with
@@ -1350,10 +1352,12 @@ let top_level_declaration (env : env) (x : CST.top_level_declaration) :
         | Some x -> block env x
         | None -> Empty
       in
-      [ DFunc (tfunc, id, tparams, ({ fparams; fresults }, body)) ]
+      [
+        DFunc (tfunc, id, tparams, ({ ftok = tfunc; fparams; fresults }, body));
+      ]
   | `Meth_decl (v1, v2, v3, v4, v5, v6) ->
-      let v1 = token env v1 (* "func" *) in
-      let v2 = parameter_list env v2 in
+      let ftok = token env v1 (* "func" *) in
+      let _l, v2, _r = parameter_list env v2 in
       let v3 = identifier env v3 (* identifier *) in
       let v4 = parameter_list env v4 in
       let v5 =
@@ -1372,7 +1376,9 @@ let top_level_declaration (env : env) (x : CST.top_level_declaration) :
         | [ ParamClassic x ] -> x
         | _ -> failwith "expected one receiver"
       in
-      [ DMethod (v1, v3, receiver, ({ fparams = v4; fresults = v5 }, v6)) ]
+      [
+        DMethod (ftok, v3, receiver, ({ ftok; fparams = v4; fresults = v5 }, v6));
+      ]
   | `Import_decl (v1, v2) ->
       let v1 = token env v1 (* "import" *) in
       let v2 =

--- a/semgrep-core/src/pfff/lang_go/parsing/ast_go.ml
+++ b/semgrep-core/src/pfff/lang_go/parsing/ast_go.ml
@@ -92,8 +92,9 @@ and type_arguments = type_ list bracket (* at least 1 elt *)
 
 and chan_dir = TSend | TRecv | TBidirectional
 and func_type =  {
-  fparams: parameter_binding list;
-  fresults: parameter_binding list;
+  ftok: (* 'func' *) tok;
+  fparams: parameter_binding list bracket;
+  fresults: parameter_binding list; (* TODO: bracket also here *)
 }
 and parameter_binding =
   | ParamClassic of parameter
@@ -354,6 +355,8 @@ type top_decl =
   | Package of tok * ident
   | Import of import
 
+  (* TODO: the first tok is now redundant because the 'func' keyword is now in
+   * function_ in ftok *)
   | DFunc   of tok * ident * type_parameters option (* generics *) * function_
   | DMethod of tok * ident * parameter (* receiver *) * function_
   | DTop of decl

--- a/semgrep-core/tests/patterns/go/misc_functype_0arg.go
+++ b/semgrep-core/tests/patterns/go/misc_functype_0arg.go
@@ -1,0 +1,8 @@
+package foo
+
+// this used to crash semgrep with --json with a NoTokenLocation
+// exn because the  func() function type didn't have any token.
+//ERROR: match
+func asd(a func()) {
+	a()
+}

--- a/semgrep-core/tests/patterns/go/misc_functype_0arg.sgrep
+++ b/semgrep-core/tests/patterns/go/misc_functype_0arg.sgrep
@@ -1,0 +1,3 @@
+func $FUNC($ARG $X) {
+        ...
+      }


### PR DESCRIPTION
This will help #6715

test plan:
No more NoTokenLocation in the output below
```
yy -l go -f misc_functype_0arg.sgrep misc_functype_0arg.go -json
+ /home/pad/yy/_build/default/src/main/Main.exe -l go -f misc_functype_0arg.sgrep misc_functype_0arg.go -json
.
{"matches":[{"rule_id":"-e","location":{"path":"misc_functype_0arg.go","start":{"line":6,"col":1,"offset":157},"end":{"line":8,"col":2,"offset":184}},"extra":{"message":"","metavars":{"$FUNC":{"start":{"line":6,"col":6,"offset":162},"end":{"line":6,"col":9,"offset":165},"abstract_content":"asd"},"$ARG":{"start":{"line":6,"col":10,"offset":166},"end":{"line":6,"col":11,"offset":167},"abstract_content":"a"},"$X":{"start":{"line":6,"col":16,"offset":172},"end":{"line":6,"col":17,"offset":173},"abstract_content":"("}}}}],"errors":[],"stats":{"okfiles":1,"errorfiles":0}}
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)