### PR TITLE
feat: switch back to GH-hosted macos runners for homebrew checks

### DIFF
--- a/.github/workflows/homebrew-core-head.yml
+++ b/.github/workflows/homebrew-core-head.yml
@@ -19,22 +19,14 @@ on:
 jobs:
   brew-build:
     name: Build Semgrep via Brew from `returntocorp/semgrep:develop`
-    runs-on: ["self-hosted", "macOS", "X64"]
+    runs-on: macos-12
     steps:
-      - name: Uninstall semgrep
-        # This is sub-optimal - our workflows shouldn't have to conform to their environment.
-        # However, on the runner side, we can't hook into the workflow run to clean up after.
-        run: brew uninstall semgrep || true
-      - name: Cleanup semgrep
-        run: brew cleanup --prune=all semgrep
       - name: Brew update
         run: brew update
       - name: Brew Install
         run: brew install semgrep --HEAD
       - name: Check installed correctly
         run: brew test semgrep --HEAD
-      - name: Clean up semgrep installation
-        run: brew uninstall semgrep
 
   notify-failure:
     needs: [brew-build]

--- a/changelog.d/devop-1036.infra
+++ b/changelog.d/devop-1036.infra
@@ -1,0 +1,1 @@
+Homebrew Nightly Test: Fixes issues encountered in nightly homebrew checks by reverting to a GHA-hosted runner. Previous issues there have been addressed.


### PR DESCRIPTION
As of [this run](https://github.com/returntocorp/semgrep/actions/runs/4004540001), our nightly homebrew check began failing. The root cause of this failure was not determined, but we found it likely that our self-hosted x86 runners were at least partially responsible, so the most maintainable and time-efficient fix is to switch back to GHA-hosted runners. 

Previous issues with GHA-hosted x86 mac runners have since been fixed. [An issue we filed](https://github.com/actions/runner-images/issues/6129) seems to have [gotten a resolution](https://github.com/actions/runner-images/issues/6364) later on, meaning we are clear to switch back. 

Test Plan:

I've run this workflow in go/test-gh-actions - will mark this PR ready for review once we're seeing consistent successes there. Previous attempts at this were met with flaky success/passes, so we will be waiting for >=3 successes.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
