### PR TITLE
fix: Fix race condition when creating parse cache dir

### DIFF
--- a/changelog.d/pa-2335.fixed
+++ b/changelog.d/pa-2335.fixed
@@ -1,0 +1,1 @@
+Fixed a race condition related to the parsing cache that could lead to internal errors


### PR DESCRIPTION
Since the check and directory creation isn't an atomic operation, it is at risk of race conditions. The directory can get created by another worker process between the check and creation, so then the `mkdir` fails with `EEXIST`.

Test plan: `semgrep --config p/deepsemgrep --deep -j 12` on the Angular repo. Before, there were 11 internal errors on each run (`Unix.Unix_error(Unix.EEXIST, "mkdir", "_deepsemgrepcache")`), now it finishes successfully.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
