### PR TITLE
cli: Switch to Semgrep PRO binaries (deprecate DeepSemgrep)

### DIFF
--- a/changelog.d/pa-2389.changed
+++ b/changelog.d/pa-2389.changed
@@ -1,0 +1,4 @@
+DeepSemgrep is now Semgrep PRO! To install the Semgrep PRO engine run:
+`semgrep install-semgrep-pro`. This engine is still invoked using the
+`--deep` flag, but please expect changes to the CLI in the near future.
+The new Semgrep PRO engine adds support for Apex!

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -6,7 +6,7 @@ from typing import Dict
 import click
 
 from semgrep.commands.ci import ci
-from semgrep.commands.install import install_deep_semgrep
+from semgrep.commands.install import install_semgrep_pro
 from semgrep.commands.login import login
 from semgrep.commands.login import logout
 from semgrep.commands.lsp import lsp
@@ -91,6 +91,6 @@ cli.add_command(login)
 cli.add_command(logout)
 cli.add_command(publish)
 cli.add_command(scan)
-cli.add_command(install_deep_semgrep)
+cli.add_command(install_semgrep_pro)
 cli.add_command(shouldafound)
 cli.add_command(lsp)

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -17,8 +17,8 @@ import click
 import semgrep.semgrep_main
 from semgrep.app import auth
 from semgrep.app.scans import ScanHandler
-from semgrep.commands.install import determine_deep_semgrep_path
-from semgrep.commands.install import run_install_deep_semgrep
+from semgrep.commands.install import determine_semgrep_pro_path
+from semgrep.commands.install import run_install_semgrep_pro
 from semgrep.commands.scan import CONTEXT_SETTINGS
 from semgrep.commands.scan import scan_options
 from semgrep.commands.wrapper import handle_command_errors
