### PR TITLE
OCaml: start to parse core type with annotation

### DIFF
--- a/tests/parsing/ocaml/attribute_type.ml
+++ b/tests/parsing/ocaml/attribute_type.ml
@@ -1,0 +1,1 @@
+type foo = int [@opaque]


### PR DESCRIPTION
This is useful for codemap so it can parse SAST.ml
in semgrep-pro

test plan:
test file included


PR checklist:

- [ ] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [ ] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [ ] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [ ] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)