### PR TITLE
feat(cli): make pretty dataflow traces

### DIFF
--- a/changelog.d/pa-2471.fixed
+++ b/changelog.d/pa-2471.fixed
@@ -1,0 +1,2 @@
+Dataflow traces: Findings now always display the separating line with `--dataflow-traces` in the CLI, to reduce
+confusion over where the findings fall between the dataflow traces.

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -266,7 +266,7 @@ class TextFormatter(BaseFormatter):
                         per_finding_max_lines_limit,
                         per_line_max_chars_limit,
                         False,
-                        True,
+                        False,
                     )
 
             if isinstance(call_trace.value, out.CliCall):
@@ -324,7 +324,7 @@ class TextFormatter(BaseFormatter):
                         per_finding_max_lines_limit,
                         per_line_max_chars_limit,
                         False,
-                        True,
+                        False,
                     )
 
             if sink:

--- a/cli/src/semgrep/formatter/text.py
+++ b/cli/src/semgrep/formatter/text.py
@@ -336,6 +336,7 @@ class TextFormatter(BaseFormatter):
                     per_finding_max_lines_limit,
                     per_line_max_chars_limit,
                 )
+                yield ""
 
     @staticmethod
     def _get_details_shortlink(rule_match: RuleMatch) -> Optional[str]:
@@ -573,7 +574,10 @@ class TextFormatter(BaseFormatter):
                 color_output,
                 per_finding_max_lines_limit,
                 per_line_max_chars_limit,
-                is_same_file,
+                # if we have dataflow traces on, then we should print the separator,
+                # because otherwise it is easy to mistake taint traces as belonging
+                # to a different finding
+                is_same_file or dataflow_traces,
             )
 
             if dataflow_traces:


### PR DESCRIPTION
## What:
This PR makes dataflow traces in the CLI more easily readable.

## Why:
Currently, separating lines are not always printed on the findings themselves, leading to big blocks of taint traces which might make it difficult to parse which finding they actually attach to.

## How:
Added a newline where appropriate, and made it such that separating lines between findings are always printed when dataflow traces are specified.

On this file:
```

public class Foo {
   public int foo(int arg) {
     sink(arg);
   }

   public int bar(int arg) {
     sink(arg);
   }

   public int qux(int arg) {
     sink(arg);
   }



   public void main() {
     int x = 150;

     foo(x);
     bar(x);
     qux(x);
   }
}
```
with this rule
```
rules:
- id: test
  mode: taint
  pattern-sources:
    - pattern: |
        150 
  pattern-sinks:
    - pattern: |
        sink(...)
  message: stop
  languages: [java]
  severity: WARNING
  metadata:
    deepsemgrep: true
```
currently we see the following findings, in either the case where we limit it to one call to `foo`, and three calls to all three of `foo`, `bar`, and `qux`:
![image](https://user-images.githubusercontent.com/49291449/215629832-7918c379-3a62-4357-8f21-17d1d232ddb4.png)
![image](https://user-images.githubusercontent.com/49291449/215629886-caf72877-694f-4357-b27e-cb958e84d968.png)

After this change, they will now be viewed as:
![image](https://user-images.githubusercontent.com/49291449/215629915-7b389b5d-25e2-42a4-9860-03715622a0ce.png)
![image](https://user-images.githubusercontent.com/49291449/215629927-2ad237f9-c260-442b-92f7-4bff0996edc6.png)

Note that this will always add the separating line, even when there is only one finding, when `--dataflow-traces` is specified. I view this as an OK compromise, though.

Closes PA-2471

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
