### PR TITLE
fix: Correct range for mvars bound in `metavariable-pattern`

### DIFF
--- a/tests/rules/persistent_metavariable_pattern2.py
+++ b/tests/rules/persistent_metavariable_pattern2.py
@@ -1,0 +1,2 @@
+# ruleid:
+'asdf'

--- a/tests/rules/persistent_metavariable_pattern2.yaml
+++ b/tests/rules/persistent_metavariable_pattern2.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: persistent-metavariable-pattern2
+  patterns:
+    - pattern: |
+        '$STR'
+    - metavariable-pattern:
+        metavariable: $STR
+        language: generic
+        pattern: $B
+    - focus-metavariable: $B
+  message: Test
+  languages: [python]
+  severity: ERROR


### PR DESCRIPTION
Followup to #7052. It hasn't been released yet, so I'm not adding anything to the changelog here.

Specifically in the case where the `metavariable-pattern` uses a different language, the metavariable binding location was not correctly calculated.

I just pulled out the `revert_loc` and `fix_loc` functions into an outer scope, so that `revert_loc` is also available in the case where the `metavariable-pattern` is evaluated using a different language.

I added some TODOs inline because I'm suspicious of the way that the location are adjusted. However, since `fix_loc` predates #7502 and `revert_loc` is simply the inverse, I don't want to mess with it right now.

Test plan: Automated tests. Without this change, the added test has no matches, since the `focus-metavariable` range doesn't intersect with the original match's range.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