@@ -329,7 +329,7 @@ def ci(
             # Run DeepSemgrep when available but only for full scans
             is_full_scan = metadata.merge_base_ref is None
             deep = scan_handler.deepsemgrep if scan_handler and is_full_scan else False
-            deep_semgrep_path = determine_deep_semgrep_path()
+            (semgrep_pro_path, _deep_semgrep_path) = determine_semgrep_pro_path()
 
             # Set a default max_memory for CI runs when DeepSemgrep is on because
             # DeepSemgrep is likely to run out
@@ -338,8 +338,8 @@ def ci(
                     max_memory = DEFAULT_MAX_MEMORY_DEEP_CI
                 else:
                     max_memory = 0  # unlimited
-            if deep and not deep_semgrep_path.exists():
-                run_install_deep_semgrep()
+            if deep and not semgrep_pro_path.exists():
+                run_install_semgrep_pro()
             if deep:
                 # Add the p/deepsemgrep rules
                 # TODO this is a temporary hack!!! In the future,

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -42,7 +42,7 @@ def run_install_semgrep_pro() -> None:
     (semgrep_pro_path, deep_semgrep_path) = determine_semgrep_pro_path()
     if deep_semgrep_path.exists():
         logger.warning(
-            f"""You have an old DeepSemgrep binary installed in {deep_semgrep_path}
+            f"""You have an old DeepSemgrep binary installed in {deep_semgrep_path}.
 DeepSemgrep has been renamed to Semgrep PRO, which we will proceed to install.
 Please delete {deep_semgrep_path} manually to make this warning disappear!
 """
@@ -103,10 +103,10 @@ Please delete {deep_semgrep_path} manually to make this warning disappear!
     logger.info(f"Installed Semgrep PRO to {semgrep_pro_path}")
 
     version = sub_check_output(
-        [str(semgrep_pro_path), "--version"],
+        [str(semgrep_pro_path), "-pro_version"],
         timeout=10,
         encoding="utf-8",
-        stderr=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
     ).rstrip()
     logger.info(f"Semgrep PRO Version Info: ({version})")
 

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -40,6 +40,10 @@ def run_install_semgrep_pro() -> None:
     state.terminal.configure(verbose=False, debug=False, quiet=False, force_color=False)
 
     (semgrep_pro_path, deep_semgrep_path) = determine_semgrep_pro_path()
+
+    # TODO This is a temporary solution to help offline users
+    logger.info(f"Semgrep PRO engine will be installed in {semgrep_pro_path}")
+
     if deep_semgrep_path.exists():
         logger.warning(
             f"""You have an old DeepSemgrep binary installed in {deep_semgrep_path}.
@@ -48,11 +52,9 @@ Please delete {deep_semgrep_path} manually to make this warning disappear!
 """
         )
     if semgrep_pro_path.exists():
-        logger.info(f"Overwriting Semgrep PRO already installed in {semgrep_pro_path}")
+        logger.info(f"Overwriting Semgrep PRO engine already installed!")
 
     if state.app_session.token is None:
-        # TODO This is a temporary solution to help offline users
-        logger.info(f"Trying to install to {deep_semgrep_path}")
         logger.info("run `semgrep login` before using `semgrep install`")
         sys.exit(INVALID_API_KEY_EXIT_CODE)
 

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -5,6 +5,7 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
+from typing import Tuple
 
 import click
 from tqdm import tqdm
@@ -20,7 +21,7 @@ from semgrep.verbose_logging import getLogger
 logger = getLogger(__name__)
 
 
-def determine_deep_semgrep_path() -> Path:
+def determine_semgrep_pro_path() -> Tuple[Path, Path]:
     core_path = SemgrepCore.path()
     if core_path is None:
         logger.info(
@@ -30,18 +31,24 @@ def determine_deep_semgrep_path() -> Path:
         sys.exit(FATAL_EXIT_CODE)
 
     deep_semgrep_path = Path(core_path).parent / "deep-semgrep"
-    return deep_semgrep_path
+    semgrep_pro_path = Path(core_path).parent / "semgrep-core-proprietary"
+    return (semgrep_pro_path, deep_semgrep_path)
 
 
-def run_install_deep_semgrep() -> None:
+def run_install_semgrep_pro() -> None:
     state = get_state()
     state.terminal.configure(verbose=False, debug=False, quiet=False, force_color=False)
 
-    deep_semgrep_path = determine_deep_semgrep_path()
+    (semgrep_pro_path, deep_semgrep_path) = determine_semgrep_pro_path()
     if deep_semgrep_path.exists():
-        logger.info(
-            f"Overwriting DeepSemgrep binary already installed in {deep_semgrep_path}"
+        logger.warning(
+            f"""You have an old DeepSemgrep binary installed in {deep_semgrep_path}
+DeepSemgrep has been renamed to Semgrep PRO, which we will proceed to install.
+Please delete {deep_semgrep_path} manually to make this warning disappear!
+"""
         )
+    if semgrep_pro_path.exists():
+        logger.info(f"Overwriting Semgrep PRO already installed in {semgrep_pro_path}")
 
     if state.app_session.token is None:
         # TODO This is a temporary solution to help offline users
@@ -81,7 +88,7 @@ def run_install_deep_semgrep() -> None:
 
         file_size = int(r.headers.get("Content-Length", 0))
 
-        with open(deep_semgrep_path, "wb") as f:
+        with open(semgrep_pro_path, "wb") as f:
             with tqdm.wrapattr(r.raw, "read", total=file_size) as r_raw:
                 shutil.copyfileobj(r_raw, f)
 
@@ -90,30 +97,30 @@ def run_install_deep_semgrep() -> None:
     #        execute it should not be a problem.
     # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
     os.chmod(
-        deep_semgrep_path,
-        os.stat(deep_semgrep_path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH,
+        semgrep_pro_path,
+        os.stat(semgrep_pro_path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH,
     )
-    logger.info(f"Installed deepsemgrep to {deep_semgrep_path}")
+    logger.info(f"Installed Semgrep PRO to {semgrep_pro_path}")
 
     version = sub_check_output(
-        [str(deep_semgrep_path), "--version"],
+        [str(semgrep_pro_path), "--version"],
         timeout=10,
         encoding="utf-8",
         stderr=subprocess.DEVNULL,
     ).rstrip()
-    logger.info(f"DeepSemgrep Version Info: ({version})")
+    logger.info(f"Semgrep PRO Version Info: ({version})")
 
 
 @click.command(hidden=True)
 @handle_command_errors
-def install_deep_semgrep() -> None:
+def install_semgrep_pro() -> None:
     """
-    Install the DeepSemgrep binary (Experimental)
+    Install the Semgrep PRO binary (Experimental)
 
     The binary is installed in the same directory that semgrep-core
     is installed in.
 
-    Must be logged in and have access to DeepSemgrep beta
+    Must be logged in and have access to Semgrep PRO beta
     Visit https://semgrep.dev/deep-semgrep-beta for more information
     """
-    run_install_deep_semgrep()
+    run_install_semgrep_pro()

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -789,7 +789,8 @@ class CoreRunner:
             }
 
             # Run semgrep
-            cmd = [SemgrepCore.path()] + [
+            cmd_bin = SemgrepCore.path()
+            cmd_args = [
                 "-json",
                 "-rules",
                 rule_file.name,
@@ -810,10 +811,10 @@ class CoreRunner:
                 logger.info(
                     f"Running with user defined core options: {self._core_opts}"
                 )
-                cmd.extend(self._core_opts)
+                cmd_args.extend(self._core_opts)
 
             if self._optimizations != "none":
-                cmd.append("-fast")
+                cmd_args.append("-fast")
 
             # TODO: use exact same command-line arguments so just
             # need to replace the SemgrepCore.path() part.
@@ -835,45 +836,82 @@ class CoreRunner:
                 else:
                     raise SemgrepError("deep mode needs a single target (root) dir")
 
-                deep_path = SemgrepCore.deep_path()
-                if deep_path is None:
-                    raise SemgrepError(
-                        "Could not run deep analysis: DeepSemgrep not installed. Run `semgrep install-deep-semgrep`"
+                deep_path = (
+                    SemgrepCore.deep_path()
+                )  # DEPRECATED: To be removed by Feb 2023 launch
+                pro_path = SemgrepCore.pro_path()
+
+                if pro_path is None:
+                    if deep_path is None:
+                        raise SemgrepError(
+                            "Could not run deep analysis: Semgrep PRO not installed. Run `semgrep install-semgrep-pro`"
+                        )
+                    else:
+                        logger.warning(
+                            f"""You have an old DeepSemgrep binary installed in {deep_path}
+DeepSemgrep is now Semgrep PRO, run `semgrep install-semgrep-pro` to install it,
+then please delete {deep_path} manually.
+This time, we will continue running your old DeepSemgrep binary.
+"""
+                        )
+
+                if pro_path is not None:
+                    logger.info(f"Using Semgrep PRO installed in {pro_path}")
+                    version = sub_check_output(
+                        [pro_path, "-pro_version"],
+                        timeout=10,
+                        encoding="utf-8",
+                        stderr=subprocess.STDOUT,
+                    ).rstrip()
+                    logger.info(f"Semgrep PRO Version Info: ({version})")
+
+                    cmd_bin = pro_path
+                    cmd_args += [
+                        "-json_time"
+                    ]  # TODO: When do we stop adding this by default?
+                    cmd_args += ["-deep_inter_file"]
+                    cmd_args += [root]
+                elif (
+                    deep_path is not None
+                ):  # DEPRECATED: To be removed by Feb 2023 launch
+                    logger.info(
+                        f"Using old DeepSemgrep installed in {deep_path} - Please upgrade to Semgrep PRO!"
                     )
+                    version = sub_check_output(
+                        [deep_path, "--version"],
+                        timeout=10,
+                        encoding="utf-8",
+                        stderr=subprocess.DEVNULL,
+                    ).rstrip()
+                    logger.info(f"DeepSemgrep Version Info: ({version})")
 
-                logger.info(f"Using DeepSemgrep installed in {deep_path}")
-                version = sub_check_output(
-                    [deep_path, "--version"],
-                    timeout=10,
-                    encoding="utf-8",
-                    stderr=subprocess.DEVNULL,
-                ).rstrip()
-                logger.info(f"DeepSemgrep Version Info: ({version})")
-
-                cmd = [deep_path] + [
-                    "--json",
-                    "--rules",
-                    rule_file.name,
-                    "-j",
-                    str(self._jobs),
-                    "--targets",
-                    target_file.name,
-                    "--root",
-                    root,
-                    "--json_time",
-                    # "--timeout",
-                    # str(self._timeout),
-                    # "--timeout_threshold",
-                    # str(self._timeout_threshold),
-                    "--max_memory",
-                    str(self._max_memory),
-                ]
+                    cmd_bin = deep_path
+                    cmd_args = [
+                        "--json",
+                        "--rules",
+                        rule_file.name,
+                        "-j",
+                        str(self._jobs),
+                        "--targets",
+                        target_file.name,
+                        "--root",
+                        root,
+                        "--json_time",
+                        # "--timeout",
+                        # str(self._timeout),
+                        # "--timeout_threshold",
+                        # str(self._timeout_threshold),
+                        "--max_memory",
+                        str(self._max_memory),
+                    ]
 
             stderr: Optional[int] = subprocess.PIPE
             if state.terminal.is_debug:
-                cmd += ["--debug"]
+                cmd_args += ["--debug"]
 
-            logger.debug("Running semgrep-core with command:")
+            cmd = [cmd_bin] + cmd_args
+
+            logger.debug("Running Semgrep engine with command:")
             logger.debug(" ".join(cmd))
 
             if dump_command_for_core:
@@ -975,10 +1013,10 @@ class CoreRunner:
                 logger.error(
                     f"""
 
-DeepSemgrep crashed during execution (unknown reason).
-This can sometimes happen because either DeepSemgrep or Semgrep is out of date.
+Semgrep PRO crashed during execution (unknown reason).
+This can sometimes happen because either Semgrep PRO or Semgrep is out of date.
 
-Try updating your version of DeepSemgrep (`semgrep install-deep-semgrep`) or your version of Semgrep (`pip install semgrep/brew install semgrep`).
+Try updating your version of Semgrep PRO (`semgrep install-semgrep-pro`) or your version of Semgrep (`pip install semgrep/brew install semgrep`).
 If both are up-to-date and the crash persists, please contact support to report an issue!
 
 Exception raised: `{e}`

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -866,9 +866,6 @@ This time, we will continue running your old DeepSemgrep binary anyways.
                     logger.info(f"Semgrep PRO Version Info: ({version})")
 
                     cmd_bin = pro_path
-                    cmd_args += [
-                        "-json_time"
-                    ]  # TODO: When do we stop adding this by default?
                     cmd_args += ["-deep_inter_file"]
                     cmd_args += [root]
                 elif (

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -844,14 +844,14 @@ class CoreRunner:
                 if pro_path is None:
                     if deep_path is None:
                         raise SemgrepError(
-                            "Could not run deep analysis: Semgrep PRO not installed. Run `semgrep install-semgrep-pro`"
+                            "Could not run deep analysis: Semgrep PRO engine not installed. Run `semgrep install-semgrep-pro`"
                         )
                     else:
                         logger.warning(
                             f"""You have an old DeepSemgrep binary installed in {deep_path}
 DeepSemgrep is now Semgrep PRO, run `semgrep install-semgrep-pro` to install it,
 then please delete {deep_path} manually.
-This time, we will continue running your old DeepSemgrep binary.
+This time, we will continue running your old DeepSemgrep binary anyways.
 """
                         )
 

--- a/cli/src/semgrep/semgrep_core.py
+++ b/cli/src/semgrep/semgrep_core.py
@@ -48,7 +48,10 @@ class SemgrepCore:
     # yet.
     _SEMGREP_PATH_: Optional[str] = None
 
+    # DEPRECATED: To be removed by Feb 2023 launch
     _DEEP_PATH_: Optional[str] = None
+
+    _PRO_PATH_: Optional[str] = None
 
     # Reference to the bridge module if we are using it.
     _bridge_module: Optional[types.ModuleType] = None
@@ -135,8 +138,15 @@ class SemgrepCore:
         """
         return cls._bridge_module is not None
 
+    # DEPRECATED: To be removed by Feb 2023 launch
     @classmethod
     def deep_path(cls) -> Optional[str]:
         if cls._DEEP_PATH_ is None:
             cls._DEEP_PATH_ = compute_executable_path("deep-semgrep")
         return cls._DEEP_PATH_
+
+    @classmethod
+    def pro_path(cls) -> Optional[str]:
+        if cls._PRO_PATH_ is None:
+            cls._PRO_PATH_ = compute_executable_path("semgrep-core-proprietary")
+        return cls._PRO_PATH_

--- a/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_github_ci_bad_base_sha/results.txt
@@ -68,7 +68,7 @@ Rules:
 - taint-test
 Passing whole rules directly to semgrep_core
 Scanning 1 file with 4 python rules.
-Running semgrep-core with command:
+Running Semgrep engine with command:
 /<MASKED>/semgrep<MASKED> -json -rules <MASKED>-json_time -fast --debug
 --- semgrep-core stderr ---
 <MASKED>

--- a/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
+++ b/cli/tests/e2e/snapshots/test_output/test_debug_experimental_rule/results.txt
@@ -36,7 +36,7 @@ Experimental Rules:
 - rules.experiment.research-experiment
 Passing whole rules directly to semgrep_core
 Scanning 1 file.
-Running semgrep-core with command:
+Running Semgrep engine with command:
 /<MASKED>/semgrep<MASKED> -json -rules <MASKED>-json_time -fast --debug
 --- semgrep-core stderr ---
 <MASKED>


### PR DESCRIPTION
Closes PA-2389

test plan:
```
% semgrep -c p/default semgrep/parsing-stats/lang/java/tmp/square-retrofit
  # ^ try this with deep-semgrep installed, then remove deep-semgrep and try again,
  # then run `semgrep install-semgrep-pro` and try one more time
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
