### PR TITLE
chore(ci): stop running other pre-commit hooks on manual stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 # which are only exercised in CI (see .github/workflows/lint.yml).
 
 exclude: "^cli/tests/e2e/(targets|snapshots|rules/syntax)|^tests|^semgrep-core/src/pfff/tests|^cli/src/semgrep/external|\\binvalid\\b|^cli/.test_durations|^cli/scripts|TOPORT"
-
+default_stages: [commit]
 # See https://pre-commit.com/#pre-commit-configyaml---repos
 # for more information on the format of the content below
 repos:


### PR DESCRIPTION
All the pre-commit hooks were running when hook-stage manual mode was on. This is because all pre-commit hooks are added to the manual mode by default. This changes it so the main hooks only run on commit (the usual pre-commit running) and only the once we force into manual mode are run when we run manual.

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
