### PR TITLE
feat!: Pro Testing Workflow

### DIFF
--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/image.tar
+      - name: See images
+        run: |
+          docker images
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -37,9 +37,6 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/image.tar
-      - name: See images
-        run: |
-          docker images
       - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -27,16 +27,17 @@ jobs:
     name: Set up Docker tag based on if this is a pull request
     runs-on: ubuntu-22.04
     outputs:
-      docker-tag: ${{steps.setup-docker-tag.outputs.docker-tag}}
+      docker-tag: ${{ steps.setup-docker-tag.outputs.docker-tag }}
     steps:
       - name:
         id: setup-docker-tag
         run: |
+          echo "Github event is ${{ github.event_name }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "docker-tag=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo ::set-output name=docker-tag::${{ github.event.pull_request.number }}
             echo "Setting docker tag to current pull request number"
           else
-            echo "docker-tag=develop" >> $GITHUB_OUTPUT
+            echo ::set-output name=docker-tag::develop
             echo "Setting dry-run to develop"
           fi
   test-semgrep-pro:

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -57,6 +57,9 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/image.tar
+      - name: See images
+        run: |
+          docker images
       - name: Run Semgrep Pro Engine!
         run: |
           docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -68,4 +68,4 @@ jobs:
           pwd
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:pr-${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:pr-${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -59,5 +59,4 @@ jobs:
           docker load --input /tmp/image.tar
       - name: Run Semgrep Pro Engine!
         run: |
-          ls
-          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "/tmp/image.tar" /root/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -71,18 +71,13 @@ jobs:
           role-duration-seconds: 900
           role-session-name: "semgrep-deploy"
           aws-region: us-west-2
-      - name: Download Semgrep Pro binary
+      # This is the `develop` binary, so this is truly the most recent version of
+      # `semgrep-proprietary` from that repository's `develop` branch.
+      # We test with this so that we know whether any changes we make on this PR are breaking with
+      # the `develop` branch of `pro`.
+      - name: Download Semgrep Pro `develop` binary
         run: |
           aws s3 cp s3://web-assets.r2c.dev/assets/semgrep-core-proprietary-manylinux-develop ./semgrep-core-proprietary
-      - name: See images
-        run: |
-          docker images
-      - name: ls
-        run: |
-          ls -a
-      - name: pwd
-        run: |
-          pwd
       - name: Run Semgrep Pro Engine!
         run: |
           docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:pr-${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -27,12 +27,12 @@ jobs:
     name: Set up Docker tag based on if this is a pull request
     runs-on: ubuntu-22.04
     outputs:
-      dry-run: ${{steps.setup-docker-tag.outputs.docker-tag}}
+      docker-tag: ${{steps.setup-docker-tag.outputs.docker-tag}}
     steps:
       - name:
         id: setup-docker-tag
         run: |
-          if [ ${{ github.event_name }} = 'pull_request' ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "docker-tag=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "Setting docker tag to current pull request number"
           else
@@ -59,4 +59,4 @@ jobs:
           docker load --input /tmp/image.tar
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -v $(pwd):/root -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ steps.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ steps.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -59,4 +59,5 @@ jobs:
           docker load --input /tmp/image.tar
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh
+          ls
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "/tmp/image.tar" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -79,7 +79,7 @@ jobs:
           docker images
       - name: ls
         run: |
-          ls
+          ls -a
       - name: pwd
         run: |
           pwd

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -34,10 +34,10 @@ jobs:
         run: |
           echo "Github event is ${{ github.event_name }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "docker-tag=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "docker-tag=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "Setting docker tag to current pull request number"
           else
-            echo "docker-tag=develop" >> $GITHUB_OUTPUT
+            echo "docker-tag=develop" >> "$GITHUB_OUTPUT"
             echo "Setting dry-run to develop"
           fi
   test-semgrep-pro:

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -62,4 +62,4 @@ jobs:
           docker images
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:pr-${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -42,7 +42,6 @@ jobs:
           fi
   test-semgrep-pro:
     name: Test Semgrep Pro Engine
-    if: ${{ github.event.pull_request.number != null }}
     runs-on: ubuntu-22.04
     needs: setup-docker-tag
     env:
@@ -60,4 +59,4 @@ jobs:
           docker load --input /tmp/image.tar
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ steps.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -47,6 +47,10 @@ jobs:
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Download artifact
@@ -57,6 +61,16 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/image.tar
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::338683922796:role/returntocorp-semgrep-deploy-role
+          role-duration-seconds: 900
+          role-session-name: "semgrep-deploy"
+          aws-region: us-west-2
+      - name: Download Semgrep Pro binary
+        run: |
+          aws s3 cp s3://web-assets.r2c.dev/assets/semgrep-core-proprietary-manylinux-develop ./semgrep-core-proprietary
       - name: See images
         run: |
           docker images

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -23,8 +23,9 @@ on:
         description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
 
 jobs:
-  push-docker:
-    name: Test Semgrep Pro Engine
+  test-semgrep-pro-with-pr:
+    name: Test Semgrep Pro Engine with PR version of Semgrep
+    if: ${{ github.event.pull_request.number != null }}
     runs-on: ubuntu-22.04
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
@@ -39,10 +40,33 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/image.tar
-      - uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -it "returntocorp/semgrep:pr-{{ github.event.pull_request.number }}" --config "p/deepsemgrep" . --interfile
+          docker run --rm -it -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint bash "${{ inputs.repository_name }}:pr-${{ github.event.pull_request.number }}"
+
+          semgrep install-semgrep-pro
+          semgrep --config "p/deepsemgrep" . --interfile
+
+  test-semgrep-pro-with-develop:
+    name: Test Semgrep Pro Engine with develop version of Semgrep
+    if: ${{ github.event.pull_request.number == null }}
+    runs-on: ubuntu-22.04
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/image.tar
+      - name: Run Semgrep Pro Engine!
+        run: |
+          docker run --rm -it -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint bash "${{ inputs.repository_name }}:pr-${{ github.event.pull_request.number }}"
+
+          semgrep install-semgrep-pro
+          semgrep --config "p/deepsemgrep" . --interfile

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -1,0 +1,48 @@
+name: test-semgrep-pro
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact-name:
+        required: true
+        type: string
+        description: Name (key) to use when uploading the docker image tarball as a artifact
+      repository-name:
+        required: true
+        type: string
+        description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
+  workflow_call:
+    inputs:
+      artifact-name:
+        required: true
+        type: string
+        description: Name (key) to use when uploading the docker image tarball as a artifact
+      repository-name:
+        required: true
+        type: string
+        description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
+
+jobs:
+  push-docker:
+    name: Test Semgrep Pro Engine
+    runs-on: ubuntu-22.04
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/image.tar
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Run Semgrep Pro Engine!
+        run: |
+          docker run --rm -it "returntocorp/semgrep:pr-{{ github.event.pull_request.number }}" --config "p/deepsemgrep" . --interfile

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -33,10 +33,10 @@ jobs:
         id: setup-docker-tag
         run: |
           if [ ${{ github.event_name }} = 'pull_request' ]; then
-            echo ::set-output name=docker-tag::${{ github.event.pull_request.number}}
+            echo "docker-tag=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "Setting docker tag to current pull request number"
           else
-            echo ::set-output name=docker-tag::develop
+            echo "docker-tag=develop" >> $GITHUB_OUTPUT
             echo "Setting dry-run to develop"
           fi
   test-semgrep-pro:
@@ -59,4 +59,4 @@ jobs:
           docker load --input /tmp/image.tar
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -v (pwd):/root -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository_name }}:${{ steps.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh
+          docker run --rm -v $(pwd):/root -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ steps.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -23,10 +23,27 @@ on:
         description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
 
 jobs:
-  test-semgrep-pro-with-pr:
-    name: Test Semgrep Pro Engine with PR version of Semgrep
+  setup-docker-tag:
+    name: Set up Docker tag based on if this is a pull request
+    runs-on: ubuntu-22.04
+    outputs:
+      dry-run: ${{steps.setup-docker-tag.outputs.docker-tag}}
+    steps:
+      - name:
+        id: setup-docker-tag
+        run: |
+          if [ ${{ github.event_name }} = 'pull_request' ]; then
+            echo ::set-output name=docker-tag::${{ github.event.pull_request.number}}
+            echo "Setting docker tag to current pull request number"
+          else
+            echo ::set-output name=docker-tag::develop
+            echo "Setting dry-run to develop"
+          fi
+  test-semgrep-pro:
+    name: Test Semgrep Pro Engine
     if: ${{ github.event.pull_request.number != null }}
     runs-on: ubuntu-22.04
+    needs: setup-docker-tag
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     steps:
@@ -42,31 +59,4 @@ jobs:
           docker load --input /tmp/image.tar
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -it -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint bash "${{ inputs.repository_name }}:pr-${{ github.event.pull_request.number }}"
-
-          semgrep install-semgrep-pro
-          semgrep --config "p/deepsemgrep" . --interfile
-
-  test-semgrep-pro-with-develop:
-    name: Test Semgrep Pro Engine with develop version of Semgrep
-    if: ${{ github.event.pull_request.number == null }}
-    runs-on: ubuntu-22.04
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: /tmp
-      - name: Load image
-        run: |
-          docker load --input /tmp/image.tar
-      - name: Run Semgrep Pro Engine!
-        run: |
-          docker run --rm -it -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint bash "${{ inputs.repository_name }}:pr-${{ github.event.pull_request.number }}"
-
-          semgrep install-semgrep-pro
-          semgrep --config "p/deepsemgrep" . --interfile
+          docker run --rm -v (pwd):/root -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository_name }}:${{ steps.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -34,10 +34,10 @@ jobs:
         run: |
           echo "Github event is ${{ github.event_name }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo ::set-output name=docker-tag::${{ github.event.pull_request.number }}
+            echo "docker-tag=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
             echo "Setting docker tag to current pull request number"
           else
-            echo ::set-output name=docker-tag::develop
+            echo "docker-tag=develop" >> $GITHUB_OUTPUT
             echo "Setting dry-run to develop"
           fi
   test-semgrep-pro:

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -60,6 +60,12 @@ jobs:
       - name: See images
         run: |
           docker images
+      - name: ls
+        run: |
+          ls
+      - name: pwd
+        run: |
+          pwd
       - name: Run Semgrep Pro Engine!
         run: |
           docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:pr-${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/test-pro.sh

--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -43,6 +43,9 @@ jobs:
   test-semgrep-pro:
     name: Test Semgrep Pro Engine
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     needs: setup-docker-tag
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -352,6 +352,15 @@ jobs:
       artifact-name: image-dev
       repository-name: ${{ github.repository }}-dev
 
+  test-semgrep-pro:
+    needs: [build-test-dev-docker]
+    uses: ./.github/workflows/test-semgrep-pro.yaml
+    if: github.ref == 'refs/heads/develop'
+    secrets: inherit
+    with:
+      artifact-name: image-dev
+      repository-name: ${{ github.repository }}-dev
+
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml
     secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -353,12 +353,12 @@ jobs:
       repository-name: ${{ github.repository }}-dev
 
   test-semgrep-pro:
-    needs: [build-test-dev-docker, push-dev-docker]
+    needs: [build-test-docker, push-docker]
     uses: ./.github/workflows/test-semgrep-pro.yaml
     secrets: inherit
     with:
-      artifact-name: image-dev
-      repository-name: ${{ github.repository }}-dev
+      artifact-name: image-test
+      repository-name: ${{ github.repository }}
 
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -353,7 +353,7 @@ jobs:
       repository-name: ${{ github.repository }}-dev
 
   test-semgrep-pro:
-    needs: [build-test-dev-docker]
+    needs: [build-test-dev-docker, push-dev-docker]
     uses: ./.github/workflows/test-semgrep-pro.yaml
     secrets: inherit
     with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -355,7 +355,6 @@ jobs:
   test-semgrep-pro:
     needs: [build-test-dev-docker]
     uses: ./.github/workflows/test-semgrep-pro.yaml
-    if: github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       artifact-name: image-dev

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -2,4 +2,4 @@
 
 cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
-semgrep --config "p/deepsemgrep" src --interfile
+semgrep --config "p/deepsemgrep" /root --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -4,4 +4,6 @@ cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
 chmod +x /usr/local/bin/semgrep-core-proprietary
 
-semgrep --config "p/default-v2" /root --interfile
+cd /root
+
+semgrep --config "p/default-v2" . --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+semgrep install-semgrep-pro
+
+semgrep --config "p/deepsemgrep" . --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
 
-cp semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
+cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
 semgrep --config "p/deepsemgrep" src --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -9,5 +9,6 @@ chmod +x /usr/local/bin/semgrep-core-proprietary
 
 # Relocate to the directory, because otherwise some weirdness happens and
 # we run with all the rules, taking ~30 minutes.
-cd /root
+cd /root || exit
+
 semgrep --config "p/default-v2" . --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
 
-cp ./semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
+cp semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
 semgrep --config "p/deepsemgrep" src --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -2,4 +2,6 @@
 
 cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
+chmod +x /usr/local/bin/semgrep-core-proprietary
+
 semgrep --config "p/deepsemgrep" /root --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -4,4 +4,4 @@ cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
 chmod +x /usr/local/bin/semgrep-core-proprietary
 
-semgrep --config "p/deepsemgrep" /root --interfile
+semgrep --config "p/default-v2" /root --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
 
-semgrep install-semgrep-pro
+cp ./semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
-semgrep --config "p/deepsemgrep" . --interfile
+semgrep --config "p/deepsemgrep" src --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,4 +1,6 @@
-#! /usr/bin/env bash -e
+#! /usr/bin/env bash
+
+set e
 
 cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -2,8 +2,10 @@
 
 cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 
+# We need to give it executable permissions or it won't run
 chmod +x /usr/local/bin/semgrep-core-proprietary
 
+# Relocate to the directory, because otherwise some weirdness happens and
+# we run with all the rules, taking ~30 minutes.
 cd /root
-
 semgrep --config "p/default-v2" . --interfile

--- a/scripts/test-pro.sh
+++ b/scripts/test-pro.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#! /usr/bin/env bash -e
 
 cp /root/semgrep-core-proprietary /usr/local/bin/semgrep-core-proprietary
 


### PR DESCRIPTION
## What:
This PR adds in a GitHub action that, on PR and dispatch, will run the most recent version of Semgrep Pro (that is, the one built by the current `develop` branch) with the latest built `semgrep-core` and `semgrep` code.

## Why:
This is important to make sure that we know when we are releasing breaking changes that are incompatible with the latest version of Semgrep Pro! Once we merge this, then we will know that so long as this test passed (the repo is green), and there hasn't been a possibly-breaking `semgrep-proprietary` PR since then (which there shouldn't be, I think), then it is safe to release.

## How:
Added an extra test which will downloaded Semgrep Pro and run it with the just-built version of Semgrep. This means that on PR, the local changes to the PR will be taken into account.

## Test plan:
CI!

Closes PA-2390

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
