### PR TITLE
feat(devops): add a command to dump just the path to the engine

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -624,7 +624,7 @@ def scan_options(func: Callable) -> Callable:
     # help="contact support@r2c.dev for more information on this"
 )
 @click.option(
-    "--engine-path",
+    "--dump-engine-path",
     is_flag=True,
     hidden=True
     # help="contact support@r2c.dev for more information on this"
@@ -639,7 +639,7 @@ def scan(
     core_opts: Optional[str],
     debug: bool,
     deep: bool,
-    engine_path: bool,
+    dump_engine_path: bool,
     pro: bool,
     interproc: bool,
     interfile: bool,
@@ -718,7 +718,7 @@ def scan(
             version_check()
         return None
 
-    if engine_path:
+    if dump_engine_path:
         print(SemgrepCore.path())
         return None
 

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -44,6 +44,7 @@ from semgrep.output import OutputSettings
 from semgrep.project import get_project_url
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatchMap
+from semgrep.semgrep_core import SemgrepCore
 from semgrep.semgrep_types import LANGUAGE
 from semgrep.state import get_state
 from semgrep.target_manager import write_pipes_to_disk
@@ -622,6 +623,12 @@ def scan_options(func: Callable) -> Callable:
     hidden=True
     # help="contact support@r2c.dev for more information on this"
 )
+@click.option(
+    "--engine-path",
+    is_flag=True,
+    hidden=True
+    # help="contact support@r2c.dev for more information on this"
+)
 @scan_options
 @handle_command_errors
 def scan(
@@ -632,6 +639,7 @@ def scan(
     core_opts: Optional[str],
     debug: bool,
     deep: bool,
+    engine_path: bool,
     pro: bool,
     interproc: bool,
     interfile: bool,
@@ -708,6 +716,10 @@ def scan(
             from semgrep.app.version import version_check
 
             version_check()
+        return None
+
+    if engine_path:
+        print(SemgrepCore.path())
         return None
 
     if show_supported_languages:


### PR DESCRIPTION
This is a quick PR to output the path to the engine. We'll probably want to also be able to output the path to the pro engine, but for now this will unblock devops. I will follow up this PR with a refactor.

Test plan: `semgrep --engine-path`

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
