### PR TITLE
Start of commons.opam

### DIFF
--- a/commons.opam
+++ b/commons.opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "commons"
+version: "1.5.2"
+synopsis: "Yet another set of common utilities"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0" }
+  "alcotest"
+  "ANSITerminal"
+  "easy_logging" { = "0.8.1" }
+  "easy_logging_yojson" { = "0.8.1" }
+  "yojson"
+  "ppxlib"
+  "ppx_deriving"
+]
+
+build: ["dune" "build" "./_build/default/commons.install"]
+install: ["dune" "install" "commons"]


### PR DESCRIPTION
The goal is to release semgrep internal libraries as OPAM packages.

test plan:
opam install ./commons.opam


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)