### PR TITLE
fix(pre-commit): add back semgrep in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -214,42 +214,44 @@ repos:
             # want an OCaml rule to be applied on a script.
             "--skip-unknown-extensions",
           ]
-  #! # Dogfooding .pre-commit-hooks.yml and setup.py
-  #! - repo: https://github.com/returntocorp/semgrep
-  #!   rev: v1.5.1
-  #!   hooks:
-  #!     - id: semgrep
-  #!       name: Semgrep Python
-  #!       types: [python]
-  #!       exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
-  #!       args: ["--config", "https://semgrep.dev/p/python", "--error"]
-  #!     - id: semgrep
-  #!       name: Semgrep Bandit
-  #!       types: [python]
-  #!       exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
-  #!       args: ["--config", "https://semgrep.dev/p/bandit", "--error"]
+  # Dogfooding .pre-commit-hooks.yml and setup.py
+  # Use a fixed version of p/python and p/bandit to not get new findings
+  # We run `semgrep ci` for our main rulesets
+  - repo: https://github.com/returntocorp/semgrep
+    rev: v1.5.1
+    hooks:
+      - id: semgrep
+        name: Semgrep Python
+        types: [python]
+        exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
+        args: ["--config", "tests/precommit_dogfooding/python.yml", "--error"]
+      - id: semgrep
+        name: Semgrep Bandit
+        types: [python]
+        exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
+        args: ["--config", "tests/precommit_dogfooding/bandit.yml", "--error"]
 
-  #! # Run Semgrep Docker images. Only used in CI since it's slower for local developmemt.
-  #! # To run locally use `pre-commit run --hook-stage manual semgrep-docker-develop`
-  #! - repo: https://github.com/returntocorp/semgrep
-  #!   # Note that the 'rev:' below is the revision to use to clone the URL
-  #!   # above and to fetch its .pre-commit-hooks.yaml file. It does not always
-  #!   # mean which version of semgrep to use for the hook itself.
-  #!   # For example in .pre-commit-hooks.yaml if you use an entry with
-  #!   # the 'language: docker_image', the 'entry:' field will then specify
-  #!   # which version to use. In the case below, we're actually running
-  #!   # returntocorp/semgrep:develop if you look at .pre-commit-hooks.yaml
-  #!   rev: v1.5.1
-  #!   hooks:
-  #!     - id: semgrep-docker-develop
-  #!       name: Semgrep Develop Python
-  #!       types: [python]
-  #!       exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
-  #!       args: ["--config", "p/python", "--error"]
-  #!       stages: [manual]
-  #!     - id: semgrep-docker-develop
-  #!       name: Semgrep Develop Bandit
-  #!       types: [python]
-  #!       exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
-  #!       args: ["--config", "p/bandit", "--error"]
-  #!       stages: [manual]
+  # Run Semgrep Docker images. Only used in CI since it's slower for local developmemt.
+  # To run locally use `pre-commit run --hook-stage manual semgrep-docker-develop`
+  - repo: https://github.com/returntocorp/semgrep
+    # Note that the 'rev:' below is the revision to use to clone the URL
+    # above and to fetch its .pre-commit-hooks.yaml file. It does not always
+    # mean which version of semgrep to use for the hook itself.
+    # For example in .pre-commit-hooks.yaml if you use an entry with
+    # the 'language: docker_image', the 'entry:' field will then specify
+    # which version to use. In the case below, we're actually running
+    # returntocorp/semgrep:develop if you look at .pre-commit-hooks.yaml
+    rev: v1.5.1
+    hooks:
+      - id: semgrep-docker-develop
+        name: Semgrep Develop Python
+        types: [python]
+        exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
+        args: ["--config", "tests/precommit_dogfooding/python.yml", "--error"]
+        stages: [manual]
+      - id: semgrep-docker-develop
+        name: Semgrep Develop Bandit
+        types: [python]
+        exclude: "^cli/tests/.+$|^scripts/.+$|^cli/setup.py$"
+        args: ["--config", "tests/precommit_dogfooding/bandit.yml", "--error"]
+        stages: [manual]

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -100,7 +100,7 @@ Please delete {deep_semgrep_path} manually to make this warning disappear!
     # THINK: Do we need to give exec permissions to everybody? Can this be a security risk?
     #        The binary should not have setuid or setgid rights, so letting others
     #        execute it should not be a problem.
