### PR TITLE
Use match based key instead of syntactic content to dedup diffs

### DIFF
--- a/changelog.d/pa-2481.fix
+++ b/changelog.d/pa-2481.fix
@@ -1,0 +1,3 @@
+fix: deduplicate based on the match based key rather than syntactic content for diff scans.
+This means that if `logger.error("log 1")` is a finding on develop, and your diff changes
+the line to `logger.error("log 2")`, a new finding will not be reported.

--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -238,12 +238,13 @@ def remove_matches_in_baseline(
         if len(matches) == 0:
             continue
         baseline_matches = {
-            match.ci_unique_key for match in baseline_matches_by_rule.get(rule, [])
+            match.match_based_unique_key
+            for match in baseline_matches_by_rule.get(rule, [])
         }
         kept_matches_by_rule[rule] = [
             match
             for match in matches
-            if match.get_path_changed_ci_unique_key(file_renames)
+            if match.get_path_changed_match_based_key(file_renames)
             not in baseline_matches
         ]
         num_removed += len(matches) - len(kept_matches_by_rule[rule])

--- a/cli/tests/e2e/snapshots/test_baseline/test_match_based_key/baseline_error.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_match_based_key/baseline_error.txt
@@ -1,0 +1,13 @@
+Scanning 1 file.
+  Current version has 1 finding.
+
+Switching repository to baseline commit 'baseline-commit'.
+  Will report findings introduced by these commits (may be incomplete for shallow checkouts):
+    * 3d2d2f0 commit #2
+
+Scanning 1 file.
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files changed since baseline commit.
+
+Ran 1 rule on 1 file: 0 findings.

--- a/cli/tests/e2e/snapshots/test_baseline/test_match_based_key/error.txt
+++ b/cli/tests/e2e/snapshots/test_baseline/test_match_based_key/error.txt
@@ -1,0 +1,6 @@
+Scanning 1 file.
+
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+Ran 1 rule on 1 file: 1 finding.


### PR DESCRIPTION
This is what we expected the cli to do, but apparently it did not. The effect will be that changing `logger.error("log 1")` to `logger.error("log 2")` will not trigger a new finding if the rule is `logger.error(...)`, since the finding was already there.

Test plan: make test

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
