### PR TITLE
chore: fix pro testing workflow

### DIFF
--- a/.github/workflows/test-semgrep-pro.yaml
+++ b/.github/workflows/test-semgrep-pro.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "Github event is ${{ github.event_name }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "docker-tag=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "docker-tag=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "Setting docker tag to current pull request number"
           else
             echo "docker-tag=develop" >> "$GITHUB_OUTPUT"
@@ -80,4 +80,4 @@ jobs:
           aws s3 cp s3://web-assets.r2c.dev/assets/semgrep-core-proprietary-manylinux-develop ./semgrep-core-proprietary
       - name: Run Semgrep Pro Engine!
         run: |
-          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:pr-${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh
+          docker run --rm -v "$(pwd):/root" -e SEMGREP_APP_TOKEN=${{ secrets.SEMGREP_APP_TOKEN }} --entrypoint=bash "${{ inputs.repository-name }}:${{ needs.setup-docker-tag.outputs.docker-tag }}" /root/scripts/test-pro.sh


### PR DESCRIPTION
## What:
This fixes the pro-testing workflow when it runs on a non-PR.

## How:
The workflow was wrong in the case where it was not a PR, and would still prepend `pr-` to the docker tag. Whoops.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
