### PR TITLE
Fix the build in release mode

### DIFF
--- a/dune
+++ b/dune
@@ -9,10 +9,8 @@
 ; See issue https://github.com/ocaml/ocaml/issues/10432 for details.
 ;
 (env
-  (dev
-    (flags (:standard  -w -52-6)))
-  (release
-    (flags (:standard -O3))))
+  (_
+    (flags (:standard  -w -52-6))))
 
 (dirs
   src

--- a/tools/oncall_email/dune
+++ b/tools/oncall_email/dune
@@ -2,9 +2,7 @@
  (dev
   ; TODO :standard is
   ; -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs
-  (flags (-w +A-4-6-29-44-45-52-70 -warn-error +a)))
- (release
-  (flags (:standard -O3))))
+  (flags (-w +A-4-6-29-44-45-52-70 -warn-error +a))))
 
 (executables
  (names oncall)


### PR DESCRIPTION
`-O3` does not exist for ocamlc, thus building this package in release mode results in:
```
ocamlc.opt: unknown option '-O3'.
```
Noticed in https://github.com/ocaml/opam-repository/pull/23027