### PR TITLE
fix(semgrep-pro): allow people to pass --max-memory 0 to semgrep ci

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -333,7 +333,7 @@ def ci(
 
             # Set a default max_memory for CI runs when DeepSemgrep is on because
             # DeepSemgrep is likely to run out
-            if not max_memory:
+            if max_memory is None:
                 if deep:
                     max_memory = DEFAULT_MAX_MEMORY_DEEP_CI
                 else:


### PR DESCRIPTION
Previously this would be overriden because of a bug.

Test plan: I put some print statements to confirm the correct field was being passed to semgrep-pro

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
