### PR TITLE
cli: intuitive order ci findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,7 @@ repos:
           - packaging~=21.0
           - requests~=2.22
           - defusedxml~=0.7.1
+          - tomli~=2.0.1
           # other packages have separate typings published
           - types-colorama~=0.4.0
           - types-jsonschema~=4.6.0

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -278,7 +278,10 @@ class ScanHandler:
             for matches_of_rule in matches_by_rule.values()
             for match in matches_of_rule
         ]
-        all_matches.reverse()  # rising filename and line numbers in app
+        # we want date stamps assigned by the app to be assigned such that the
+        # current sort by relevant_since results in findings within a given scan
+        # appear in an intuitive order.  this requires reversed ordering here.
+        all_matches.reverse()
         sort_order = {  # used only to order rules by severity
             "EXPERIMENT": 0,
             "INVENTORY": 1,
@@ -286,6 +289,8 @@ class ScanHandler:
             "WARNING": 3,
             "ERROR": 4,
         }
+        # NB: sorted guarantees stable sort, so within a given severity level
+        # issues remain sorted as before
         all_matches = sorted(
             all_matches, key=lambda match: sort_order[match.severity.value]
         )

--- a/cli/src/semgrep/app/scans.py
+++ b/cli/src/semgrep/app/scans.py
@@ -278,6 +278,17 @@ class ScanHandler:
             for matches_of_rule in matches_by_rule.values()
             for match in matches_of_rule
         ]
+        all_matches.reverse()  # rising filename and line numbers in app
+        sort_order = {  # used only to order rules by severity
+            "EXPERIMENT": 0,
+            "INVENTORY": 1,
+            "INFO": 2,
+            "WARNING": 3,
+            "ERROR": 4,
+        }
+        all_matches = sorted(
+            all_matches, key=lambda match: sort_order[match.severity.value]
+        )
         new_ignored, new_matches = partition(
             all_matches, lambda match: bool(match.is_ignored)
         )

