### PR TITLE
chore: add back `install-deep-semgrep` to suggest real command

### DIFF
--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -6,6 +6,7 @@ from typing import Dict
 import click
 
 from semgrep.commands.ci import ci
+from semgrep.commands.install import install_deep_semgrep
 from semgrep.commands.install import install_semgrep_pro
 from semgrep.commands.login import login
 from semgrep.commands.login import logout
@@ -92,5 +93,7 @@ cli.add_command(logout)
 cli.add_command(publish)
 cli.add_command(scan)
 cli.add_command(install_semgrep_pro)
+# Just for backwards compat
+cli.add_command(install_deep_semgrep)
 cli.add_command(shouldafound)
 cli.add_command(lsp)

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -126,3 +126,18 @@ def install_semgrep_pro() -> None:
     Visit https://semgrep.dev/deep-semgrep-beta for more information
     """
     run_install_semgrep_pro()
+
+
+@click.command(hidden=True)
+@handle_command_errors
+def install_deep_semgrep() -> None:
+    """
+    This no longer installs the DeepSemgrep binary, but it will suggest
+    to you the real command that does.
+    """
+    logger.info(f"This command no longer installs the DeepSemgrep binary.")
+    logger.info(
+        f"Instead, try installing the Semgrep PRO engine via `semgrep install-semgrep-pro`."
+    )
+
+    sys.exit(FATAL_EXIT_CODE)


### PR DESCRIPTION
## What:
`semgrep install-deep-semgrep` has been deprecated in favor of `semgrep install-semgrep-pro`. We totally killed the command, but this PR just adds it back and makes it suggest the real command. Customer-First!

## Why:
Cause it's confusing.

## How:
Boring excellence.

![image](https://user-images.githubusercontent.com/49291449/214125645-2bab01fb-e4a4-4536-9fd0-ec64920a76e5.png)


PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
