### PR TITLE
feat!: type coercions for Terraform

### DIFF
--- a/changelog.d/gh-6898.fixed
+++ b/changelog.d/gh-6898.fixed
@@ -1,0 +1,1 @@
+Terraform: Implicit coercions between strings, bools, ints, and floats are now allowed to match.

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -1171,38 +1171,37 @@ and m_for_or_if_comp a b =
 *)
 and m_literal a b =
   Trace_matching.(if on then print_literal_pair a b);
-  fun tin ->
-    if Lang.equal tin.lang Lang.Hcl then
-      (* Is it ugly? Yes.
-         Is it clear what it does? Also yes, I think. Moreso than factorizing it.
-         So let's just let it be.
-      *)
-      match (a, b) with
-      | G.Int (a1, a2), B.String (b1, b2) ->
-          let i = Option.map Int.to_string a1 in
-          m_wrap_m_string_opt (i, a2) (Some b1, b2) tin
-      | G.String (a1, a2), B.Int (b1, b2) ->
-          let i = Option.map Int.to_string b1 in
-          m_wrap_m_string_opt (Some a1, a2) (i, b2) tin
-      | G.Bool (a1, a2), B.String (b1, b2) ->
-          let b = Bool.to_string a1 in
-          m_wrap m_string (b, a2) (b1, b2) tin
-      | G.String (a1, a2), B.Bool (b1, b2) ->
-          let b = Bool.to_string b1 in
-          m_wrap m_string (a1, a2) (b, b2) tin
-      (* For the float case, we coerce from string to float, rather
-         than float to string.
-         While this is not strictly what Hcl does, this is because we
-         may have inconsistency in how floats are represented, as strings.
-      *)
-      | G.Float (a1, a2), B.String (b1, b2) ->
-          let f = Float.of_string_opt b1 in
-          m_wrap_m_float_opt (a1, a2) (f, b2) tin
-      | G.String (a1, a2), B.Float (b1, b2) ->
-          let f = Float.of_string_opt a1 in
-          m_wrap_m_float_opt (f, a2) (b1, b2) tin
-      | __else__ -> m_literal_inner a b tin
-    else m_literal_inner a b tin
+  with_lang (fun lang ->
+      if Lang.equal lang Lang.Hcl then
+        (* We choose not to use an or-pattern to maintain the
+           sides of the trees.
+        *)
+        match (a, b) with
+        | G.Int (a1, a2), B.String (b1, b2) ->
+            let i = Option.map Int.to_string a1 in
+            m_wrap_m_string_opt (i, a2) (Some b1, b2)
+        | G.String (a1, a2), B.Int (b1, b2) ->
+            let i = Option.map Int.to_string b1 in
+            m_wrap_m_string_opt (Some a1, a2) (i, b2)
+        | G.Bool (a1, a2), B.String (b1, b2) ->
+            let b = Bool.to_string a1 in
+            m_wrap m_string (b, a2) (b1, b2)
+        | G.String (a1, a2), B.Bool (b1, b2) ->
+            let b = Bool.to_string b1 in
+            m_wrap m_string (a1, a2) (b, b2)
+        (* For the float case, we coerce from string to float, rather
+           than float to string.
+           While this is not strictly what Hcl does, this is because we
+           may have inconsistency in how floats are represented, as strings.
+        *)
+        | G.Float (a1, a2), B.String (b1, b2) ->
+            let f = Float.of_string_opt b1 in
+            m_wrap_m_float_opt (a1, a2) (f, b2)
+        | G.String (a1, a2), B.Float (b1, b2) ->
+            let f = Float.of_string_opt a1 in
+            m_wrap_m_float_opt (f, a2) (b1, b2)
+        | __else__ -> m_literal_inner a b
+      else m_literal_inner a b)
 
 and m_literal_inner a b =
   Trace_matching.(if on then print_literal_pair a b);
@@ -1259,7 +1258,6 @@ and m_wrap_m_int_opt (a1, a2) (b1, b2) =
 
 and m_wrap_m_string_opt (a1, a2) (b1, b2) =
   match (a1, b1) with
-  (* iso: semantic equivalence of value! 0x8 can match 8 *)
   | Some s1, Some s2 when String.equal s1 s2 -> return ()
   | _ ->
       let a1 = Parse_info.str_of_info a2 in

--- a/tests/rules/terraform_coercions.tf
+++ b/tests/rules/terraform_coercions.tf
@@ -1,0 +1,16 @@
+
+resource "fakeresource" "fakername" {
+    # ruleid: terraform-coercions 
+    thing1 = 150
+    # ruleid: terraform-coercions 
+    thing2 = true
+    # ruleid: terraform-coercions 
+    thing3 = 1.50
+
+    # ruleid: terraform-coercions 
+    thing1_coerced = "150"
+    # ruleid: terraform-coercions 
+    thing2_coerced = "true"
+    # ruleid: terraform-coercions 
+    thing3_coerced = "1.50"
+}

--- a/tests/rules/terraform_coercions.yaml
+++ b/tests/rules/terraform_coercions.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: terraform-coercions
+  pattern-either:
+  - pattern: |
+      $ID = 150
+  - pattern: |
+      $ID = true
+  - pattern: |
+      $ID = 1.50
+  message: Working!
+  severity: WARNING
+  languages: [hcl]


### PR DESCRIPTION
## What:
This PR adds in coercions from literals of bools, ints, and floats to strings, in the matching engine.

## Why:
This is how Terraform works, and it was requested by a user: #6898 

## How:
I added a wrapper for `m_literal`, which first checks if the language is `hcl`. If so, then it does the coercions on the necessary cases. Otherwise, it will defer to the original `m_literal`, now named `m_literal_inner`.

## Test plan:
`make test`

Closes #6898 

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
