### PR TITLE
jsonnet: add semgrep ellipsis constructs to AST_jsonnet.ml

### DIFF
--- a/languages/jsonnet/ast/AST_jsonnet.ml
+++ b/languages/jsonnet/ast/AST_jsonnet.ml
@@ -1,6 +1,6 @@
 (* Yoann Padioleau
  *
- * Copyright (C) 2022 r2c
+ * Copyright (C) 2022-2023 r2c
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -103,6 +103,9 @@ type expr =
   | Error of tok (* 'error' *) * expr
   (* for the CST *)
   | ParenExpr of expr bracket
+  (* semgrep: *)
+  | Ellipsis of tok
+  | DeepEllipsis of expr bracket
 
 (* ------------------------------------------------------------------------- *)
 (* literals *)
@@ -196,14 +199,22 @@ and function_definition = {
   f_body : expr;
 }
 
-(* semgrep: LATER can have ParamEllipsis *)
-and parameter = P of ident * (tok (* '=' *) * expr) option
+and parameter =
+  | P of ident * (tok (* '=' *) * expr) option
+  (* semgrep: *)
+  | ParamEllipsis of tok
 
 (* ------------------------------------------------------------------------- *)
 (* Objects  *)
 (* ------------------------------------------------------------------------- *)
 and obj_inside = Object of obj_member list | ObjectComp of obj_comprehension
-and obj_member = OLocal of obj_local | OField of field | OAssert of assert_
+
+and obj_member =
+  | OLocal of obj_local
+  | OField of field
+  | OAssert of assert_
+  (* semgrep: *)
+  | OEllipsis of tok
 
 and field = {
   fld_name : field_name;

--- a/libs/ojsonnet/Desugar_jsonnet.ml
+++ b/libs/ojsonnet/Desugar_jsonnet.ml
@@ -218,6 +218,9 @@ and desugar_expr_aux env v =
   | ParenExpr v ->
       let _, e, _ = (desugar_bracket desugar_expr) env v in
       e
+  | Ellipsis tk
+  | DeepEllipsis (tk, _, _) ->
+      error tk "Ellipsis can appear only in semgrep patterns"
 
 and desugar_special _env v =
   match v with
@@ -363,6 +366,8 @@ and desugar_parameter env v =
             ( id,
               fk,
               C.Error (fk, C.L (mk_str_literal ("Parameter not bound", fk))) ))
+  | ParamEllipsis tk ->
+      error tk "ParamEllipsis can appear only in semgrep patterns"
 
 and desugar_obj_inside env (l, v, r) : C.expr =
   let l = desugar_tok env l in
@@ -373,6 +378,8 @@ and desugar_obj_inside env (l, v, r) : C.expr =
         v
         |> Common.partition_either3 (function
              | OLocal (_tlocal, x) -> Left3 x
+             | OEllipsis tk ->
+                 error tk "OEllipsis can appear only in semgrep patterns"
              | OAssert x -> Middle3 x
              | OField x -> Right3 x)
       in


### PR DESCRIPTION
Also fixed a few todos in Jsonnet_to_generic.ml

This will help
https://linear.app/r2c/issue/PA-2112/ast-jsonnet-to-ast-generic-translation

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)