### PR TITLE
fix!: reinstate deduplication of taint findings with different sources

### DIFF
--- a/changelog.d/pa-2336.fixed
+++ b/changelog.d/pa-2336.fixed
@@ -1,0 +1,2 @@
+Reverted a change which caused findings with different sources (but the same sink) to be deduplicated. This would cause findings which
+looked identical in range and data, but had different taint traces.

--- a/cli/src/semgrep/rule_match.py
+++ b/cli/src/semgrep/rule_match.py
@@ -190,10 +190,12 @@ class RuleMatch:
             self.start.offset,
             self.end.offset,
             self.message,
+            # TODO: Bring this back.
             # This is necessary so we don't deduplicate taint findings which have different sources.
-            self.match.extra.dataflow_trace.to_json_string
-            if self.match.extra.dataflow_trace
-            else None,
+            # self.match.extra.dataflow_trace.to_json_string
+            # if self.match.extra.dataflow_trace
+            # else None,
+            None,
         )
 
     @ci_unique_key.default


### PR DESCRIPTION
## What:
A bit ago, we merged https://github.com/returntocorp/semgrep/pull/6626, which killed deduplicating of taint findings with different sources, as this would cause confusing behavior for future direction with Semgrep, where you could fix a finding and then cause another finding to emerge. More generally, we want to be transparent and show all such relevant findings, if they have different data.

## Why:
Unfortunately, right now we don't have the infra to show users the data that is differentiating findings. This causes confusing behavior, where two findings can seem the  exact same, because there is hidden data differentiating them. See https://returntocorp.slack.com/archives/C01NXGX2EHZ/p1671195500068649

## How:
I just set the thing which differentiates the findings according to dataflow traces to `None`, so that field is always the same.

## Test plan:
`make test` and CI

Closes PA-2336

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
