### PR TITLE
fix semgrep.jsonnet, problem using new syntax

### DIFF
--- a/semgrep.jsonnet
+++ b/semgrep.jsonnet
@@ -9,21 +9,22 @@ local test_code_globs = ["Unit_*.ml", "Test_*.ml"];
 local less_important_code_globs = ["spacegrep/*", "experiments/*", "scripts/*"];
 
 local semgrep_rules = [
-  #TODO: this rule could be moved in pfff/semgrep.yml at some point
-  { id: "pfff-no-open-in",
-    match: { or: ["open_in_bin ...", "open_in ..."]},
-    # Same but using The old syntax:
-    #  "pattern-either": [
-    #    { pattern: "open_in_bin ..." },
-    #    { pattern: "open_in ..." },
-    #   ],
-    languages: ["ocaml"],
-    severity: "ERROR",
-    message: |||
-        It is easy to forget to close `open_in` with `close_in`.
-        Use `Common.with_open_infile()` instead.
-    |||,
-  },
+#TODO: does not parse anymore!!
+#  #TODO: this rule could be moved in pfff/semgrep.yml at some point
+#  { id: "pfff-no-open-in",
+#    match: { or: ["open_in_bin ...", "open_in ..."]},
+#    # Same but using The old syntax:
+#    #  "pattern-either": [
+#    #    { pattern: "open_in_bin ..." },
+#    #    { pattern: "open_in ..." },
+#    #   ],
+#    languages: ["ocaml"],
+#    severity: "ERROR",
+#    message: |||
+#        It is easy to forget to close `open_in` with `close_in`.
+#        Use `Common.with_open_infile()` instead.
+#    |||,
+#  },
   #TODO: this is an experimental rule. It has lots of findings, so maybe it is too
   # noisy, but it's nice to dogfood how to handle noisy rules.
   # 564 findings before the exclude


### PR DESCRIPTION
We should find why the regression, but in the mean time
I've commented the problematic rule

test plan:
make check_with_docker


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)