### PR TITLE
feat: parse new syntax for taint

### DIFF
--- a/tests/rules/new_syntax_taint.py
+++ b/tests/rules/new_syntax_taint.py
@@ -1,0 +1,29 @@
+
+x = tainted1
+# ruleid: new-syntax-taint
+sink(x)
+
+x = tainted1
+# ruleid: new-syntax-taint
+sink2(x)
+
+x = tainted2([])
+# ruleid: new-syntax-taint
+sink(x)
+
+
+y = tainted1
+z = clean(y)
+sink(z)
+
+y = tainted1
+z = clean2(y)
+sink(z)
+
+y = tainted1 
+dict = 0
+dict.foo(y)
+# ruleid: new-syntax-taint
+sink(dict)
+
+

--- a/tests/rules/new_syntax_taint.yaml
+++ b/tests/rules/new_syntax_taint.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: new-syntax-taint 
+    languages:
+      - python 
+    message: Found insecure crypto usage
+    mode: taint
+    taint:
+      sources:
+        - "tainted1" 
+        - pattern: "tainted2($A)"
+          where:
+            - comparison: $A == $A 
+      sinks:
+        - "sink(...)"
+        - pattern: |
+            sink2(...)
+      propagators:
+        - pattern: |
+            $A.foo($B)
+          from: $B 
+          to: $A
+      sanitizers:
+        - "clean(...)"
+        - pattern: |
+            clean2(...)
+    severity: ERROR


### PR DESCRIPTION
## What:
This PR adds in the new syntax for taint rules. It's basically taint patterns, but only allowed in certain areas.

## Why:
This is a part of an experiment with playtesting the new syntax. I hadn't yet implemented it for taint, since my original plan was to have taint patterns, so this PR just goes and does it for taint, since that's a large portion of the rules that we write.

## How:
Just augmented the parsing logic.

## Alternatives considered
I could have pulled out the parsing functions for each individual construct, like sinks, out into their own `new` and not `new` versions. I felt it was cleaner to consolidate them, though, to reduce code duplication and to make it nicer if we ever want to extend those constructs in the future. Rule parsing is not a very significant amount of runtime at all, so I prioritized readability, which I think is still fairly clear in this code.

## Test plan:
`make test`

I also verified the schema against a few examples to see whether it would work or not. It correctly rejects rules which have don't have `sinks` and `sources`, and it allows things with `propagators` or `sanitizers`.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
