### PR TITLE
feat!: unique names

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -308,7 +308,6 @@ and resolved_name_kind =
    * canonical_name, but we also want to match the pattern `foo.bar` so we will
    * store ['foo', 'bar'] as an alternate name.
    * *)
-
   | GlobalName of canonical_name * alternate_name list
 
 (* The enclosed token is not relevant for matching purposes.
@@ -1986,13 +1985,20 @@ let basic_id_info ?(hidden = false) resolved =
 
 (* TODO: move AST_generic_helpers.name_of_id and ids here *)
 
-let canonical_append {unqualified; _} {unqualified = unqualified2; tok} =
-  { unqualified = unqualified @ unqualified2; tok}
+let canonical_append { unqualified; _ } { unqualified = unqualified2; tok } =
+  { unqualified = unqualified @ unqualified2; tok }
 
-let dotted_to_canonical xs = 
-  (* TODO: Change if used on a function name which needs to be disambiguated *)
+let dotted_to_canonical xs =
+  (* WARNING: Do not use this function on a dotted which must be referred to uniquely! *)
   { unqualified = Common.map fst xs; tok = None }
-let canonical_to_dotted tid { unqualified = xs; _ } = xs |> Common.map (fun s -> (s, tid))
+
+(* Here, we ignore the enclosed token.
+   This token is useful for uniqueness purposes, but it is not supposed to be used for
+   matching.
+*)
+let canonical_to_dotted tid { unqualified = xs; _ } =
+  xs |> Common.map (fun s -> (s, tid))
+
 let alternate_name_to_dotted tid xs = xs |> Common.map (fun s -> (s, tid))
 
 (* ------------------------------------------------------------------------- *)

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1985,6 +1985,18 @@ let basic_id_info ?(hidden = false) resolved =
 
 (* TODO: move AST_generic_helpers.name_of_id and ids here *)
 
+(* `canonical_append` is needed in one spot in the code, but it helps in that we can
+   just look here if we ever need to change something about the way that we deal with
+   canonical names.
+   Right now, we just throw away tokens, but if this is ever needed in the future,
+   we can easily change that.
+
+   I don't believe we should need the tokens right now in the canonical names, however,
+   as our default behavior for the time being will be to just use the `unqualified`
+   parts of the canonical names in the OSS engine.
+
+   The token will be used and passed back by the Pro engine, however.
+*)
 let canonical_append { unqualified; _ } { unqualified = unqualified2; tok } =
   { unqualified = unqualified @ unqualified2; tok }
 

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -382,7 +382,7 @@ and id_info = {
    * a typed entity, which can be interpreted as a TypedMetavar in semgrep.
    * alt: have an explicity type_ field in entity.
    *)
-  id_type : type_ option ref; [@equal fun _a _b -> true]
+  id_type : type_ option ref;
   (* type checker (typing) *)
   (* sgrep: this is for sgrep constant propagation hack.
    * todo? associate only with Id?

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -96,8 +96,8 @@ let rec map_resolved_name (v1, v2) =
   let v2 = AST_generic.SId.to_int v2 in
   (v1, v2)
 
-and map_canonical_name v1 =
-  map_of_list (fun x -> (map_of_string x, map_tok fk)) v1
+and map_canonical_name {unqualified; _} =
+  map_of_list (fun x -> (map_of_string x, map_tok fk)) unqualified
 
 and map_resolved_name_kind = function
   | LocalVar -> `Local

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -96,7 +96,7 @@ let rec map_resolved_name (v1, v2) =
   let v2 = AST_generic.SId.to_int v2 in
   (v1, v2)
 
-and map_canonical_name {unqualified; _} =
+and map_canonical_name { unqualified; _ } =
   map_of_list (fun x -> (map_of_string x, map_tok fk)) unqualified
 
 and map_resolved_name_kind = function

--- a/libs/ast_generic/Map_AST.ml
+++ b/libs/ast_generic/Map_AST.ml
@@ -109,12 +109,11 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let v1 = map_resolved_name_kind v1 in
     let v2 = map_sid v2 in
     (v1, v2)
-  and map_canonical_name {unqualified; tok} = 
+  and map_canonical_name { unqualified; tok } =
     let v1 = map_of_list map_of_string unqualified in
     let v2 = map_of_option map_tok tok in
-    {unqualified = v1; tok = v2}
-  and map_alternate_name v1 =
-    map_of_list map_of_string v1
+    { unqualified = v1; tok = v2 }
+  and map_alternate_name v1 = map_of_list map_of_string v1
   and map_resolved_name_kind = function
     | LocalVar -> LocalVar
     | Parameter -> Parameter

--- a/libs/ast_generic/Map_AST.ml
+++ b/libs/ast_generic/Map_AST.ml
@@ -109,7 +109,12 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let v1 = map_resolved_name_kind v1 in
     let v2 = map_sid v2 in
     (v1, v2)
-  and map_canonical_name v1 = map_of_list map_of_string v1
+  and map_canonical_name {unqualified; tok} = 
+    let v1 = map_of_list map_of_string unqualified in
+    let v2 = map_of_option map_tok tok in
+    {unqualified = v1; tok = v2}
+  and map_alternate_name v1 =
+    map_of_list map_of_string v1
   and map_resolved_name_kind = function
     | LocalVar -> LocalVar
     | Parameter -> Parameter
@@ -126,7 +131,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | TypeName -> TypeName
     | GlobalName (v1, v2) ->
         let v1 = map_canonical_name v1 in
-        let v2 = map_of_list map_canonical_name v2 in
+        let v2 = map_of_list map_alternate_name v2 in
         GlobalName (v1, v2)
   and map_name_info
       {

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -44,7 +44,7 @@ let rec vof_resolved_name (v1, v2) =
   let v2 = OCaml.vof_int (SId.to_int v2) in
   OCaml.VTuple [ v1; v2 ]
 
-and vof_canonical_name {unqualified; tok} = 
+and vof_canonical_name { unqualified; tok } =
   let bnds = [] in
   let arg = OCaml.vof_option (fun x -> vof_tok x) tok in
   let bnd = ("tok", arg) in
@@ -54,8 +54,7 @@ and vof_canonical_name {unqualified; tok} =
   let bnds = bnd :: bnds in
   OCaml.VDict bnds
 
-and vof_alternate_name v1 =
-  OCaml.vof_list OCaml.vof_string v1
+and vof_alternate_name v1 = OCaml.vof_list OCaml.vof_string v1
 
 and vof_resolved_name_kind = function
   | LocalVar -> OCaml.VSum ("LocalVar", [])

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -44,7 +44,18 @@ let rec vof_resolved_name (v1, v2) =
   let v2 = OCaml.vof_int (SId.to_int v2) in
   OCaml.VTuple [ v1; v2 ]
 
-and vof_canonical_name v1 = OCaml.vof_list OCaml.vof_string v1
+and vof_canonical_name {unqualified; tok} = 
+  let bnds = [] in
+  let arg = OCaml.vof_option (fun x -> vof_tok x) tok in
+  let bnd = ("tok", arg) in
+  let bnds = bnd :: bnds in
+  let arg = OCaml.vof_list OCaml.vof_string unqualified in
+  let bnd = ("unqualified", arg) in
+  let bnds = bnd :: bnds in
+  OCaml.VDict bnds
+
+and vof_alternate_name v1 =
+  OCaml.vof_list OCaml.vof_string v1
 
 and vof_resolved_name_kind = function
   | LocalVar -> OCaml.VSum ("LocalVar", [])
@@ -62,7 +73,7 @@ and vof_resolved_name_kind = function
   | TypeName -> OCaml.VSum ("TypeName", [])
   | GlobalName (v1, v2) ->
       let v1 = vof_canonical_name v1 in
-      let v2 = OCaml.vof_list vof_canonical_name v2 in
+      let v2 = OCaml.vof_list vof_alternate_name v2 in
       OCaml.VSum ("GlobalName", [ v1; v2 ])
 
 let rec vof_qualifier = function

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -172,7 +172,11 @@ let (mk_visitor :
   and v_resolved_name (v1, v2) =
     v_resolved_name_kind v1;
     v_sid v2
-  and v_canonical_name v1 = v_list v_string v1
+  and v_canonical_name {unqualified; tok} = 
+    v_list v_string unqualified;
+    v_option v_tok tok
+  and v_alternate_name v1 = 
+    v_list v_string v1 
   and v_resolved_name_kind = function
     | LocalVar -> ()
     | Parameter -> ()
@@ -189,7 +193,7 @@ let (mk_visitor :
     | TypeName -> ()
     | GlobalName (v1, v2) ->
         let v1 = v_canonical_name v1 in
-        let v2 = v_list v_canonical_name v2 in
+        let v2 = v_list v_alternate_name v2 in
         ()
   and v_name_info
       { name_middle = v4; name_top = v3; name_last = v1; name_info = v2 } =

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -172,11 +172,10 @@ let (mk_visitor :
   and v_resolved_name (v1, v2) =
     v_resolved_name_kind v1;
     v_sid v2
-  and v_canonical_name {unqualified; tok} = 
+  and v_canonical_name { unqualified; tok } =
     v_list v_string unqualified;
     v_option v_tok tok
-  and v_alternate_name v1 = 
-    v_list v_string v1 
+  and v_alternate_name v1 = v_list v_string v1
   and v_resolved_name_kind = function
     | LocalVar -> ()
     | Parameter -> ()

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -56,7 +56,7 @@ let warning _tok s =
 let str_of_name name = spf "%s:%s" (fst name.ident) (G.SId.show name.sid)
 
 (* TODO: depends on the language? sometimes '.', sometimes '->' or '#' *)
-let str_of_canonical_name { G.unqualified; _ } = String.concat "." unqualified 
+let str_of_canonical_name { G.unqualified; _ } = String.concat "." unqualified
 
 (*****************************************************************************)
 (* Constness *)

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -56,7 +56,7 @@ let warning _tok s =
 let str_of_name name = spf "%s:%s" (fst name.ident) (G.SId.show name.sid)
 
 (* TODO: depends on the language? sometimes '.', sometimes '->' or '#' *)
-let str_of_canonical_name name = String.concat "." name
+let str_of_canonical_name { G.unqualified; _ } = String.concat "." unqualified 
 
 (*****************************************************************************)
 (* Constness *)

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -478,7 +478,7 @@ let rec m_name a b =
       | G.Id ((str, _tok), _info) when MV.is_metavar_name str -> fail ()
       | _ ->
           (* Try matching against parent classes *)
-          try_parents dotted)
+          try_parents unique)
   | G.Id (a1, a2), B.Id (b1, b2) ->
       (* this will handle metavariables in Id *)
       m_ident_and_id_info (a1, a2) (b1, b2)
@@ -3107,9 +3107,16 @@ and m_class_parent a b =
   | (a1, None), ({ t = B.TyN (B.Id (id, { id_resolved; _ })); _ }, None) ->
       let xs =
         match !id_resolved with
+<<<<<<< HEAD
         | Some (B.ImportedEntity canonical, _sid) ->
             G.canonical_to_dotted (snd id) canonical
         | _ -> [ id ]
+=======
+        | Some (B.ImportedEntity xs, _sid) ->
+            { AST_generic.dotted = xs; tok = None }
+        | Some (B.ResolvedName (unique, _), _sid) -> unique
+        | _ -> { dotted = [ id ]; tok = None }
+>>>>>>> 7d13ab974 (change possible parents hook, prefer unique names to dotted)
       in
       (* deep: *)
       let candidates =

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -433,7 +433,7 @@ let rec m_name a b =
     | B.GlobalName (_, alternate_names) ->
         List.fold_left
           (fun acc alternate_name ->
-            let dotted = G.canonical_to_dotted tidb alternate_name in
+            let dotted = G.alternate_name_to_dotted tidb alternate_name in
             acc >||> m_name a (H.name_of_ids dotted))
           (fail ()) alternate_names
     | _ -> fail ()

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -478,7 +478,7 @@ let rec m_name a b =
       | G.Id ((str, _tok), _info) when MV.is_metavar_name str -> fail ()
       | _ ->
           (* Try matching against parent classes *)
-          try_parents unique)
+          try_parents canonical)
   | G.Id (a1, a2), B.Id (b1, b2) ->
       (* this will handle metavariables in Id *)
       m_ident_and_id_info (a1, a2) (b1, b2)
@@ -505,7 +505,7 @@ let rec m_name a b =
          } as nameinfo) ) ->
       (* TODO? use all the tokens in b1? not just idb? *)
       let dotted = G.canonical_to_dotted (snd idb) canonical in
-      try_parents dotted
+      try_parents canonical
       >||> try_alternate_names idb resolved
       (* try without resolving anything *)
       >||> m_name a
@@ -560,8 +560,7 @@ let rec m_name a b =
            _;
          } as b1) ) -> (
       (* TODO? use all the tokens in the name? not just idb? *)
-      let dotted = G.canonical_to_dotted (snd idb) canonical in
-      try_parents dotted
+      try_parents canonical
       >||> try_alternate_names idb resolved
       >||>
       match a with
@@ -3105,24 +3104,18 @@ and m_class_parent a b =
   match (a, b) with
   (* less: this could be generalized, but let's go simple first *)
   | (a1, None), ({ t = B.TyN (B.Id (id, { id_resolved; _ })); _ }, None) ->
-      let xs =
+      let canonical =
         match !id_resolved with
-<<<<<<< HEAD
-        | Some (B.ImportedEntity canonical, _sid) ->
-            G.canonical_to_dotted (snd id) canonical
-        | _ -> [ id ]
-=======
-        | Some (B.ImportedEntity xs, _sid) ->
-            { AST_generic.dotted = xs; tok = None }
-        | Some (B.ResolvedName (unique, _), _sid) -> unique
-        | _ -> { dotted = [ id ]; tok = None }
->>>>>>> 7d13ab974 (change possible parents hook, prefer unique names to dotted)
+        | Some (B.ImportedEntity canonical, _sid)
+        | Some (B.GlobalName (canonical, _), _sid) ->
+            canonical
+        | _ -> { unqualified = [ fst id ]; tok = None }
       in
       (* deep: *)
       let candidates =
         match !hook_find_possible_parents with
         | None -> []
-        | Some f -> f xs
+        | Some f -> f canonical
       in
       (* less: use a fold *)
       let rec aux xs =

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -413,11 +413,15 @@ let m_regexp_options a_opt b_opt =
  * TODO: remove MV.Id and use always MV.N?
  *)
 let rec m_name a b =
-  let try_parents dotted =
+  (* `try_parents` should take in the canonical name of some identifier.
+     This is because we may want to find the parents of a specific class,
+     which should be disambiguated.
+  *)
+  let try_parents canonical =
     let parents =
       match !hook_find_possible_parents with
       | None -> []
-      | Some f -> f dotted
+      | Some f -> f canonical
     in
     (* less: use a fold *)
     let rec aux xs =

--- a/src/matching/Generic_vs_generic.mli
+++ b/src/matching/Generic_vs_generic.mli
@@ -20,4 +20,4 @@ val m_raw_tree : AST_generic.raw_tree Matching_generic.matcher
 val m_any : AST_generic.any Matching_generic.matcher
 
 val hook_find_possible_parents :
-  (AST_generic.dotted_ident -> AST_generic.name list) option ref
+  (AST_generic.unique_name -> AST_generic.name list) option ref

--- a/src/matching/Generic_vs_generic.mli
+++ b/src/matching/Generic_vs_generic.mli
@@ -20,4 +20,4 @@ val m_raw_tree : AST_generic.raw_tree Matching_generic.matcher
 val m_any : AST_generic.any Matching_generic.matcher
 
 val hook_find_possible_parents :
-  (AST_generic.unique_name -> AST_generic.name list) option ref
+  (AST_generic.canonical_name -> AST_generic.name list) option ref

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -848,7 +848,7 @@ let resolve lang prog =
                       let sid = SId.unsafe_default in
                       let rest_of_middle = Common.map fst rest_of_middle in
                       let canonical =
-                        xs @ dotted_to_canonical (rest_of_middle @ [ id ])
+                        canonical_append xs (dotted_to_canonical (rest_of_middle @ [ id ]))
                       in
                       let resolved =
                         untyped_ent (ImportedEntity canonical, sid)

--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -848,7 +848,8 @@ let resolve lang prog =
                       let sid = SId.unsafe_default in
                       let rest_of_middle = Common.map fst rest_of_middle in
                       let canonical =
-                        canonical_append xs (dotted_to_canonical (rest_of_middle @ [ id ]))
+                        canonical_append xs
+                          (dotted_to_canonical (rest_of_middle @ [ id ]))
                       in
                       let resolved =
                         untyped_ent (ImportedEntity canonical, sid)

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -732,9 +732,9 @@ and id env (s, { id_resolved; _ }) : string =
   | _ -> s
 
 (* TODO: factorize with dotted_access *)
-and canonical_name _env {unqualified; _} = 
-  let rec pp_unqualified unqualified = 
-    match unqualified with 
+and canonical_name _env { unqualified; _ } =
+  let rec pp_unqualified unqualified =
+    match unqualified with
     | [] -> ""
     | [ x ] -> x
     | x :: y :: xs -> x ^ "." ^ pp_unqualified (y :: xs)

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -732,10 +732,14 @@ and id env (s, { id_resolved; _ }) : string =
   | _ -> s
 
 (* TODO: factorize with dotted_access *)
-and canonical_name env = function
-  | [] -> ""
-  | [ x ] -> x
-  | x :: y :: xs -> x ^ "." ^ canonical_name env (y :: xs)
+and canonical_name _env {unqualified; _} = 
+  let rec pp_unqualified unqualified = 
+    match unqualified with 
+    | [] -> ""
+    | [ x ] -> x
+    | x :: y :: xs -> x ^ "." ^ pp_unqualified (y :: xs)
+  in
+  pp_unqualified unqualified
 
 (* TODO: look at name_top too *)
 and id_qualified env { name_last = id, _toptTODO; name_middle; name_top; _ } =


### PR DESCRIPTION
## What:
This PR adds in a new type, `unique_name`, which is meant to uniquely refer to a given name in a program. It is a `dotted_ident` and `tok`. It also changes `ResolvedName` to instead use this new type.

Motivation and details of this PR are in the accompanying PR, https://github.com/returntocorp/semgrep-proprietary/pull/435

## Test plan:
The actual changes which make use of this will be in `DeepSemgrep`, so I cannot add any substantial tests here. 

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
