### PR TITLE
test(java): Add additional cases to java_private_prop test

### DIFF
--- a/semgrep-core/tests/rules/java_private_prop.java
+++ b/semgrep-core/tests/rules/java_private_prop.java
@@ -17,4 +17,18 @@ public class Class {
     z = 3;
     return z; 
   }
+
+  public void foo1() {
+    // ruleid: java-private-prop
+    return this.x;
+  }
+
+  public void bar1() {
+    return this.y;
+  }
+
+  public void qux1() {
+    this.z = 3;
+    return this.z;
+  }
 }


### PR DESCRIPTION
This ensures that Semgrep treats properties referenced through `this` the same as properties referenced directly. Currently, there is a discrepancy between these in DeepSemgrep which we should address.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
