### PR TITLE
chore: add `--dataflow-traces` if `--deep`

### DIFF
--- a/changelog.d/pa-2274.fixed
+++ b/changelog.d/pa-2274.fixed
@@ -1,0 +1,1 @@
+DeepSemgrep: Enabled `--dataflow-traces` by default when `--deep` is specified

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -729,6 +729,10 @@ def scan(
     elif vim:
         output_format = OutputFormat.VIM
 
+    # If `deep` is enabled, turn on `dataflow_traces` by default.
+    if deep:
+        dataflow_traces = True
+
     output_settings = OutputSettings(
         output_format=output_format,
         output_destination=output,


### PR DESCRIPTION
## What:
Just enables `--dataflow-traces` if `--deep` is specified.

## Why:
https://linear.app/r2c/issue/PA-2274/use-dataflow-traces-as-default-with-deep-semgrep

## Test plan:
![image](https://user-images.githubusercontent.com/49291449/211683709-d438969b-725e-4e19-8d25-93518ffc1767.png)

Closes PA-2274

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
