### PR TITLE
ojsonnet: add some [@@profiling]

### DIFF
--- a/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Desugar_jsonnet.ml
@@ -474,6 +474,8 @@ and desugar_import env v : C.expr =
 (* Entry point *)
 (*****************************************************************************)
 
+let desugar_expr_profiled env e = desugar_expr env e [@@profiling]
+
 let desugar_program ?(import_callback = default_callback) ?(use_std = true)
     (file : Common.filename) (e : program) : C.program =
   let env =
@@ -489,5 +491,5 @@ let desugar_program ?(import_callback = default_callback) ?(use_std = true)
       Local (fk, [ B (("std", fk), fk, std) ], fk, e)
     else e
   in
-  let core = desugar_expr env e in
+  let core = desugar_expr_profiled env e in
   core

--- a/semgrep-core/src/ojsonnet/interpreting/Eval_jsonnet.ml
+++ b/semgrep-core/src/ojsonnet/interpreting/Eval_jsonnet.ml
@@ -663,3 +663,4 @@ let eval_program (e : Core_jsonnet.program) : Value_jsonnet.value_ =
   let empty_env = { locals = Map_.empty; depth = 0 } in
   let v = eval_expr empty_env e in
   v
+  [@@profiling]

--- a/semgrep-core/src/osemgrep/cli_scan/Rule_fetching.ml
+++ b/semgrep-core/src/osemgrep/cli_scan/Rule_fetching.ml
@@ -125,6 +125,7 @@ let import_callback base str =
              Common2.with_tmp_file ~str:content ~ext:"yaml" (fun file ->
                  (* LATER: adjust locations so refer to registry URL *)
                  parse_yaml_for_jsonnet file))
+  [@@profiling]
 
 (* similar to Parse_rule.parse_file but with special import callbacks
  * for a registry-aware jsonnet.


### PR DESCRIPTION
test plan:
```
$ osemgrep --dump-config ~/github/semgrep/semgrep.jsonnet --profile
...
---------------------
profiling result
---------------------
CLI.dispatch_subcommand                  :      1.040 sec          1 count
Desugar_jsonnet.desugar_expr_profiled    :      0.944 sec          1 count
Rule_fetching.import_callback            :      0.942 sec          3 count
Network.get                              :      0.937 sec          1 count
Common.full_charpos_to_pos_large         :      0.006 sec         81 count
Unix.stat                                :      0.002 sec         83 count
Common.=~                                :      0.000 sec       1239 count
Parse_python.tokens                      :      0.000 sec          8 count
Common.read_file                         :      0.000 sec          3 count
file_type_of_file                        :      0.000 sec          1 count
Regexp_engine.pcre_compile               :      0.000 sec          2 count
Eval_jsonnet.eval_program                :      0.000 sec          1 count
...
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)