### PR TITLE
Fix commons.opam for opam-repository linter

### DIFF
--- a/commons.opam
+++ b/commons.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "commons"
-version: "1.5.2"
+version: "1.5.3"
 synopsis: "Yet another set of common utilities"
 description: """
 This is a small library of utilities used by Semgrep and
@@ -9,7 +9,7 @@ a few other projects developed at r2c.
 
 maintainer: "Yoann Padioleau <pad@r2c.dev>"
 authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
-license: "LGPL-2.1"
+license: "LGPL-2.1-only"
 homepage: "https://semgrep.dev"
 dev-repo: "git+https://github.com/returntocorp/semgrep"
 bug-reports: "https://github.com/returntocorp/semgrep/issues"


### PR DESCRIPTION
test plan:
looked at https://spdx.org/licenses/ and found
a license that is accepted by the opam-repo linter.
wait for opam-repository CI.


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)