### PR TITLE
fix: Use GH API to get merge base instead of fetching

### DIFF
--- a/changelog.d/gha-mergebase.fixed
+++ b/changelog.d/gha-mergebase.fixed
@@ -1,0 +1,1 @@
+Use the GitHub REST API when possible to compute the merge base for `semgrep ci`, improving performance on shallow clones of large repositories.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -379,6 +379,7 @@ def ci(
                 skip_unknown_extensions=(not scan_unknown_extensions),
                 optimizations=optimizations,
                 baseline_commit=metadata.merge_base_ref,
+                baseline_commit_is_mergebase=True,
             )
     except SemgrepError as e:
         output_handler.handle_semgrep_errors([e])

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -302,6 +302,7 @@ def main(
     severity: Optional[Sequence[str]] = None,
     optimizations: str = "none",
     baseline_commit: Optional[str] = None,
+    baseline_commit_is_mergebase: bool = False,
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -380,7 +381,9 @@ def main(
     baseline_handler = None
     if baseline_commit:
         try:
-            baseline_handler = BaselineHandler(baseline_commit)
+            baseline_handler = BaselineHandler(
+                baseline_commit, is_mergebase=baseline_commit_is_mergebase
+            )
         # TODO better handling
         except Exception as e:
             raise SemgrepError(e)


### PR DESCRIPTION
As noted inline, fetching enough commits to compute the merge base can be very expensive on large repositories, and reduces or even eliminates the performance benefits that shallow clones provide. We can get around this by calling out to GitHub's rest API to get the merge base between two commits, rather than fetching enough to compute it locally.

Test plan:

```
docker build .
docker tag <hash> nmote/semgrep
docker push nmote/semgrep
```

Then, set up a test repo (https://github.com/nmote/gha-test/) with an action that runs `semgrep ci --config semgrep.yaml --debug --dry-run` using the `nmote/semgrep` image (this repo has to be private so that I can test the authentication portion, but I can add anyone who is interested).

Observe the following log line in the output of the GitHub Action, and observe that Semgrep runs as expected:

```
Got merge base using GitHub API: 73d928285096a2b2bec33e6d7d50cf3def74e8af
```

We could mock out the GH API and add a test for this, but the code here is actually quite simple, and most of what might break is how Semgrep interacts with external systems, which wouldn't be tested.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
