### PR TITLE
Add support for records and tuples to otarzan

### DIFF
--- a/semgrep-core/src/experiments/otarzan/lib/Print.ml
+++ b/semgrep-core/src/experiments/otarzan/lib/Print.ml
@@ -9,7 +9,14 @@ open Ast_ml
 (* Pretty-printing *)
 (*****************************************************************************)
 
-type out = Line of string | Inline of out list | Block of out list
+(*
+   Line: single line of text, indented as needed.
+   Block: Add extra indentation.
+   Inline: groups multiple items into one like Block but without introducing
+           extra indentation like Line. This is convenient to avoids calls to
+           List.flatten or (@) when combining pieces of generated code.
+*)
+type out = Line of string | Block of out list | Inline of out list
 
 (* Generic pretty-printer *)
 let print (xs : out list) =
@@ -40,29 +47,37 @@ let intersperse sep xs =
 
 let insert_blank_lines xs = intersperse (Line "") xs
 
-(* generate a string with a list of vars: " (v1, v2, v3, ...)"
- * and a function that can be called later with and idx to get the varname
- *)
-let vxxx_of_list xs =
-  let n_args = List.length xs in
-  let xs = Common.index_list_1 xs in
-  (* v1, v2, v3, ... *)
-  let var i = if n_args = 1 then "v" else sprintf "v%d" i in
-  let args =
-    match xs with
-    | [] -> ""
-    | [ _ ] -> " " ^ var 1
-    | _ ->
-        sprintf " (%s)"
-          (xs |> Common.map snd
-          |> Common.map (fun i -> sprintf "v%d" i)
-          |> String.concat ", ")
-  in
-  (args, n_args, xs, var)
+(* Associate a local variable name to each element of a list:
+    [x] -> [(x, "v")]
+    [foo; bar] -> [(foo, "v1"); (bar, "v2")]
+*)
+let arg_names_of_list xs =
+  match xs with
+  | [] -> []
+  | [ x ] -> [ (x, "v") ]
+  | xs -> List.mapi (fun i x -> (x, sprintf "v%i" (i + 1))) xs
+
+(* Create tuple pattern or expression:
+     "()"
+     "v"
+     "(v1, v2, v3)"
+*)
+let tuple_of_list ?(use_unit = true) ?(spaced = false) xs =
+  let vars = arg_names_of_list xs |> Common.map snd in
+  let space = if spaced then " " else "" in
+  match vars with
+  | [] -> if use_unit then space ^ "()" else ""
+  | [ var ] -> space ^ var
+  | _ -> sprintf "%s(%s)" space (String.concat ", " vars)
+
+let case_args_of_list xs = tuple_of_list ~use_unit:false ~spaced:true xs
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
+
+let func_for_str_name (conf : Conf.t) (name : string) : string =
+  conf.fun_prefix ^ name
 
 let func_for_name (conf : Conf.t) (name : name) : string =
   match name with
@@ -71,102 +86,206 @@ let func_for_name (conf : Conf.t) (name : name) : string =
       let prefix = qu |> Common.map str_of_ident |> String.concat "." in
       sprintf "%s.%s%s" prefix conf.fun_prefix (str_of_ident id)
 
-let rec func_for_type (conf : Conf.t) (typ : type_) : string =
+(*
+   Return the name of the function to call for a given type.
+   If the type doesn't have a name, we create a local definition and
+   return it. This function definition will have to be inserted just
+   before the function call.
+
+   Example for an anonymous tuple:
+
+    | Foo of (a * b)
+             ^^^^^^^
+   ->
+
+    | Foo v1 ->
+        let map_local (v1, v2) =
+          (map_a v1, map_b v2)
+        in
+        Foo (map_local v1)
+
+   In this case, func_for_type would have returned (def, "map_local")
+   where def is the definition of map_local.
+*)
+let rec func_for_type (conf : Conf.t) (typ : type_) : out list * string =
   match typ with
-  | TyName name -> func_for_name conf name
-  | TyVar _ -> "TODOTyVar"
+  | TyName name -> ([], func_for_name conf name)
+  | TyVar _ -> ([], "TODOTyVar")
   | TyAny _ -> error "TyAny not handled"
-  | TyFunction _ -> "TODOTyFunction"
+  | TyFunction _ -> ([], "TODOTyFunction")
   | TyApp ([ ty ], name) ->
       let s1 = func_for_name conf name in
-      let s2 = func_for_type conf ty in
-      sprintf "(%s %s)" s1 s2
-  | TyApp (_tys, _name) -> "TodoTyAppManyArgs"
+      let def, s2 = func_for_type conf ty in
+      (def, sprintf "(%s %s)" s1 s2)
+  | TyApp (_tys, _name) -> ([], "TodoTyAppManyArgs")
+  | TyTuple types ->
+      assert (List.length types >= 2);
+      let local_name = "tuple" in
+      let def =
+        gen_typedef conf true
+          (TyDecl
+             {
+               tname = (local_name, Parse_info.unsafe_sc);
+               tparams = [];
+               tbody = CoreType typ;
+             })
+      in
+      let local_def = [ Inline def; Line "in" ] in
+      (local_def, func_for_str_name conf local_name)
   (* should be handled in CoreType case in gen_typedef below *)
