### PR TITLE
Mv src/parsing/Parse_tree_sitter_helpers.ml -> libs/lib_parsing

### DIFF
--- a/libs/lib_parsing/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing/Parse_tree_sitter_helpers.ml
@@ -14,7 +14,6 @@
  *)
 open Common
 module PI = Parse_info
-module G = AST_generic
 
 let logger = Logging.get_logger [ __MODULE__ ]
 
@@ -90,41 +89,6 @@ let str env (tok : Tree_sitter_run.Token.t) =
   let _, s = tok in
   (s, token env tok)
 
-(* This is a temporary fix until
- * https://github.com/returntocorp/ocaml-tree-sitter-core/issues/5
- * is fixed.
- *)
-let str_if_wrong_content_temporary_fix env (tok : Tree_sitter_run.Token.t) =
-  let loc, _wrong_str = tok in
-
-  let file = env.file in
-  let h = env.conv in
-
-  let charpos, line, column =
-    let pos = loc.Tree_sitter_run.Loc.start in
-    (* Parse_info is 1-line based and 0-column based, like Emacs *)
-    let line = pos.Tree_sitter_run.Loc.row + 1 in
-    let column = pos.Tree_sitter_run.Loc.column in
-    try (Hashtbl.find h (line, column), line, column) with
-    | Not_found ->
-        failwith (spf "could not find line:%d x col:%d in %s" line column file)
-  in
-  let charpos2 =
-    let pos = loc.Tree_sitter_run.Loc.end_ in
-    (* Parse_info is 1-line based and 0-column based, like Emacs *)
-    let line = pos.Tree_sitter_run.Loc.row + 1 in
-    let column = pos.Tree_sitter_run.Loc.column in
-    try Hashtbl.find h (line, column) with
-    | Not_found ->
-        failwith (spf "could not find line:%d x col:%d in %s" line column file)
-  in
-  (* Range.t is inclusive, so we need -1 to remove the char at the pos *)
-  let charpos2 = charpos2 - 1 in
-  let r = { Range.start = charpos; end_ = charpos2 } in
-  let str = Range.content_at_range file r in
-  let tok_loc = { PI.str; charpos; line; column; file } in
-  (str, PI.mk_info_of_loc tok_loc)
-
 let combine_tokens_DEPRECATED env xs =
   match xs with
   | [] -> failwith "combine_tokens: empty list"
@@ -174,11 +138,3 @@ let wrap_parser tree_sitter_parser ast_mapper =
       H.debug_sexp_cst_after_error (CST.sexp_of_program cst);
       raise exn
 *)
-
-let parse_number_literal (s, t) =
-  match Common2.int_of_string_c_octal_opt s with
-  | Some i -> G.Int (Some i, t)
-  | None -> (
-      match float_of_string_opt s with
-      | Some f -> G.Float (Some f, t)
-      | None -> G.Int (None, t))

--- a/libs/lib_parsing/Parse_tree_sitter_helpers.mli
+++ b/libs/lib_parsing/Parse_tree_sitter_helpers.mli
@@ -9,9 +9,6 @@ val line_col_to_pos : Common.filename -> (int * int, int) Hashtbl.t
 val token : 'a env -> Tree_sitter_run.Token.t -> Parse_info.t
 val str : 'a env -> Tree_sitter_run.Token.t -> string * Parse_info.t
 
-val str_if_wrong_content_temporary_fix :
-  'a env -> Tree_sitter_run.Token.t -> string * Parse_info.t
-
 (* Use Parse_info.combine_infos instead *)
 val combine_tokens_DEPRECATED :
   'a env -> Tree_sitter_run.Token.t list -> Parse_info.t
@@ -27,5 +24,3 @@ val wrap_parser :
   (unit -> 'cst Tree_sitter_run.Parsing_result.t) ->
   ('cst -> 'ast) ->
   'ast Tree_sitter_run.Parsing_result.t
-
-val parse_number_literal : string * Parse_info.t -> AST_generic.literal

--- a/libs/lib_parsing/dune
+++ b/libs/lib_parsing/dune
@@ -8,6 +8,7 @@
 
    commons
    profiling
+   tree-sitter.run ; Parse_tree_sitter_helpers
  )
  (preprocess (pps ppx_profiling ppx_deriving.show ppx_deriving.eq))
 )


### PR DESCRIPTION
This is required to start moving some Parse_xxx_tree_sitter.ml
out of semgrep in libs/

test plan:
make test


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)