### PR TITLE
CI: Add Apex support to diff scans when Pro is available

### DIFF
--- a/changelog.d/pa-2462.added
+++ b/changelog.d/pa-2462.added
@@ -1,0 +1,2 @@
+Pro: If the "Semgrep Pro Engine" toggle is enabled in App, `semgrep ci` will add
+support for Apex in all scans (including diff scans).


### PR DESCRIPTION
Previously, it only worked in full scans.

Closes PA-2462

test plan: Not sure how to test this since Editor doesn't allow you to
           save a rule for Apex. And `semgrep ci` doesn't allow you to
           specify a config.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
