### PR TITLE
chore: expose js angular decorators helper

### DIFF
--- a/src/naming/Naming_AST.ml
+++ b/src/naming/Naming_AST.ml
@@ -412,11 +412,19 @@ let params_of_parameters env xs =
    parameters.
    This also works for `@Component`.
 *)
+let is_js_angular_decorator s =
+  match s with
+  | "Injectable"
+  | "Component" ->
+      true
+  | _ -> false
+
 let js_get_angular_constructor_args env attrs defs =
   let is_injectable =
     List.exists
       (function
-        | NamedAttr (_, Id ((("Injectable" | "Component"), _), _), _) -> true
+        | NamedAttr (_, Id ((s, _), _), _) when is_js_angular_decorator s ->
+            true
         | _ -> false)
       attrs
   in

--- a/src/naming/Naming_AST.mli
+++ b/src/naming/Naming_AST.mli
@@ -3,4 +3,12 @@
  * specific to a language.
  *)
 val resolve : Lang.t -> AST_generic.program -> unit
+
+(* We expose this language-specific (and framework-specific!)
+   function here because it is needed in Semgrep Pro.
+   This lets us avoid having to duplicate the logic of this function.
+
+   There's not really a better place to put this, so we'll just
+   let it exist here.
+*)
 val is_js_angular_decorator : string -> bool

--- a/src/naming/Naming_AST.mli
+++ b/src/naming/Naming_AST.mli
@@ -3,3 +3,4 @@
  * specific to a language.
  *)
 val resolve : Lang.t -> AST_generic.program -> unit
+val is_js_angular_decorator : string -> bool

--- a/tests/rules/js_constructor_naming.js
+++ b/tests/rules/js_constructor_naming.js
@@ -14,7 +14,7 @@ class ClassName {
   }
 
 @Component
-class ClassName {
+class ClassName2 {
     foo () {
         // ruleid: js-constructor-naming
         return this.http.thing
@@ -30,7 +30,7 @@ class ClassName {
   
 
 // not injectable
-class ClassName {
+class ClassName3 {
     foo () {
         return this.http.thing
     }


### PR DESCRIPTION
## What:
To fix a regression in DeepSemgrep, I have to add logic in `Naming_SAST` duplicating something I already did in `Naming_AST`.

To avoid having to duplicate hard-coded values, I want to expose an `is_js_angular_decorator` function which will tell if a decorator is possibly an Angular JS decorator, in which case different behavior should occur.

## Why:
This will allow me to make changes in DeepSemgrep without having to hard-code values

## How:
Exposed aforementioend function

## Test plan:
in Semgrep PRO

No changelog because not user-facing

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
