### PR TITLE
Make abstract_content more meaningful

### DIFF
--- a/cli/tests/e2e/test_join_rules.py
+++ b/cli/tests/e2e/test_join_rules.py
@@ -49,9 +49,22 @@ def test_join_rules(run_semgrep_in_tmp, snapshot, rule, target):
         # TODO: regression because of
         # https://github.com/returntocorp/semgrep/pull/6900
         # commented for now
+        #
+        # Let's say you have a pattern `func($X)` to match `func(bar)` where `bar`
+        # comes from package `foo`. Semgrep-core returns two matches, in each match
+        # the abstract_content of $X is different, in one it is `bar` and in the
+        # other it is `foo.bar`. Right, but the token associated with both is now
+        # the same since PR #6900, it's the token of `bar` for both matches! And
+        # CLI ignores abstract_content and instead takes that token and reads the
+        # content from the file, so for CLI both matches are exactly the same, they
+        # set $X to `bar`. So it picks any one of them. However, join-mode does use
+        # abstract_content, so the difference between the matches does matter. Then,
+        # if join-mode tries to join rules R and S, and for rule R the CLI picked a
+        # match with abstract_content equals to `foo.bar`, whereas for rule S the
+        # CLI picked a match with abstract_content equals to `bar`... it won't work.
         # (
-        #    "rules/join_rules/recursive/flask-deep-stored-xss-example/flask-stored-xss.yaml",
-        #    "join_rules/recursive/flask-deep-stored-xss-example",
+        #     "rules/join_rules/recursive/flask-deep-stored-xss-example/flask-stored-xss.yaml",
+        #     "join_rules/recursive/flask-deep-stored-xss-example",
         # ),
     ],
 )

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -1979,7 +1979,9 @@ let basic_id_info ?(hidden = false) resolved =
 (* TODO: move AST_generic_helpers.name_of_id and ids here *)
 
 let dotted_to_canonical xs = Common.map fst xs
-let canonical_to_dotted tid xs = xs |> Common.map (fun s -> (s, tid))
+
+let canonical_to_dotted tid xs =
+  xs |> Common.map (fun s -> (s, Parse_info.fake_info tid s))
 
 (* ------------------------------------------------------------------------- *)
 (* Entities *)

--- a/libs/ast_generic/Visitor_AST.ml
+++ b/libs/ast_generic/Visitor_AST.ml
@@ -1474,7 +1474,7 @@ let extract_ranges :
         ranges := Some (smaller orig_left left, larger orig_right right)
   in
   let incorporate_token tok =
-    if PI.is_origintok tok then
+    if PI.has_origin_loc tok then
       let tok_loc = PI.unsafe_token_location_of_info tok in
       incorporate_tokens (tok_loc, tok_loc)
   in
@@ -1516,7 +1516,7 @@ let extract_ranges :
     res
 
 let range_of_tokens tokens =
-  List.filter PI.is_origintok tokens |> PI.min_max_ii_by_pos
+  List.filter PI.has_origin_loc tokens |> PI.min_max_ii_by_pos
   [@@profiling]
 
 let range_of_any_opt any =

--- a/libs/lib_parsing/Parse_info.ml
+++ b/libs/lib_parsing/Parse_info.ml
@@ -327,6 +327,13 @@ let is_origintok ii =
   | OriginTok _ -> true
   | _ -> false
 
+let has_origin_loc ii =
+  match ii.token with
+  | OriginTok _
+  | FakeTokStr (_, Some _) ->
+      true
+  | _ -> false
+
 (* info about the current location *)
 
 (* original info *)
@@ -347,7 +354,9 @@ type posrv =
 
 let compare_pos ii1 ii2 =
   let get_pos = function
-    | OriginTok pi -> Real pi
+    | OriginTok pi
+    | FakeTokStr (_, Some (pi, _)) ->
+        Real pi
     (* todo? I have this for lang_php/
         | FakeTokStr (s, Some (pi_orig, offset)) ->
             Virt (pi_orig, offset)

--- a/libs/lib_parsing/Parse_info.mli
+++ b/libs/lib_parsing/Parse_info.mli
@@ -143,6 +143,9 @@ val fake_token_location : token_location
 val is_fake : t -> bool
 val is_origintok : t -> bool
 
+val has_origin_loc : t -> bool
+(** Either an OriginTok or a FakeTokStr associated with a real location. *)
+
 (* NOTE: These functions introduce unsafe fake tokens, prefer safe functions
  * below, use these only as a last resort! *)
 val unsafe_fake_info : string -> t

--- a/src/core/Range.ml
+++ b/src/core/Range.ml
@@ -110,7 +110,7 @@ let range_of_token_locations (start_loc : PI.token_location)
 
 let range_of_tokens xs =
   try
-    let xs = List.filter PI.is_origintok xs in
+    let xs = List.filter PI.has_origin_loc xs in
     let mini, maxi = PI.min_max_ii_by_pos xs in
     let start = PI.pos_of_info mini in
     let end_ =

--- a/src/reporting/JSON_report.ml
+++ b/src/reporting/JSON_report.ml
@@ -117,7 +117,7 @@ let metavar_string_of_any any =
      we have y = 2 but there is no source location for 2.
      Handle such cases *)
   any |> V.ii_of_any
-  |> List.filter PI.is_origintok
+  |> List.filter PI.has_origin_loc
   |> List.sort Parse_info.compare_pos
   |> Common.map PI.str_of_info |> Matching_report.join_with_space_if_needed
 
@@ -185,7 +185,7 @@ let tokens_to_single_loc toks =
    * taint rule finding but it shouldn't happen in practice. *)
   let locations =
     tokens_to_locations
-      (List.filter PI.is_origintok toks |> List.sort PI.compare_pos)
+      (List.filter PI.has_origin_loc toks |> List.sort PI.compare_pos)
   in
   let* first_loc, last_loc = first_and_last locations in
   Some


### PR DESCRIPTION
Instead of attaching "origin" tokens to "fake" ids, we attach to them "fake" tokens that are associated with real locations.

Follows: 291df812a61 ("ResolvedName of dotted_ident -> GlobalName of string list (#6900)")

test plan:
% bin/semgrep-core -l py -e 'return $F(...)' tests/rules/taint_flask.py -json
     #^ abstract_content for $F is "flask.render_template" as you would expect!

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
