### PR TITLE
chore: Add Vue to parsing stats

### DIFF
--- a/parsing-stats/lang/javascript/projects.txt
+++ b/parsing-stats/lang/javascript/projects.txt
@@ -13,7 +13,6 @@ https://github.com/hakimel/reveal.js.git
 
 # The following projects use Flow, which extends the syntax of
 # javascript but keep the .js extension.
-#https://github.com/vuejs/vue.git
 #https://github.com/facebook/react.git
 #https://github.com/facebook/react-native.git
 #https://github.com/facebook/create-react-app.git

--- a/parsing-stats/lang/typescript/projects.txt
+++ b/parsing-stats/lang/typescript/projects.txt
@@ -31,6 +31,7 @@ https://github.com/swimlane/ngx-datatable
 https://github.com/NativeScript/NativeScript
 https://github.com/ant-design/ant-design-mobile
 https://github.com/basarat/typescript-book
+https://github.com/vuejs/vue.git
 
 # popular and used by R2C
 https://github.com/microsoft/vscode


### PR DESCRIPTION
This project is TS now. Semgrep has a 99.99% parse rate on it.

Test plan: From `parsing-stats`, `./run-lang typescript`, then look at the JSON output for vue.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
