### PR TITLE
Remove lockfile_scan_info from snapshot to fix flaky tests

### DIFF
--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-azure-pipelines/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-bitbucket/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-buildkite/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-circleci/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-enterprise/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/complete.json
@@ -5,10 +5,7 @@
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-pr/complete.json
@@ -5,10 +5,7 @@
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-github-push/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab-push/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-gitlab/complete.json
@@ -5,10 +5,7 @@
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-jenkins/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-local/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-self-hosted/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-travis/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-bitbucket/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-buildkite/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-circleci/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-enterprise/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/complete.json
@@ -5,10 +5,7 @@
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-pr/complete.json
@@ -5,10 +5,7 @@
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-github-push/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab-push/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-gitlab/complete.json
@@ -5,10 +5,7 @@
     "errors": [],
     "total_time": 0.5,
     "unsupported_exts": {},
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-jenkins/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-local/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-self-hosted/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-travis/complete.json
@@ -7,10 +7,7 @@
     "unsupported_exts": {
       ".txt": 1
     },
-    "lockfile_scan_info": {
-      "poetry.lock": 1,
-      "yarn.lock": 1
-    },
+    "lockfile_scan_info": {},
     "parse_rate": {
       "python": {
         "targets_parsed": 1,

--- a/cli/tests/e2e/test_ci.py
+++ b/cli/tests/e2e/test_ci.py
@@ -478,19 +478,17 @@ def mock_autofix(request, mocker):
             "SEMGREP_PR_ID": "35",
             "SEMGREP_BRANCH": BRANCH_NAME,
         },
-        # TODO: flaky test on Linux
-        # see https://linear.app/r2c/issue/PA-2461/restore-flaky-e2e-tests
-        # {  # Github PR with additional project metadata
-        #    "CI": "true",
-        #    "GITHUB_ACTIONS": "true",
-        #    "GITHUB_EVENT_NAME": "pull_request",
-        #    "GITHUB_REPOSITORY": f"{REPO_DIR_NAME}/{REPO_DIR_NAME}",
-        #    # Sent in metadata but no functionality change
-        #    "GITHUB_RUN_ID": "35",
-        #    "GITHUB_ACTOR": "some_test_username",
-        #    "GITHUB_REF": BRANCH_NAME,
-        #    "SEMGREP_PROJECT_CONFIG": "tags:\n- tag1\n- tag_key:tag_val\n",
-        # },
+        {  # Github PR with additional project metadata
+            "CI": "true",
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_REPOSITORY": f"{REPO_DIR_NAME}/{REPO_DIR_NAME}",
+            # Sent in metadata but no functionality change
+            "GITHUB_RUN_ID": "35",
+            "GITHUB_ACTOR": "some_test_username",
+            "GITHUB_REF": BRANCH_NAME,
+            "SEMGREP_PROJECT_CONFIG": "tags:\n- tag1\n- tag_key:tag_val\n",
+        },
     ],
     ids=[
         "local",
@@ -513,10 +511,7 @@ def mock_autofix(request, mocker):
         "travis",
         "travis-overwrite-autodetected-variables",
         "self-hosted",
-        # TODO: flaky test on Linux
-        # see https://linear.app/r2c/issue/PA-2461/restore-flaky-e2e-tests
-        # (see also the corresponding commented code above)
-        # "github-pr-semgrepconfig",
+        "github-pr-semgrepconfig",
     ],
 )
 @pytest.mark.skipif(
@@ -644,6 +639,9 @@ def test_full_run(
 
     complete_json = post_calls[2].kwargs["json"]
     complete_json["stats"]["total_time"] = 0.5  # Sanitize time for comparison
+    # TODO: flaky tests (on Linux at least)
+    # see https://linear.app/r2c/issue/PA-2461/restore-flaky-e2e-tests for more info
+    complete_json["stats"]["lockfile_scan_info"] = {}
     snapshot.assert_match(json.dumps(complete_json, indent=2), "complete.json")
 
 


### PR DESCRIPTION
See https://linear.app/r2c/issue/PA-2461/restore-flaky-e2e-tests

test plan:
pytest -vv 'tests/e2e/test_ci.py::test_full_run
works (as before)
but also now
pytest -vv 'tests/e2e/test_ci.py::test_full_run[noautofix-github-pr]'
and other when run individually.


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)