### PR TITLE
tech debt: get rid of resolved_name in AST_Python

### DIFF
--- a/languages/go/ast/ast_go.ml
+++ b/languages/go/ast/ast_go.ml
@@ -139,7 +139,7 @@ and expr =
    * To disambiguate requires semantic information.
    * Selector (Name,'.', ident) can be many things.
    *)
-  | Id of ident (* * AST_generic.resolved_name option ref *)
+  | Id of ident
   (* A Selector can be a
    *  - a field access of a struct
    *  - a top decl access of a package

--- a/languages/javascript/ast/ast_js.ml
+++ b/languages/javascript/ast/ast_js.ml
@@ -99,10 +99,6 @@ type sc = Parse_info.t [@@deriving show] (* with tarzan *)
 
 type a_ident = string wrap [@@deriving show]
 
-(* old: there used to be 'resolved_name' and 'qualified_name' types, but
- * the name resolution is now done on the generic AST instead.
- *)
-
 type special =
   (* Special values *)
   | Null

--- a/languages/javascript/ast/visitor_js.ml
+++ b/languages/javascript/ast/visitor_js.ml
@@ -349,7 +349,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
         let v1 = v_stmt v1 in
         ()
   and v_dot_operator _ = ()
-  and v_resolved_name _ = ()
   and v_def (ent, defkind) =
     v_entity ent;
     v_definition_kind defkind

--- a/languages/python/ast/AST_python.ml
+++ b/languages/python/ast/AST_python.ml
@@ -101,21 +101,6 @@ type module_name =
   tok (* . or ... toks *) list option (* levels, for relative imports *)
 [@@deriving show]
 
-(* TODO: reuse AST_generic one? or just get rid of it? *)
-type resolved_name =
-  (* this can be computed by a visitor *)
-  | LocalVar
-  | Parameter
-  | GlobalVar
-  | ClassField
-  (* both dotted_name should contain at least one element! *)
-  | ImportedModule of dotted_name
-  | ImportedEntity of dotted_name
-  (* default case *)
-  | NotResolved
-[@@deriving show { with_path = false }]
-(* with tarzan *)
-
 (*****************************************************************************)
 (* Expression *)
 (*****************************************************************************)
@@ -133,7 +118,7 @@ type expr =
   | Bool of bool wrap
   | None_ of tok
   (* introduce new vars when expr_context = Store *)
-  | Name of name (* id *) * expr_context (* ctx *) * resolved_name ref
+  | Name of name (* id *) * expr_context (* ctx *)
   (* TODO: in some context the tuple does not have the enclosing brackets
    * (in which case they are represented by fake tokens)
    *)
@@ -492,7 +477,7 @@ let str_of_name = fst
 let context_of_expr = function
   | Attribute (_, _, _, ctx) -> Some ctx
   | Subscript (_, _, ctx) -> Some ctx
-  | Name (_, ctx, _) -> Some ctx
+  | Name (_, ctx) -> Some ctx
   | List (_, ctx) -> Some ctx
   | Tuple (_, ctx) -> Some ctx
   | _ -> None

--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -93,7 +93,6 @@ let is_in_scope env s =
 let id x = x
 let option = Option.map
 let list = Common.map
-let vref f x = ref (f !x)
 let string = id
 let bool = id
 let fake tok s = Parse_info.fake_info tok s
@@ -135,19 +134,6 @@ let module_name env (v1, dots) =
       in
       let s = String.concat "/" (prefixes @ elems) in
       G.FileName (s, tok)
-
-let resolved_name = function
-  | LocalVar -> Some (G.LocalVar, G.SId.unsafe_default)
-  | Parameter -> Some (G.Parameter, G.SId.unsafe_default)
-  | GlobalVar -> Some (G.Global, G.SId.unsafe_default)
-  | ClassField -> None
-  | ImportedModule xs ->
-      let xs = G.dotted_to_canonical xs in
-      Some (G.ImportedModule xs, G.SId.unsafe_default)
-  | ImportedEntity xs ->
-      let xs = G.dotted_to_canonical xs in
-      Some (G.ImportedEntity xs, G.SId.unsafe_default)
-  | NotResolved -> None
 
 let expr_context = function
   | Load -> ()
@@ -223,11 +209,9 @@ let rec expr env (x : expr) =
       G.Call
         (G.IdSpecial (G.Spread, unsafe_fake "spread") |> G.e, fb [ G.arg v1 ])
       |> G.e
-  | Name (v1, v2, v3) ->
-      let v1 = name env v1
-      and _v2TODO = expr_context v2
-      and v3 = vref resolved_name v3 in
-      G.N (G.Id (v1, { (G.empty_id_info ()) with G.id_resolved = v3 })) |> G.e
+  | Name (v1, v2) ->
+      let v1 = name env v1 and _v2TODO = expr_context v2 in
+      G.N (G.Id (v1, G.empty_id_info ())) |> G.e
   | Tuple (CompList v1, v2) ->
       let v1 = bracket (list (expr env)) v1 and _v2TODO = expr_context v2 in
       G.Container (G.Tuple, v1) |> G.e
@@ -745,7 +729,7 @@ and stmt_aux env x =
   | AugAssign (v1, (v2, tok), v3) ->
       let v1 = expr env v1 and v2 = operator v2 and v3 = expr env v3 in
       [ G.exprstmt (G.AssignOp (v1, (v2, tok), v3) |> G.e) ]
-  | Cast (Name (id, _kind, _ref), _tok, ty) ->
+  | Cast (Name (id, _kind), _tok, ty) ->
       (* In the following example, `x : int` is not a type cast but a variable
        * declaration:
        *
@@ -848,11 +832,11 @@ and stmt_aux env x =
   | Continue t -> [ G.Continue (t, G.LNone, G.sc) |> G.s ]
   (* python2: *)
   | Print (tok, _dest, vals, _nl) ->
-      let id = Name (("print", tok), Load, ref NotResolved) in
+      let id = Name (("print", tok), Load) in
       stmt_aux env
         (ExprStmt (Call (id, fb (vals |> Common.map (fun e -> Arg e)))))
   | Exec (tok, e, _eopt, _eopt2) ->
-      let id = Name (("exec", tok), Load, ref NotResolved) in
+      let id = Name (("exec", tok), Load) in
       stmt_aux env (ExprStmt (Call (id, fb [ Arg e ])))
 
 and cases_and_body env = function

--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -62,8 +62,8 @@ let rewrap_paren_if_tuple l e r =
  * CompForIf though is not an lvalue.
 *)
 let rec set_expr_ctx ctx = function
-  | Name (id, _, x) ->
-      Name (id, ctx, x)
+  | Name (id, _) ->
+      Name (id, ctx)
   | Attribute (value, t, attr, _) ->
       Attribute (value, t, attr, ctx)
   | Subscript (value, slice, _) ->
@@ -776,7 +776,7 @@ type_for_lsif:
 (*----------------------------*)
 
 atom:
-  | NAME        { Name ($1, Load, ref NotResolved) }
+  | NAME        { Name ($1, Load) }
 
   | INT         { Num (Int ($1)) }
   | LONGINT     { Num (LongInt ($1)) }
@@ -1064,6 +1064,6 @@ argument:
 
   | test "=" test
       { match $1 with
-        | Name (id, _, _) -> ArgKwd (id, $3)
+        | Name (id, _) -> ArgKwd (id, $3)
         | _ -> raise Parsing.Parse_error
       }

--- a/languages/python/menhir/Visitor_python.ml
+++ b/languages/python/menhir/Visitor_python.ml
@@ -78,18 +78,6 @@ let (mk_visitor : visitor_in -> visitor_out) =
     let v1 = v_dotted_name v1 in
     let v2 = v_option (v_list v_tok) v2 in
     ()
-  and v_resolved_name = function
-    | LocalVar -> ()
-    | Parameter -> ()
-    | GlobalVar -> ()
-    | ClassField -> ()
-    | ImportedModule v ->
-        let _ = v_dotted_name v in
-        ()
-    | ImportedEntity v ->
-        let _ = v_dotted_name v in
-        ()
-    | NotResolved -> ()
   and v_expr (x : expr) =
     (* tweak *)
     let k x =
@@ -127,10 +115,8 @@ let (mk_visitor : visitor_in -> visitor_out) =
       | ConcatenatedString v1 ->
           let v1 = v_list v_expr v1 in
           ()
-      | Name (v1, v2, v3) ->
-          let v1 = v_name v1
-          and v2 = v_expr_context v2
-          and v3 = v_ref_do_not_visit v_resolved_name v3 in
+      | Name (v1, v2) ->
+          let v1 = v_name v1 and v2 = v_expr_context v2 in
           ()
       | TypedMetavar (v1, v2, v3) ->
           let v1 = v_name v1 in

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -47,7 +47,7 @@ let invalid () = raise (PI.NoTokenLocation "Invalid program")
  * parser_python.mly
  *)
 
-let name_of_id id = Name (id, no_ctx, ref NotResolved)
+let name_of_id id = Name (id, no_ctx)
 
 let single_or_tuple e xs =
   match xs with


### PR DESCRIPTION
We used to do some naming for each separate AST but
now instead do it on the generic AST, so we don't
need anymore those resolved_name ref in the
language-specific ASTs

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)