### PR TITLE
Bash: Parse_bash_tree_sitter.ml should return intermediate AST

### DIFF
--- a/languages/bash/generic/Bash_to_generic.ml
+++ b/languages/bash/generic/Bash_to_generic.ml
@@ -516,7 +516,7 @@ and expansion (env : env) (x : expansion) : G.expr =
 
 and expand loc (var_expr : G.expr) : G.expr = call loc C.expand [ var_expr ]
 
-let program (env : env) x = blist (env : env) x |> Common.map as_stmt
+let program_with_env (env : env) x = blist (env : env) x |> Common.map as_stmt
 
 (*
    Unwrap the pattern tree as much as possible to maximize matches.
@@ -534,12 +534,16 @@ let pattern (x : blist) =
    * problem with Parse_pattern.normalize_any probably
    *)
   | None -> (
-      match program env x with
+      match program_with_env env x with
       | [ { G.s = G.ExprStmt (e, _semicolon); _ } ] -> G.E e
       | [ stmt ] -> G.S stmt
       | stmts -> G.Ss stmts)
 
 let any (env : env) x : G.any =
   match env with
-  | Program -> G.Ss (program env x)
+  | Program -> G.Ss (program_with_env env x)
   | Pattern -> pattern x
+
+let program x =
+  let env = Program in
+  program_with_env env x

--- a/languages/bash/generic/Bash_to_generic.mli
+++ b/languages/bash/generic/Bash_to_generic.mli
@@ -6,5 +6,10 @@
    Convert a target program to the generic AST.
    May raise AST_generic.Error.
 *)
-val program : AST_bash.input_kind -> AST_bash.program -> AST_generic.program
+val program : AST_bash.program -> AST_generic.program
+val pattern : AST_bash.program -> AST_generic.any
 val any : AST_bash.input_kind -> AST_bash.program -> AST_generic.any
+
+(* internal function used also in Dockerfile_to_generic *)
+val program_with_env :
+  AST_bash.input_kind -> AST_bash.program -> AST_generic.program

--- a/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
+++ b/languages/bash/tree-sitter/Parse_bash_tree_sitter.ml
@@ -1447,22 +1447,20 @@ and right_hand_side (env : env) (x : CST.anon_choice_lit_bbf16c7) : expression =
 (*****************************************************************************)
 
 let parse file =
-  let input_kind = AST_bash.Program in
   H.wrap_parser
     (fun () -> Tree_sitter_bash.Parse.file file)
     (fun cst ->
-      let env = { H.file; conv = H.line_col_to_pos file; extra = input_kind } in
+      let env =
+        { H.file; conv = H.line_col_to_pos file; extra = AST_bash.Program }
+      in
       let tok = PI.fake_info_loc (PI.first_loc_of_file file) "" in
-      let bash_ast = program env ~tok cst in
-      Bash_to_generic.(program input_kind bash_ast))
+      program env ~tok cst)
 
 let parse_pattern str =
-  let input_kind = AST_bash.Pattern in
   H.wrap_parser
     (fun () -> Tree_sitter_bash.Parse.string str)
     (fun cst ->
       let file = "<pattern>" in
-      let env = { H.file; conv = Hashtbl.create 0; extra = input_kind } in
+      let env = { H.file; conv = Hashtbl.create 0; extra = AST_bash.Pattern } in
       let tok = PI.fake_info_loc (PI.first_loc_of_file file) "" in
-      let bash_ast = program env ~tok cst in
-      Bash_to_generic.any input_kind bash_ast)
+      program env ~tok cst)

--- a/languages/bash/tree-sitter/Parse_bash_tree_sitter.mli
+++ b/languages/bash/tree-sitter/Parse_bash_tree_sitter.mli
@@ -12,7 +12,5 @@ type env = AST_bash.input_kind Parse_tree_sitter_helpers.env
 val program :
   env -> tok:Parse_info.t -> Tree_sitter_bash.CST.program -> AST_bash.blist
 
-val parse :
-  Common.filename -> AST_generic.program Tree_sitter_run.Parsing_result.t
-
-val parse_pattern : string -> AST_generic.any Tree_sitter_run.Parsing_result.t
+val parse : Common.filename -> AST_bash.program Tree_sitter_run.Parsing_result.t
+val parse_pattern : string -> AST_bash.program Tree_sitter_run.Parsing_result.t

--- a/languages/dockerfile/generic/Dockerfile_to_generic.ml
+++ b/languages/dockerfile/generic/Dockerfile_to_generic.ml
@@ -116,7 +116,7 @@ let argv_or_shell (env : env) (x : argv_or_shell) : G.expr list =
   | Command_semgrep_ellipsis tok -> [ G.Ellipsis tok |> G.e ]
   | Argv (_loc, array) -> [ string_array array ]
   | Sh_command (loc, x) ->
-      let args = Bash_to_generic.program env x |> expr_of_stmts loc in
+      let args = Bash_to_generic.program_with_env env x |> expr_of_stmts loc in
       [ call_shell loc Sh [ args ] ]
   | Other_shell_command (shell_compat, code) ->
       let args = [ string_expr code ] in

--- a/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
+++ b/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
@@ -999,4 +999,10 @@ let parse_pattern str =
   if dockerfile_res.errors =*= [] then dockerfile_res
   else
     let bash_res = Parse_bash_tree_sitter.parse_pattern str in
-    if bash_res.errors =*= [] then bash_res else dockerfile_res
+    let any_opt =
+      match bash_res.program with
+      | None -> None
+      | Some program -> Some (Bash_to_generic.pattern program)
+    in
+    if bash_res.errors =*= [] then { bash_res with program = any_opt }
+    else dockerfile_res

--- a/src/parsing/Parse_pattern.ml
+++ b/src/parsing/Parse_pattern.ml
@@ -136,7 +136,10 @@ let parse_pattern lang ?(print_errors = false) str =
         extract_pattern_from_tree_sitter_result res print_errors
     | Lang.Bash ->
         let res = Parse_bash_tree_sitter.parse_pattern str in
-        extract_pattern_from_tree_sitter_result res print_errors
+        let program =
+          extract_pattern_from_tree_sitter_result res print_errors
+        in
+        Bash_to_generic.pattern program
     | Lang.Dockerfile ->
         let res = Parse_dockerfile_tree_sitter.parse_pattern str in
         extract_pattern_from_tree_sitter_result res print_errors

--- a/src/parsing/Parse_target.ml
+++ b/src/parsing/Parse_target.ml
@@ -297,7 +297,9 @@ let rec just_parse_with_lang lang file =
       run file [ TreeSitter Parse_julia_tree_sitter.parse ] (fun x -> x)
   | Lang.Lua -> run file [ TreeSitter Parse_lua_tree_sitter.parse ] (fun x -> x)
   | Lang.Bash ->
-      run file [ TreeSitter Parse_bash_tree_sitter.parse ] (fun x -> x)
+      run file
+        [ TreeSitter Parse_bash_tree_sitter.parse ]
+        Bash_to_generic.program
   | Lang.Dockerfile ->
       run file [ TreeSitter Parse_dockerfile_tree_sitter.parse ] (fun x -> x)
   | Lang.Rust ->


### PR DESCRIPTION
Follow what we do in the other parser where we use an
intermediate AST

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)