### PR TITLE
Python: convert "self" to IdSpecial Self in python_to_generic

### DIFF
--- a/languages/python/ast/AST_python.ml
+++ b/languages/python/ast/AST_python.ml
@@ -117,7 +117,11 @@ type expr =
   (* python3: true/false are now officially reserved keywords *)
   | Bool of bool wrap
   | None_ of tok
-  (* introduce new vars when expr_context = Store *)
+  (* Introduce new vars when expr_context = Store.
+   * Note that the ident can be "self".
+   * alt: we could use an IdSpecial for it but self is actually not a
+   * Python keyword; you can use a different name for it.
+   *)
   | Name of name (* id *) * expr_context (* ctx *)
   (* TODO: in some context the tuple does not have the enclosing brackets
    * (in which case they are represented by fake tokens)

--- a/languages/python/menhir/Lexer_python.mll
+++ b/languages/python/menhir/Lexer_python.mll
@@ -493,7 +493,9 @@ and _token python2 state = parse
         | "print" when python2 -> PRINT (tokinfo lexbuf)
         | "exec" when python2 -> EXEC (tokinfo lexbuf)
         (* python3-ext: no more: print, exec *)
-
+        (* Note that "self" is not listed above because it's not considered
+         * a Python keyword. In theory you could use different names for self.
+         *)
         | _          -> NAME (id, (tokinfo lexbuf))
     }
 

--- a/src/printing/Pretty_print_AST.ml
+++ b/src/printing/Pretty_print_AST.ml
@@ -762,6 +762,7 @@ and id_qualified env { name_last = id, _toptTODO; name_middle; name_top; _ } =
 
 and special env = function
   | This, _ -> "this"
+  | Self, _ -> "self"
   | Op op, tok -> arithop env (op, tok)
   | IncrDecr _, _ -> "" (* should be captured in the call *)
   | sp, tok -> todo (E (IdSpecial (sp, tok) |> G.e))


### PR DESCRIPTION
This will avoid some special case in Naming_SAST.ml

test plan:
make core-test


PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)