### PR TITLE
Remove redundant MacOS test steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -430,44 +430,6 @@ jobs:
           perf/compare-perf cli/baseline_timing1.json cli/baseline_timing2.json cli/timing1.json cli/timing2.json ${{ secrets.GITHUB_TOKEN }} ${{ github.event.number }}
           perf/compare-bench-findings cli/findings.json
 
-  build-macos-release:
-    runs-on: ["self-hosted", "macOS", "X64"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - name: Fetch semgrep-cli submodules
-        run: git submodule update --init --recursive --recommend-shallow cli/src/semgrep/lang cli/src/semgrep/semgrep_interfaces
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      # TODO why not the specific 2022.6.7 version here?
-      - run: sudo python3 -m pip install pipenv
-      - name: Run OSX build
-        run: ./scripts/osx-release.sh
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: semgrep-osx
-          path: artifacts
-
-  test-macos-release:
-    name: test macOS release
-    runs-on: ["self-hosted", "macOS", "X64"]
-    needs: [build-macos-release]
-    steps:
-      - name: download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: semgrep-osx
-          path: test-artifacts
-      - name: Remove pcre dynamic lib
-        run: rm /usr/local/opt/pcre/lib/libpcre.1.dylib || true
-      - name: test build artifacts
-        run: |
-          chmod +x ./test-artifacts/semgrep-core
-          ./test-artifacts/semgrep-core -help
-
   build-ubuntu-release:
     needs: [build-semgrep-core]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The build-test-osx-{x86|m1} steps provide coverage for both architectures and use the exact same checks as during releases.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
