### PR TITLE
fix!: yaml parsing for literal and folded styles

### DIFF
--- a/changelog.d/pa-2347.fixed
+++ b/changelog.d/pa-2347.fixed
@@ -1,0 +1,9 @@
+YAML: Fixed a bug where literal or folded blocks would not be parsed properly.
+
+So for instance, in:
+```
+key: |
+  string goes here
+```
+
+A metavariable matching the contents of the string value might not be correct.

--- a/cli/tests/e2e/rules/yaml_key.yaml
+++ b/cli/tests/e2e/rules/yaml_key.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: yaml-key
+    pattern: |
+      key: $VALUE
+    message: |
+      $VALUE
+    languages: [yaml]
+    severity: ERROR

--- a/cli/tests/e2e/snapshots/test_output/test_yaml_metavariables/report.json
+++ b/cli/tests/e2e/snapshots/test_output/test_yaml_metavariables/report.json
@@ -1,0 +1,308 @@
+{
+  "errors": [],
+  "paths": {
+    "_comment": "<add --verbose for a list of skipped paths>",
+    "scanned": [
+      "targets/yaml/target.yaml"
+    ]
+  },
+  "results": [
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 13,
+        "line": 1,
+        "offset": 12
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: \"one\"",
+        "message": "\"one\"\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": "\"one\"",
+            "end": {
+              "col": 13,
+              "line": 1,
+              "offset": 12
+            },
+            "start": {
+              "col": 8,
+              "line": 1,
+              "offset": 7
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 1,
+        "offset": 2
+      }
+    },
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 13,
+        "line": 2,
+        "offset": 25
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: 'two'",
+        "message": "'two'\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": "'two'",
+            "end": {
+              "col": 13,
+              "line": 2,
+              "offset": 25
+            },
+            "start": {
+              "col": 8,
+              "line": 2,
+              "offset": 20
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 2,
+        "offset": 15
+      }
+    },
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 11,
+        "line": 4,
+        "offset": 45
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: |\n    three",
+        "message": "|\n    three\n\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": "|\n    three\n",
+            "end": {
+              "col": 1,
+              "line": 5,
+              "offset": 45
+            },
+            "start": {
+              "col": 8,
+              "line": 3,
+              "offset": 33
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 3,
+        "offset": 28
+      }
+    },
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 9,
+        "line": 6,
+        "offset": 62
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: |\n   four",
+        "message": "|\n   four\n\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": "|\n   four\n",
+            "end": {
+              "col": 1,
+              "line": 7,
+              "offset": 62
+            },
+            "start": {
+              "col": 8,
+              "line": 5,
+              "offset": 52
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 5,
+        "offset": 47
+      }
+    },
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 8,
+        "line": 10,
+        "offset": 93
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: |       \n    fi\n\n    ve",
+        "message": "|       \n    fi\n\n    ve\n\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": "|       \n    fi\n\n    ve\n",
+            "end": {
+              "col": 1,
+              "line": 11,
+              "offset": 93
+            },
+            "start": {
+              "col": 8,
+              "line": 7,
+              "offset": 69
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 7,
+        "offset": 64
+      }
+    },
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 6,
+        "line": 15,
+        "offset": 123
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: |\n    si\n\n      x",
+        "message": "|\n    si\n\n      x\n    \n\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": "|\n    si\n\n      x\n    \n",
+            "end": {
+              "col": 1,
+              "line": 16,
+              "offset": 123
+            },
+            "start": {
+              "col": 8,
+              "line": 11,
+              "offset": 100
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 11,
+        "offset": 95
+      }
+    },
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 11,
+        "line": 17,
+        "offset": 142
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: >\n    seven",
+        "message": ">\n    seven\n\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": ">\n    seven\n",
+            "end": {
+              "col": 1,
+              "line": 18,
+              "offset": 142
+            },
+            "start": {
+              "col": 8,
+              "line": 16,
+              "offset": 130
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 16,
+        "offset": 125
+      }
+    },
+    {
+      "check_id": "rules.yaml-key",
+      "end": {
+        "col": 7,
+        "line": 21,
+        "offset": 166
+      },
+      "extra": {
+        "fingerprint": "0x42",
+        "is_ignored": false,
+        "lines": "- key: >\n    eig\n\n    ht",
+        "message": ">\n    eig\n\n    ht\n",
+        "metadata": {},
+        "metavars": {
+          "$VALUE": {
+            "abstract_content": ">\n    eig\n\n    ht",
+            "end": {
+              "col": 7,
+              "line": 21,
+              "offset": 166
+            },
+            "start": {
+              "col": 8,
+              "line": 18,
+              "offset": 149
+            }
+          }
+        },
+        "severity": "ERROR"
+      },
+      "path": "targets/yaml/target.yaml",
+      "start": {
+        "col": 3,
+        "line": 18,
+        "offset": 144
+      }
+    }
+  ],
+  "version": "0.42"
+}

--- a/cli/tests/e2e/targets/yaml/target.yaml
+++ b/cli/tests/e2e/targets/yaml/target.yaml
@@ -1,0 +1,21 @@
+- key: "one"
+- key: 'two'
+- key: |
+    three
+- key: |
+   four
+- key: |       
+    fi
+
+    ve
+- key: |
+    si
+
+      x
+    
+- key: >
+    seven
+- key: >
+    eig
+
+    ht

