### PR TITLE
chore: allow matching inside of `Cast`

### DIFF
--- a/changelog.d/pa-1133.fixed
+++ b/changelog.d/pa-1133.fixed
@@ -1,0 +1,1 @@
+Matching: Fixed a bug where expressions would not match to explicit type casts of matching expressions

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -760,7 +760,6 @@ and m_expr ?(is_root = false) ?(is_first_invocation = true) a b =
   *)
   | _, G.Cast (_, _, b1) when is_first_invocation ->
       m_expr a b1 >||> m_expr ~is_first_invocation:false a b
-  (* I want to make sure this second call does not re-enter the Cast case... *)
   (* equivalence: name resolving! *)
   (* todo: it would be nice to factorize the aliasing code by just calling
    * m_name, but below we use make_dotted, which is different from what

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -739,7 +739,12 @@ and m_expr_root a b = m_expr ~is_root:true a b
 (* coupling: if you add special sgrep hooks here, you should probably
  * also add them in m_pattern
  *)
-and m_expr ?(is_root = false) a b =
+(* `is_first_invocation` should be false if this is not the first time
+   `m_expr` has recursively tried to match the same `a` and `b`.
+   This allows some cases to be "try-once", and fall-through to the others in
+   all the other cases.
+*)
+and m_expr ?(is_root = false) ?(is_first_invocation = true) a b =
   Trace_matching.(if on then print_expr_pair a b);
   match (a.G.e, b.G.e) with
   (* the order of the matches matters! take care! *)
@@ -748,6 +753,14 @@ and m_expr ?(is_root = false) a b =
   | _, G.Alias (_alias, b1) -> m_expr a b1
   (* equivalence: user-defined equivalence! *)
   | G.DisjExpr (a1, a2), _b -> m_expr a1 b >||> m_expr a2 b
+  (* This case should only run exactly once.
+     This is so we do not endlessly loop trying to match to the same two things.
+     By setting `is_first_invocation` to false, we ensure that we fall-through to
+     the cases that do decompose on `a` or `b`.
+  *)
+  | _, G.Cast (_, _, b1) when is_first_invocation ->
+      m_expr a b1 >||> m_expr ~is_first_invocation:false a b
+  (* I want to make sure this second call does not re-enter the Cast case... *)
   (* equivalence: name resolving! *)
   (* todo: it would be nice to factorize the aliasing code by just calling
    * m_name, but below we use make_dotted, which is different from what

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -739,12 +739,12 @@ and m_expr_root a b = m_expr ~is_root:true a b
 (* coupling: if you add special sgrep hooks here, you should probably
  * also add them in m_pattern
  *)
-(* `is_first_invocation` should be false if this is not the first time
-   `m_expr` has recursively tried to match the same `a` and `b`.
+(* `arguments_have_changed` should be false if this is not the first time
+   `m_expr` has recursively tried to match the SAME `a` and `b`.
    This allows some cases to be "try-once", and fall-through to the others in
    all the other cases.
 *)
-and m_expr ?(is_root = false) ?(is_first_invocation = true) a b =
+and m_expr ?(is_root = false) ?(arguments_have_changed = true) a b =
   Trace_matching.(if on then print_expr_pair a b);
   match (a.G.e, b.G.e) with
   (* the order of the matches matters! take care! *)
@@ -755,11 +755,11 @@ and m_expr ?(is_root = false) ?(is_first_invocation = true) a b =
   | G.DisjExpr (a1, a2), _b -> m_expr a1 b >||> m_expr a2 b
   (* This case should only run exactly once.
      This is so we do not endlessly loop trying to match to the same two things.
-     By setting `is_first_invocation` to false, we ensure that we fall-through to
+     By setting `arguments_have_changed` to false, we ensure that we fall-through to
      the cases that do decompose on `a` or `b`.
   *)
-  | _, G.Cast (_, _, b1) when is_first_invocation ->
-      m_expr a b1 >||> m_expr ~is_first_invocation:false a b
+  | _, G.Cast (_, _, b1) when arguments_have_changed ->
+      m_expr a b1 >||> m_expr ~arguments_have_changed:false a b
   (* equivalence: name resolving! *)
   (* todo: it would be nice to factorize the aliasing code by just calling
    * m_name, but below we use make_dotted, which is different from what

--- a/tests/patterns/ts/ignore_types_function.ts
+++ b/tests/patterns/ts/ignore_types_function.ts
@@ -4,7 +4,7 @@ function foo(x: number) {
   return x;
 }
 
-// TODO: those are parsed as TodoK "TypeAssert" for now
+// ERROR: 
 function foo(x: number) {
   let y = x + 1;
   return <string>x;


### PR DESCRIPTION
## What:
This PR allows `e1` to try to match to `e2` when matching `Cast(_, _, e2)`.

## Why:
If we are trying to find an expression, it's a fair bet that, in langauges that allow dynamic type casts, we should match the thing that is being type-cast. It's still a valid instance of the expression.

## How:
This is tricky because what you want to do is say that matching a `Cast` allows you to match inside, but also let it match regularly (the other cases). If we just naively write that, we will loop forever, since we will continuously re-enter the `Cast` case. We need to somehow remember that we already unpacked the inner logic, and try the other cases in the next recursive call.

This PR adds in an `is_first_invocation` flag, which is normally always `true`. Any recursive case which should occur exactly once, but might not deconstruct on `a` or `b`, and doesn't want to loop, should set `is_first_invocation` to `false`, and then require `is_first_invocation` on the relevant call. This effectively makes such cases "invisible" after the first pass.

## Test plan:
`make test`, and:
![image](https://user-images.githubusercontent.com/49291449/217672509-e5dc1400-c9e0-4cb3-8d22-f9b5bd00f0a3.png)

## Alternatives considered:

I considered extracting `m_expr` to an inner helper, and using an outer `m_expr` which just does the `Cast` case, and then defers to the inner helper (which will call only the inner helper in the `Cast` case). I thought that would induce more bloat into `Generic_vs_generic` (which `m_expr_root` already does), and this is less invasive of a change, which is still only relevant to the clauses that mention `is_first_invocation`.

Closes PA-1133

PR checklist:

- [X] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [X] Tests included or PR comment includes a reproducible test plan
- [X] Documentation is up-to-date
- [X] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [X] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
