### PR TITLE
chore: defer persistent bindings from metavariable-pattern until after filter

### DIFF
--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -521,20 +521,24 @@ let children_explanations_of_xpat (env : env) (xpat : Xpattern.t) : ME.t list =
 (* Metavariable condition evaluation *)
 (*****************************************************************************)
 
-let rec filter_ranges (env : env) (xs : RM.ranges) (cond : R.metavar_cond) :
-    RM.ranges =
-  let map_bool r b = if b then [ r ] else [] in
+let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
+    (cond : R.metavar_cond) : (RM.t * MV.bindings list) list =
   xs
-  |> List.concat_map (fun r ->
+  |> List.filter_map (fun (r, new_bindings) ->
+         let map_bool r b = if b then Some (r, new_bindings) else None in
          let bindings = r.RM.mvars in
          match cond with
          | R.CondEval e ->
              let env = Eval_generic.bindings_to_env env.xconf.config bindings in
              Eval_generic.eval_bool env e |> map_bool r
-         | R.CondNestedFormula (mvar, opt_lang, formula) ->
+         | R.CondNestedFormula (mvar, opt_lang, formula) -> (
              (* TODO: could return expl for nested matching! *)
-             Metavariable_pattern.satisfies_metavar_pattern_condition
-               get_nested_formula_matches env r mvar opt_lang formula
+             match
+               Metavariable_pattern.satisfies_metavar_pattern_condition
+                 get_nested_formula_matches env r mvar opt_lang formula
+             with
+             | [] -> None
+             | bindings -> Some (r, bindings @ new_bindings))
          (* todo: would be nice to have CondRegexp also work on
           * eval'ed bindings.
           * We could also use re.match(), to be close to python, but really
@@ -749,16 +753,42 @@ and evaluate_formula (env : env) (opt_context : RM.t option) (e : R.formula) :
           let ranges, filter_expls =
             conds
             |> List.fold_left
-                 (fun (ranges, acc_expls) (tok, cond) ->
-                   let ranges = filter_ranges env ranges cond in
+                 (fun (ranges_with_bindings, acc_expls) (tok, cond) ->
+                   let ranges_with_bindings =
+                     filter_ranges env ranges_with_bindings cond
+                   in
                    let expl =
-                     if_explanations env ranges []
+                     if_explanations env
+                       (Common.map fst ranges_with_bindings)
+                       []
                        (Out.Filter (PI.str_of_info tok), tok)
                    in
-                   (ranges, expl :: acc_expls))
-                 (ranges, [])
+                   (ranges_with_bindings, expl :: acc_expls))
+                 (Common.map (fun x -> (x, [])) ranges, [])
           in
-          let ranges = apply_focus_on_ranges env focus ranges in
+
+          (* Here, we unpack all the persistent bindings for each instance of the inner
+             `metavariable-pattern`s that succeeded.
+
+             We just take those persistent bindings and add them to the original range,
+             now that we're done with the filtering step.
+          *)
+          let ranges_with_persistent_bindings =
+            ranges
+            |> List.concat_map (fun (r, new_bindings_list) ->
+                   (* At a prior step, we ensured that all these new bindings were nonempty.
+                      We should keep around a copy of the original range, because otherwise
+                      if we have no new bindings to add, we'll kill the range.
+                   *)
+                   r
+                   :: (new_bindings_list
+                      |> Common.map (fun new_bindings ->
+                             { r with RM.mvars = new_bindings @ r.RM.mvars })))
+          in
+
+          let ranges =
+            apply_focus_on_ranges env focus ranges_with_persistent_bindings
+          in
           let focus_expls =
             match focus with
             | [] -> []

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -534,7 +534,7 @@ let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
          | R.CondNestedFormula (mvar, opt_lang, formula) -> (
              (* TODO: could return expl for nested matching! *)
              match
-               Metavariable_pattern.satisfies_metavar_pattern_condition
+               Metavariable_pattern.get_nested_metavar_pattern_bindings
                  get_nested_formula_matches env r mvar opt_lang formula
              with
              | [] -> None

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -60,16 +60,10 @@ let adjust_content_for_language (xlang : Xlang.t) (content : string) : string =
     This may also produce duplicate ranges, depending on how many metavariables
     are in the file.
 *)
-let add_new_mvars_to_range range mvars =
-  (* These bindings are from the original, adjusted text.
-     We need to change it back.
-  *)
-  let new_mvars =
-    mvars
-    |> List.filter (fun (mvar, _) ->
-           not (Option.is_some (List.assoc_opt mvar range.RM.mvars)))
-  in
-  { range with RM.mvars = new_mvars @ range.RM.mvars }
+let filter_new_mvars_by_range range mvars =
+  mvars
+  |> List.filter (fun (mvar, _) ->
+         not (Option.is_some (List.assoc_opt mvar range.RM.mvars)))
 
 (* We take the bindings from the nested matches, and produce a new match where we add
    the enclosed metavariables to the original range.
@@ -78,7 +72,7 @@ let add_new_mvars_to_range range mvars =
    information, so we need to construct a visitor so we can convert the mvalues to have
    tokens with the correct information.
 *)
-let augment_range_with_nested_matches revert_loc r nested_matches =
+let get_persistent_bindings revert_loc r nested_matches =
   let reverting_visitor = Map_AST.mk_fix_token_locations revert_loc in
   nested_matches
   |> Common.map (fun nested_match ->
@@ -99,7 +93,7 @@ let augment_range_with_nested_matches revert_loc r nested_matches =
                   | Some mval -> Some (mvar, mval))
          in
          { nested_match with RM.mvars = readjusted_mvars })
-  |> Common.map (fun r' -> add_new_mvars_to_range r r'.RM.mvars)
+  |> Common.map (fun r' -> filter_new_mvars_by_range r r'.RM.mvars)
 
 (*****************************************************************************)
 (* Entry point *)
@@ -201,7 +195,7 @@ let satisfies_metavar_pattern_condition get_nested_formula_matches env r mvar
                          matches
                       *)
                       get_nested_formula_matches { env with xtarget } formula r'
-                      |> augment_range_with_nested_matches revert_loc r))
+                      |> get_persistent_bindings revert_loc r))
           | Some xlang -> (
               let content =
                 (* Previously we only allowed metavariable-pattern with a
@@ -286,4 +280,4 @@ let satisfies_metavar_pattern_condition get_nested_formula_matches env r mvar
                          matches
                       *)
                       get_nested_formula_matches { env with xtarget } formula r'
-                      |> augment_range_with_nested_matches revert_loc r))))
+                      |> get_persistent_bindings revert_loc r))))

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -98,7 +98,7 @@ let get_persistent_bindings revert_loc r nested_matches =
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
-let satisfies_metavar_pattern_condition get_nested_formula_matches env r mvar
+let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
     opt_xlang formula =
   let bindings = r.RM.mvars in
   (* If anything goes wrong the default is to filter out! *)

