### PR TITLE
ojsonnet: implement std.objectHasEx builtin

### DIFF
--- a/semgrep-core/tests/jsonnet/interpreting/objectHas.jsonnet
+++ b/semgrep-core/tests/jsonnet/interpreting/objectHas.jsonnet
@@ -1,0 +1,9 @@
+local o = { foo: 1, bar: 2};
+[
+std.objectHas(o, 'foo'),
+std.objectHas(o, 'nope')
+]
+
+// possible errors to handle
+//std.objectHas(1, 'foo')
+//std.objectHas(o, 2)


### PR DESCRIPTION
test plan:
```
$ /home/pad/yy/_build/default/src/main/Main.exe -dump_jsonnet_json objectHas.jsonnet
[true,false]
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)