### PR TITLE
chore: Fix the help text for when deepsemgrep crashes

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -968,7 +968,7 @@ class CoreRunner:
 DeepSemgrep crashed during execution (unknown reason).
 This can sometimes happen because either DeepSemgrep or Semgrep is out of date.
 
-Try updating your version of DeepSemgrep (`semgrep --install-deep-semgrep`) or your version of Semgrep (`pip install semgrep/brew install semgrep`).
+Try updating your version of DeepSemgrep (`semgrep install-deep-semgrep`) or your version of Semgrep (`pip install semgrep/brew install semgrep`).
 If both are up-to-date and the crash persists, please contact support to report an issue!
 
 Exception raised: `{e}`


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
