### PR TITLE
CLI: Clean --deep code and add --pro and --fast-deep

### DIFF
--- a/changelog.d/pa-2440.changed
+++ b/changelog.d/pa-2440.changed
@@ -1,0 +1,3 @@
+PRO: Add **experimental** flags --pro and --fast-deep. Using --pro you can enable
+Apex support, and with --fast-deep you can enable intra-file inter-procedural
+taint analysis.

--- a/changelog.d/pa-2440.changed
+++ b/changelog.d/pa-2440.changed
@@ -1,3 +1,4 @@
 PRO: Add **experimental** flags --pro and --fast-deep. Using --pro you can enable
 Apex support, and with --fast-deep you can enable intra-file inter-procedural
-taint analysis.
+taint analysis. Note that to use any of the PRO features you must first run
+`semgrep install-semgrep-pro` while being logged in.

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -24,6 +24,7 @@ from semgrep.commands.scan import scan_options
 from semgrep.commands.wrapper import handle_command_errors
 from semgrep.config_resolver import Config
 from semgrep.constants import DEFAULT_MAX_MEMORY_DEEP_CI
+from semgrep.constants import EngineType
 from semgrep.constants import OutputFormat
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import INVALID_API_KEY_EXIT_CODE
@@ -380,7 +381,7 @@ def ci(
                 lockfile_scan_info,
             ) = semgrep.semgrep_main.main(
                 core_opts_str=core_opts,
-                deep=deep,
+                engine=EngineType.DEEP_INTER if deep else EngineType.OSS,
                 output_handler=output_handler,
                 target=[os.curdir],  # semgrep ci only scans cwd
                 pattern=None,

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -128,6 +128,7 @@ def install_semgrep_pro() -> None:
     run_install_semgrep_pro()
 
 
+# DEPRECATED: To be removed by Feb 2023 launch
 @click.command(hidden=True)
 @handle_command_errors
 def install_deep_semgrep() -> None:

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -29,6 +29,17 @@ RETURNTOCORP_LEVER_URL = "https://api.lever.co/v0/postings/returntocorp?mode=jso
 UNSUPPORTED_EXT_IGNORE_LANGS = {"generic", "regex"}
 
 
+class EngineType(Enum):
+    OSS = auto()
+    PRO = auto()
+    DEEP_INTRA = auto()
+    DEEP_INTER = auto()
+
+    @property
+    def is_pro(self) -> bool:
+        return self.value >= EngineType.PRO.value
+
+
 class OutputFormat(Enum):
     TEXT = auto()
     JSON = auto()

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -33,6 +33,7 @@ import semgrep.output_from_core as core
 from semgrep.app import auth
 from semgrep.config_resolver import Config
 from semgrep.constants import Colors
+from semgrep.constants import EngineType
 from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
 from semgrep.core_output import core_error_to_semgrep_error
 from semgrep.core_output import core_matches_to_rule_matches
@@ -518,14 +519,16 @@ class CoreRunner:
     def __init__(
         self,
         jobs: Optional[int],
-        deep: bool,
+        engine: EngineType,
         timeout: int,
         max_memory: int,
         timeout_threshold: int,
         optimizations: str,
         core_opts_str: Optional[str],
     ):
-        self._jobs = jobs if jobs else 1 if deep else get_cpu_count()
+        self._jobs = (
+            jobs if jobs else 1 if engine is EngineType.DEEP_INTER else get_cpu_count()
+        )
         self._timeout = timeout
         self._max_memory = max_memory
         self._timeout_threshold = timeout_threshold
@@ -727,7 +730,7 @@ class CoreRunner:
         rules: List[Rule],
         target_manager: TargetManager,
         dump_command_for_core: bool,
-        deep: bool,
+        engine: EngineType,
     ) -> Tuple[
         RuleMatchMap,
         List[SemgrepError],
@@ -818,7 +821,7 @@ class CoreRunner:
 
             # TODO: use exact same command-line arguments so just
             # need to replace the SemgrepCore.path() part.
-            if deep:
+            if engine.is_pro:
                 if auth.get_token() is None:
                     logger.error("!!!This is a proprietary extension of semgrep.!!!")
                     logger.error("!!!You must be logged in to access this extension!!!")
@@ -826,15 +829,10 @@ class CoreRunner:
                     logger.error(
                         "You are using the Semgrep Pro Engine, our advanced analysis system uniquely designed to refine and enhance your results."
                     )
-                    logger.error(
-                        "You can expect to see longer scan times - we're taking our time to make sure everything is just right for you. With <3, the Semgrep team."
-                    )
-
-                targets = target_manager.targets
-                if len(targets) == 1 and targets[0].path.is_dir():
-                    root = str(targets[0].path)
-                else:
-                    raise SemgrepError("deep mode needs a single target (root) dir")
+                    if engine is EngineType.DEEP_INTER:
+                        logger.error(
+                            "You can expect to see longer scan times - we're taking our time to make sure everything is just right for you. With <3, the Semgrep team."
+                        )
 
                 deep_path = (
                     SemgrepCore.deep_path()
@@ -842,18 +840,16 @@ class CoreRunner:
                 pro_path = SemgrepCore.pro_path()
 
                 if pro_path is None:
-                    if deep_path is None:
-                        raise SemgrepError(
-                            "Could not run deep analysis: Semgrep PRO engine not installed. Run `semgrep install-semgrep-pro`"
-                        )
-                    else:
-                        logger.warning(
+                    if deep_path is not None:
+                        logger.error(
                             f"""You have an old DeepSemgrep binary installed in {deep_path}
 DeepSemgrep is now Semgrep PRO, run `semgrep install-semgrep-pro` to install it,
 then please delete {deep_path} manually.
-This time, we will continue running your old DeepSemgrep binary anyways.
 """
                         )
+                    raise SemgrepError(
+                        "Could not run deep analysis: Semgrep PRO engine not installed. Run `semgrep install-semgrep-pro`"
+                    )
 
                 if pro_path is not None:
                     logger.info(f"Using Semgrep PRO installed in {pro_path}")
@@ -866,41 +862,20 @@ This time, we will continue running your old DeepSemgrep binary anyways.
                     logger.info(f"Semgrep PRO Version Info: ({version})")
 
                     cmd_bin = pro_path
-                    cmd_args += ["-deep_inter_file"]
-                    cmd_args += [root]
-                elif (
-                    deep_path is not None
-                ):  # DEPRECATED: To be removed by Feb 2023 launch
-                    logger.info(
-                        f"Using old DeepSemgrep installed in {deep_path} - Please upgrade to Semgrep PRO!"
-                    )
-                    version = sub_check_output(
-                        [deep_path, "--version"],
-                        timeout=10,
-                        encoding="utf-8",
-                        stderr=subprocess.DEVNULL,
-                    ).rstrip()
-                    logger.info(f"DeepSemgrep Version Info: ({version})")
 
-                    cmd_bin = deep_path
-                    cmd_args = [
-                        "--json",
-                        "--rules",
-                        rule_file.name,
-                        "-j",
-                        str(self._jobs),
-                        "--targets",
-                        target_file.name,
-                        "--root",
-                        root,
-                        "--json_time",
-                        # "--timeout",
-                        # str(self._timeout),
-                        # "--timeout_threshold",
-                        # str(self._timeout_threshold),
-                        "--max_memory",
-                        str(self._max_memory),
-                    ]
+                    if engine is EngineType.DEEP_INTER:
+                        targets = target_manager.targets
+                        if len(targets) == 1 and targets[0].path.is_dir():
+                            root = str(targets[0].path)
+                        else:
+                            # TODO: This is no longer true...
+                            raise SemgrepError(
+                                "deep mode needs a single target (root) dir"
+                            )
+                        cmd_args += ["-deep_inter_file"]
+                        cmd_args += [root]
+                    elif engine is EngineType.DEEP_INTRA:
+                        cmd_args += ["-deep_intra_file"]
 
             stderr: Optional[int] = subprocess.PIPE
             if state.terminal.is_debug:
@@ -919,9 +894,7 @@ This time, we will continue running your old DeepSemgrep binary anyways.
                 printed_cmd = cmd.copy()
                 printed_cmd[0] = (
                     pro_path
-                    if pro_path and deep
-                    else deep_path
-                    if deep_path and deep
+                    if pro_path and engine.is_pro
                     else SemgrepCore.executable_path()
                 )
                 print(" ".join(printed_cmd))
@@ -988,7 +961,7 @@ This time, we will continue running your old DeepSemgrep binary anyways.
         rules: List[Rule],
         target_manager: TargetManager,
         dump_command_for_core: bool,
-        deep: bool,
+        engine: EngineType,
     ) -> Tuple[
         RuleMatchMap,
         List[SemgrepError],
@@ -1007,10 +980,10 @@ This time, we will continue running your old DeepSemgrep binary anyways.
         """
         try:
             return self._run_rules_direct_to_semgrep_core_helper(
-                rules, target_manager, dump_command_for_core, deep
+                rules, target_manager, dump_command_for_core, engine
             )
         except Exception as e:
-            if deep:
+            if engine.is_pro:
                 logger.error(
                     f"""
 
@@ -1033,7 +1006,7 @@ Exception raised: `{e}`
         target_manager: TargetManager,
         rules: List[Rule],
         dump_command_for_core: bool,
-        deep: bool,
+        engine: EngineType,
     ) -> Tuple[
         RuleMatchMap,
         List[SemgrepError],
@@ -1055,7 +1028,7 @@ Exception raised: `{e}`
             parsing_data,
             explanations,
         ) = self._run_rules_direct_to_semgrep_core(
-            rules, target_manager, dump_command_for_core, deep
+            rules, target_manager, dump_command_for_core, engine
         )
 
         logger.debug(

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -526,9 +526,14 @@ class CoreRunner:
         optimizations: str,
         core_opts_str: Optional[str],
     ):
-        self._jobs = (
-            jobs if jobs else 1 if engine is EngineType.DEEP_INTER else get_cpu_count()
-        )
+        if jobs is None:
+            if engine is EngineType.DEEP_INTER:
+                # In some cases inter-file analysis consumes too much memory, and
+                # not using multi-core seems to help containing the problem.
+                jobs = 1
+            else:
+                jobs = get_cpu_count()
+        self._jobs = jobs
         self._timeout = timeout
         self._max_memory = max_memory
         self._timeout_threshold = timeout_threshold

--- a/cli/src/semgrep/lsp/config.py
+++ b/cli/src/semgrep/lsp/config.py
@@ -18,6 +18,7 @@ import semgrep.output_from_core as core
 import semgrep.semgrep_main
 from semgrep.app.scans import ScanHandler
 from semgrep.config_resolver import get_config
+from semgrep.constants import EngineType
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
 from semgrep.error import SemgrepError
@@ -253,7 +254,7 @@ class LSPConfig:
         get_state().metrics.configure(self.metrics, None)
         return partial(
             semgrep.semgrep_main.main,
-            deep=False,
+            engine=EngineType.OSS,
             configs=configs,
             severity=self.severity,
             exclude=self.exclude,

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -20,6 +20,7 @@ from semgrep import __VERSION__
 from semgrep.autofix import apply_fixes
 from semgrep.config_resolver import get_config
 from semgrep.constants import DEFAULT_TIMEOUT
+from semgrep.constants import EngineType
 from semgrep.constants import OutputFormat
 from semgrep.constants import RuleSeverity
 from semgrep.core_runner import CoreRunner
@@ -143,7 +144,7 @@ def run_rules(
     core_runner: CoreRunner,
     output_handler: OutputHandler,
     dump_command_for_core: bool,
-    deep: bool,
+    engine: EngineType,
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -168,7 +169,7 @@ def run_rules(
         parsing_data,
         explanations,
     ) = core_runner.invoke_semgrep(
-        target_manager, rest_of_the_rules, dump_command_for_core, deep
+        target_manager, rest_of_the_rules, dump_command_for_core, engine
     )
 
     if join_rules:
@@ -277,7 +278,7 @@ def main(
     *,
     core_opts_str: Optional[str] = None,
     dump_command_for_core: bool = False,
-    deep: bool = False,
+    engine: EngineType = EngineType.OSS,
     output_handler: OutputHandler,
     target: Sequence[str],
     pattern: Optional[str],
@@ -406,7 +407,7 @@ def main(
     core_start_time = time.time()
     core_runner = CoreRunner(
         jobs=jobs,
-        deep=deep,
+        engine=engine,
         timeout=timeout,
         max_memory=max_memory,
         timeout_threshold=timeout_threshold,
@@ -440,7 +441,7 @@ def main(
         core_runner,
         output_handler,
         dump_command_for_core,
-        deep,
+        engine,
     )
     profiler.save("core_time", core_start_time)
     output_handler.handle_semgrep_errors(semgrep_errors)
@@ -505,7 +506,7 @@ def main(
                         core_runner,
                         output_handler,
                         dump_command_for_core,
-                        deep,
+                        engine,
                     )
                     rule_matches_by_rule = remove_matches_in_baseline(
                         rule_matches_by_rule,

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -34,6 +34,7 @@ from boltons.iterutils import partition
 from ruamel.yaml import YAML
 
 from semgrep.constants import BREAK_LINE
+from semgrep.constants import EngineType
 from semgrep.semgrep_main import invoke_semgrep
 from semgrep.util import final_suffix_matches
 from semgrep.util import is_config_fixtest_suffix
@@ -445,7 +446,7 @@ def generate_test_results(
     config: Path,
     strict: bool,
     json_output: bool,
-    deep: bool,
+    engine: EngineType,
     optimizations: str = "none",
 ) -> None:
     config_filenames = get_config_filenames(config)
@@ -466,7 +467,7 @@ def generate_test_results(
 
     invoke_semgrep_fn = functools.partial(
         invoke_semgrep_multi,
-        deep=deep,
+        engine=engine,
         no_git_ignore=True,
         no_rewrite_rule_ids=True,
         strict=strict,
@@ -554,7 +555,7 @@ def generate_test_results(
 
     # This is the invocation of semgrep for testing autofix.
     #
-    # TODO: should 'deep' be set to 'deep=deep' or always 'deep=False'?
+    # TODO: should 'engine' be set to 'engine=engine' or always 'engine=EngineType.OSS'?
     invoke_semgrep_with_autofix_fn = functools.partial(
         invoke_semgrep_multi,
         no_git_ignore=True,
@@ -681,7 +682,7 @@ def test_main(
     strict: bool,
     json: bool,
     optimizations: str,
-    deep: bool,
+    engine: EngineType,
 ) -> None:
 
     if len(target) != 1:
@@ -702,6 +703,6 @@ def test_main(
         config=config_path,
         strict=strict,
         json_output=json,
-        deep=deep,
+        engine=engine,
         optimizations=optimizations,
     )


### PR DESCRIPTION
Closes PA-2440

test plan:
```
% semgrep --pro -l apex -e 'foo(...)' \
      semgrep-proprietary/tests/patterns/apex/dots_string.cls
% semgrep --fast-deep \
      -c semgrep-proprietary/tests/tainting/python/simple_intrafile_eval/deep.yaml \
      semgrep-proprietary/tests/tainting/python/simple_intrafile_eval/intrafile.py
```

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
