### PR TITLE
const-prop: Recognize Python's `cond and X or Y` idiom

### DIFF
--- a/changelog.d/gh-6079.added
+++ b/changelog.d/gh-6079.added
@@ -1,0 +1,3 @@
+Python: Constant propagation will now recognize the idiom `cond and X or Y`,
+as well as `True and X` and `False or X`. So e.g. `cond and "a" or "b"` will
+be identified as a constant string.

--- a/tests/rules/cp_python_and_or.py
+++ b/tests/rules/cp_python_and_or.py
@@ -1,0 +1,13 @@
+# https://github.com/returntocorp/semgrep/issues/6079
+def test(x):
+    a = x >= 80300 and "typarray" or "NULL"
+    #ruleid: test
+    foo(a)
+
+    b = x >= 80300 and v or "NULL"
+    #ok: test
+    foo(b)
+
+    c = x >= 80300 and "typarray" or w
+    #ok: test
+    foo(c)

--- a/tests/rules/cp_python_and_or.yaml
+++ b/tests/rules/cp_python_and_or.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: test
+    message: Test
+    severity: ERROR
+    languages:
+      - python
+    pattern: foo("...")
+


### PR DESCRIPTION
As well as `True and X` and `False or X`.

Closes #6079
Closes PA-1877

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
