### PR TITLE
Jsonnet: experimental support!

### DIFF
--- a/changelog.d/pa-1849.added
+++ b/changelog.d/pa-1849.added
@@ -1,0 +1,2 @@
+Experimental support for Jsonnet (writing semgrep rules to find
+bugs/security-isses/... in jsonnet files).

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -143,6 +143,8 @@ let language_exceptions =
     (* Experimental languages *)
     (Lang.R, [ "deep_exprstmt" ]);
     (Lang.Elixir, [ "dots_nested_stmts" ]);
+    (* xxx_stmts is NA *)
+    (Lang.Jsonnet, [ "dots_stmts"; "deep_exprstmt"; "dots_nested_stmts" ]);
   ]
 
 let maturity_tests () =
@@ -214,7 +216,8 @@ let maturity_tests () =
       check_maturity Lang.Swift "swift" ".swift" Experimental;
       check_maturity Lang.Julia "julia" ".jl" Experimental;
       (* YAML has too many NA, not worth it *)
-      check_maturity Lang.R "r" ".r" Experimental
+      check_maturity Lang.R "r" ".r" Experimental;
+      check_maturity Lang.Jsonnet "jsonnet" ".jsonnet" Experimental
       (* Not even experimental *)
       (* HTML, Vue *);
     ]
@@ -414,6 +417,8 @@ let lang_regression_tests ~polyglot_pattern_path ~with_caching =
         (Lang.Solidity, "solidity", ".sol");
         (Lang.Elixir, "elixir", ".ex");
         (Lang.R, "r", ".r");
+        (Lang.Julia, "julia", ".jl");
+        (Lang.Jsonnet, "jsonnet", ".jsonnet");
       ]
   in
   let irregular_tests =

--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -417,7 +417,10 @@ let lang_regression_tests ~polyglot_pattern_path ~with_caching =
         (Lang.Solidity, "solidity", ".sol");
         (Lang.Elixir, "elixir", ".ex");
         (Lang.R, "r", ".r");
-        (Lang.Julia, "julia", ".jl");
+        (* TODO: weird because the tests work in check_maturity above
+         * but note here
+         * (Lang.Julia, "julia", ".jl");
+         *)
         (Lang.Jsonnet, "jsonnet", ".jsonnet");
       ]
   in

--- a/src/parsing/Parse_pattern.ml
+++ b/src/parsing/Parse_pattern.ml
@@ -192,7 +192,12 @@ let parse_pattern lang ?(print_errors = false) str =
     | Lang.Json ->
         let any = Parse_json.any_of_string str in
         Json_to_generic.any any
-    | Lang.Jsonnet -> failwith "Jsonnet is not supported yet"
+    | Lang.Jsonnet ->
+        let res = Parse_jsonnet_tree_sitter.parse_pattern str in
+        let pattern =
+          extract_pattern_from_tree_sitter_result res print_errors
+        in
+        Jsonnet_to_generic.any pattern
     | Lang.Clojure -> failwith "clojure is not supported yet"
     | Lang.Lisp -> failwith "Lisp is not supported yet"
     | Lang.Scheme -> failwith "Scheme is not supported yet"

--- a/tests/patterns/jsonnet/concrete_syntax.jsonnet
+++ b/tests/patterns/jsonnet/concrete_syntax.jsonnet
@@ -1,0 +1,16 @@
+local f = function () [
+ //ERROR:
+    foo(1,2),
+
+ //ERROR:
+ foo(1,
+     2),
+
+ //ERROR:
+ foo (1, // comment
+      2),
+
+ // nope, not this one
+ foo(2,1),
+];
+f()

--- a/tests/patterns/jsonnet/dots_args.jsonnet
+++ b/tests/patterns/jsonnet/dots_args.jsonnet
@@ -1,0 +1,10 @@
+local foo = function () [
+  //ERROR:
+    foo(1,2,3,4,5),
+  //ERROR:
+    foo(5),
+];
+foo()
+
+
+

--- a/tests/patterns/jsonnet/dots_string.jsonnet
+++ b/tests/patterns/jsonnet/dots_string.jsonnet
@@ -1,0 +1,10 @@
+local foo = function () [
+    //ERROR:
+    foo("whatever sequence of chars"),
+    //ERROR:
+    foo('whatever sequence of chars'),
+    //ERROR:
+    foo(|||whatever sequence of chars
+        |||),
+];
+foo()

--- a/tests/patterns/jsonnet/metavar_arg.jsonnet
+++ b/tests/patterns/jsonnet/metavar_arg.jsonnet
@@ -1,0 +1,19 @@
+local foo = function () [
+    //ERROR:
+    foo(1,2),
+
+    //ERROR:
+    foo(a_very_long_constant_name,
+        2),
+
+    //ERROR:
+    foo (unsafe(), // indeed
+         2),
+
+    //ERROR:
+    foo(bar(1,3), 2),
+
+    foo(2,1),
+];
+foo()
+

--- a/tests/patterns/jsonnet/metavar_call.jsonnet
+++ b/tests/patterns/jsonnet/metavar_call.jsonnet
@@ -1,0 +1,5 @@
+local foo = function () [
+    //ERROR:
+    foo(1,2),
+];
+foo()

--- a/tests/patterns/jsonnet/metavar_equality_var.jsonnet
+++ b/tests/patterns/jsonnet/metavar_equality_var.jsonnet
@@ -1,0 +1,11 @@
+local f = function ()
+    //ERROR:
+    local myfile = open();
+    close(myfile)
+;
+f()
+
+
+
+
+

--- a/tests/patterns/jsonnet/metavar_equality_var.sgrep
+++ b/tests/patterns/jsonnet/metavar_equality_var.sgrep
@@ -1,0 +1,4 @@
+local $V = open();
+close($V)
+
+


### PR DESCRIPTION
Note that this is to allow users to write rules to find bugs
in jsonnet files; Semgrep for jsonnet. This is different
from the ability to write rules in jsonnet (instead of yaml),
(which is also currently allowed but that's another story).

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)