### PR TITLE
fix: Avoid fatal merge-base calls on shallow checkouts

### DIFF
--- a/changelog.d/merge-base.fixed
+++ b/changelog.d/merge-base.fixed
@@ -1,0 +1,1 @@
+Fixed a crash that could occur when using the GitHub API to fetch the merge base rather than computing it locally.

--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -196,6 +196,16 @@ class BaselineHandler:
 
         return GitStatus(added, modified, removed, unmerged, renamed)
 
+    def _get_git_merge_base(self) -> str:
+        # If we already know that the base commit is the merge base, just return
+        # the base commit. This allows us to operate on shallow checkouts where
+        # we might not have the information locally to compute the merge base.
+        # In this case, calling `git merge-base` may fail.
+        if self._is_mergebase:
+            return self._base_commit
+        else:
+            return git_check_output(["git", "merge-base", self._base_commit, "HEAD"])
+
     def _get_dirty_paths_by_status(self) -> Dict[str, List[Path]]:
         """
         Returns all paths that have a git status, grouped by change type.
@@ -296,10 +306,7 @@ class BaselineHandler:
 
         current_head = git_check_output(["git", "rev-parse", "HEAD"])
         try:
-            merge_base_sha = git_check_output(
-                ["git", "merge-base", self._base_commit, "HEAD"]
-            )
-
+            merge_base_sha = self._get_git_merge_base()
             logger.debug("Running git checkout for baseline context")
             git_check_output(["git", "reset", "--hard", merge_base_sha])
             logger.debug("Finished git checkout for baseline context")
@@ -338,10 +345,10 @@ class BaselineHandler:
 
     def print_git_log(self) -> None:
         base_commit_sha = git_check_output(["git", "rev-parse", self._base_commit])
-        merge_base_sha = git_check_output(
-            ["git", "merge-base", self._base_commit, "HEAD"]
+        merge_base_sha = self._get_git_merge_base()
+        logger.info(
+            "  Will report findings introduced by these commits (may be incomplete for shallow checkouts):"
         )
-        logger.info("  Will report findings introduced by these commits:")
         log = git_check_output(
             ["git", "log", "--oneline", "--graph", f"{merge_base_sha}..HEAD"]
         )

--- a/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/baseline_error.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_all_intersect/baseline_error.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 1 finding.
 
 Switching repository to baseline commit 'baseline-commit'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * 8ebfb32 commit #2
 
 Scanning 1 file.

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stderr.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-baz/stderr.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 9 findings.
 
 Switching repository to baseline commit 'baz'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * ea6d96d commit #9
     * 0367792 commit #8
   The current branch is missing these commits from the baseline branch:

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stderr.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/bar-foo/stderr.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 9 findings.
 
 Switching repository to baseline commit 'foo'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * ea6d96d commit #9
     * 0367792 commit #8
     * 4a37202 commit #7

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stderr.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-bar/stderr.txt
@@ -2,7 +2,7 @@ Scanning 2 files.
   Current version has 14 findings.
 
 Switching repository to baseline commit 'bar'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * ff8459e commit #9
     * a0592d5 commit #8
     * 4ec8882 commit #7

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stderr.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/baz-foo/stderr.txt
@@ -3,7 +3,7 @@ Scanning 3 files.
   Current version has 21 findings.
 
 Switching repository to baseline commit 'foo'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * ff8459e commit #9
     * a0592d5 commit #8
     * 4ec8882 commit #7

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stderr.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-bar/stderr.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 9 findings.
 
 Switching repository to baseline commit 'bar'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * fe51afb merging bar~6
     * 4917fac commit #9
     * 9914f12 commit #8

--- a/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stderr.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_crisscrossing_merges/foo-baz/stderr.txt
@@ -3,7 +3,7 @@ Scanning 2 files.
   Current version has 12 findings.
 
 Switching repository to baseline commit 'baz'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     *   fe51afb merging bar~6
     |\  
     | * 97acb1c commit #3

--- a/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/diff.err
+++ b/cli/tests/e2e/snapshots/test_baseline/test_dir_changed_to_file/diff.err
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 1 finding.
 
 Switching repository to baseline commit 'HEAD^'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * 321d62c commit #2
 
 Scanning 1 file.

--- a/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.err
+++ b/cli/tests/e2e/snapshots/test_baseline/test_file_changed_to_dir/diff.err
@@ -2,7 +2,7 @@ Scanning 2 files.
   Current version has 2 findings.
 
 Switching repository to baseline commit 'HEAD^'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * 998446a commit #2
 
 Scanning 1 file.

--- a/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_error.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_no_findings_baseline/baseline_error.txt
@@ -2,7 +2,7 @@ Scanning 2 files.
   Current version has 2 findings.
 
 Switching repository to baseline commit 'baseline-commit'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * 217a2f3 commit #2
 
 Scanning 1 file.

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/diff.err
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_dir/diff.err
@@ -2,7 +2,7 @@ Scanning 2 files.
   Current version has 2 findings.
 
 Switching repository to baseline commit 'HEAD^'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * 94d55d4 commit #2
 
 Scanning 2 files.

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/baseline_error.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-insensitive/baseline_error.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 2 findings.
 
 Switching repository to baseline commit 'baseline-commit'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * ac0f5a0 commit #2
 
 Scanning 1 file.

--- a/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/baseline_error.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_renamed_file/case-sensitive/baseline_error.txt
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 2 findings.
 
 Switching repository to baseline commit 'baseline-commit'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * 11a6bea commit #2
 
 Scanning 1 file.

--- a/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.err
+++ b/cli/tests/e2e/snapshots/test_baseline/test_symlink_changed_to_file/diff.err
@@ -2,7 +2,7 @@ Scanning 1 file.
   Current version has 1 finding.
 
 Switching repository to baseline commit 'HEAD^'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * ea47e9e commit #2
 
 Nothing to scan.

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -66,7 +66,7 @@ Scanning 1 file with 4 python rules.
   Current version has 14 findings.
 
 Switching repository to baseline commit '<MASKED>'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * <MASKED> Some other commit/ message
 
 Scanning 1 file with 4 python rules.

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -63,7 +63,7 @@ Scanning 1 file with 4 python rules.
   Current version has 14 findings.
 
 Switching repository to baseline commit '<MASKED>'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * <MASKED> Some other commit/ message
 
 Scanning 1 file with 4 python rules.

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -60,7 +60,7 @@ Scanning 1 file with 4 python rules.
   Current version has 14 findings.
 
 Switching repository to baseline commit '<MASKED>'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * <MASKED> Some other commit/ message
 
 Scanning 1 file with 4 python rules.

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -66,7 +66,7 @@ Scanning 1 file with 4 python rules.
   Current version has 14 findings.
 
 Switching repository to baseline commit '<MASKED>'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * <MASKED> Some other commit/ message
 
 Scanning 1 file with 4 python rules.

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -63,7 +63,7 @@ Scanning 1 file with 4 python rules.
   Current version has 14 findings.
 
 Switching repository to baseline commit '<MASKED>'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * <MASKED> Some other commit/ message
 
 Scanning 1 file with 4 python rules.

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -60,7 +60,7 @@ Scanning 1 file with 4 python rules.
   Current version has 14 findings.
 
 Switching repository to baseline commit '<MASKED>'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * <MASKED> Some other commit/ message
 
 Scanning 1 file with 4 python rules.

--- a/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_shallow_wrong_merge_base/bad_results.txt
@@ -42,7 +42,7 @@ Scanning 2 files with 4 python rules.
   Current version has 3 findings.
 
 Switching repository to baseline commit 'b903231925961ac9d787ae53ee0bd15ec156e689'.
-  Will report findings introduced by these commits:
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
     * 7b5cda4 commit #4
     * 5b37988 commit #3
 


### PR DESCRIPTION
#6756 allows us to use the GitHub API to find the merge base, rather than relying on the sometimes slow process of fetching additional commits until we can compute it locally.

However, downstream code assumes that we have enough history to compute the merge base. When it tries to do so, Git fatals and Semgrep aborts. This was reported to us when a customer tried to make use of this optimization.

I missed this while testing the original PR because my test PR on my test repo added the file with the finding. When all the files with findings are added in the PR being scanned, Semgrep doesn't bother doing a baseline scan, which I overlooked.

Test plan:

Same as #6756 except the test PR modifies an existing file with findings rather than creating a new file. When using the current `returntocorp/semgrep` image, Semgrep fails on the merge base call in the same way as described by the customer. When using the locally-built `nmote/semgrep` image with the change in this PR, Semgrep runs correctly.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
