### PR TITLE
add dry-run to docker push step

### DIFF
--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
+      dry-run:
+        required: true
+        type: boolean
+        description: Whether a dry-run (e.g., print tags to push) should be peformed. Actually push images if false.
+
   workflow_call:
     inputs:
       artifact-name:
@@ -21,6 +26,10 @@ on:
         required: true
         type: string
         description: The repository/name of the docker image to push, e.g., returntocorp/semgrep
+      dry-run:
+        required: true
+        type: boolean
+        description: Whether a dry-run (e.g., print tags to push) should be peformed. Actually push images if false.
 
 jobs:
   push-docker:
@@ -37,10 +46,16 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/image.tar
+      - name: List Images
+        if: ${{ inputs.dry-run }}
+        run: |
+          docker image list --digests
       - uses: docker/login-action@v2
+        if: ${{ ! inputs.dry-run }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Push Image
+        if: ${{ ! inputs.dry-run }}
         run: |
           docker push --all-tags "${{ inputs.repository-name }}"

--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -15,6 +15,7 @@ on:
         required: true
         type: boolean
         description: Whether a dry-run (e.g., print tags to push) should be peformed. Actually push images if false.
+        default: true
 
   workflow_call:
     inputs:
@@ -30,6 +31,7 @@ on:
         required: true
         type: boolean
         description: Whether a dry-run (e.g., print tags to push) should be peformed. Actually push images if false.
+        default: true
 
 jobs:
   push-docker:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -382,6 +382,7 @@ jobs:
     with:
       artifact-name: image-test
       repository-name: ${{ github.repository }}
+      dry-run: false
 
   build-test-dev-docker:
     uses: ./.github/workflows/build-test-docker.yaml
@@ -407,6 +408,7 @@ jobs:
     with:
       artifact-name: image-dev
       repository-name: ${{ github.repository }}-dev
+      dry-run: true
 
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -403,14 +403,12 @@ jobs:
   push-dev-docker:
     needs: [build-test-dev-docker]
     uses: ./.github/workflows/push-docker.yaml
-    # TODO: remove before flight
-    # if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       artifact-name: image-dev
       repository-name: ${{ github.repository }}-dev
-      # TODO: remove before flight
-      dry-run: true
+      dry-run: false
 
   build-test-core-x86:
     uses: ./.github/workflows/build-test-core-x86.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -403,11 +403,13 @@ jobs:
   push-dev-docker:
     needs: [build-test-dev-docker]
     uses: ./.github/workflows/push-docker.yaml
-    if: github.ref == 'refs/heads/develop'
+    # TODO: remove before flight
+    # if: github.ref == 'refs/heads/develop'
     secrets: inherit
     with:
       artifact-name: image-dev
       repository-name: ${{ github.repository }}-dev
+      # TODO: remove before flight
       dry-run: true
 
   build-test-core-x86:


### PR DESCRIPTION
Test Plan:

Ensure PR checks run as expected (push-dev should do a dry run), then toggle switch and push.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
