### PR TITLE
feat!: make nested blocks visible to taint

### DIFF
--- a/changelog.d/pa-2475.fixed
+++ b/changelog.d/pa-2475.fixed
@@ -1,4 +1,4 @@
-Terraform: Blocks can now be used as sources and sinks for taint.
+Terraform: Nested blocks can now be used as sources and sinks for taint.
 For instance, the block `x` in
 
 resource $A $B {

--- a/changelog.d/pa-2475.fixed
+++ b/changelog.d/pa-2475.fixed
@@ -1,0 +1,8 @@
+Terraform: Blocks can now be used as sources and sinks for taint.
+For instance, the block `x` in
+
+resource $A $B {
+  x {
+    ...
+  }
+}

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -890,7 +890,9 @@ and record env ((_tok, origfields, _) as record_def) =
                 we just want it in there at all so that we can use it as a sink.
              *)
              let field_expr = record env fields in
-             (* it is not clear to me if the prior_expr is necessary here. *)
+             (* We need to use the entire `prior_expr` here, or the range won't be quite
+                right (we'll leave out the identifier)
+             *)
              Some (Field (id, { field_expr with eorig = SameAs prior_expr }))
          | _ when is_hcl env.lang ->
              (* For HCL constructs such as `lifecycle` blocks within a module call, the

--- a/tests/rules/terraform_block_sink.tf
+++ b/tests/rules/terraform_block_sink.tf
@@ -1,5 +1,6 @@
 
 resource "r1" "r2" {
+  # ruleid: terraform-block-sink 
   x {
     sink = 150
   }

--- a/tests/rules/terraform_block_sink.tf
+++ b/tests/rules/terraform_block_sink.tf
@@ -1,0 +1,6 @@
+
+resource "r1" "r2" {
+  x {
+    sink = 150
+  }
+}

--- a/tests/rules/terraform_block_sink.yaml
+++ b/tests/rules/terraform_block_sink.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: terraform-block-sink
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        150
+  pattern-sinks: 
+    - pattern: |
+        x {
+          ...
+        }
+  message: Working!
+  severity: WARNING
+  languages: [hcl]


### PR DESCRIPTION
## What:
This PR just makes nested blocks visible to the taint engine, notably making them usable as sources or sinks.

## Why:
Sometimes we want to write rules which check if bad values go into nested blocks. This enables that functionality.

For instance, consider the following Terraform code:
```
resource "resource_ty" "resource_name" {
  setting1 = true 

  x { 
    sensitive_setting = var.x
  }
}
```

We would like to be able to write rules which track whether taint goes to the `sensitive_setting`. Unfortunately, it is inside of a `resource`, specifically inside of a `Record`. A `Call` inside of a `Record` is not understood, so this is just killed, and never makes it to the IL, and thus it can't be a source or a sink.

This PR just makes sure it makes it there.

## How:
Just made it so that when in `hcl`, the AST to IL conversion allows nested blocks.

Closes PA-2475

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
