### PR TITLE
Ensure manylinux build passes at PR time

### DIFF
--- a/.github/workflows/build-test-manylinux-x86.yaml
+++ b/.github/workflows/build-test-manylinux-x86.yaml
@@ -1,0 +1,82 @@
+name: build-test-manylinux-x86
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build-core-manylinux:
+    name: semgrep-core make test and semgrep make test/qa-test
+    runs-on: ubuntu-latest
+    container: returntocorp/ocaml:alpine-2022-09-24
+    # We need this hack because GHA tampers with the HOME in container
+    # and this does not play well with 'opam' installed in /root
+    env:
+      HOME: /root
+    steps:
+      - name: Make checkout speedy
+        run: git config --global fetch.parallel 50
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Build semgrep-core
+        run: ./scripts/install-alpine-semgrep-core
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ocaml-build-artifacts
+          path: ocaml-build-artifacts.tgz
+      - name: Test semgrep-core
+        run: opam exec -- make core-test
+
+  build-wheels-manylinux:
+    runs-on: ubuntu-latest
+    container: returntocorp/sgrep-build:ubuntu-16.04
+    needs: [build-core-manylinux]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ocaml-build-artifacts
+      - name: Install artifacts
+        run: tar xf ocaml-build-artifacts.tgz
+      - name: Setup Python
+        run: |
+          rm /usr/bin/python
+          ln `which python3.7` /usr/bin/python
+      - name: Install zip & musl-tools
+        run: apt-get update && apt install -y zip musl-tools
+      - name: Build the wheels
+        env:
+          # Relative because build-wheels does a 'cd semgrep'
+          SEMGREP_CORE_BIN: ../ocaml-build-artifacts/bin/semgrep-core
+        run: ./scripts/build-wheels.sh
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: manylinux-wheel
+          path: cli/dist.zip
+
+  test-wheels-manylinux:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux1_x86_64
+    needs: [build-wheels-manylinux]
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: manylinux-wheel
+      - name: unzip dist
+        run: unzip ./manylinux-wheel/dist.zip
+      - name: install package
+        run: /opt/python/cp37-cp37m/bin/pip install dist/*.whl
+      - name: test package
+        working-directory: /opt/python/cp37-cp37m/bin/
+        run: ./semgrep --version
+      - name: e2e semgrep-core test
+        working-directory: /opt/python/cp37-cp37m/bin/
+        run: echo '1 == 1' | ./semgrep -l python -e '$X == $X' -
+      - name: e2e spacegrep test
+        working-directory: /opt/python/cp37-cp37m/bin/
+        run: echo '1 == 1' | ./semgrep -l generic -e '$X == $X' -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
     if: ${{ !contains(github.ref,'-test-release') }}
     needs:
       [
-        test-wheels-manylinux,
+        build-test-manylinux-x86,
         build-test-osx-x86,
         build-test-osx-m1,
         check-m1-build,
@@ -258,64 +258,15 @@ jobs:
           name: semgrep-ubuntu-16.04-${{ github.sha }}
           path: artifacts.tar.gz
 
-  build-wheels-manylinux:
-    runs-on: ubuntu-latest
-    container: returntocorp/sgrep-build:ubuntu-16.04
-    needs: [build-core]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: ocaml-build-artifacts
-      - name: Install artifacts
-        run: tar xf ocaml-build-artifacts.tgz
-      - name: Setup Python
-        run: |
-          rm /usr/bin/python
-          ln `which python3.7` /usr/bin/python
-      - name: Install zip & musl-tools
-        run: apt-get update && apt install -y zip musl-tools
-      - name: Build the wheels
-        env:
-          # Relative because build-wheels does a 'cd semgrep'
-          SEMGREP_CORE_BIN: ../ocaml-build-artifacts/bin/semgrep-core
-        run: ./scripts/build-wheels.sh
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: manylinux-wheel
-          path: cli/dist.zip
-
-  test-wheels-manylinux:
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux1_x86_64
-    needs: [build-wheels-manylinux]
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: manylinux-wheel
-      - name: unzip dist
-        run: unzip ./manylinux-wheel/dist.zip
-      - name: install package
-        run: /opt/python/cp37-cp37m/bin/pip install dist/*.whl
-      - name: test package
-        working-directory: /opt/python/cp37-cp37m/bin/
-        run: ./semgrep --version
-      - name: e2e semgrep-core test
-        working-directory: /opt/python/cp37-cp37m/bin/
-        run: echo '1 == 1' | ./semgrep -l python -e '$X == $X' -
-      - name: e2e spacegrep test
-        working-directory: /opt/python/cp37-cp37m/bin/
-        run: echo '1 == 1' | ./semgrep -l generic -e '$X == $X' -
+  build-test-manylinux-x86:
+    uses: ./.github/workflows/build-test-manylinux-x86.yaml
+    secrets: inherit
 
   upload-wheels:
     runs-on: ubuntu-latest
     needs:
       [
-        test-wheels-manylinux,
+        build-test-manylinux-x86,
         build-test-osx-x86,
         build-test-osx-m1,
         check-m1-build,

--- a/.github/workflows/test-build-outputs.yaml
+++ b/.github/workflows/test-build-outputs.yaml
@@ -12,6 +12,10 @@ on:
       - "**.md"
 
 jobs:
+  build-test-manylinux-x86:
+    uses: ./.github/workflows/build-test-manylinux-x86.yaml
+    secrets: inherit
+
   build-test-osx-x86:
     uses: ./.github/workflows/build-test-osx-x86.yaml
     secrets: inherit


### PR DESCRIPTION
Extract the manylinux build and test steps into a reusable workflow and run the exact same actions as in the release workflow to shift left issues from release time to commit time.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
