### PR TITLE
fix(perf): stage visitor in `extract_ranges` better

### DIFF
--- a/semgrep-core/src/core/ast/Visitor_AST.ml
+++ b/semgrep-core/src/core/ast/Visitor_AST.ml
@@ -1444,7 +1444,8 @@ let first_info_of_any any =
 (*****************************************************************************)
 
 (*s: function [[Lib_AST.extract_info_visitor]] *)
-let extract_ranges recursor =
+let extract_ranges :
+    AST_generic.any -> (PI.token_location * PI.token_location) option =
   let ranges = ref None in
   let smaller t1 t2 =
     if compare t1.PI.charpos t2.PI.charpos < 0 then t1 else t2
@@ -1494,8 +1495,11 @@ let extract_ranges recursor =
     }
   in
   let vout = mk_visitor hooks in
-  recursor vout;
-  !ranges
+  fun any ->
+    vout any;
+    let res = !ranges in
+    ranges := None;
+    res
 
 let range_of_tokens tokens =
   List.filter PI.is_origintok tokens |> PI.min_max_ii_by_pos
@@ -1515,5 +1519,5 @@ let range_of_any_opt any =
       | Ok tok_loc -> Some (tok_loc, tok_loc)
       | Error _ -> None)
   | G.Anys [] -> None
-  | _ -> extract_ranges (fun visitor -> visitor any)
+  | _ -> extract_ranges any
   [@@profiling]


### PR DESCRIPTION
## What:
This PR stages the computation of the `extract_ranges` visitor such that `mk_visitor` is called only once.

## Why:
Currently, `extract_ranges` sets up a ref, along with some subsidiary helpers that reference it, and then uses those to call the expensive function `mk_visitor`. It then calls that same visitor and returns the contents of the cell.

If we are visiting with essentially the same "functionality", it is wasteful to call `mk_visitor` for every single time that we try to `extract_ranges` from an `any`. This would mean that we call it every single time we match, essentially.

## How:
Moved the computation of the visitor to before the binding of the function value to `extract_ranges`.

## Performance:
I observed, via the `deepsemgrep-sqli-rules.yaml` on the `OpenClinica` repository, the following statistics with `semgrep` normally running:
- `2173M` of memory usage, taking `518.12s` of time to run.

With this change, I observed the following performance:
- `2188M` of memory usage, taking `366.53s` of time to run.

I consider the memory usage variance to be well within normal deviation. The time increase is significant though -- 30% speedup.

## Test plan:
`make test`

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