--- a/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
+++ b/cli/tests/e2e/snapshots/test_ci/test_dryrun/results.txt
@@ -80,140 +80,6 @@ Would have sent findings and ignores blob: {
     "gitlab_token": null,
     "findings": [
         {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 4,
-            "column": 5,
-            "end_line": 4,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 0,
-            "commit_date": <MASKED>
-            "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-        },
-        {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 5,
-            "column": 5,
-            "end_line": 5,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 1,
-            "commit_date": <MASKED>
-            "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-        },
-        {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 7,
-            "column": 5,
-            "end_line": 7,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 3,
-            "commit_date": <MASKED>
-            "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-        },
-        {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 11,
-            "column": 5,
-            "end_line": 11,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 0,
-            "commit_date": <MASKED>
-            "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-        },
-        {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 23,
-            "column": 5,
-            "end_line": 23,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 0,
-            "commit_date": <MASKED>
-            "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-        },
-        {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 24,
-            "column": 5,
-            "end_line": 24,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 0,
-            "commit_date": <MASKED>
-            "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-        },
-        {
-            "check_id": "eqeq-five",
-            "path": "foo.py",
-            "line": 15,
-            "column": 5,
-            "end_line": 15,
-            "end_column": 11,
-            "message": "useless comparison to 5",
-            "severity": 2,
-            "index": 0,
-            "commit_date": <MASKED>
-            "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-            "metadata": {
-                "dev.semgrep.actions": []
-            },
-            "is_blocking": false,
-            "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-        },
-        {
-            "check_id": "eqeq-four",
-            "path": "foo.py",
-            "line": 19,
-            "column": 5,
-            "end_line": 19,
-            "end_column": 13,
-            "message": "useless comparison to 4",
-            "severity": 2,
-            "index": 1,
-            "commit_date": <MASKED>
-            "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-            "metadata": {
-                "dev.semgrep.actions": [
-                    "block"
-                ]
-            },
-            "is_blocking": true,
-            "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-        },
-        {
             "check_id": "taint-test",
             "path": "foo.py",
             "line": 27,
@@ -327,6 +193,140 @@ Would have sent findings and ignores blob: {
                     "lockfile": "poetry.lock"
                 }
             }
+        },
+        {
+            "check_id": "eqeq-four",
+            "path": "foo.py",
+            "line": 19,
+            "column": 5,
+            "end_line": 19,
+            "end_column": 13,
+            "message": "useless comparison to 4",
+            "severity": 2,
+            "index": 1,
+            "commit_date": <MASKED>
+            "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+            "metadata": {
+                "dev.semgrep.actions": [
+                    "block"
+                ]
+            },
+            "is_blocking": true,
+            "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+        },
+        {
+            "check_id": "eqeq-five",
+            "path": "foo.py",
+            "line": 15,
+            "column": 5,
+            "end_line": 15,
+            "end_column": 11,
+            "message": "useless comparison to 5",
+            "severity": 2,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+            "metadata": {
+                "dev.semgrep.actions": []
+            },
+            "is_blocking": false,
+            "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 24,
+            "column": 5,
+            "end_line": 24,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 23,
+            "column": 5,
+            "end_line": 23,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 11,
+            "column": 5,
+            "end_line": 11,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 7,
+            "column": 5,
+            "end_line": 7,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 3,
+            "commit_date": <MASKED>
+            "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 5,
+            "column": 5,
+            "end_line": 5,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 1,
+            "commit_date": <MASKED>
+            "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 4,
+            "column": 5,
+            "end_line": 4,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
         }
     ],
     "searched_paths": [
@@ -344,52 +344,24 @@ Would have sent findings and ignores blob: {
     "cai_ids": [],
     "ignores": [
         {
-            "check_id": "eqeq-bad",
+            "check_id": "eqeq-four",
             "path": "foo.py",
-            "line": 6,
+            "line": 18,
             "column": 5,
-            "end_line": 6,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 2,
-            "commit_date": <MASKED>
-            "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-        },
-        {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 9,
-            "column": 5,
-            "end_line": 9,
-            "end_column": 11,
-            "message": "useless comparison",
+            "end_line": 18,
+            "end_column": 13,
+            "message": "useless comparison to 4",
             "severity": 2,
             "index": 0,
             "commit_date": <MASKED>
-            "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-            "metadata": {},
+            "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+            "metadata": {
+                "dev.semgrep.actions": [
+                    "block"
+                ]
+            },
             "is_blocking": true,
-            "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-        },
-        {
-            "check_id": "eqeq-bad",
-            "path": "foo.py",
-            "line": 13,
-            "column": 5,
-            "end_line": 13,
-            "end_column": 11,
-            "message": "useless comparison",
-            "severity": 2,
-            "index": 0,
-            "commit_date": <MASKED>
-            "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-            "metadata": {},
-            "is_blocking": true,
-            "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+            "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
         },
         {
             "check_id": "eqeq-five",
@@ -410,24 +382,52 @@ Would have sent findings and ignores blob: {
             "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
         },
         {
-            "check_id": "eqeq-four",
+            "check_id": "eqeq-bad",
             "path": "foo.py",
-            "line": 18,
+            "line": 13,
             "column": 5,
-            "end_line": 18,
-            "end_column": 13,
-            "message": "useless comparison to 4",
+            "end_line": 13,
+            "end_column": 11,
+            "message": "useless comparison",
             "severity": 2,
             "index": 0,
             "commit_date": <MASKED>
-            "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-            "metadata": {
-                "dev.semgrep.actions": [
-                    "block"
-                ]
-            },
+            "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+            "metadata": {},
             "is_blocking": true,
-            "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+            "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 9,
+            "column": 5,
+            "end_line": 9,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 0,
+            "commit_date": <MASKED>
+            "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+        },
+        {
+            "check_id": "eqeq-bad",
+            "path": "foo.py",
+            "line": 6,
+            "column": 5,
+            "end_line": 6,
+            "end_column": 11,
+            "message": "useless comparison",
+            "severity": 2,
+            "index": 2,
+            "commit_date": <MASKED>
+            "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+            "metadata": {},
+            "is_blocking": true,
+            "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
         }
     ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -212,6 +75,143 @@
           ]
         ]
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -229,52 +229,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -298,24 +270,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -212,6 +75,143 @@
           ]
         ]
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -229,52 +229,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -298,24 +270,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -212,6 +75,143 @@
           ]
         ]
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -229,52 +229,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -298,24 +270,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/findings_and_ignores.json
@@ -3,143 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
-      "fixed_lines": [
-        "    (x == 2)"
-      ]
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -253,6 +116,143 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0",
+      "fixed_lines": [
+        "    (x == 2)"
+      ]
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -270,52 +270,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -339,24 +311,52 @@
       ]
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -209,6 +75,140 @@
           ]
         ]
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -226,52 +226,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -292,24 +264,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -209,6 +75,140 @@
           ]
         ]
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -226,52 +226,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -292,24 +264,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -209,6 +75,140 @@
           ]
         ]
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -226,52 +226,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -292,24 +264,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/findings_and_ignores.json
@@ -3,140 +3,6 @@
   "gitlab_token": null,
   "findings": [
     {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 4,
-      "column": 5,
-      "end_line": 4,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 5,
-      "column": 5,
-      "end_line": 5,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 7,
-      "column": 5,
-      "end_line": 7,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 3,
-      "commit_date": "sanitized",
-      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 11,
-      "column": 5,
-      "end_line": 11,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 23,
-      "column": 5,
-      "end_line": 23,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 24,
-      "column": 5,
-      "end_line": 24,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
-    },
-    {
-      "check_id": "eqeq-five",
-      "path": "foo.py",
-      "line": 15,
-      "column": 5,
-      "end_line": 15,
-      "end_column": 11,
-      "message": "useless comparison to 5",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
-      "metadata": {
-        "dev.semgrep.actions": []
-      },
-      "is_blocking": false,
-      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
-    },
-    {
-      "check_id": "eqeq-four",
-      "path": "foo.py",
-      "line": 19,
-      "column": 5,
-      "end_line": 19,
-      "end_column": 13,
-      "message": "useless comparison to 4",
-      "severity": 2,
-      "index": 1,
-      "commit_date": "sanitized",
-      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
-      "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
-    },
-    {
       "check_id": "taint-test",
       "path": "foo.py",
       "line": 27,
@@ -250,6 +116,140 @@
           "lockfile": "poetry.lock"
         }
       }
