### PR TITLE
Remove runs-on which is not a reusable workflow argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,6 @@ jobs:
       enable-tests: true
 
   push-docker:
-    name: Push Semgrep Docker image
     needs: [wait-for-build-test, dry-run]
     if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     uses: ./.github/workflows/push-docker.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,6 @@ jobs:
 
   push-docker:
     name: Push Semgrep Docker image
-    runs-on: ubuntu-latest
     needs: [wait-for-build-test, dry-run]
     if: ${{ !contains(github.ref, '-test-release') && needs.dry-run.outputs.dry-run != 'true' }}
     uses: ./.github/workflows/push-docker.yaml


### PR DESCRIPTION
PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
