### PR TITLE
circleCI: switch to semgrep:develop for semgrep jsonnet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
-##########################################################################################
+###############################################################################
 # Prelude
-##########################################################################################
+###############################################################################
 # The main goals of this pipeline are to:
 # - dogfood Semgrep by running it on each semgrep PRs.
 # - check that Semgrep can run in alternate CI platforms like Circle CI
@@ -11,23 +11,19 @@
 
 version: 2.1
 
-##########################################################################################
+###############################################################################
 # The jobs
-##########################################################################################
+###############################################################################
 
 jobs:
   # Dogfood!
   semgrep:
-    #TODO: used to be returntocorp/semgrep:develop for maximum dogfooding
-    # but something broke after https://app.circleci.com/pipelines/github/returntocorp/semgrep/14848   # which seems unrelated. Weird.
     docker:
       - image: returntocorp/semgrep:develop
         user: root
     working_directory: /src
     steps:
       - checkout
-      # we now need the submodules because semgrep.jsonnet includes semgrep-core/pfff/semgrep.yml
-      - run: git submodule update --init --recursive --recommend-shallow semgrep-core/src/pfff
       # Dogfooding on the bleeding edge by using jsonnet and the new syntax!
       # coupling: see also 'make check'
       - run: semgrep --config semgrep.jsonnet --error --verbose --exclude tests --exclude pfff
@@ -97,9 +93,9 @@ jobs:
             PATH=$PATH:"$(pip3 show semgrep | grep '^Location' | sed -e 's/Location: //')/semgrep/bin"
             opam exec -- ./autofix-printing-stats/run --upload
 
-##########################################################################################
+###############################################################################
 # The workflows
-##########################################################################################
+###############################################################################
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     #TODO: used to be returntocorp/semgrep:develop for maximum dogfooding
     # but something broke after https://app.circleci.com/pipelines/github/returntocorp/semgrep/14848   # which seems unrelated. Weird.
     docker:
-      - image: returntocorp/semgrep:0.118.0
+      - image: returntocorp/semgrep:develop
         user: root
     working_directory: /src
     steps:

--- a/semgrep-core/src/core_cli/Core_CLI.ml
+++ b/semgrep-core/src/core_cli/Core_CLI.ml
@@ -175,7 +175,7 @@ let json_of_v (v : OCaml.v) =
         match xs with
         | [] -> J.String (spf "%s" s)
         | [ one_element ] -> J.Object [ (s, aux one_element) ]
-        | _ -> J.Object [ (s, J.Array (Common.map aux xs)) ])
+        | _ :: _ :: _ -> J.Object [ (s, J.Array (Common.map aux xs)) ])
     | OCaml.VVar (s, i64) -> J.String (spf "%s_%d" s (Int64.to_int i64))
     | OCaml.VArrow _ -> failwith "Arrow TODO"
     | OCaml.VNone -> J.Null


### PR DESCRIPTION
test plan:
wait for circleCI


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)