### PR TITLE
revert!: Revert "fix(deep): `metavariable-pattern` matching error (#6700)"

### DIFF
--- a/changelog.d/pa-2263.fixed
+++ b/changelog.d/pa-2263.fixed
@@ -1,1 +1,0 @@
-Semgrep no longer crashes in certain cases when `metavariable-pattern/regex` are used on a metavariable referencing a variable which has been imported.

--- a/semgrep-core/src/matching/Generic_vs_generic.mli
+++ b/semgrep-core/src/matching/Generic_vs_generic.mli
@@ -13,12 +13,7 @@ val m_attribute : AST_generic.attribute Matching_generic.matcher
 val m_partial : AST_generic.partial Matching_generic.matcher
 val m_field : AST_generic.field Matching_generic.matcher
 val m_fields : AST_generic.field list Matching_generic.matcher
-
-(* `is_resolved` is for checking if this name we are matching in the target
-   is resulting from a resolved or imported name, which may consist of tokens
-   that are not contiguous in the target program.
-*)
-val m_name : ?is_resolved:bool -> AST_generic.name Matching_generic.matcher
+val m_name : AST_generic.name Matching_generic.matcher
 
 (* used only for unit testing *)
 val m_any : AST_generic.any Matching_generic.matcher


### PR DESCRIPTION
This reverts commit e38c1eb95e3d965460b17213f12506bd70bdfe8c.

I was too hasty in merging it, and the PR I had to `semgrep-proprietary` verifying that the tests still passed turned out to be for an older version of #6700. #6700 is best lumped in with #6749.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
