### PR TITLE
chore: make engine_kind optional (2/3)

### DIFF
--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -701,16 +701,15 @@ class TextFormatter(BaseFormatter):
                     f"First-Party {blocking_description}", first_party_blocking
                 )
             else:
-                oss_matches = [
-                    x
-                    for x in first_party_blocking
-                    if isinstance(x.match.extra.engine_kind.value, out.OSSMatch)
-                ]
-                pro_matches = [
-                    x
-                    for x in first_party_blocking
-                    if isinstance(x.match.extra.engine_kind.value, out.ProMatch)
-                ]
+                oss_matches = []
+                pro_matches = []
+                for x in first_party_blocking:
+                    if x.match.extra.engine_kind is None or isinstance(
+                        x.match.extra.engine_kind.value, out.OSSMatch
+                    ):
+                        oss_matches.append(x)
+                    elif isinstance(x.match.extra.engine_kind.value, out.ProMatch):
+                        pro_matches.append(x)
                 generate_output(f"{blocking_description}", oss_matches)
                 generate_output(f"Semgrep PRO Findings", pro_matches)
 

--- a/src/osemgrep/cli_scan/Cli_json_output.ml
+++ b/src/osemgrep/cli_scan/Cli_json_output.ml
@@ -379,7 +379,9 @@ let cli_match_of_core_match (env : env) (x : Out.core_match) : Out.cli_match =
             sca_info = None;
             fixed_lines = None;
             dataflow_trace = None;
-            engine_kind;
+            (* It's optional in the CLI output, but not in the core match results!
+             *)
+            engine_kind = Some engine_kind;
           };
       }
 

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -252,7 +252,7 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
         metavars = x.env |> Common.map (metavars startp);
         dataflow_trace;
         rendered_fix;
-        engine_kind = convert_engine_kind x.engine_kind;
+        engine_kind = Some (convert_engine_kind x.engine_kind);
       };
   }
 

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -252,7 +252,7 @@ let unsafe_match_to_match render_fix_opt (x : Pattern_match.t) : Out.core_match
         metavars = x.env |> Common.map (metavars startp);
         dataflow_trace;
         rendered_fix;
-        engine_kind = Some (convert_engine_kind x.engine_kind);
+        engine_kind = convert_engine_kind x.engine_kind;
       };
   }
 


### PR DESCRIPTION
## What:
This PR incorporates the `semgrep-interfaces` change that makes `engine_kind` optional in the CLI output, ensuring backwards compatibility.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
