### PR TITLE
refactor(cli): select binary path at CoreRunner creation time

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -555,6 +555,28 @@ class CoreRunner:
         self._optimizations = optimizations
         self._core_opts = shlex.split(core_opts_str) if core_opts_str else []
 
+        self._binary_path = SemgrepCore.path()
+
+        if engine.is_pro:
+            deep_path = (
+                SemgrepCore.deep_path()
+            )  # DEPRECATED: To be removed by Feb 2023 launch
+            pro_path = SemgrepCore.pro_path()
+
+            if pro_path is None:
+                if deep_path is not None:
+                    logger.error(
+                        f"""You have an old DeepSemgrep binary installed in {deep_path}
+  DeepSemgrep is now Semgrep Pro, run `semgrep install-semgrep-pro` to install it,
+  then please delete {deep_path} manually.
+  """
+                    )
+                raise SemgrepError(
+                    "Could not use deep features: Semgrep Pro Engine not installed. Run `semgrep install-semgrep-pro`"
+                )
+
+            self._binary_path = pro_path
+
     def _extract_core_output(
         self,
         rules: List[Rule],
@@ -761,7 +783,6 @@ class CoreRunner:
         file_timeouts: Dict[Path, int] = collections.defaultdict(lambda: 0)
         max_timeout_files: Set[Path] = set()
         # TODO this is a quick fix, refactor this logic
-        pro_path = None
 
         profiling_data: ProfilingData = ProfilingData()
         parsing_data: ParsingData = ParsingData()
@@ -807,8 +828,8 @@ class CoreRunner:
             }
 
             # Run semgrep