+    },
+    {
+      "check_id": "eqeq-four",
+      "path": "foo.py",
+      "line": 19,
+      "column": 5,
+      "end_line": 19,
+      "end_column": 13,
+      "message": "useless comparison to 4",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "87cd1247dfc84bbd502c872035c71a63",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
+      "is_blocking": true,
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_1"
+    },
+    {
+      "check_id": "eqeq-five",
+      "path": "foo.py",
+      "line": 15,
+      "column": 5,
+      "end_line": 15,
+      "end_column": 11,
+      "message": "useless comparison to 5",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8646a2dfc020913606969dcfe84e53c0",
+      "metadata": {
+        "dev.semgrep.actions": []
+      },
+      "is_blocking": false,
+      "match_based_id": "186b96f64aca90b7f5a9c75f2e44538885d0e727ed3161ef7b6d46c40b3d078acfc8859b290e118cb8ca42f5b41e61afe73b0f416f47a2f16abce67b1be307d3_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 24,
+      "column": 5,
+      "end_line": 24,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "f3b21c38bc22a1f1f870d49fc3a40244",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_4"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 23,
+      "column": 5,
+      "end_line": 23,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "a557d3b401636ba873e590c81b693a8f",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "e536489e68267e16e71dd76a61e27815fd86a7e2417d96f8e0c43af48540a41d41e6acad52f7ccda83b5c6168dd5559cd49169617e3aac1b7ea091d8a20ebf12_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 11,
+      "column": 5,
+      "end_line": 11,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "d44049421636e370e7906a6bed5fce54",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "5efd0945774f190445f7cf2b0b85568a845cc46dddc11e029205b882436dccf78e12a752408c13dfe97b572f8bc795099ca0bddb89b3040afcaf6a6d8c17b570_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 7,
+      "column": 5,
+      "end_line": 7,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 3,
+      "commit_date": "sanitized",
+      "syntactic_id": "f6c666e6921a44028a2015d0de15cc14",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_3"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 5,
+      "column": 5,
+      "end_line": 5,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 1,
+      "commit_date": "sanitized",
+      "syntactic_id": "8abb389b2f01d0e52d663251e1d24ba7",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_1"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 4,
+      "column": 5,
+      "end_line": 4,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "8c695a6a4ab5ffff33d0103309a310c1",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_0"
     }
   ],
   "searched_paths": [
@@ -267,52 +267,24 @@
   "cai_ids": [],
   "ignores": [
     {
-      "check_id": "eqeq-bad",
+      "check_id": "eqeq-four",
       "path": "foo.py",
-      "line": 6,
+      "line": 18,
       "column": 5,
-      "end_line": 6,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 2,
-      "commit_date": "sanitized",
-      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 9,
-      "column": 5,
-      "end_line": 9,
-      "end_column": 11,
-      "message": "useless comparison",
+      "end_line": 18,
+      "end_column": 13,
+      "message": "useless comparison to 4",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
-      "metadata": {},
+      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
+      "metadata": {
+        "dev.semgrep.actions": [
+          "block"
+        ]
+      },
       "is_blocking": true,
-      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
-    },
-    {
-      "check_id": "eqeq-bad",
-      "path": "foo.py",
-      "line": 13,
-      "column": 5,
-      "end_line": 13,
-      "end_column": 11,
-      "message": "useless comparison",
-      "severity": 2,
-      "index": 0,
-      "commit_date": "sanitized",
-      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
-      "metadata": {},
-      "is_blocking": true,
-      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
     },
     {
       "check_id": "eqeq-five",
@@ -333,24 +305,52 @@
       "match_based_id": "d2d0825f113f2fee5f7cbd5fb160772b3f3ab5043120b912101f2f20d4a0cce42df32b8e89f889f945daa1b216f9755eb958b9cb73c4c4ddf2ef5ecd0b4d1ad3_0"
     },
     {
-      "check_id": "eqeq-four",
+      "check_id": "eqeq-bad",
       "path": "foo.py",
-      "line": 18,
+      "line": 13,
       "column": 5,
-      "end_line": 18,
-      "end_column": 13,
-      "message": "useless comparison to 4",
+      "end_line": 13,
+      "end_column": 11,
+      "message": "useless comparison",
       "severity": 2,
       "index": 0,
       "commit_date": "sanitized",
-      "syntactic_id": "0c6353c9e29a6595b15fe4f554cd4134",
-      "metadata": {
-        "dev.semgrep.actions": [
-          "block"
-        ]
-      },
+      "syntactic_id": "0db994486d207a88b9e7bc0475d8a14a",
+      "metadata": {},
       "is_blocking": true,
-      "match_based_id": "e7f900087df67093981e7d10847997734cfe6e3f1bcca3e05b81ff799e15d217834c0ae1d8114b52bef34242153efcbd3708167ca823100cdca2a843046972b8_0"
+      "match_based_id": "f33d61e2c4592fb3a295213cb9d829c7d314041cef354f9b4199bf18526d72df596c0ef4c8e56289511e1ea8e2183752f403fd922f382d090846c456744367d2_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 9,
+      "column": 5,
+      "end_line": 9,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 0,
+      "commit_date": "sanitized",
+      "syntactic_id": "bf0f44ff9d49cd5ca3771b3ee6d2fcfc",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "83fb2cbc6be00fffc142621a1b10702bdd228f97c42ca16ba5f902ec393231e1424bed8472cec7c9213190cb1f576e5a495b3aba5cef09ac2791715d3bf9e983_0"
+    },
+    {
+      "check_id": "eqeq-bad",
+      "path": "foo.py",
+      "line": 6,
+      "column": 5,
+      "end_line": 6,
+      "end_column": 11,
+      "message": "useless comparison",
+      "severity": 2,
+      "index": 2,
+      "commit_date": "sanitized",
+      "syntactic_id": "c2d65932166aec2a4a96ff0e8deebd97",
+      "metadata": {},
+      "is_blocking": true,
+      "match_based_id": "0357b19d63972f62544383b820b32bdcbeda622708aa4a5b798b8cac7290deacdbb32468495f0b29732cfcaa0ff9fe9ec3ca672f4fcc67f987cd889ac08b1c6a_2"
     }
   ]
 }

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
@@ -39,7 +39,7 @@ Files skipped:
 
   [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
 
-   • [36m[22m[24mtargets/bad/invalid_python.py (3 lines skipped)[0m
+   • [36m[22m[24mtargets/bad/invalid_python.py (2 lines skipped)[0m
 
 
 Some files were skipped or only partially analyzed.

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/error.txt
@@ -39,7 +39,7 @@ Files skipped:
 
   [1m[24mSkipped by analysis failure due to parsing or internal Semgrep error[0m
 
-   • [36m[22m[24mtargets/bad/invalid_python.py (2 lines skipped)[0m
+   • [36m[22m[24mtargets/bad/invalid_python.py (3 lines skipped)[0m
 
 
 Some files were skipped or only partially analyzed.

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
@@ -3,13 +3,13 @@
     {
       "code": 3,
       "level": "warn",
-      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')\n    root = tree.getroot()` was unexpected",
+      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')` was unexpected",
       "path": "targets/bad/invalid_python.py",
       "spans": [
         {
           "end": {
-            "col": 26,
-            "line": 3
+            "col": 49,
+            "line": 2
           },
           "file": "targets/bad/invalid_python.py",
           "start": {

--- a/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
+++ b/cli/tests/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings1/out.json
@@ -3,13 +3,13 @@
     {
       "code": 3,
       "level": "warn",
-      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')` was unexpected",
+      "message": "Syntax error at line targets/bad/invalid_python.py:1:\n `def foo(a)\n    tree = ElementTree.parse('country_data.xml')\n    root = tree.getroot()` was unexpected",
       "path": "targets/bad/invalid_python.py",
       "spans": [
         {
           "end": {
-            "col": 49,
-            "line": 2
+            "col": 26,
+            "line": 3
           },
           "file": "targets/bad/invalid_python.py",
           "start": {


### PR DESCRIPTION
This is a small change to provide more intuitive default findings sort order in the app when using the ci command with semgrep.  This is a short-term improvement as other intentional (rather than arbitrary) ordering schemes are in the works.  PR also includes addition of tomli to pre commit yaml to enable `pre-commit run --all` to pass.
 
Current behavior: arbitrary ordering of rules (based on dictionary key ordering) and decreasing alphabetical / line numbering tracking where issues are found.
New behavior: rules with higher severity appear first, file names appear alphabetically and line numbers increment.

Test plan: this change is difficult to fully test locally.  I uploaded findings on a test repo (juicebox) to semgrep.dev and confirm ordering is as expected.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
