### PR TITLE
chore: add tests for resolved names

### DIFF
--- a/tests/rules/resolved_metavariables.js
+++ b/tests/rules/resolved_metavariables.js
@@ -1,0 +1,20 @@
+// MATCH:
+import {bar as baz} from "foo";
+
+// MATCH:
+var res1 = baz()
+
+// MATCH:
+var res2 = baz()
+
+// MATCH:
+var res3 = baz()
+
+// MATCH:
+var res4 = baz()
+
+var res5 = baz()
+
+var res6 = baz()
+
+var res7 = baz()

--- a/tests/rules/resolved_metavariables.js
+++ b/tests/rules/resolved_metavariables.js
@@ -1,20 +1,26 @@
-// MATCH:
+// ruleid: resolved-metavariables 
 import {bar as baz} from "foo";
 
-// MATCH:
+// ruleid: resolved-metavariables 
 var res1 = baz()
 
-// MATCH:
+// ruleid: resolved-metavariables 
 var res2 = baz()
 
-// MATCH:
+// ruleid: resolved-metavariables 
 var res3 = baz()
 
-// MATCH:
+// ruleid: resolved-metavariables 
 var res4 = baz()
 
+// OK:
 var res5 = baz()
 
+// OK:
 var res6 = baz()
 
+// OK:
 var res7 = baz()
+
+// OK:
+var res8 = baz()

--- a/tests/rules/resolved_metavariables.yaml
+++ b/tests/rules/resolved_metavariables.yaml
@@ -43,6 +43,9 @@ rules:
             metavariable: $PACKAGE
             comparison: |
               $PACKAGE == $ID
+    - patterns:
+        - pattern: |
+            var res8 = $PACKAGE.$PACKAGE()
   message: | 
     We should be able to decompose on a resolved name with a 
     metavariable in a sensible way.

--- a/tests/rules/resolved_metavariables.yaml
+++ b/tests/rules/resolved_metavariables.yaml
@@ -1,0 +1,53 @@
+rules:
+- id: resolved-metavariables
+  pattern-either:
+    - patterns:
+        - pattern: |
+            var res1 = foo.bar()
+    - patterns: 
+        - pattern: |
+            var res2 = $ID()
+        - metavariable-pattern: 
+            metavariable: $ID
+            pattern: |
+              foo.bar
+    - patterns:
+        - pattern: |
+            var res3 = $PACKAGE.$ID()
+        - metavariable-pattern:
+            metavariable: $PACKAGE
+            pattern: |
+              foo
+    - patterns:
+        - pattern: |
+            var res4 = $PACKAGE.$ID()
+        - metavariable-regex: 
+            metavariable: $PACKAGE
+            regex: "^foo"
+    - patterns:
+        - pattern: |
+            ...
+            var res5 = $PACKAGE.$ID()
+        - focus-metavariable: $PACKAGE 
+    - patterns:
+        - pattern: |
+            var res6 = $PACKAGE.$ID()
+        - metavariable-comparison:
+            metavariable: $PACKAGE
+            comparison: |
+              str($PACKAGE) == str($ID)
+    - patterns:
+        - pattern: |
+            var res7 = $PACKAGE.$ID()
+        - metavariable-comparison:
+            metavariable: $PACKAGE
+            comparison: |
+              $PACKAGE == $ID
+  message: | 
+    We should be able to decompose on a resolved name with a 
+    metavariable in a sensible way.
+    Note that $PACKAGE and $ID will both resolve to `baz`,
+    in the interpolated message.
+  severity: WARNING
+  languages: [javascript]
+


### PR DESCRIPTION
## What:
This is the test suite that ideally should describe the engine behavior for matching resolved names (as well as imported entities) to metavariables.

The main tests that are contentious are tests 4, 5, 6, and 7, due to things like `focus-metavariable`, `metavariable-regex`, and `metavariable-comparison`.

I did check, and noted that metavariables seem to not unify in situations they should not, as for unresolved metavariables the content of the metavariable "as stated" is what is used for comparison, not the actual content at the location. So the tokens don't change that.

I added it here in `semgrep` because I think it should be able to pass for both OSS and pro.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
