### PR TITLE
fix(metrics): send metrics after configs are resolved

### DIFF
--- a/cli/src/semgrep/semgrep_main.py
+++ b/cli/src/semgrep/semgrep_main.py
@@ -309,19 +309,21 @@ def main(
     project_url = get_project_url()
     profiler = ProfileManager()
 
-    # Metrics send part 1: add environment information
-    metrics = get_state().metrics
-    if metrics.is_enabled:
-        metrics.add_project_url(project_url)
-        metrics.add_configs(configs)
-        metrics.add_engine_type(engine)
-
     rule_start_time = time.time()
     configs_obj, config_errors = get_config(
         pattern, lang, configs, replacement=replacement, project_url=project_url
     )
     all_rules = configs_obj.get_rules(no_rewrite_rule_ids)
     profiler.save("config_time", rule_start_time)
+
+    # Metrics send part 1: add environment information
+    # Must happen after configs are resolved because it is determined
+    # then whether metrics are sent or not
+    metrics = get_state().metrics
+    if metrics.is_enabled:
+        metrics.add_project_url(project_url)
+        metrics.add_configs(configs)
+        metrics.add_engine_type(engine)
 
     if not severity:
         shown_severities = DEFAULT_SHOWN_SEVERITIES


### PR DESCRIPTION
We determine whether or not to send metrics based on the config type, so we should wait for that determination before trying to send anything.

Test plan: after the release there should be no more places where the engine type is empty

Shouldn't need any privacy policy updates because this is just doing what we claimed to do

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
