### PR TITLE
Rust: add alpha tests and enable back check_maturity for Rust

### DIFF
--- a/src/engine/Unit_engine.ml
+++ b/src/engine/Unit_engine.ml
@@ -147,6 +147,8 @@ let language_exceptions =
     (Lang.Jsonnet, [ "dots_stmts"; "deep_exprstmt"; "dots_nested_stmts" ]);
     (* TODO *)
     (Lang.Clojure, [ "deep_exprstmt"; "dots_nested_stmts" ]);
+    (* TODO *)
+    (Lang.Rust, [ "dots_nested_stmts" ]);
   ]
 
 let maturity_tests () =
@@ -210,9 +212,7 @@ let maturity_tests () =
       check_maturity Lang.Lua "lua" ".lua" Experimental;
       check_maturity Lang.Ocaml "ocaml" ".ml" Experimental;
       (* TODO we say we support R, but not really actually *)
-      (* TODO: too many exns, we need to write tests!
-         check_maturity Lang.Rust "rust" ".rust" Experimental;
-      *)
+      check_maturity Lang.Rust "rust" ".rs" Experimental;
       check_maturity Lang.Solidity "solidity" ".sol" Experimental;
       check_maturity Lang.Elixir "elixir" ".ex" Experimental;
       check_maturity Lang.Swift "swift" ".swift" Experimental;

--- a/tests/patterns/rust/concrete_syntax.rs
+++ b/tests/patterns/rust/concrete_syntax.rs
@@ -1,0 +1,14 @@
+fn foo() {
+ //ERROR:
+    foo(1,2);
+
+ //ERROR:
+ foo(1,
+     2);
+
+ //ERROR:
+ foo (1, // comment
+      2);
+
+ foo(2,1);
+}

--- a/tests/patterns/rust/deep_exprstmt.rs
+++ b/tests/patterns/rust/deep_exprstmt.rs
@@ -1,0 +1,14 @@
+fn foo() {
+    //ERROR: match
+    foo();
+    bar();
+    //ERROR: match
+    foo();
+    x = bar();
+    //ERROR: match
+    foo();
+    print(bar());
+    //ERROR: match
+    foo();
+    return bar();
+}

--- a/tests/patterns/rust/dots_args.rs
+++ b/tests/patterns/rust/dots_args.rs
@@ -1,0 +1,8 @@
+fn foo() {
+  //ERROR:
+    foo(1,2,3,4,5);
+  //ERROR:
+    foo(5);
+}
+
+

--- a/tests/patterns/rust/dots_stmts.rs
+++ b/tests/patterns/rust/dots_stmts.rs
@@ -1,0 +1,8 @@
+fn foo() {
+
+    //ERROR:
+    user_data = get();
+    print("do stuff");
+    foobar();
+    eval(user_data);
+}

--- a/tests/patterns/rust/dots_string.rs
+++ b/tests/patterns/rust/dots_string.rs
@@ -1,0 +1,6 @@
+fn foo() {
+    //ERROR:
+    foo("whatever sequence of chars");
+    // TODO other form of string in Rust?
+    //foo('whatever sequence of chars');
+}

--- a/tests/patterns/rust/metavar_arg.rs
+++ b/tests/patterns/rust/metavar_arg.rs
@@ -1,0 +1,17 @@
+fn foo() {
+    //ERROR:
+    foo(1,2);
+
+    //ERROR:
+    foo(a_very_long_constant_name,
+        2);
+
+    //ERROR:
+    foo (unsafe_func(), // indeed
+         2);
+
+    //ERROR:
+    foo(bar(1,3), 2);
+
+    foo(2,1);
+}

--- a/tests/patterns/rust/metavar_call.rs
+++ b/tests/patterns/rust/metavar_call.rs
@@ -1,0 +1,8 @@
+fn foo() {
+    //ERROR:
+    foo(1,2);
+
+    return 1;
+}
+
+

--- a/tests/patterns/rust/metavar_equality_var.rs
+++ b/tests/patterns/rust/metavar_equality_var.rs
@@ -1,0 +1,9 @@
+fn foo() {
+  //ERROR:
+    myfile = open();
+    close(myfile);
+}
+
+
+
+


### PR DESCRIPTION
This will help #6545

test plan:
test file included
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)