### PR TITLE
ojsonnet: implement std.filter builtin

### DIFF
--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1393,6 +1393,12 @@ let parse_file ?error_recovery file =
     | FT.Config FT.Jsonnet ->
         if use_ojsonnet then
           let ast = Parse_jsonnet.parse_program file in
+          (* Note that here we do not support registry-aware import;
+           * those are defined in osemgrep/.../Rule_fetching.ml where
+           * we use Network.get functions. Thus, semgrep-core -dump_rule
+           * will not work with registry-aware import either.
+           * Use osemgrep --dump-config instead.
+           *)
           let core = Desugar_jsonnet.desugar_program file ast in
           let value_ = Eval_jsonnet.eval_program core in
           Manifest_jsonnet_to_AST_generic.manifest_value value_

--- a/semgrep-core/tests/jsonnet/interpreting/filter.jsonnet
+++ b/semgrep-core/tests/jsonnet/interpreting/filter.jsonnet
@@ -1,0 +1,8 @@
+local arr = [1, 2, 3];
+std.filter(function(v) v > 1, arr)
+
+//possible errors to handle:
+//std.filter(1, 2) // This should generate a runtime error
+
+//std.filter(function() true, arr)
+


### PR DESCRIPTION
test plan:
```
$ /home/pad/yy/_build/default/src/main/Main.exe -dump_jsonnet_json filter.jsonnet
[2,3]
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)