### PR TITLE
chore: add `install-semgrep-pro` to help text

### DIFF
--- a/changelog.d/pa-2505.fixed
+++ b/changelog.d/pa-2505.fixed
@@ -1,0 +1,1 @@
+CLI: Added `install-semgrep-pro` to the list of commands in the `semgrep --help` help text.

--- a/cli/src/semgrep/commands/install.py
+++ b/cli/src/semgrep/commands/install.py
@@ -116,11 +116,11 @@ Please delete {deep_semgrep_path} manually to make this warning disappear!
     logger.info(f"Semgrep Pro Engine Version Info: ({version})")
 
 
-@click.command(hidden=True)
+@click.command()
 @handle_command_errors
 def install_semgrep_pro() -> None:
     """
-    Install the Semgrep Pro Engine binary (Experimental)
+    Install the Semgrep Pro Engine
 
     The binary is installed in the same directory that semgrep-core
     is installed in.

--- a/cli/tests/e2e/snapshots/test_help/test_help_text/--help/help.txt
+++ b/cli/tests/e2e/snapshots/test_help/test_help_text/--help/help.txt
@@ -10,10 +10,11 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  ci            The recommended way to run semgrep in CI
-  login         Obtain and save credentials for semgrep.dev
-  logout        Remove locally stored credentials to semgrep.dev
-  lsp           [EXPERIMENTAL] Start the Semgrep LSP server
-  publish       Upload rule to semgrep.dev
-  scan          Run semgrep rules on files
-  shouldafound  Report a false negative in this project.
+  ci                   The recommended way to run semgrep in CI
+  install-semgrep-pro  Install the Semgrep Pro Engine
+  login                Obtain and save credentials for semgrep.dev
+  logout               Remove locally stored credentials to semgrep.dev
+  lsp                  [EXPERIMENTAL] Start the Semgrep LSP server
+  publish              Upload rule to semgrep.dev
+  scan                 Run semgrep rules on files
+  shouldafound         Report a false negative in this project.

--- a/cli/tests/e2e/snapshots/test_help/test_help_text/-h/help.txt
+++ b/cli/tests/e2e/snapshots/test_help/test_help_text/-h/help.txt
@@ -10,10 +10,11 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  ci            The recommended way to run semgrep in CI
-  login         Obtain and save credentials for semgrep.dev
-  logout        Remove locally stored credentials to semgrep.dev
-  lsp           [EXPERIMENTAL] Start the Semgrep LSP server
-  publish       Upload rule to semgrep.dev
-  scan          Run semgrep rules on files
-  shouldafound  Report a false negative in this project.
+  ci                   The recommended way to run semgrep in CI
+  install-semgrep-pro  Install the Semgrep Pro Engine
+  login                Obtain and save credentials for semgrep.dev
+  logout               Remove locally stored credentials to semgrep.dev
+  lsp                  [EXPERIMENTAL] Start the Semgrep LSP server
+  publish              Upload rule to semgrep.dev
+  scan                 Run semgrep rules on files
+  shouldafound         Report a false negative in this project.


### PR DESCRIPTION
## What:
This PR adds `install-semgrep-pro` to the `semgrep --help` text.

## Why:
People should know about this command, and use it!

## How:
Just un-hid the command.

## Test plan:
<img width="757" alt="image" src="https://user-images.githubusercontent.com/49291449/217121633-bbd69d47-d759-48ee-9f15-40c05200ad00.png">

Closes PA-2505

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
