### PR TITLE
feat: refactor push-docker into separate workflow

### DIFF
--- a/.github/workflows/build-test-docker.yaml
+++ b/.github/workflows/build-test-docker.yaml
@@ -2,26 +2,50 @@ name: build-test-docker
 
 on:
   workflow_dispatch:
+    inputs:
+      docker-tags:
+        required: true
+        type: string
+        description: A multi-line string in the format accepted by docker metadata tag action for the tags to apply to the image
   workflow_call:
+    inputs:
+      docker-tags:
+        required: true
+        type: string
+        description: A multi-line string in the format accepted by docker metadata tag action for the tags to apply to the image
 
 jobs:
-  release-docker:
+  build-test-docker:
     name: Build and test Semgrep Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - id: meta
+        name: Set tags and labels
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+          # :latest is also added automatically
+          tags: ${{ inputs.docker-tags }}
+
       - name: Build image
         uses: docker/build-push-action@v3
         with:
-          load: true
-          tags: candidate-image
+          outputs: type=docker,dest=/tmp/image.tar
           cache-from: type=gha,src=/tmp/.buildx-cache
           cache-to: type=gha,dest=/tmp/.buildx-cache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Check the semgrep Docker image
-        run: ./scripts/validate-docker-build.sh candidate-image
+        run: ./scripts/validate-docker-build.sh ${{ steps.build-image.outputs.imageid }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: image
+          path: /tmp/image.tar

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -1,0 +1,28 @@
+name: push-docker
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  push-docker:
+    name: Push Semgrep Docker Image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: image
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/image.tar
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push Image
+        run: |
+          docker push --all-tags "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,37 +182,17 @@ jobs:
   build-test-docker:
     uses: ./.github/workflows/build-test-docker.yaml
     secrets: inherit
+    with:
+      docker-tags: |
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
 
   push-docker:
     name: Push Semgrep Docker image
-    runs-on: ubuntu-latest
     needs: [wait-for-build-test, dry-run]
     if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - id: meta
-        name: Set tags and labels
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ github.repository }}
-          # :latest is also added automatically
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: Push image
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,src=/tmp/.buildx-cache
-          cache-to: type=gha,dest=/tmp/.buildx-cache,mode=max
+    uses: ./.github/workflows/push-docker.yaml
+    secrets: inherit
 
   build-test-osx-x86:
     uses: ./.github/workflows/build-test-osx-x86.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -461,6 +461,14 @@ jobs:
   build-test-docker:
     uses: ./.github/workflows/build-test-docker.yaml
     secrets: inherit
+    with:
+      docker-tags: |
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+        type=ref,event=pr
+        type=ref,event=branch
+        type=sha,event=branch
+        type=edge
 
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml


### PR DESCRIPTION
Breaks up docker build and push into separate jobs, uses artifacts instead of relying on cached layers + rebuild.  

PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
