### PR TITLE
chore: Add ocamlgraph to semgrep.opam

### DIFF
--- a/semgrep-core/semgrep.opam
+++ b/semgrep-core/semgrep.opam
@@ -56,6 +56,7 @@ depends: [
   "cohttp-lwt-unix" # this brings lots of dependencies. This is for osemgrep.
   "lsp" {= "1.7.0"}
   "comby-kernel" {= "1.4.1"}
+  "ocamlgraph"
 ]
 
 build: [make]


### PR DESCRIPTION
This is used by the graph_code dune package. That's not used in Semgrep, but it is used in Semgrep Pro. We should probably move it over unless we have plans to use it in Semgrep.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
