### PR TITLE
chore: fix reported command when using `semgrep-core-proprietary`

### DIFF
--- a/changelog.d/pa-2417.fixed
+++ b/changelog.d/pa-2417.fixed
@@ -1,0 +1,1 @@
+CLI: No longer reports the wrong command if you are using the `semgrep-core-proprietary` executable.

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -918,7 +918,11 @@ This time, we will continue running your old DeepSemgrep binary anyways.
                 # still visible in the log message above.)
                 printed_cmd = cmd.copy()
                 printed_cmd[0] = (
-                    deep_path if deep_path and deep else SemgrepCore.executable_path()
+                    pro_path
+                    if pro_path and deep
+                    else deep_path
+                    if deep_path and deep
+                    else SemgrepCore.executable_path()
                 )
                 print(" ".join(printed_cmd))
                 sys.exit(0)


### PR DESCRIPTION
## What:
This makes the `semgrep` CLI report the proper command when you are using the `semgrep-core-proprietary` executable.

## Why:
Due to a mismatch in logic, this was making it report that you were using the `deep-semgrep` or `semgrep-core` executables, possibly, if you were really using `semgrep-core-proprietary`.

## How:
Just made it switch to `semgrep-core-proprietary` under the right conditions.

## Test plan:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/49291449/213985930-7c1c597d-19b7-4f8e-a424-ed41acc6b8c7.png">

Closes PA-2417.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
