### PR TITLE
fix: Fix location reported by nested metavariables

### DIFF
--- a/changelog.d/extracted-metavar-loc.fix
+++ b/changelog.d/extracted-metavar-loc.fix
@@ -1,0 +1,1 @@
+Fix the location associated with metavariables bound inside of `metavariable-pattern` clauses, which could lead to matches being incorrectly displayed.

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -136,13 +136,18 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
             |> PI.unsafe_token_location_of_info
           in
           let fix_loc file loc =
+            (* The column is only perturbed if this loc is on the first line of
+             * the original metavariable match *)
+            let column =
+              if loc.PI.line =|= mast_start_loc.PI.line then
+                loc.column - mast_start_loc.column
+              else loc.column
+            in
             {
               loc with
               PI.charpos = loc.PI.charpos - mast_start_loc.charpos;
               line = loc.line - mast_start_loc.line + 1;
-              (* TODO Is column wrong if loc.line does not equal
-               * mast_start_loc.line? *)
-              column = loc.column - mast_start_loc.column;
+              column;
               file;
             }
           in
@@ -151,12 +156,16 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
              the original file.
           *)
           let revert_loc loc =
+            (* See fix_loc *)
+            let column =
+              if loc.PI.line =|= 1 then loc.column + mast_start_loc.column
+              else loc.column
+            in
             {
               loc with
               PI.charpos = loc.PI.charpos + mast_start_loc.charpos;
               line = loc.line + mast_start_loc.line - 1;
-              (* TODO Is column wrong if loc.line is not 1? *)
-              column = loc.column + mast_start_loc.column;
+              column;
               file = mval_file;
             }
           in


### PR DESCRIPTION
When we evaluate a `metavariable-pattern` we make a temp file with the original contents. We adjust each location in the original AST to match the temp file. When we get metavariable bindings out, we need to adjust their locations back to the original file.

We only need to adjust the column for locations that are on the first line of the original metavariable match. For subsequent lines, the column will already be correct. Previously we were blindly adjusting the column, leading to the incorrect results outlined in the test plan below.

This does not appear to affect matching in any way. I tried a few times to construct a test that would fail. It does affect how matches are displayed in the playground, though, and it probably affects autofix.

Test plan:

Unfortunately we don't have automated tests for semgrep core which check the reported column for a match. We have autofix tests, but those rely on the offset only, and I believe they are only set up for pattern tests anyway, not full rule tests. We do have end to end tests for the CLI, but they are brittle and each one comes with a decent maintenance burden. For this, I think it makes sense to just manually test.

Rule:

```
rules:
- id: test
  patterns:
    - pattern: |
        '$STR'
    - metavariable-pattern:
        metavariable: $STR
        language: generic
        pattern: |
          ... a $B c ...
    - focus-metavariable: $B
  message: test
  languages: [js]
  severity: WARNING
```

Test file:

```
const asdf = 'a b c';

const asdfasdfasdf = '\
a b c\
';
```

Test command:

`semgrep-core -l js -rules test.yaml test.js -json_nodots | jq`

Before: https://gist.github.com/nmote/77b0127105fbfe801f2049eb8a5a7ad2

After: https://gist.github.com/nmote/3091a3996dff2f5c363f625c4f4a6fc0

Note that the location of the first match is unchanged, but the location of the second match now correctly reports the start column as 3 and end as 4 instead of 25 to 26. The location of the metavar `$B` is similarly updated.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was [added to changelog.d](https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry) for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)

If you're unsure on any of this, please see:

- [Contribution guidelines](https://semgrep.dev/docs/contributing/contributing-code)!
- [One of the more specific guides located here](https://semgrep.dev/docs/contributing/contributing/)
