### PR TITLE
fix/feat!: yaml quotes behavior

### DIFF
--- a/changelog.d/pa-2332.fixed
+++ b/changelog.d/pa-2332.fixed
@@ -1,0 +1,2 @@
+YAML: Fixed a bug where metavariables matching YAML double-quoted strings would not capture the entire range of the string, and would
+not contain the double-quotes. Also added the ability to properly use patterns like `"$FOO"`, which will unpack the contents of the matched string.

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -99,7 +99,9 @@ let tok (index, line, column) str env =
     Parse_info.transfo = NoTransfo;
   }
 
-let mk_tok { E.start_mark = { M.index; M.line; M.column }; _ } str env =
+let mk_tok ?(double_quoted = false)
+    { E.start_mark = { M.index; M.line; M.column }; _ } str env =
+  let str = if double_quoted then "\"" ^ str ^ "\"" else str in
   (* their tokens are 0 indexed for line and column, AST_generic's are 1
    * indexed for line, 0 for column *)
   tok (index, line, column) str env
@@ -185,16 +187,23 @@ let make_alias anchor pos env =
 
 (* Scalars must first be checked for sgrep patterns *)
 (* Then, they may need to be converted from a string to a value *)
-let scalar (_tag, pos, value) env : G.expr * E.pos =
+let scalar (_tag, pos, value, style) env : G.expr * E.pos =
   (* If it's a target, then we don't want to parse it like a metavariable,
      or else matching will mess up when it attempts to match a pattern
      metavariable to target YAML code which looks like a metavariable
      (but ought to be interpreted as a string)
   *)
