### PR TITLE
add re to commons.opam

### DIFF
--- a/commons.opam
+++ b/commons.opam
@@ -22,6 +22,7 @@ depends: [
   "easy_logging" { = "0.8.1" }
   "easy_logging_yojson" { = "0.8.1" }
   "yojson"
+  "re"
   "ppxlib"
   "ppx_deriving"
 ]

--- a/libs/commons/dune
+++ b/libs/commons/dune
@@ -3,6 +3,7 @@
  (wrapped false)
  (libraries
    str unix
+   re
    yojson easy_logging_yojson
    alcotest
    ANSITerminal


### PR DESCRIPTION
Found in opam-ci job failure for
https://github.com/ocaml/opam-repository/pull/23026

test plan:
wait for opam-ci to kick in


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)