### PR TITLE
chore: parse object types in js

### DIFF
--- a/changelog.d/pa-2414.fixed
+++ b/changelog.d/pa-2414.fixed
@@ -1,0 +1,1 @@
+JS/TS: Object types now support metavariables properly

--- a/languages/javascript/ast/ast_js.ml
+++ b/languages/javascript/ast/ast_js.ml
@@ -348,7 +348,7 @@ and type_ =
   | TyArray of type_ * (tok * unit * tok)
   | TyTuple of (tok * tuple_type_member list * tok)
   | TyFun of parameter list * type_ option
-  | TyRecordAnon of (tok * unit * tok)
+  | TyRecordAnon of (tok * property list * tok)
   | TyOr of type_ * tok * type_
   | TyAnd of type_ * tok * type_
   (* ex: KeyOf, This, *, LitType, LookupType, CondType, IndexKey, Typeof

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -487,8 +487,10 @@ and type_ x =
         | Some t -> type_ t
       in
       G.TyFun (params, rett) |> G.t
-  | TyRecordAnon (lt, (), rt) ->
-      G.TyRecordAnon ((G.Class, PI.fake_info lt ""), (lt, [], rt)) |> G.t
+  | TyRecordAnon (lt, properties, rt) ->
+      G.TyRecordAnon
+        ((G.Class, PI.fake_info lt ""), (lt, Common.map property properties, rt))
+      |> G.t
   | TyOr (t1, tk, t2) ->
       let t1 = type_ t1 in
       let t2 = type_ t2 in

--- a/languages/javascript/menhir/parser_js.mly
+++ b/languages/javascript/menhir/parser_js.mly
@@ -967,8 +967,8 @@ primary_type2:
  | predefined_type      { TyName ([$1]) }
  | type_reference       { $1 }
  | object_type
-    { let (t1, _xsTODO, t2) = $1 in
-      TyRecordAnon ((t1, (), t2)) }
+    { let (t1, xs, t2) = $1 in
+      TyRecordAnon ((t1, Common.map (fun x -> Field x) xs, t2)) }
  | "[" listc(type_) "]" { let members = List.map (fun x -> TyTupMember x) $2 in
                           TyTuple ($1, members, $3) }
  (* not in Typescript grammar *)

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -1758,14 +1758,14 @@ and primary_type (env : env) (x : CST.primary_type) : type_ =
   | `Gene_type x -> TyName (generic_type env x)
   | `Obj_type x ->
       let t1, xs, t2 = object_type env x in
-      let _xs =
+      let xs =
         xs
         |> Common.map_filter (function
              (* TODO *)
-             | Left _fld -> None
+             | Left prop -> Some prop
              | Right _sts -> None)
       in
-      TyRecordAnon (t1, (), t2)
+      TyRecordAnon (t1, xs, t2)
   | `Array_type (v1, v2, v3) ->
       let type_ = primary_type env v1 in
       let open_ = token env v2 (* "[" *) in

--- a/tests/rules/metavariable_object_type.ts
+++ b/tests/rules/metavariable_object_type.ts
@@ -1,0 +1,2 @@
+// ruleid: metavariable-object-type
+export type PayoutsApiToken = string & { match: void };

--- a/tests/rules/metavariable_object_type.ts
+++ b/tests/rules/metavariable_object_type.ts
@@ -1,4 +1,4 @@
 // ruleid: metavariable-object-type
-export type PayoutsApiToken = string & { match: void };
+export type Foo = string & { match: string };
 
-export type PayoutsApiToken = string & { foo: void };
+export type Bar = string & { foo: string };

--- a/tests/rules/metavariable_object_type.ts
+++ b/tests/rules/metavariable_object_type.ts
@@ -1,2 +1,4 @@
 // ruleid: metavariable-object-type
 export type PayoutsApiToken = string & { match: void };
+
+export type PayoutsApiToken = string & { foo: void };

--- a/tests/rules/metavariable_object_type.yaml
+++ b/tests/rules/metavariable_object_type.yaml
@@ -4,7 +4,7 @@ rules:
       - ts
     patterns:
       - pattern: |
-          type $TYPENAME = $TYPE & {$REGEX: void};
+          type $TYPENAME = $TYPE & {$REGEX: string};
       - metavariable-regex:
           metavariable: $REGEX
           regex: "match"

--- a/tests/rules/metavariable_object_type.yaml
+++ b/tests/rules/metavariable_object_type.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: metavariable-object-type 
+    languages:
+      - ts
+    patterns:
+      - pattern: |
+          type $TYPENAME = $TYPE & {$REGEX: void};
+      - metavariable-regex:
+          metavariable: $REGEX
+          regex: "match"
+    message: $REGEX should match the actual identifier 
+    severity: WARNING


### PR DESCRIPTION
## What:
Object types in JS are a TODO, meaning that metavariables in them don't currently match anything.

## Why:
See https://returntocorp.slack.com/archives/C01NXGX2EHZ/p1674238865924039

## How:
just consumed the already-parsed data

Closes PA-2414

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
