### PR TITLE
Go: remove redundant token in Ast_go.DFunc and DMethod

### DIFF
--- a/semgrep-core/src/parsing/pfff/go_to_generic.ml
+++ b/semgrep-core/src/parsing/pfff/go_to_generic.ml
@@ -128,10 +128,10 @@ let top_func () =
         let t1, _v1, t2 = bracket tok v1 and v2 = type_ v2 in
         G.TyArray ((t1, None, t2), v2)
     | TFunc v1 ->
-        let (l, params, _r), ret = func_type v1 in
+        let _ftok, (_l, params, r), ret = func_type v1 in
         let ret =
           match ret with
-          | None -> G.ty_builtin ("void", l)
+          | None -> G.ty_builtin ("void", r)
           | Some t -> t
         in
         G.TyFun (params, ret)
@@ -157,11 +157,11 @@ let top_func () =
     | TRecv -> G.TyN (G.Id (unsafe_fake_id "recv", G.empty_id_info ())) |> G.t
     | TBidirectional ->
         G.TyN (G.Id (unsafe_fake_id "bidirectional", G.empty_id_info ())) |> G.t
-  and func_type { ftok = _TODO; fparams = l, params, r; fresults } :
-      G.parameters bracket * G.type_ option =
+  and func_type { ftok; fparams = l, params, r; fresults } :
+      G.tok * G.parameters bracket * G.type_ option =
     let fparams = list parameter_binding params in
     let fresults = list parameter_binding fresults in
-    ((l, fparams, r), return_type_of_results fresults)
+    (ftok, (l, fparams, r), return_type_of_results fresults)
   and parameter_binding x =
     match x with
     | ParamClassic x -> parameter x
@@ -203,11 +203,10 @@ let top_func () =
   and interface_field = function
     | Method (v1, v2) ->
         let v1 = ident v1 in
-        let (_l, params, _r), ret = func_type v2 in
+        let ftok, (_l, params, _r), ret = func_type v2 in
         let ent = G.basic_entity v1 in
         let fdef =
-          G.FuncDef
-            (mk_func_def (G.Method, G.fake "") params ret (G.FBDecl G.sc))
+          G.FuncDef (mk_func_def (G.Method, ftok) params ret (G.FBDecl G.sc))
         in
         G.fld (ent, fdef)
     | EmbeddedInterface v1 ->
@@ -297,9 +296,8 @@ let top_func () =
         let v3 = type_ v3 in
         G.TypedMetavar (v1, v2, v3)
     | FuncLit (v1, v2) ->
-        let (_l, params, _r), ret = func_type v1 and v2 = stmt v2 in
-        G.Lambda
-          (mk_func_def (G.LambdaKind, G.fake "") params ret (G.FBStmt v2))
+        let ftok, (_l, params, _r), ret = func_type v1 and v2 = stmt v2 in
+        G.Lambda (mk_func_def (G.LambdaKind, ftok) params ret (G.FBStmt v2))
     | Receive (v1, v2) ->
         let v1 = tok v1 and v2 = expr v2 in
         G.OtherExpr (("Receive", v1), [ G.E v2 ])
@@ -606,24 +604,24 @@ let top_func () =
     let p = parameter_binding v in
     G.OtherTypeParam (("Param", G.fake ""), [ G.Pa p ])
   and top_decl = function
-    | DFunc (t, v1, v2, (v3, v4)) ->
+    | DFunc (v1, v2, (v3, v4)) ->
         let v1 = ident v1 in
         let tparams = option type_parameters v2 |> Common.optlist_to_list in
-        let (_l, params, _r), ret = func_type v3 in
+        let ftok, (_l, params, _r), ret = func_type v3 in
         let body = stmt v4 in
         let ent = G.basic_entity v1 ~tparams in
         G.DefStmt
           ( ent,
-            G.FuncDef (mk_func_def (G.Function, t) params ret (G.FBStmt body))
-          )
+            G.FuncDef
+              (mk_func_def (G.Function, ftok) params ret (G.FBStmt body)) )
         |> G.s
-    | DMethod (t, v1, v2, (v3, v4)) ->
+    | DMethod (v1, v2, (v3, v4)) ->
         let v1 = ident v1
         and v2 = parameter v2
-        and (_l, params, _r), ret = func_type v3
+        and ftok, (_l, params, _r), ret = func_type v3
         and v4 = stmt v4 in
         let ent = G.basic_entity v1 in
