### PR TITLE
chore(cli): fix autofix log spew

### DIFF
--- a/changelog.d/pa-2393.fixed
+++ b/changelog.d/pa-2393.fixed
@@ -1,0 +1,1 @@
+CLI: Made an error message for when two autofix matches overlap have a more helpful message, as well as be displayed as a debug message.

--- a/cli/src/semgrep/autofix.py
+++ b/cli/src/semgrep/autofix.py
@@ -186,7 +186,9 @@ def deduplicate_overlapping_matches(
             continue
 
         if matches_overlap(acc, match):
-            logger.warning("Two autofix matches overlap, arbitrarily picking first one")
+            logger.debug(
+                f"Two autofix matches from rules {acc.rule_id} and {match.rule_id} overlap, arbitrarily picking first one"
+            )
             # Don't do anything, keep `acc` the same, and throw `match` out.`
 
         else:


### PR DESCRIPTION
## What:
This PR changes it so an error message displayed when autofixes overlap is hidden as a debug message, and also says which rules it came from.

## Why:
This came up in the dry run, and was causing log spew.

## How:
Just changed it to `logger.debug` and displayed the rule IDs.

## Test plan:
Manual inspection. Here's without `--debug`:
<img width="873" alt="image" src="https://user-images.githubusercontent.com/49291449/212275005-c24bb172-e9de-481c-a820-aa951191604c.png">

Here's with:
<img width="1219" alt="image" src="https://user-images.githubusercontent.com/49291449/212275063-9ba1f82c-2896-4428-ac9e-d50b175a883d.png">


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
