### PR TITLE
feat: Allow metavariable-pattern to be more widely used with generic mode

### DIFF
--- a/changelog.d/metavar-pattern-generic.feat
+++ b/changelog.d/metavar-pattern-generic.feat
@@ -1,0 +1,1 @@
+Allow metavariable-pattern clauses that use `language: generic` to run (and potentially match) on any metavariable binding kind, not just strings. For example, with the pattern `foo($...ARGS)`, it is now possible to use a `metavariable-pattern` on `$...ARGS` with `language: generic`, and match using generic mode against whatever text `$...ARGS` is bound to.

--- a/tests/rules/metavar_pattern_generic.js
+++ b/tests/rules/metavar_pattern_generic.js
@@ -1,0 +1,13 @@
+// ok because of how generic mode works
+foo(1234);
+
+// ruleid:
+foo(2);
+
+// ruleid:
+foo(1, 2, 3, 4);
+
+foo(1, 3, 4);
+
+// ruleid:
+foo('2');

--- a/tests/rules/metavar_pattern_generic.yaml
+++ b/tests/rules/metavar_pattern_generic.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: rule_template_id
+  languages:
+  - javascript
+  patterns:
+    - pattern: foo($...ARGS)
+    - metavariable-pattern:
+        metavariable: $...ARGS
+        language: generic
+        pattern: 2
+  message: rule_template_message
+  severity: ERROR


### PR DESCRIPTION
As I've explained inline in more detail, we now allow metavariable-pattern to be used on any kind of metavariable binding as long as the target language for the metavariable-pattern is generic. Previously we only allowed metavariable-pattern to be used with a sub language if the metavariable in question was bound to a string literal.

Test plan: Automated tests

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
