### PR TITLE
GHA: fix regexp for hashFiles for core-cache optimisation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ocaml-build-artifacts.tgz
-          key: "${{ runner.os }}-core-binary-${{ hashFiles('libs/**', 'languages/**', 'src/**', 'libs/**', 'tools/**', '.github/workflows/tests.yml', 'scripts/install-alpine-semgrep-core') }}-${{ steps.submodule-status.outputs.versions-hash }}"
+          key: "${{ runner.os }}-core-binary-${{ hashFiles('src/**', 'languages/**', 'libs/**', 'tools/**', '.github/workflows/tests.yml', 'scripts/install-alpine-semgrep-core') }}-${{ steps.submodule-status.outputs.versions-hash }}"
       - uses: actions/checkout@v3
         if: steps.core-cache.outputs.cache-hit != 'true'
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo ::set-output name=versions-hash::$(git submodule status --cached | sha256sum | cut -d" " -f1)
       # Without the step below, the core-cache step further below would fail with:
       #	  Error: The template is not valid. .github/workflows/tests.yml (Line: 39, Col: 16):
-      #     hashFiles('semgrep-core/**, .github/workflows/tests.yml, scripts/install-alpine-semgrep-core') failed.
+      #     hashFiles(...) failed.
       # Fail to hash files under directory '/home/runner/work/semgrep/semgrep'
       - name: Remove broken symlinks for hashFiles in core-cache steps
         run: find -L . -type l -exec rm {} \;
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ocaml-build-artifacts.tgz
-          key: "${{ runner.os }}-core-binary-${{ hashFiles('semgrep-core/**', '.github/workflows/tests.yml', 'scripts/install-alpine-semgrep-core') }}-${{ steps.submodule-status.outputs.versions-hash }}"
+          key: "${{ runner.os }}-core-binary-${{ hashFiles('libs/**', 'languages/**', 'src/**', 'libs/**', 'tools/**', '.github/workflows/tests.yml', 'scripts/install-alpine-semgrep-core') }}-${{ steps.submodule-status.outputs.versions-hash }}"
       - uses: actions/checkout@v3
         if: steps.core-cache.outputs.cache-hit != 'true'
         with:

--- a/dune
+++ b/dune
@@ -12,6 +12,8 @@
   (_
     (flags (:standard  -w -52-6))))
 
+; coupling: if you modify this, you probably need to modify the core-cache
+; regexps in .github/workflow/tests.yml passed to the hashFiles function
 (dirs
   src
   libs


### PR DESCRIPTION
Not sure it's worth keeping this optimisation now that
most of the modifications are in OCaml code anyway.

test plan:
We should now see a CI failure, because develop is currently
broken, but it remained unnoticed because we were using
old semgrep-core version to run the tests


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)