-            cmd_bin = SemgrepCore.path()
-            cmd_args = [
+            cmd = [
+                self._binary_path,
                 "-json",
                 "-rules",
                 rule_file.name,
@@ -829,10 +850,10 @@ class CoreRunner:
                 logger.info(
                     f"Running with user defined core options: {self._core_opts}"
                 )
-                cmd_args.extend(self._core_opts)
+                cmd.extend(self._core_opts)
 
             if self._optimizations != "none":
-                cmd_args.append("-fast")
+                cmd.append("-fast")
 
             # TODO: use exact same command-line arguments so just
             # need to replace the SemgrepCore.path() part.
@@ -849,58 +870,34 @@ class CoreRunner:
                             "You can expect to see longer scan times - we're taking our time to make sure everything is just right for you. With <3, the Semgrep team."
                         )
 
-                deep_path = (
-                    SemgrepCore.deep_path()
-                )  # DEPRECATED: To be removed by Feb 2023 launch
-                pro_path = SemgrepCore.pro_path()
+                logger.info(f"Using Semgrep Pro installed in {self._binary_path}")
+                version = sub_check_output(
+                    [self._binary_path, "-pro_version"],
+                    timeout=10,
+                    encoding="utf-8",
+                    stderr=subprocess.STDOUT,
+                ).rstrip()
+                logger.info(f"Semgrep Pro Version Info: ({version})")
 
-                if pro_path is None:
-                    if deep_path is not None:
-                        logger.error(
-                            f"""You have an old DeepSemgrep binary installed in {deep_path}
-DeepSemgrep is now Semgrep PRO, run `semgrep install-semgrep-pro` to install it,
-then please delete {deep_path} manually.
-"""
-                        )
-                    raise SemgrepError(
-                        "Could not run deep analysis: Semgrep Pro Engine not installed. Run `semgrep install-semgrep-pro`"
-                    )
-
-                if pro_path is not None:
-                    logger.info(f"Using Semgrep Pro installed in {pro_path}")
-                    version = sub_check_output(
-                        [pro_path, "-pro_version"],
-                        timeout=10,
-                        encoding="utf-8",
-                        stderr=subprocess.STDOUT,
-                    ).rstrip()
-                    logger.info(f"Semgrep Pro Version Info: ({version})")
-
-                    cmd_bin = pro_path
-
-                    if engine is EngineType.INTERFILE:
-                        targets = target_manager.targets
-                        if len(targets) == 1 and targets[0].path.is_dir():
-                            root = str(targets[0].path)
-                        else:
-                            # TODO: This is no longer true...
-                            raise SemgrepError(
-                                "deep mode needs a single target (root) dir"
-                            )
-                        cmd_args += ["-deep_inter_file"]
-                        cmd_args += [
-                            "-timeout_for_interfile_analysis",
-                            str(self._interfile_timeout),
-                        ]
-                        cmd_args += [root]
-                    elif engine is EngineType.INTERPROC:
-                        cmd_args += ["-deep_intra_file"]
+                if engine is EngineType.INTERFILE:
+                    targets = target_manager.targets
+                    if len(targets) == 1 and targets[0].path.is_dir():
+                        root = str(targets[0].path)
+                    else:
+                        # TODO: This is no longer true...
+                        raise SemgrepError("deep mode needs a single target (root) dir")
+                    cmd += ["-deep_inter_file"]
+                    cmd += [
+                        "-timeout_for_interfile_analysis",
+                        str(self._interfile_timeout),
+                    ]
+                    cmd += [root]
+                elif engine is EngineType.INTERPROC:
+                    cmd += ["-deep_intra_file"]
 
             stderr: Optional[int] = subprocess.PIPE
             if state.terminal.is_debug:
-                cmd_args += ["--debug"]
-
-            cmd = [cmd_bin] + cmd_args
+                cmd += ["--debug"]
 
             logger.debug("Running Semgrep engine with command:")
             logger.debug(" ".join(cmd))
@@ -911,11 +908,7 @@ then please delete {deep_path} manually.
                 # to copy+paste it to a shell.  (The real command is
                 # still visible in the log message above.)
                 printed_cmd = cmd.copy()
-                printed_cmd[0] = (
-                    pro_path
-                    if pro_path and engine.is_pro
-                    else SemgrepCore.executable_path()
-                )
+                printed_cmd[0] = self._binary_path
                 print(" ".join(printed_cmd))
                 sys.exit(0)
 
@@ -1070,7 +1063,7 @@ Exception raised: `{e}`
             rule_file.flush()
 
             cmd = (
-                [SemgrepCore.path()]
+                [self._binary_path]
                 + [
                     "-json",
                     "-check_rules",


### PR DESCRIPTION
## What:
This PR makes it so that the binary that we use (`semgrep-core` or `semgrep-core-proprietary`) is not selected when we use a `CoreRunner` object, but when we create the `CoreRunner` object in the first place.

## Why:
This is aesthetically pleasing, and also will fix the problem in PA-2484. The logic for selecting this path shouldn't be localized to specifically when we decide to run Semgrep on some rules, the CoreRunner object should just correspond to a particular executable, "statically".

## How:
The `__init__` method on the `CoreRunner` class now contains the logic for dealing with the `pro_path` and whatnot, which used to be in `run_rules_to_semgrep_core_helper`. Some simplifications in logic were able to be done in a few other places, and in particular, `--validate` can just use that pre-selected path.

## Test plan:
For `--dump-command-for-core`:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/49291449/217126198-2a661f01-01d6-4cc1-b8e8-0a41429bed50.png">

For running Semgrep:
<img width="844" alt="image" src="https://user-images.githubusercontent.com/49291449/217126262-278cf04f-c938-49e6-9a37-dc86992ce372.png">

For validating an Apex rule:
<img width="966" alt="image" src="https://user-images.githubusercontent.com/49291449/217126348-5ab27c17-323f-4911-9bcf-84761310f9fb.png">

For when using `--pro` with a `deep-semgrep` binary installed:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/49291449/217126426-71d6d0de-07a0-4871-80a5-7bfb5c80694e.png">

For when using `--pro` without either binary installed:
<img width="946" alt="image" src="https://user-images.githubusercontent.com/49291449/217126516-37110320-b840-4d68-b116-6d4c7b51f657.png">

Closes PA-2484

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
