### PR TITLE
metavariable-pattern: Force Spacegrep to analyze requested text

### DIFF
--- a/changelog.d/pa-2386.changed
+++ b/changelog.d/pa-2386.changed
@@ -1,0 +1,6 @@
+metavariable-pattern: For performance reasons Generic mode ignores target files
+that look like machine generated. Unfortunately, this also prevented using the
+`metavariable-pattern` operator on text that may look like (or in fact be)
+machine generated, such as an RSA key contained in a legit file. Now, when the
+analysis is requested within a `metavariable-pattern` operator, Generic mode
+will always match any text even if it looks like machine generated.

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -41,6 +41,8 @@ type id_to_match_results = (pattern_id, Pattern_match.t) Hashtbl.t
 type xconfig = {
   config : Config_semgrep.t; (* corresponds to rule `options` key *)
   equivs : Equivalence.equivalences;
+  nested_formula : bool;
+  (* ^^^ i.e. we are evaluating a nested formula within `metavariable-pattern`. *)
   (* Fields coming from Runner_config.t used by the engine.
    * We could just include the whole Runner_config.t, but it's
    * cleaner to explicitely state what the engine depends on
@@ -96,6 +98,7 @@ let default_xconfig =
   {
     config = Config_semgrep.default_config;
     equivs = [];
+    nested_formula = false;
     matching_explanations = false;
     (* TODO: set to true by default?
      * Anyway it's set to true in Runner_config.default so it will default to

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -455,8 +455,7 @@ let matches_of_xpatterns ~mvar_context rule (xconf : xconfig)
   RP.collate_pattern_results
     [
       matches_of_patterns ~mvar_context rule xconf xtarget patterns;
-      (let config = (xconf.config, xconf.equivs) in
-       Xpattern_match_spacegrep.matches_of_spacegrep config spacegreps file);
+      Xpattern_match_spacegrep.matches_of_spacegrep xconf spacegreps file;
       Xpattern_match_regexp.matches_of_regexs regexps lazy_content file;
       Xpattern_match_comby.matches_of_combys combys lazy_content file;
     ]
@@ -610,7 +609,9 @@ let rec filter_ranges (env : env) (xs : RM.ranges) (cond : R.metavar_cond) :
 
 and nested_formula_has_matches env formula opt_context =
   let res, final_ranges =
-    matches_of_formula env.xconf env.rule env.xtarget formula opt_context
+    matches_of_formula
+      { env.xconf with nested_formula = true }
+      env.rule env.xtarget formula opt_context
   in
   env.errors := Report.ErrorSet.union res.RP.errors !(env.errors);
   match final_ranges with

--- a/src/engine/Xpattern_match_spacegrep.ml
+++ b/src/engine/Xpattern_match_spacegrep.ml
@@ -27,11 +27,10 @@ let lexing_pos_to_loc file x str =
   let column = x.Lexing.pos_cnum - x.Lexing.pos_bol in
   { PI.str; charpos; file; line; column }
 
-let spacegrep_matcher config (doc, src) file pat =
-  let (config : Config_semgrep.t), _equivalences = config in
+let spacegrep_matcher (xconfig : Match_env.xconfig) (doc, src) file pat =
   let search_param =
     Spacegrep.Match.create_search_param
-      ~ellipsis_max_span:config.generic_ellipsis_max_span ()
+      ~ellipsis_max_span:xconfig.config.generic_ellipsis_max_span ()
   in
   let matches = Spacegrep.Match.search search_param src pat doc in
   matches
@@ -53,8 +52,8 @@ let spacegrep_matcher config (doc, src) file pat =
          ((loc1, loc2), env))
 
 (* Preprocess spacegrep pattern or target to remove comments *)
-let preprocess_spacegrep ((config : Config_semgrep.t), _equivalences) src =
-  match config.generic_comment_style with
+let preprocess_spacegrep (xconfig : Match_env.xconfig) src =
+  match xconfig.config.generic_comment_style with
   | None -> src
   | Some style ->
       let style =
@@ -65,40 +64,51 @@ let preprocess_spacegrep ((config : Config_semgrep.t), _equivalences) src =
       in
       Spacegrep.Comment.remove_comments_from_src style src
 
-let matches_of_spacegrep config spacegreps file =
+let matches_of_spacegrep (xconfig : Match_env.xconfig) spacegreps file =
   matches_of_matcher spacegreps
     {
       init =
         (fun _ ->
-          (* coupling: mostly copypaste of Spacegrep_main.run_all *)
-          (*
+          if xconfig.nested_formula then
+            (* If we are in a nested call to the search engine (i.e. within a
+             * `metavariable-pattern` operator) then the rule is *explicitly*
+             * requesting that Spacegrep analyzes this piece of text. We must
+             * do so even if the text looks like gibberish. It can e.g. be
+             * an RSA key. *)
+            let src =
+              file |> Spacegrep.Src_file.of_file |> preprocess_spacegrep xconfig
+            in
+            Some (Spacegrep.Parse_doc.of_src src, src)
+          else
+            (* coupling: mostly copypaste of Spacegrep_main.run_all *)
+            (*
            We inspect the first 4096 bytes to guess whether the file type.
            This saves time on large files, by reading typically just one
            block from the file system.
           *)
-          let peek_length = 4096 in
-          let partial_doc_src =
-            Spacegrep.Src_file.of_file ~max_len:peek_length file
-          in
-          let doc_type = Spacegrep.File_type.classify partial_doc_src in
-          match doc_type with
-          | Minified
-          | Binary ->
-              logger#info "ignoring gibberish file: %s\n%!" file;
-              None
-          | Text
-          | Short ->
-              let src =
-                if
-                  Spacegrep.Src_file.length partial_doc_src < peek_length
-                  (* it's actually complete, no need to re-input the file *)
-                then partial_doc_src
-                else Spacegrep.Src_file.of_file file
-              in
-              let src = preprocess_spacegrep config src in
-              (* pr (Spacegrep.Doc_AST.show doc); *)
-              Some (Spacegrep.Parse_doc.of_src src, src));
-      matcher = spacegrep_matcher config;
+            let peek_length = 4096 in
+            let partial_doc_src =
+              Spacegrep.Src_file.of_file ~max_len:peek_length file
+            in
+            let doc_type = Spacegrep.File_type.classify partial_doc_src in
+            match doc_type with
+            | Minified
+            | Binary ->
+                logger#info "ignoring gibberish file: %s\n%!" file;
+                None
+            | Text
+            | Short ->
+                let src =
+                  if
+                    Spacegrep.Src_file.length partial_doc_src < peek_length
+                    (* it's actually complete, no need to re-input the file *)
+                  then partial_doc_src
+                  else Spacegrep.Src_file.of_file file
+                in
+                let src = preprocess_spacegrep xconfig src in
+                (* pr (Spacegrep.Doc_AST.show doc); *)
+                Some (Spacegrep.Parse_doc.of_src src, src));
+      matcher = spacegrep_matcher xconfig;
     }
     file
   [@@profiling]

--- a/src/engine/Xpattern_match_spacegrep.mli
+++ b/src/engine/Xpattern_match_spacegrep.mli
@@ -1,5 +1,5 @@
 val matches_of_spacegrep :
-  Config_semgrep.t * Equivalence.equivalences ->
+  Match_env.xconfig ->
   (Spacegrep.Pattern_AST.t * Xpattern.pattern_id * string) list ->
   Common.filename ->
   Report.times Report.match_result

--- a/src/runner/Run_semgrep.ml
+++ b/src/runner/Run_semgrep.ml
@@ -668,6 +668,7 @@ let semgrep_with_rules config ((rules, invalid_rules), rules_parse_time) =
              {
                Match_env.config = Config_semgrep.default_config;
                equivs = parse_equivalences config.equivalences_file;
+               nested_formula = false;
                matching_explanations = config.matching_explanations;
                filter_irrelevant_rules = config.filter_irrelevant_rules;
              }

--- a/tests/rules/metavar_pattern_generic_gibberish.js
+++ b/tests/rules/metavar_pattern_generic_gibberish.js
@@ -1,0 +1,5 @@
+// We want Spacegrep to analyze the string literal even if it looks like gibberish,
+// the rule is requesting this explicitly via metavariable-pattern.
+//ruleid: test
+const privateKey = '-----BEGIN RSA PRIVATE KEY-----\r\nMIICXAIBAAKBgQDNwqLEe9wgTXCbC7+RPdDbBbeqjdbs4kOPOIGzqLpXvJXlxxW8iMz0EaM4BKUqYsIa+ndv3NAn2RxCd5ubVdJJcX43zO6Ko0TFEZx/65gY3BE0O6syCEmUP4qbSd6exou/F+WTISzbQ5FBVPVmhnYhG/kpwt/cIxK5iUn5hm+4tQIDAQABAoGBAI+8xiPoOrA+KMnG/T4jJsG6TsHQcDHvJi7o1IKC/hnIXha0atTX5AUkRRce95qSfvKFweXdJXSQ0JMGJyfuXgU6dI0TcseFRfewXAa/ssxAC+iUVR6KUMh1PE2wXLitfeI6JLvVtrBYswm2I7CtY0q8n5AGimHWVXJPLfGV7m0BAkEA+fqFt2LXbLtyg6wZyxMA/cnmt5Nt3U2dAu77MzFJvibANUNHE4HPLZxjGNXN+a6m0K6TD4kDdh5HfUYLWWRBYQJBANK3carmulBwqzcDBjsJ0YrIONBpCAsXxk8idXb8jL9aNIg15Wumm2enqqObahDHB5jnGOLmbasizvSVqypfM9UCQCQl8xIqy+YgURXzXCN+kwUgHinrutZms87Jyi+D8Br8NY0+Nlf+zHvXAomD2W5CsEK7C+8SLBr3k/TsnRWHJuECQHFE9RA2OP8WoaLPuGCyFXaxzICThSRZYluVnWkZtxsBhW2W8z1b8PvWUE7kMy7TnkzeJS2LSnaNHoyxi7IaPQUCQCwWU4U+v4lD7uYBw00Ga/xt+7+UqFPlPVdz1yyr4q24Zxaw0LgmuEvgU5dycq8N7JxjTubX0MIRR+G9fmDBBl8=\r\n-----END RSA PRIVATE KEY-----'
+

--- a/tests/rules/metavar_pattern_generic_gibberish.yaml
+++ b/tests/rules/metavar_pattern_generic_gibberish.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: find-private-key
+    message: $X
+    severity: WARNING
+    languages:
+      - js
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              '$X'
+      - focus-metavariable: $X
+      - metavariable-pattern:
+          metavariable: $X
+          language: generic
+          patterns:
+            - pattern: -----BEGIN RSA PRIVATE KEY-----$...MIDDLE-----END RSA PRIVATE KEY-----
+            - metavariable-analysis:
+                analyzer: entropy
+                metavariable: $...MIDDLE


### PR DESCRIPTION
Even if the text matched by a metavariable looks like machine generated, Spacegrep must analyze it because it has been requested explicitly. This is text coming from a presumably legit file, so it's not the same as ignoring an entire file that looks like machine generated.

Closes PA-2386

test plan:
make test # added one test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
