### PR TITLE
feat: add release dry-run capability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,14 @@
 name: release
 
 on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run the release in dry-run mode, e.g., without changing external state (like pushing to PyPI/Docker)"
+        required: true
+        type: boolean
+        default: true
+
   push:
     branches:
       # Sequence of patterns matched against refs/tags
@@ -15,6 +23,23 @@ on:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
+  dry-run:
+    name: Evaluate Dry Run
+    runs-on: ubuntu-22.04
+    outputs:
+      dry-run: ${{steps.dry-run.outputs.dry-run}}
+    steps:
+      - name: Evaluate Dry Run
+        id: dry-run
+        run: |
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo ::set-output name=dry-run::true
+            echo "Setting dry-run to TRUE"
+          else
+            echo ::set-output name=dry-run::false
+            echo "Setting dry-run to FALSE"
+          fi
+
   wait-for-build-test:
     name: Wait for Build/Test All Platforms
     runs-on: ubuntu-22.04
@@ -33,8 +58,8 @@ jobs:
   create-release:
     name: Create the Github Release
     runs-on: ubuntu-latest
-    needs: [wait-for-build-test]
-    if: ${{ !contains(github.ref, '-test-release') }}
+    needs: [wait-for-build-test, dry-run]
+    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Get the version
         id: get-version
@@ -105,8 +130,8 @@ jobs:
   create-release-interfaces:
     name: Create the Github Release on Semgrep Interfaces
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, '-test-release') }}
-    needs: [wait-for-build-test]
+    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
+    needs: [wait-for-build-test, dry-run]
     steps:
       - name: Get the version
         id: get-version
@@ -153,8 +178,8 @@ jobs:
   push-docker:
     name: Push Semgrep Docker image
     runs-on: ubuntu-latest
-    needs: [wait-for-build-test]
-    if: ${{ !contains(github.ref,'-test-release') }}
+    needs: [wait-for-build-test, dry-run]
+    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -206,7 +231,8 @@ jobs:
   upload-wheels:
     name: Upload Wheels to PyPI
     runs-on: ubuntu-latest
-    needs: [wait-for-build-test]
+    needs: [wait-for-build-test, dry-run]
+    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v3
@@ -250,6 +276,7 @@ jobs:
   park-pypi-packages:
     name: Park PyPI package names
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     defaults:
       run:
         working-directory: cli/
@@ -289,7 +316,7 @@ jobs:
     # Need to wait for pypi to propagate ssince pipgrip relies on it being published on pypi
     needs: [upload-wheels]
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref,'-test-release') }}
+    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Sleep 10 min
         run: sleep 10m
@@ -298,7 +325,7 @@ jobs:
     name: Update on Homebrew-Core
     needs: [sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-12
-    if: ${{ !contains(github.ref,'-test-release') }}
+    if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
       - name: Get the version
         id: get-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,7 @@ jobs:
   park-pypi-packages:
     name: Park PyPI package names
     runs-on: ubuntu-latest
+    needs: [dry-run]
     if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     defaults:
       run:
@@ -314,7 +315,7 @@ jobs:
   sleep-before-homebrew:
     name: Sleep 10 min before releasing to homebrew
     # Need to wait for pypi to propagate ssince pipgrip relies on it being published on pypi
-    needs: [upload-wheels]
+    needs: [dry-run, upload-wheels]
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:
@@ -323,7 +324,7 @@ jobs:
 
   homebrew-core-pr:
     name: Update on Homebrew-Core
-    needs: [sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
+    needs: [dry-run, sleep-before-homebrew] # Needs to run after pypi released so brew can update pypi dependency hashes
     runs-on: macos-12
     if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     steps:


### PR DESCRIPTION
Add capability for dry-running the release workflow. Will iterate on this and expand the portions included in a dry-run.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
