### PR TITLE
Extend parsing stats reports to include a count of untranslated nodes

### DIFF
--- a/interfaces/Parsing_stats.atd
+++ b/interfaces/Parsing_stats.atd
@@ -37,4 +37,15 @@ type project_stats = {
   (* Number of files that were parsed with one or more errors.
      It is in the range [0, file_count]. *)
   error_file_count: int;
+
+  (*
+     AST stats for evaluating the fraction of the AST that's made of
+     nodes that need a proper translation. These numbers depend on which
+     types of nodes counted, and of whether shallow todo nodes or
+     raw subtrees are used in the AST. The latter will produce more nodes
+     since they preserve whole sections of the original CST. Interpret
+     with care.
+  *)
+  total_node_count: int;
+  untranslated_node_count: int;
 }

--- a/libs/ast_generic/Visitor_AST.mli
+++ b/libs/ast_generic/Visitor_AST.mli
@@ -31,6 +31,8 @@ type visitor_in = {
   ksvalue : (svalue -> unit) * visitor_out -> svalue -> unit;
   kargument : (argument -> unit) * visitor_out -> argument -> unit;
   klit : (literal -> unit) * visitor_out -> literal -> unit;
+  ktodo : (todo_kind -> unit) * visitor_out -> todo_kind -> unit;
+  kraw : (raw_tree -> unit) * visitor_out -> raw_tree -> unit;
 }
 
 (* note that internally the visitor uses OCaml.v_ref_do_not_visit *)

--- a/libs/lib_parsing/Parsing_stat.ml
+++ b/libs/lib_parsing/Parsing_stat.ml
@@ -26,6 +26,8 @@ let logger = Logging.get_logger [ __MODULE__ ]
 (* Types *)
 (*****************************************************************************)
 
+type ast_stat = { total_node_count : int; untranslated_node_count : int }
+
 type t = {
   filename : Common.filename;
   total_line_count : int;
@@ -44,6 +46,7 @@ type t = {
   (* for instance to report most problematic macros when parse c/c++ *)
   mutable problematic_lines :
     (string list (* ident in error line *) * int (* line_error *)) list;
+  ast_stat : ast_stat option;
 }
 
 (* deprecated *)
@@ -62,10 +65,11 @@ let default_stat file =
   {
     filename = file;
     total_line_count = n;
-    have_timeout = false;
     error_line_count = 0;
+    have_timeout = false;
     commentized = 0;
     problematic_lines = [];
+    ast_stat = None;
   }
 
 let bad_stat file =

--- a/libs/lib_parsing/Parsing_stat.mli
+++ b/libs/lib_parsing/Parsing_stat.mli
@@ -1,3 +1,9 @@
+(*
+   Type holding parsing stats and optionally AST stats.
+*)
+
+type ast_stat = { total_node_count : int; untranslated_node_count : int }
+
 type t = {
   filename : Common.filename;
   total_line_count : int;
@@ -8,23 +14,22 @@ type t = {
    *)
   mutable commentized : int;
   mutable problematic_lines : (string list * int) list;
+  (* AST stats obtained by inspecting the resulting AST, if any. *)
+  ast_stat : ast_stat option;
 }
 
-(* alias, deprecated *)
-type parsing_stat = t
-
-val default_stat : Common.filename -> parsing_stat
-val bad_stat : Common.filename -> parsing_stat
-val correct_stat : Common.filename -> parsing_stat
+val default_stat : Common.filename -> t
+val bad_stat : Common.filename -> t
+val correct_stat : Common.filename -> t
 
 (*
    Print file name and number of lines and error lines in compact format
    suitable for logging.
 *)
-val summary_of_stat : parsing_stat -> string
-val print_parsing_stat_list : ?verbose:bool -> parsing_stat list -> unit
-val print_recurring_problematic_tokens : parsing_stat list -> unit
-val aggregate_stats : parsing_stat list -> int * int (* total * bad *)
+val summary_of_stat : t -> string
+val print_parsing_stat_list : ?verbose:bool -> t list -> unit
+val print_recurring_problematic_tokens : t list -> unit
+val aggregate_stats : t list -> int * int (* total * bad *)
 
 val print_regression_information :
   ext:string -> Common2.path list -> Common2.score -> unit

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -92,6 +92,7 @@ let stat_of_tree_sitter_stat file (stat : Tree_sitter_run.Parsing_result.stat) =
     have_timeout = false;
     commentized = 0;
     problematic_lines = [];
+    ast_stat = None;
   }
 
 let (run_parser : 'ast parser -> Common.filename -> 'ast internal_result) =

