### PR TITLE
chore: fix snapshots

### DIFF
--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/autofix-unparsable_url/complete.json
@@ -15,6 +15,8 @@
         "bytes_parsed": 366,
         "num_bytes": 366
       }
-    }
+    },
+    "event_id": "xxxxxxxxxx",
+    "engine_requested": "OSS"
   }
 }

--- a/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/complete.json
+++ b/cli/tests/e2e/snapshots/test_ci/test_full_run/noautofix-unparsable_url/complete.json
@@ -15,6 +15,8 @@
         "bytes_parsed": 366,
         "num_bytes": 366
       }
-    }
+    },
+    "event_id": "xxxxxxxxxx",
+    "engine_requested": "OSS"
   }
 }


### PR DESCRIPTION
After #7081, tests are failing on `develop`. I have no idea why these snapshots didn't err in CI, and also because I ran `make regenerate-tests` like a billion times on that PR, but oh well.

Test plan: `make test`, and the other `complete.json`s have it too.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
