### PR TITLE
chore(ci): revert moving jsonnet lint to ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,7 +184,6 @@ repos:
       - id: semgrep-jsonnet
         name: semgrep jsonnet
         # Only run this job in CI since it is slow
-        stages: [manual]
         language: docker_image
         # See .pre-commit-hooks.yaml for why we need to set those
         # SEMGREP_XXX variables.  Ideally we would not need this


### PR DESCRIPTION
For some reason the jsonnet job being in CI kept getting skipped. Reverting so we don't lose coverage

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
