### PR TITLE
feat!: `unique_name`s

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -303,7 +303,16 @@ and resolved_name_kind =
    * resolved_name, but we also want to match the pattern `foo.bar` so we will
    * store ['foo', 'bar'] as an alternate name.
    * *)
-  | ResolvedName of dotted_ident * dotted_ident list
+  | ResolvedName of unique_name * unique_name list
+
+(* This is not relevant for matching purposes.
+   `unique_name` is a record of all the information necessary to
+   disambiguate two `ResolvedName`s from each other.
+   In particular, two `ResolvedName`s may indicate two overloaded functions,
+   which are named the same. Then, we need to use the function signature information
+   to disambiguate them from each other.
+*)
+and unique_name = { dotted : dotted_ident; tok : tok option }
 [@@deriving show { with_path = false }, eq, hash]
 
 (* Start of big mutually recursive types because of the use of 'any'
@@ -365,7 +374,7 @@ and id_info = {
    * a typed entity, which can be interpreted as a TypedMetavar in semgrep.
    * alt: have an explicity type_ field in entity.
    *)
-  id_type : type_ option ref;
+  id_type : type_ option ref; [@equal fun _a _b -> true]
   (* type checker (typing) *)
   (* sgrep: this is for sgrep constant propagation hack.
    * todo? associate only with Id?

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -374,7 +374,7 @@ and id_info = {
    * a typed entity, which can be interpreted as a TypedMetavar in semgrep.
    * alt: have an explicity type_ field in entity.
    *)
-  id_type : type_ option ref; [@equal fun _a _b -> true]
+  id_type : type_ option ref;
   (* type checker (typing) *)
   (* sgrep: this is for sgrep constant propagation hack.
    * todo? associate only with Id?

--- a/libs/ast_generic/AST_generic_to_v1.ml
+++ b/libs/ast_generic/AST_generic_to_v1.ml
@@ -110,7 +110,7 @@ and map_resolved_name_kind = function
   | Macro -> `OtherResolvedNameKind "Macro"
   | EnumConstant -> `OtherResolvedNameKind "EnumConstant"
   | TypeName -> `OtherResolvedNameKind "TypeName"
-  | ResolvedName (v1, _v2less) ->
+  | ResolvedName ({ dotted = v1; _ }, _v2less) ->
       let v1 = map_dotted_ident v1 in
       `ImportedEntity v1
 

--- a/libs/ast_generic/Map_AST.ml
+++ b/libs/ast_generic/Map_AST.ml
@@ -98,6 +98,10 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let e = map_expr e in
         let t = map_tok t in
         QExpr (e, t)
+  and map_unique_name { dotted; tok } =
+    let v_dotted = map_dotted_ident dotted in
+    let v_tok = map_of_option map_tok tok in
+    { dotted = v_dotted; tok = v_tok }
   and map_module_name = function
     | FileName v1 ->
         let v1 = map_wrap map_of_string v1 in
@@ -124,8 +128,8 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | EnumConstant -> EnumConstant
     | TypeName -> TypeName
     | ResolvedName (v1, v2) ->
-        let v1 = map_dotted_ident v1 in
-        let v2 = map_of_list map_dotted_ident v2 in
+        let v1 = map_unique_name v1 in
+        let v2 = map_of_list map_unique_name v2 in
         ResolvedName (v1, v2)
   and map_name_info
       {

--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -59,9 +59,19 @@ and vof_resolved_name_kind = function
   | EnumConstant -> OCaml.VSum ("EnumConstant", [])
   | TypeName -> OCaml.VSum ("TypeName", [])
   | ResolvedName (v1, v2) ->
-      let v1 = vof_dotted_ident v1 in
-      let v2 = OCaml.vof_list vof_dotted_ident v2 in
+      let v1 = vof_unique_name v1 in
+      let v2 = OCaml.vof_list vof_unique_name v2 in
       OCaml.VSum ("ResolvedName", [ v1; v2 ])
+
+and vof_unique_name { dotted; tok } =
+  let bnds = [] in
+  let arg = OCaml.vof_option (fun x -> vof_tok x) tok in
+  let bnd = ("tok", arg) in
+  let bnds = bnd :: bnds in
+  let arg = vof_dotted_ident dotted in
+  let bnd = ("dotted", arg) in
+  let bnds = bnd :: bnds in
+  OCaml.VDict bnds
 
 let rec vof_qualifier = function
   | QDots v1 ->

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -162,6 +162,9 @@ let (mk_visitor :
     | QExpr (e, t) ->
         v_expr e;
         v_tok t
+  and v_unique_name { dotted = v1; tok = _IGNORED } =
+    let v1 = v_dotted_ident v1 in
+    ()
   and v_module_name = function
     | FileName v1 ->
         let v1 = v_wrap v_string v1 in
@@ -187,8 +190,8 @@ let (mk_visitor :
     | EnumConstant -> ()
     | TypeName -> ()
     | ResolvedName (v1, v2) ->
-        let v1 = v_dotted_ident v1 in
-        let v2 = v_list v_dotted_ident v2 in
+        let v1 = v_unique_name v1 in
+        let v2 = v_list v_unique_name v2 in
         ()
   and v_name_info
       { name_middle = v4; name_top = v3; name_last = v1; name_info = v2 } =

--- a/src/analyzing/Dataflow_svalue.ml
+++ b/src/analyzing/Dataflow_svalue.ml
@@ -54,7 +54,7 @@ let warning _tok s =
 
 let str_of_name name = spf "%s:%s" (fst name.ident) (G.SId.show name.sid)
 
-let str_of_resolved_name name =
+let str_of_resolved_name { G.dotted = name; _ } =
   let name = Common.map fst name in
   String.concat "." name
 

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -458,8 +458,7 @@ let rec m_name a b =
   let try_alternate_names = function
     | B.ResolvedName (_, alternate_names) ->
         List.fold_left
-          (fun acc alternate_name ->
-            acc >||> m_name a (H.name_of_ids alternate_name))
+          (fun acc { B.dotted; _ } -> acc >||> m_name a (H.name_of_ids dotted))
           (fail ()) alternate_names
     | _ -> fail ()
   in
@@ -475,7 +474,7 @@ let rec m_name a b =
                    Some
                      ( (( B.ImportedEntity dotted
                         | B.ImportedModule (B.DottedName dotted)
-                        | B.ResolvedName (dotted, _) ) as resolved),
+                        | B.ResolvedName ({ dotted; _ }, _) ) as resolved),
                        _sid );
                };
              _;
@@ -518,8 +517,8 @@ let rec m_name a b =
                  {
                    contents =
                      Some
-                       ( ((B.ImportedEntity dotted | B.ResolvedName (dotted, _))
-                         as resolved),
+                       ( (( B.ImportedEntity dotted
+                          | B.ResolvedName ({ dotted; _ }, _) ) as resolved),
                          _sid );
                  };
                _;
@@ -572,7 +571,7 @@ let rec m_name a b =
                      Some
                        ( (( B.ImportedEntity dotted
                           | B.ImportedModule (B.DottedName dotted)
-                          | B.ResolvedName (dotted, _) ) as resolved),
+                          | B.ResolvedName ({ dotted; _ }, _) ) as resolved),
                          _sid );
                  };
                _;

--- a/src/matching/Generic_vs_generic.mli
+++ b/src/matching/Generic_vs_generic.mli
@@ -19,4 +19,4 @@ val m_name : AST_generic.name Matching_generic.matcher
 val m_any : AST_generic.any Matching_generic.matcher
 
 val hook_find_possible_parents :
-  (AST_generic.dotted_ident -> AST_generic.name list) option ref
+  (AST_generic.unique_name -> AST_generic.name list) option ref


### PR DESCRIPTION
## What:
This PR adds in `unique_name`, which is a transparent type equivalent to `Name.t`, for use in OSS Semgrep.

## Why:
This will help to uniquely identify names in the PRO engine. This information needs to be passed back to OSS, and since we don't have the `Name.t` type, we mint one that is just equivalent.

## How:
Boilerplate.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
