### PR TITLE
feat(pro): Output where semgrep pro is installed

### DIFF
--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -44,6 +44,8 @@ def run_install_deep_semgrep() -> None:
         )
 
     if state.app_session.token is None:
+        # TODO This is a temporary solution to help offline users
+        logger.info(f"Trying to install to {deep_semgrep_path}")
         logger.info("run `semgrep login` before using `semgrep install`")
         sys.exit(INVALID_API_KEY_EXIT_CODE)
 


### PR DESCRIPTION
This helps for trials.

Test plan: log out and delete the installed `deep-semgrep` binary. Now run `semgrep install-deep-semgrep`. This should show you where it would be installed.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
