### PR TITLE
Restore 'make dev' like we had before in semgrep-core/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ check_for_emacs:
 #
 .PHONY: dev
 dev:
-	$(MAKE) all
+	$(MAKE) semgrep-core
 	rm -f cli/src/semgrep/bin/semgrep-core
 	ln -s ../../../../bin/semgrep-core \
 	  cli/src/semgrep/bin/semgrep-core


### PR DESCRIPTION
I use `make dev` because I don't want to rebuild the Python stuff every time I make a change in the OCaml code.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
