### PR TITLE
chore: change expected number of dots to 3x for `--interfile`

### DIFF
--- a/changelog.d/pa-2313.fixed
+++ b/changelog.d/pa-2313.fixed
@@ -1,0 +1,1 @@
+CLI: Progress bar for Semgrep Pro Engine interfile scans now reflects actual progress more faithfully

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -40,6 +40,10 @@ class EngineType(Enum):
     def is_pro(self) -> bool:
         return self.value >= EngineType.PRO_LANG.value
 
+    @property
+    def is_interfile(self) -> bool:
+        return self.value == EngineType.PRO_INTERFILE.value
+
 
 class OutputFormat(Enum):
     TEXT = auto()

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -913,7 +913,12 @@ class CoreRunner:
                 sys.exit(0)
 
             runner = StreamingSemgrepCore(
-                cmd, plan.num_targets * 3 if engine.is_pro else plan.num_targets
+                # We expect to see 3 dots for each target, when running interfile analysis:
+                # - once when finishing phase 4, name resolution, on that target
+                # - once when finishing phase 5, taint configs, on that target
+                # - once when finishing analysis on that target as usual
+                cmd,
+                plan.num_targets * 3 if engine.is_interfile else plan.num_targets,
             )
             runner.vfs_map = vfs_map
             returncode = runner.execute()

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -912,7 +912,9 @@ class CoreRunner:
                 print(" ".join(printed_cmd))
                 sys.exit(0)
 
-            runner = StreamingSemgrepCore(cmd, plan.num_targets)
+            runner = StreamingSemgrepCore(
+                cmd, plan.num_targets * 3 if engine.is_pro else plan.num_targets
+            )
             runner.vfs_map = vfs_map
             returncode = runner.execute()
 


### PR DESCRIPTION
## What:
This PR, in conjunction with https://github.com/returntocorp/semgrep-proprietary/pull/523, makes the progress bar for running interfile scans smoother.

More details in the other PR. This one just changes the number of expected dots to 3x for interfile scans.

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