-        let def = mk_func_def (G.Method, t) params ret (G.FBStmt v4) in
+        let def = mk_func_def (G.Method, ftok) params ret (G.FBStmt v4) in
         let receiver = G.OtherParam (("Receiver", snd v1), [ G.Pa v2 ]) in
         G.DefStmt
           (ent, G.FuncDef { def with G.fparams = receiver :: def.G.fparams })

--- a/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_go_tree_sitter.ml
@@ -1352,9 +1352,7 @@ let top_level_declaration (env : env) (x : CST.top_level_declaration) :
         | Some x -> block env x
         | None -> Empty
       in
-      [
-        DFunc (tfunc, id, tparams, ({ ftok = tfunc; fparams; fresults }, body));
-      ]
+      [ DFunc (id, tparams, ({ ftok = tfunc; fparams; fresults }, body)) ]
   | `Meth_decl (v1, v2, v3, v4, v5, v6) ->
       let ftok = token env v1 (* "func" *) in
       let _l, v2, _r = parameter_list env v2 in
@@ -1376,9 +1374,7 @@ let top_level_declaration (env : env) (x : CST.top_level_declaration) :
         | [ ParamClassic x ] -> x
         | _ -> failwith "expected one receiver"
       in
-      [
-        DMethod (ftok, v3, receiver, ({ ftok; fparams = v4; fresults = v5 }, v6));
-      ]
+      [ DMethod (v3, receiver, ({ ftok; fparams = v4; fresults = v5 }, v6)) ]
   | `Import_decl (v1, v2) ->
       let v1 = token env v1 (* "import" *) in
       let v2 =

--- a/semgrep-core/src/pfff/lang_go/parsing/ast_go.ml
+++ b/semgrep-core/src/pfff/lang_go/parsing/ast_go.ml
@@ -355,10 +355,9 @@ type top_decl =
   | Package of tok * ident
   | Import of import
 
-  (* TODO: the first tok is now redundant because the 'func' keyword is now in
-   * function_ in ftok *)
-  | DFunc   of tok * ident * type_parameters option (* generics *) * function_
-  | DMethod of tok * ident * parameter (* receiver *) * function_
+  (* the 'func' keyword is accessible in function_ in ftok *)
+  | DFunc   of ident * type_parameters option (* generics *) * function_
+  | DMethod of ident * parameter (* receiver *) * function_
   | DTop of decl
   (* tree-sitter-go: not used in pfff Go grammar *)
   | STop of stmt

--- a/semgrep-core/src/pfff/lang_go/parsing/parser_go.mly
+++ b/semgrep-core/src/pfff/lang_go/parsing/parser_go.mly
@@ -311,7 +311,7 @@ sgrep_spatch_pattern:
          * empty functions/methods, but I doubt people want explicitely
          * to match that => better to return a Partial
          *)
-        | DFunc (_, _, _, (_, Empty)) | DMethod (_, _, _, (_, Empty))
+        | DFunc (_, _, (_, Empty)) | DMethod (_, _, (_, Empty))
            -> Partial (PartialDecl top_decl)
         | _ -> item1 $1
         )
@@ -338,7 +338,7 @@ sgrep_spatch_pattern:
     { let pret =
          [ParamClassic { pname = None; ptype = $5; pdots = None }] in
       let ftype = { ftok = $2; fparams = ($2, $3, $4); fresults = pret } in
-      let top_decl = DFunc ($2, $1, None, (ftype, Empty)) in
+      let top_decl = DFunc ($1, None, (ftype, Empty)) in
       Partial (PartialDecl top_decl)
     }
 
@@ -996,7 +996,7 @@ xfndcl: LFUNC fndcl fnbody
 fndcl:
 |   sym "(" oarg_type_list_ocomma ")" fnres
      { fun ftok body ->
-        DFunc (ftok, $1, None, ({ ftok; fparams=($2, $3, $4); fresults = $5; },body))
+        DFunc ($1, None, ({ ftok; fparams=($2, $3, $4); fresults = $5; },body))
      }
 |   "(" oarg_type_list_ocomma ")" sym
     "(" oarg_type_list_ocomma ")" fnres
@@ -1004,7 +1004,7 @@ fndcl:
       fun ftok body ->
         match $2 with
         | [ParamClassic x] ->
-            DMethod (ftok, $4, x, ({ ftok; fparams = ($5, $6, $7); fresults = $8 }, body))
+            DMethod ($4, x, ({ ftok; fparams = ($5, $6, $7); fresults = $8 }, body))
         | [] -> error $1 "method has no receiver"
         | [ParamEllipsis _] -> error $1 "method has ... for receiver"
         | _::_::_ -> error $1 "method has multiple receivers"


### PR DESCRIPTION
This token is now accessible in ftok.

test plan:
make


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)