### PR TITLE
Refactor Core_CLI to facilitate re-using options and all_actions

### DIFF
--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -520,7 +520,7 @@ let all_actions () =
   @ Test_dataflow_tainting.actions ()
   @ Test_naming_generic.actions ~parse_program:Parse_target.parse_program
 
-let options () =
+let options actions =
   [
     ("-e", Arg.Set_string pattern_string, " <str> use the string as the pattern");
     ( "-f",
@@ -676,7 +676,7 @@ let options () =
         " keep temporary generated files" );
     ]
   @ Meta_parse_info.cmdline_flags_precision ()
-  @ Common.options_of_actions action (all_actions ())
+  @ Common.options_of_actions action (actions ())
   @ [
       ( "-version",
         Arg.Unit
@@ -733,7 +733,9 @@ let main (sys_argv : string array) : unit =
   in
 
   (* does side effect on many global flags *)
-  let args = Common.parse_options (options ()) usage_msg (Array.of_list argv) in
+  let args =
+    Common.parse_options (options all_actions) usage_msg (Array.of_list argv)
+  in
 
   let config = mk_config () in
 


### PR DESCRIPTION
This is useful to avoid duplicating code in semgrep-core-proprietary.

test plan:
make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
