### PR TITLE
Update cli/src/semgrep/lang with latest

### DIFF
--- a/tests/extract/python_jupyter.ipynb
+++ b/tests/extract/python_jupyter.ipynb
@@ -27,6 +27,7 @@
       "source": [
        "data = [\"This\", \"is\", \"an\", \"example\"] \n",
        "with open(\"test.pkl\", 'wb') as f:\n",
+       "#ruleid: forbid-pickle",
        "    pickle.dump(data, f)"
       ]
      },

--- a/tests/extract/python_jupyter.yaml
+++ b/tests/extract/python_jupyter.yaml
@@ -12,3 +12,9 @@ rules:
     extract: $CODE
     transform: concat_json_string_array
     dest-language: python
+  - id: forbid-pickle
+    languages: [python]
+    message: found pickle
+    severity: ERROR
+    pattern: |
+      pickle.dump(...)


### PR DESCRIPTION
This will help extracting python code from
.ipynb json files (now recognized as json files
thanks to update in lang.json)

This will help #4477

test plan:
```
semgrep-core -l python -rules tests/extract/python_jupyter.yaml
tests/extract/python_jupyter.ipynb
...
tmp/extracted-605342-11f987Python:5 with rule forbid-pickle
     pickle.dump(data, f)
```

With -json it gives:
```
{"matches":[{"rule_id":"forbid-pickle","location":{"path":"tests/extract/python_jupyter.ipynb","start":{"line":30,"col":5,"offset":574},"end":{"line":30,"col":25,"offset":594}},"extra":{"message":"found pickle","metavars":{},"engine_kind":"OSSMatch"}}],"errors":[],"stats":{"okfiles":1,"errorfiles":0}}

```

but I dunno why but this does not work from semgrep:
```
semgrep --config python_jupyter.yaml python_jupyter.ipynb
Scanning 1 file.

Ran 2 rules on 1 file: 0 findings.
If Semgrep missed a finding, please send us feedback to let us know!
  $ semgrep shouldafound --help
```


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)