### PR TITLE
discussion: pattern-inside-taint and reviving taint patterns

### DIFF
--- a/semgrep-core/src/engine/Match_tainting_mode.ml
+++ b/semgrep-core/src/engine/Match_tainting_mode.ml
@@ -474,8 +474,10 @@ let pm_of_finding finding =
            Lazy.from_val
              (taint_trace_of_src_to_sink source tokens sink))
       in
+      let source_pm, _ = T.pm_of_trace source in
       let sink_pm, _ = T.pm_of_trace sink in
-      Some { sink_pm with env = merged_env; taint_trace }
+      Some { sink_pm with env = merged_env; taint_trace;
+                          range_loc = fst source_pm.range_loc, snd sink_pm.range_loc }
   | T.SrcToReturn _
   (* TODO: We might want to report functions that let input taint
    * go into a sink (?) *)

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-taint.java
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-taint.java
@@ -1,0 +1,19 @@
+class C {
+    public void f() {
+        Foo foo;
+        // ok: pattern-inside-taint (before taint)
+        foo.qux();
+        if(true) {
+            foo = provider.foo();
+            // ruleid: pattern-inside-taint
+            foo.qux();
+        }
+        // ok: pattern-inside-taint (different object)
+        baz.qux();
+        // ruleid: pattern-inside-taint
+        foo.qux();
+        foo.bar();
+        // ok: pattern-inside-taint (after taint)
+        foo.qux();
+    }
+}

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-taint.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-taint.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: pattern-inside-taint
+  message: matches a statement inside a control flow
+  languages: [java]
+  severity: WARNING
+  match:
+    and:
+    - $FOO.qux();
+    - inside:
+        taint:
+          sources:
+          - pattern: $FOO = $PROVIDER.foo();
+          sinks:
+          - pattern: $FOO.bar();

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-taint2.js
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-taint2.js
@@ -1,0 +1,25 @@
+// ok: pattern-inside-taint (before taint)
+foo.qux();
+if(true) {
+    foo = provider.foo();
+    // ruleid: pattern-inside-taint
+    foo.qux();
+}
+
+// ok: pattern-inside-taint (different object)
+baz.qux();
+// ruleid: pattern-inside-taint
+foo.qux();
+foo.bar();
+// ok: pattern-inside-taint (after taint)
+foo.qux();
+
+
+foo2 = provider.foo();
+// ok: pattern-inside-taint (different object)
+foo.qux();
+// ruleid: pattern-inside-taint
+foo2.qux();
+foo2.bar();
+// ok: pattern-inside-taint (after taint)
+foo2.qux();

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-taint2.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-taint2.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: pattern-inside-taint
+  message: matches a statement inside a control flow
+  languages: [javascript]
+  severity: WARNING
+  match:
+    and:
+    - $FOO.qux();
+    - inside:
+        taint:
+          sources:
+          - pattern: $FOO = $PROVIDER.foo();
+          sinks:
+          - pattern: $FOO.bar();

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-taint3.py
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-taint3.py
@@ -1,0 +1,24 @@
+# ok: pattern-inside-taint (before taint)
+foo.qux()
+if True:
+    foo = provider.foo()
+    # ruleid: pattern-inside-taint
+    foo.qux()
+
+# ok: pattern-inside-taint (different object)
+baz.qux()
+# ruleid: pattern-inside-taint
+foo.qux()
+foo.bar()
+# ok: pattern-inside-taint (after taint)
+foo.qux()
+
+
+foo2 = provider.foo()
+# ok: pattern-inside-taint (different object)
+foo.qux()
+# ruleid: pattern-inside-taint
+foo2.qux()
+foo2.bar()
+# ok: pattern-inside-taint (after taint)
+foo2.qux()

--- a/semgrep-core/tests/OTHER/rules/pattern-inside-taint3.yaml
+++ b/semgrep-core/tests/OTHER/rules/pattern-inside-taint3.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: test
+  message: matches a statement inside a control flow
+  languages: [python]
+  severity: WARNING
+  match:
+    and:
+    - $FOO.qux()
+    - inside:
+        taint:
+          sources:
+          - pattern: $FOO = $PROVIDER.foo()
+          sinks:
+          - pattern: $FOO.bar()


### PR DESCRIPTION
This is not a contribution yet, just a demo implementation of #3801 pattern inside a control flow, starting from the stale #5993.

Tests successfully in three languages, but it breaks many other tests, so it would need a flag (or a `where`?)

Instead of returning the range of the sink, it returns the range from the start of the source to the end of the sink.

I implemented pattern-inside-taint a year ago, but only found time now to catch up with all the exciting changes and hopefully contribute back.

Is there any interest in reviving taint patterns #5993? As soon as I saw the whiteboard in new pattern operators #5916, I realized that others had implemented this feature in a much better way than I had. 😉 