### PR TITLE
Always build for M1 mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,6 @@ jobs:
         build-test-manylinux-x86,
         build-test-osx-x86,
         build-test-osx-m1,
-        check-m1-build,
       ]
     steps:
       - name: Set up Docker Buildx
@@ -212,23 +211,7 @@ jobs:
     uses: ./.github/workflows/build-test-osx-x86.yaml
     secrets: inherit
 
-  check-m1-build:
-    name: Check build status for M1
-    runs-on: ubuntu-latest
-    outputs:
-      m1_support: ${{ steps.my-key.outputs.defined }}
-    steps:
-      - id: my-key
-        run: |
-          if [[ "${{ secrets.M1_SUPPORT }}" == "1" ]]; \
-          then
-            echo "::set-output name=defined::true"
-          else
-            echo "::set-output name=defined::false"
-          fi
-
   build-test-osx-m1:
-    if: ${{needs.check-m1-build.outputs.m1_support == 'true'}}
     uses: ./.github/workflows/build-test-osx-m1.yaml
     secrets: inherit
 
@@ -269,7 +252,6 @@ jobs:
         build-test-manylinux-x86,
         build-test-osx-x86,
         build-test-osx-m1,
-        check-m1-build,
       ]
     if: |
       always() &&
@@ -287,7 +269,6 @@ jobs:
           path: osx-wheel
       - name: Download Artifact
         uses: actions/download-artifact@v3
-        if: needs.check-m1-build.outputs.m1_support != ''
         with:
           name: m1-wheel
           path: m1-wheel
@@ -297,7 +278,6 @@ jobs:
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
         run: unzip ./osx-wheel/dist.zip "*.whl"
       - name: Unzip M1 Wheel
-        if: needs.check-m1-build.outputs.m1_support != ''
         # Don't unzip tar.gz because it already exists from ./manylinux-wheel/dist.zip.
         run: unzip ./m1-wheel/dist.zip "*.whl"
       - name: Publish to Pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,12 +135,7 @@ jobs:
     name: Build and push Semgrep Docker image
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref,'-test-release') }}
-    needs:
-      [
-        build-test-manylinux-x86,
-        build-test-osx-x86,
-        build-test-osx-m1,
-      ]
+    needs: [build-test-manylinux-x86, build-test-osx-x86, build-test-osx-m1]
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -247,12 +242,7 @@ jobs:
 
   upload-wheels:
     runs-on: ubuntu-latest
-    needs:
-      [
-        build-test-manylinux-x86,
-        build-test-osx-x86,
-        build-test-osx-m1,
-      ]
+    needs: [build-test-manylinux-x86, build-test-osx-x86, build-test-osx-m1]
     if: |
       always() &&
       (needs.build-test-osx-m1.result == 'success' || needs.build-test-osx-m1.result == 'skipped')


### PR DESCRIPTION
Secrets can only be written by GitHub Admins, so the switch to enable/disable M1 build would be better implemented using GitHub Action inputs which can be set by any user who runs the workflow. We have been building M1 for the last several months, so removing this switch for now is considered acceptable.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