-    # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    # nosemgrep: tests.precommit_dogfooding.python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
     os.chmod(
         semgrep_pro_path,
         os.stat(semgrep_pro_path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH,

--- a/tests/precommit_dogfooding/bandit.yml
+++ b/tests/precommit_dogfooding/bandit.yml
@@ -1,0 +1,403 @@
+rules:
+- id: python.jinja2.security.audit.autoescape-disabled.autoescape-disabled
+  patterns:
+  - pattern-not: jinja2.Environment(..., autoescape=True, ...)
+  - pattern-not: jinja2.Environment(..., autoescape=jinja2.select_autoescape(...),
+      ...)
+  - pattern: jinja2.Environment(...)
+  fix-regex:
+    regex: (.*)\)
+    replacement: \1, autoescape=True)
+  message: Detected a Jinja2 environment without autoescaping. Jinja2 does not autoescape
+    by default. This is dangerous if you are rendering to a browser because this allows
+    for cross-site scripting (XSS) attacks. If you are in a web context, enable autoescaping
+    by setting 'autoescape=True.' You may also consider using 'jinja2.select_autoescape()'
+    to only enable automatic escaping for certain file extensions.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html
+    cwe: 'CWE-116: Improper Encoding or Escaping of Output'
+    owasp: 'A6: Security Misconfiguration'
+    references:
+    - https://jinja.palletsprojects.com/en/2.11.x/api/#basics
+    category: security
+    technology:
+    - jinja2
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.jinja2.security.audit.autoescape-disabled.autoescape-disabled
+    shortlink: https://sg.run/KlGX
+    semgrep.dev:
+      rule:
+        rule_id: pKUOrp
+        version_id: yeTDg8
+        url: https://semgrep.dev/playground/r/yeTDg8/python.jinja2.security.audit.autoescape-disabled.autoescape-disabled
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+  pattern: hashlib.sha1(...)
+  fix-regex:
+    regex: sha1
+    replacement: sha256
+  message: Detected SHA1 hash algorithm which is considered insecure. SHA1 is not
+    collision resistant and is therefore not suitable as a cryptographic signature.
+    Use SHA256 or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B303
+    asvs:
+      section: V6 Stored Cryptography Verification Requirements
+      control_id: 6.2.2 Insecure Custom Algorithm
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x14-V6-Cryptography.md#v62-algorithms
+      version: '4'
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - python
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    shortlink: https://sg.run/ydYx
+    semgrep.dev:
+      rule:
+        rule_id: x8UnBk
+        version_id: e1TA7A
+        url: https://semgrep.dev/playground/r/e1TA7A/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+  severity: WARNING
+  languages:
+  - python
+- id: python.lang.security.deserialization.pickle.avoid-pickle
+  metadata:
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://docs.python.org/3/library/pickle.html
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.deserialization.pickle.avoid-pickle
+    shortlink: https://sg.run/OPwB
+    semgrep.dev:
+      rule:
+        rule_id: EwU2BJ
+        version_id: jQTeDJ
+        url: https://semgrep.dev/playground/r/jQTeDJ/python.lang.security.deserialization.pickle.avoid-pickle
+  languages:
+  - python
+  message: Avoid using `pickle`, which is known to lead to code execution vulnerabilities.
+    When unpickling, the serialized data could be manipulated to run arbitrary code.
+    Instead, consider serializing the relevant data as JSON or a similar text-based
+    serialization format.
+  severity: WARNING
+  patterns:
+  - pattern-either:
+    - pattern: pickle.$FUNC(...)
+    - pattern: _pickle.$FUNC(...)
+  - pattern-not: pickle.$FUNC("...")
+  - pattern-not: _pickle.$FUNC("...")
+- id: contrib.dlint.dlint-equivalent.insecure-xml-use
+  message: Insecure XML parsing functionality, prefer 'defusedxml'
+  languages:
+  - python
+  severity: WARNING
+  metadata:
+    source_rule_url: https://github.com/dlint-py/dlint/blob/master/docs/linters/DUO107.md
+    category: security
+    technology:
+    - python
+    references:
+    - https://github.com/dlint-py/dlint/blob/master/docs/linters/DUO107.md
+    owasp:
+    - A09:2017 - Using Components with Known Vulnerabilities
+    - A06:2021 - Vulnerable and Outdated Components
+    cwe:
+    - 'CWE-611: Improper Restriction of XML External Entity Reference'
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/contrib.dlint.dlint-equivalent.insecure-xml-use
+    shortlink: https://sg.run/5QOW
+    semgrep.dev:
+      rule:
+        rule_id: zdUkvA
+        version_id: 0bToER
+        url: https://semgrep.dev/playground/r/0bToER/contrib.dlint.dlint-equivalent.insecure-xml-use
+  pattern-either:
+  - patterns:
+    - pattern: xml.$ANYTHING
+    - pattern-not: xml.sax.saxutils
+    - pattern-not: xml.etree.ElementTree.Element
+    - pattern-not: xml.etree.ElementTree.SubElement
+  - pattern: xmlrpclib.$ANYTHING
+- id: python.lang.security.use-defused-xml.use-defused-xml
+  metadata:
+    owasp:
+    - A04:2017 - XML External Entities (XXE)
+    - A05:2021 - Security Misconfiguration
+    cwe:
+    - 'CWE-611: Improper Restriction of XML External Entity Reference'
+    references:
+    - https://docs.python.org/3/library/xml.html
+    - https://github.com/tiran/defusedxml
+    - https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.use-defused-xml.use-defused-xml
+    shortlink: https://sg.run/kX47
+    semgrep.dev:
+      rule:
+        rule_id: d8UjRx
+        version_id: nWTwqD
+        url: https://semgrep.dev/playground/r/nWTwqD/python.lang.security.use-defused-xml.use-defused-xml
+  message: The Python documentation recommends using `defusedxml` instead of `xml`
+    because the native Python `xml` library is vulnerable to XML External Entity (XXE)
+    attacks. These attacks can leak confidential data and "XML bombs" can cause denial
+    of service.
+  languages:
+  - python
+  severity: ERROR
+  pattern: import xml
+- id: python.requests.security.disabled-cert-validation.disabled-cert-validation
+  message: Certificate verification has been explicitly disabled. This permits insecure
+    connections to insecure servers. Re-enable certification validation.
+  metadata:
+    cwe:
+    - 'CWE-295: Improper Certificate Validation'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://stackoverflow.com/questions/41740361/is-it-safe-to-disable-ssl-certificate-verification-in-pythonss-requests-lib
+    category: security
+    technology:
+    - requests
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.requests.security.disabled-cert-validation.disabled-cert-validation
+    shortlink: https://sg.run/AlYp
+    semgrep.dev:
+      rule:
+        rule_id: qNUoYR
+        version_id: rxTbO4
+        url: https://semgrep.dev/playground/r/rxTbO4/python.requests.security.disabled-cert-validation.disabled-cert-validation
+  languages:
+  - python
+  severity: ERROR
+  pattern-either:
+  - pattern: requests.put(..., verify=False, ...)
+  - pattern: requests.patch(..., verify=False, ...)
+  - pattern: requests.delete(..., verify=False, ...)
+  - pattern: requests.head(..., verify=False, ...)
+  - pattern: requests.options(..., verify=False, ...)
+  - pattern: requests.request(..., verify=False, ...)
+  - pattern: requests.get(..., verify=False, ...)
+  - pattern: requests.post(..., verify=False, ...)
+  fix-regex:
+    regex: verify(\s)*=(\s)*False
+    replacement: verify=True
+- id: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+  patterns:
+  - pattern: subprocess.$FUNC(..., shell=True, ...)
+  - pattern-not: subprocess.$FUNC("...", shell=True, ...)
+  message: Found 'subprocess' function '$FUNC' with 'shell=True'. This is dangerous
+    because this call will spawn the command using a shell process. Doing so propagates
+    current shell settings and variables, which makes it much easier for a malicious
+    actor to execute commands. Use 'shell=False' instead.
+  fix-regex:
+    regex: (shell\s*=\s*)True
+    replacement: \1False
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    references:
+    - https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
+    - https://docs.python.org/3/library/subprocess.html
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+    shortlink: https://sg.run/J92w
+    semgrep.dev:
+      rule:
+        rule_id: DbUpz2
+        version_id: 6xT0p5
+        url: https://semgrep.dev/playground/r/6xT0p5/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+  languages:
+  - python
+  severity: ERROR
+- id: python.lang.security.audit.formatted-sql-query.formatted-sql-query
+  message: Detected possible formatted SQL query. Use parameterized queries instead.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    references:
+    - https://stackoverflow.com/questions/775296/mysql-parameterized-queries
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: HIGH
+    confidence: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.formatted-sql-query.formatted-sql-query
+    shortlink: https://sg.run/EkWw
+    semgrep.dev:
+      rule:
+        rule_id: 3qUP9k
+        version_id: vdT3k4
+        url: https://semgrep.dev/playground/r/vdT3k4/python.lang.security.audit.formatted-sql-query.formatted-sql-query
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: $DB.execute("..." % ...)
+  - pattern: $DB.execute("...".format(...))
+  - pattern: $DB.execute(f"...")
+  - patterns:
+    - pattern-either:
+      - pattern-inside: |
+          $SQL = "..." % ...
+          ...
+      - pattern-inside: |
+          $SQL = "...".format(...)
+          ...
+      - pattern-inside: |
+          $SQL = f"...{$X}..."
+          ...
+    - pattern: $DB.execute($SQL)
+- id: python.django.security.audit.avoid-mark-safe.avoid-mark-safe
+  patterns:
+  - pattern-not-inside: django.utils.html.format_html(...)
+  - pattern-not: django.utils.safestring.mark_safe("...")
+  - pattern: django.utils.safestring.mark_safe(...)
+  message: '''mark_safe()'' is used to mark a string as "safe" for HTML output. This
+    disables escaping and could therefore subject the content to XSS attacks. Use
+    ''django.utils.html.format_html()'' to build HTML for rendering instead.'
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b703_django_mark_safe.html
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    references:
+    - https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.safestring.mark_safe
+    - https://docs.djangoproject.com/en/3.0/ref/utils/#django.utils.html.format_html
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.audit.avoid-mark-safe.avoid-mark-safe
+    shortlink: https://sg.run/yd0P
+    semgrep.dev:
+      rule:
+        rule_id: eqU8Wr
+        version_id: DkTeDR
+        url: https://semgrep.dev/playground/r/DkTeDR/python.django.security.audit.avoid-mark-safe.avoid-mark-safe
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.audit.eval-detected.eval-detected
+  patterns:
+  - pattern-not: eval("...")
+  - pattern: eval(...)
+  message: Detected the use of eval(). eval() can be dangerous if used to evaluate
+    dynamic content. If this content can be input from outside the program, this may
+    be a code injection vulnerability. Ensure evaluated content is not definable by
+    external sources.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b307-eval
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.2.4 Dyanmic Code Execution Features
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: HIGH
+    confidence: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.eval-detected.eval-detected
+    shortlink: https://sg.run/ZvrD
+    semgrep.dev:
+      rule:
+        rule_id: gxU149
+        version_id: O9TZ0D
+        url: https://semgrep.dev/playground/r/O9TZ0D/python.lang.security.audit.eval-detected.eval-detected
+  languages:
+  - python
+  severity: WARNING

--- a/tests/precommit_dogfooding/python.yml
+++ b/tests/precommit_dogfooding/python.yml
@@ -1,0 +1,12467 @@
+rules:
+- id: python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load
+  metadata:
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-18342
+    category: security
+    technology:
+    - pyyaml
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load
+    shortlink: https://sg.run/we9Y
+    semgrep.dev:
+      rule:
+        rule_id: ZqU5jZ
+        version_id: kbTZ4W
+        url: https://semgrep.dev/playground/r/kbTZ4W/python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load
+  languages:
+  - python
+  message: Detected a possible YAML deserialization vulnerability. `yaml.unsafe_load`,
+    `yaml.Loader`, `yaml.CLoader`, and `yaml.UnsafeLoader` are all known to be unsafe
+    methods of deserializing YAML. An attacker with control over the YAML input could
+    create special YAML input that allows the attacker to run arbitrary Python code.
+    This would allow the attacker to steal files, download and install malware, or
+    otherwise take over the machine. Use `yaml.safe_load` or `yaml.SafeLoader` instead.
+  fix-regex:
+    regex: unsafe_load
+    replacement: safe_load
+    count: 1
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      import yaml
+      ...
+  - pattern-not-inside: |
+      $YAML = ruamel.yaml.YAML(...)
+      ...
+  - pattern-either:
+    - pattern: yaml.unsafe_load(...)
+    - pattern: yaml.load(..., Loader=yaml.Loader, ...)
+    - pattern: yaml.load(..., Loader=yaml.UnsafeLoader, ...)
+    - pattern: yaml.load(..., Loader=yaml.CLoader, ...)
+    - pattern: yaml.load_all(..., Loader=yaml.Loader, ...)
+    - pattern: yaml.load_all(..., Loader=yaml.UnsafeLoader, ...)
+    - pattern: yaml.load_all(..., Loader=yaml.CLoader, ...)
+- id: python.lang.security.deserialization.pickle.avoid-shelve
+  metadata:
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://docs.python.org/3/library/pickle.html
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.deserialization.pickle.avoid-shelve
+    shortlink: https://sg.run/dKkZ
+    semgrep.dev:
+      rule:
+        rule_id: 8GUje2
+        version_id: yeTbGQ
+        url: https://semgrep.dev/playground/r/yeTbGQ/python.lang.security.deserialization.pickle.avoid-shelve
+  languages:
+  - python
+  message: Avoid using `shelve`, which uses `pickle`, which is known to lead to code
+    execution vulnerabilities. When unpickling, the serialized data could be manipulated
+    to run arbitrary code. Instead, consider serializing the relevant data as JSON
+    or a similar text-based serialization format.
+  severity: WARNING
+  pattern: shelve.$FUNC(...)
+- id: python.lang.security.audit.network.http-not-https-connection.http-not-https-connection
+  message: Detected HTTPConnectionPool. This will transmit data in cleartext. It is
+    recommended to use HTTPSConnectionPool instead for to encrypt communications.
+  metadata:
+    cwe:
+    - 'CWE-319: Cleartext Transmission of Sensitive Information'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://urllib3.readthedocs.io/en/1.2.1/pools.html#urllib3.connectionpool.HTTPSConnectionPool
+    category: security
+    technology:
+    - python
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.network.http-not-https-connection.http-not-https-connection
+    shortlink: https://sg.run/N4Np
+    semgrep.dev:
+      rule:
+        rule_id: v8UnWQ
+        version_id: RGTwvl
+        url: https://semgrep.dev/playground/r/RGTwvl/python.lang.security.audit.network.http-not-https-connection.http-not-https-connection
+  languages:
+  - python
+  severity: ERROR
+  pattern-either:
+  - pattern: urllib3.HTTPConnectionPool(...)
+  - pattern: urllib3.connectionpool.HTTPConnectionPool(...)
+- id: python.lang.security.audit.network.bind.avoid-bind-to-all-interfaces
+  message: Running `socket.bind` to 0.0.0.0, ::, or empty string could unexpectedly
+    expose the server publicly as it binds to all available interfaces. Consider instead
+    getting correct address from an environment variable or configuration file.
+  metadata:
+    cwe:
+    - 'CWE-200: Exposure of Sensitive Information to an Unauthorized Actor'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - python
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.network.bind.avoid-bind-to-all-interfaces
+    shortlink: https://sg.run/rdln
+    semgrep.dev:
+      rule:
+        rule_id: OrU3og
+        version_id: 5PTY5G
+        url: https://semgrep.dev/playground/r/5PTY5G/python.lang.security.audit.network.bind.avoid-bind-to-all-interfaces
+  languages:
+  - python
+  severity: INFO
+  pattern-either:
+  - pattern: |
+      $S = socket.socket(...)
+      ...
+      $S.bind(("0.0.0.0", ...))
+  - pattern: |
+      $S = socket.socket(...)
+      ...
+      $S.bind(("::", ...))
+  - pattern: |
+      $S = socket.socket(...)
+      ...
+      $S.bind(("", ...))
+- id: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+  patterns:
+  - pattern: |
+      $LOGGER_OBJ.$LOGGER_CALL($FORMAT_STRING,...)
+  - metavariable-regex:
+      metavariable: $LOGGER_OBJ
+      regex: (?i)(_logger|logger|self.logger|log)
+  - metavariable-regex:
+      metavariable: $LOGGER_CALL
+      regex: (debug|info|warn|warning|error|exception|critical)
+  - metavariable-regex:
+      metavariable: $FORMAT_STRING
+      regex: (?i).*(api.key|secret|credential|token|password).*\%s.*
+  message: Detected a python logger call with a potential hardcoded secret $FORMAT_STRING
+    being logged. This may lead to secret credentials being exposed. Make sure that
+    the logger is not logging  sensitive information.
+  severity: WARNING
+  languages:
+  - python
+  metadata:
+    cwe:
+    - 'CWE-532: Insertion of Sensitive Information into Log File'
+    category: security
+    technology:
+    - python
+    owasp:
+    - A09:2021 - Security Logging and Monitoring Failures
+    references:
+    - https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+    shortlink: https://sg.run/ydNx
+    semgrep.dev:
+      rule:
+        rule_id: x8UnJk
+        version_id: w8TvNW
+        url: https://semgrep.dev/playground/r/w8TvNW/python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+- id: python.flask.security.injection.path-traversal-open.path-traversal-open
+  languages:
+  - python
+  severity: ERROR
+  message: Found request data in a call to 'open'. Ensure the request data is validated
+    or sanitized, otherwise it could result in path traversal attacks.
+  metadata:
+    cwe:
+    - 'CWE-22: Improper Limitation of a Pathname to a Restricted Directory (''Path
+      Traversal'')'
+    owasp:
+    - A05:2017 - Broken Access Control
+    - A01:2021 - Broken Access Control
+    references:
+    - https://owasp.org/www-community/attacks/Path_Traversal
+    category: security
+    technology:
+    - flask
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.path-traversal-open.path-traversal-open
+    shortlink: https://sg.run/PJRW
+    semgrep.dev:
+      rule:
+        rule_id: DbUpOQ
+        version_id: rxT8xO
+        url: https://semgrep.dev/playground/r/rxT8xO/python.flask.security.injection.path-traversal-open.path-traversal-open
+  pattern-either:
+  - patterns:
+    - pattern: open(...)
+    - pattern-either:
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            open(..., <... $ROUTEVAR ...>, ...)
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            with open(..., <... $ROUTEVAR ...>, ...) as $FD:
+              ...
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            $INTERM = <... $ROUTEVAR ...>
+            ...
+            open(..., <... $INTERM ...>, ...)
+  - pattern: open(..., <... flask.request.$W.get(...) ...>, ...)
+  - pattern: open(..., <... flask.request.$W[...] ...>, ...)
+  - pattern: open(..., <... flask.request.$W(...) ...>, ...)
+  - pattern: open(..., <... flask.request.$W ...>, ...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
+          ...
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
+          ...
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
+          ...
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
+          ...
+    - pattern: open(...)
+- id: python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default
+  patterns:
+  - pattern: pyramid.authentication.$FUNC($...PARAMS)
+  - metavariable-pattern:
+      metavariable: $FUNC
+      pattern-either:
+      - pattern: AuthTktCookieHelper
+      - pattern: AuthTktAuthenticationPolicy
+  - pattern-not: pyramid.authentication.$FUNC(..., httponly=$HTTPONLY, ...)
+  - pattern-not: pyramid.authentication.$FUNC(..., **$PARAMS, ...)
+  - focus-metavariable: $...PARAMS
+  fix: |
+    $...PARAMS, httponly=True
+  message: Found a Pyramid Authentication Ticket cookie without the httponly option
+    correctly set. Pyramid cookies should be handled securely by setting httponly=True.
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-1004: Sensitive Cookie Without ''HttpOnly'' Flag'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default
+    shortlink: https://sg.run/EprB
+    semgrep.dev:
+      rule:
+        rule_id: bwUXKB
+        version_id: rxTglX
+        url: https://semgrep.dev/playground/r/rxTglX/python.pyramid.audit.authtkt-cookie-httponly-unsafe-default.pyramid-authtkt-cookie-httponly-unsafe-default
+  languages:
+  - python
+  severity: WARNING
+- id: python.flask.security.injection.nan-injection.nan-injection
+  message: Found user input going directly into typecast for bool(), float(), or complex().
+    This allows  an attacker to inject Python's not-a-number (NaN) into the typecast.
+    This results in undefind behavior, particularly when doing comparisons. Either
+    cast to a different type, or add a guard checking for all capitalizations of the
+    string 'nan'.
+  languages:
+  - python
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+  - pattern-either:
+    - pattern: flask.request.$SOMETHING.get(...)
+    - pattern: flask.request.$SOMETHING[...]
+    - patterns:
+      - pattern-inside: |
+          @$APP.route(...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+      - pattern: $ROUTEVAR
+  pattern-sinks:
+  - pattern-either:
+    - pattern: float(...)
+    - pattern: bool(...)
+    - pattern: complex(...)
+  pattern-sanitizers:
+  - not_conflicting: true
+    pattern: $ANYTHING(...)
+  metadata:
+    references:
+    - https://discuss.python.org/t/nan-breaks-min-max-and-sorting-functions-a-solution/2868
+    - https://blog.bitdiscovery.com/2021/12/python-nan-injection/
+    category: security
+    cwe:
+    - 'CWE-704: Incorrect Type Conversion or Cast'
+    technology:
+    - flask
+    subcategory:
+    - vuln
+    impact: MEDIUM
+    likelihood: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.nan-injection.nan-injection
+    shortlink: https://sg.run/e598
+    semgrep.dev:
+      rule:
+        rule_id: WAUdj7
+        version_id: 9lTnjK
+        url: https://semgrep.dev/playground/r/9lTnjK/python.flask.security.injection.nan-injection.nan-injection
+- id: python.lang.security.dangerous-os-exec.dangerous-os-exec
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+          - patterns:
+            - pattern-inside: |
+                @$APP.route(...)
+                def $FUNC(..., $ROUTEVAR, ...):
+                  ...
+            - pattern: $ROUTEVAR
+      - patterns:
+        - pattern-inside: |
+            def $FUNC(request, ...):
+              ...
+        - pattern-either:
+          - pattern: request.$PROPERTY.get(...)
+          - pattern: request.$PROPERTY[...]
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              @rest_framework.decorators.api_view(...)
+              def $FUNC($REQ, ...):
+                ...
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  class $VIEW(..., rest_framework.views.APIView, ...):
+                    ...
+              - pattern-inside: "class $VIEW(..., rest_framework.generics.GenericAPIView,
+                  ...):\n  ...                              \n"
+            - pattern-inside: |
+                def $METHOD(self, $REQ, ...):
+                  ...
+            - metavariable-regex:
+                metavariable: $METHOD
+                regex: (get|post|put|patch|delete|head)
+        - pattern-either:
+          - pattern: $REQ.POST.get(...)
+          - pattern: $REQ.POST[...]
+          - pattern: $REQ.FILES.get(...)
+          - pattern: $REQ.FILES[...]
+          - pattern: $REQ.DATA.get(...)
+          - pattern: $REQ.DATA[...]
+          - pattern: $REQ.QUERY_PARAMS.get(...)
+          - pattern: $REQ.QUERY_PARAMS[...]
+          - pattern: $REQ.data.get(...)
+          - pattern: $REQ.data[...]
+          - pattern: $REQ.query_params.get(...)
+          - pattern: $REQ.query_params[...]
+          - pattern: $REQ.content_type
+          - pattern: $REQ.content_type
+          - pattern: $REQ.stream
+          - pattern: $REQ.stream
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              class $SERVER(..., http.server.BaseHTTPRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.StreamRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.DatagramRequestHandler, ...):
+                ...
+        - pattern-either:
+          - pattern: self.requestline
+          - pattern: self.path
+          - pattern: self.headers[...]
+          - pattern: self.headers.get(...)
+          - pattern: self.rfile
+      - patterns:
+        - pattern-inside: |
+            @pyramid.view.view_config( ... )
+            def $VIEW($REQ):
+              ...
+        - pattern: $REQ.$ANYTHING
+        - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-not: os.$METHOD("...", ...)
+        - pattern: os.$METHOD(...)
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (execl|execle|execlp|execlpe|execv|execve|execvp|execvpe)
+      - patterns:
+        - pattern-not: os.$METHOD("...", [$PATH,"...","...",...],...)
+        - pattern-inside: os.$METHOD($BASH,[$PATH,"-c",$CMD,...],...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (execv|execve|execvp|execvpe)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+      - patterns:
+        - pattern-not: os.$METHOD("...", $PATH, "...", "...",...)
+        - pattern-inside: os.$METHOD($BASH, $PATH, "-c", $CMD,...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (execl|execle|execlp|execlpe)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+  message: Found user controlled content when spawning a process. This is dangerous
+    because it allows a malicious actor to execute commands.
+  metadata:
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    confidence: MEDIUM
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.dangerous-os-exec.dangerous-os-exec
+    shortlink: https://sg.run/yL9x
+    semgrep.dev:
+      rule:
+        rule_id: qNUR13
+        version_id: jQT9Or
+        url: https://semgrep.dev/playground/r/jQT9Or/python.lang.security.dangerous-os-exec.dangerous-os-exec
+  languages:
+  - python
+  severity: ERROR
+- id: python.django.security.injection.command.subprocess-injection.subprocess-injection
+  languages:
+  - python
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-inside: |
+        def $FUNC(..., $REQUEST, ...):
+          ...
+    - focus-metavariable: $REQUEST
+    - metavariable-pattern:
+        metavariable: $REQUEST
+        patterns:
+        - pattern: request
+        - pattern-not-inside: request.build_absolute_uri
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern: subprocess.$FUNC(...)
+        - pattern-not: subprocess.$FUNC("...", ...)
+        - pattern-not: subprocess.$FUNC(["...", ...], ...)
+        - pattern-not-inside: |
+            $CMD = ["...", ...]
+            ...
+            subprocess.$FUNC($CMD, ...)
+      - patterns:
+        - pattern: subprocess.$FUNC(["$SHELL", "-c", ...], ...)
+        - metavariable-regex:
+            metavariable: $SHELL
+            regex: ^(sh|bash|ksh|csh|tcsh|zsh)$
+      - patterns:
+        - pattern: subprocess.$FUNC(["$INTERPRETER", ...], ...)
+        - metavariable-regex:
+            metavariable: $INTERPRETER
+            regex: ^(python|python\d)$
+  pattern-sanitizers:
+  - patterns:
+    - pattern: $DICT[$KEY]
+    - focus-metavariable: $KEY
+  severity: ERROR
+  message: Detected user input entering a `subprocess` call unsafely. This could result
+    in a command injection vulnerability. An attacker could use this vulnerability
+    to execute arbitrary commands on the host, which allows them to download malware,
+    scan sensitive data, or run any command they wish on the server. Do not let users
+    choose the command to run. In general, prefer to use Python API versions of system
+    commands. If you must use subprocess, use a dictionary to allowlist a set of commands.
+  metadata:
+    category: security
+    technology:
+    - flask
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    confidence: HIGH
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.command.subprocess-injection.subprocess-injection
+    shortlink: https://sg.run/49BE
+    semgrep.dev:
+      rule:
+        rule_id: EwUepx
+        version_id: gET5bA
+        url: https://semgrep.dev/playground/r/gET5bA/python.django.security.injection.command.subprocess-injection.subprocess-injection
+- id: python.pyramid.audit.authtkt-cookie-secure-unsafe-value.pyramid-authtkt-cookie-secure-unsafe-value
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern-not: pyramid.authentication.AuthTktCookieHelper(..., **$PARAMS)
+      - pattern: pyramid.authentication.AuthTktCookieHelper(..., secure=$SECURE, ...)
+    - patterns:
+      - pattern-not: pyramid.authentication.AuthTktAuthenticationPolicy(..., **$PARAMS)
+      - pattern: pyramid.authentication.AuthTktAuthenticationPolicy(..., secure=$SECURE,
+          ...)
+  - pattern: $SECURE
+  - metavariable-pattern:
+      metavariable: $SECURE
+      pattern: |
+        False
+  fix: |
+    True
+  message: Found a Pyramid Authentication Ticket cookie without the secure option
+    correctly set. Pyramid cookies should be handled securely by setting secure=True.
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-614: Sensitive Cookie in HTTPS Session Without ''Secure'' Attribute'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.authtkt-cookie-secure-unsafe-value.pyramid-authtkt-cookie-secure-unsafe-value
+    shortlink: https://sg.run/gjp5
+    semgrep.dev:
+      rule:
+        rule_id: x8UqAp
+        version_id: qkT9YY
+        url: https://semgrep.dev/playground/r/qkT9YY/python.pyramid.audit.authtkt-cookie-secure-unsafe-value.pyramid-authtkt-cookie-secure-unsafe-value
+  languages:
+  - python
+  severity: WARNING
+- id: python.django.security.injection.code.user-exec.user-exec
+  message: Found user data in a call to 'exec'. This is extremely dangerous because
+    it can enable an attacker to execute arbitrary remote code on the system. Instead,
+    refactor your code to not use 'eval' and instead use a safe library for the specific
+    functionality you need.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - django
+    references:
+    - https://owasp.org/www-community/attacks/Code_Injection
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.code.user-exec.user-exec
+    shortlink: https://sg.run/5Q3X
+    semgrep.dev:
+      rule:
+        rule_id: 0oU5AW
+        version_id: LjTp1q
+        url: https://semgrep.dev/playground/r/LjTp1q/python.django.security.injection.code.user-exec.user-exec
+  patterns:
+  - pattern-inside: |
+      def $F(...):
+        ...
+  - pattern-either:
+    - pattern: exec(..., request.$W.get(...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        exec(..., $V, ...)
+    - pattern: exec(..., request.$W(...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        exec(..., $V, ...)
+    - pattern: exec(..., request.$W[...], ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        exec(..., $V, ...)
+    - pattern: |
+        loop = asyncio.get_running_loop()
+        ...
+        await loop.run_in_executor(None, exec, request.$W[...])
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        loop = asyncio.get_running_loop()
+        ...
+        await loop.run_in_executor(None, exec, $V)
+    - pattern: |
+        loop = asyncio.get_running_loop()
+        ...
+        await loop.run_in_executor(None, exec, request.$W.get(...))
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        loop = asyncio.get_running_loop()
+        ...
+        await loop.run_in_executor(None, exec, $V)
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.dangerous-testcapi-run-in-subinterp.dangerous-testcapi-run-in-subinterp
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+          - patterns:
+            - pattern-inside: |
+                @$APP.route(...)
+                def $FUNC(..., $ROUTEVAR, ...):
+                  ...
+            - pattern: $ROUTEVAR
+      - patterns:
+        - pattern-inside: |
+            def $FUNC(request, ...):
+              ...
+        - pattern-either:
+          - pattern: request.$PROPERTY.get(...)
+          - pattern: request.$PROPERTY[...]
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              @rest_framework.decorators.api_view(...)
+              def $FUNC($REQ, ...):
+                ...
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  class $VIEW(..., rest_framework.views.APIView, ...):
+                    ...
+              - pattern-inside: "class $VIEW(..., rest_framework.generics.GenericAPIView,
+                  ...):\n  ...                              \n"
+            - pattern-inside: |
+                def $METHOD(self, $REQ, ...):
+                  ...
+            - metavariable-regex:
+                metavariable: $METHOD
+                regex: (get|post|put|patch|delete|head)
+        - pattern-either:
+          - pattern: $REQ.POST.get(...)
+          - pattern: $REQ.POST[...]
+          - pattern: $REQ.FILES.get(...)
+          - pattern: $REQ.FILES[...]
+          - pattern: $REQ.DATA.get(...)
+          - pattern: $REQ.DATA[...]
+          - pattern: $REQ.QUERY_PARAMS.get(...)
+          - pattern: $REQ.QUERY_PARAMS[...]
+          - pattern: $REQ.data.get(...)
+          - pattern: $REQ.data[...]
+          - pattern: $REQ.query_params.get(...)
+          - pattern: $REQ.query_params[...]
+          - pattern: $REQ.content_type
+          - pattern: $REQ.content_type
+          - pattern: $REQ.stream
+          - pattern: $REQ.stream
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              class $SERVER(..., http.server.BaseHTTPRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.StreamRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.DatagramRequestHandler, ...):
+                ...
+        - pattern-either:
+          - pattern: self.requestline
+          - pattern: self.path
+          - pattern: self.headers[...]
+          - pattern: self.headers.get(...)
+          - pattern: self.rfile
+      - patterns:
+        - pattern-inside: |
+            @pyramid.view.view_config( ... )
+            def $VIEW($REQ):
+              ...
+        - pattern: $REQ.$ANYTHING
+        - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern-inside: |
+          _testcapi.run_in_subinterp($PAYLOAD, ...)
+      - pattern-inside: |
+          test.support.run_in_subinterp($PAYLOAD, ...)
+    - pattern: $PAYLOAD
+    - pattern-not: |
+        _testcapi.run_in_subinterp("...", ...)
+    - pattern-not: |
+        test.support.run_in_subinterp("...", ...)
+  message: Found user controlled content in `run_in_subinterp`. This is dangerous  because
+    it allows a malicious actor to run arbitrary Python code.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.dangerous-testcapi-run-in-subinterp.dangerous-testcapi-run-in-subinterp
+    shortlink: https://sg.run/wLpY
+    semgrep.dev:
+      rule:
+        rule_id: GdUkxR
+        version_id: bZT405
+        url: https://semgrep.dev/playground/r/bZT405/python.lang.security.dangerous-testcapi-run-in-subinterp.dangerous-testcapi-run-in-subinterp
+  severity: WARNING
+  languages:
+  - python
+- id: python.flask.security.injection.os-system-injection.os-system-injection
+  languages:
+  - python
+  severity: ERROR
+  message: User data detected in os.system. This could be vulnerable to a command
+    injection and should be avoided. If this must be done, use the 'subprocess' module
+    instead and pass the arguments as a list.
+  metadata:
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://owasp.org/www-community/attacks/Command_Injection
+    category: security
+    technology:
+    - flask
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.os-system-injection.os-system-injection
+    shortlink: https://sg.run/4xzz
+    semgrep.dev:
+      rule:
+        rule_id: BYUN99
+        version_id: yeTd6w
+        url: https://semgrep.dev/playground/r/yeTd6w/python.flask.security.injection.os-system-injection.os-system-injection
+  pattern-either:
+  - patterns:
+    - pattern: os.system(...)
+    - pattern-either:
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            os.system(..., <... $ROUTEVAR ...>, ...)
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            $INTERM = <... $ROUTEVAR ...>
+            ...
+            os.system(..., <... $INTERM ...>, ...)
+  - pattern: os.system(..., <... flask.request.$W.get(...) ...>, ...)
+  - pattern: os.system(..., <... flask.request.$W[...] ...>, ...)
+  - pattern: os.system(..., <... flask.request.$W(...) ...>, ...)
+  - pattern: os.system(..., <... flask.request.$W ...>, ...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)
+- id: python.django.security.injection.sql.sql-injection-extra.sql-injection-using-extra-where
+  message: User-controlled data from a request is passed to 'extra()'. This could
+    lead to a SQL injection and therefore protected information could be leaked. Instead,
+    use parameterized queries or escape the user-controlled data by using `params`
+    and not using quote placeholders in the SQL string.
+  metadata:
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://docs.djangoproject.com/en/3.0/ref/models/expressions/#.objects.extra
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.sql.sql-injection-extra.sql-injection-using-extra-where
+    shortlink: https://sg.run/0Ql5
+    semgrep.dev:
+      rule:
+        rule_id: zdUkx1
+        version_id: K3TOp8
+        url: https://semgrep.dev/playground/r/K3TOp8/python.django.security.injection.sql.sql-injection-extra.sql-injection-using-extra-where
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: $MODEL.objects.extra(..., where=[..., $S.format(..., request.$W.get(...),
+        ...), ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., $S % request.$W.get(...), ...],
+        ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., f"...{request.$W.get(...)}...",
+        ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., request.$W.get(...), ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR.format(..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., f"...{$DATA}...", ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR + $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: $A = $MODEL.objects.extra(..., where=[..., request.$W.get(...), ...],
+        ...)
+    - pattern: return $MODEL.objects.extra(..., where=[..., request.$W.get(...), ...],
+        ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., $S.format(..., request.$W(...),
+        ...), ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., $S % request.$W(...), ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., f"...{request.$W(...)}...", ...],
+        ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., request.$W(...), ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR.format(..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., f"...{$DATA}...", ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR + $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: $A = $MODEL.objects.extra(..., where=[..., request.$W(...), ...], ...)
+    - pattern: return $MODEL.objects.extra(..., where=[..., request.$W(...), ...],
+        ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., $S.format(..., request.$W[...],
+        ...), ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., $S % request.$W[...], ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., f"...{request.$W[...]}...", ...],
+        ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., request.$W[...], ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.extra(..., where=[..., $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR.format(..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.extra(..., where=[..., f"...{$DATA}...", ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR + $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: $A = $MODEL.objects.extra(..., where=[..., request.$W[...], ...], ...)
+    - pattern: return $MODEL.objects.extra(..., where=[..., request.$W[...], ...],
+        ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., $S.format(..., request.$W, ...),
+        ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., $S % request.$W, ...], ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., f"...{request.$W}...", ...],
+        ...)
+    - pattern: $MODEL.objects.extra(..., where=[..., request.$W, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.extra(..., where=[..., $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR.format(..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.extra(..., where=[..., f"...{$DATA}...", ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR + $DATA, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: $A = $MODEL.objects.extra(..., where=[..., request.$W, ...], ...)
+    - pattern: return $MODEL.objects.extra(..., where=[..., request.$W, ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % (..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % (..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % (..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.extra(..., where=[..., $STR % (..., $DATA, ...), ...], ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.extra(..., where=[..., $INTERM, ...], ...)
+- id: python.pyramid.audit.set-cookie-samesite-unsafe-value.pyramid-set-cookie-samesite-unsafe-value
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        @pyramid.view.view_config(...)
+        def $VIEW($REQUEST):
+            ...
+            $RESPONSE = $REQUEST.response
+            ...
+    - pattern-inside: |
+        def $VIEW(...):
+            ...
+            $RESPONSE = pyramid.httpexceptions.HTTPFound(...)
+            ...
+  - pattern-not: $RESPONSE.set_cookie(..., **$PARAMS)
+  - pattern: $RESPONSE.set_cookie(..., samesite=$SAMESITE, ...)
+  - pattern: $SAMESITE
+  - metavariable-regex:
+      metavariable: $SAMESITE
+      regex: (?!'Lax')
+  fix: |
+    'Lax'
+  message: Found a Pyramid cookie without the samesite option correctly set. Pyramid
+    cookies should be handled securely by setting samesite='Lax' in response.set_cookie(...).
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-1275: Sensitive Cookie with Improper SameSite Attribute'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.set-cookie-samesite-unsafe-value.pyramid-set-cookie-samesite-unsafe-value
+    shortlink: https://sg.run/GXR6
+    semgrep.dev:
+      rule:
+        rule_id: EwUgpY
+        version_id: 2KTAlP
+        url: https://semgrep.dev/playground/r/2KTAlP/python.pyramid.audit.set-cookie-samesite-unsafe-value.pyramid-set-cookie-samesite-unsafe-value
+  languages:
+  - python
+  severity: WARNING
+- id: python.distributed.security.require-encryption
+  patterns:
+  - pattern: |
+      distributed.security.Security(..., require_encryption=$VAL, ...)
+  - metavariable-pattern:
+      metavariable: $VAL
+      pattern: |
+        False
+  - focus-metavariable: $VAL
+  fix: |
+    True
+  message: Initializing a security context for Dask (`distributed`) without "require_encryption"
+    keyword argument may silently fail to provide security.
+  severity: WARNING
+  metadata:
+    cwe:
+    - 'CWE-319: Cleartext Transmission of Sensitive Information'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://distributed.dask.org/en/latest/tls.html?highlight=require_encryption#parameters
+    category: security
+    technology:
+    - distributed
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.distributed.security.require-encryption
+    shortlink: https://sg.run/AvQ2
+    semgrep.dev:
+      rule:
+        rule_id: YGURy0
+        version_id: A8T1k6
+        url: https://semgrep.dev/playground/r/A8T1k6/python.distributed.security.require-encryption
+  languages:
+  - python
+- id: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+  patterns:
+  - pattern: sqlalchemy.text(...)
+  - pattern-not-inside: sqlalchemy.text("...")
+  message: sqlalchemy.text passes the constructed SQL statement to the database mostly
+    unchanged. This means that the usual SQL injection protections are not applied
+    and this function is vulnerable to SQL injection if user input can reach here.
+    Use normal SQLAlchemy operators (such as or_, and_, etc.) to construct SQL.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    category: security
+    technology:
+    - sqlalchemy
+    confidence: MEDIUM
+    references:
+    - https://docs.sqlalchemy.org/en/14/core/tutorial.html#using-textual-sql
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+    shortlink: https://sg.run/yP1O
+    semgrep.dev:
+      rule:
+        rule_id: r6U2wE
+        version_id: kbTrKW
+        url: https://semgrep.dev/playground/r/kbTrKW/python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+  languages:
+  - python
+  severity: ERROR
+- id: python.lang.security.audit.dangerous-spawn-process-tainted-env-args.dangerous-spawn-process-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-not: os.$METHOD($MODE, "...", ...)
+        - pattern-inside: os.$METHOD($MODE, $CMD, ...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnl|spawnle|spawnlp|spawnlpe|spawnv|spawnve|spawnvp|spawnvp|spawnvpe|posix_spawn|posix_spawnp|startfile)
+      - patterns:
+        - pattern-not: os.$METHOD($MODE, "...", ["...","...",...], ...)
+        - pattern-inside: os.$METHOD($MODE, $BASH, ["-c",$CMD,...],...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnv|spawnve|spawnvp|spawnvp|spawnvpe|posix_spawn|posix_spawnp)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+      - patterns:
+        - pattern-not: os.$METHOD($MODE, "...", "...", "...", ...)
+        - pattern-inside: os.$METHOD($MODE, $BASH, "-c", $CMD,...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnl|spawnle|spawnlp|spawnlpe)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+  message: Found user controlled content when spawning a process. This is dangerous
+    because it allows a malicious actor to execute commands.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-spawn-process-tainted-env-args.dangerous-spawn-process-tainted-env-args
+    shortlink: https://sg.run/Y3Ke
+    semgrep.dev:
+      rule:
+        rule_id: JDUz34
+        version_id: X0TJPb
+        url: https://semgrep.dev/playground/r/X0TJPb/python.lang.security.audit.dangerous-spawn-process-tainted-env-args.dangerous-spawn-process-tainted-env-args
+  languages:
+  - python
+  severity: ERROR
+- id: python.flask.security.injection.subprocess-injection.subprocess-injection
+  languages:
+  - python
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - pattern-either:
+    - patterns:
+      - pattern-either:
+        - pattern: flask.request.form.get(...)
+        - pattern: flask.request.form[...]
+        - pattern: flask.request.args.get(...)
+        - pattern: flask.request.args[...]
+        - pattern: flask.request.values.get(...)
+        - pattern: flask.request.values[...]
+        - pattern: flask.request.cookies.get(...)
+        - pattern: flask.request.cookies[...]
+        - pattern: flask.request.stream
+        - pattern: flask.request.headers.get(...)
+        - pattern: flask.request.headers[...]
+        - pattern: flask.request.data
+        - pattern: flask.request.full_path
+        - pattern: flask.request.url
+        - pattern: flask.request.json
+        - pattern: flask.request.get_json()
+        - pattern: flask.request.view_args.get(...)
+        - pattern: flask.request.view_args[...]
+    - patterns:
+      - pattern: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+      - focus-metavariable: $ROUTEVAR
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern: subprocess.$FUNC(...)
+        - pattern-not: subprocess.$FUNC("...", ...)
+        - pattern-not: subprocess.$FUNC(["...", ...], ...)
+        - pattern-not-inside: |
+            $CMD = ["...", ...]
+            ...
+            subprocess.$FUNC($CMD, ...)
+      - patterns:
+        - pattern: subprocess.$FUNC(["$SHELL", "-c", ...], ...)
+        - metavariable-regex:
+            metavariable: $SHELL
+            regex: ^(sh|bash|ksh|csh|tcsh|zsh)$
+      - patterns:
+        - pattern: subprocess.$FUNC(["$INTERPRETER", ...], ...)
+        - metavariable-regex:
+            metavariable: $INTERPRETER
+            regex: ^(python|python\d)$
+  pattern-sanitizers:
+  - patterns:
+    - pattern: $DICT[$KEY]
+    - focus-metavariable: $KEY
+  severity: ERROR
+  message: Detected user input entering a `subprocess` call unsafely. This could result
+    in a command injection vulnerability. An attacker could use this vulnerability
+    to execute arbitrary commands on the host, which allows them to download malware,
+    scan sensitive data, or run any command they wish on the server. Do not let users
+    choose the command to run. In general, prefer to use Python API versions of system
+    commands. If you must use subprocess, use a dictionary to allowlist a set of commands.
+  metadata:
+    category: security
+    technology:
+    - flask
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    confidence: HIGH
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.subprocess-injection.subprocess-injection
+    shortlink: https://sg.run/5gW3
+    semgrep.dev:
+      rule:
+        rule_id: 8GU3qp
+        version_id: kbTZ7j
+        url: https://semgrep.dev/playground/r/kbTZ7j/python.flask.security.injection.subprocess-injection.subprocess-injection
+- id: python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host
+  message: Running flask app with host 0.0.0.0 could expose the server publicly.
+  metadata:
+    cwe:
+    - 'CWE-668: Exposure of Resource to Wrong Sphere'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - flask
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host
+    shortlink: https://sg.run/eLby
+    semgrep.dev:
+      rule:
+        rule_id: L1Uy1n
+        version_id: K3TOpE
+        url: https://semgrep.dev/playground/r/K3TOpE/python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host
+  languages:
+  - python
+  severity: WARNING
+  pattern-either:
+  - pattern: app.run(..., host="0.0.0.0", ...)
+  - pattern: app.run(..., "0.0.0.0", ...)
+- id: python.django.security.nan-injection.nan-injection
+  message: Found user input going directly into typecast for bool(), float(), or complex().
+    This allows  an attacker to inject Python's not-a-number (NaN) into the typecast.
+    This results in undefind behavior, particularly when doing comparisons. Either
+    cast to a different type, or add a guard checking for all capitalizations of the
+    string 'nan'.
+  languages:
+  - python
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-inside: |
+        def $FUNC(request, ...):
+          ...
+    - pattern-either:
+      - pattern: request.$PROPERTY.get(...)
+      - pattern: request.$PROPERTY[...]
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: float(...)
+      - pattern: bool(...)
+      - pattern: complex(...)
+    - pattern-not-inside: |
+        if $COND:
+          ...
+        ...
+  pattern-sanitizers:
+  - pattern: $ANYTHING(...)
+    not_conflicting: true
+  metadata:
+    references:
+    - https://discuss.python.org/t/nan-breaks-min-max-and-sorting-functions-a-solution/2868
+    - https://blog.bitdiscovery.com/2021/12/python-nan-injection/
+    category: security
+    cwe:
+    - 'CWE-704: Incorrect Type Conversion or Cast'
+    technology:
+    - django
+    subcategory:
+    - vuln
+    impact: MEDIUM
+    likelihood: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.nan-injection.nan-injection
+    shortlink: https://sg.run/Og7L
+    semgrep.dev:
+      rule:
+        rule_id: DbUGvk
+        version_id: BjTG9n
+        url: https://semgrep.dev/playground/r/BjTG9n/python.django.security.nan-injection.nan-injection
+- id: python.pyramid.audit.set-cookie-samesite-unsafe-default.pyramid-set-cookie-samesite-unsafe-default
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        @pyramid.view.view_config(...)
+        def $VIEW($REQUEST):
+            ...
+            $RESPONSE = $REQUEST.response
+            ...
+    - pattern-inside: |
+        def $VIEW(...):
+            ...
+            $RESPONSE = pyramid.httpexceptions.HTTPFound(...)
+            ...
+  - pattern-not: $RESPONSE.set_cookie(..., samesite=$SAMESITE, ...)
+  - pattern-not: $RESPONSE.set_cookie(..., **$PARAMS)
+  - pattern: $RESPONSE.set_cookie(...)
+  fix-regex:
+    regex: (.*)\)
+    replacement: \1, samesite='Lax')
+  message: Found a Pyramid cookie using an unsafe value for the samesite option. Pyramid
+    cookies should be handled securely by setting samesite='Lax' in response.set_cookie(...).
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-1275: Sensitive Cookie with Improper SameSite Attribute'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.set-cookie-samesite-unsafe-default.pyramid-set-cookie-samesite-unsafe-default
+    shortlink: https://sg.run/5AWj
+    semgrep.dev:
+      rule:
+        rule_id: nJUp80
+        version_id: pZTqPw
+        url: https://semgrep.dev/playground/r/pZTqPw/python.pyramid.audit.set-cookie-samesite-unsafe-default.pyramid-set-cookie-samesite-unsafe-default
+  languages:
+  - python
+  severity: WARNING
+- id: python.django.security.injection.email.xss-send-mail-html-message.xss-send-mail-html-message
+  message: Found request data in 'send_mail(...)' that uses 'html_message'. This is
+    dangerous because HTML emails are susceptible to XSS. An attacker could inject
+    data into this HTML email, causing XSS.
+  metadata:
+    cwe:
+    - 'CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream
+      Component (''Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://www.damonkohler.com/2008/12/email-injection.html
+    category: security
+    technology:
+    - django
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.email.xss-send-mail-html-message.xss-send-mail-html-message
+    shortlink: https://sg.run/Avx8
+    semgrep.dev:
+      rule:
+        rule_id: lBU9Ll
+        version_id: 44TYX2
+        url: https://semgrep.dev/playground/r/44TYX2/python.django.security.injection.email.xss-send-mail-html-message.xss-send-mail-html-message
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: django.core.mail.send_mail(..., html_message=request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.send_mail(..., html_message=f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: $A = django.core.mail.send_mail(..., html_message=request.$W.get(...),
+        ...)
+    - pattern: return django.core.mail.send_mail(..., html_message=request.$W.get(...),
+        ...)
+    - pattern: django.core.mail.send_mail(..., html_message=request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.send_mail(..., html_message=f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.send_mail(..., html_message=$STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: $A = django.core.mail.send_mail(..., html_message=request.$W(...),
+        ...)
+    - pattern: return django.core.mail.send_mail(..., html_message=request.$W(...),
+        ...)
+    - pattern: django.core.mail.send_mail(..., html_message=request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.send_mail(..., html_message=$DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.send_mail(..., html_message=$STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.send_mail(..., html_message=$STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.send_mail(..., html_message=f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.send_mail(..., html_message=$STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: $A = django.core.mail.send_mail(..., html_message=request.$W[...],
+        ...)
+    - pattern: return django.core.mail.send_mail(..., html_message=request.$W[...],
+        ...)
+    - pattern: django.core.mail.send_mail(..., html_message=request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.send_mail(..., html_message=$DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.send_mail(..., html_message=$STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.send_mail(..., html_message=$STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.send_mail(..., html_message=f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.send_mail(..., html_message=$STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.core.mail.send_mail(..., html_message=$INTERM, ...)
+    - pattern: $A = django.core.mail.send_mail(..., html_message=request.$W, ...)
+    - pattern: return django.core.mail.send_mail(..., html_message=request.$W, ...)
+- id: python.flask.security.injection.tainted-url-host.tainted-url-host
+  languages:
+  - python
+  message: User data flows into the host portion of this manually-constructed URL.
+    This could allow an attacker to send data to their own server, potentially exposing
+    sensitive data such as cookies or authorization information sent with this request.
+    They could also probe internal servers or other resources that the server runnig
+    this code can access. (This is called server-side request forgery, or SSRF.) Do
+    not allow arbitrary hosts. Instead, create an allowlist for approved hosts hardcode
+    the correct host.
+  metadata:
+    cwe:
+    - 'CWE-918: Server-Side Request Forgery (SSRF)'
+    owasp:
+    - A10:2021 - Server-Side Request Forgery (SSRF)
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+    category: security
+    technology:
+    - flask
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    impact: MEDIUM
+    likelihood: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.flask.security.injection.tainted-url-host.tainted-url-host
+    shortlink: https://sg.run/RXpK
+    semgrep.dev:
+      rule:
+        rule_id: ReU3Wb
+        version_id: xyT34W
+        url: https://semgrep.dev/playground/r/xyT34W/python.flask.security.injection.tainted-url-host.tainted-url-host
+  mode: taint
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern: '"$URLSTR" % ...'
+        - metavariable-pattern:
+            metavariable: $URLSTR
+            language: generic
+            patterns:
+            - pattern-either:
+              - pattern: $SCHEME://%s
+              - pattern: $SCHEME://%r
+      - patterns:
+        - pattern: '"$URLSTR".format(...)'
+        - metavariable-pattern:
+            metavariable: $URLSTR
+            language: generic
+            pattern: $SCHEME:// { ... }
+      - patterns:
+        - pattern: '"$URLSTR" + ...'
+        - metavariable-regex:
+            metavariable: $URLSTR
+            regex: .*://$
+      - patterns:
+        - pattern: f"$URLSTR{...}..."
+        - metavariable-regex:
+            metavariable: $URLSTR
+            regex: .*://$
+      - patterns:
+        - pattern-inside: |
+            $URL = "$URLSTR"
+            ...
+        - pattern: $URL += ...
+        - metavariable-regex:
+            metavariable: $URLSTR
+            regex: .*://$
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: flask.request.$ANYTHING
+      - patterns:
+        - pattern-inside: |
+            @$APP.route(...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+        - pattern: $ROUTEVAR
+  severity: WARNING
+- id: python.lang.security.audit.weak-ssl-version.weak-ssl-version
+  message: An insecure SSL version was detected. TLS versions 1.0, 1.1, and all SSL
+    versions are considered weak encryption and are deprecated. Use 'ssl.PROTOCOL_TLSv1_2'
+    or higher.
+  metadata:
+    cwe:
+    - 'CWE-326: Inadequate Encryption Strength'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/insecure_ssl_tls.py#L30
+    asvs:
+      section: V9 Communications Verification Requirements
+      control_id: 9.1.3 Weak TLS
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x17-V9-Communications.md#v91-client-communications-security-requirements
+      version: '4'
+    references:
+    - https://tools.ietf.org/html/rfc7568
+    - https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-02.html
+    - https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1_2
+    category: security
+    technology:
+    - python
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.weak-ssl-version.weak-ssl-version
+    shortlink: https://sg.run/RoZO
+    semgrep.dev:
+      rule:
+        rule_id: KxUbNG
+        version_id: pZTQ9w
+        url: https://semgrep.dev/playground/r/pZTQ9w/python.lang.security.audit.weak-ssl-version.weak-ssl-version
+  languages:
+  - python
+  severity: WARNING
+  pattern-either:
+  - pattern: ssl.PROTOCOL_SSLv2
+  - pattern: ssl.PROTOCOL_SSLv3
+  - pattern: ssl.PROTOCOL_TLSv1
+  - pattern: ssl.PROTOCOL_TLSv1_1
+  - pattern: pyOpenSSL.SSL.SSLv2_METHOD
+  - pattern: pyOpenSSL.SSL.SSLv23_METHOD
+  - pattern: pyOpenSSL.SSL.SSLv3_METHOD
+  - pattern: pyOpenSSL.SSL.TLSv1_METHOD
+  - pattern: pyOpenSSL.SSL.TLSv1_1_METHOD
+- id: python.django.security.injection.command.command-injection-os-system.command-injection-os-system
+  message: Request data detected in os.system. This could be vulnerable to a command
+    injection and should be avoided. If this must be done, use the 'subprocess' module
+    instead and pass the arguments as a list. See https://owasp.org/www-community/attacks/Command_Injection
+    for more information.
+  metadata:
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://owasp.org/www-community/attacks/Command_Injection
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.command.command-injection-os-system.command-injection-os-system
+    shortlink: https://sg.run/Gen2
+    semgrep.dev:
+      rule:
+        rule_id: KxUbp2
+        version_id: 8KTLd4
+        url: https://semgrep.dev/playground/r/8KTLd4/python.django.security.injection.command.command-injection-os-system.command-injection-os-system
+  languages:
+  - python
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: os.system(..., request.$W.get(...), ...)
+    - pattern: os.system(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: os.system(..., $S % request.$W.get(...), ...)
+    - pattern: os.system(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        os.system(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        os.system(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        os.system(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        os.system(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        os.system(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: $A = os.system(..., request.$W.get(...), ...)
+    - pattern: $A = os.system(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: $A = os.system(..., $S % request.$W.get(...), ...)
+    - pattern: $A = os.system(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: return os.system(..., request.$W.get(...), ...)
+    - pattern: return os.system(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: return os.system(..., $S % request.$W.get(...), ...)
+    - pattern: return os.system(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: os.system(..., request.$W(...), ...)
+    - pattern: os.system(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: os.system(..., $S % request.$W(...), ...)
+    - pattern: os.system(..., f"...{request.$W(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        os.system(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        os.system(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        os.system(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        os.system(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        os.system(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: $A = os.system(..., request.$W(...), ...)
+    - pattern: $A = os.system(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: $A = os.system(..., $S % request.$W(...), ...)
+    - pattern: $A = os.system(..., f"...{request.$W(...)}...", ...)
+    - pattern: return os.system(..., request.$W(...), ...)
+    - pattern: return os.system(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: return os.system(..., $S % request.$W(...), ...)
+    - pattern: return os.system(..., f"...{request.$W(...)}...", ...)
+    - pattern: os.system(..., request.$W[...], ...)
+    - pattern: os.system(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: os.system(..., $S % request.$W[...], ...)
+    - pattern: os.system(..., f"...{request.$W[...]}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        os.system(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        os.system(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        os.system(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        os.system(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        os.system(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: $A = os.system(..., request.$W[...], ...)
+    - pattern: $A = os.system(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: $A = os.system(..., $S % request.$W[...], ...)
+    - pattern: $A = os.system(..., f"...{request.$W[...]}...", ...)
+    - pattern: return os.system(..., request.$W[...], ...)
+    - pattern: return os.system(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: return os.system(..., $S % request.$W[...], ...)
+    - pattern: return os.system(..., f"...{request.$W[...]}...", ...)
+    - pattern: os.system(..., request.$W, ...)
+    - pattern: os.system(..., $S.format(..., request.$W, ...), ...)
+    - pattern: os.system(..., $S % request.$W, ...)
+    - pattern: os.system(..., f"...{request.$W}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        os.system(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        os.system(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        os.system(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        os.system(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        os.system(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        os.system(..., $INTERM, ...)
+    - pattern: $A = os.system(..., request.$W, ...)
+    - pattern: $A = os.system(..., $S.format(..., request.$W, ...), ...)
+    - pattern: $A = os.system(..., $S % request.$W, ...)
+    - pattern: $A = os.system(..., f"...{request.$W}...", ...)
+    - pattern: return os.system(..., request.$W, ...)
+    - pattern: return os.system(..., $S.format(..., request.$W, ...), ...)
+    - pattern: return os.system(..., $S % request.$W, ...)
+    - pattern: return os.system(..., f"...{request.$W}...", ...)
+- id: python.pyramid.security.sqlalchemy-sql-injection.pyramid-sqlalchemy-sql-injection
+  message: Distinct, Having, Group_by, Order_by, and Filter in SQLAlchemy can cause
+    sql injections if the developer inputs raw SQL into the before-mentioned clauses.
+    This pattern captures relevant cases in which the developer inputs raw SQL into
+    the distinct, having, group_by, order_by or filter clauses and injects user-input
+    into the raw SQL with any function besides "bindparams". Use bindParams to securely
+    bind user-input to SQL statements.
+  languages:
+  - python
+  severity: ERROR
+  metadata:
+    category: security
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://docs.sqlalchemy.org/en/14/tutorial/data_select.html#tutorial-selecting-data
+    technology:
+    - pyramid
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.security.sqlalchemy-sql-injection.pyramid-sqlalchemy-sql-injection
+    shortlink: https://sg.run/W7eE
+    semgrep.dev:
+      rule:
+        rule_id: QrUZ7l
+        version_id: yeTQk2
+        url: https://semgrep.dev/playground/r/yeTQk2/python.pyramid.security.sqlalchemy-sql-injection.pyramid-sqlalchemy-sql-injection
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-inside: |
+        from pyramid.view import view_config
+        ...
+        @view_config( ... )
+        def $VIEW($REQ):
+          ...
+    - pattern: $REQ.$ANYTHING
+    - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-inside: |
+        $QUERY = $REQ.dbsession.query(...)
+        ...
+    - pattern-either:
+      - pattern: |
+          $QUERY.$SQLFUNC("...".$FORMATFUNC(..., $SINK, ...))
+      - pattern: |
+          $QUERY.join(...).$SQLFUNC("...".$FORMATFUNC(..., $SINK, ...))
+    - pattern: $SINK
+    - metavariable-regex:
+        metavariable: $SQLFUNC
+        regex: (group_by|order_by|distinct|having|filter)
+    - metavariable-regex:
+        metavariable: $FORMATFUNC
+        regex: (?!bindparams)
+  fix-regex:
+    regex: format
+    replacement: bindparams
+- id: python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly
+  patterns:
+  - pattern-not-inside: |
+      if __name__ == '__main__':
+        ...
+  - pattern-not-inside: |
+      def $X(...):
+        ...
+  - pattern: app.run(...)
+  message: top-level app.run(...) is ignored by flask. Consider putting app.run(...)
+    behind a guard, like inside a function
+  metadata:
+    cwe:
+    - 'CWE-668: Exposure of Resource to Wrong Sphere'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - flask
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly
+    shortlink: https://sg.run/vz5b
+    semgrep.dev:
+      rule:
+        rule_id: 8GUjdX
+        version_id: qkTK0D
+        url: https://semgrep.dev/playground/r/qkTK0D/python.flask.security.audit.app-run-security-config.avoid_using_app_run_directly
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-not: os.$METHOD("...", ...)
+        - pattern: os.$METHOD(...)
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (execl|execle|execlp|execlpe|execv|execve|execvp|execvpe)
+      - patterns:
+        - pattern-not: os.$METHOD("...", [$PATH,"...","...",...],...)
+        - pattern-inside: os.$METHOD($BASH,[$PATH,"-c",$CMD,...],...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (execv|execve|execvp|execvpe)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+      - patterns:
+        - pattern-not: os.$METHOD("...", $PATH, "...", "...",...)
+        - pattern-inside: os.$METHOD($BASH, $PATH, "-c", $CMD,...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (execl|execle|execlp|execlpe)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+  message: Found user controlled content when spawning a process. This is dangerous
+    because it allows a malicious actor to execute commands.
+  metadata:
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    confidence: MEDIUM
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
+    shortlink: https://sg.run/qL6z
+    semgrep.dev:
+      rule:
+        rule_id: 4bUEAY
+        version_id: pZTQrY
+        url: https://semgrep.dev/playground/r/pZTQrY/python.lang.security.audit.dangerous-os-exec-tainted-env-args.dangerous-os-exec-tainted-env-args
+  languages:
+  - python
+  severity: ERROR
+- id: python.pyramid.audit.set-cookie-httponly-unsafe-default.pyramid-set-cookie-httponly-unsafe-default
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        @pyramid.view.view_config(...)
+        def $VIEW($REQUEST):
+            ...
+            $RESPONSE = $REQUEST.response
+            ...
+    - pattern-inside: |
+        def $VIEW(...):
+            ...
+            $RESPONSE = pyramid.httpexceptions.HTTPFound(...)
+            ...
+  - pattern-not: $RESPONSE.set_cookie(..., httponly=$HTTPONLY, ...)
+  - pattern-not: $RESPONSE.set_cookie(..., **$PARAMS)
+  - pattern: $RESPONSE.set_cookie(...)
+  fix-regex:
+    regex: (.*)\)
+    replacement: \1, httponly=True)
+  message: Found a Pyramid cookie using an unsafe default for the httponly option.
+    Pyramid cookies should be handled securely by setting httponly=True in response.set_cookie(...).
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-1004: Sensitive Cookie Without ''HttpOnly'' Flag'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.set-cookie-httponly-unsafe-default.pyramid-set-cookie-httponly-unsafe-default
+    shortlink: https://sg.run/P19v
+    semgrep.dev:
+      rule:
+        rule_id: d8UPQ7
+        version_id: o5TWXe
+        url: https://semgrep.dev/playground/r/o5TWXe/python.pyramid.audit.set-cookie-httponly-unsafe-default.pyramid-set-cookie-httponly-unsafe-default
+  languages:
+  - python
+  severity: WARNING
+- id: python.django.security.injection.csv-writer-injection.csv-writer-injection
+  languages:
+  - python
+  message: Detected user input into a generated CSV file using the built-in `csv`
+    module. If user data is used to generate the data in this file, it is possible
+    that an attacker could inject a formula when the CSV is imported into a spreadsheet
+    application that runs an attacker script, which could steal data from the importing
+    user or, at worst, install malware on the user's computer. `defusedcsv` is a drop-in
+    replacement with the same API that will attempt to mitigate formula injection
+    attempts. You can use `defusedcsv` instead of `csv` to safely generate CSVs.
+  metadata:
+    category: security
+    confidence: MEDIUM
+    cwe:
+    - 'CWE-1236: Improper Neutralization of Formula Elements in a CSV File'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://github.com/raphaelm/defusedcsv
+    - https://owasp.org/www-community/attacks/CSV_Injection
+    - https://web.archive.org/web/20220516052229/https://www.contextis.com/us/blog/comma-separated-vulnerabilities
+    technology:
+    - django
+    - python
+    subcategory:
+    - vuln
+    impact: MEDIUM
+    likelihood: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.csv-writer-injection.csv-writer-injection
+    shortlink: https://sg.run/Pw9q
+    semgrep.dev:
+      rule:
+        rule_id: 7KUK1y
+        version_id: QkTQ4z
+        url: https://semgrep.dev/playground/r/QkTQ4z/python.django.security.injection.csv-writer-injection.csv-writer-injection
+  mode: taint
+  pattern-sinks:
+  - patterns:
+    - pattern-inside: |
+        $WRITER = csv.writer(...)
+
+        ...
+
+        $WRITER.$WRITE(...)
+    - pattern: $WRITER.$WRITE(...)
+    - metavariable-regex:
+        metavariable: $WRITE
+        regex: ^(writerow|writerows|writeheader)$
+  pattern-sources:
+  - patterns:
+    - pattern-inside: |
+        def $FUNC(..., $REQUEST, ...):
+          ...
+    - focus-metavariable: $REQUEST
+    - metavariable-pattern:
+        metavariable: $REQUEST
+        patterns:
+        - pattern: request
+        - pattern-not-inside: request.build_absolute_uri
+  severity: ERROR
+- id: python.jinja2.security.audit.autoescape-disabled-false.incorrect-autoescape-disabled
+  patterns:
+  - pattern: jinja2.Environment(... , autoescape=$VAL, ...)
+  - pattern-not: jinja2.Environment(... , autoescape=True, ...)
+  - pattern-not: jinja2.Environment(... , autoescape=jinja2.select_autoescape(...),
+      ...)
+  - focus-metavariable: $VAL
+  fix: |
+    True
+  message: Detected a Jinja2 environment with 'autoescaping' disabled. This is dangerous
+    if you are rendering to a browser because this allows for cross-site scripting
+    (XSS) attacks. If you are in a web context, enable 'autoescaping' by setting 'autoescape=True.'
+    You may also consider using 'jinja2.select_autoescape()' to only enable automatic
+    escaping for certain file extensions.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html
+    cwe:
+    - 'CWE-116: Improper Encoding or Escaping of Output'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://jinja.palletsprojects.com/en/2.11.x/api/#basics
+    category: security
+    technology:
+    - jinja2
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.jinja2.security.audit.autoescape-disabled-false.incorrect-autoescape-disabled
+    shortlink: https://sg.run/L2L7
+    semgrep.dev:
+      rule:
+        rule_id: QrU1Xg
+        version_id: WrT2Or
+        url: https://semgrep.dev/playground/r/WrT2Or/python.jinja2.security.audit.autoescape-disabled-false.incorrect-autoescape-disabled
+  languages:
+  - python
+  severity: WARNING
+- id: python.flask.security.injection.tainted-sql-string.tainted-sql-string
+  message: Detected user input used to manually construct a SQL string. This is usually
+    bad practice because manual construction could accidentally result in a SQL injection.
+    An attacker could use a SQL injection to steal or modify contents of the database.
+    Instead, use a parameterized query which is available by default in most database
+    engines. Alternatively, consider using an object-relational mapper (ORM) such
+    as SQLAlchemy which will protect your queries.
+  metadata:
+    cwe:
+    - 'CWE-704: Incorrect Type Conversion or Cast'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://docs.sqlalchemy.org/en/14/core/tutorial.html#using-textual-sql
+    - https://www.tutorialspoint.com/sqlalchemy/sqlalchemy_quick_guide.htm
+    - https://docs.sqlalchemy.org/en/14/core/tutorial.html#using-more-specific-text-with-table-expression-literal-column-and-expression-column
+    category: security
+    technology:
+    - sqlalchemy
+    - flask
+    subcategory:
+    - vuln
+    impact: MEDIUM
+    likelihood: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.tainted-sql-string.tainted-sql-string
+    shortlink: https://sg.run/JxZj
+    semgrep.dev:
+      rule:
+        rule_id: YGUDKQ
+        version_id: w8T03J
+        url: https://semgrep.dev/playground/r/w8T03J/python.flask.security.injection.tainted-sql-string.tainted-sql-string
+  severity: ERROR
+  languages:
+  - python
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: flask.request.$ANYTHING
+      - patterns:
+        - pattern-inside: |
+            @$APP.route(...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+        - pattern: $ROUTEVAR
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          "$SQLSTR" + ...
+      - pattern: |
+          "$SQLSTR" % ...
+      - pattern: |
+          "$SQLSTR".format(...)
+      - pattern: |
+          f"$SQLSTR{...}..."
+    - metavariable-regex:
+        metavariable: $SQLSTR
+        regex: \s*(?i)(select|delete|insert|create|update|alter|drop)\b.*
+- id: python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4
+  message: Detected MD4 hash algorithm which is considered insecure. MD4 is not collision
+    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
+    or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4
+    shortlink: https://sg.run/Lve6
+    semgrep.dev:
+      rule:
+        rule_id: BYUJy4
+        version_id: PkTnAP
+        url: https://semgrep.dev/playground/r/PkTnAP/python.pycryptodome.security.insecure-hash-algorithm-md4.insecure-hash-algorithm-md4
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Crypto.Hash.MD4.new(...)
+  - pattern: Cryptodome.Hash.MD4.new (...)
+- id: python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-not: subprocess.$FUNC("...", ...)
+        - pattern-not: subprocess.$FUNC(["...",...], ...)
+        - pattern-not: subprocess.$FUNC(("...",...), ...)
+        - pattern-not: subprocess.CalledProcessError(...)
+        - pattern-not: subprocess.SubprocessError(...)
+        - pattern: subprocess.$FUNC($CMD, ...)
+      - patterns:
+        - pattern-not: subprocess.$FUNC("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c","...",...)
+        - pattern: subprocess.$FUNC("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c", $CMD)
+      - patterns:
+        - pattern-not: subprocess.$FUNC(["=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c","...",...],...)
+        - pattern-not: subprocess.$FUNC(("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c","...",...),...)
+        - pattern-either:
+          - pattern: subprocess.$FUNC(["=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c", $CMD],
+              ...)
+          - pattern: subprocess.$FUNC(("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c", $CMD),
+              ...)
+      - patterns:
+        - pattern-not: subprocess.$FUNC("=~/(python)/","...",...)
+        - pattern: subprocess.$FUNC("=~/(python)/", $CMD)
+      - patterns:
+        - pattern-not: subprocess.$FUNC(["=~/(python)/","...",...],...)
+        - pattern-not: subprocess.$FUNC(("=~/(python)/","...",...),...)
+        - pattern-either:
+          - pattern: subprocess.$FUNC(["=~/(python)/", $CMD],...)
+          - pattern: subprocess.$FUNC(("=~/(python)/", $CMD),...)
+    - focus-metavariable: $CMD
+  message: Detected subprocess function '$FUNC' with user controlled data. A malicious
+    actor could leverage this to perform command injection. You may consider using
+    'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
+    - https://docs.python.org/3/library/subprocess.html
+    - https://docs.python.org/3/library/shlex.html
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
+    shortlink: https://sg.run/pLGg
+    semgrep.dev:
+      rule:
+        rule_id: AbUgrZ
+        version_id: o5TQo9
+        url: https://semgrep.dev/playground/r/o5TQo9/python.lang.security.audit.dangerous-subprocess-use-tainted-env-args.dangerous-subprocess-use-tainted-env-args
+  languages:
+  - python
+  severity: ERROR
+- id: python.django.security.injection.sql.sql-injection-rawsql.sql-injection-using-rawsql
+  message: User-controlled data from request is passed to 'RawSQL()'. This could lead
+    to a SQL injection and therefore protected information could be leaked. Instead,
+    use parameterized queries or escape the user-controlled data by using `params`
+    and not using quote placeholders in the SQL string.
+  metadata:
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://docs.djangoproject.com/en/3.0/ref/models/expressions/#django.db.models.expressions.RawSQL
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.sql.sql-injection-rawsql.sql-injection-using-rawsql
+    shortlink: https://sg.run/Kl4X
+    semgrep.dev:
+      rule:
+        rule_id: pKUOBp
+        version_id: qkTK0J
+        url: https://semgrep.dev/playground/r/qkTK0J/python.django.security.injection.sql.sql-injection-rawsql.sql-injection-using-rawsql
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: django.db.models.expressions.RawSQL(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: django.db.models.expressions.RawSQL(..., $S % request.$W.get(...),
+        ...)
+    - pattern: django.db.models.expressions.RawSQL(..., f"...{request.$W.get(...)}...",
+        ...)
+    - pattern: django.db.models.expressions.RawSQL(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.db.models.expressions.RawSQL(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: $A = django.db.models.expressions.RawSQL(..., request.$W.get(...),
+        ...)
+    - pattern: return django.db.models.expressions.RawSQL(..., request.$W.get(...),
+        ...)
+    - pattern: django.db.models.expressions.RawSQL(..., $S.format(..., request.$W(...),
+        ...), ...)
+    - pattern: django.db.models.expressions.RawSQL(..., $S % request.$W(...), ...)
+    - pattern: django.db.models.expressions.RawSQL(..., f"...{request.$W(...)}...",
+        ...)
+    - pattern: django.db.models.expressions.RawSQL(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.db.models.expressions.RawSQL(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.db.models.expressions.RawSQL(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: $A = django.db.models.expressions.RawSQL(..., request.$W(...), ...)
+    - pattern: return django.db.models.expressions.RawSQL(..., request.$W(...), ...)
+    - pattern: django.db.models.expressions.RawSQL(..., $S.format(..., request.$W[...],
+        ...), ...)
+    - pattern: django.db.models.expressions.RawSQL(..., $S % request.$W[...], ...)
+    - pattern: django.db.models.expressions.RawSQL(..., f"...{request.$W[...]}...",
+        ...)
+    - pattern: django.db.models.expressions.RawSQL(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.db.models.expressions.RawSQL(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.db.models.expressions.RawSQL(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.db.models.expressions.RawSQL(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.db.models.expressions.RawSQL(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.db.models.expressions.RawSQL(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: $A = django.db.models.expressions.RawSQL(..., request.$W[...], ...)
+    - pattern: return django.db.models.expressions.RawSQL(..., request.$W[...], ...)
+    - pattern: django.db.models.expressions.RawSQL(..., $S.format(..., request.$W,
+        ...), ...)
+    - pattern: django.db.models.expressions.RawSQL(..., $S % request.$W, ...)
+    - pattern: django.db.models.expressions.RawSQL(..., f"...{request.$W}...", ...)
+    - pattern: django.db.models.expressions.RawSQL(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.db.models.expressions.RawSQL(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.db.models.expressions.RawSQL(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.db.models.expressions.RawSQL(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.db.models.expressions.RawSQL(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.db.models.expressions.RawSQL(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.db.models.expressions.RawSQL(..., $INTERM, ...)
+    - pattern: $A = django.db.models.expressions.RawSQL(..., request.$W, ...)
+    - pattern: return django.db.models.expressions.RawSQL(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.db.models.expressions.RawSQL($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.db.models.expressions.RawSQL($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.db.models.expressions.RawSQL($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.db.models.expressions.RawSQL($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        django.db.models.expressions.RawSQL($INTERM, ...)
+- id: python.aws-lambda.security.dangerous-system-call.dangerous-system-call
+  mode: taint
+  message: Detected `os` function with argument tainted by `event` object. This is
+    dangerous if external data can reach this function call because it allows a malicious
+    actor to execute commands. Use the 'subprocess' module instead, which is easier
+    to use without accidentally exposing a command injection vulnerability.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.2.4 Dyanmic Code Execution Features
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.dangerous-system-call.dangerous-system-call
+    shortlink: https://sg.run/jDvN
+    semgrep.dev:
+      rule:
+        rule_id: QrUkg6
+        version_id: NdTQlw
+        url: https://semgrep.dev/playground/r/NdTQlw/python.aws-lambda.security.dangerous-system-call.dangerous-system-call
+  languages:
+  - python
+  severity: ERROR
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $CMD
+    - pattern-either:
+      - pattern: os.system($CMD,...)
+      - pattern: os.popen($CMD,...)
+      - pattern: os.popen2($CMD,...)
+      - pattern: os.popen3($CMD,...)
+      - pattern: os.popen4($CMD,...)
+- id: python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization
+  metadata:
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://docs.python.org/3/library/pickle.html
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization
+    shortlink: https://sg.run/9oyr
+    semgrep.dev:
+      rule:
+        rule_id: OrU3e6
+        version_id: BjTGwp
+        url: https://semgrep.dev/playground/r/BjTGwp/python.django.security.audit.avoid-insecure-deserialization.avoid-insecure-deserialization
+  message: Avoid using insecure deserialization library, backed by `pickle`, `_pickle`,
+    `cpickle`, `dill`, `shelve`, or `yaml`, which are known to lead to remote code
+    execution vulnerabilities.
+  languages:
+  - python
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+  - pattern-either:
+    - patterns:
+      - pattern-inside: |
+          def $INSIDE(..., $PARAM, ...):
+            ...
+      - pattern-either:
+        - pattern: request.$REQFUNC(...)
+        - pattern: request.$REQFUNC.get(...)
+        - pattern: request.$REQFUNC[...]
+  pattern-sinks:
+  - pattern-either:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            pickle.$PICKLEFUNC(...)
+        - pattern: |
+            _pickle.$PICKLEFUNC(...)
+        - pattern: |
+            cPickle.$PICKLEFUNC(...)
+        - pattern: |
+            shelve.$PICKLEFUNC(...)
+      - metavariable-regex:
+          metavariable: $PICKLEFUNC
+          regex: dumps|dump|load|loads
+    - patterns:
+      - pattern: dill.$DILLFUNC(...)
+      - metavariable-regex:
+          metavariable: $DILLFUNC
+          regex: dump|dump_session|dumps|load|load_session|loads
+    - patterns:
+      - pattern: yaml.$YAMLFUNC(...)
+      - pattern-not: yaml.$YAMLFUNC(..., Dumper=SafeDumper, ...)
+      - pattern-not: yaml.$YAMLFUNC(..., Dumper=yaml.SafeDumper, ...)
+      - pattern-not: yaml.$YAMLFUNC(..., Loader=SafeLoader, ...)
+      - pattern-not: yaml.$YAMLFUNC(..., Loader=yaml.SafeLoader, ...)
+      - metavariable-regex:
+          metavariable: $YAMLFUNC
+          regex: dump|dump_all|load|load_all
+- id: python.django.security.injection.path-traversal.path-traversal-open.path-traversal-open
+  message: Found request data in a call to 'open'.  Ensure the request data is validated
+    or sanitized,  otherwise it could result in path traversal attacks and  therefore
+    sensitive data being leaked. To mitigate, consider using os.path.abspath or os.path.realpath
+    or the pathlib library.
+  metadata:
+    cwe:
+    - 'CWE-22: Improper Limitation of a Pathname to a Restricted Directory (''Path
+      Traversal'')'
+    owasp:
+    - A05:2017 - Broken Access Control
+    - A01:2021 - Broken Access Control
+    references:
+    - https://owasp.org/www-community/attacks/Path_Traversal
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.path-traversal.path-traversal-open.path-traversal-open
+    shortlink: https://sg.run/W8qg
+    semgrep.dev:
+      rule:
+        rule_id: oqUe7z
+        version_id: RGTwXA
+        url: https://semgrep.dev/playground/r/RGTwXA/python.django.security.injection.path-traversal.path-traversal-open.path-traversal-open
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: open(..., request.$W.get(...), ...)
+    - pattern: open(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: open(..., $S % request.$W.get(...), ...)
+    - pattern: open(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        open(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        open(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        open(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        open(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        open(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: $A = open(..., request.$W.get(...), ...)
+    - pattern: $A = open(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: $A = open(..., $S % request.$W.get(...), ...)
+    - pattern: $A = open(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: return open(..., request.$W.get(...), ...)
+    - pattern: return open(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: return open(..., $S % request.$W.get(...), ...)
+    - pattern: return open(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        with open(..., $DATA, ...) as $FD:
+          ...
+    - pattern: open(..., request.$W(...), ...)
+    - pattern: open(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: open(..., $S % request.$W(...), ...)
+    - pattern: open(..., f"...{request.$W(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        open(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        open(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        open(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        open(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        open(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: $A = open(..., request.$W(...), ...)
+    - pattern: $A = open(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: $A = open(..., $S % request.$W(...), ...)
+    - pattern: $A = open(..., f"...{request.$W(...)}...", ...)
+    - pattern: return open(..., request.$W(...), ...)
+    - pattern: return open(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: return open(..., $S % request.$W(...), ...)
+    - pattern: return open(..., f"...{request.$W(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        with open(..., $DATA, ...) as $FD:
+          ...
+    - pattern: open(..., request.$W[...], ...)
+    - pattern: open(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: open(..., $S % request.$W[...], ...)
+    - pattern: open(..., f"...{request.$W[...]}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        open(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        open(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        open(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        open(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        open(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: $A = open(..., request.$W[...], ...)
+    - pattern: $A = open(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: $A = open(..., $S % request.$W[...], ...)
+    - pattern: $A = open(..., f"...{request.$W[...]}...", ...)
+    - pattern: return open(..., request.$W[...], ...)
+    - pattern: return open(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: return open(..., $S % request.$W[...], ...)
+    - pattern: return open(..., f"...{request.$W[...]}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        with open(..., $DATA, ...) as $FD:
+          ...
+    - pattern: open(..., request.$W, ...)
+    - pattern: open(..., $S.format(..., request.$W, ...), ...)
+    - pattern: open(..., $S % request.$W, ...)
+    - pattern: open(..., f"...{request.$W}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        open(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W
+        ...
+        open(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W
+        ...
+        open(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W
+        ...
+        open(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: |
+        $DATA = request.$W
+        ...
+        open(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        open(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        with open(..., $INTERM, ...) as $FD:
+          ...
+    - pattern: $A = open(..., request.$W, ...)
+    - pattern: $A = open(..., $S.format(..., request.$W, ...), ...)
+    - pattern: $A = open(..., $S % request.$W, ...)
+    - pattern: $A = open(..., f"...{request.$W}...", ...)
+    - pattern: return open(..., request.$W, ...)
+    - pattern: return open(..., $S.format(..., request.$W, ...), ...)
+    - pattern: return open(..., $S % request.$W, ...)
+    - pattern: return open(..., f"...{request.$W}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        with open(..., $DATA, ...) as $FD:
+          ...
+- id: python.django.security.injection.code.user-eval.user-eval
+  message: Found user data in a call to 'eval'. This is extremely dangerous because
+    it can enable an attacker to execute arbitrary remote code on the system. Instead,
+    refactor your code to not use 'eval' and instead use a safe library for the specific
+    functionality you need.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+    - https://owasp.org/www-community/attacks/Code_Injection
+    category: security
+    technology:
+    - django
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.code.user-eval.user-eval
+    shortlink: https://sg.run/PJDW
+    semgrep.dev:
+      rule:
+        rule_id: DbUpDQ
+        version_id: ExTYJB
+        url: https://semgrep.dev/playground/r/ExTYJB/python.django.security.injection.code.user-eval.user-eval
+  patterns:
+  - pattern-inside: |
+      def $F(...):
+        ...
+  - pattern-either:
+    - pattern: eval(..., request.$W.get(...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        eval(..., $V, ...)
+    - pattern: eval(..., request.$W(...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        eval(..., $V, ...)
+    - pattern: eval(..., request.$W[...], ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        eval(..., $V, ...)
+  languages:
+  - python
+  severity: WARNING
+- id: python.flask.security.injection.ssrf-requests.ssrf-requests
+  languages:
+  - python
+  severity: ERROR
+  message: Data from request object is passed to a new server-side request. This could
+    lead to a server-side request forgery (SSRF). To mitigate, ensure that schemes
+    and hosts are validated against an allowlist, do not forward the response to the
+    user, and ensure proper authentication and transport-layer security in the proxied
+    request.
+  metadata:
+    cwe:
+    - 'CWE-918: Server-Side Request Forgery (SSRF)'
+    owasp:
+    - A10:2021 - Server-Side Request Forgery (SSRF)
+    references:
+    - https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+    category: security
+    technology:
+    - flask
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.ssrf-requests.ssrf-requests
+    shortlink: https://sg.run/J9LW
+    semgrep.dev:
+      rule:
+        rule_id: WAUoRx
+        version_id: zyT0e1
+        url: https://semgrep.dev/playground/r/zyT0e1/python.flask.security.injection.ssrf-requests.ssrf-requests
+  pattern-either:
+  - patterns:
+    - pattern: requests.$FUNC(...)
+    - pattern-either:
+      - pattern-inside: |
+          @$APP.$ROUTE_METHOD($ROUTE, ...)
+          def $ROUTE_FUNC(..., $ROUTEVAR, ...):
+            ...
+            requests.$FUNC(..., <... $ROUTEVAR ...>, ...)
+      - pattern-inside: |
+          @$APP.$ROUTE_METHOD($ROUTE, ...)
+          def $ROUTE_FUNC(..., $ROUTEVAR, ...):
+            ...
+            $INTERM = <... $ROUTEVAR ...>
+            ...
+            requests.$FUNC(..., <... $INTERM ...>, ...)
+  - pattern: requests.$FUNC(..., <... flask.request.$W.get(...) ...>, ...)
+  - pattern: requests.$FUNC(..., <... flask.request.$W[...] ...>, ...)
+  - pattern: requests.$FUNC(..., <... flask.request.$W(...) ...>, ...)
+  - pattern: requests.$FUNC(..., <... flask.request.$W ...>, ...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        requests.$FUNC(<... $INTERM ...>, ...)
+    - pattern: requests.$FUNC(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        requests.$FUNC(<... $INTERM ...>, ...)
+    - pattern: requests.$FUNC(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        requests.$FUNC(<... $INTERM ...>, ...)
+    - pattern: requests.$FUNC(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        requests.$FUNC(<... $INTERM ...>, ...)
+    - pattern: requests.$FUNC(...)
+- id: python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication
+  message: 'An encryption mode of operation is being used without proper message authentication.  This
+    can potentially result in the encrypted content to be decrypted by an attacker.  Consider
+    instead use an AEAD mode of operation like GCM. '
+  languages:
+  - python
+  severity: ERROR
+  metadata:
+    category: security
+    technology:
+    - cryptography
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication
+    shortlink: https://sg.run/N9JL
+    semgrep.dev:
+      rule:
+        rule_id: lBUpNZ
+        version_id: RGTw5A
+        url: https://semgrep.dev/playground/r/RGTw5A/python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern: |
+          Cipher(..., $HAZMAT_MODE(...),...)
+      - pattern-not-inside: |
+          Cipher(..., $HAZMAT_MODE(...),...)
+          ...
+          HMAC(...)
+      - pattern-not-inside: |
+          Cipher(..., $HAZMAT_MODE(...),...)
+          ...
+          hmac.HMAC(...)
+  - metavariable-pattern:
+      metavariable: $HAZMAT_MODE
+      patterns:
+      - pattern-either:
+        - pattern: modes.CTR
+        - pattern: modes.CBC
+        - pattern: modes.CFB
+        - pattern: modes.OFB
+- id: python.lang.security.dangerous-subinterpreters-run-string.dangerous-subinterpreters-run-string
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+          - patterns:
+            - pattern-inside: |
+                @$APP.route(...)
+                def $FUNC(..., $ROUTEVAR, ...):
+                  ...
+            - pattern: $ROUTEVAR
+      - patterns:
+        - pattern-inside: |
+            def $FUNC(request, ...):
+              ...
+        - pattern-either:
+          - pattern: request.$PROPERTY.get(...)
+          - pattern: request.$PROPERTY[...]
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              @rest_framework.decorators.api_view(...)
+              def $FUNC($REQ, ...):
+                ...
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  class $VIEW(..., rest_framework.views.APIView, ...):
+                    ...
+              - pattern-inside: "class $VIEW(..., rest_framework.generics.GenericAPIView,
+                  ...):\n  ...                              \n"
+            - pattern-inside: |
+                def $METHOD(self, $REQ, ...):
+                  ...
+            - metavariable-regex:
+                metavariable: $METHOD
+                regex: (get|post|put|patch|delete|head)
+        - pattern-either:
+          - pattern: $REQ.POST.get(...)
+          - pattern: $REQ.POST[...]
+          - pattern: $REQ.FILES.get(...)
+          - pattern: $REQ.FILES[...]
+          - pattern: $REQ.DATA.get(...)
+          - pattern: $REQ.DATA[...]
+          - pattern: $REQ.QUERY_PARAMS.get(...)
+          - pattern: $REQ.QUERY_PARAMS[...]
+          - pattern: $REQ.data.get(...)
+          - pattern: $REQ.data[...]
+          - pattern: $REQ.query_params.get(...)
+          - pattern: $REQ.query_params[...]
+          - pattern: $REQ.content_type
+          - pattern: $REQ.content_type
+          - pattern: $REQ.stream
+          - pattern: $REQ.stream
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              class $SERVER(..., http.server.BaseHTTPRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.StreamRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.DatagramRequestHandler, ...):
+                ...
+        - pattern-either:
+          - pattern: self.requestline
+          - pattern: self.path
+          - pattern: self.headers[...]
+          - pattern: self.headers.get(...)
+          - pattern: self.rfile
+      - patterns:
+        - pattern-inside: |
+            @pyramid.view.view_config( ... )
+            def $VIEW($REQ):
+              ...
+        - pattern: $REQ.$ANYTHING
+        - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-inside: |
+        _xxsubinterpreters.run_string($ID, $PAYLOAD, ...)
+    - pattern-not: |
+        _xxsubinterpreters.run_string($ID, "...", ...)
+    - pattern: $PAYLOAD
+  message: Found user controlled content in `run_string`. This is dangerous because
+    it allows a malicious actor to run arbitrary Python code.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://bugs.python.org/issue43472
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.dangerous-subinterpreters-run-string.dangerous-subinterpreters-run-string
+    shortlink: https://sg.run/bPop
+    semgrep.dev:
+      rule:
+        rule_id: PeURWr
+        version_id: 9lTnDy
+        url: https://semgrep.dev/playground/r/9lTnDy/python.lang.security.dangerous-subinterpreters-run-string.dangerous-subinterpreters-run-string
+  severity: WARNING
+  languages:
+  - python
+- id: python.django.security.injection.code.user-exec-format-string.user-exec-format-string
+  message: Found user data in a call to 'exec'. This is extremely dangerous because
+    it can enable an attacker to execute arbitrary remote code on the system. Instead,
+    refactor your code to not use 'eval' and instead use a safe library for the specific
+    functionality you need.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - django
+    references:
+    - https://owasp.org/www-community/attacks/Code_Injection
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.code.user-exec-format-string.user-exec-format-string
+    shortlink: https://sg.run/J9JW
+    semgrep.dev:
+      rule:
+        rule_id: WAUovx
+        version_id: 7ZTYLz
+        url: https://semgrep.dev/playground/r/7ZTYLz/python.django.security.injection.code.user-exec-format-string.user-exec-format-string
+  patterns:
+  - pattern-inside: |
+      def $F(...):
+        ...
+  - pattern-either:
+    - pattern: exec(..., $STR % request.$W.get(...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        exec(..., $STR % $V, ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        $S = $STR % $V
+        ...
+        exec(..., $S, ...)
+    - pattern: exec(..., "..." % request.$W(...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        exec(..., $STR % $V, ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        $S = $STR % $V
+        ...
+        exec(..., $S, ...)
+    - pattern: exec(..., $STR % request.$W[...], ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        exec(..., $STR % $V, ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        $S = $STR % $V
+        ...
+        exec(..., $S, ...)
+    - pattern: exec(..., $STR.format(..., request.$W.get(...), ...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        exec(..., $STR.format(..., $V, ...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        $S = $STR.format(..., $V, ...)
+        ...
+        exec(..., $S, ...)
+    - pattern: exec(..., $STR.format(..., request.$W(...), ...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        exec(..., $STR.format(..., $V, ...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        $S = $STR.format(..., $V, ...)
+        ...
+        exec(..., $S, ...)
+    - pattern: exec(..., $STR.format(..., request.$W[...], ...), ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        exec(..., $STR.format(..., $V, ...), ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        $S = $STR.format(..., $V, ...)
+        ...
+        exec(..., $S, ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        exec(..., f"...{$V}...", ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        $S = f"...{$V}..."
+        ...
+        exec(..., $S, ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        exec(..., f"...{$V}...", ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        $S = f"...{$V}..."
+        ...
+        exec(..., $S, ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        exec(..., f"...{$V}...", ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        $S = f"...{$V}..."
+        ...
+        exec(..., $S, ...)
+    - pattern: exec(..., base64.decodestring($S.format(..., request.$W.get(...), ...),
+        ...), ...)
+    - pattern: exec(..., base64.decodestring($S % request.$W.get(...), ...), ...)
+    - pattern: exec(..., base64.decodestring(f"...{request.$W.get(...)}...", ...),
+        ...)
+    - pattern: exec(..., base64.decodestring(request.$W.get(...), ...), ...)
+    - pattern: exec(..., base64.decodestring(bytes($S.format(..., request.$W.get(...),
+        ...), ...), ...), ...)
+    - pattern: exec(..., base64.decodestring(bytes($S % request.$W.get(...), ...),
+        ...), ...)
+    - pattern: exec(..., base64.decodestring(bytes(f"...{request.$W.get(...)}...",
+        ...), ...), ...)
+    - pattern: exec(..., base64.decodestring(bytes(request.$W.get(...), ...), ...),
+        ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        exec(..., base64.decodestring($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = base64.decodestring($DATA, ...)
+        ...
+        exec(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        exec(..., base64.decodestring(bytes($DATA, ...), ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = base64.decodestring(bytes($DATA, ...), ...)
+        ...
+        exec(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        exec(..., base64.decodestring($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = base64.decodestring($DATA, ...)
+        ...
+        exec(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        exec(..., base64.decodestring(bytes($DATA, ...), ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = base64.decodestring(bytes($DATA, ...), ...)
+        ...
+        exec(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        exec(..., base64.decodestring($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = base64.decodestring($DATA, ...)
+        ...
+        exec(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        exec(..., base64.decodestring(bytes($DATA, ...), ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = base64.decodestring(bytes($DATA, ...), ...)
+        ...
+        exec(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        exec(..., base64.decodestring($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = base64.decodestring($DATA, ...)
+        ...
+        exec(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        exec(..., base64.decodestring(bytes($DATA, ...), ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = base64.decodestring(bytes($DATA, ...), ...)
+        ...
+        exec(..., $INTERM, ...)
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+  patterns:
+  - pattern: subprocess.$FUNC(..., shell=True, ...)
+  - pattern-not: subprocess.$FUNC("...", shell=True, ...)
+  message: Found 'subprocess' function '$FUNC' with 'shell=True'. This is dangerous
+    because this call will spawn the command using a shell process. Doing so propagates
+    current shell settings and variables, which makes it much easier for a malicious
+    actor to execute commands. Use 'shell=False' instead.
+  fix-regex:
+    regex: (shell\s*=\s*)True
+    replacement: \1False
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    references:
+    - https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
+    - https://docs.python.org/3/library/subprocess.html
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+    shortlink: https://sg.run/J92w
+    semgrep.dev:
+      rule:
+        rule_id: DbUpz2
+        version_id: 6xT0p5
+        url: https://semgrep.dev/playground/r/6xT0p5/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
+  languages:
+  - python
+  severity: ERROR
+- id: python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
+  message: '''$VAR'' is using the empty string as its default and is being used to
+    set the password on ''$MODEL''. If you meant to set an unusable password, set
+    the default value to ''None'' or call ''set_unusable_password()''.'
+  metadata:
+    cwe:
+    - 'CWE-521: Weak Password Requirements'
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#django.contrib.auth.models.User.set_password
+    category: security
+    technology:
+    - django
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
+    shortlink: https://sg.run/zvBW
+    semgrep.dev:
+      rule:
+        rule_id: yyUn6Z
+        version_id: qkTgLQ
+        url: https://semgrep.dev/playground/r/qkTgLQ/python.django.security.passwords.use-none-for-password-default.use-none-for-password-default
+  languages:
+  - python
+  severity: ERROR
+  patterns:
+  - pattern-either:
+    - pattern: |
+        $VAR = request.$W.get($X, $EMPTY)
+        ...
+        $MODEL.set_password($VAR)
+        ...
+        $MODEL.save(...)
+    - pattern: |
+        def $F(..., $VAR=$EMPTY, ...):
+          ...
+          $MODEL.set_password($VAR)
+  - focus-metavariable: $EMPTY
+  fix: |
+    None
+- id: python.pymongo.security.mongodb.mongo-client-bad-auth
+  pattern: |
+    pymongo.MongoClient(..., authMechanism='MONGODB-CR')
+  message: Warning MONGODB-CR was deprecated with the release of MongoDB 3.6 and is
+    no longer supported by MongoDB 4.0 (see https://api.mongodb.com/python/current/examples/authentication.html
+    for details).
+  fix-regex:
+    regex: MONGODB-CR
+    replacement: SCRAM-SHA-256
+  severity: WARNING
+  languages:
+  - python
+  metadata:
+    cwe:
+    - 'CWE-477: Use of Obsolete Function'
+    category: security
+    technology:
+    - pymongo
+    references:
+    - https://cwe.mitre.org/data/definitions/477.html
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pymongo.security.mongodb.mongo-client-bad-auth
+    shortlink: https://sg.run/YXRd
+    semgrep.dev:
+      rule:
+        rule_id: d8UlOX
+        version_id: BjTG2w
+        url: https://semgrep.dev/playground/r/BjTG2w/python.pymongo.security.mongodb.mongo-client-bad-auth
+- id: python.lang.security.dangerous-system-call.dangerous-system-call
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+          - patterns:
+            - pattern-inside: |
+                @$APP.route(...)
+                def $FUNC(..., $ROUTEVAR, ...):
+                  ...
+            - pattern: $ROUTEVAR
+      - patterns:
+        - pattern-inside: |
+            def $FUNC(request, ...):
+              ...
+        - pattern-either:
+          - pattern: request.$PROPERTY.get(...)
+          - pattern: request.$PROPERTY[...]
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              @rest_framework.decorators.api_view(...)
+              def $FUNC($REQ, ...):
+                ...
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  class $VIEW(..., rest_framework.views.APIView, ...):
+                    ...
+              - pattern-inside: "class $VIEW(..., rest_framework.generics.GenericAPIView,
+                  ...):\n  ...                              \n"
+            - pattern-inside: |
+                def $METHOD(self, $REQ, ...):
+                  ...
+            - metavariable-regex:
+                metavariable: $METHOD
+                regex: (get|post|put|patch|delete|head)
+        - pattern-either:
+          - pattern: $REQ.POST.get(...)
+          - pattern: $REQ.POST[...]
+          - pattern: $REQ.FILES.get(...)
+          - pattern: $REQ.FILES[...]
+          - pattern: $REQ.DATA.get(...)
+          - pattern: $REQ.DATA[...]
+          - pattern: $REQ.QUERY_PARAMS.get(...)
+          - pattern: $REQ.QUERY_PARAMS[...]
+          - pattern: $REQ.data.get(...)
+          - pattern: $REQ.data[...]
+          - pattern: $REQ.query_params.get(...)
+          - pattern: $REQ.query_params[...]
+          - pattern: $REQ.content_type
+          - pattern: $REQ.content_type
+          - pattern: $REQ.stream
+          - pattern: $REQ.stream
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              class $SERVER(..., http.server.BaseHTTPRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.StreamRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.DatagramRequestHandler, ...):
+                ...
+        - pattern-either:
+          - pattern: self.requestline
+          - pattern: self.path
+          - pattern: self.headers[...]
+          - pattern: self.headers.get(...)
+          - pattern: self.rfile
+      - patterns:
+        - pattern-inside: |
+            @pyramid.view.view_config( ... )
+            def $VIEW($REQ):
+              ...
+        - pattern: $REQ.$ANYTHING
+        - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-not: os.$W("...", ...)
+    - pattern-either:
+      - pattern: os.system(...)
+      - pattern: getattr(os, "system")(...)
+      - pattern: __import__("os").system(...)
+      - pattern: getattr(__import__("os"), "system")(...)
+      - pattern: |
+          $X = __import__("os")
+          ...
+          $X.system(...)
+      - pattern: |
+          $X = __import__("os")
+          ...
+          getattr($X, "system")(...)
+      - pattern: |
+          $X = getattr(os, "system")
+          ...
+          $X(...)
+      - pattern: |
+          $X = __import__("os")
+          ...
+          $Y = getattr($X, "system")
+          ...
+          $Y(...)
+      - pattern: os.popen(...)
+      - pattern: os.popen2(...)
+      - pattern: os.popen3(...)
+      - pattern: os.popen4(...)
+  message: Found user-controlled data used in a system call. This could allow a malicious
+    actor to execute commands. Use the 'subprocess' module instead, which is easier
+    to use without accidentally exposing a command injection vulnerability.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.2.4 Dyanmic Code Execution Features
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.dangerous-system-call.dangerous-system-call
+    shortlink: https://sg.run/k0W7
+    semgrep.dev:
+      rule:
+        rule_id: 5rUoP1
+        version_id: rxT8P4
+        url: https://semgrep.dev/playground/r/rxT8P4/python.lang.security.dangerous-system-call.dangerous-system-call
+  languages:
+  - python
+  severity: ERROR
+- id: python.aws-lambda.security.tainted-html-string.tainted-html-string
+  languages:
+  - python
+  severity: WARNING
+  message: Detected user input flowing into a manually constructed HTML string. You
+    may be accidentally bypassing secure methods of rendering HTML by manually constructing
+    HTML and this could create a cross-site scripting vulnerability, which could let
+    attackers steal sensitive user data. To be sure this is safe, check that the HTML
+    is rendered safely. Otherwise, use templates which will safely render HTML instead.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - aws-lambda
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.tainted-html-string.tainted-html-string
+    shortlink: https://sg.run/8zNy
+    semgrep.dev:
+      rule:
+        rule_id: JDUlwy
+        version_id: nWTwKe
+        url: https://semgrep.dev/playground/r/nWTwKe/python.aws-lambda.security.tainted-html-string.tainted-html-string
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: '"$HTMLSTR" % ...'
+          - pattern: '"$HTMLSTR".format(...)'
+          - pattern: '"$HTMLSTR" + ...'
+          - pattern: f"$HTMLSTR{...}..."
+      - patterns:
+        - pattern-inside: |
+            $HTML = "$HTMLSTR"
+            ...
+        - pattern-either:
+          - pattern: $HTML % ...
+          - pattern: $HTML.format(...)
+          - pattern: $HTML + ...
+    - metavariable-pattern:
+        metavariable: $HTMLSTR
+        language: generic
+        pattern: <$TAG ...
+    - pattern-not-inside: |
+        print(...)
+- id: python.pyramid.audit.set-cookie-httponly-unsafe-value.pyramid-set-cookie-httponly-unsafe-value
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        @pyramid.view.view_config(...)
+        def $VIEW($REQUEST):
+            ...
+            $RESPONSE = $REQUEST.response
+            ...
+    - pattern-inside: |
+        def $VIEW(...):
+            ...
+            $RESPONSE = pyramid.httpexceptions.HTTPFound(...)
+            ...
+  - pattern-not: $RESPONSE.set_cookie(..., **$PARAMS)
+  - pattern: $RESPONSE.set_cookie(..., httponly=$HTTPONLY, ...)
+  - pattern: $HTTPONLY
+  - metavariable-pattern:
+      metavariable: $HTTPONLY
+      pattern: |
+        False
+  fix: |
+    True
+  message: Found a Pyramid cookie without the httponly option correctly set. Pyramid
+    cookies should be handled securely by setting httponly=True in response.set_cookie(...).
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-1004: Sensitive Cookie Without ''HttpOnly'' Flag'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    references:
+    - https://owasp.org/www-community/controls/SecureCookieAttribute
+    - https://owasp.org/www-community/HttpOnly
+    - https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#httponly-attribute
+    category: security
+    technology:
+    - pyramid
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.set-cookie-httponly-unsafe-value.pyramid-set-cookie-httponly-unsafe-value
+    shortlink: https://sg.run/JbqP
+    semgrep.dev:
+      rule:
+        rule_id: ZqU37W
+        version_id: zyTXqy
+        url: https://semgrep.dev/playground/r/zyTXqy/python.pyramid.audit.set-cookie-httponly-unsafe-value.pyramid-set-cookie-httponly-unsafe-value
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.audit.ssl-wrap-socket-is-deprecated.ssl-wrap-socket-is-deprecated
+  pattern: ssl.wrap_socket(...)
+  message: '''ssl.wrap_socket()'' is deprecated. This function creates an insecure
+    socket without server name indication or hostname matching. Instead, create an
+    SSL context using ''ssl.SSLContext()'' and use that to wrap a socket.'
+  metadata:
+    cwe:
+    - 'CWE-326: Inadequate Encryption Strength'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://docs.python.org/3/library/ssl.html#ssl.wrap_socket
+    - https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket
+    category: security
+    technology:
+    - python
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.ssl-wrap-socket-is-deprecated.ssl-wrap-socket-is-deprecated
+    shortlink: https://sg.run/PJOY
+    semgrep.dev:
+      rule:
+        rule_id: BYUN2e
+        version_id: YDT8XN
+        url: https://semgrep.dev/playground/r/YDT8XN/python.lang.security.audit.ssl-wrap-socket-is-deprecated.ssl-wrap-socket-is-deprecated
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+  pattern: hashlib.md5(...)
+  message: Detected MD5 hash algorithm which is considered insecure. MD5 is not collision
+    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
+    or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B303
+    asvs:
+      section: V6 Stored Cryptography Verification Requirements
+      control_id: 6.2.2 Insecure Custom Algorithm
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x14-V6-Cryptography.md#v62-algorithms
+      version: '4'
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - python
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+    shortlink: https://sg.run/vYrY
+    semgrep.dev:
+      rule:
+        rule_id: PeU2e2
+        version_id: O9TZoR
+        url: https://semgrep.dev/playground/r/O9TZoR/python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+  severity: WARNING
+  languages:
+  - python
+- id: python.django.security.injection.open-redirect.open-redirect
+  message: Data from request ($DATA) is passed to redirect(). This is an open redirect
+    and could be exploited. Ensure you are redirecting to safe URLs by using django.utils.http.is_safe_url().
+    See https://cwe.mitre.org/data/definitions/601.html for more information.
+  metadata:
+    cwe:
+    - 'CWE-601: URL Redirection to Untrusted Site (''Open Redirect'')'
+    owasp:
+    - A01:2021 - Broken Access Control
+    references:
+    - https://www.djm.org.uk/posts/djangos-little-protections-word-redirect-dangers/
+    - https://github.com/django/django/blob/d1b7bd030b1db111e1a3505b1fc029ab964382cc/django/utils/http.py#L231
+    category: security
+    technology:
+    - django
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.open-redirect.open-redirect
+    shortlink: https://sg.run/Ave2
+    semgrep.dev:
+      rule:
+        rule_id: PeUZgr
+        version_id: JdTZJ6
+        url: https://semgrep.dev/playground/r/JdTZJ6/python.django.security.injection.open-redirect.open-redirect
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-not-inside: |
+      def $FUNC(...):
+        ...
+        django.utils.http.is_safe_url(...)
+        ...
+  - pattern-not-inside: |
+      def $FUNC(...):
+        ...
+        if <... django.utils.http.is_safe_url(...) ...>:
+          ...
+  - pattern-either:
+    - pattern: django.shortcuts.redirect(..., request.$W.get(...), ...)
+    - pattern: django.shortcuts.redirect(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: django.shortcuts.redirect(..., $S % request.$W.get(...), ...)
+    - pattern: django.shortcuts.redirect(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.shortcuts.redirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.shortcuts.redirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.shortcuts.redirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.shortcuts.redirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.shortcuts.redirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: $A = django.shortcuts.redirect(..., request.$W.get(...), ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S % request.$W.get(...), ...)
+    - pattern: $A = django.shortcuts.redirect(..., f"...{request.$W.get(...)}...",
+        ...)
+    - pattern: return django.shortcuts.redirect(..., request.$W.get(...), ...)
+    - pattern: return django.shortcuts.redirect(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: return django.shortcuts.redirect(..., $S % request.$W.get(...), ...)
+    - pattern: return django.shortcuts.redirect(..., f"...{request.$W.get(...)}...",
+        ...)
+    - pattern: django.shortcuts.redirect(..., request.$W(...), ...)
+    - pattern: django.shortcuts.redirect(..., $S.format(..., request.$W(...), ...),
+        ...)
+    - pattern: django.shortcuts.redirect(..., $S % request.$W(...), ...)
+    - pattern: django.shortcuts.redirect(..., f"...{request.$W(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.shortcuts.redirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.shortcuts.redirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.shortcuts.redirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.shortcuts.redirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.shortcuts.redirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: $A = django.shortcuts.redirect(..., request.$W(...), ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S.format(..., request.$W(...),
+        ...), ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S % request.$W(...), ...)
+    - pattern: $A = django.shortcuts.redirect(..., f"...{request.$W(...)}...", ...)
+    - pattern: return django.shortcuts.redirect(..., request.$W(...), ...)
+    - pattern: return django.shortcuts.redirect(..., $S.format(..., request.$W(...),
+        ...), ...)
+    - pattern: return django.shortcuts.redirect(..., $S % request.$W(...), ...)
+    - pattern: return django.shortcuts.redirect(..., f"...{request.$W(...)}...", ...)
+    - pattern: django.shortcuts.redirect(..., request.$W[...], ...)
+    - pattern: django.shortcuts.redirect(..., $S.format(..., request.$W[...], ...),
+        ...)
+    - pattern: django.shortcuts.redirect(..., $S % request.$W[...], ...)
+    - pattern: django.shortcuts.redirect(..., f"...{request.$W[...]}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.shortcuts.redirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.shortcuts.redirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.shortcuts.redirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.shortcuts.redirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.shortcuts.redirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: $A = django.shortcuts.redirect(..., request.$W[...], ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S.format(..., request.$W[...],
+        ...), ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S % request.$W[...], ...)
+    - pattern: $A = django.shortcuts.redirect(..., f"...{request.$W[...]}...", ...)
+    - pattern: return django.shortcuts.redirect(..., request.$W[...], ...)
+    - pattern: return django.shortcuts.redirect(..., $S.format(..., request.$W[...],
+        ...), ...)
+    - pattern: return django.shortcuts.redirect(..., $S % request.$W[...], ...)
+    - pattern: return django.shortcuts.redirect(..., f"...{request.$W[...]}...", ...)
+    - pattern: django.shortcuts.redirect(..., request.$W, ...)
+    - pattern: django.shortcuts.redirect(..., $S.format(..., request.$W, ...), ...)
+    - pattern: django.shortcuts.redirect(..., $S % request.$W, ...)
+    - pattern: django.shortcuts.redirect(..., f"...{request.$W}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.shortcuts.redirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.shortcuts.redirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.shortcuts.redirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.shortcuts.redirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.shortcuts.redirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.shortcuts.redirect(..., $INTERM, ...)
+    - pattern: $A = django.shortcuts.redirect(..., request.$W, ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S.format(..., request.$W, ...),
+        ...)
+    - pattern: $A = django.shortcuts.redirect(..., $S % request.$W, ...)
+    - pattern: $A = django.shortcuts.redirect(..., f"...{request.$W}...", ...)
+    - pattern: return django.shortcuts.redirect(..., request.$W, ...)
+    - pattern: return django.shortcuts.redirect(..., $S.format(..., request.$W, ...),
+        ...)
+    - pattern: return django.shortcuts.redirect(..., $S % request.$W, ...)
+    - pattern: return django.shortcuts.redirect(..., f"...{request.$W}...", ...)
+    - pattern: django.http.HttpResponseRedirect(..., request.$W.get(...), ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S % request.$W.get(...), ...)
+    - pattern: django.http.HttpResponseRedirect(..., f"...{request.$W.get(...)}...",
+        ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseRedirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseRedirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseRedirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseRedirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseRedirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., request.$W.get(...), ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S % request.$W.get(...),
+        ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., f"...{request.$W.get(...)}...",
+        ...)
+    - pattern: return django.http.HttpResponseRedirect(..., request.$W.get(...), ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S % request.$W.get(...),
+        ...)
+    - pattern: return django.http.HttpResponseRedirect(..., f"...{request.$W.get(...)}...",
+        ...)
+    - pattern: django.http.HttpResponseRedirect(..., request.$W(...), ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S.format(..., request.$W(...),
+        ...), ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S % request.$W(...), ...)
+    - pattern: django.http.HttpResponseRedirect(..., f"...{request.$W(...)}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseRedirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseRedirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseRedirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseRedirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseRedirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., request.$W(...), ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S.format(..., request.$W(...),
+        ...), ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S % request.$W(...), ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., f"...{request.$W(...)}...",
+        ...)
+    - pattern: return django.http.HttpResponseRedirect(..., request.$W(...), ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S.format(..., request.$W(...),
+        ...), ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S % request.$W(...),
+        ...)
+    - pattern: return django.http.HttpResponseRedirect(..., f"...{request.$W(...)}...",
+        ...)
+    - pattern: django.http.HttpResponseRedirect(..., request.$W[...], ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S.format(..., request.$W[...],
+        ...), ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S % request.$W[...], ...)
+    - pattern: django.http.HttpResponseRedirect(..., f"...{request.$W[...]}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseRedirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseRedirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseRedirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseRedirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseRedirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., request.$W[...], ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S.format(..., request.$W[...],
+        ...), ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S % request.$W[...], ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., f"...{request.$W[...]}...",
+        ...)
+    - pattern: return django.http.HttpResponseRedirect(..., request.$W[...], ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S.format(..., request.$W[...],
+        ...), ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S % request.$W[...],
+        ...)
+    - pattern: return django.http.HttpResponseRedirect(..., f"...{request.$W[...]}...",
+        ...)
+    - pattern: django.http.HttpResponseRedirect(..., request.$W, ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S.format(..., request.$W, ...),
+        ...)
+    - pattern: django.http.HttpResponseRedirect(..., $S % request.$W, ...)
+    - pattern: django.http.HttpResponseRedirect(..., f"...{request.$W}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseRedirect(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseRedirect(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseRedirect(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseRedirect(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseRedirect(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseRedirect(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., request.$W, ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S.format(..., request.$W,
+        ...), ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., $S % request.$W, ...)
+    - pattern: $A = django.http.HttpResponseRedirect(..., f"...{request.$W}...", ...)
+    - pattern: return django.http.HttpResponseRedirect(..., request.$W, ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S.format(..., request.$W,
+        ...), ...)
+    - pattern: return django.http.HttpResponseRedirect(..., $S % request.$W, ...)
+    - pattern: return django.http.HttpResponseRedirect(..., f"...{request.$W}...",
+        ...)
+  - metavariable-regex:
+      metavariable: $W
+      regex: (?!get_full_path)
+- id: python.flask.security.audit.debug-enabled.debug-enabled
+  patterns:
+  - pattern-inside: |
+      import flask
+      ...
+  - pattern: $APP.run(..., debug=True, ...)
+  message: Detected Flask app with debug=True. Do not deploy to production with this
+    flag enabled as it will leak sensitive information. Instead, consider using Flask
+    configuration variables or setting 'debug' using system environment variables.
+  metadata:
+    cwe:
+    - 'CWE-489: Active Debug Code'
+    owasp: A06:2017 - Security Misconfiguration
+    references:
+    - https://labs.detectify.com/2015/10/02/how-patreon-got-hacked-publicly-exposed-werkzeug-debugger/
+    category: security
+    technology:
+    - flask
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.audit.debug-enabled.debug-enabled
+    shortlink: https://sg.run/dKrd
+    semgrep.dev:
+      rule:
+        rule_id: gxU1bd
+        version_id: qkTPK2
+        url: https://semgrep.dev/playground/r/qkTPK2/python.flask.security.audit.debug-enabled.debug-enabled
+  severity: WARNING
+  languages:
+  - python
+- id: python.pyramid.audit.csrf-origin-check-disabled-globally.pyramid-csrf-origin-check-disabled-globally
+  patterns:
+  - pattern-inside: |
+      $CONFIG.set_default_csrf_options(..., check_origin=$CHECK_ORIGIN, ...)
+  - pattern: $CHECK_ORIGIN
+  - metavariable-comparison:
+      metavariable: $CHECK_ORIGIN
+      comparison: $CHECK_ORIGIN == False
+  message: Automatic check of the referrer for cross-site request forgery tokens has
+    been explicitly disabled globally, which might leave views unprotected when an
+    unsafe CSRF storage policy is used. Use 'pyramid.config.Configurator.set_default_csrf_options(check_origin=True)'
+    to turn the automatic check for all unsafe methods (per RFC2616).
+  languages:
+  - python
+  severity: ERROR
+  fix: |
+    True
+  metadata:
+    cwe:
+    - 'CWE-352: Cross-Site Request Forgery (CSRF)'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.csrf-origin-check-disabled-globally.pyramid-csrf-origin-check-disabled-globally
+    shortlink: https://sg.run/3GeW
+    semgrep.dev:
+      rule:
+        rule_id: eqU9Le
+        version_id: YDTzqN
+        url: https://semgrep.dev/playground/r/YDTzqN/python.pyramid.audit.csrf-origin-check-disabled-globally.pyramid-csrf-origin-check-disabled-globally
+- id: python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response
+  message: Detected data rendered directly to the end user via 'Response'. This bypasses
+    Pyramid's built-in cross-site scripting (XSS) defenses and could result in an
+    XSS vulnerability. Use Pyramid's template engines to safely render HTML.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response
+    shortlink: https://sg.run/DX8G
+    semgrep.dev:
+      rule:
+        rule_id: gxUeA8
+        version_id: 9lTEQy
+        url: https://semgrep.dev/playground/r/9lTEQy/python.pyramid.security.direct-use-of-response.pyramid-direct-use-of-response
+  languages:
+  - python
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-inside: |
+        @pyramid.view.view_config( ... )
+        def $VIEW($REQ):
+          ...
+    - pattern: $REQ.$ANYTHING
+    - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          pyramid.request.Response.text($SINK)
+      - pattern: |
+          pyramid.request.Response($SINK)
+      - pattern: |
+          $REQ.response.body = $SINK
+      - pattern: |
+          $REQ.response.text = $SINK
+      - pattern: |
+          $REQ.response.ubody = $SINK
+      - pattern: |
+          $REQ.response.unicode_body = $SINK
+    - pattern: $SINK
+- id: python.pyramid.audit.authtkt-cookie-secure-unsafe-default.pyramid-authtkt-cookie-secure-unsafe-default
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern-not: pyramid.authentication.AuthTktCookieHelper(..., secure=$SECURE,
+          ...)
+      - pattern-not: pyramid.authentication.AuthTktCookieHelper(..., **$PARAMS)
+      - pattern: pyramid.authentication.AuthTktCookieHelper(...)
+    - patterns:
+      - pattern-not: pyramid.authentication.AuthTktAuthenticationPolicy(..., secure=$SECURE,
+          ...)
+      - pattern-not: pyramid.authentication.AuthTktAuthenticationPolicy(..., **$PARAMS)
+      - pattern: pyramid.authentication.AuthTktAuthenticationPolicy(...)
+  fix-regex:
+    regex: (.*)\)
+    replacement: \1, secure=True)
+  message: Found a Pyramid Authentication Ticket cookie using an unsafe default for
+    the secure option. Pyramid cookies should be handled securely by setting secure=True.
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-614: Sensitive Cookie in HTTPS Session Without ''Secure'' Attribute'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.authtkt-cookie-secure-unsafe-default.pyramid-authtkt-cookie-secure-unsafe-default
+    shortlink: https://sg.run/8WxQ
+    semgrep.dev:
+      rule:
+        rule_id: wdUKzn
+        version_id: K3TONN
+        url: https://semgrep.dev/playground/r/K3TONN/python.pyramid.audit.authtkt-cookie-secure-unsafe-default.pyramid-authtkt-cookie-secure-unsafe-default
+  languages:
+  - python
+  severity: WARNING
+- id: python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
+  message: Detected RC2 cipher algorithm which is considered insecure. This algorithm
+    is not cryptographically secure and can be reversed easily. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://cwe.mitre.org/data/definitions/326.html
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
+    shortlink: https://sg.run/nAbY
+    semgrep.dev:
+      rule:
+        rule_id: GdUYlW
+        version_id: gET59j
+        url: https://semgrep.dev/playground/r/gET59j/python.pycryptodome.security.insecure-cipher-algorithm-rc2.insecure-cipher-algorithm-rc2
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Cryptodome.Cipher.ARC2.new(...)
+  - pattern: Crypto.Cipher.ARC2.new(...)
+- id: python.django.security.injection.ssrf.ssrf-injection-urllib.ssrf-injection-urllib
+  message: Data from request object is passed to a new server-side request. This could
+    lead to a server-side request forgery (SSRF), which could result in attackers
+    gaining access to private organization data. To mitigate, ensure that schemes
+    and hosts are validated against an allowlist, do not forward the response to the
+    user, and ensure proper authentication and transport-layer security in the proxied
+    request.
+  metadata:
+    cwe:
+    - 'CWE-918: Server-Side Request Forgery (SSRF)'
+    owasp:
+    - A10:2021 - Server-Side Request Forgery (SSRF)
+    references:
+    - https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.ssrf.ssrf-injection-urllib.ssrf-injection-urllib
+    shortlink: https://sg.run/6n2B
+    semgrep.dev:
+      rule:
+        rule_id: 10UKDo
+        version_id: 5PTYvx
+        url: https://semgrep.dev/playground/r/5PTYvx/python.django.security.injection.ssrf.ssrf-injection-urllib.ssrf-injection-urllib
+  languages:
+  - python
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: urllib.request.urlopen(..., $S.format(..., request.$W.get(...), ...),
+        ...)
+    - pattern: urllib.request.urlopen(..., $S % request.$W.get(...), ...)
+    - pattern: urllib.request.urlopen(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: urllib.request.urlopen(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        urllib.request.urlopen(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        urllib.request.urlopen(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        urllib.request.urlopen(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        urllib.request.urlopen(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        urllib.request.urlopen(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: $A = urllib.request.urlopen(..., request.$W.get(...), ...)
+    - pattern: return urllib.request.urlopen(..., request.$W.get(...), ...)
+    - pattern: urllib.request.urlopen(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: urllib.request.urlopen(..., $S % request.$W(...), ...)
+    - pattern: urllib.request.urlopen(..., f"...{request.$W(...)}...", ...)
+    - pattern: urllib.request.urlopen(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        urllib.request.urlopen(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        urllib.request.urlopen(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        urllib.request.urlopen(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        urllib.request.urlopen(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        urllib.request.urlopen(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: $A = urllib.request.urlopen(..., request.$W(...), ...)
+    - pattern: return urllib.request.urlopen(..., request.$W(...), ...)
+    - pattern: urllib.request.urlopen(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: urllib.request.urlopen(..., $S % request.$W[...], ...)
+    - pattern: urllib.request.urlopen(..., f"...{request.$W[...]}...", ...)
+    - pattern: urllib.request.urlopen(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        urllib.request.urlopen(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        urllib.request.urlopen(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        urllib.request.urlopen(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        urllib.request.urlopen(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        urllib.request.urlopen(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: $A = urllib.request.urlopen(..., request.$W[...], ...)
+    - pattern: return urllib.request.urlopen(..., request.$W[...], ...)
+    - pattern: urllib.request.urlopen(..., $S.format(..., request.$W, ...), ...)
+    - pattern: urllib.request.urlopen(..., $S % request.$W, ...)
+    - pattern: urllib.request.urlopen(..., f"...{request.$W}...", ...)
+    - pattern: urllib.request.urlopen(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        urllib.request.urlopen(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        urllib.request.urlopen(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        urllib.request.urlopen(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        urllib.request.urlopen(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        urllib.request.urlopen(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        urllib.request.urlopen(..., $INTERM, ...)
+    - pattern: $A = urllib.request.urlopen(..., request.$W, ...)
+    - pattern: return urllib.request.urlopen(..., request.$W, ...)
+- id: python.lang.security.dangerous-subprocess-use.dangerous-subprocess-use
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+          - patterns:
+            - pattern-inside: |
+                @$APP.route(...)
+                def $FUNC(..., $ROUTEVAR, ...):
+                  ...
+            - pattern: $ROUTEVAR
+      - patterns:
+        - pattern-inside: |
+            def $FUNC(request, ...):
+              ...
+        - pattern-either:
+          - pattern: request.$PROPERTY.get(...)
+          - pattern: request.$PROPERTY[...]
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              @rest_framework.decorators.api_view(...)
+              def $FUNC($REQ, ...):
+                ...
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  class $VIEW(..., rest_framework.views.APIView, ...):
+                    ...
+              - pattern-inside: "class $VIEW(..., rest_framework.generics.GenericAPIView,
+                  ...):\n  ...                              \n"
+            - pattern-inside: |
+                def $METHOD(self, $REQ, ...):
+                  ...
+            - metavariable-regex:
+                metavariable: $METHOD
+                regex: (get|post|put|patch|delete|head)
+        - pattern-either:
+          - pattern: $REQ.POST.get(...)
+          - pattern: $REQ.POST[...]
+          - pattern: $REQ.FILES.get(...)
+          - pattern: $REQ.FILES[...]
+          - pattern: $REQ.DATA.get(...)
+          - pattern: $REQ.DATA[...]
+          - pattern: $REQ.QUERY_PARAMS.get(...)
+          - pattern: $REQ.QUERY_PARAMS[...]
+          - pattern: $REQ.data.get(...)
+          - pattern: $REQ.data[...]
+          - pattern: $REQ.query_params.get(...)
+          - pattern: $REQ.query_params[...]
+          - pattern: $REQ.content_type
+          - pattern: $REQ.content_type
+          - pattern: $REQ.stream
+          - pattern: $REQ.stream
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              class $SERVER(..., http.server.BaseHTTPRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.StreamRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.DatagramRequestHandler, ...):
+                ...
+        - pattern-either:
+          - pattern: self.requestline
+          - pattern: self.path
+          - pattern: self.headers[...]
+          - pattern: self.headers.get(...)
+          - pattern: self.rfile
+      - patterns:
+        - pattern-inside: |
+            @pyramid.view.view_config( ... )
+            def $VIEW($REQ):
+              ...
+        - pattern: $REQ.$ANYTHING
+        - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-not: subprocess.$FUNC("...", ...)
+        - pattern-not: subprocess.$FUNC(["...",...], ...)
+        - pattern-not: subprocess.$FUNC(("...",...), ...)
+        - pattern-not: subprocess.CalledProcessError(...)
+        - pattern-not: subprocess.SubprocessError(...)
+        - pattern: subprocess.$FUNC($CMD, ...)
+      - patterns:
+        - pattern-not: subprocess.$FUNC("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c","...",...)
+        - pattern: subprocess.$FUNC("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c", $CMD)
+      - patterns:
+        - pattern-not: subprocess.$FUNC(["=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c","...",...],...)
+        - pattern-not: subprocess.$FUNC(("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c","...",...),...)
+        - pattern-either:
+          - pattern: subprocess.$FUNC(["=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c", $CMD],
+              ...)
+          - pattern: subprocess.$FUNC(("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c", $CMD),
+              ...)
+      - patterns:
+        - pattern-not: subprocess.$FUNC("=~/(python)/","...",...)
+        - pattern: subprocess.$FUNC("=~/(python)/", $CMD)
+      - patterns:
+        - pattern-not: subprocess.$FUNC(["=~/(python)/","...",...],...)
+        - pattern-not: subprocess.$FUNC(("=~/(python)/","...",...),...)
+        - pattern-either:
+          - pattern: subprocess.$FUNC(["=~/(python)/", $CMD],...)
+          - pattern: subprocess.$FUNC(("=~/(python)/", $CMD),...)
+    - focus-metavariable: $CMD
+  message: Detected subprocess function '$FUNC' with user controlled data. A malicious
+    actor could leverage this to perform command injection. You may consider using
+    'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
+    - https://docs.python.org/3/library/subprocess.html
+    - https://docs.python.org/3/library/shlex.html
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.dangerous-subprocess-use.dangerous-subprocess-use
+    shortlink: https://sg.run/NWxp
+    semgrep.dev:
+      rule:
+        rule_id: JDUz3R
+        version_id: X0Tekk
+        url: https://semgrep.dev/playground/r/X0Tekk/python.lang.security.dangerous-subprocess-use.dangerous-subprocess-use
+  languages:
+  - python
+  severity: ERROR
+- id: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
+  pattern: |
+    jwt.decode(..., verify=False, ...)
+  message: Detected JWT token decoded with 'verify=False'. This bypasses any integrity
+    checks for the token which means the token could be tampered with by malicious
+    actors. Ensure that the JWT token is verified.
+  metadata:
+    owasp:
+    - A02:2017 - Broken Authentication
+    - A07:2021 - Identification and Authentication Failures
+    cwe:
+    - 'CWE-287: Improper Authentication'
+    references:
+    - https://github.com/we45/Vulnerable-Flask-App/blob/752ee16087c0bfb79073f68802d907569a1f0df7/app/app.py#L96
+    category: security
+    technology:
+    - jwt
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
+    shortlink: https://sg.run/6nyB
+    semgrep.dev:
+      rule:
+        rule_id: 10UKjo
+        version_id: A8TnR1
+        url: https://semgrep.dev/playground/r/A8TnR1/python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
+  fix-regex:
+    regex: (verify\s*=\s*)False
+    replacement: \1True
+  severity: ERROR
+  languages:
+  - python
+- id: python.lang.security.dangerous-code-run.dangerous-interactive-code-run
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+          - patterns:
+            - pattern-inside: |
+                @$APP.route(...)
+                def $FUNC(..., $ROUTEVAR, ...):
+                  ...
+            - pattern: $ROUTEVAR
+      - patterns:
+        - pattern-inside: |
+            def $FUNC(request, ...):
+              ...
+        - pattern-either:
+          - pattern: request.$PROPERTY.get(...)
+          - pattern: request.$PROPERTY[...]
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              @rest_framework.decorators.api_view(...)
+              def $FUNC($REQ, ...):
+                ...
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  class $VIEW(..., rest_framework.views.APIView, ...):
+                    ...
+              - pattern-inside: "class $VIEW(..., rest_framework.generics.GenericAPIView,
+                  ...):\n  ...                              \n"
+            - pattern-inside: |
+                def $METHOD(self, $REQ, ...):
+                  ...
+            - metavariable-regex:
+                metavariable: $METHOD
+                regex: (get|post|put|patch|delete|head)
+        - pattern-either:
+          - pattern: $REQ.POST.get(...)
+          - pattern: $REQ.POST[...]
+          - pattern: $REQ.FILES.get(...)
+          - pattern: $REQ.FILES[...]
+          - pattern: $REQ.DATA.get(...)
+          - pattern: $REQ.DATA[...]
+          - pattern: $REQ.QUERY_PARAMS.get(...)
+          - pattern: $REQ.QUERY_PARAMS[...]
+          - pattern: $REQ.data.get(...)
+          - pattern: $REQ.data[...]
+          - pattern: $REQ.query_params.get(...)
+          - pattern: $REQ.query_params[...]
+          - pattern: $REQ.content_type
+          - pattern: $REQ.content_type
+          - pattern: $REQ.stream
+          - pattern: $REQ.stream
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              class $SERVER(..., http.server.BaseHTTPRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.StreamRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.DatagramRequestHandler, ...):
+                ...
+        - pattern-either:
+          - pattern: self.requestline
+          - pattern: self.path
+          - pattern: self.headers[...]
+          - pattern: self.headers.get(...)
+          - pattern: self.rfile
+      - patterns:
+        - pattern-inside: |
+            @pyramid.view.view_config( ... )
+            def $VIEW($REQ):
+              ...
+        - pattern: $REQ.$ANYTHING
+        - pattern-not: $REQ.dbsession
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern-inside: |
+          $X = code.InteractiveConsole(...)
+          ...
+      - pattern-inside: |
+          $X = code.InteractiveInterpreter(...)
+          ...
+    - pattern-either:
+      - pattern-inside: |
+          $X.push($PAYLOAD,...)
+      - pattern-inside: |
+          $X.runsource($PAYLOAD,...)
+      - pattern-inside: |
+          $X.runcode(code.compile_command($PAYLOAD),...)
+      - pattern-inside: |
+          $PL = code.compile_command($PAYLOAD,...)
+          ...
+          $X.runcode($PL,...)
+    - pattern: $PAYLOAD
+    - pattern-not: |
+        $X.push("...",...)
+    - pattern-not: |
+        $X.runsource("...",...)
+    - pattern-not: |
+        $X.runcode(code.compile_command("..."),...)
+    - pattern-not: |
+        $PL = code.compile_command("...",...)
+        ...
+        $X.runcode($PL,...)
+  message: Found user controlled data inside InteractiveConsole/InteractiveInterpreter
+    method. This is dangerous if external data can reach this function call because
+    it allows a malicious actor to run arbitrary Python code.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.dangerous-code-run.dangerous-interactive-code-run
+    shortlink: https://sg.run/9pRY
+    semgrep.dev:
+      rule:
+        rule_id: KxUKzx
+        version_id: 2KT6WP
+        url: https://semgrep.dev/playground/r/2KT6WP/python.lang.security.dangerous-code-run.dangerous-interactive-code-run
+  severity: WARNING
+  languages:
+  - python
+- id: python.flask.security.injection.user-eval.eval-injection
+  languages:
+  - python
+  severity: ERROR
+  message: Detected user data flowing into eval. This is code injection and should
+    be avoided.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+    category: security
+    technology:
+    - flask
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.user-eval.eval-injection
+    shortlink: https://sg.run/5QpX
+    semgrep.dev:
+      rule:
+        rule_id: 0oU54W
+        version_id: O9TZyD
+        url: https://semgrep.dev/playground/r/O9TZyD/python.flask.security.injection.user-eval.eval-injection
+  pattern-either:
+  - patterns:
+    - pattern: eval(...)
+    - pattern-either:
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            eval(..., <... $ROUTEVAR ...>, ...)
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            $INTERM = <... $ROUTEVAR ...>
+            ...
+            eval(..., <... $INTERM ...>, ...)
+  - pattern: eval(..., <... flask.request.$W.get(...) ...>, ...)
+  - pattern: eval(..., <... flask.request.$W[...] ...>, ...)
+  - pattern: eval(..., <... flask.request.$W(...) ...>, ...)
+  - pattern: eval(..., <... flask.request.$W ...>, ...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)
+- id: python.aws-lambda.security.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $CMD
+    - pattern-either:
+      - pattern-inside: asyncio.create_subprocess_exec($PROG, $CMD, ...)
+      - pattern-inside: asyncio.create_subprocess_exec($PROG, [$CMD, ...], ...)
+      - pattern-inside: asyncio.subprocess.create_subprocess_exec($PROG, $CMD, ...)
+      - pattern-inside: asyncio.subprocess.create_subprocess_exec($PROG, [$CMD, ...],
+          ...)
+      - pattern-inside: asyncio.create_subprocess_exec($PROG, "=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", $CMD, ...)
+      - pattern-inside: asyncio.create_subprocess_exec($PROG, ["=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", $CMD, ...], ...)
+      - pattern-inside: asyncio.subprocess.create_subprocess_exec($PROG, "=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", $CMD, ...)
+      - pattern-inside: asyncio.subprocess.create_subprocess_exec($PROG, ["=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", $CMD, ...], ...)
+  message: Detected 'create_subprocess_exec' function with argument tainted by `event`
+    object. If this data can be controlled by a malicious actor, it may be an instance
+    of command injection. Audit the use of this call to ensure it is not controllable
+    by an external resource. You may consider using 'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.create_subprocess_exec
+    - https://docs.python.org/3/library/shlex.html
+    category: security
+    technology:
+    - python
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.aws-lambda.security.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec
+    shortlink: https://sg.run/oyv0
+    semgrep.dev:
+      rule:
+        rule_id: EwUrX8
+        version_id: 1QTXlr
+        url: https://semgrep.dev/playground/r/1QTXlr/python.aws-lambda.security.dangerous-asyncio-create-exec.dangerous-asyncio-create-exec
+  languages:
+  - python
+  severity: ERROR
+- id: python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+  patterns:
+  - pattern-either:
+    - pattern: cryptography.hazmat.primitives.asymmetric.dsa.generate_private_key(...,
+        key_size=$SIZE, ...)
+    - pattern: cryptography.hazmat.primitives.asymmetric.dsa.generate_private_key($SIZE,
+        ...)
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
+  message: Detected an insufficient key size for DSA. NIST recommends a key size of
+    2048 or higher.
+  metadata:
+    cwe:
+    - 'CWE-326: Inadequate Encryption Strength'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+    shortlink: https://sg.run/5Qb0
+    semgrep.dev:
+      rule:
+        rule_id: KxUb0x
+        version_id: JdTZd6
+        url: https://semgrep.dev/playground/r/JdTZd6/python.cryptography.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+  languages:
+  - python
+  severity: WARNING
+- id: python.sqlalchemy.security.sqlalchemy-sql-injection.sqlalchemy-sql-injection
+  patterns:
+  - pattern-either:
+    - pattern: |
+        def $FUNC(...,$VAR,...):
+          ...
+          $SESSION.query(...).$SQLFUNC("...".$FORMATFUNC(...,$VAR,...))
+    - pattern: |
+        def $FUNC(...,$VAR,...):
+          ...
+          $SESSION.query.join(...).$SQLFUNC("...".$FORMATFUNC(...,$VAR,...))
+    - pattern: |
+        def $FUNC(...,$VAR,...):
+          ...
+          $SESSION.query.$SQLFUNC("...".$FORMATFUNC(...,$VAR,...))
+    - pattern: |
+        def $FUNC(...,$VAR,...):
+          ...
+          query.$SQLFUNC("...".$FORMATFUNC(...,$VAR,...))
+  - metavariable-regex:
+      metavariable: $SQLFUNC
+      regex: (group_by|order_by|distinct|having|filter)
+  - metavariable-regex:
+      metavariable: $FORMATFUNC
+      regex: (?!bindparams)
+  message: Distinct, Having, Group_by, Order_by, and Filter in SQLAlchemy can cause
+    sql injections if the developer inputs raw SQL into the before-mentioned clauses.
+    This pattern captures relevant cases in which the developer inputs raw SQL into
+    the distinct, having, group_by, order_by or filter clauses and injects user-input
+    into the raw SQL with any function besides "bindparams". Use bindParams to securely
+    bind user-input to SQL statements.
+  fix-regex:
+    regex: format
+    replacement: bindparams
+  languages:
+  - python
+  severity: WARNING
+  metadata:
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    category: security
+    technology:
+    - sqlalchemy
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.sqlalchemy.security.sqlalchemy-sql-injection.sqlalchemy-sql-injection
+    shortlink: https://sg.run/J3Xo
+    semgrep.dev:
+      rule:
+        rule_id: BYUBWo
+        version_id: xyT9Lw
+        url: https://semgrep.dev/playground/r/xyT9Lw/python.sqlalchemy.security.sqlalchemy-sql-injection.sqlalchemy-sql-injection
+- id: python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+  patterns:
+  - pattern: cryptography.hazmat.primitives.hashes.$SHA(...)
+  - metavariable-pattern:
+      metavariable: $SHA
+      pattern: |
+        SHA1
+  - focus-metavariable: $SHA
+  fix: |
+    SHA256
+  message: Detected SHA1 hash algorithm which is considered insecure. SHA1 is not
+    collision resistant and is therefore not suitable as a cryptographic signature.
+    Use SHA256 or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B303
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    shortlink: https://sg.run/J9Qy
+    semgrep.dev:
+      rule:
+        rule_id: 0oU5dN
+        version_id: DkToXW
+        url: https://semgrep.dev/playground/r/DkToXW/python.cryptography.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+  severity: WARNING
+  languages:
+  - python
+- id: python.lang.security.audit.dangerous-asyncio-exec-tainted-env-args.dangerous-asyncio-exec-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - pattern-either:
+    - patterns:
+      - pattern-not: $LOOP.subprocess_exec($PROTOCOL, "...", ...)
+      - pattern-not: $LOOP.subprocess_exec($PROTOCOL, ["...",...], ...)
+      - pattern: $LOOP.subprocess_exec(...)
+    - patterns:
+      - pattern-not: $LOOP.subprocess_exec($PROTOCOL, "=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", "...", ...)
+      - pattern: $LOOP.subprocess_exec($PROTOCOL, "=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c",...)
+    - patterns:
+      - pattern-not: $LOOP.subprocess_exec($PROTOCOL, ["=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", "...", ...], ...)
+      - pattern: $LOOP.subprocess_exec($PROTOCOL, ["=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", ...], ...)
+  message: Detected subprocess function '$LOOP.subprocess_exec' with user controlled
+    data. You may consider using 'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.subprocess_exec
+    - https://docs.python.org/3/library/shlex.html
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-asyncio-exec-tainted-env-args.dangerous-asyncio-exec-tainted-env-args
+    shortlink: https://sg.run/Apjp
+    semgrep.dev:
+      rule:
+        rule_id: 7KUE1E
+        version_id: qkTKND
+        url: https://semgrep.dev/playground/r/qkTKND/python.lang.security.audit.dangerous-asyncio-exec-tainted-env-args.dangerous-asyncio-exec-tainted-env-args
+  languages:
+  - python
+  severity: ERROR
+- id: python.pycryptodome.security.insecure-hash-algorithm.insecure-hash-algorithm-sha1
+  message: Detected SHA1 hash algorithm which is considered insecure. SHA1 is not
+    collision resistant and is therefore not suitable as a cryptographic signature.
+    Use SHA256 or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-hash-algorithm.insecure-hash-algorithm-sha1
+    shortlink: https://sg.run/3ALr
+    semgrep.dev:
+      rule:
+        rule_id: ReUPO3
+        version_id: 5PTYnG
+        url: https://semgrep.dev/playground/r/5PTYnG/python.pycryptodome.security.insecure-hash-algorithm.insecure-hash-algorithm-sha1
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Crypto.Hash.SHA.new(...)
+  - pattern: Cryptodome.Hash.SHA.new (...)
+- id: python.aws-lambda.security.tainted-html-response.tainted-html-response
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $BODY
+    - pattern-inside: |
+        {..., "headers": {..., "Content-Type": "text/html", ...}, "body": $BODY, ... }
+  message: Detected user input flowing into an HTML response. You may be accidentally
+    bypassing secure methods of rendering HTML by manually constructing HTML and this
+    could create a cross-site scripting vulnerability, which could let attackers steal
+    sensitive user data.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - aws-lambda
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.tainted-html-response.tainted-html-response
+    shortlink: https://sg.run/k9vP
+    semgrep.dev:
+      rule:
+        rule_id: ReUKrk
+        version_id: ZRTyrw
+        url: https://semgrep.dev/playground/r/ZRTyrw/python.aws-lambda.security.tainted-html-response.tainted-html-response
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.audit.dangerous-subinterpreters-run-string-tainted-env-args.dangerous-subinterpreters-run-string-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-inside: |
+        _xxsubinterpreters.run_string($ID, $PAYLOAD, ...)
+    - pattern-not: |
+        _xxsubinterpreters.run_string($ID, "...", ...)
+    - pattern: $PAYLOAD
+  message: Found user controlled content in `run_string`. This is dangerous because
+    it allows a malicious actor to run arbitrary Python code.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://bugs.python.org/issue43472
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-subinterpreters-run-string-tainted-env-args.dangerous-subinterpreters-run-string-tainted-env-args
+    shortlink: https://sg.run/oLl9
+    semgrep.dev:
+      rule:
+        rule_id: GdUkxO
+        version_id: 1QTXjj
+        url: https://semgrep.dev/playground/r/1QTXjj/python.lang.security.audit.dangerous-subinterpreters-run-string-tainted-env-args.dangerous-subinterpreters-run-string-tainted-env-args
+  severity: WARNING
+  languages:
+  - python
+- id: python.aws-lambda.security.psycopg-sqli.psycopg-sqli
+  languages:
+  - python
+  message: 'Detected SQL statement that is tainted by `event` object. This could lead
+    to SQL injection if the variable is user-controlled and not properly sanitized.
+    In order to prevent SQL injection, used parameterized queries or prepared statements
+    instead. You can use parameterized statements like so: `cursor.execute(''SELECT
+    * FROM projects WHERE status = %s'', ''active'')`'
+  mode: taint
+  metadata:
+    references:
+    - https://www.psycopg.org/docs/cursor.html#cursor.execute
+    - https://www.psycopg.org/docs/cursor.html#cursor.executemany
+    - https://www.psycopg.org/docs/cursor.html#cursor.mogrify
+    category: security
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    technology:
+    - aws-lambda
+    - psycopg
+    - psycopg2
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.psycopg-sqli.psycopg-sqli
+    shortlink: https://sg.run/9L8r
+    semgrep.dev:
+      rule:
+        rule_id: 4bUQG1
+        version_id: xyT3oz
+        url: https://semgrep.dev/playground/r/xyT3oz/python.aws-lambda.security.psycopg-sqli.psycopg-sqli
+  pattern-sinks:
+  - patterns:
+    - pattern: $QUERY
+    - pattern-either:
+      - pattern-inside: $CURSOR.execute($QUERY,...)
+      - pattern-inside: $CURSOR.executemany($QUERY,...)
+      - pattern-inside: $CURSOR.mogrify($QUERY,...)
+    - pattern-inside: |
+        import psycopg2
+        ...
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  severity: WARNING
+- id: python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret
+  message: 'Hardcoded JWT secret or private key is used. This is a Insufficiently
+    Protected Credentials weakness: https://cwe.mitre.org/data/definitions/522.html
+    Consider using an appropriate security mechanism to protect the credentials (e.g.
+    keeping secrets in environment variables)'
+  metadata:
+    cwe:
+    - 'CWE-522: Insufficiently Protected Credentials'
+    owasp:
+    - A02:2017 - Broken Authentication
+    - A04:2021 - Insecure Design
+    references:
+    - https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    category: security
+    technology:
+    - jwt
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret
+    shortlink: https://sg.run/l2E9
+    semgrep.dev:
+      rule:
+        rule_id: X5U8P5
+        version_id: GxTW2b
+        url: https://semgrep.dev/playground/r/GxTW2b/python.jwt.security.jwt-hardcode.jwt-python-hardcoded-secret
+  patterns:
+  - pattern: |
+      jwt.encode($X, $SECRET, ...)
+  - focus-metavariable: $SECRET
+  - pattern: |
+      "..."
+  languages:
+  - python
+  severity: ERROR
+- id: python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+  pattern: hashlib.sha1(...)
+  fix-regex:
+    regex: sha1
+    replacement: sha256
+  message: Detected SHA1 hash algorithm which is considered insecure. SHA1 is not
+    collision resistant and is therefore not suitable as a cryptographic signature.
+    Use SHA256 or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B303
+    asvs:
+      section: V6 Stored Cryptography Verification Requirements
+      control_id: 6.2.2 Insecure Custom Algorithm
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x14-V6-Cryptography.md#v62-algorithms
+      version: '4'
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - python
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+    shortlink: https://sg.run/ydYx
+    semgrep.dev:
+      rule:
+        rule_id: x8UnBk
+        version_id: e1TA7A
+        url: https://semgrep.dev/playground/r/e1TA7A/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+  severity: WARNING
+  languages:
+  - python
+- id: python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
+  message: Detected Flask route directly returning a formatted string. This is subject
+    to cross-site scripting if user input can reach the string. Consider using the
+    template engine instead and rendering pages with 'render_template()'.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - flask
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
+    shortlink: https://sg.run/Zv6o
+    semgrep.dev:
+      rule:
+        rule_id: QrUz49
+        version_id: YDT839
+        url: https://semgrep.dev/playground/r/YDT839/python.flask.security.audit.directly-returned-format-string.directly-returned-format-string
+  languages:
+  - python
+  severity: WARNING
+  mode: taint
+  pattern-sources:
+  - pattern-either:
+    - patterns:
+      - pattern-inside: |
+          @$APP.route(...)
+          def $FUNC(..., $PARAM, ...):
+            ...
+      - pattern: $PARAM
+    - pattern: |
+        request.$FUNC.get(...)
+    - pattern: |
+        request.$FUNC(...)
+    - pattern: request.$FUNC[...]
+  pattern-sinks:
+  - patterns:
+    - pattern-not-inside: return "..."
+    - pattern-either:
+      - pattern: return "...".format(...)
+      - pattern: return "..." % ...
+      - pattern: return "..." + ...
+      - pattern: return ... + "..."
+      - pattern: return f"...{...}..."
+      - patterns:
+        - pattern: return $X
+        - pattern-either:
+          - pattern-inside: |
+              $X = "...".format(...)
+              ...
+          - pattern-inside: |
+              $X = "..." % ...
+              ...
+          - pattern-inside: |
+              $X = "..." + ...
+              ...
+          - pattern-inside: |
+              $X = ... + "..."
+              ...
+          - pattern-inside: |
+              $X = f"...{...}..."
+              ...
+        - pattern-not-inside: |
+            $X = "..."
+            ...
+- id: python.aws-lambda.security.pymssql-sqli.pymssql-sqli
+  languages:
+  - python
+  message: 'Detected SQL statement that is tainted by `event` object. This could lead
+    to SQL injection if the variable is user-controlled and not properly sanitized.
+    In order to prevent SQL injection, used parameterized queries or prepared statements
+    instead. You can use parameterized statements like so: `cursor.execute(''SELECT
+    * FROM projects WHERE status = %s'', ''active'')`'
+  mode: taint
+  metadata:
+    references:
+    - https://pypi.org/project/pymssql/
+    category: security
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    technology:
+    - aws-lambda
+    - pymssql
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.pymssql-sqli.pymssql-sqli
+    shortlink: https://sg.run/yXvP
+    semgrep.dev:
+      rule:
+        rule_id: PeUxO0
+        version_id: O9TZYb
+        url: https://semgrep.dev/playground/r/O9TZYb/python.aws-lambda.security.pymssql-sqli.pymssql-sqli
+  pattern-sinks:
+  - patterns:
+    - pattern: $QUERY
+    - pattern-inside: $CURSOR.execute($QUERY,...)
+    - pattern-inside: |
+        import pymssql
+        ...
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  severity: WARNING
+- id: python.django.security.passwords.password-empty-string.password-empty-string
+  message: '''$VAR'' is the empty string and is being used to set the password on
+    ''$MODEL''. If you meant to set an unusable password, set the password to None
+    or call ''set_unusable_password()''.'
+  metadata:
+    cwe:
+    - 'CWE-521: Weak Password Requirements'
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#django.contrib.auth.models.User.set_password
+    category: security
+    technology:
+    - django
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.passwords.password-empty-string.password-empty-string
+    shortlink: https://sg.run/oxnR
+    semgrep.dev:
+      rule:
+        rule_id: 9AU1jW
+        version_id: DkTeOP
+        url: https://semgrep.dev/playground/r/DkTeOP/python.django.security.passwords.password-empty-string.password-empty-string
+  patterns:
+  - pattern-either:
+    - pattern: |
+        $MODEL.set_password($EMPTY)
+        ...
+        $MODEL.save()
+    - pattern: |
+        $VAR = $EMPTY
+        ...
+        $MODEL.set_password($VAR)
+        ...
+        $MODEL.save()
+  - metavariable-regex:
+      metavariable: $EMPTY
+      regex: (\'\'|\"\")
+  languages:
+  - python
+  severity: ERROR
+- id: python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled
+  message: Origin check for the CSRF token is disabled for this view. This might represent
+    a security risk if the CSRF storage policy is not known to be secure.
+  metadata:
+    cwe:
+    - 'CWE-352: Cross-Site Request Forgery (CSRF)'
+    owasp:
+    - A01:2021 - Broken Access Control
+    asvs:
+      section: V4 Access Control
+      control_id: 4.2.2 CSRF
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x12-V4-Access-Control.md#v42-operation-level-access-control
+      version: '4'
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled
+    shortlink: https://sg.run/4RB9
+    semgrep.dev:
+      rule:
+        rule_id: v8UGpL
+        version_id: 6xTAb5
+        url: https://semgrep.dev/playground/r/6xTAb5/python.pyramid.audit.csrf-origin-check-disabled.pyramid-csrf-origin-check-disabled
+  severity: WARNING
+  languages:
+  - python
+  patterns:
+  - pattern-inside: |
+      from pyramid.view import view_config
+      ...
+      @view_config(..., check_origin=$CHECK_ORIGIN, ...)
+      def $VIEW(...):
+        ...
+  - pattern: $CHECK_ORIGIN
+  - metavariable-comparison:
+      metavariable: $CHECK_ORIGIN
+      comparison: $CHECK_ORIGIN == False
+  fix: |
+    True
+- id: python.django.security.injection.reflected-data-httpresponsebadrequest.reflected-data-httpresponsebadrequest
+  message: Found user-controlled request data passed into a HttpResponseBadRequest.
+    This could be vulnerable to XSS, leading to attackers gaining access to user cookies
+    and protected information. Ensure that the request data is properly escaped or
+    sanitzed.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    references:
+    - https://django-book.readthedocs.io/en/latest/chapter20.html#cross-site-scripting-xss
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.reflected-data-httpresponsebadrequest.reflected-data-httpresponsebadrequest
+    shortlink: https://sg.run/DoZP
+    semgrep.dev:
+      rule:
+        rule_id: 5rUOX1
+        version_id: DkTeOR
+        url: https://semgrep.dev/playground/r/DkTeOR/python.django.security.injection.reflected-data-httpresponsebadrequest.reflected-data-httpresponsebadrequest
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: django.http.HttpResponseBadRequest(..., $S.format(..., request.$W.get(...),
+        ...), ...)
+    - pattern: django.http.HttpResponseBadRequest(..., $S % request.$W.get(...), ...)
+    - pattern: django.http.HttpResponseBadRequest(..., f"...{request.$W.get(...)}...",
+        ...)
+    - pattern: django.http.HttpResponseBadRequest(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseBadRequest(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseBadRequest(..., request.$W.get(...), ...)
+    - pattern: return django.http.HttpResponseBadRequest(..., request.$W.get(...),
+        ...)
+    - pattern: django.http.HttpResponseBadRequest(..., $S.format(..., request.$W(...),
+        ...), ...)
+    - pattern: django.http.HttpResponseBadRequest(..., $S % request.$W(...), ...)
+    - pattern: django.http.HttpResponseBadRequest(..., f"...{request.$W(...)}...",
+        ...)
+    - pattern: django.http.HttpResponseBadRequest(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseBadRequest(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponseBadRequest(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseBadRequest(..., request.$W(...), ...)
+    - pattern: return django.http.HttpResponseBadRequest(..., request.$W(...), ...)
+    - pattern: django.http.HttpResponseBadRequest(..., $S.format(..., request.$W[...],
+        ...), ...)
+    - pattern: django.http.HttpResponseBadRequest(..., $S % request.$W[...], ...)
+    - pattern: django.http.HttpResponseBadRequest(..., f"...{request.$W[...]}...",
+        ...)
+    - pattern: django.http.HttpResponseBadRequest(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseBadRequest(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseBadRequest(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseBadRequest(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseBadRequest(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponseBadRequest(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseBadRequest(..., request.$W[...], ...)
+    - pattern: return django.http.HttpResponseBadRequest(..., request.$W[...], ...)
+    - pattern: django.http.HttpResponseBadRequest(..., $S.format(..., request.$W,
+        ...), ...)
+    - pattern: django.http.HttpResponseBadRequest(..., $S % request.$W, ...)
+    - pattern: django.http.HttpResponseBadRequest(..., f"...{request.$W}...", ...)
+    - pattern: django.http.HttpResponseBadRequest(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseBadRequest(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseBadRequest(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseBadRequest(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseBadRequest(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponseBadRequest(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponseBadRequest(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponseBadRequest(..., request.$W, ...)
+    - pattern: return django.http.HttpResponseBadRequest(..., request.$W, ...)
+- id: python.pyramid.audit.set-cookie-secure-unsafe-value.pyramid-set-cookie-secure-unsafe-value
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        @pyramid.view.view_config(...)
+        def $VIEW($REQUEST):
+            ...
+            $RESPONSE = $REQUEST.response
+            ...
+    - pattern-inside: |
+        def $VIEW(...):
+            ...
+            $RESPONSE = pyramid.httpexceptions.HTTPFound(...)
+            ...
+  - pattern-not: $RESPONSE.set_cookie(..., **$PARAMS)
+  - pattern: $RESPONSE.set_cookie(..., secure=$SECURE, ...)
+  - pattern: $SECURE
+  - metavariable-pattern:
+      metavariable: $SECURE
+      pattern: |
+        False
+  fix: |
+    True
+  message: Found a Pyramid cookie without the secure option correctly set. Pyramid
+    cookies should be handled securely by setting secure=True in response.set_cookie(...).
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-614: Sensitive Cookie in HTTPS Session Without ''Secure'' Attribute'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.set-cookie-secure-unsafe-value.pyramid-set-cookie-secure-unsafe-value
+    shortlink: https://sg.run/AzjB
+    semgrep.dev:
+      rule:
+        rule_id: L1UX2J
+        version_id: jQTLkr
+        url: https://semgrep.dev/playground/r/jQTLkr/python.pyramid.audit.set-cookie-secure-unsafe-value.pyramid-set-cookie-secure-unsafe-value
+  languages:
+  - python
+  severity: WARNING
+- id: python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
+  patterns:
+  - pattern-inside: cryptography.hazmat.primitives.asymmetric.ec.generate_private_key(...)
+  - pattern: cryptography.hazmat.primitives.asymmetric.ec.$SIZE
+  - metavariable-pattern:
+      metavariable: $SIZE
+      pattern-either:
+      - pattern: SECP192R1
+      - pattern: SECT163K1
+      - pattern: SECT163R2
+  - focus-metavariable: $SIZE
+  fix: |
+    SECP256R1
+  message: Detected an insufficient curve size for EC. NIST recommends a key size
+    of 224 or higher. For example, use 'ec.SECP256R1'.
+  metadata:
+    cwe:
+    - 'CWE-326: Inadequate Encryption Strength'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    - https://cryptography.io/en/latest/hazmat/primitives/asymmetric/ec/#elliptic-curves
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
+    shortlink: https://sg.run/GeQq
+    semgrep.dev:
+      rule:
+        rule_id: qNUjZ3
+        version_id: WrT5GP
+        url: https://semgrep.dev/playground/r/WrT5GP/python.cryptography.security.insufficient-ec-key-size.insufficient-ec-key-size
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.audit.md5-used-as-password.md5-used-as-password
+  severity: WARNING
+  message: It looks like MD5 is used as a password hash. MD5 is not considered a secure
+    password hash because it can be cracked by an attacker in a short amount of time.
+    Use a suitable password hashing function such as scrypt. You can use `hashlib.scrypt`.
+  languages:
+  - python
+  metadata:
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://tools.ietf.org/html/rfc6151
+    - https://crypto.stackexchange.com/questions/44151/how-does-the-flame-malware-take-advantage-of-md5-collision
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    - https://security.stackexchange.com/questions/211/how-to-securely-hash-passwords
+    - https://github.com/returntocorp/semgrep-rules/issues/1609
+    - https://docs.python.org/3/library/hashlib.html#hashlib.scrypt
+    category: security
+    technology:
+    - pycryptodome
+    - hashlib
+    - md5
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.md5-used-as-password.md5-used-as-password
+    shortlink: https://sg.run/5DwD
+    semgrep.dev:
+      rule:
+        rule_id: 6JU1w1
+        version_id: JdTZgr
+        url: https://semgrep.dev/playground/r/JdTZgr/python.lang.security.audit.md5-used-as-password.md5-used-as-password
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: hashlib.md5
+      - pattern: hashlib.new(..., name="MD5", ...)
+      - pattern: Cryptodome.Hash.MD5
+      - pattern: Crypto.Hash.MD5
+      - pattern: cryptography.hazmat.primitives.hashes.MD5
+  pattern-sinks:
+  - patterns:
+    - pattern: $FUNCTION(...)
+    - metavariable-regex:
+        metavariable: $FUNCTION
+        regex: (?i)(.*password.*)
+- id: python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication
+  message: 'An encryption mode of operation is being used without proper message authentication.  This
+    can potentially result in the encrypted content to be decrypted by an attacker.  Consider
+    instead use an AEAD mode of operation like GCM. '
+  languages:
+  - python
+  severity: ERROR
+  metadata:
+    category: security
+    technology:
+    - cryptography
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication
+    shortlink: https://sg.run/k1K1
+    semgrep.dev:
+      rule:
+        rule_id: YGUw8w
+        version_id: A8Tnb4
+        url: https://semgrep.dev/playground/r/A8Tnb4/python.pycryptodome.security.mode-without-authentication.crypto-mode-without-authentication
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            AES.new(..., $PYCRYPTODOME_MODE)
+      - pattern-not-inside: |
+          AES.new(..., $PYCRYPTODOME_MODE)
+          ...
+          HMAC.new
+      - metavariable-pattern:
+          metavariable: $PYCRYPTODOME_MODE
+          patterns:
+          - pattern-either:
+            - pattern: AES.MODE_CBC
+            - pattern: AES.MODE_CTR
+            - pattern: AES.MODE_CFB
+            - pattern: AES.MODE_OFB
+- id: python.django.security.injection.reflected-data-httpresponse.reflected-data-httpresponse
+  message: Found user-controlled request data passed into HttpResponse. This could
+    be vulnerable to XSS, leading to attackers gaining access to user cookies and
+    protected information. Ensure that the request data is properly escaped or sanitzed.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    references:
+    - https://django-book.readthedocs.io/en/latest/chapter20.html#cross-site-scripting-xss
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.reflected-data-httpresponse.reflected-data-httpresponse
+    shortlink: https://sg.run/BkvA
+    semgrep.dev:
+      rule:
+        rule_id: JDUydR
+        version_id: BjTG9p
+        url: https://semgrep.dev/playground/r/BjTG9p/python.django.security.injection.reflected-data-httpresponse.reflected-data-httpresponse
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: django.http.HttpResponse(..., $S.format(..., request.$W.get(...), ...),
+        ...)
+    - pattern: django.http.HttpResponse(..., $S % request.$W.get(...), ...)
+    - pattern: django.http.HttpResponse(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: django.http.HttpResponse(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponse(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponse(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponse(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponse(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.HttpResponse(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponse(..., request.$W.get(...), ...)
+    - pattern: return django.http.HttpResponse(..., request.$W.get(...), ...)
+    - pattern: django.http.HttpResponse(..., $S.format(..., request.$W(...), ...),
+        ...)
+    - pattern: django.http.HttpResponse(..., $S % request.$W(...), ...)
+    - pattern: django.http.HttpResponse(..., f"...{request.$W(...)}...", ...)
+    - pattern: django.http.HttpResponse(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponse(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponse(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponse(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponse(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.HttpResponse(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponse(..., request.$W(...), ...)
+    - pattern: return django.http.HttpResponse(..., request.$W(...), ...)
+    - pattern: django.http.HttpResponse(..., $S.format(..., request.$W[...], ...),
+        ...)
+    - pattern: django.http.HttpResponse(..., $S % request.$W[...], ...)
+    - pattern: django.http.HttpResponse(..., f"...{request.$W[...]}...", ...)
+    - pattern: django.http.HttpResponse(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponse(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponse(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponse(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponse(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.HttpResponse(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: $A = django.http.HttpResponse(..., request.$W[...], ...)
+    - pattern: return django.http.HttpResponse(..., request.$W[...], ...)
+    - pattern: django.http.HttpResponse(..., $S.format(..., request.$W, ...), ...)
+    - pattern: django.http.HttpResponse(..., $S % request.$W, ...)
+    - pattern: django.http.HttpResponse(..., f"...{request.$W}...", ...)
+    - pattern: django.http.HttpResponse(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponse(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponse(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponse(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponse(..., f"...{$DATA}...", ...)
+    - pattern: $A = django.http.HttpResponse(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $A = django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: return django.http.HttpResponse(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.HttpResponse(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        django.http.HttpResponse(..., $INTERM, ...)
+- id: python.pycryptodome.security.insecure-cipher-algorithm.insecure-cipher-algorithm-xor
+  message: Detected XOR cipher algorithm which is considered insecure. This algorithm
+    is not cryptographically secure and can be reversed easily. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://stackoverflow.com/questions/1135186/whats-wrong-with-xor-encryption
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-cipher-algorithm.insecure-cipher-algorithm-xor
+    shortlink: https://sg.run/L0yr
+    semgrep.dev:
+      rule:
+        rule_id: PeUk5W
+        version_id: 3ZTx98
+        url: https://semgrep.dev/playground/r/3ZTx98/python.pycryptodome.security.insecure-cipher-algorithm.insecure-cipher-algorithm-xor
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Cryptodome.Cipher.XOR.new(...)
+  - pattern: Crypto.Cipher.XOR.new(...)
+- id: python.aws-lambda.security.dangerous-spawn-process.dangerous-spawn-process
+  mode: taint
+  message: Detected `os` function with argument tainted by `event` object. This is
+    dangerous if external data can reach this function call because it allows a malicious
+    actor to execute commands. Ensure no external data reaches here.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    - aws-lambda
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.aws-lambda.security.dangerous-spawn-process.dangerous-spawn-process
+    shortlink: https://sg.run/2AjL
+    semgrep.dev:
+      rule:
+        rule_id: 8GUGBq
+        version_id: rxT83W
+        url: https://semgrep.dev/playground/r/rxT83W/python.aws-lambda.security.dangerous-spawn-process.dangerous-spawn-process
+  languages:
+  - python
+  severity: ERROR
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $CMD
+    - pattern-either:
+      - patterns:
+        - pattern-inside: os.$METHOD($MODE, $CMD, ...)
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnl|spawnle|spawnlp|spawnlpe|spawnv|spawnve|spawnvp|spawnvp|spawnvpe|posix_spawn|posix_spawnp|startfile)
+      - patterns:
+        - pattern-inside: os.$METHOD($MODE, $BASH, ["-c", $CMD,...],...)
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnv|spawnve|spawnvp|spawnvp|spawnvpe|posix_spawn|posix_spawnp)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+      - patterns:
+        - pattern-inside: os.$METHOD($MODE, $BASH, "-c", $CMD,...)
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnl|spawnle|spawnlp|spawnlpe)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+- id: python.aws-lambda.security.pymysql-sqli.pymysql-sqli
+  languages:
+  - python
+  message: 'Detected SQL statement that is tainted by `event` object. This could lead
+    to SQL injection if the variable is user-controlled and not properly sanitized.
+    In order to prevent SQL injection, used parameterized queries or prepared statements
+    instead. You can use parameterized statements like so: `cursor.execute(''SELECT
+    * FROM projects WHERE status = %s'', (''active''))`'
+  mode: taint
+  metadata:
+    references:
+    - https://pypi.org/project/PyMySQL/#id4
+    category: security
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    technology:
+    - aws-lambda
+    - pymysql
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.pymysql-sqli.pymysql-sqli
+    shortlink: https://sg.run/reve
+    semgrep.dev:
+      rule:
+        rule_id: JDUlel
+        version_id: e1TAnn
+        url: https://semgrep.dev/playground/r/e1TAnn/python.aws-lambda.security.pymysql-sqli.pymysql-sqli
+  pattern-sinks:
+  - patterns:
+    - pattern: $QUERY
+    - pattern-inside: $CURSOR.execute($QUERY,...)
+    - pattern-either:
+      - pattern-inside: |
+          import pymysql
+          ...
+      - pattern-inside: |
+          import pymysql.cursors
+          ...
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  severity: WARNING
+- id: python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
+  message: Detected Blowfish cipher algorithm which is considered insecure. This algorithm
+    is not cryptographically secure and can be reversed easily. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://stackoverflow.com/questions/1135186/whats-wrong-with-xor-encryption
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
+    shortlink: https://sg.run/dlOE
+    semgrep.dev:
+      rule:
+        rule_id: JDUGnK
+        version_id: LjTp6W
+        url: https://semgrep.dev/playground/r/LjTp6W/python.pycryptodome.security.insecure-cipher-algorithm-blowfish.insecure-cipher-algorithm-blowfish
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Cryptodome.Cipher.Blowfish.new(...)
+  - pattern: Crypto.Cipher.Blowfish.new(...)
+- id: python.pyramid.audit.authtkt-cookie-samesite.pyramid-authtkt-cookie-samesite
+  patterns:
+  - pattern-either:
+    - pattern: pyramid.authentication.AuthTktCookieHelper(..., samesite=$SAMESITE,
+        ...)
+    - pattern: pyramid.authentication.AuthTktAuthenticationPolicy(..., samesite=$SAMESITE,
+        ...)
+  - pattern: $SAMESITE
+  - metavariable-regex:
+      metavariable: $SAMESITE
+      regex: (?!'Lax')
+  fix: |
+    'Lax'
+  message: Found a Pyramid Authentication Ticket without the samesite option correctly
+    set. Pyramid cookies should be handled securely by setting samesite='Lax'. If
+    this parameter is not properly set, your cookies are not properly protected and
+    are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-1275: Sensitive Cookie with Improper SameSite Attribute'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.authtkt-cookie-samesite.pyramid-authtkt-cookie-samesite
+    shortlink: https://sg.run/LYrY
+    semgrep.dev:
+      rule:
+        rule_id: kxUYjY
+        version_id: 0bT6WO
+        url: https://semgrep.dev/playground/r/0bT6WO/python.pyramid.audit.authtkt-cookie-samesite.pyramid-authtkt-cookie-samesite
+  languages:
+  - python
+  severity: WARNING
+- id: python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
+  pattern: cryptography.hazmat.primitives.ciphers.algorithms.ARC4(...)
+  message: Detected ARC4 cipher algorithm which is considered insecure. The algorithm
+    is considered weak and has been deprecated. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L98
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://tools.ietf.org/html/rfc5469
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
+    shortlink: https://sg.run/xoZL
+    semgrep.dev:
+      rule:
+        rule_id: KxU8gK
+        version_id: 8KTLp4
+        url: https://semgrep.dev/playground/r/8KTLp4/python.cryptography.security.insecure-cipher-algorithms-arc4.insecure-cipher-algorithm-arc4
+  severity: WARNING
+  languages:
+  - python
+- id: python.boto3.security.hardcoded-token.hardcoded-token
+  message: A hard-coded credential was detected. It is not recommended  to store credentials
+    in source-code, as this risks secrets being leaked and used by either an internal
+    or external malicious adversary.  It is recommended to use environment variables
+    to  securely provide credentials or retrieve credentials from  a secure vault
+    or HSM (Hardware Security Module).
+  metadata:
+    cwe:
+    - 'CWE-798: Use of Hard-coded Credentials'
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_CheatSheet.html
+    - https://bento.dev/checks/boto3/hardcoded-access-token/
+    - https://aws.amazon.com/blogs/security/what-to-do-if-you-inadvertently-expose-an-aws-access-key/
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    category: security
+    technology:
+    - boto3
+    - secrets
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.boto3.security.hardcoded-token.hardcoded-token
+    shortlink: https://sg.run/LwQ6
+    semgrep.dev:
+      rule:
+        rule_id: 5rUOwK
+        version_id: LjTpwq
+        url: https://semgrep.dev/playground/r/LjTpwq/python.boto3.security.hardcoded-token.hardcoded-token
+  languages:
+  - python
+  severity: WARNING
+  mode: taint
+  pattern-sources:
+  - pattern: |
+      "..."
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: $W(...,$TOKEN="$VALUE",...)
+      - pattern: $BOTO. ... .$W(...,$TOKEN="$VALUE",...)
+    - metavariable-regex:
+        metavariable: $TOKEN
+        regex: (aws_session_token|aws_access_key_id|aws_secret_access_key)
+    - metavariable-pattern:
+        language: generic
+        metavariable: $VALUE
+        patterns:
+        - pattern-either:
+          - pattern-regex: ^AKI
+          - pattern-regex: ^[A-Za-z0-9/+=]+$
+    - metavariable-analysis:
+        metavariable: $VALUE
+        analyzer: entropy
+- id: python.flask.security.injection.user-exec.exec-injection
+  languages:
+  - python
+  severity: ERROR
+  message: Detected user data flowing into exec. This is code injection and should
+    be avoided.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://nedbatchelder.com/blog/201206/exec_really_is_dangerous.html
+    category: security
+    technology:
+    - flask
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.user-exec.exec-injection
+    shortlink: https://sg.run/Ge42
+    semgrep.dev:
+      rule:
+        rule_id: KxUbl2
+        version_id: e1TAxz
+        url: https://semgrep.dev/playground/r/e1TAxz/python.flask.security.injection.user-exec.exec-injection
+  pattern-either:
+  - patterns:
+    - pattern: exec(...)
+    - pattern-either:
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            exec(..., <... $ROUTEVAR ...>, ...)
+      - pattern-inside: |
+          @$APP.route($ROUTE, ...)
+          def $FUNC(..., $ROUTEVAR, ...):
+            ...
+            $INTERM = <... $ROUTEVAR ...>
+            ...
+            exec(..., <... $INTERM ...>, ...)
+  - pattern: exec(..., <... flask.request.$W.get(...) ...>, ...)
+  - pattern: exec(..., <... flask.request.$W[...] ...>, ...)
+  - pattern: exec(..., <... flask.request.$W(...) ...>, ...)
+  - pattern: exec(..., <... flask.request.$W ...>, ...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)
+- id: python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+  patterns:
+  - pattern-either:
+    - pattern: Crypto.PublicKey.DSA.generate(..., bits=$SIZE, ...)
+    - pattern: Crypto.PublicKey.DSA.generate($SIZE, ...)
+    - pattern: Cryptodome.PublicKey.DSA.generate(..., bits=$SIZE, ...)
+    - pattern: Cryptodome.PublicKey.DSA.generate($SIZE, ...)
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
+  message: Detected an insufficient key size for DSA. NIST recommends a key size of
+    2048 or higher.
+  metadata:
+    cwe:
+    - 'CWE-326: Inadequate Encryption Strength'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+    shortlink: https://sg.run/4y8l
+    semgrep.dev:
+      rule:
+        rule_id: AbUWje
+        version_id: GxTW9e
+        url: https://semgrep.dev/playground/r/GxTW9e/python.pycryptodome.security.insufficient-dsa-key-size.insufficient-dsa-key-size
+  languages:
+  - python
+  severity: WARNING
+- id: python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
+  pattern: cryptography.hazmat.primitives.ciphers.algorithms.Blowfish(...)
+  message: Detected Blowfish cipher algorithm which is considered insecure. The algorithm
+    is considered weak and has been deprecated. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L98
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://tools.ietf.org/html/rfc5469
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
+    shortlink: https://sg.run/OdzL
+    semgrep.dev:
+      rule:
+        rule_id: qNULvO
+        version_id: gET5wA
+        url: https://semgrep.dev/playground/r/gET5wA/python.cryptography.security.insecure-cipher-algorithms-blowfish.insecure-cipher-algorithm-blowfish
+  severity: WARNING
+  languages:
+  - python
+- id: python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+  pattern: cryptography.hazmat.primitives.hashes.MD5(...)
+  message: Detected MD5 hash algorithm which is considered insecure. MD5 is not collision
+    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
+    or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B303
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+    shortlink: https://sg.run/eY88
+    semgrep.dev:
+      rule:
+        rule_id: lBUopp
+        version_id: 44TYn2
+        url: https://semgrep.dev/playground/r/44TYn2/python.cryptography.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
+  severity: WARNING
+  languages:
+  - python
+- id: python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
+  message: Detected DES cipher algorithm which is considered insecure. This algorithm
+    is not cryptographically secure and can be reversed easily. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://cwe.mitre.org/data/definitions/326.html
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
+    shortlink: https://sg.run/Z5bw
+    semgrep.dev:
+      rule:
+        rule_id: 5rUr73
+        version_id: 8KTLe6
+        url: https://semgrep.dev/playground/r/8KTLe6/python.pycryptodome.security.insecure-cipher-algorithm-des.insecure-cipher-algorithm-des
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Cryptodome.Cipher.DES.new(...)
+  - pattern: Crypto.Cipher.DES.new(...)
+- id: python.lang.security.audit.dangerous-code-run-tainted-env-args.dangerous-interactive-code-run-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern-inside: |
+          $X = code.InteractiveConsole(...)
+          ...
+      - pattern-inside: |
+          $X = code.InteractiveInterpreter(...)
+          ...
+    - pattern-either:
+      - pattern-inside: |
+          $X.push($PAYLOAD,...)
+      - pattern-inside: |
+          $X.runsource($PAYLOAD,...)
+      - pattern-inside: |
+          $X.runcode(code.compile_command($PAYLOAD),...)
+      - pattern-inside: |
+          $PL = code.compile_command($PAYLOAD,...)
+          ...
+          $X.runcode($PL,...)
+    - pattern: $PAYLOAD
+    - pattern-not: |
+        $X.push("...",...)
+    - pattern-not: |
+        $X.runsource("...",...)
+    - pattern-not: |
+        $X.runcode(code.compile_command("..."),...)
+    - pattern-not: |
+        $PL = code.compile_command("...",...)
+        ...
+        $X.runcode($PL,...)
+  message: Found user controlled data inside InteractiveConsole/InteractiveInterpreter
+    method. This is dangerous if external data can reach this function call because
+    it allows a malicious actor to run arbitrary Python code.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-code-run-tainted-env-args.dangerous-interactive-code-run-tainted-env-args
+    shortlink: https://sg.run/0Bgv
+    semgrep.dev:
+      rule:
+        rule_id: QrUG72
+        version_id: o5T5n1
+        url: https://semgrep.dev/playground/r/o5T5n1/python.lang.security.audit.dangerous-code-run-tainted-env-args.dangerous-interactive-code-run-tainted-env-args
+  severity: WARNING
+  languages:
+  - python
+- id: python.pyramid.audit.set-cookie-secure-unsafe-default.pyramid-set-cookie-secure-unsafe-default
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        @pyramid.view.view_config(...)
+        def $VIEW($REQUEST):
+            ...
+            $RESPONSE = $REQUEST.response
+            ...
+    - pattern-inside: |
+        def $VIEW(...):
+            ...
+            $RESPONSE = pyramid.httpexceptions.HTTPFound(...)
+            ...
+  - pattern-not: $RESPONSE.set_cookie(..., secure=$SECURE, ...)
+  - pattern-not: $RESPONSE.set_cookie(..., **$PARAMS)
+  - pattern: $RESPONSE.set_cookie(...)
+  fix-regex:
+    regex: (.*)\)
+    replacement: \1, secure=True)
+  message: Found a Pyramid cookie using an unsafe default for the secure option. Pyramid
+    cookies should be handled securely by setting secure=True in response.set_cookie(...).
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-614: Sensitive Cookie in HTTPS Session Without ''Secure'' Attribute'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.set-cookie-secure-unsafe-default.pyramid-set-cookie-secure-unsafe-default
+    shortlink: https://sg.run/RbrN
+    semgrep.dev:
+      rule:
+        rule_id: 7KUr15
+        version_id: X0ToWg
+        url: https://semgrep.dev/playground/r/X0ToWg/python.pyramid.audit.set-cookie-secure-unsafe-default.pyramid-set-cookie-secure-unsafe-default
+  languages:
+  - python
+  severity: WARNING
+- id: python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+  patterns:
+  - pattern-either:
+    - pattern: cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key(...,
+        key_size=$SIZE, ...)
+    - pattern: cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key($EXP,
+        $SIZE, ...)
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
+  message: Detected an insufficient key size for RSA. NIST recommends a key size of
+    2048 or higher.
+  metadata:
+    cwe:
+    - 'CWE-326: Inadequate Encryption Strength'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+    shortlink: https://sg.run/RoQq
+    semgrep.dev:
+      rule:
+        rule_id: lBU9jn
+        version_id: GxTWQo
+        url: https://semgrep.dev/playground/r/GxTWQo/python.cryptography.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+  languages:
+  - python
+  severity: WARNING
+- id: python.aws-lambda.security.mysql-sqli.mysql-sqli
+  languages:
+  - python
+  message: 'Detected SQL statement that is tainted by `event` object. This could lead
+    to SQL injection if the variable is user-controlled and not properly sanitized.
+    In order to prevent SQL injection, used parameterized queries or prepared statements
+    instead. You can use parameterized statements like so: `cursor.execute(''SELECT
+    * FROM projects WHERE status = %s'', (''active''))`'
+  mode: taint
+  metadata:
+    references:
+    - https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-execute.html
+    - https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-executemany.html
+    category: security
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    technology:
+    - aws-lambda
+    - mysql
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.mysql-sqli.mysql-sqli
+    shortlink: https://sg.run/1RjG
+    semgrep.dev:
+      rule:
+        rule_id: 3qU3eE
+        version_id: w8T0wb
+        url: https://semgrep.dev/playground/r/w8T0wb/python.aws-lambda.security.mysql-sqli.mysql-sqli
+  pattern-sinks:
+  - patterns:
+    - pattern: $QUERY
+    - pattern-either:
+      - pattern-inside: $CURSOR.execute($QUERY,...)
+      - pattern-inside: $CURSOR.executemany($QUERY,...)
+    - pattern-either:
+      - pattern-inside: |
+          import mysql
+          ...
+      - pattern-inside: |
+          import mysql.cursors
+          ...
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  severity: WARNING
+- id: python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
+  pattern: cryptography.hazmat.primitives.ciphers.algorithms.IDEA(...)
+  message: Detected IDEA cipher algorithm which is considered insecure. The algorithm
+    is considered weak and has been deprecated. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L98
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://tools.ietf.org/html/rfc5469
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
+    shortlink: https://sg.run/3xyK
+    semgrep.dev:
+      rule:
+        rule_id: BYUNPg
+        version_id: QkTQbz
+        url: https://semgrep.dev/playground/r/QkTQbz/python.cryptography.security.insecure-cipher-algorithms.insecure-cipher-algorithm-idea
+  severity: WARNING
+  languages:
+  - python
+- id: python.lang.security.insecure-hash-function.insecure-hash-function
+  message: Detected use of an insecure MD4 or MD5 hash function. These functions have
+    known vulnerabilities and are considered deprecated. Consider using 'SHA256' or
+    a similar function instead.
+  metadata:
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/hashlib_new_insecure_functions.py
+    asvs:
+      section: V6 Stored Cryptography Verification Requirements
+      control_id: 6.2.2 Insecure Custom Algorithm
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x14-V6-Cryptography.md#v62-algorithms
+      version: '4'
+    references:
+    - https://tools.ietf.org/html/rfc6151
+    - https://crypto.stackexchange.com/questions/44151/how-does-the-flame-malware-take-advantage-of-md5-collision
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - python
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.insecure-hash-function.insecure-hash-function
+    shortlink: https://sg.run/rdBn
+    semgrep.dev:
+      rule:
+        rule_id: OrU30g
+        version_id: vdT3WD
+        url: https://semgrep.dev/playground/r/vdT3WD/python.lang.security.insecure-hash-function.insecure-hash-function
+  languages:
+  - python
+  severity: WARNING
+  pattern-either:
+  - pattern: hashlib.new("=~/[M|m][D|d][4|5]/", ...)
+  - pattern: hashlib.new(..., name="=~/[M|m][D|d][4|5]/", ...)
+- id: python.aws-lambda.security.tainted-pickle-deserialization.tainted-pickle-deserialization
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $SINK
+    - pattern-either:
+      - pattern-inside: pickle.load($SINK,...)
+      - pattern-inside: pickle.loads($SINK,...)
+      - pattern-inside: _pickle.load($SINK,...)
+      - pattern-inside: _pickle.loads($SINK,...)
+      - pattern-inside: cPickle.load($SINK,...)
+      - pattern-inside: cPickle.loads($SINK,...)
+      - pattern-inside: dill.load($SINK,...)
+      - pattern-inside: dill.loads($SINK,...)
+      - pattern-inside: shelve.open($SINK,...)
+  message: Avoid using `pickle`, which is known to lead to code execution vulnerabilities.
+    When unpickling, the serialized data could be manipulated to run arbitrary code.
+    Instead, consider serializing the relevant data as JSON or a similar text-based
+    serialization format.
+  metadata:
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://docs.python.org/3/library/pickle.html
+    - https://davidhamann.de/2020/04/05/exploiting-python-pickle/
+    category: security
+    technology:
+    - python
+    - aws-lambda
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.tainted-pickle-deserialization.tainted-pickle-deserialization
+    shortlink: https://sg.run/JbjW
+    semgrep.dev:
+      rule:
+        rule_id: JDUDQg
+        version_id: ExTYGB
+        url: https://semgrep.dev/playground/r/ExTYGB/python.aws-lambda.security.tainted-pickle-deserialization.tainted-pickle-deserialization
+  languages:
+  - python
+  severity: WARNING
+- id: python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+  patterns:
+  - pattern-either:
+    - pattern: Crypto.PublicKey.RSA.generate(..., bits=$SIZE, ...)
+    - pattern: Crypto.PublicKey.RSA.generate($SIZE, ...)
+    - pattern: Cryptodome.PublicKey.RSA.generate(..., bits=$SIZE, ...)
+    - pattern: Cryptodome.PublicKey.RSA.generate($SIZE, ...)
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
+  message: Detected an insufficient key size for RSA. NIST recommends a key size of
+    2048 or higher.
+  metadata:
+    cwe:
+    - 'CWE-326: Inadequate Encryption Strength'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/weak_cryptographic_key.py
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+    shortlink: https://sg.run/PprY
+    semgrep.dev:
+      rule:
+        rule_id: BYUBWe
+        version_id: RGTw1l
+        url: https://semgrep.dev/playground/r/RGTw1l/python.pycryptodome.security.insufficient-rsa-key-size.insufficient-rsa-key-size
+  languages:
+  - python
+  severity: WARNING
+- id: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+  languages:
+  - python
+  severity: WARNING
+  metadata:
+    category: security
+    owasp:
+    - A01:2021 - Broken Access Control
+    cwe:
+    - 'CWE-276: Incorrect Default Permissions'
+    technology:
+    - python
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    shortlink: https://sg.run/AXY4
+    semgrep.dev:
+      rule:
+        rule_id: zdUYqR
+        version_id: ExTYkN
+        url: https://semgrep.dev/playground/r/ExTYkN/python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+  message: These permissions `$BITS` are widely permissive and grant access to more
+    people than may be necessary. A good default is `0o644` which gives read and write
+    access to yourself and read access to everyone else.
+  patterns:
+  - pattern-inside: os.$METHOD(...)
+  - metavariable-pattern:
+      metavariable: $METHOD
+      patterns:
+      - pattern-either:
+        - pattern: chmod
+        - pattern: lchmod
+        - pattern: fchmod
+  - pattern-either:
+    - patterns:
+      - pattern: os.$METHOD($FILE, $BITS, ...)
+      - metavariable-comparison:
+          metavariable: $BITS
+          comparison: $BITS >= 0o650 and $BITS < 0o100000
+    - patterns:
+      - pattern: os.$METHOD($FILE, $BITS)
+      - metavariable-comparison:
+          metavariable: $BITS
+          comparison: $BITS >= 0o100650
+    - patterns:
+      - pattern: os.$METHOD($FILE, $BITS, ...)
+      - metavariable-pattern:
+          metavariable: $BITS
+          patterns:
+          - pattern-either:
+            - pattern: <... stat.S_IWGRP ...>
+            - pattern: <... stat.S_IXGRP ...>
+            - pattern: <... stat.S_IWOTH ...>
+            - pattern: <... stat.S_IXOTH ...>
+            - pattern: <... stat.S_IRWXO ...>
+            - pattern: <... stat.S_IRWXG ...>
+    - patterns:
+      - pattern: os.$METHOD($FILE, $EXPR | $MOD, ...)
+      - metavariable-comparison:
+          metavariable: $MOD
+          comparison: $MOD == 0o111
+- id: python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
+  pattern: cryptography.hazmat.primitives.ciphers.modes.ECB(...)
+  message: Detected ECB cipher mode which is considered insecure. The algorithm can
+    potentially leak information about the plaintext. Use CBC mode instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L101
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B305
+    references:
+    - https://crypto.stackexchange.com/questions/20941/why-shouldnt-i-use-ecb-encryption
+    category: security
+    technology:
+    - cryptography
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
+    shortlink: https://sg.run/4xr5
+    semgrep.dev:
+      rule:
+        rule_id: DbUp5g
+        version_id: 3ZTxvB
+        url: https://semgrep.dev/playground/r/3ZTxvB/python.cryptography.security.insecure-cipher-mode-ecb.insecure-cipher-mode-ecb
+  severity: WARNING
+  languages:
+  - python
+- id: python.flask.security.injection.csv-writer-injection.csv-writer-injection
+  languages:
+  - python
+  message: Detected user input into a generated CSV file using the built-in `csv`
+    module. If user data is used to generate the data in this file, it is possible
+    that an attacker could inject a formula when the CSV is imported into a spreadsheet
+    application that runs an attacker script, which could steal data from the importing
+    user or, at worst, install malware on the user's computer. `defusedcsv` is a drop-in
+    replacement with the same API that will attempt to mitigate formula injection
+    attempts. You can use `defusedcsv` instead of `csv` to safely generate CSVs.
+  metadata:
+    category: security
+    confidence: MEDIUM
+    cwe:
+    - 'CWE-1236: Improper Neutralization of Formula Elements in a CSV File'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://github.com/raphaelm/defusedcsv
+    - https://owasp.org/www-community/attacks/CSV_Injection
+    - https://web.archive.org/web/20220516052229/https://www.contextis.com/us/blog/comma-separated-vulnerabilities
+    technology:
+    - python
+    - flask
+    subcategory:
+    - vuln
+    impact: MEDIUM
+    likelihood: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.flask.security.injection.csv-writer-injection.csv-writer-injection
+    shortlink: https://sg.run/JzqQ
+    semgrep.dev:
+      rule:
+        rule_id: L1UR2K
+        version_id: 1QTXDj
+        url: https://semgrep.dev/playground/r/1QTXDj/python.flask.security.injection.csv-writer-injection.csv-writer-injection
+  mode: taint
+  pattern-sinks:
+  - patterns:
+    - pattern-inside: |
+        $WRITER = csv.writer(...)
+
+        ...
+
+        $WRITER.$WRITE(...)
+    - pattern: $WRITER.$WRITE(...)
+    - metavariable-regex:
+        metavariable: $WRITE
+        regex: ^(writerow|writerows|writeheader)$
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+      - patterns:
+        - pattern: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+        - focus-metavariable: $ROUTEVAR
+  severity: ERROR
+- id: python.jinja2.security.audit.missing-autoescape-disabled.missing-autoescape-disabled
+  patterns:
+  - pattern-not: jinja2.Environment(..., autoescape=$VAL, ...)
+  - pattern: jinja2.Environment(...)
+  fix-regex:
+    regex: (.*)\)
+    replacement: \1, autoescape=True)
+  message: Detected a Jinja2 environment without autoescaping. Jinja2 does not autoescape
+    by default. This is dangerous if you are rendering to a browser because this allows
+    for cross-site scripting (XSS) attacks. If you are in a web context, enable autoescaping
+    by setting 'autoescape=True.' You may also consider using 'jinja2.select_autoescape()'
+    to only enable automatic escaping for certain file extensions.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html
+    cwe:
+    - 'CWE-116: Improper Encoding or Escaping of Output'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://jinja.palletsprojects.com/en/2.11.x/api/#basics
+    category: security
+    technology:
+    - jinja2
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.jinja2.security.audit.missing-autoescape-disabled.missing-autoescape-disabled
+    shortlink: https://sg.run/8kY4
+    semgrep.dev:
+      rule:
+        rule_id: 3qULRx
+        version_id: PkTnYn
+        url: https://semgrep.dev/playground/r/PkTnYn/python.jinja2.security.audit.missing-autoescape-disabled.missing-autoescape-disabled
+  languages:
+  - python
+  severity: WARNING
+- id: python.jwt.security.jwt-none-alg.jwt-python-none-alg
+  message: Detected use of the 'none' algorithm in a JWT token. The 'none' algorithm
+    assumes the integrity of the token has already been verified. This would allow
+    a malicious actor to forge a JWT token that will automatically be verified. Do
+    not explicitly use the 'none' algorithm. Instead, use an algorithm such as 'HS256'.
+  metadata:
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    category: security
+    technology:
+    - jwt
+    references:
+    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.jwt.security.jwt-none-alg.jwt-python-none-alg
+    shortlink: https://sg.run/Yvp4
+    semgrep.dev:
+      rule:
+        rule_id: j2UvKw
+        version_id: RGTwbW
+        url: https://semgrep.dev/playground/r/RGTwbW/python.jwt.security.jwt-none-alg.jwt-python-none-alg
+  languages:
+  - python
+  severity: ERROR
+  pattern-either:
+  - pattern: |
+      jwt.encode(...,algorithm="none",...)
+  - pattern: jwt.decode(...,algorithms=[...,"none",...],...)
+- id: python.lang.security.audit.dangerous-system-call-tainted-env-args.dangerous-system-call-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-not: os.$W("...", ...)
+    - pattern-either:
+      - pattern: os.system(...)
+      - pattern: |
+          $X = __import__("os")
+          ...
+          $X.system(...)
+      - pattern: |
+          $X = __import__("os")
+          ...
+          getattr($X, "system")(...)
+      - pattern: |
+          $X = getattr(os, "system")
+          ...
+          $X(...)
+      - pattern: |
+          $X = __import__("os")
+          ...
+          $Y = getattr($X, "system")
+          ...
+          $Y(...)
+      - pattern: os.popen(...)
+      - pattern: os.popen2(...)
+      - pattern: os.popen3(...)
+      - pattern: os.popen4(...)
+  message: Found user-controlled data used in a system call. This could allow a malicious
+    actor to execute commands. Use the 'subprocess' module instead, which is easier
+    to use without accidentally exposing a command injection vulnerability.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.2.4 Dyanmic Code Execution Features
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-system-call-tainted-env-args.dangerous-system-call-tainted-env-args
+    shortlink: https://sg.run/XR2K
+    semgrep.dev:
+      rule:
+        rule_id: DbUR9g
+        version_id: NdTQOg
+        url: https://semgrep.dev/playground/r/NdTQOg/python.lang.security.audit.dangerous-system-call-tainted-env-args.dangerous-system-call-tainted-env-args
+  languages:
+  - python
+  severity: ERROR
+- id: python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute
+  message: User-controlled data from a request is passed to 'execute()'. This could
+    lead to a SQL injection and therefore protected information could be leaked. Instead,
+    use django's QuerySets, which are built with query parameterization and therefore
+    not vulnerable to sql injection. For example, you could use `Entry.objects.filter(date=2006)`.
+  metadata:
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://docs.djangoproject.com/en/3.0/topics/security/#sql-injection-protection
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute
+    shortlink: https://sg.run/qx7y
+    semgrep.dev:
+      rule:
+        rule_id: 2ZUbDL
+        version_id: DkT4q8
+        url: https://semgrep.dev/playground/r/DkT4q8/python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: $CURSOR.execute(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: $CURSOR.execute(..., $S % request.$W.get(...), ...)
+    - pattern: $CURSOR.execute(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: $CURSOR.execute(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $CURSOR.execute(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $CURSOR.execute(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $CURSOR.execute(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $CURSOR.execute(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $CURSOR.execute(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: $A = $CURSOR.execute(..., request.$W.get(...), ...)
+    - pattern: return $CURSOR.execute(..., request.$W.get(...), ...)
+    - pattern: $CURSOR.execute(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: $CURSOR.execute(..., $S % request.$W(...), ...)
+    - pattern: $CURSOR.execute(..., f"...{request.$W(...)}...", ...)
+    - pattern: $CURSOR.execute(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $CURSOR.execute(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $CURSOR.execute(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $CURSOR.execute(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $CURSOR.execute(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $CURSOR.execute(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: $A = $CURSOR.execute(..., request.$W(...), ...)
+    - pattern: return $CURSOR.execute(..., request.$W(...), ...)
+    - pattern: $CURSOR.execute(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: $CURSOR.execute(..., $S % request.$W[...], ...)
+    - pattern: $CURSOR.execute(..., f"...{request.$W[...]}...", ...)
+    - pattern: $CURSOR.execute(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $CURSOR.execute(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $CURSOR.execute(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $CURSOR.execute(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $CURSOR.execute(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $CURSOR.execute(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: $A = $CURSOR.execute(..., request.$W[...], ...)
+    - pattern: return $CURSOR.execute(..., request.$W[...], ...)
+    - pattern: $CURSOR.execute(..., $S.format(..., request.$W, ...), ...)
+    - pattern: $CURSOR.execute(..., $S % request.$W, ...)
+    - pattern: $CURSOR.execute(..., f"...{request.$W}...", ...)
+    - pattern: $CURSOR.execute(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $CURSOR.execute(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $CURSOR.execute(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $CURSOR.execute(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $CURSOR.execute(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $CURSOR.execute(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $CURSOR.execute(..., $INTERM, ...)
+    - pattern: $A = $CURSOR.execute(..., request.$W, ...)
+    - pattern: return $CURSOR.execute(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $CURSOR.execute($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $CURSOR.execute($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $CURSOR.execute($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $CURSOR.execute($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $CURSOR.execute($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $CURSOR.execute($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $CURSOR.execute($INTERM, ...)
+    - pattern: |-
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $CURSOR.execute($INTERM, ...)
+- id: python.django.security.injection.sql.sql-injection-using-raw.sql-injection-using-raw
+  message: Data that is possible user-controlled from a python request is passed to
+    `raw()`. This could lead to SQL injection and attackers gaining access to protected
+    information. Instead, use django's QuerySets, which are built with query parameterization
+    and therefore not vulnerable to sql injection. For example, you could use `Entry.objects.filter(date=2006)`.
+  metadata:
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://docs.djangoproject.com/en/3.0/topics/security/#sql-injection-protection
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.sql.sql-injection-using-raw.sql-injection-using-raw
+    shortlink: https://sg.run/l2v9
+    semgrep.dev:
+      rule:
+        rule_id: X5U8v5
+        version_id: YDT838
+        url: https://semgrep.dev/playground/r/YDT838/python.django.security.injection.sql.sql-injection-using-raw.sql-injection-using-raw
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: $MODEL.objects.raw(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: $MODEL.objects.raw(..., $S % request.$W.get(...), ...)
+    - pattern: $MODEL.objects.raw(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: $MODEL.objects.raw(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.raw(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.raw(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.raw(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.raw(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.raw(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: $A = $MODEL.objects.raw(..., request.$W.get(...), ...)
+    - pattern: return $MODEL.objects.raw(..., request.$W.get(...), ...)
+    - pattern: $MODEL.objects.raw(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: $MODEL.objects.raw(..., $S % request.$W(...), ...)
+    - pattern: $MODEL.objects.raw(..., f"...{request.$W(...)}...", ...)
+    - pattern: $MODEL.objects.raw(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.raw(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.raw(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.raw(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.raw(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.raw(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: $A = $MODEL.objects.raw(..., request.$W(...), ...)
+    - pattern: return $MODEL.objects.raw(..., request.$W(...), ...)
+    - pattern: $MODEL.objects.raw(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: $MODEL.objects.raw(..., $S % request.$W[...], ...)
+    - pattern: $MODEL.objects.raw(..., f"...{request.$W[...]}...", ...)
+    - pattern: $MODEL.objects.raw(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.raw(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.raw(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.raw(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.raw(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.raw(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: $A = $MODEL.objects.raw(..., request.$W[...], ...)
+    - pattern: return $MODEL.objects.raw(..., request.$W[...], ...)
+    - pattern: $MODEL.objects.raw(..., $S.format(..., request.$W, ...), ...)
+    - pattern: $MODEL.objects.raw(..., $S % request.$W, ...)
+    - pattern: $MODEL.objects.raw(..., f"...{request.$W}...", ...)
+    - pattern: $MODEL.objects.raw(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.raw(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.raw(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.raw(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.raw(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.raw(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        $MODEL.objects.raw(..., $INTERM, ...)
+    - pattern: $A = $MODEL.objects.raw(..., request.$W, ...)
+    - pattern: return $MODEL.objects.raw(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $MODEL.objects.raw($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $MODEL.objects.raw($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $MODEL.objects.raw($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $MODEL.objects.raw($STR % (..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.raw($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.raw($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.raw($INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % (..., $DATA, ...)
+        ...
+        $MODEL.objects.raw($INTERM, ...)
+- id: python.django.security.injection.raw-html-format.raw-html-format
+  languages:
+  - python
+  severity: WARNING
+  message: Detected user input flowing into a manually constructed HTML string. You
+    may be accidentally bypassing secure methods of rendering HTML by manually constructing
+    HTML and this could create a cross-site scripting vulnerability, which could let
+    attackers steal sensitive user data. To be sure this is safe, check that the HTML
+    is rendered safely. Otherwise, use templates (`django.shortcuts.render`) which
+    will safely render HTML instead.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - django
+    references:
+    - https://docs.djangoproject.com/en/3.2/topics/http/shortcuts/#render
+    - https://docs.djangoproject.com/en/3.2/topics/security/#cross-site-scripting-xss-protection
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.django.security.injection.raw-html-format.raw-html-format
+    shortlink: https://sg.run/oYj1
+    semgrep.dev:
+      rule:
+        rule_id: 2ZUPER
+        version_id: A8Tn65
+        url: https://semgrep.dev/playground/r/A8Tn65/python.django.security.injection.raw-html-format.raw-html-format
+  mode: taint
+  pattern-sanitizers:
+  - pattern: django.utils.html.escape(...)
+  pattern-sources:
+  - patterns:
+    - pattern: request.$ANYTHING
+    - pattern-not: request.build_absolute_uri
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: '"$HTMLSTR" % ...'
+          - pattern: '"$HTMLSTR".format(...)'
+          - pattern: '"$HTMLSTR" + ...'
+          - pattern: f"$HTMLSTR{...}..."
+      - patterns:
+        - pattern-inside: |
+            $HTML = "$HTMLSTR"
+            ...
+        - pattern-either:
+          - pattern: $HTML % ...
+          - pattern: $HTML.format(...)
+          - pattern: $HTML + ...
+    - metavariable-pattern:
+        metavariable: $HTMLSTR
+        language: generic
+        pattern: <$TAG ...
+- id: python.lang.security.dangerous-spawn-process.dangerous-spawn-process
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: flask.request.form.get(...)
+          - pattern: flask.request.form[...]
+          - pattern: flask.request.args.get(...)
+          - pattern: flask.request.args[...]
+          - pattern: flask.request.values.get(...)
+          - pattern: flask.request.values[...]
+          - pattern: flask.request.cookies.get(...)
+          - pattern: flask.request.cookies[...]
+          - pattern: flask.request.stream
+          - pattern: flask.request.headers.get(...)
+          - pattern: flask.request.headers[...]
+          - pattern: flask.request.data
+          - pattern: flask.request.full_path
+          - pattern: flask.request.url
+          - pattern: flask.request.json
+          - pattern: flask.request.get_json()
+          - pattern: flask.request.view_args.get(...)
+          - pattern: flask.request.view_args[...]
+          - patterns:
+            - pattern-inside: |
+                @$APP.route(...)
+                def $FUNC(..., $ROUTEVAR, ...):
+                  ...
+            - pattern: $ROUTEVAR
+      - patterns:
+        - pattern-inside: |
+            def $FUNC(request, ...):
+              ...
+        - pattern-either:
+          - pattern: request.$PROPERTY.get(...)
+          - pattern: request.$PROPERTY[...]
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              @rest_framework.decorators.api_view(...)
+              def $FUNC($REQ, ...):
+                ...
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  class $VIEW(..., rest_framework.views.APIView, ...):
+                    ...
+              - pattern-inside: "class $VIEW(..., rest_framework.generics.GenericAPIView,
+                  ...):\n  ...                              \n"
+            - pattern-inside: |
+                def $METHOD(self, $REQ, ...):
+                  ...
+            - metavariable-regex:
+                metavariable: $METHOD
+                regex: (get|post|put|patch|delete|head)
+        - pattern-either:
+          - pattern: $REQ.POST.get(...)
+          - pattern: $REQ.POST[...]
+          - pattern: $REQ.FILES.get(...)
+          - pattern: $REQ.FILES[...]
+          - pattern: $REQ.DATA.get(...)
+          - pattern: $REQ.DATA[...]
+          - pattern: $REQ.QUERY_PARAMS.get(...)
+          - pattern: $REQ.QUERY_PARAMS[...]
+          - pattern: $REQ.data.get(...)
+          - pattern: $REQ.data[...]
+          - pattern: $REQ.query_params.get(...)
+          - pattern: $REQ.query_params[...]
+          - pattern: $REQ.content_type
+          - pattern: $REQ.content_type
+          - pattern: $REQ.stream
+          - pattern: $REQ.stream
+      - patterns:
+        - pattern-either:
+          - pattern-inside: |
+              class $SERVER(..., http.server.BaseHTTPRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.StreamRequestHandler, ...):
+                ...
+          - pattern-inside: |
+              class $SERVER(..., http.server.DatagramRequestHandler, ...):
+                ...
+        - pattern-either:
+          - pattern: self.requestline
+          - pattern: self.path
+          - pattern: self.headers[...]
+          - pattern: self.headers.get(...)
+          - pattern: self.rfile
+      - patterns:
+        - pattern-inside: |
+            @pyramid.view.view_config( ... )
+            def $VIEW($REQ):
+              ...
+        - pattern: $REQ.$ANYTHING
+        - pattern-not: $REQ.dbsession
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ['$ANYTHING']
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb['$ANYTHING']
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv[...]
+              - pattern: sys.orig_argv[...]
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-not: os.$METHOD($MODE, "...", ...)
+        - pattern-inside: os.$METHOD($MODE, $CMD, ...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnl|spawnle|spawnlp|spawnlpe|spawnv|spawnve|spawnvp|spawnvp|spawnvpe|posix_spawn|posix_spawnp|startfile)
+      - patterns:
+        - pattern-not: os.$METHOD($MODE, "...", ["...","...",...], ...)
+        - pattern-inside: os.$METHOD($MODE, $BASH, ["-c",$CMD,...],...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnv|spawnve|spawnvp|spawnvp|spawnvpe|posix_spawn|posix_spawnp)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+      - patterns:
+        - pattern-not: os.$METHOD($MODE, "...", "...", "...", ...)
+        - pattern-inside: os.$METHOD($MODE, $BASH, "-c", $CMD,...)
+        - pattern: $CMD
+        - metavariable-regex:
+            metavariable: $METHOD
+            regex: (spawnl|spawnle|spawnlp|spawnlpe)
+        - metavariable-regex:
+            metavariable: $BASH
+            regex: (.*)(sh|bash|ksh|csh|tcsh|zsh)
+  message: Found user controlled content when spawning a process. This is dangerous
+    because it allows a malicious actor to execute commands.
+  metadata:
+    source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.dangerous-spawn-process.dangerous-spawn-process
+    shortlink: https://sg.run/r8Zn
+    semgrep.dev:
+      rule:
+        rule_id: lBUJrn
+        version_id: 1QTXg4
+        url: https://semgrep.dev/playground/r/1QTXg4/python.lang.security.dangerous-spawn-process.dangerous-spawn-process
+  languages:
+  - python
+  severity: ERROR
+- id: python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5
+  message: Detected MD5 hash algorithm which is considered insecure. MD5 is not collision
+    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
+    or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5
+    shortlink: https://sg.run/85JN
+    semgrep.dev:
+      rule:
+        rule_id: DbUXwo
+        version_id: JdTZ7r
+        url: https://semgrep.dev/playground/r/JdTZ7r/python.pycryptodome.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Crypto.Hash.MD5.new(...)
+  - pattern: Cryptodome.Hash.MD5.new (...)
+- id: python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2
+  message: Detected MD2 hash algorithm which is considered insecure. MD2 is not collision
+    resistant and is therefore not suitable as a cryptographic signature. Use SHA256
+    or SHA3 instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L59
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://www.schneier.com/blog/archives/2012/10/when_will_we_se.html
+    - https://www.trendmicro.com/vinfo/us/security/news/vulnerabilities-and-exploits/sha-1-collision-signals-the-end-of-the-algorithm-s-viability
+    - http://2012.sharcs.org/slides/stevens.pdf
+    - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2
+    shortlink: https://sg.run/7JP2
+    semgrep.dev:
+      rule:
+        rule_id: AbU0Ex
+        version_id: 44TYvr
+        url: https://semgrep.dev/playground/r/44TYvr/python.pycryptodome.security.insecure-hash-algorithm-md2.insecure-hash-algorithm-md2
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Crypto.Hash.MD2.new(...)
+  - pattern: Cryptodome.Hash.MD2.new (...)
+- id: python.aws-lambda.security.dangerous-asyncio-shell.dangerous-asyncio-shell
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $CMD
+    - pattern-either:
+      - pattern-inside: $LOOP.subprocess_shell($PROTOCOL, $CMD)
+      - pattern-inside: asyncio.subprocess.create_subprocess_shell($CMD, ...)
+      - pattern-inside: asyncio.create_subprocess_shell($CMD, ...)
+  message: Detected asyncio subprocess function with argument tainted by `event` object.
+    If this data can be controlled by a malicious actor, it may be an instance of
+    command injection. Audit the use of this call to ensure it is not controllable
+    by an external resource. You may consider using 'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://docs.python.org/3/library/asyncio-subprocess.html
+    - https://docs.python.org/3/library/shlex.html
+    category: security
+    technology:
+    - python
+    - aws-lambda
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.aws-lambda.security.dangerous-asyncio-shell.dangerous-asyncio-shell
+    shortlink: https://sg.run/p9vZ
+    semgrep.dev:
+      rule:
+        rule_id: L1UEl7
+        version_id: yeTdjl
+        url: https://semgrep.dev/playground/r/yeTdjl/python.aws-lambda.security.dangerous-asyncio-shell.dangerous-asyncio-shell
+  languages:
+  - python
+  severity: ERROR
+- id: python.lang.security.audit.dangerous-asyncio-shell-tainted-env-args.dangerous-asyncio-shell-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern-inside: $LOOP.subprocess_shell($PROTOCOL, $CMD)
+      - pattern-inside: asyncio.subprocess.create_subprocess_shell($CMD, ...)
+      - pattern-inside: asyncio.create_subprocess_shell($CMD, ...)
+    - focus-metavariable: $CMD
+    - pattern-not-inside: |
+        $CMD = "..."
+        ...
+    - pattern-not: $LOOP.subprocess_shell($PROTOCOL, "...")
+    - pattern-not: asyncio.subprocess.create_subprocess_shell("...", ...)
+    - pattern-not: asyncio.create_subprocess_shell("...", ...)
+  message: Detected asyncio subprocess function with user controlled data. You may
+    consider using 'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://docs.python.org/3/library/asyncio-subprocess.html
+    - https://docs.python.org/3/library/shlex.html
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-asyncio-shell-tainted-env-args.dangerous-asyncio-shell-tainted-env-args
+    shortlink: https://sg.run/Dx8Y
+    semgrep.dev:
+      rule:
+        rule_id: 8GU5q3
+        version_id: YDT8o9
+        url: https://semgrep.dev/playground/r/YDT8o9/python.lang.security.audit.dangerous-asyncio-shell-tainted-env-args.dangerous-asyncio-shell-tainted-env-args
+  languages:
+  - python
+  severity: ERROR
+- id: python.lang.security.unverified-ssl-context.unverified-ssl-context
+  patterns:
+  - pattern-either:
+    - pattern: ssl._create_unverified_context(...)
+    - pattern: ssl._create_default_https_context = ssl._create_unverified_context
+  fix-regex:
+    regex: _create_unverified_context
+    replacement: create_default_context
+  message: Unverified SSL context detected. This will permit insecure connections
+    without verifying SSL certificates. Use 'ssl.create_default_context' instead.
+  metadata:
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A07:2021 - Identification and Authentication Failures
+    cwe:
+    - 'CWE-295: Improper Certificate Validation'
+    references:
+    - https://docs.python.org/3/library/ssl.html#ssl-security
+    - https://docs.python.org/3/library/http.client.html#http.client.HTTPSConnection
+    category: security
+    technology:
+    - python
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.unverified-ssl-context.unverified-ssl-context
+    shortlink: https://sg.run/N4lp
+    semgrep.dev:
+      rule:
+        rule_id: v8UnkQ
+        version_id: bZTJeE
+        url: https://semgrep.dev/playground/r/bZTJeE/python.lang.security.unverified-ssl-context.unverified-ssl-context
+  severity: ERROR
+  languages:
+  - python
+- id: python.aws-lambda.security.tainted-sql-string.tainted-sql-string
+  languages:
+  - python
+  message: Detected user input used to manually construct a SQL string. This is usually
+    bad practice because manual construction could accidentally result in a SQL injection.
+    An attacker could use a SQL injection to steal or modify contents of the database.
+    Instead, use a parameterized query which is available by default in most database
+    engines. Alternatively, consider using an object-relational mapper (ORM) such
+    as Sequelize which will protect your queries.
+  metadata:
+    references:
+    - https://owasp.org/www-community/attacks/SQL_Injection
+    category: security
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    technology:
+    - aws-lambda
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.tainted-sql-string.tainted-sql-string
+    shortlink: https://sg.run/wXvA
+    semgrep.dev:
+      rule:
+        rule_id: AbU3LX
+        version_id: 7ZTY2z
+        url: https://semgrep.dev/playground/r/7ZTY2z/python.aws-lambda.security.tainted-sql-string.tainted-sql-string
+  mode: taint
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          "$SQLSTR" + ...
+      - pattern: |
+          "$SQLSTR" % ...
+      - pattern: |
+          "$SQLSTR".format(...)
+      - pattern: |
+          f"$SQLSTR{...}..."
+    - metavariable-regex:
+        metavariable: $SQLSTR
+        regex: \s*(?i)(select|delete|insert|create|update|alter|drop)\b.*=
+    - pattern-not-inside: |
+        print(...)
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  severity: ERROR
+- id: python.aws-lambda.security.dynamodb-filter-injection.dynamodb-filter-injection
+  mode: taint
+  metadata:
+    cwe:
+    - 'CWE-943: Improper Neutralization of Special Elements in Data Query Logic'
+    owasp:
+    - A01:2017 - Injection
+    category: security
+    technology:
+    - python
+    - boto3
+    - aws-lambda
+    - dynamodb
+    references:
+    - https://medium.com/appsecengineer/dynamodb-injection-1db99c2454ac
+    subcategory:
+    - vuln
+    impact: MEDIUM
+    likelihood: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.dynamodb-filter-injection.dynamodb-filter-injection
+    shortlink: https://sg.run/jjrl
+    semgrep.dev:
+      rule:
+        rule_id: KxUJ2B
+        version_id: kbTZXl
+        url: https://semgrep.dev/playground/r/kbTZXl/python.aws-lambda.security.dynamodb-filter-injection.dynamodb-filter-injection
+  message: Detected DynamoDB query filter that is tainted by `$EVENT` object. This
+    could lead to NoSQL injection if the variable is user-controlled and not properly
+    sanitized. Explicitly assign query params instead of passing data from `$EVENT`
+    directly to DynamoDB client.
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sanitizers:
+  - patterns:
+    - pattern: |
+        {...}
+  pattern-sinks:
+  - patterns:
+    - pattern: $SINK
+    - pattern-either:
+      - pattern-inside: $TABLE.scan(..., ScanFilter = $SINK, ...)
+      - pattern-inside: $TABLE.query(..., QueryFilter = $SINK, ...)
+    - pattern-either:
+      - patterns:
+        - pattern-inside: |
+            $TABLE = $DB.Table(...)
+            ...
+        - pattern-inside: |
+            $DB = boto3.resource('dynamodb', ...)
+            ...
+      - pattern-inside: |
+          $TABLE = boto3.client('dynamodb', ...)
+          ...
+  severity: ERROR
+  languages:
+  - python
+- id: python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4
+  message: Detected ARC4 cipher algorithm which is considered insecure. This algorithm
+    is not cryptographically secure and can be reversed easily. Use AES instead.
+  metadata:
+    source-rule-url: https://github.com/PyCQA/bandit/blob/d5f8fa0d89d7b11442fc6ec80ca42953974354c8/bandit/blacklists/calls.py#L84
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    bandit-code: B304
+    references:
+    - https://cwe.mitre.org/data/definitions/326.html
+    category: security
+    technology:
+    - pycryptodome
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4
+    shortlink: https://sg.run/Eo6N
+    semgrep.dev:
+      rule:
+        rule_id: ReUnEB
+        version_id: QkTQKP
+        url: https://semgrep.dev/playground/r/QkTQKP/python.pycryptodome.security.insecure-cipher-algorithm-rc4.insecure-cipher-algorithm-rc4
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+  - pattern: Cryptodome.Cipher.ARC4.new(...)
+  - pattern: Crypto.Cipher.ARC4.new(...)
+- id: python.lang.security.deserialization.avoid-unsafe-ruamel.avoid-unsafe-ruamel
+  metadata:
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://yaml.readthedocs.io/en/latest/basicuse.html?highlight=typ
+    category: security
+    technology:
+    - ruamel.yaml
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.deserialization.avoid-unsafe-ruamel.avoid-unsafe-ruamel
+    shortlink: https://sg.run/x1rz
+    semgrep.dev:
+      rule:
+        rule_id: nJUzqK
+        version_id: w8T0QN
+        url: https://semgrep.dev/playground/r/w8T0QN/python.lang.security.deserialization.avoid-unsafe-ruamel.avoid-unsafe-ruamel
+  languages:
+  - python
+  message: Avoid using unsafe `ruamel.yaml.YAML()`. `ruamel.yaml.YAML` can create
+    arbitrary Python objects. A malicious actor could exploit this to run arbitrary
+    code. Use `YAML(typ='rt')` or `YAML(typ='safe')` instead.
+  severity: ERROR
+  pattern-either:
+  - pattern: ruamel.yaml.YAML(..., typ='unsafe', ...)
+  - pattern: ruamel.yaml.YAML(..., typ='base', ...)
+- id: python.aws-lambda.security.dangerous-asyncio-exec.dangerous-asyncio-exec
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $CMD
+    - pattern-either:
+      - pattern-inside: $LOOP.subprocess_exec($PROTOCOL, $CMD, ...)
+      - pattern-inside: $LOOP.subprocess_exec($PROTOCOL, [$CMD, ...], ...)
+      - pattern-inside: $LOOP.subprocess_exec($PROTOCOL, "=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", $CMD, ...)
+      - pattern-inside: $LOOP.subprocess_exec($PROTOCOL, ["=~/(sh|bash|ksh|csh|tcsh|zsh)/",
+          "-c", $CMD, ...], ...)
+  message: Detected subprocess function '$LOOP.subprocess_exec' with argument tainted
+    by `event` object. If this data can be controlled by a malicious actor, it may
+    be an instance of command injection. Audit the use of this call to ensure it is
+    not controllable by an external resource. You may consider using 'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.subprocess_exec
+    - https://docs.python.org/3/library/shlex.html
+    category: security
+    technology:
+    - python
+    - aws-lambda
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.aws-lambda.security.dangerous-asyncio-exec.dangerous-asyncio-exec
+    shortlink: https://sg.run/z14d
+    semgrep.dev:
+      rule:
+        rule_id: 7KUxXg
+        version_id: 9lTnB2
+        url: https://semgrep.dev/playground/r/9lTnB2/python.aws-lambda.security.dangerous-asyncio-exec.dangerous-asyncio-exec
+  languages:
+  - python
+  severity: ERROR
+- id: python.pyramid.security.csrf-check-disabled-globally.pyramid-csrf-check-disabled-globally
+  patterns:
+  - pattern-inside: |
+      $CONFIG.set_default_csrf_options(..., require_csrf=$REQUIRE_CSRF, ...)
+  - pattern: $REQUIRE_CSRF
+  - metavariable-comparison:
+      metavariable: $REQUIRE_CSRF
+      comparison: $REQUIRE_CSRF == False
+  message: Automatic check of cross-site request forgery tokens has been explicitly
+    disabled globally, which might leave views unprotected. Use 'pyramid.config.Configurator.set_default_csrf_options(require_csrf=True)'
+    to turn the automatic check for all unsafe methods (per RFC2616).
+  languages:
+  - python
+  severity: ERROR
+  fix: |
+    True
+  metadata:
+    cwe:
+    - 'CWE-352: Cross-Site Request Forgery (CSRF)'
+    owasp:
+    - A01:2021 - Broken Access Control
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A01_2021-Broken_Access_Control
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.security.csrf-check-disabled-globally.pyramid-csrf-check-disabled-globally
+    shortlink: https://sg.run/Bx2R
+    semgrep.dev:
+      rule:
+        rule_id: 8GUKqP
+        version_id: 1QT084
+        url: https://semgrep.dev/playground/r/1QT084/python.pyramid.security.csrf-check-disabled-globally.pyramid-csrf-check-disabled-globally
+- id: python.django.security.injection.email.xss-html-email-body.xss-html-email-body
+  message: Found request data in an EmailMessage that is set to use HTML. This is
+    dangerous because HTML emails are susceptible to XSS. An attacker could inject
+    data into this HTML email, causing XSS.
+  metadata:
+    cwe:
+    - 'CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream
+      Component (''Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://www.damonkohler.com/2008/12/email-injection.html
+    category: security
+    technology:
+    - django
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.email.xss-html-email-body.xss-html-email-body
+    shortlink: https://sg.run/RoBe
+    semgrep.dev:
+      rule:
+        rule_id: qNUj02
+        version_id: 3ZTxoB
+        url: https://semgrep.dev/playground/r/3ZTxoB/python.django.security.injection.email.xss-html-email-body.xss-html-email-body
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+        $EMAIL.content_subtype = "html"
+        ...
+  - pattern-either:
+    - pattern: django.core.mail.EmailMessage($SUBJ, request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $B.$C(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $B.$C(..., $DATA, ...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: $A = django.core.mail.EmailMessage($SUBJ, request.$W.get(...), ...)
+    - pattern: return django.core.mail.EmailMessage($SUBJ, request.$W.get(...), ...)
+    - pattern: django.core.mail.EmailMessage($SUBJ, request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $B.$C(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $B.$C(..., $DATA, ...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: $A = django.core.mail.EmailMessage($SUBJ, request.$W(...), ...)
+    - pattern: return django.core.mail.EmailMessage($SUBJ, request.$W(...), ...)
+    - pattern: django.core.mail.EmailMessage($SUBJ, request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.EmailMessage($SUBJ, $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.EmailMessage($SUBJ, $B.$C(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $B.$C(..., $DATA, ...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.EmailMessage($SUBJ, $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.core.mail.EmailMessage($SUBJ, f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: $A = django.core.mail.EmailMessage($SUBJ, request.$W[...], ...)
+    - pattern: return django.core.mail.EmailMessage($SUBJ, request.$W[...], ...)
+    - pattern: django.core.mail.EmailMessage($SUBJ, request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.EmailMessage($SUBJ, $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.EmailMessage($SUBJ, $B.$C(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $B.$C(..., $DATA, ...)
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.EmailMessage($SUBJ, $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.core.mail.EmailMessage($SUBJ, f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        django.core.mail.EmailMessage($SUBJ, $INTERM, ...)
+    - pattern: $A = django.core.mail.EmailMessage($SUBJ, request.$W, ...)
+    - pattern: return django.core.mail.EmailMessage($SUBJ, request.$W, ...)
+- id: python.pyramid.audit.authtkt-cookie-httponly-unsafe-value.pyramid-authtkt-cookie-httponly-unsafe-value
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern-not: pyramid.authentication.AuthTktCookieHelper(..., **$PARAMS)
+      - pattern: pyramid.authentication.AuthTktCookieHelper(..., httponly=$HTTPONLY,
+          ...)
+    - patterns:
+      - pattern-not: pyramid.authentication.AuthTktAuthenticationPolicy(..., **$PARAMS)
+      - pattern: pyramid.authentication.AuthTktAuthenticationPolicy(..., httponly=$HTTPONLY,
+          ...)
+  - pattern: $HTTPONLY
+  - metavariable-pattern:
+      metavariable: $HTTPONLY
+      pattern: |
+        False
+  fix: |
+    True
+  message: Found a Pyramid Authentication Ticket cookie without the httponly option
+    correctly set. Pyramid cookies should be handled securely by setting httponly=True.
+    If this parameter is not properly set, your cookies are not properly protected
+    and are at risk of being stolen by an attacker.
+  metadata:
+    cwe:
+    - 'CWE-1004: Sensitive Cookie Without ''HttpOnly'' Flag'
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    category: security
+    technology:
+    - pyramid
+    references:
+    - https://owasp.org/Top10/A05_2021-Security_Misconfiguration
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.pyramid.audit.authtkt-cookie-httponly-unsafe-value.pyramid-authtkt-cookie-httponly-unsafe-value
+    shortlink: https://sg.run/7DgQ
+    semgrep.dev:
+      rule:
+        rule_id: NbUq9e
+        version_id: WrT6rb
+        url: https://semgrep.dev/playground/r/WrT6rb/python.pyramid.audit.authtkt-cookie-httponly-unsafe-value.pyramid-authtkt-cookie-httponly-unsafe-value
+  languages:
+  - python
+  severity: WARNING
+- id: python.flask.security.injection.raw-html-concat.raw-html-format
+  languages:
+  - python
+  severity: WARNING
+  message: Detected user input flowing into a manually constructed HTML string. You
+    may be accidentally bypassing secure methods of rendering HTML by manually constructing
+    HTML and this could create a cross-site scripting vulnerability, which could let
+    attackers steal sensitive user data. To be sure this is safe, check that the HTML
+    is rendered safely. Otherwise, use templates (`flask.render_template`) which will
+    safely render HTML instead.
+  metadata:
+    cwe:
+    - 'CWE-79: Improper Neutralization of Input During Web Page Generation (''Cross-site
+      Scripting'')'
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - flask
+    references:
+    - https://flask.palletsprojects.com/en/2.0.x/security/#cross-site-scripting-xss
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.flask.security.injection.raw-html-concat.raw-html-format
+    shortlink: https://sg.run/Pb7e
+    semgrep.dev:
+      rule:
+        rule_id: GdUrJv
+        version_id: bZT4Gb
+        url: https://semgrep.dev/playground/r/bZT4Gb/python.flask.security.injection.raw-html-concat.raw-html-format
+  mode: taint
+  pattern-sanitizers:
+  - pattern: jinja2.escape(...)
+  - pattern: flask.escape(...)
+  - pattern: flask.render_template("~=/.*\.html", ...)
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: flask.request.$ANYTHING
+      - patterns:
+        - pattern-inside: |
+            @$APP.route(...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+        - pattern: $ROUTEVAR
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: '"$HTMLSTR" % ...'
+          - pattern: '"$HTMLSTR".format(...)'
+          - pattern: '"$HTMLSTR" + ...'
+          - pattern: f"$HTMLSTR{...}..."
+      - patterns:
+        - pattern-inside: |
+            $HTML = "$HTMLSTR"
+            ...
+        - pattern-either:
+          - pattern: $HTML % ...
+          - pattern: $HTML.format(...)
+          - pattern: $HTML + ...
+    - metavariable-pattern:
+        metavariable: $HTMLSTR
+        language: generic
+        pattern: <$TAG ...
+- id: python.django.security.injection.code.user-eval-format-string.user-eval-format-string
+  message: Found user data in a call to 'eval'. This is extremely dangerous because
+    it can enable an attacker to execute remote code. See https://owasp.org/www-community/attacks/Code_Injection
+    for more information.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+    category: security
+    technology:
+    - django
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.code.user-eval-format-string.user-eval-format-string
+    shortlink: https://sg.run/4x2z
+    semgrep.dev:
+      rule:
+        rule_id: BYUNw9
+        version_id: nWTwBe
+        url: https://semgrep.dev/playground/r/nWTwBe/python.django.security.injection.code.user-eval-format-string.user-eval-format-string
+  patterns:
+  - pattern-inside: |
+      def $F(...):
+        ...
+  - pattern-either:
+    - pattern: eval(..., $STR % request.$W.get(...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        eval(..., $STR % $V, ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        $S = $STR % $V
+        ...
+        eval(..., $S, ...)
+    - pattern: eval(..., "..." % request.$W(...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        eval(..., $STR % $V, ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        $S = $STR % $V
+        ...
+        eval(..., $S, ...)
+    - pattern: eval(..., $STR % request.$W[...], ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        eval(..., $STR % $V, ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        $S = $STR % $V
+        ...
+        eval(..., $S, ...)
+    - pattern: eval(..., $STR.format(..., request.$W.get(...), ...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        eval(..., $STR.format(..., $V, ...), ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        $S = $STR.format(..., $V, ...)
+        ...
+        eval(..., $S, ...)
+    - pattern: eval(..., $STR.format(..., request.$W(...), ...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        eval(..., $STR.format(..., $V, ...), ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        $S = $STR.format(..., $V, ...)
+        ...
+        eval(..., $S, ...)
+    - pattern: eval(..., $STR.format(..., request.$W[...], ...), ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        eval(..., $STR.format(..., $V, ...), ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        $S = $STR.format(..., $V, ...)
+        ...
+        eval(..., $S, ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        eval(..., f"...{$V}...", ...)
+    - pattern: |
+        $V = request.$W.get(...)
+        ...
+        $S = f"...{$V}..."
+        ...
+        eval(..., $S, ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        eval(..., f"...{$V}...", ...)
+    - pattern: |
+        $V = request.$W(...)
+        ...
+        $S = f"...{$V}..."
+        ...
+        eval(..., $S, ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        eval(..., f"...{$V}...", ...)
+    - pattern: |
+        $V = request.$W[...]
+        ...
+        $S = f"...{$V}..."
+        ...
+        eval(..., $S, ...)
+  languages:
+  - python
+  severity: WARNING
+- id: python.aws-lambda.security.tainted-code-exec.tainted-code-exec
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: eval($CODE, ...)
+      - pattern: exec($CODE, ...)
+  message: Detected the use of `exec/eval`.This can be dangerous if used to evaluate
+    dynamic content. If this content can be input from outside the program, this may
+    be a code injection vulnerability. Ensure evaluated content is not definable by
+    external sources.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.2.4 Dyanmic Code Execution Features
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v52-sanitization-and-sandboxing-requirements
+      version: '4'
+    category: security
+    technology:
+    - python
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.aws-lambda.security.tainted-code-exec.tainted-code-exec
+    shortlink: https://sg.run/Ng7y
+    semgrep.dev:
+      rule:
+        rule_id: GdUDJP
+        version_id: d6TbZB
+        url: https://semgrep.dev/playground/r/d6TbZB/python.aws-lambda.security.tainted-code-exec.tainted-code-exec
+  languages:
+  - python
+  severity: WARNING
+- id: python.django.security.injection.ssrf.ssrf-injection-requests.ssrf-injection-requests
+  message: Data from request object is passed to a new server-side request. This could
+    lead to a server-side request forgery (SSRF). To mitigate, ensure that schemes
+    and hosts are validated against an allowlist, do not forward the response to the
+    user, and ensure proper authentication and transport-layer security in the proxied
+    request. See https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+    to learn more about SSRF vulnerabilities.
+  metadata:
+    cwe:
+    - 'CWE-918: Server-Side Request Forgery (SSRF)'
+    owasp:
+    - A10:2021 - Server-Side Request Forgery (SSRF)
+    references:
+    - https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.ssrf.ssrf-injection-requests.ssrf-injection-requests
+    shortlink: https://sg.run/YvY4
+    semgrep.dev:
+      rule:
+        rule_id: j2UvEw
+        version_id: JdTZJ2
+        url: https://semgrep.dev/playground/r/JdTZJ2/python.django.security.injection.ssrf.ssrf-injection-requests.ssrf-injection-requests
+  languages:
+  - python
+  severity: ERROR
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: requests.$METHOD(..., $S.format(..., request.$W.get(...), ...), ...)
+    - pattern: requests.$METHOD(..., $S % request.$W.get(...), ...)
+    - pattern: requests.$METHOD(..., f"...{request.$W.get(...)}...", ...)
+    - pattern: requests.$METHOD(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        requests.$METHOD(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        requests.$METHOD(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        requests.$METHOD(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        requests.$METHOD(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        requests.$METHOD(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: $A = requests.$METHOD(..., request.$W.get(...), ...)
+    - pattern: return requests.$METHOD(..., request.$W.get(...), ...)
+    - pattern: requests.$METHOD(..., $S.format(..., request.$W(...), ...), ...)
+    - pattern: requests.$METHOD(..., $S % request.$W(...), ...)
+    - pattern: requests.$METHOD(..., f"...{request.$W(...)}...", ...)
+    - pattern: requests.$METHOD(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        requests.$METHOD(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        requests.$METHOD(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        requests.$METHOD(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        requests.$METHOD(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        requests.$METHOD(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: $A = requests.$METHOD(..., request.$W(...), ...)
+    - pattern: return requests.$METHOD(..., request.$W(...), ...)
+    - pattern: requests.$METHOD(..., $S.format(..., request.$W[...], ...), ...)
+    - pattern: requests.$METHOD(..., $S % request.$W[...], ...)
+    - pattern: requests.$METHOD(..., f"...{request.$W[...]}...", ...)
+    - pattern: requests.$METHOD(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        requests.$METHOD(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        requests.$METHOD(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        requests.$METHOD(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        requests.$METHOD(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        requests.$METHOD(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: $A = requests.$METHOD(..., request.$W[...], ...)
+    - pattern: return requests.$METHOD(..., request.$W[...], ...)
+    - pattern: requests.$METHOD(..., $S.format(..., request.$W, ...), ...)
+    - pattern: requests.$METHOD(..., $S % request.$W, ...)
+    - pattern: requests.$METHOD(..., f"...{request.$W}...", ...)
+    - pattern: requests.$METHOD(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        requests.$METHOD(..., $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        requests.$METHOD(..., $STR.format(..., $DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR.format(..., $DATA, ...)
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        requests.$METHOD(..., $STR % $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR % $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        requests.$METHOD(..., f"...{$DATA}...", ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = f"...{$DATA}..."
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        requests.$METHOD(..., $STR + $DATA, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = $STR + $DATA
+        ...
+        requests.$METHOD(..., $INTERM, ...)
+    - pattern: $A = requests.$METHOD(..., request.$W, ...)
+    - pattern: return requests.$METHOD(..., request.$W, ...)
+- id: python.lang.security.audit.dangerous-testcapi-run-in-subinterp-tainted-env-args.dangerous-testcapi-run-in-subinterp-tainted-env-args
+  mode: taint
+  options:
+    symbolic_propagation: true
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
+          - pattern: os.environ
+          - pattern: os.environ.get('$FOO', ...)
+          - pattern: os.environb
+          - pattern: os.environb.get('$FOO', ...)
+          - pattern: os.getenv('$ANYTHING', ...)
+          - pattern: os.getenvb('$ANYTHING', ...)
+      - patterns:
+        - pattern-either:
+          - patterns:
+            - pattern-either:
+              - pattern: sys.argv
+              - pattern: sys.orig_argv
+          - patterns:
+            - pattern-inside: |
+                $PARSER = argparse.ArgumentParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-inside: |
+                $PARSER = optparse.OptionParser(...)
+                ...
+            - pattern-inside: |
+                $ARGS = $PARSER.parse_args()
+            - pattern: <... $ARGS ...>
+          - patterns:
+            - pattern-either:
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.getopt(...)
+                  ...
+              - pattern-inside: |
+                  $OPTS, $ARGS = getopt.gnu_getopt(...)
+                  ...
+            - pattern-either:
+              - patterns:
+                - pattern-inside: |
+                    for $O, $A in $OPTS:
+                      ...
+                - pattern: $A
+              - pattern: $ARGS
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern-inside: |
+          _testcapi.run_in_subinterp($PAYLOAD, ...)
+      - pattern-inside: |
+          test.support.run_in_subinterp($PAYLOAD, ...)
+    - pattern: $PAYLOAD
+    - pattern-not: |
+        _testcapi.run_in_subinterp("...", ...)
+    - pattern-not: |
+        test.support.run_in_subinterp("...", ...)
+  message: Found user controlled content in `run_in_subinterp`. This is dangerous  because
+    it allows a malicious actor to run arbitrary Python code.
+  metadata:
+    cwe:
+    - 'CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code
+      (''Eval Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    references:
+    - https://semgrep.dev/docs/cheat-sheets/python-command-injection/
+    category: security
+    technology:
+    - python
+    confidence: MEDIUM
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.dangerous-testcapi-run-in-subinterp-tainted-env-args.dangerous-testcapi-run-in-subinterp-tainted-env-args
+    shortlink: https://sg.run/1DLw
+    semgrep.dev:
+      rule:
+        rule_id: 0oUK7N
+        version_id: w8T02J
+        url: https://semgrep.dev/playground/r/w8T02J/python.lang.security.audit.dangerous-testcapi-run-in-subinterp-tainted-env-args.dangerous-testcapi-run-in-subinterp-tainted-env-args
+  severity: WARNING
+  languages:
+  - python
+- id: python.aws-lambda.security.dangerous-subprocess-use.dangerous-subprocess-use
+  mode: taint
+  message: Detected subprocess function with argument tainted by `event` object. If
+    this data can be controlled by a malicious actor, it may be an instance of command
+    injection. Audit the use of this call to ensure it is not controllable by an external
+    resource. You may consider using 'shlex.escape()'.
+  metadata:
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-78: Improper Neutralization of Special Elements used in an OS Command (''OS
+      Command Injection'')'
+    asvs:
+      section: 'V5: Validation, Sanitization and Encoding Verification Requirements'
+      control_id: 5.3.8 OS Command Injection
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v53-output-encoding-and-injection-prevention-requirements
+      version: '4'
+    references:
+    - https://docs.python.org/3/library/subprocess.html
+    - https://docs.python.org/3/library/shlex.html
+    category: security
+    technology:
+    - python
+    - aws-lambda
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    source: https://semgrep.dev/r/python.aws-lambda.security.dangerous-subprocess-use.dangerous-subprocess-use
+    shortlink: https://sg.run/XZ7B
+    semgrep.dev:
+      rule:
+        rule_id: gxUyn1
+        version_id: bZT4v2
+        url: https://semgrep.dev/playground/r/bZT4v2/python.aws-lambda.security.dangerous-subprocess-use.dangerous-subprocess-use
+  languages:
+  - python
+  severity: ERROR
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  pattern-sinks:
+  - patterns:
+    - pattern: $CMD
+    - pattern-either:
+      - pattern-inside: subprocess.$FUNC($CMD, ...)
+      - pattern-inside: subprocess.$FUNC([$CMD,...], ...)
+      - pattern-inside: subprocess.$FUNC("=~/(sh|bash|ksh|csh|tcsh|zsh)/", "-c", $CMD,
+          ...)
+      - pattern-inside: subprocess.$FUNC(["=~/(sh|bash|ksh|csh|tcsh|zsh)/", "-c",
+          $CMD, ...], ...)
+      - pattern-inside: subprocess.$FUNC("=~/(python)/", $CMD, ...)
+      - pattern-inside: subprocess.$FUNC(["=~/(python)/",$CMD,...],...)
+  pattern-sanitizers:
+  - pattern: shlex.escape(...)
+- id: python.django.security.injection.request-data-fileresponse.request-data-fileresponse
+  message: Found user-controlled request data being passed into a file open, which
+    is them passed as an argument into  the FileResponse. This is dangerous because
+    an attacker could specify an arbitrary file to read, which could result in leaking
+    important data. Be sure to validate or sanitize the user-inputted filename in
+    the request data before using it in FileResponse.
+  metadata:
+    cwe:
+    - 'CWE-22: Improper Limitation of a Pathname to a Restricted Directory (''Path
+      Traversal'')'
+    owasp:
+    - A05:2017 - Broken Access Control
+    - A01:2021 - Broken Access Control
+    references:
+    - https://django-book.readthedocs.io/en/latest/chapter20.html#cross-site-scripting-xss
+    category: security
+    technology:
+    - django
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.request-data-fileresponse.request-data-fileresponse
+    shortlink: https://sg.run/W862
+    semgrep.dev:
+      rule:
+        rule_id: GdU7QR
+        version_id: WrT6R8
+        url: https://semgrep.dev/playground/r/WrT6R8/python.django.security.injection.request-data-fileresponse.request-data-fileresponse
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-inside: |
+      def $FUNC(...):
+        ...
+  - pattern-either:
+    - pattern: django.http.FileResponse(..., request.$W.get(...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        django.http.FileResponse(..., open($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W.get(...)
+        ...
+        $INTERM = open($DATA, ...)
+        ...
+        django.http.FileResponse(..., $INTERM, ...)
+    - pattern: $A = django.http.FileResponse(..., request.$W.get(...), ...)
+    - pattern: return django.http.FileResponse(..., request.$W.get(...), ...)
+    - pattern: django.http.FileResponse(..., request.$W(...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        django.http.FileResponse(..., open($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W(...)
+        ...
+        $INTERM = open($DATA, ...)
+        ...
+        django.http.FileResponse(..., $INTERM, ...)
+    - pattern: $A = django.http.FileResponse(..., request.$W(...), ...)
+    - pattern: return django.http.FileResponse(..., request.$W(...), ...)
+    - pattern: django.http.FileResponse(..., request.$W[...], ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        django.http.FileResponse(..., open($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W[...]
+        ...
+        $INTERM = open($DATA, ...)
+        ...
+        django.http.FileResponse(..., $INTERM, ...)
+    - pattern: $A = django.http.FileResponse(..., request.$W[...], ...)
+    - pattern: return django.http.FileResponse(..., request.$W[...], ...)
+    - pattern: django.http.FileResponse(..., request.$W, ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        django.http.FileResponse(..., open($DATA, ...), ...)
+    - pattern: |
+        $DATA = request.$W
+        ...
+        $INTERM = open($DATA, ...)
+        ...
+        django.http.FileResponse(..., $INTERM, ...)
+    - pattern: $A = django.http.FileResponse(..., request.$W, ...)
+    - pattern: return django.http.FileResponse(..., request.$W, ...)
+- id: python.django.security.injection.request-data-write.request-data-write
+  message: Found user-controlled request data passed into '.write(...)'. This could
+    be dangerous if a malicious actor is able to control data into sensitive files.
+    For example, a malicious actor could force rolling of critical log files, or cause
+    a denial-of-service by using up available disk space. Instead, ensure that request
+    data is properly escaped or sanitized.
+  metadata:
+    cwe:
+    - 'CWE-93: Improper Neutralization of CRLF Sequences (''CRLF Injection'')'
+    owasp:
+    - A03:2021 - Injection
+    category: security
+    technology:
+    - django
+    references:
+    - https://owasp.org/Top10/A03_2021-Injection
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.django.security.injection.request-data-write.request-data-write
+    shortlink: https://sg.run/0Q6j
+    semgrep.dev:
+      rule:
+        rule_id: ReUg5z
+        version_id: 0bT64G
+        url: https://semgrep.dev/playground/r/0bT64G/python.django.security.injection.request-data-write.request-data-write
+  languages:
+  - python
+  severity: WARNING
+  pattern-either:
+  - pattern: $F.write(..., request.$W.get(...), ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $F.write(..., $DATA, ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $INTERM = $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $F.write(..., $B.$C(..., $DATA, ...), ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $INTERM = $B.$C(..., $DATA, ...)
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $F.write(..., $STR % $DATA, ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $INTERM = $STR % $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $F.write(..., f"...{$DATA}...", ...)
+  - pattern: |
+      $DATA = request.$W.get(...)
+      ...
+      $INTERM = f"...{$DATA}..."
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: $A = $F.write(..., request.$W.get(...), ...)
+  - pattern: return $F.write(..., request.$W.get(...), ...)
+  - pattern: $F.write(..., request.$W(...), ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $F.write(..., $DATA, ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $INTERM = $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $F.write(..., $B.$C(..., $DATA, ...), ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $INTERM = $B.$C(..., $DATA, ...)
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $F.write(..., $STR % $DATA, ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $INTERM = $STR % $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $F.write(..., f"...{$DATA}...", ...)
+  - pattern: |
+      $DATA = request.$W(...)
+      ...
+      $INTERM = f"...{$DATA}..."
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: $A = $F.write(..., request.$W(...), ...)
+  - pattern: return $F.write(..., request.$W(...), ...)
+  - pattern: $F.write(..., request.$W[...], ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $F.write(..., $DATA, ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $INTERM = $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $F.write(..., $B.$C(..., $DATA, ...), ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $INTERM = $B.$C(..., $DATA, ...)
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $F.write(..., $STR % $DATA, ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $INTERM = $STR % $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $F.write(..., f"...{$DATA}...", ...)
+  - pattern: |
+      $DATA = request.$W[...]
+      ...
+      $INTERM = f"...{$DATA}..."
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: $A = $F.write(..., request.$W[...], ...)
+  - pattern: return $F.write(..., request.$W[...], ...)
+  - pattern: $F.write(..., request.$W, ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $F.write(..., $DATA, ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $INTERM = $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $F.write(..., $B.$C(..., $DATA, ...), ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $INTERM = $B.$C(..., $DATA, ...)
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $F.write(..., $STR % $DATA, ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $INTERM = $STR % $DATA
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $F.write(..., f"...{$DATA}...", ...)
+  - pattern: |
+      $DATA = request.$W
+      ...
+      $INTERM = f"...{$DATA}..."
+      ...
+      $F.write(..., $INTERM, ...)
+  - pattern: $A = $F.write(..., request.$W, ...)
+  - pattern: return $F.write(..., request.$W, ...)
+- id: python.lang.security.audit.network.disabled-cert-validation.disabled-cert-validation
+  patterns:
+  - pattern-either:
+    - pattern: urllib3.PoolManager(..., cert_reqs=$REQS, ...)
+    - pattern: urllib3.ProxyManager(..., cert_reqs=$REQS, ...)
+    - pattern: urllib3.HTTPSConnectionPool(..., cert_reqs=$REQS, ...)
+    - pattern: urllib3.connectionpool.HTTPSConnectionPool(..., cert_reqs=$REQS, ...)
+    - pattern: urllib3.connection_from_url(..., cert_reqs=$REQS, ...)
+    - pattern: urllib3.proxy_from_url(..., cert_reqs=$REQS, ...)
+    - pattern: $CONTEXT.wrap_socket(..., cert_reqs=$REQS, ...)
+    - pattern: ssl.wrap_socket(..., cert_reqs=$REQS, ...)
+  - metavariable-regex:
+      metavariable: $REQS
+      regex: (NONE|CERT_NONE|CERT_OPTIONAL|ssl\.CERT_NONE|ssl\.CERT_OPTIONAL|\'NONE\'|\"NONE\"|\'OPTIONAL\'|\"OPTIONAL\")
+  message: certificate verification explicitly disabled, insecure connections possible
+  metadata:
+    cwe:
+    - 'CWE-295: Improper Certificate Validation'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A07:2021 - Identification and Authentication Failures
+    category: security
+    technology:
+    - python
+    references:
+    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.network.disabled-cert-validation.disabled-cert-validation
+    shortlink: https://sg.run/b7yp
+    semgrep.dev:
+      rule:
+        rule_id: eqU87k
+        version_id: GxTWwe
+        url: https://semgrep.dev/playground/r/GxTWwe/python.lang.security.audit.network.disabled-cert-validation.disabled-cert-validation
+  languages:
+  - python
+  severity: ERROR
+- id: python.aws-lambda.security.sqlalchemy-sqli.sqlalchemy-sqli
+  languages:
+  - python
+  message: 'Detected SQL statement that is tainted by `event` object. This could lead
+    to SQL injection if the variable is user-controlled and not properly sanitized.
+    In order to prevent SQL injection, used parameterized queries or prepared statements
+    instead. You can use parameterized statements like so: `cursor.execute(''SELECT
+    * FROM projects WHERE status = ?'', ''active'')`'
+  mode: taint
+  metadata:
+    references:
+    - https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection.execute
+    category: security
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    cwe:
+    - 'CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+      (''SQL Injection'')'
+    technology:
+    - aws-lambda
+    - sqlalchemy
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.aws-lambda.security.sqlalchemy-sqli.sqlalchemy-sqli
+    shortlink: https://sg.run/b48W
+    semgrep.dev:
+      rule:
+        rule_id: 5rUy3N
+        version_id: vdT3Pq
+        url: https://semgrep.dev/playground/r/vdT3Pq/python.aws-lambda.security.sqlalchemy-sqli.sqlalchemy-sqli
+  pattern-sinks:
+  - patterns:
+    - pattern: $QUERY
+    - pattern-inside: $CURSOR.execute($QUERY,...)
+    - pattern-inside: |
+        import sqlalchemy
+        ...
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context):
+          ...
+  severity: WARNING
+- id: python.lang.security.use-defused-xml.use-defused-xml
+  metadata:
+    owasp:
+    - A04:2017 - XML External Entities (XXE)
+    - A05:2021 - Security Misconfiguration
+    cwe:
+    - 'CWE-611: Improper Restriction of XML External Entity Reference'
+    references:
+    - https://docs.python.org/3/library/xml.html
+    - https://github.com/tiran/defusedxml
+    - https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
+    category: security
+    technology:
+    - python
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.use-defused-xml.use-defused-xml
+    shortlink: https://sg.run/kX47
+    semgrep.dev:
+      rule:
+        rule_id: d8UjRx
+        version_id: nWTwqD
+        url: https://semgrep.dev/playground/r/nWTwqD/python.lang.security.use-defused-xml.use-defused-xml
+  message: The Python documentation recommends using `defusedxml` instead of `xml`
+    because the native Python `xml` library is vulnerable to XML External Entity (XXE)
+    attacks. These attacks can leak confidential data and "XML bombs" can cause denial
+    of service.
+  languages:
+  - python
+  severity: ERROR
+  pattern: import xml
+- id: python.lang.security.audit.insecure-transport.requests.request-session-http-in-with-context.request-session-http-in-with-context
+  options:
+    symbolic_propagation: true
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: |
+        "$URL"
+    - metavariable-pattern:
+        metavariable: $URL
+        language: regex
+        patterns:
+        - pattern-regex: http://
+        - pattern-not-regex: .*://localhost
+        - pattern-not-regex: .*://127\.0\.0\.1
+  pattern-sinks:
+  - patterns:
+    - pattern-inside: |
+        with requests.Session(...) as $SESSION:
+          ...
+    - pattern-either:
+      - pattern: $SESSION.$W($SINK, ...)
+      - pattern: $SESSION.request($METHOD, $SINK, ...)
+    - focus-metavariable: $SINK
+  fix-regex:
+    regex: '[Hh][Tt][Tt][Pp]://'
+    replacement: https://
+    count: 1
+  message: Detected a request using 'http://'. This request will be unencrypted. Use
+    'https://' instead.
+  metadata:
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    cwe:
+    - 'CWE-319: Cleartext Transmission of Sensitive Information'
+    asvs:
+      section: V9 Communications Verification Requirements
+      control_id: 9.2.1 Weak TLS
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x17-V9-Communications.md#v92-server-communications-security-requirements
+      version: '4'
+    category: security
+    technology:
+    - requests
+    references:
+    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.insecure-transport.requests.request-session-http-in-with-context.request-session-http-in-with-context
+    shortlink: https://sg.run/Bk5W
+    semgrep.dev:
+      rule:
+        rule_id: lBU9BZ
+        version_id: zyTgNb
+        url: https://semgrep.dev/playground/r/zyTgNb/python.lang.security.audit.insecure-transport.requests.request-session-http-in-with-context.request-session-http-in-with-context
+  languages:
+  - python
+  severity: INFO
+- id: python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http
+  options:
+    symbolic_propagation: true
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: |
+        "$URL"
+    - metavariable-pattern:
+        metavariable: $URL
+        language: regex
+        patterns:
+        - pattern-regex: http://
+        - pattern-not-regex: .*://localhost
+        - pattern-not-regex: .*://127\.0\.0\.1
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: requests.Session(...).$W($SINK, ...)
+      - pattern: requests.Session(...).request($METHOD, $SINK, ...)
+    - focus-metavariable: $SINK
+  fix-regex:
+    regex: '[Hh][Tt][Tt][Pp]://'
+    replacement: https://
+    count: 1
+  message: Detected a request using 'http://'. This request will be unencrypted. Use
+    'https://' instead.
+  languages:
+  - python
+  severity: INFO
+  metadata:
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    cwe:
+    - 'CWE-319: Cleartext Transmission of Sensitive Information'
+    asvs:
+      section: V9 Communications Verification Requirements
+      control_id: 9.1.1 Weak TLS
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x17-V9-Communications.md#v92-server-communications-security-requirements
+      version: '4'
+    category: security
+    technology:
+    - requests
+    references:
+    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http
+    shortlink: https://sg.run/DoBY
+    semgrep.dev:
+      rule:
+        rule_id: YGURXw
+        version_id: pZTgen
+        url: https://semgrep.dev/playground/r/pZTgen/python.lang.security.audit.insecure-transport.requests.request-session-with-http.request-session-with-http
+- id: python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+  fix-regex:
+    regex: '[Hh][Tt][Tt][Pp]://'
+    replacement: https://
+    count: 1
+  message: Detected a request using 'http://'. This request will be unencrypted, and
+    attackers could listen into traffic on the network and be able to obtain sensitive
+    information. Use 'https://' instead.
+  metadata:
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    cwe:
+    - 'CWE-319: Cleartext Transmission of Sensitive Information'
+    asvs:
+      section: V9 Communications Verification Requirements
+      control_id: 9.1.1 Weak TLS
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x17-V9-Communications.md#v92-server-communications-security-requirements
+      version: '4'
+    category: security
+    technology:
+    - requests
+    references:
+    - https://owasp.org/Top10/A02_2021-Cryptographic_Failures
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    source: https://semgrep.dev/r/python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+    shortlink: https://sg.run/W8J4
+    semgrep.dev:
+      rule:
+        rule_id: 6JUjpG
+        version_id: 2KTN5R
+        url: https://semgrep.dev/playground/r/2KTN5R/python.lang.security.audit.insecure-transport.requests.request-with-http.request-with-http
+  languages:
+  - python
+  severity: INFO
+  options:
+    symbolic_propagation: true
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern: |
+        "$URL"
+    - metavariable-pattern:
+        metavariable: $URL
+        language: regex
+        patterns:
+        - pattern-regex: http://
+        - pattern-not-regex: .*://localhost
+        - pattern-not-regex: .*://127\.0\.0\.1
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: requests.$W($SINK, ...)
+      - pattern: requests.request($METHOD, $SINK, ...)
+      - pattern: requests.Request($METHOD, $SINK, ...)
+    - focus-metavariable: $SINK
+- id: python.cryptography.security.empty-aes-key.empty-aes-key
+  message: Potential empty AES encryption key. Using an empty key in AES encryption
+    can result in weak encryption and may allow attackers to easily decrypt sensitive
+    data. Ensure that a strong, non-empty key is used for AES encryption.
+  patterns:
+  - pattern: AES.new("",...)
+  languages:
+  - python
+  severity: WARNING
+  metadata:
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    - 'CWE-310: Cryptographic Issues'
+    references:
+    - https://cwe.mitre.org/data/definitions/327.html
+    - https://cwe.mitre.org/data/definitions/310.html
+    category: security
+    technology:
+    - python
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    owasp: A6:2017 misconfiguration
+    source: https://semgrep.dev/r/python.cryptography.security.empty-aes-key.empty-aes-key
+    shortlink: https://sg.run/zQ9G
+    semgrep.dev:
+      rule:
+        rule_id: OrUADK
+        version_id: zyTOjq
+        url: https://semgrep.dev/playground/r/zyTOjq/python.cryptography.security.empty-aes-key.empty-aes-key


### PR DESCRIPTION
Use local rules for precommit to avoid blocking. Our main flow of rule management is through semgrep ci, so this run is mostly intended to help dogfood.

Test plan: precommit

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