--- a/src/engine/Metavariable_pattern.mli
+++ b/src/engine/Metavariable_pattern.mli
@@ -14,4 +14,4 @@ val satisfies_metavar_pattern_condition :
   Metavariable.mvar ->
   Xlang.t option ->
   Rule.formula ->
-  Range_with_metavars.t list
+  Metavariable.bindings list

--- a/src/engine/Metavariable_pattern.mli
+++ b/src/engine/Metavariable_pattern.mli
@@ -2,8 +2,11 @@
  * Match_search_mode.nested_formula_has_matches which is passed to break
  * mutual recursivity between Metavariable_pattern and Match_search_mode
  * as handling metavariable-pattern: requires nested search.
+ *
+ * This function returns a list of all the nonempty new bindings introduced
+ * by  the `metavariable-pattern`, for each instance of the match.
  *)
-val satisfies_metavar_pattern_condition :
+val get_nested_metavar_pattern_bindings :
   (Match_env.env ->
   Rule.formula ->
   Range_with_metavars.t ->

--- a/tests/rules/defer-persistent-binding.py
+++ b/tests/rules/defer-persistent-binding.py
@@ -1,0 +1,13 @@
+
+# We should produce this finding, because the binding from the first `metavariable-pattern`
+# should not express a constraint on the second `metavariable-pattern`.
+
+# Because the binding is deferred, both `$B`s are understood to be separate.
+
+# ruleid: defer-persistent-binding 
+foo(
+  inside(
+    bar(1),
+    qux(2)
+  )
+)

--- a/tests/rules/defer-persistent-binding.yaml
+++ b/tests/rules/defer-persistent-binding.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: defer-persistent-binding 
+    languages:
+      - python 
+    message: Match Found!
+    pattern-either: 
+      - patterns:
+        - pattern: |
+            foo($A)
+        - metavariable-pattern: 
+            metavariable: $A
+            pattern: |
+              bar($B)
+        - metavariable-pattern:
+            metavariable: $A
+            pattern: |
+              qux($B)
+      - patterns:
+        - pattern: |
+            foo($A) 
+        - metavariable-pattern:
+            metavariable: $A
+            pattern: |
+              qux($B)
+        - metavariable-pattern: 
+            metavariable: $A
+            pattern: |
+              bar($B)
+    severity: WARNING


### PR DESCRIPTION
## What:
This PR changes it such that persistent metavariable bindings from `metavariable-pattern` are not applied until right before `focus-metavariable`.

## Why:
In #7052, we introduced persistent metavariable bindings that are introduced by the filtering step in `metavariable-pattern`. Unfortunately, they were done in such a way that they could be visible from other `metavariable-pattern`s, making them dependent on the order of the filtering. 

## How:
I just floated up the bindings introduced and collected them through each filtering step, until I combined them right before focusing-time.

## Test plan:
`make test`
and `make test` on `proprietary` (I remembered this time, @nmote!)

I declined a `changelog` entry because the previous change hasn't been released yet, and this should be how it worked in the first place anyways.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
