### PR TITLE
Jupyter Notebook support in "extract mode"

### DIFF
--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -209,7 +209,7 @@ type extract_spec = {
   dst_lang : Xlang.t;
   (* e.g., $...BODY, $CMD *)
   extract : MV.mvar;
-  json : bool;
+  transform : extract_transform;
 }
 
 (* Method to combine extracted ranges within a file:
@@ -217,6 +217,12 @@ type extract_spec = {
     - concatentate them together
 *)
 and extract_reduction = Separate | Concat [@@deriving show]
+
+(* Method to transform extracted content:
+    - either treat them as a raw string; or
+    - transform JSON array into a raw string
+*)
+and extract_transform = Unquote | ConcatJsonArray [@@deriving show]
 
 (*****************************************************************************)
 (* The rule *)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -209,6 +209,7 @@ type extract_spec = {
   dst_lang : Xlang.t;
   (* e.g., $...BODY, $CMD *)
   extract : MV.mvar;
+  json: bool;
 }
 
 (* Method to combine extracted ranges within a file:

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -222,7 +222,8 @@ and extract_reduction = Separate | Concat [@@deriving show]
     - either treat them as a raw string; or
     - transform JSON array into a raw string
 *)
-and extract_transform = Unquote | ConcatJsonArray [@@deriving show]
+and extract_transform = NoTransform | Unquote | ConcatJsonArray
+[@@deriving show]
 
 (*****************************************************************************)
 (* The rule *)

--- a/semgrep-core/src/core/Rule.ml
+++ b/semgrep-core/src/core/Rule.ml
@@ -209,7 +209,7 @@ type extract_spec = {
   dst_lang : Xlang.t;
   (* e.g., $...BODY, $CMD *)
   extract : MV.mvar;
-  json: bool;
+  json : bool;
 }
 
 (* Method to combine extracted ranges within a file:

--- a/semgrep-core/src/engine/Match_extract_mode.ml
+++ b/semgrep-core/src/engine/Match_extract_mode.ml
@@ -147,7 +147,7 @@ let extract_code_from_json json =
   Yojson.Basic.from_string json'
   |> Yojson.Basic.Util.member "semgrep_fake_payload"
   |> Yojson.Basic.Util.to_list
-  |> List.map (fun x -> x |> Yojson.Basic.Util.to_string)
+  |> Common.map (fun x -> x |> Yojson.Basic.Util.to_string)
   |> String.concat "\n"
 
 (*****************************************************************************)
@@ -308,8 +308,12 @@ let extract_and_concat erule_table xtarget rule_ids matches =
                       seek_in chan start_pos;
                       really_input_string chan extract_size)
                 in
-                let contents = (let (`Extract { Rule.json; _ }) = r.Rule.mode in
-                  if json then extract_code_from_json contents_raw else contents_raw) in
+                (* Convert from JSON to plaintext, if required *)
+                let contents =
+                  let (`Extract { Rule.json; _ }) = r.Rule.mode in
+                  if json then extract_code_from_json contents_raw
+                  else contents_raw
+                in
                 logger#trace
                   "Extract rule %s extracted the following from %s at bytes \
                    %d-%d\n\
@@ -403,8 +407,12 @@ let extract_as_separate erule_table xtarget rule_ids matches =
                    seek_in chan start_extract_pos;
                    really_input_string chan extract_size)
              in
-             let contents = (let (`Extract { Rule.json; _ }) = erule.mode in
-              if json then extract_code_from_json contents_raw else contents_raw) in
+             (* Convert from JSON to plaintext, if required *)
+             let contents =
+               let (`Extract { Rule.json; _ }) = erule.mode in
+               if json then extract_code_from_json contents_raw
+               else contents_raw
+             in
              logger#trace
                "Extract rule %s extracted the following from %s at bytes %d-%d\n\
                 %s"

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1220,12 +1220,15 @@ let parse_mode env mode_opt (rule_dict : dict) : R.mode =
       in
       (* TODO: determine fmt---string with interpolated metavars? *)
       let extract = take rule_dict env parse_string "extract" in
+      let json = take_opt rule_dict env parse_bool "json"
+        |> Option.value ~default:false
+      in
       let reduce =
         take_opt rule_dict env parse_string_wrap "reduce"
         |> Option.map (parse_extract_reduction ~id:env.id)
         |> Option.value ~default:R.Separate
       in
-      `Extract { formula; dst_lang; extract; reduce }
+      `Extract { formula; dst_lang; extract; reduce; json }
   | Some key ->
       error_at_key env key
         (spf

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1163,6 +1163,7 @@ let parse_extract_reduction ~id (s, t) =
 
 let parse_extract_transform ~id (s, t) =
   match s with
+  | "no_transform" -> R.NoTransform
   | "unquote_string" -> R.Unquote
   | "concat_json_string_array" -> R.ConcatJsonArray
   | s ->

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -1220,8 +1220,8 @@ let parse_mode env mode_opt (rule_dict : dict) : R.mode =
       in
       (* TODO: determine fmt---string with interpolated metavars? *)
       let extract = take rule_dict env parse_string "extract" in
-      let json = take_opt rule_dict env parse_bool "json"
-        |> Option.value ~default:false
+      let json =
+        take_opt rule_dict env parse_bool "json" |> Option.value ~default:false
       in
       let reduce =
         take_opt rule_dict env parse_string_wrap "reduce"

--- a/semgrep-core/tests/extract/python_jupyter.ipynb
+++ b/semgrep-core/tests/extract/python_jupyter.ipynb
@@ -1,0 +1,63 @@
+{
+    "cells": [
+     {
+      "cell_type": "markdown",
+      "id": "68ac0197",
+      "metadata": {},
+      "source": [
+       "This is an example"
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "6cb7c3d3",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "import pickle"
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "28ed696c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "data = [\"This\", \"is\", \"an\", \"example\"] \n",
+       "with open(\"test.pkl\", 'wb') as f:\n",
+       "    pickle.dump(data, f)"
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "68eb1af3",
+      "metadata": {},
+      "outputs": [],
+      "source": []
+     }
+    ],
+    "metadata": {
+     "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+     },
+     "language_info": {
+      "codemirror_mode": {
+       "name": "ipython",
+       "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.6"
+     }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+   }

--- a/semgrep-core/tests/extract/python_jupyter.yaml
+++ b/semgrep-core/tests/extract/python_jupyter.yaml
@@ -10,5 +10,5 @@ rules:
         "source": $CODE
       }
     extract: $CODE
-    json: true
+    transform: concat_json_string_array
     dest-language: python

--- a/semgrep-core/tests/extract/python_jupyter.yaml
+++ b/semgrep-core/tests/extract/python_jupyter.yaml
@@ -1,0 +1,14 @@
+rules:
+  - id: extract-jupyter-to-python
+    mode: extract
+    languages:
+    - json
+    pattern: |
+      {
+        "cell_type": "code",
+        ...,
+        "source": $CODE
+      }
+    extract: $CODE
+    json: true
+    dest-language: python


### PR DESCRIPTION
This pull request creates a "json" flag in the "extract mode" experiment feature. This new flag allows to decode the extracted content as a JSON array and, as a result, it can be used to detect python vulnerabilities in Jupyter Notebook files.

This is part of a pull request modifying several repositories:
- https://github.com/returntocorp/semgrep/pull/6797
- https://github.com/returntocorp/semgrep-langs/pull/24
- https://github.com/returntocorp/semgrep-interfaces/pull/46
- https://github.com/returntocorp/semgrep-docs/pull/843

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
