### PR TITLE
fix lowerdep issues in commons.opam

### DIFF
--- a/commons.opam
+++ b/commons.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "commons"
-version: "1.5.3"
+version: "1.5.4"
 synopsis: "Yet another set of common utilities"
 description: """
 This is a small library of utilities used by Semgrep and
@@ -17,14 +17,14 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 depends: [
   "ocaml" {>= "4.12.0"}
   "dune" {>= "2.7.0" }
-  "alcotest"
-  "ANSITerminal"
+  "alcotest" {>= "1.5.0"}
+  "ANSITerminal" {>= "0.8.4"}
   "easy_logging" { = "0.8.1" }
   "easy_logging_yojson" { = "0.8.1" }
-  "yojson"
-  "re"
-  "ppxlib"
-  "ppx_deriving"
+  "yojson" {>= "1.7.0"}
+  "re" {>= "1.10.4"}
+  "ppxlib" {>= "0.25.0"}
+  "ppx_deriving" {>= "5.2.1"}
 ]
 
 build: ["dune" "build" "./_build/default/commons.install"]

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -61,7 +61,9 @@ let ( =:= ) : bool -> bool -> bool = ( = )
 (* dangerous, do not use, see the comment in Common.mli *)
 let ( =*= ) = ( = )
 
-(* to forbid people to use the polymorphic '=' *)
+(* To forbid people to use the polymorphic '='.
+ * See https://blog.janestreet.com/the-perils-of-polymorphic-compare/
+ *)
 let ( = ) = String.equal
 
 (*****************************************************************************)


### PR DESCRIPTION
Found via opam-ci. Easier to pin the version
of the libraries we depend on.

test plan:
wait for opam-ci and got all green.
see https://github.com/ocaml/opam-repository/pull/23027


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)