### PR TITLE
ojsonnet: naive plus for objects

### DIFF
--- a/semgrep-core/tests/jsonnet/interpreting/plus_object.jsonnet
+++ b/semgrep-core/tests/jsonnet/interpreting/plus_object.jsonnet
@@ -1,0 +1,3 @@
+local x1 = { foo: 1, bar: 2};
+local x2 = { foo: 2, foobar: 2};
+x1 + x2


### PR DESCRIPTION
Note that osemgrep --dump-config=semgrep.jsonnet works starting
from this PR! ojsonnet can handle all the jsonnet code currently
used in semgrep.jsonnet so we could start to dogfood osemgrep!

test plan:
```
 /home/pad/yy/_build/default/src/main/Main.exe -dump_jsonnet_json plus_object.jsonnet
{"bar":2,"foo":2,"foobar":2}
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)