### PR TITLE
sym-prop: Prevent infinite loops during matching

### DIFF
--- a/changelog.d/pa-2324.fixed
+++ b/changelog.d/pa-2324.fixed
@@ -1,0 +1,4 @@
+In rare situations, mainly in DeepSemgrep and related to naming bugs, the use of
+symbolic propagation could make Semgrep fall into an infinite loop during matching.
+This has been fixed by bounding the number of times that Semgrep can follow
+symbolically-propagated values.

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -386,14 +386,23 @@ let m_deep (deep_fun : G.expr Matching_generic.matcher)
       in
       b |> sub_fun |> aux)
 
-let m_with_symbolic_propagation ~is_root f b =
-  if_config
+(* In Match_patterns.match_rules_and_recurse we create a new env for each attempt
+ * at matching a "mini-rule" against a sub-AST, so this bound doesn't need to be
+ * large. Our test suite only needs it to be >= 3 to pass! *)
+let max_SYMBOLIC_PROPAGATION = 100
+
+let m_with_symbolic_propagation ~is_root f b tin =
+  if
     (* If we are not at the root, then we permit recursing into substituted values. *)
-      (fun x ->
-      x.Config.constant_propagation && x.Config.symbolic_propagation
-      && not is_root)
-    ~then_:
-      (match b.G.e with
+    tin.config.Config.constant_propagation
+    && tin.config.Config.symbolic_propagation && not is_root
+  then
+    (* In the past, naming bugs have introduced circular references causing
+     * infinite loops, and not all are caught by the defensive check `b1 == b`
+     * below. We enforce a bound just to make sure that we never hang due to
+     * one of these bugs. *)
+    if !(tin.followed_sym_vals) < max_SYMBOLIC_PROPAGATION then
+      match b.G.e with
       | G.N (G.Id ((id, _), { id_svalue = { contents = Some (G.Sym b1) }; _ }))
         ->
           (* We shouldn't end up with a symbol that resolves to itself, but if
@@ -406,14 +415,21 @@ let m_with_symbolic_propagation ~is_root f b =
            *
            * nosemgrep *)
           if b1 == b then (
-            logger#warning
+            logger#error
               "Aborting symbolic propagation: Circular reference encountered \
                (\"%s\")"
               id;
-            fail ())
-          else f b1
-      | ___else___ -> fail ())
-    ~else_:(fail ())
+            fail () tin)
+          else (
+            incr tin.followed_sym_vals;
+            f b1 tin)
+      | ___else___ -> fail () tin
+    else (
+      logger#error
+        "Aborting symbolic propagation: a bug in Semgrep may be causing an \
+         infinite loop";
+      fail () tin)
+  else fail () tin
 
 (* Match regexp matching options such as 'i' in '/a*/i' *)
 let m_regexp_options a_opt b_opt =

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -81,7 +81,7 @@ type tin = {
   (* TODO: this does not have to be in tout; maybe split tin in 2? *)
   lang : Lang.t;
   config : Config_semgrep.t;
-  followed_sym_vals : int ref;
+  deref_sym_vals : int;
 }
 
 (* list of possible outcoming matching environments *)
@@ -364,7 +364,7 @@ let empty_environment ?(mvar_context = None) opt_cache lang config =
     cache = opt_cache;
     lang;
     config;
-    followed_sym_vals = ref 0;
+    deref_sym_vals = 0;
   }
 
 (*****************************************************************************)

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -81,6 +81,7 @@ type tin = {
   (* TODO: this does not have to be in tout; maybe split tin in 2? *)
   lang : Lang.t;
   config : Config_semgrep.t;
+  followed_sym_vals : int ref;
 }
 
 (* list of possible outcoming matching environments *)
@@ -357,7 +358,14 @@ let empty_environment ?(mvar_context = None) opt_cache lang config =
     | Some bindings ->
         { full_env = bindings; min_env = []; last_stmt_backrefs = Set_.empty }
   in
-  { mv; stmts_match_span = Empty; cache = opt_cache; lang; config }
+  {
+    mv;
+    stmts_match_span = Empty;
+    cache = opt_cache;
+    lang;
+    config;
+    followed_sym_vals = ref 0;
+  }
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/matching/Matching_generic.mli
+++ b/src/matching/Matching_generic.mli
@@ -8,7 +8,7 @@ type tin = {
   (* TODO: this does not have to be in tout; maybe split tin in 2? *)
   lang : Lang.t;
   config : Config_semgrep.t;
-  followed_sym_vals : int ref;
+  deref_sym_vals : int;
       (** Counts the number of times that we "follow" symbollically propagated
     * values. This is bound to prevent potential infinite loops. *)
 }

--- a/src/matching/Matching_generic.mli
+++ b/src/matching/Matching_generic.mli
@@ -8,6 +8,9 @@ type tin = {
   (* TODO: this does not have to be in tout; maybe split tin in 2? *)
   lang : Lang.t;
   config : Config_semgrep.t;
+  followed_sym_vals : int ref;
+      (** Counts the number of times that we "follow" symbollically propagated
+    * values. This is bound to prevent potential infinite loops. *)
 }
 
 (* list of possible outcoming matching environments *)


### PR DESCRIPTION
Previously, naming-related bugs have introduced circular references in symbolically-propagated values, leading to infinite loops during matching. There are some sanity checks in place already, but here we introduce a last-resort check to avoid falling into infinite loops. (Q: Should we remove other checks?) We restrict the number of times that the engine can follow symbolically-propagated values during matching.

Closes PA-2324

test plan:
Set `max_NESTED_SYMBOLIC_PROPAGATION` to 1 or 2 and run `make test`, a bunch of tests will fail.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
