### PR TITLE
fix: port env var from install to test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,8 @@ jobs:
           HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew install semgrep --HEAD
       - name: Check installed correctly
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: brew test semgrep --HEAD
       - name: Clean up semgrep installation
         run: brew uninstall semgrep


### PR DESCRIPTION
Our [nightly homebrew job](https://github.com/returntocorp/semgrep/actions/runs/4102198494/jobs/7082933739) was failing to test the semgrep installation. A previous fix for the same error was applied to the `brew install` step, and likely needs to be applied here as well. 

Test Plan:

Run workflow_dispatch on this branch to ensure fix is successful.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
