### PR TITLE
chore(cli): made semgrep pro message less yelly

### DIFF
--- a/changelog.d/pa-2396.fixed
+++ b/changelog.d/pa-2396.fixed
@@ -1,0 +1,1 @@
+CLI: Made the warning message when using Semgrep Pro more friendly when logged in

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -30,6 +30,7 @@ from tqdm import tqdm
 
 import semgrep.fork_subprocess as fork_subprocess
 import semgrep.output_from_core as core
+from semgrep.app import auth
 from semgrep.config_resolver import Config
 from semgrep.constants import Colors
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
@@ -817,8 +818,17 @@ class CoreRunner:
             # TODO: use exact same command-line arguments so just
             # need to replace the SemgrepCore.path() part.
             if deep:
-                logger.error("!!!This is a proprietary extension of semgrep.!!!")
-                logger.error("!!!You must be logged in to access this extension!!!")
+                if auth.get_token() is None:
+                    logger.error("!!!This is a proprietary extension of semgrep.!!!")
+                    logger.error("!!!You must be logged in to access this extension!!!")
+                else:
+                    logger.error(
+                        "You are using the Semgrep Pro Engine, our advanced analysis system uniquely designed to refine and enhance your results."
+                    )
+                    logger.error(
+                        "You can expect to see longer scan times - we're taking our time to make sure everything is just right for you. With <3, the Semgrep team."
+                    )
+
                 targets = target_manager.targets
                 if len(targets) == 1 and targets[0].path.is_dir():
                     root = str(targets[0].path)


### PR DESCRIPTION
## What:
This PR makes it so that when logged in, the Semgrep Pro proprietary warning message is instead friendly and inviting.

## Why:
Logged in users shouldn't see a bunch of exclamation marks, it's spooky.

## How:
Did the thing. I could also make it exit if not logged in, but I just left it this way for now.

## Test plan:
<img width="1554" alt="image" src="https://user-images.githubusercontent.com/49291449/212460992-b9cbf24e-e633-46a9-8935-945ee3956940.png">

Closes PA-2396

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
