### PR TITLE
fix: cleanup semgrep brew caches before re-running

### DIFF
--- a/.github/workflows/homebrew-core-head.yml
+++ b/.github/workflows/homebrew-core-head.yml
@@ -25,6 +25,8 @@ jobs:
         # This is sub-optimal - our workflows shouldn't have to conform to their environment.
         # However, on the runner side, we can't hook into the workflow run to clean up after.
         run: brew uninstall semgrep || true
+      - name: Cleanup semgrep
+        run: brew cleanup --prune=all semgrep
       - name: Brew update
         run: brew update
       - name: Brew Install


### PR DESCRIPTION
The Nightly homebrew checks were failing due to a not-hermetic build (moved submodules caused us issues again). This cleans up as a stopgap, MTF on a more permanent fix.

There's likely more discussion here on whether this affects other workflows. Will discuss this before marking this PR as ready for review.

Test Plan:

1. Run a nightly test using this branch ([success](https://github.com/returntocorp/semgrep/actions/runs/3992135935))

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
