### PR TITLE
feat(matching): do not match resolvednames if possible

### DIFF
--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -362,7 +362,7 @@ and id_info = {
    * a typed entity, which can be interpreted as a TypedMetavar in semgrep.
    * alt: have an explicity type_ field in entity.
    *)
-  id_type : type_ option ref;
+  id_type : type_ option ref; [@equal fun _a _b -> true]
   (* type checker (typing) *)
   (* sgrep: this is for sgrep constant propagation hack.
    * todo? associate only with Id?

--- a/semgrep-core/src/core/ast/AST_generic.ml
+++ b/semgrep-core/src/core/ast/AST_generic.ml
@@ -361,6 +361,9 @@ and id_info = {
   (* sgrep: in OCaml we also use that to store the type of
    * a typed entity, which can be interpreted as a TypedMetavar in semgrep.
    * alt: have an explicity type_ field in entity.
+   * We do not use this for equality, because we want to say that two variables
+   * are the same if their resolved names are the same, even if type analysis
+   * did not propagate the same type to them.
    *)
   id_type : type_ option ref; [@equal fun _a _b -> true]
   (* type checker (typing) *)

--- a/semgrep-core/src/matching/Generic_vs_generic.ml
+++ b/semgrep-core/src/matching/Generic_vs_generic.ml
@@ -426,7 +426,7 @@ let m_regexp_options a_opt b_opt =
 (* start of recursive need *)
 (* TODO: factorize with metavariable and aliasing logic in m_expr
  * TODO: remove MV.Id and use always MV.N?
- * `is_resolved` should be true if `b` is the result of unpacking a resolved name,
+   `is_resolved` should be true if `b` is the result of unpacking a resolved name,
    resulting from ImportedEntity, ImportedModule, or ResolvedName.
    If it is, then we prevent calls to `envf`, because this will produce a match
    with a nonsensical range, because the tokens that constitute it may be distributed

--- a/semgrep-core/src/matching/Generic_vs_generic.mli
+++ b/semgrep-core/src/matching/Generic_vs_generic.mli
@@ -13,7 +13,12 @@ val m_attribute : AST_generic.attribute Matching_generic.matcher
 val m_partial : AST_generic.partial Matching_generic.matcher
 val m_field : AST_generic.field Matching_generic.matcher
 val m_fields : AST_generic.field list Matching_generic.matcher
-val m_name : AST_generic.name Matching_generic.matcher
+
+(* `is_resolved` is for checking if this name we are matching in the target
+   is resulting from a resolved or imported name, which may consist of tokens
+   that are not contiguous in the target program.
+*)
+val m_name : ?is_resolved:bool -> AST_generic.name Matching_generic.matcher
 
 (* used only for unit testing *)
 val m_any : AST_generic.any Matching_generic.matcher

--- a/semgrep-core/tests/patterns/python/misc_class_regression.py
+++ b/semgrep-core/tests/patterns/python/misc_class_regression.py
@@ -1,3 +1,4 @@
+# MATCH:
 class A:
     def method1(self, args):
         pass

--- a/semgrep-core/tests/patterns/python/misc_class_regression.py
+++ b/semgrep-core/tests/patterns/python/misc_class_regression.py
@@ -1,4 +1,3 @@
-#ERROR: match
 class A:
     def method1(self, args):
         pass

--- a/semgrep-core/tests/patterns/python/misc_class_regression.py
+++ b/semgrep-core/tests/patterns/python/misc_class_regression.py
@@ -1,4 +1,4 @@
-# MATCH:
+#ERROR: match 
 class A:
     def method1(self, args):
         pass

--- a/semgrep-core/tests/rules/imported_matching.py
+++ b/semgrep-core/tests/rules/imported_matching.py
@@ -1,0 +1,11 @@
+# ruleid: my-pattern-id
+from A import x
+# ruleid: my-pattern-id
+from B import y
+
+res1 = x
+
+def foo(x):
+    return x
+
+res2 = y

--- a/semgrep-core/tests/rules/imported_matching.yaml
+++ b/semgrep-core/tests/rules/imported_matching.yaml
@@ -1,0 +1,26 @@
+rules:
+- id: my_pattern_id
+  pattern-either:
+    - pattern: |
+        res1 = $X
+        ...
+        def $FUNC(...):
+          return $X 
+    - patterns:
+        - pattern: |
+            ...
+            res1 = A.$X
+        - focus-metavariable: $X
+    - patterns:
+        - pattern: |
+            ...
+            res2 = $B.y
+        - focus-metavariable: $B
+  message: |
+    We do not want a match here. This rule is looking for `foo` being called on an identifier
+    which does not start with `_`, which clearly `_y` does.
+    Unfortunately, because of our matching logic, we decide to produce a match to both the
+    identifier, and the resolved name. So we flag this, even though in intention it isn't
+    faithful. 
+  severity: WARNING
+  languages: [python]

--- a/semgrep-core/tests/rules/imported_matching.yaml
+++ b/semgrep-core/tests/rules/imported_matching.yaml
@@ -17,10 +17,7 @@ rules:
             res2 = $B.y
         - focus-metavariable: $B
   message: |
-    We do not want a match here. This rule is looking for `foo` being called on an identifier
-    which does not start with `_`, which clearly `_y` does.
-    Unfortunately, because of our matching logic, we decide to produce a match to both the
-    identifier, and the resolved name. So we flag this, even though in intention it isn't
-    faithful. 
+    We want to make sure that we can unpack imported names, at least partially, with metavariables.
+    Also, different variables should not unify.
   severity: WARNING
   languages: [python]

--- a/semgrep-core/tests/rules/metavar_regex_import.js
+++ b/semgrep-core/tests/rules/metavar_regex_import.js
@@ -1,0 +1,4 @@
+import {x as _y} from 'z';
+
+// ok: my_pattern_id
+var res = foo(_y);

--- a/semgrep-core/tests/rules/metavar_regex_import.yaml
+++ b/semgrep-core/tests/rules/metavar_regex_import.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: my_pattern_id
+  patterns:
+  - pattern: |
+      foo($BAR)
+  - metavariable-regex:
+      metavariable: $BAR
+      regex: "^[^_].*"
+  message: |
+    We do not want a match here. This rule is looking for `foo` being called on an identifier
+    which does not start with `_`, which clearly `_y` does.
+    Unfortunately, because of our matching logic, we decide to produce a match to both the
+    identifier, and the resolved name. So we flag this, even though in intention it isn't
+    faithful. 
+  severity: WARNING
+  languages: [javascript]


### PR DESCRIPTION
## What:
This PR adds in some changes to the matching logic, to prefer to not unpack the `ResolvedName`, `ImportedEntity`, or `ImportedModule` of an identifier, if at all possible.

This comes up in examples like the following:
```
rules:
- id: insufficient-postmessage-origin-validation
  message: >-
    blahblah
  languages:
  - javascript
  - typescript
  severity: WARNING
  patterns:
    - pattern: |
        foo('blah', $FUNC)
    - metavariable-pattern:
        pattern: |
          $ANY
        metavariable: $FUNC
```
matching
```
var badResolved = 2;

foo("blah", badResolved);
```
The reason for this is that we are permitting metavariables to match in envf to IdQualifieds constructed from ResolvedNames, which always have fake tokens. This means that, when looking up the metavariable's range, Semgrep crashes.

## Why:
We do not want Semgrep to have internal errors.

As a corollary, metavariables should not match to non-contiguous ranges. This causes issues further down, where if we `metavariable-pattern` or something, we will try to extract the source file's text, except because the range doesn't make sense we will cause an error. In addition, this causes weird behavior with `metavariable-regex`, where we can get cases like:
```
import {x as _y} from 'z';

// ok: my_pattern_id
var res = foo(_y);
```
matching
```
patterns:
- pattern: |
    foo($BAR)
- metavariable-regex:
    metavariable: $BAR
    regex: "^[^_].*"
```
In this case, clearly we are looking for the argument to `foo` to not start with an underscore. With Semgrep right now, we will actually produce a match here, on account of the fact that we also match the `ResolvedName`.

An additional motivation is that we want to succeed on matching the `ResolvedName` in _some_ cases. For instance:
```
import {x as y} from 'z';

var res = foo(y)
```
matching
```
patterns:
- pattern: |
    foo($BAR)
- metavariable-pattern:
    metavariable: $BAR
    pattern: |
      z.$X
```
In this case, this happens in two phases. The first is that we want `$BAR` to match to the identifier _containing_ the `ResolvedName` `z.x`, and then we want to be able to decompose on that information in the `metavariable-pattern`. We also want `$X` to be able to match the `x` which was imported, which is on the first line. 

## How:
This PR implements the behavior as described above. It factorizes the `m_name` logic to be slightly easier to understand, and to get rid of the previous way that it was done, which was to produce _two_ matches, one to the identifier which has been cleared of naming data, and one to the fully qualified name.

Now, we prefer to match the original identifier, which contains the naming data. This has the advantage of working analogously to how we do things with symbolic propagation, as well as ensuring that we never allow a metavariable to match a language construct which has a non-contiguous range in the source text. 

Should we fail to produce a match to the original identifier, however, we will then allow the possibility of unpacking the fully qualified name. If we do that, however, we still maintain the property that we should only match a metavariable to a single identifier, at best, and not to any string of tokens which might not be a contiguous range.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
