### PR TITLE
Fix path to ocaml-tree-sitter-core

### DIFF
--- a/dune
+++ b/dune
@@ -29,7 +29,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (subdir
-   semgrep-core/src/ocaml-tree-sitter-core/src/gen
+   libs/ocaml-tree-sitter-core/src/gen
    (data_only_dirs bin)
 )
 

--- a/scripts/osx-m1-release.sh
+++ b/scripts/osx-m1-release.sh
@@ -37,7 +37,7 @@ make setup
 
 # Remove dynamically linked libraries to force MacOS to use static ones
 # This needs to be done after make setup but before make build-*
-TREESITTER_LIBDIR=semgrep-core/src/ocaml-tree-sitter-core/tree-sitter/lib
+TREESITTER_LIBDIR=libs/ocaml-tree-sitter-core/tree-sitter/lib
 echo "TREESITTER_LIBDIR is $TREESITTER_LIBDIR and contains:"
 ls -l "$TREESITTER_LIBDIR" || true
 

--- a/scripts/osx-release.sh
+++ b/scripts/osx-release.sh
@@ -27,7 +27,7 @@ make setup
 
 # Remove dynamically linked libraries to force MacOS to use static ones
 # This needs to be done after make setup but before make build-*
-TREESITTER_LIBDIR=semgrep-core/src/ocaml-tree-sitter-core/tree-sitter/lib
+TREESITTER_LIBDIR=libs/ocaml-tree-sitter-core/tree-sitter/lib
 echo "TREESITTER_LIBDIR is $TREESITTER_LIBDIR and contains:"
 ls -l "$TREESITTER_LIBDIR" || true
 


### PR DESCRIPTION
This follows recent major reorganization of the repo structure.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
