### PR TITLE
Add option to specify the semgrep-core executable

### DIFF
--- a/parsing-stats/Makefile
+++ b/parsing-stats/Makefile
@@ -1,6 +1,8 @@
+SEMGREP_CORE ?= semgrep-core
+
 .PHONY: all
 all:
-	./run-all
+	./run-all --semgrep-core "$(SEMGREP_CORE)"
 
 .PHONY: test
 test:

--- a/parsing-stats/run-all
+++ b/parsing-stats/run-all
@@ -16,23 +16,20 @@ Run parsing stats for all the languages supported by semgrep-core.
 Options:
   --help
      Show this message and exit.
-  --upload
-     Upload the stats to the semgrep dashboard as soon as they're available
-     for each language.
+  [OTHER]
+     All other arguments are forwarded to './run-lang'.
+     See './run-lang --help'.
 EOF
 }
 
 while [[ $# != 0 ]]; do
   case "$1" in
-    --upload)
-      forwarded_option_list+=" --upload"
-      ;;
     --help)
       usage
       exit 0
       ;;
     *)
-      error "Unsupported command-line argument: $1"
+      forwarded_option_list+=" $1"
   esac
   shift
 done

--- a/parsing-stats/run-lang
+++ b/parsing-stats/run-lang
@@ -10,19 +10,20 @@ progname=$(basename "$0")
 
 usage() {
   cat <<EOF
-Usage: $progname [--upload] LANG
+Usage: $progname [--upload] [--semgrep-core CMD_NAME] LANG
 
 Expects:
 - lang/LANG/projects.txt: contains one git URL per line
-- semgrep-core command must be available
+- semgrep-core command must be available unless an alternative is specified
+  with '--semgrep-core'.
 
 Produces lang/LANG/stats.json.
 
-Example: $progname java
+Examples:
+  $progname java
+  $progname apex --semgrep-core semgrep-core-proprietary
 EOF
 }
-
-echo using `which semgrep-core`
 
 error() {
   echo "Error: $*" >&2
@@ -32,12 +33,17 @@ error() {
 projects_file=projects.txt
 lang=""
 with_upload=false
+semgrep_core="semgrep-core"
 
 while [[ $# != 0 ]]; do
   case "$1" in
     --help)
       usage
       exit 0
+      ;;
+    --semgrep-core)
+      semgrep_core=$2
+      shift
       ;;
     --upload)
       with_upload=true
@@ -92,6 +98,11 @@ EOF
 }
 
 main() {
+  if sc=$(which "$semgrep_core"); then
+    echo "semgrep-core is: $sc"
+  else
+    error "failed to locate $semgrep_core"
+  fi
   (
     cd lang/"$lang"
 
@@ -113,7 +124,7 @@ main() {
       # 'Fatal error: out of memory' that even Memory_limit can't intercept.
       # See the long comment in Test_parsing.parsing_common about
       # mem_limit_mb.
-      semgrep-core -lang "$lang" -parsing_stats -json $project_list
+      "$semgrep_core" -lang "$lang" -parsing_stats -json $project_list
     ) > stats.json 2> stats.log
   )
 
@@ -122,7 +133,7 @@ main() {
   fi
   echo "stats available in lang/$lang/stats.json"
   #alt: cat lang/$lang/stats.json | jq .global
-  semgrep-core -lang json -e '"global": { ... }' lang/"$lang"/stats.json
+  "$semgrep_core" -lang json -e '"global": { ... }' lang/"$lang"/stats.json
 }
 
 main


### PR DESCRIPTION
This is to support https://github.com/returntocorp/semgrep-proprietary/pull/414 (private).

test plan: run parsing stats in semgrep-proprietary (see https://github.com/returntocorp/semgrep-proprietary/pull/414)

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