--- a/src/parsing/Parse_target.mli
+++ b/src/parsing/Parse_target.mli
@@ -3,7 +3,7 @@ type parsing_result = {
   ast : AST_generic.program;
   (* Partial errors while parsing the file (tree-sitter only) *)
   skipped_tokens : Parse_info.token_location list;
-  stat : Parsing_stat.parsing_stat;
+  stat : Parsing_stat.t;
 }
 
 (* This uses a pfff or tree-sitter parser, or both.

--- a/src/parsing/tests/AST_stat.ml
+++ b/src/parsing/tests/AST_stat.ml
@@ -1,0 +1,60 @@
+(*
+   Estimate the fraction of untranslated nodes in the generic AST.
+*)
+
+module G = AST_generic
+
+type t = Parsing_stat.ast_stat
+
+let stat (ast : G.program) : t =
+  let total_node_count = ref 0 in
+  let untranslated_node_count = ref 0 in
+  let count_ordinary_node (k, _) node =
+    incr total_node_count;
+    k node
+  in
+  let visit_nodes =
+    Visitor_AST.mk_visitor
+      {
+        kexpr = count_ordinary_node;
+        kstmt = count_ordinary_node;
+        ktype_ = count_ordinary_node;
+        kpattern = count_ordinary_node;
+        kfield = count_ordinary_node;
+        kfields = count_ordinary_node;
+        kpartial = count_ordinary_node;
+        kdef = count_ordinary_node;
+        kdir = count_ordinary_node;
+        kattr = count_ordinary_node;
+        kparam = count_ordinary_node;
+        ktparam = count_ordinary_node;
+        kcatch = count_ordinary_node;
+        kident = count_ordinary_node;
+        kname = count_ordinary_node;
+        kentity = count_ordinary_node;
+        kstmts = count_ordinary_node;
+        kfunction_definition = count_ordinary_node;
+        kclass_definition = count_ordinary_node;
+        kinfo = count_ordinary_node;
+        (* By default, do not visit the refs in id_info *)
+        kid_info = Visitor_AST.default_visitor.kid_info;
+        ksvalue = count_ordinary_node;
+        kargument = count_ordinary_node;
+        klit = count_ordinary_node;
+        ktodo =
+          (fun (k, _) x ->
+            incr total_node_count;
+            incr untranslated_node_count;
+            k x);
+        kraw =
+          (fun (k, _) raw_node ->
+            incr total_node_count;
+            incr untranslated_node_count;
+            k raw_node);
+      }
+  in
+  visit_nodes (G.Pr ast);
+  {
+    total_node_count = !total_node_count;
+    untranslated_node_count = !untranslated_node_count;
+  }

--- a/src/parsing/tests/AST_stat.mli
+++ b/src/parsing/tests/AST_stat.mli
@@ -1,0 +1,7 @@
+(*
+   Estimate the fraction of untranslated nodes in the generic AST.
+*)
+
+type t = Parsing_stat.ast_stat
+
+val stat : AST_generic.program -> t


### PR DESCRIPTION
This counts the `Raw_tree.t` and `todo_kind` nodes in the generic AST in addition to all the node types that have a visitor hook.

This will help us evaluate how much of the AST for a language hasn't been translated, as a fraction of actual target code.

test plan:
```
$ cd stats/parsing-stats
$ ./run-lang bash
...
stats available in lang/bash/stats.json
lang/bash/stats.json:3
   "global": {
     "name": "*",
     "parsing_rate": 0.9154876663123557,
     "line_count": 109132,
     "error_line_count": 9223,
     "file_count": 1657,
     "error_file_count": 85,
     "total_node_count": 1727935,
     "untranslated_node_count": 7325
   },
```
Check for the presence of the last two fields. `total_node_count` should be nonzero and `untranslated_node_count` should usually be nonzero due to the presence of todos or raw subtrees.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
