### PR TITLE
Update semgrep.yml to default Semgrep CI config

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,9 +1,10 @@
-# This workflow dogfoods Semgrep Code and Supply Chain by running
-# `semgrep ci` on our own Semgrep repo.
+# This workflow dogfoods Semgrep Code and Supply Chain.
 
-name: Semgrep
+name: semgrep
 on:
-  pull_request: {}
+  # Run Semgrep on contributor PRs (from outside forks) while preventing
+  # execution of unsafe code from the head of the pull request.
+  pull_request_target: {}
   push:
     branches:
       - develop
@@ -14,7 +15,7 @@ on:
     - cron: "50 15 * * *"
 jobs:
   semgrep:
-    name: Scan
+    name: semgrep ci
     runs-on: ubuntu-20.04
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,8 +2,10 @@
 
 name: semgrep
 on:
-  # Run Semgrep on contributor PRs (from outside forks) while preventing
-  # execution of unsafe code from the head of the pull request.
+  # This workflow runs on 'pull_request_target' so that PRs from forks are able
+  # to run an action that uses the SEMGREP_APP_TOKEN secret
+  # Note that any modification of this file in a PR does not reflect on said PR
+  # Changes must be merged to develop first
   pull_request_target: {}
   push:
     branches:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,25 +1,26 @@
-# The goal of this workflow is to dogfood Semgrep and Semgrep-app by
-# running returntocorp/semgrep-action@v1 on our own semgrep repo.
+# This workflow dogfoods Semgrep Code and Supply Chain by running
+# `semgrep ci` on our own Semgrep repo.
 
-name: semgrep
-
+name: Semgrep
 on:
-  workflow_dispatch:
-  # This workflow runs on 'pull_request_target' so that PRs from forks are able
-  # to run an action that uses the SEMGREP_APP_TOKEN secret
-  # Note that any modification of this file in a PR does not reflect on said PR
-  # Changes must be merged to develop first
-  pull_request_target:
-
+  pull_request: {}
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/workflows/semgrep.yml
+  schedule:
+    # random HH:MM to avoid a load spike on GitHub Actions at 00:00
+    - cron: '50 15 * * *'
 jobs:
-  semgrep-run-r2c-config:
-    name: semgrep with r2c registry
-    runs-on: ubuntu-latest
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-20.04
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    container:
+      image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - uses: returntocorp/semgrep-action@v1
-        with:
-          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: "1"
+      - run: semgrep ci

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,7 +11,7 @@ on:
       - .github/workflows/semgrep.yml
   schedule:
     # random HH:MM to avoid a load spike on GitHub Actions at 00:00
-    - cron: '50 15 * * *'
+    - cron: "50 15 * * *"
 jobs:
   semgrep:
     name: Scan


### PR DESCRIPTION
This PR updates `semgrep.yml` to use the default Semgrep CI configuration. Most notably, it departs from the prior config by:

1. Using `semgrep ci` rather than `semgrep-action`
2. Running a daily scheduled scan of `develop` (for both Code and Supply Chain)

This configuration departs from our default by using `pull_request_target`, which was already used in this workflow file. This configuration merits further discussion.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Change has no security implications (otherwise, ping security team)
- [ ] ~Tests included or PR comment includes a reproducible test plan~
- [ ] ~Documentation is up-to-date~
- [ ] ~A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change~