-  if AST_generic_.is_metavar_name value && not env.is_target then
-    (G.N (mk_id value pos env) |> G.e, pos)
+  let double_quoted =
+    match style with
+    | `Double_quoted -> true
+    | __else__ -> false
+  in
+  if
+    AST_generic_.is_metavar_name value
+    && (not env.is_target) && not double_quoted
+  then (G.N (mk_id value pos env) |> G.e, pos)
   else
-    let token = mk_tok pos value env in
+    let token = mk_tok ~double_quoted pos value env in
     let expr =
       (match value with
       | "__sgrep_ellipses__" -> G.Ellipsis (Parse_info.fake_info token "...")
@@ -303,8 +312,8 @@ let parse (env : env) : G.expr list =
         try make_alias anchor pos env with
         | UnrecognizedAlias _ ->
             (error "Unrecognized alias" (E.Alias { anchor }) pos env, pos))
-    | E.Scalar { anchor; tag; value; _ }, pos ->
-        make_node scalar anchor (tag, pos, value) env
+    | E.Scalar { anchor; tag; value; style; _ }, pos ->
+        make_node scalar anchor (tag, pos, value, style) env
     | E.Sequence_start { anchor; tag; _ }, pos ->
         make_node sequence anchor (tag, pos, read_sequence []) env
     | E.Mapping_start { anchor; tag; _ }, pos ->
@@ -337,8 +346,8 @@ let parse (env : env) : G.expr list =
   and read_mapping first_node : G.expr =
     let key, pos1 =
       match first_node with
-      | E.Scalar { anchor; tag; value; _ }, pos ->
-          make_node scalar anchor (tag, pos, value) env
+      | E.Scalar { anchor; tag; value; style; _ }, pos ->
+          make_node scalar anchor (tag, pos, value, style) env
       | E.Mapping_start _, start_pos ->
           let _mappings, end_pos = read_mappings [] in
           ( G.OtherExpr

--- a/semgrep-core/tests/rules/quotes.test.yaml
+++ b/semgrep-core/tests/rules/quotes.test.yaml
@@ -1,0 +1,10 @@
+# ruleid: bare-metavar
+- bare: "double"
+- bare: |
+    piped 
+
+- quoted: "double"
+# ruleid: quoted-metavar
+- quoted: "\"double"
+- quoted: |
+    piped 

--- a/semgrep-core/tests/rules/quotes.test.yaml
+++ b/semgrep-core/tests/rules/quotes.test.yaml
@@ -1,10 +1,16 @@
 # ruleid: bare-metavar
-- bare: "double"
-- bare: |
+- bare_double: "double"
+- bare_double: |
+    piped 
+
+# ruleid: bare-metavar
+- bare_single: 'single'
+- bare_single: |
     piped 
 
 - quoted: "double"
 # ruleid: quoted-metavar
 - quoted: "\"double"
+- quoted: 'double'
 - quoted: |
     piped 

--- a/semgrep-core/tests/rules/quotes.yaml
+++ b/semgrep-core/tests/rules/quotes.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: bare_metavar 
+    message: LANG is $FOO
+    patterns:
+      - pattern: |
+          bare: $FOO
+      - metavariable-regex:
+          metavariable: $FOO
+          regex: ^\".*+
+      - focus-metavariable: $FOO
+    languages:
+      - yaml
+    severity: ERROR
+  - id: quoted_metavar
+    message: LANG is $FOO
+    patterns:
+      - pattern: |
+          quoted: "$FOO"
+      - metavariable-regex:
+          metavariable: $FOO
+          regex: ^\".*+
+      - focus-metavariable: $FOO
+    languages:
+      - yaml
+    severity: ERROR

--- a/semgrep-core/tests/rules/quotes.yaml
+++ b/semgrep-core/tests/rules/quotes.yaml
@@ -1,25 +1,41 @@
 rules:
   - id: bare_metavar 
     message: LANG is $FOO
-    patterns:
-      - pattern: |
-          bare: $FOO
-      - metavariable-regex:
-          metavariable: $FOO
-          regex: ^\".*+
-      - focus-metavariable: $FOO
+    pattern-either:
+      - patterns: 
+          - pattern: |
+              bare_double: $FOO
+          - metavariable-regex:
+              metavariable: $FOO
+              regex: ^\".*+
+          - focus-metavariable: $FOO
+      - patterns: 
+          - pattern: |
+              bare_single: $FOO
+          - metavariable-regex:
+              metavariable: $FOO
+              regex: ^'.*
+          - focus-metavariable: $FOO
     languages:
       - yaml
     severity: ERROR
   - id: quoted_metavar
     message: LANG is $FOO
-    patterns:
-      - pattern: |
-          quoted: "$FOO"
-      - metavariable-regex:
-          metavariable: $FOO
-          regex: ^\".*+
-      - focus-metavariable: $FOO
+    pattern-either:
+      - patterns:
+          - pattern: |
+              quoted: "$FOO"
+          - metavariable-regex:
+              metavariable: $FOO
+              regex: ^".*+
+          - focus-metavariable: $FOO
+      - patterns:
+          - pattern: |
+              quoted: '$FOO'
+          - metavariable-regex:
+              metavariable: $FOO
+              regex: ^'.*+
+          - focus-metavariable: $FOO
     languages:
       - yaml
     severity: ERROR


### PR DESCRIPTION
## What:
As it stands right now, if you have:
```
key: "hi!"
```
matching pattern
```
key: $FOO
```

`$FOO` will be bound to `hi!`. This stands opposed to other languages, where we would match the verbatim textual contents, and thus match `"hi!"`.

Also, when you use a pattern like:
```
"$FOO"
```
matching a string
```
"foo"
```
the contents of the metavariable will be `"foo"`, and not `foo`, which is also inconsistent with typical Semgrep behavior.

Same with single variables, actually.

## Why:
This makes error crop up in Playground, because the metavariable is reported to be less long than the text it should be matching. Thus, weird display bugs like: https://semgrep.dev/s/ZygA

## How:
I cased on the YAML parser's output, which tells us if it matched something doubly quoted. If it's doubly quoted, we should wrap the content in quotes, for instance.

Also, when parsing a metavariable (to solve the second use case), if the metavariable is also the result of double quotes, then it must be a wrapped metavariable. Those get parsed to strings, so I just let it fall through to the typical case.

## Test plan:
`make test`

Closes PA-2332

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