-  | TyTuple _tys -> "TodoTyTuple"
   | TyEllipsis _ -> error "TyEllipsis impossible"
-  | TyTodo ((s, _), _ty) -> sprintf "TODOTyTodo_%s" s
+  | TyTodo ((s, _), _ty) -> ([], sprintf "TODOTyTodo_%s" s)
 
-let gen_typedef (conf : Conf.t) is_first typedef =
+(*
+   Generate a top-level group of mutually-recursive function definitions
+   from a group of type definitions.
+   The syntax is such that appending "in" turns it into a local definition.
+
+     let rec map_foo env x =
+       ...
+     and map_bar env x =
+       ...
+*)
+and gen_typedef (conf : Conf.t) is_first typedef : out list =
   match typedef with
   | TyDecl { tname; tparams = _TODO; tbody } ->
       let name = str_of_ident tname in
-      let body =
+      let arg_pat, body =
         match tbody with
         | AbstractType -> error "AbstractType not handled"
         | AlgebraicType ctors ->
-            let cases =
-              ctors
-              |> Common.map (fun (id, xs) ->
-                     let args, n_args, xs, var = vxxx_of_list xs in
-                     let arg_handlers, construct =
-                       match conf.format with
-                       | Map ->
-                           let arg_handlers =
-                             xs
-                             |> Common.map (fun (typ, idx) ->
-                                    let call_str = func_for_type conf typ in
-                                    Line
-                                      (sprintf "let %s = %s env %s in" (var idx)
-                                         call_str (var idx)))
-                           in
-                           let construct = Line (sprintf "todo env%s" args) in
-                           (arg_handlers, construct)
-                       | Visit ->
-                           let is_last idx = idx = n_args in
-                           let arg_handlers =
-                             xs
-                             |> Common.map (fun (typ, idx) ->
-                                    let call_str = func_for_type conf typ in
-                                    Line
-                                      (sprintf "%s env %s%s" call_str (var idx)
-                                         (if is_last idx then "" else ";")))
-                           in
-                           let construct =
-                             match xs with
-                             | [] -> Line "()"
-                             | _ -> Inline []
-                           in
-                           (arg_handlers, construct)
-                       | Compare ->
-                           (* TODO *)
-                           ([], Inline [])
-                     in
-                     Inline
-                       [
-                         Line (sprintf "| %s%s ->" (str_of_ident id) args);
-                         Block [ Block [ Inline arg_handlers; construct ] ];
-                       ])
-            in
-            [ Line "match v with"; Inline cases ]
-        | RecordType _ -> [ Line "TODO: RecordType" ]
+            let cases = Common.map (gen_case conf) ctors in
+            ("v", [ Line "match v with"; Inline cases ])
+        | RecordType (_open, fields, _close) -> ("v", gen_record conf fields)
         | CoreType typ -> (
             match typ with
             | TyTuple tys ->
-                let args, _n_args, xs, var = vxxx_of_list tys in
-                [
-                  Line (sprintf "(fun env %s ->" args);
-                  Block
-                    ((xs
-                     |> Common.map (fun (typ, idx) ->
-                            let call_str = func_for_type conf typ in
-                            Line
-                              (sprintf "let %s = %s env %s in" (var idx)
-                                 call_str (var idx))))
-                    @ [ Line (sprintf "todo env%s" args) ]);
-                  Line ") env v";
-                ]
-            | _ -> [ Line (sprintf "%s env v" (func_for_type conf typ)) ])
+                let arg_pat = tuple_of_list tys in
+                (arg_pat, gen_tuple conf tys)
+            | _ ->
+                let def, func = func_for_type conf typ in
+                ("v", [ Inline def; Line (sprintf "%s env v" func) ]))
         | TdTodo _ -> error "TdTodo not handled"
       in
       [
         Line
-          (sprintf "%s %s%s env v ="
+          (sprintf "%s %s%s env %s ="
              (if is_first then "let rec" else "and")
-             conf.fun_prefix name);
+             conf.fun_prefix name arg_pat);
         Block body;
       ]
   | TyDeclTodo _ -> error "TyDeclTodo not handled"
