### PR TITLE
Loosen pin for attrs

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -115,7 +115,7 @@ install_requires = [
     # Flexibility is achieved by, in order of preference:
     # 1. x.0~= operator pinning to x major version
     # 2. >=x,<y operator pinning to multiple major versions
-    "attrs~=21.3",
+    "attrs>=21.3",
     "boltons~=21.0",
     "colorama~=0.4.0",
     "click~=8.1",


### PR DESCRIPTION
Fixes #6757

This allows for projects with versions of attrs > v21 to install semgrep alongside. 