### PR TITLE
feat(syntax): upgrade `interfaces`, add `all` and `any`

### DIFF
--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error-in-color.txt
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error-in-color.txt
@@ -6,6 +6,6 @@
 [94m[22m[24m5 | [0m    languages: [python]
 [94m[22m[24m6 | [0m    severity: WARNING
 
-[31m[22m[24mOne of these properties is missing: 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'r2c-internal-project-depends-on'[0m
+[31m[22m[24mOne of these properties is missing: 'match', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'r2c-internal-project-depends-on'[0m
 
 [31m[41m[22m[24m[[0m[38;5;231m[41m[1m[24mERROR[0m[31m[41m[22m[24m][0m Ran with --strict and got 1 error while loading configs

--- a/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
+++ b/cli/tests/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/bad8/error.json
@@ -3,7 +3,7 @@
     {
       "code": 4,
       "level": "error",
-      "long_msg": "One of these properties is missing: 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'r2c-internal-project-depends-on'",
+      "long_msg": "One of these properties is missing: 'match', 'pattern', 'pattern-either', 'pattern-regex', 'patterns', 'r2c-internal-project-depends-on'",
       "short_msg": "Invalid rule schema",
       "spans": [
         {

--- a/semgrep-core/src/metachecking/Translate_rule.ml
+++ b/semgrep-core/src/metachecking/Translate_rule.ml
@@ -77,7 +77,7 @@ and translate_formula f : [> `O of (string * Yaml.value) list ] =
   | Inside (_, f) -> `O [ ("inside", (translate_formula f :> Yaml.value)) ]
   | And (_, { conjuncts; focus; conditions; _ }) ->
       `O
-        (("and", `A (Common.map translate_formula conjuncts :> Yaml.value list))
+        (("all", `A (Common.map translate_formula conjuncts :> Yaml.value list))
         ::
         (if focus = [] && conditions = [] then []
         else
@@ -98,7 +98,7 @@ and translate_formula f : [> `O of (string * Yaml.value) list ] =
                     focus) );
           ]))
   | Or (_, fs) ->
-      `O [ ("or", `A (Common.map translate_formula fs :> Yaml.value list)) ]
+      `O [ ("any", `A (Common.map translate_formula fs :> Yaml.value list)) ]
   | Not (_, f) -> `O [ ("not", (translate_formula f :> Yaml.value)) ]
 
 let rec json_to_yaml json : Yaml.value =

--- a/semgrep-core/src/parsing/Parse_rule.ml
+++ b/semgrep-core/src/parsing/Parse_rule.ml
@@ -836,7 +836,7 @@ let find_formula env (rule_dict : dict) : key * G.expr =
   let find key_str = Hashtbl.find_opt rule_dict.h key_str in
   match
     find_some_opt find
-      [ "pattern"; "and"; "or"; "regex"; "taint"; "not"; "inside" ]
+      [ "pattern"; "all"; "any"; "regex"; "taint"; "not"; "inside" ]
   with
   | None ->
       error env rule_dict.first_tok
@@ -1025,13 +1025,13 @@ and parse_pair env ((key, value) : key * G.expr) : R.formula =
   | "pattern" -> R.P (get_string_pattern value)
   | "not" -> R.Not (t, parse_formula env value)
   | "inside" -> R.Inside (t, parse_formula env value)
-  | "and" ->
+  | "all" ->
       let conjuncts = parse_listi env key parse_formula value in
       let pos, _ = R.split_and conjuncts in
       if pos = [] && not env.in_metavariable_pattern then
         raise (R.Err (R.InvalidRule (R.MissingPositiveTermInAnd, env.id, t)));
       R.And (t, { conjuncts; focus = []; conditions = [] })
-  | "or" -> R.Or (t, parse_listi env key parse_formula value)
+  | "any" -> R.Or (t, parse_listi env key parse_formula value)
   | "regex" ->
       let x = parse_string_wrap env key value in
       let xpat = XP.mk_xpat (Regexp (parse_regexp env x)) x in

--- a/semgrep-core/tests/rules/metavar_cond2.yaml
+++ b/semgrep-core/tests/rules/metavar_cond2.yaml
@@ -3,7 +3,7 @@ rules:
   languages:
   - python
   match:
-    and:
+    all:
     - foo($ARG)
     where:
     - comparison: $ARG > 10

--- a/semgrep-core/tests/rules/metavar_cond_octal.yaml
+++ b/semgrep-core/tests/rules/metavar_cond_octal.yaml
@@ -3,7 +3,7 @@ rules:
   languages:
   - go
   match:
-    and:
+    all:
     - os.Mkdir($NAME, $PERM)
     where:
     - comparison: $PERM > 0o600

--- a/semgrep-core/tests/rules/metavar_regex.yaml
+++ b/semgrep-core/tests/rules/metavar_regex.yaml
@@ -3,7 +3,7 @@ rules:
   languages:
   - python
   match:
-    and:
+    all:
     - foo($ARG)
     where:
     - metavariable: $ARG

--- a/semgrep-core/tests/rules/negation_ajin.yaml
+++ b/semgrep-core/tests/rules/negation_ajin.yaml
@@ -3,10 +3,10 @@ rules:
   languages:
   - python
   match:
-    and:
+    all:
     - os.environ
     - not:
-        or:
+        any:
         - inside: os.environ.get(...)
         - inside: os.environ[...]
   message: rule_template_message

--- a/semgrep-core/tests/rules/new_syntax.yaml
+++ b/semgrep-core/tests/rules/new_syntax.yaml
@@ -1,9 +1,9 @@
 rules:
 - id: new-syntax
   match:
-    and:
+    all:
       - foo(...) 
-      - or:
+      - any:
         - foo(1, ...)
         - foo(1, 2, ...)
       - not: |

--- a/semgrep-core/tests/rules/regexp.yaml
+++ b/semgrep-core/tests/rules/regexp.yaml
@@ -3,7 +3,7 @@ rules:
   languages:
   - python
   match:
-    and:
+    all:
     - foo("...")
     - regex: \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}
   message: rule_template_message

--- a/semgrep-core/tests/rules/regexp_nomatch.yaml
+++ b/semgrep-core/tests/rules/regexp_nomatch.yaml
@@ -3,7 +3,7 @@ rules:
   languages:
   - python
   match:
-    and:
+    all:
     - foo("...")
     - regex: ABCDE
   message: rule_template_message


### PR DESCRIPTION
## What:
This PR just adds in the rule schema change for the new syntax, and swaps `and` and `or` for `all` and `any`, c.f. the discussion here: https://github.com/returntocorp/semgrep/pull/5916#discussion_r948504608

## Why:
We want to dogfood these changes, so we can collect data on how rule-writing is with it. This change is one step towards that.

## How:
Just did the obvious things.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
