### PR TITLE
feat: set HOMEBREW_NO_INSTALL_FROM_API for use with `brew install --head`

### DIFF
--- a/.github/workflows/homebrew-core-head.yml
+++ b/.github/workflows/homebrew-core-head.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Brew update
         run: brew update
       - name: Brew Install
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew install semgrep --HEAD
       - name: Check installed correctly
         run: brew test semgrep --HEAD


### PR DESCRIPTION
We're still in process of working out some issues with switching back to GH-hosted `macos-12` runners, but this is a temp fix provided by [the brew maintainers](https://github.com/orgs/Homebrew/discussions/4136) that solves the issue of trying to install from HEAD after having performed a `brew cleanup`. 

Test Plan:

We've run [this job and seen success here](https://github.com/returntocorp/semgrep/actions/runs/4012496237).

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
