### PR TITLE
dataflow: Handle unsupported special operators more gracefully

### DIFF
--- a/changelog.d/gh-6920.fixed
+++ b/changelog.d/gh-6920.fixed
@@ -1,0 +1,2 @@
+Python: Taint now propagates via the splat operators `*` and `**`, thus both
+`sink(*tainted)` and `sink(**tainted)` will result in findings.

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -562,11 +562,17 @@ and expr_aux env ?(void = false) e_gen =
       let args = arguments env args in
       add_call env tok eorig ~void (fun res ->
           CallSpecial (res, special, argument env arg :: args))
-  | G.Call ({ e = G.IdSpecial spec; _ }, args) ->
+  | G.Call ({ e = G.IdSpecial spec; _ }, args) -> (
       let tok = snd spec in
-      let special = call_special env spec in
       let args = arguments env args in
-      add_call env tok eorig ~void (fun res -> CallSpecial (res, special, args))
+      try
+        let special = call_special env spec in
+        add_call env tok eorig ~void (fun res ->
+            CallSpecial (res, special, args))
+      with
+      | Fixme (kind, any_generic) ->
+          let fixme = fixme_exp kind any_generic (related_exp e_gen) in
+          add_call env tok eorig ~void (fun res -> Call (res, fixme, args)))
   | G.Call (e, args) ->
       let tok = G.fake "call" in
       call_generic env ~void tok e args

--- a/tests/rules/taint_splat.py
+++ b/tests/rules/taint_splat.py
@@ -1,0 +1,9 @@
+# https://github.com/returntocorp/semgrep/issues/6920
+def taint_test(param1):
+    x = tainted
+    #ruleid: test
+    sink(x)
+    #ruleid: test
+    sink(*x)
+    #ruleid: test
+    sink(**x)

--- a/tests/rules/taint_splat.yaml
+++ b/tests/rules/taint_splat.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: taint demo
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: tainted
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
Instead of translating `<special>(args)` as a `Fixme` node, we now translate it as `Fixme(args')`, so dataflow analyses can look at the arguments. This makes possible for taint to propagate through these operators.

Closes #6920

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