+
+and gen_case conf (id, xs) =
+  let n_args = List.length xs in
+  let xs = arg_names_of_list xs in
+  let arg_handlers, construct =
+    match conf.format with
+    | Map ->
+        let arg_handlers =
+          xs
+          |> Common.map (fun (typ, var) ->
+                 let def, call_str = func_for_type conf typ in
+                 Inline
+                   [
+                     Inline def;
+                     Line (sprintf "let %s = %s env %s in" var call_str var);
+                   ])
+        in
+        let construct = Line (sprintf "todo env %s" (tuple_of_list xs)) in
+        (arg_handlers, construct)
+    | Visit ->
+        let is_last idx = idx = n_args - 1 in
+        let arg_handlers =
+          xs
+          |> List.mapi (fun i (typ, var) ->
+                 let def, call_str = func_for_type conf typ in
+                 Inline
+                   [
+                     Inline def;
+                     Line
+                       (sprintf "%s env %s%s" call_str var
+                          (if is_last i then "" else ";"));
+                   ])
+        in
+        let construct =
+          match xs with
+          | [] -> Line "()"
+          | _ -> Inline []
+        in
+        (arg_handlers, construct)
+    | Compare ->
+        (* TODO *)
+        ([], Inline [])
+  in
+  Inline
+    [
+      Line (sprintf "| %s%s ->" (str_of_ident id) (case_args_of_list xs));
+      Block [ Block [ Inline arg_handlers; construct ] ];
+    ]
+
+and gen_record conf fields =
+  let field_names =
+    fields |> Common.map (fun ((name, _), _, _) -> name) |> String.concat "; "
+  in
+  let result =
+    match conf.format with
+    | Map ->
+        [
+          Inline
+            (Common.map
+               (fun ((name, _), type_, _mut) ->
+                 let def, func = func_for_type conf type_ in
+                 Inline
+                   [
+                     Inline def;
+                     Line (sprintf "let %s = %s env %s in" name func name);
+                   ])
+               fields);
+          Line (sprintf "{%s}" field_names);
+        ]
+    | Visit ->
+        Common.map
+          (fun ((name, _), type_, _mut) ->
+            let def, func = func_for_type conf type_ in
+            Inline [ Inline def; Line (sprintf "%s env %s;" func name) ])
+          fields
+    | Compare ->
+        (* TODO *)
+        [ Line "(* TODO *)" ]
+  in
+  [ Line (sprintf "let {%s} = v in" field_names); Inline result ]
+
+and gen_tuple conf types =
+  let types = arg_names_of_list types in
+  let tuple = tuple_of_list types in
+  match conf.format with
+  | Map ->
+      [
+        Inline
+          (types
+          |> Common.map (fun (type_, var) ->
+                 let def, call_str = func_for_type conf type_ in
+                 Inline
+                   [
+                     Inline def;
+                     Line (sprintf "let %s = %s env %s in" var call_str var);
+                   ]));
+        Line (sprintf "todo env %s" tuple);
+      ]
+  | Visit ->
+      let len = List.length types in
+      types
+      |> List.mapi (fun i (type_, var) ->
+             let def, call_str = func_for_type conf type_ in
+             Inline
+               [
+                 Inline def;
+                 Line
+                   (sprintf "%s env %s%s" call_str var
+                      (if i < len - 1 then ";" else ""));
+               ])
+  | Compare -> [ Line "TODO" ]
 
 let gen_typedef_group conf typedefs =
   let is_first =

--- a/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
+++ b/semgrep-core/src/parsing/tree_sitter/Parse_ocaml_tree_sitter.ml
@@ -3040,9 +3040,10 @@ and map_tuple_type_ext (env : env) (x : CST.tuple_type_ext) : type_ list =
 
 and map_type_ (env : env) (x : CST.type_) : type_ =
   match x with
-  | `Tuple_type_ x ->
-      let xs = map_tuple_type_ env x in
-      TyTuple xs
+  | `Tuple_type_ x -> (
+      match map_tuple_type_ env x with
+      | [ type_ ] -> type_
+      | xs -> TyTuple xs)
   | `Func_type (v1, v2, v3) ->
       let v1 =
         match v1 with

--- a/semgrep-core/src/pfff/lang_ml/parsing/ast_ml.ml
+++ b/semgrep-core/src/pfff/lang_ml/parsing/ast_ml.ml
@@ -303,7 +303,7 @@ and type_def_kind =
   (* or type *)
   | AlgebraicType of constructor_decl list
   (* and type *)
-  | RecordType   of field_decl list bracket
+  | RecordType of field_decl list bracket
   | TdTodo of todo_category
 
 and constructor_decl = ident * constructor_decl_kind


### PR DESCRIPTION
We don't have tests yet as far as I can tell. We should set up a regression test. For now, the test plan is:

```
$ ~/semgrep/semgrep-core/bin/otarzan -f map ~/semgrep/semgrep-core/src/core/ast/AST_generic.ml | less
$ ~/semgrep/semgrep-core/bin/otarzan -f visit ~/semgrep/semgrep-core/src/core/ast/AST_generic.ml | less
```
and check that it looks good.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
