### PR TITLE
feat(ci): allow users to run an individual repo in CI with a different engine

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -196,6 +196,9 @@ def ci(
     optimizations: str,
     dataflow_traces: bool,
     output: Optional[str],
+    pro_languages: bool,
+    pro_intrafile: bool,
+    pro: bool,
     sarif: bool,
     quiet: bool,
     rewrite_rule_ids: bool,
@@ -323,9 +326,18 @@ def ci(
             is_full_scan = metadata.merge_base_ref is None
             engine = EngineType.OSS
             if scan_handler and scan_handler.deepsemgrep:
-                engine = (
-                    EngineType.PRO_INTERFILE if is_full_scan else EngineType.PRO_LANG
-                )
+                if is_full_scan:
+                    if pro_intrafile:
+                        # Intra-file (inter-proc) + Pro languages
+                        engine = EngineType.PRO_INTRAFILE
+                    elif pro_languages:
+                        # Just Pro languages
+                        engine = EngineType.PRO_LANG
+                    else:
+                        # Inter-file + Pro languages
+                        engine = EngineType.PRO_INTERFILE
+                else:
+                    EngineType.PRO_LANG
 
             (semgrep_pro_path, _deep_semgrep_path) = determine_semgrep_pro_path()
 

--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -332,7 +332,10 @@ def ci(
                 logger.info(f"Could not start scan {e}")
                 sys.exit(FATAL_EXIT_CODE)
 
-            # Run DeepSemgrep when available but only for full scans
+            # Run Semgrep Pro when available
+            # By default, this is controlled by the toggle. When it is off, run
+            # the OSS engine. When it is on, for full scans run using interfile
+            # analysis and diff scans run using the pro languages
             is_full_scan = metadata.merge_base_ref is None
             engine = EngineType.OSS
             if scan_handler and scan_handler.deepsemgrep:
@@ -340,7 +343,8 @@ def ci(
                     EngineType.PRO_INTERFILE if is_full_scan else EngineType.PRO_LANG
                 )
 
-            # Flags override the toggle
+            # If the user explicitly requests an engine via a flag, the flag
+            # should override the toggle
             if pro and is_full_scan:
                 # Inter-file + Pro languages
                 # This behaves slightly differently from semgrep scan, because

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -480,6 +480,22 @@ _scan_options: List[Callable] = [
         is_flag=True,
         help="Output results in vim single-line format.",
     ),
+    optgroup.group("Semgrep Pro Engine options"),
+    optgroup.option(
+        "--pro-languages",
+        is_flag=True,
+        help="Enable Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
+    ),
+    optgroup.option(
+        "--pro-intrafile",
+        is_flag=True,
+        help="Intra-file inter-procedural taint analysis. Implies --pro-languages. Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
+    ),
+    optgroup.option(
+        "--pro",
+        is_flag=True,
+        help="Inter-file analysis and Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
+    ),
 ]
 
 
@@ -619,22 +635,6 @@ def scan_options(func: Callable) -> Callable:
     is_flag=True,
     hidden=True
     # help="contact support@r2c.dev for more information on this"
-)
-@optgroup.group("Semgrep Pro Engine options")
-@optgroup.option(
-    "--pro-languages",
-    is_flag=True,
-    help="Enable Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
-)
-@optgroup.option(
-    "--pro-intrafile",
-    is_flag=True,
-    help="Intra-file inter-procedural taint analysis. Implies --pro-languages. Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
-)
-@optgroup.option(
-    "--pro",
-    is_flag=True,
-    help="Inter-file analysis and Pro languages (currently just Apex). Requires Semgrep Pro Engine, contact support@r2c.dev for more information on this.",
 )
 @click.option(
     "--dump-engine-path",


### PR DESCRIPTION
The CLI allows users to choose between running with just pro languages, with intrafile interprocedural analysis, and with interfile analysis. We offer this to CI users too in case they wish to make an exception for a single repo. In general, they should use the toggle to control this.

Test plan: run in CI with docker image

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [ ] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