--- a/cli/tests/e2e/test_output.py
+++ b/cli/tests/e2e/test_output.py
@@ -95,7 +95,7 @@ def test_output_highlighting__force_color_and_no_color(run_semgrep_in_tmp, snaps
 # This test is just for making sure that our YAML parser interacts properly
 # with metavariables. We don't want to introduce regressions which might
 # mess this up.
-@pytest.mark.kinda_slow
+@pytest.mark.quick
 def test_yaml_metavariables(run_semgrep_in_tmp, snapshot):
     stdout, _ = run_semgrep_in_tmp(
         "rules/yaml_key.yaml",

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -51,6 +51,7 @@ module PI = Parse_info
 type env = {
   (* when we parse a pattern, the filename is fake ("<pattern_file>") *)
   file : Common.filename;
+  text : string;
   (* function *)
   charpos_to_pos : (int -> int * int) option;
   (* From yaml.mli: "[parser] tracks the state of generating {!Event.t}
@@ -99,12 +100,22 @@ let tok (index, line, column) str env =
     Parse_info.transfo = NoTransfo;
   }
 
-let mk_tok ?(quoted = None) { E.start_mark = { M.index; M.line; M.column }; _ }
-    str env =
+let mk_tok ?(style = `Plain)
+    {
+      E.start_mark = { M.index; M.line; M.column };
+      E.end_mark = { M.index = e_index; _ };
+      _;
+    } str env =
   let str =
-    match quoted with
-    | Some s -> s ^ str ^ s
-    | None -> str
+    match style with
+    (* This is for strings that use `|`, `>`, or quotes.
+     *)
+    | `Literal
+    | `Folded
+    | `Double_quoted
+    | `Single_quoted ->
+        String.sub env.text index (e_index - index)
+    | __else__ -> str
   in
   (* their tokens are 0 indexed for line and column, AST_generic's are 1
    * indexed for line, 0 for column *)
@@ -199,16 +210,15 @@ let scalar (_tag, pos, value, style) env : G.expr * E.pos =
   *)
   let quoted =
     match style with
-    | `Double_quoted -> Some "\""
-    | `Single_quoted -> Some "'"
-    | __else__ -> None
+    | `Double_quoted
+    | `Single_quoted ->
+        true
+    | __else__ -> false
   in
-  if
-    AST_generic_.is_metavar_name value
-    && (not env.is_target) && Option.is_none quoted
+  if AST_generic_.is_metavar_name value && (not env.is_target) && not quoted
   then (G.N (mk_id value pos env) |> G.e, pos)
   else
-    let token = mk_tok ~quoted pos value env in
+    let token = mk_tok ~style pos value env in
     let expr =
       (match value with
       | "__sgrep_ellipses__" -> G.Ellipsis (Parse_info.fake_info token "...")
@@ -561,6 +571,7 @@ let parse_yaml_file ~is_target file str =
   let env =
     {
       file;
+      text = str;
       charpos_to_pos;
       parser;
       anchors = Hashtbl.create 1;
@@ -580,6 +591,7 @@ let any str =
   let env =
     {
       file;
+      text = str;
       charpos_to_pos = None;
       parser;
       anchors = Hashtbl.create 1;

--- a/semgrep-core/src/parsing/other/yaml_to_generic.ml
+++ b/semgrep-core/src/parsing/other/yaml_to_generic.ml
@@ -51,6 +51,11 @@ module PI = Parse_info
 type env = {
   (* when we parse a pattern, the filename is fake ("<pattern_file>") *)
   file : Common.filename;
+  (* This is the literal text of the program.
+     We will use this to help us find the proper content of a metavariable matching
+     a "folded" or "literal" style string.
+     Essentially, a string using "|" or ">".
+  *)
   text : string;
   (* function *)
   charpos_to_pos : (int -> int * int) option;


### PR DESCRIPTION
## What:
A little bit ago, I did #6724 for fixing the way that our YAML parser interacts with scalar strings. I did not deal with "literal" and "folded" style strings, however, which are those which use `|` and `>` respectively.

## Why:
See https://semgrep.dev/s/RNgK

We get unexpected behavior in the Playground, because the range of the match tends to be shorter than it actually should be. The printed out message (the contents of the metavariable) also tends to be wrong.

## How:
I changed the YAML parser so that we use the event end marker location information to extract the literal textual contents of the file at the relevant spots. The way that the YAML parser works now is that it returns the "ideal contents" of the string within YAML, meaning that it discounts things such as the beginning bar or chevron, and gets rid of some whitespace and newlines which are actually present within the literal text.

In the favor of adhering to the syntax, I opted to have the metavariable's text contain the literal contents of what it should match. This solution ends up being more general than what I did in #6724 

## Test plan:
`make test`

Worth noting that in the metavariables which captured a literal or folded string, they end up terminated with newlines (whereas the double-quoted and single-quoted metavariables do not). I could fix this, but it's unclear to me what the intended behavior should be.

Closes PA-2347
Closes #6731 



PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
