### PR TITLE
Solidity: parse correctly unchecked blocks

### DIFF
--- a/changelog.d/gh-6055.fixed
+++ b/changelog.d/gh-6055.fixed
@@ -1,0 +1,1 @@
+Solidity: parse correctly 'unchecked' blocks

--- a/languages/solidity/generic/Parse_solidity_tree_sitter.ml
+++ b/languages/solidity/generic/Parse_solidity_tree_sitter.ml
@@ -1943,15 +1943,15 @@ let map_variable_declaration_statement (env : env)
 
 let rec map_block_statement (env : env) ((v0, v1, v2, v3) : CST.block_statement)
     =
-  let _uncheckedTODO =
-    match v0 with
-    | Some tok -> Some ((* "unchecked" *) token env tok)
-    | None -> None
-  in
   let lb = (* "{" *) token env v1 in
   let xs = Common.map (map_statement env) v2 in
   let rb = (* "}" *) token env v3 in
-  Block (lb, xs, rb) |> G.s
+  let stmt = Block (lb, xs, rb) |> G.s in
+  match v0 with
+  | Some tok ->
+      let t = (* "unchecked" *) token env tok in
+      OtherStmtWithStmt (OSWS_Block ("Unchecked", t), [], stmt) |> G.s
+  | None -> stmt
 
 and map_catch_clause (env : env) ((v1, v2, v3) : CST.catch_clause) : catch =
   let tcatch = (* "catch" *) token env v1 in

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1126,7 +1126,7 @@ and other_stmt_with_stmt_operator =
   | OSWS_With (* newscope: newvar: in OtherStmtWithStmt with LetPattern *)
   (* BEGIN/END in Ruby, Unsafe/Async/Const/Foreign/Impl in Rust,
    * Checked/Unchecked/Lock in C#, Synchronized/Static in Java,
-   * Assembly in Solidity
+   * Assembly/Unchecked in Solidity
    * alt: use a keyword_attribute instead of todo_kind
    *)
   | OSWS_Block of todo_kind

--- a/tests/patterns/solidity/misc_unchecked.sgrep
+++ b/tests/patterns/solidity/misc_unchecked.sgrep
@@ -1,0 +1,1 @@
+unchecked { ... }

--- a/tests/patterns/solidity/misc_unchecked.sol
+++ b/tests/patterns/solidity/misc_unchecked.sol
@@ -1,0 +1,13 @@
+pragma solidity 0.8.16;
+
+contract C {
+  function foo(uint256 x, uint256 y) external returns (uint256 z) {
+    z = 0;
+    //ERROR: match
+    unchecked {
+      z = x + y;
+    }
+    z = x + y;
+    return z;
+  }
+}


### PR DESCRIPTION
This closes #6055

test plan:
test file included
make test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)